### PR TITLE
[kafka-1828]add judgement for ConsumerPerformance against negative number

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -71,6 +71,12 @@ object ConsumerPerformance {
 
     val endMs = System.currentTimeMillis
     val elapsedSecs = (endMs - startMs - config.consumerConfig.consumerTimeoutMs) / 1000.0
+
+    if(elapsedSecs <= 0) {
+      println("The total running time should be more than 'consumer.timeout.ms'!")
+      System.exit(1)
+    }
+
     if (!config.showDetailedStats) {
       val totalMBRead = (totalBytesRead.get * 1.0) / (1024 * 1024)
       println(("%s, %s, %d, %.4f, %.4f, %d, %.4f").format(config.dateFormat.format(startMs), config.dateFormat.format(endMs),


### PR DESCRIPTION
The result is negative number when runnning a short time for consumer performance testing, but user doesn't the reason, so add judgement for this, and then according to the reason, user can do ConsumerPerformance.

negative result like:
start.time, end.time, fetch.size, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec
2014-12-23 19:32:39:120, 2014-12-23 19:32:39:152, 1048576, 0.0790, -0.1689, 1000, -2136.7521

anybody, could you help to check this?
