### PR TITLE
Remove non-functional variable definition in log4j.properties

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kafka.logs.dir=logs
-
 log4j.rootLogger=INFO, stdout 
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
In log4j.properties, a property kafka.logs.dir was defined. However, modifying this property has no effect because log4j.properties does not support variable substitution in this manner. Rather ${kafka.logs.dir} is looked up as a System property, which is set in bin/kafka-run-class.sh, and must currently be changed there if the log4j logging location is to be modified.
