### PR TITLE
KAFKA-1375: Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The release file can be found inside ./core/build/distributions/.
 ### Cleaning the build ###
     ./gradlew clean
 
-### Running a task on a particular version of Scala ####
-either 2.8.0, 2.8.2, 2.9.1, 2.9.2 or 2.10.1) (If building a jar with a version other than 2.8.0, the scala version variable in bin/kafka-run-class.sh needs to be changed to run quick start.)
+### Running a task on a particular version of Scala (either 2.8.0, 2.8.2, 2.9.1, 2.9.2 or 2.10.1) ###
+#### (If building a jar with a version other than 2.8.0, the scala version variable in bin/kafka-run-class.sh needs to be changed to run quick start.) ####
     ./gradlew -PscalaVersion=2.9.1 jar
     ./gradlew -PscalaVersion=2.9.1 test
     ./gradlew -PscalaVersion=2.9.1 releaseTarGz


### PR DESCRIPTION
This patch fixes formatting of instructions for using particular version of Scala when running a Gradle build task.
