### PR TITLE
KAFKA-1833: OfflinePartitionLeaderSelector may return null leader when ISR and Assgi...

### DIFF
--- a/core/src/main/scala/kafka/controller/PartitionLeaderSelector.scala
+++ b/core/src/main/scala/kafka/controller/PartitionLeaderSelector.scala
@@ -84,7 +84,7 @@ class OfflinePartitionLeaderSelector(controllerContext: ControllerContext, confi
             }
           case false =>
             val liveReplicasInIsr = liveAssignedReplicas.filter(r => liveBrokersInIsr.contains(r))
-            val newLeader = liveReplicasInIsr.head
+            val newLeader = if (liveReplicasInIsr.isEmpty) liveBrokersInIsr.head else liveReplicasInIsr.head
             debug("Some broker in ISR is alive for %s. Select %d from ISR %s to be the leader."
                   .format(topicAndPartition, newLeader, liveBrokersInIsr.mkString(",")))
             new LeaderAndIsr(newLeader, currentLeaderEpoch + 1, liveBrokersInIsr.toList, currentLeaderIsrZkPathVersion + 1)


### PR DESCRIPTION
PR for [KAFKA-1833](https://issues.apache.org/jira/browse/KAFKA-1833)

In OfflinePartitonLeaderSelector::selectLeader, when liveBrokerInIsr is not empty and have no common broker with liveAssignedreplicas, selectLeader will return no leader;
