### PR TITLE
KAFKA-1371 Ignore build output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 dist
 *classes
 target/
+build/
+.gradle/
 lib_managed/
 src_managed/
 project/boot/


### PR DESCRIPTION
This patch extends git ignore patterns to all build and .gradle dirs
