### PR TITLE
Escape the . in the kafka.Kafka chain

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -13,4 +13,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ps ax | grep -i 'kafka.Kafka' | grep -v grep | awk '{print $1}' | xargs kill -SIGTERM
+ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}' | xargs kill -SIGINT


### PR DESCRIPTION
Little modification to the stop script to be able to stop the kill the proper process.
- Escape the . in the kafka.Kafka chain
- Also add a grep java to get the real java process and exclude the kafka-run-class.sh process
