### PR TITLE
Improvements to server stop scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,16 @@ src_managed/
 project/boot/
 project/plugins/project/
 project/sbt_project_definition.iml
+build/
+data/
+logs/
 .idea
 .svn
 .classpath
+.gradle
 *~
 *#
-.#*
+.#* 
+*.log
 rat.out
 TAGS

--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -13,4 +13,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}' | xargs kill -SIGINT
+ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}' | xargs kill

--- a/bin/zookeeper-server-stop.sh
+++ b/bin/zookeeper-server-stop.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,4 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ps ax | grep -i 'zookeeper' | grep -v grep | awk '{print $1}' | xargs kill -SIGINT
+zookeepers=`ps ax | grep -i 'zookeeper.properties' | grep -v grep | awk '{print $1}'`
+if [ ${zookeepers} ]
+  then
+	echo ${zookeepers} given KILL signal
+	echo ${zookeepers} | xargs kill
+else
+	echo "Zookeeper not running"
+fi


### PR DESCRIPTION
Interrupt signal doesn't work to stop the servers (at least not on
Amazon Linux.)  Also, improved the selectivity of the stop command
for the Zookeeper stop script, so that it doesn't accidentally
kill the wrong processes.  Finally, modified the Zookeeper stop
script so that it doesn't give a cryptic message in case zookeeper
is not already stopped.
