### PR TITLE
KAFKA-1834: No Response when handle LeaderAndIsrRequest some case

### DIFF
--- a/core/src/main/scala/kafka/common/ErrorMapping.scala
+++ b/core/src/main/scala/kafka/common/ErrorMapping.scala
@@ -49,6 +49,7 @@ object ErrorMapping {
   val MessageSetSizeTooLargeCode: Short = 18
   val NotEnoughReplicasCode : Short = 19
   val NotEnoughReplicasAfterAppendCode: Short = 20
+  val InvalidBrokerCode : Short = 21
 
   private val exceptionToCode =
     Map[Class[Throwable], Short](

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -359,6 +359,7 @@ class ReplicaManager(val config: KafkaConfig,
                 "epoch %d for partition [%s,%d] as itself is not in assigned replica list %s")
                 .format(localBrokerId, controllerId, correlationId, leaderAndISRRequest.controllerEpoch,
                 topic, partition.partitionId, partitionStateInfo.allReplicas.mkString(",")))
+              responseMap.put((topic, partitionId), ErrorMapping.InvalidBrokerCode)
             }
           } else {
             // Otherwise record the error code in response


### PR DESCRIPTION
PR for [KAFKA-1834](https://issues.apache.org/jira/browse/KAFKA-1834)

When a replica become leader or follower, if this broker no exist in assigned replicas, there are no response.
