### PR TITLE
KAFKA-294

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -101,7 +101,9 @@ log.cleanup.interval.mins=1
 # This is a comma separated host:port pairs, each corresponding to a zk
 # server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 # You can also append an optional chroot string to the urls to specify the
-# root directory for all kafka znodes.
+# root directory for all kafka znodes, e.g.
+# "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002/kafka". If you use a chroot
+# string, be sure to manualy create this namespace in zookeeper.
 zk.connect=localhost:2181
 
 # Timeout in ms for connecting to zookeeper


### PR DESCRIPTION
This issue can be caused by a non-existing path but also a misunderstanding from the config file. A short example will help the user.
