### PR TITLE
Modified the async producer so it re-queues failed batches.  

### DIFF
--- a/core/src/main/scala/kafka/producer/async/ProducerSendThread.scala
+++ b/core/src/main/scala/kafka/producer/async/ProducerSendThread.scala
@@ -103,7 +103,11 @@ class ProducerSendThread[K,V](val threadName: String,
       if(size > 0)
         handler.handle(events)
     }catch {
-      case e => error("Error in handling batch of " + size + " events", e)
+      case e => 
+        for (message <- events) {
+          queue.offer(message)
+        }
+        error("Re-queued batch of " + size + " events. Queue depth " + queue.size)
     }
   }
 


### PR DESCRIPTION
I'm working on an application that needs the throughput offered by an async producer but also needs to handle send failures gracefully like a sync producer.  I modified the ProducerSendThread so it will re-queue failed batches.  This allowed me to determine the behavior I wanted from my producer with the queue config parameters.

A "queue.enqueue.timeout.ms=0" allowed me to get runtime exceptions when sends failed often enough to fill the queue.  This also allowed me to use "queue.buffering.max.messages" to control how tolerant the application is to network blips.
