### PR TITLE
Unmap before resizing

### DIFF
--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -248,6 +248,11 @@ class OffsetIndex(val file: File, val baseOffset: Long, val maxIndexSize: Int = 
     }
   }
 
+  def tryUnmap(m: MappedByteBuffer) {
+     if(m.isInstanceOf[sun.nio.ch.DirectBuffer])
+        (m.asInstanceOf[sun.nio.ch.DirectBuffer]).cleaner().clean()
+  }
+
   /**
    * Reset the size of the memory map and the underneath file. This is used in two kinds of cases: (1) in
    * trimToValidSize() which is called at closing the segment or new segment being rolled; (2) at
@@ -261,7 +266,7 @@ class OffsetIndex(val file: File, val baseOffset: Long, val maxIndexSize: Int = 
       val roundedNewSize = roundToExactMultiple(newSize, 8)
       val position = this.mmap.position
       try {
-        (this.mmap.asInstanceOf[sun.nio.ch.DirectBuffer]).cleaner().clean()
+        tryUnmap(this.mmap) 
         raf.setLength(roundedNewSize)
         this.mmap = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, roundedNewSize)
         this.mmap.position(position)

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -259,9 +259,10 @@ class OffsetIndex(val file: File, val baseOffset: Long, val maxIndexSize: Int = 
       flush()
       val raf = new RandomAccessFile(file, "rws")
       val roundedNewSize = roundToExactMultiple(newSize, 8)
+      val position = this.mmap.position
       try {
+        (this.mmap.asInstanceOf[sun.nio.ch.DirectBuffer]).cleaner().clean()
         raf.setLength(roundedNewSize)
-        val position = this.mmap.position
         this.mmap = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, roundedNewSize)
         this.mmap.position(position)
       } finally {


### PR DESCRIPTION
While I was studying how MappedByteBuffer works, I saw a sharing runtime exception on Windows. I applied what I learned to generate a patch which uses an internal open JDK API to solve this problem.

---

Caused by: java.io.IOException: The requested operation cannot be performed
on a
 file with a user-mapped section open
        at java.io.RandomAccessFile.setLength(Native Method)
        at kafka.log.OffsetIndex.liftedTree2$1(OffsetIndex.scala:263)
        at kafka.log.OffsetIndex.resize(OffsetIndex.scala:262)
        at kafka.log.OffsetIndex.trimToValidSize(OffsetIndex.scala:247)
        at kafka.log.Log.rollToOffset(Log.scala:518)
        at kafka.log.Log.roll(Log.scala:502)
        at kafka.log.Log.maybeRoll(Log.scala:484)
        at kafka.log.Log.append(Log.scala:297)
