### PR TITLE
commitOffsets can be passed the offsets to commit

### DIFF
--- a/core/src/main/scala/kafka/consumer/ConsumerConnector.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerConnector.scala
@@ -77,8 +77,8 @@ trait ConsumerConnector {
    *  Generally they should be taken from MessageAndMetadata.  Note that you are free to only update
    *  some offsets, and leave others as is
    */
-  def commitOffsets(offsets: Seq[PartitionTopicOffset]) {
-    commitOffsets(offsets.groupBy{pto => pto.topic})
+  def commitOffsets(offsets: Seq[PartitionTopicOffset], preventBackwardsCommit: Boolean) {
+    commitOffsets(offsets.groupBy{pto => pto.topic}, preventBackwardsCommit)
   }
 
   /**
@@ -86,7 +86,7 @@ trait ConsumerConnector {
    *  Generally they should be taken from MessageAndMetadata.  Note that you are free to only update
    *  some offsets, and leave others as is
    */
-  def commitOffsets(offsets: Iterable[(String, Iterable[PartitionTopicOffset])])
+  def commitOffsets(offsets: Iterable[(String, Iterable[PartitionTopicOffset])], preventBackwardsCommit: Boolean)
 
 
     /**

--- a/core/src/main/scala/kafka/consumer/ConsumerConnector.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerConnector.scala
@@ -71,8 +71,25 @@ trait ConsumerConnector {
    *  Commit the offsets of all broker partitions connected by this connector.
    */
   def commitOffsets
-  
+
   /**
+   *  Commit the given offsets.  Entirely left to the user to make sure they are committing sensible updates.
+   *  Generally they should be taken from MessageAndMetadata.  Note that you are free to only update
+   *  some offsets, and leave others as is
+   */
+  def commitOffsets(offsets: Seq[PartitionTopicOffset]) {
+    commitOffsets(offsets.groupBy{pto => pto.topic})
+  }
+
+  /**
+   *  Commit the given offsets.  Entirely left to the user to make sure they are committing sensible updates.
+   *  Generally they should be taken from MessageAndMetadata.  Note that you are free to only update
+   *  some offsets, and leave others as is
+   */
+  def commitOffsets(offsets: Iterable[(String, Iterable[PartitionTopicOffset])])
+
+
+    /**
    *  Shut down the connector
    */
   def shutdown()
@@ -101,3 +118,5 @@ object Consumer extends Logging {
     consumerConnect
   }
 }
+
+case class PartitionTopicOffset(topic: String, partition: Int, offset: Long)


### PR DESCRIPTION
This adds another version of `commitOffsets` that takes the offsets to commit as a parameter.

Without this change, getting correct user code is very hard.  Despite kafka's at-least-once guarantees, most user code doesn't actually have that guarantee, and is almost certainly wrong if doing batch processing.  Getting it right requires some very careful synchronization between all consumer threads, which is both:
1) painful to get right
2) slow b/c of the need to stop all workers during a commit.

This small change simplifies a lot of this.  This was discussed extensively on the user mailing list, on the thread "are kafka consumer apps guaranteed to see msgs at least once?"

You can also see an example implementation of a user api which makes use of this, to get proper at-least-once guarantees by _user_ code, even for batches:
https://github.com/quantifind/kafka-utils/pull/1

I'm open to any suggestions on how to add unit tests for this.
