### PR TITLE
KAFKA-724: auto socket buffer set

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -128,8 +128,10 @@ public class Selector implements Selectable {
         channel.configureBlocking(false);
         Socket socket = channel.socket();
         socket.setKeepAlive(true);
-        socket.setSendBufferSize(sendBufferSize);
-        socket.setReceiveBufferSize(receiveBufferSize);
+        if(sendBufferSize > 0)
+            socket.setSendBufferSize(sendBufferSize);
+        if(receiveBufferSize > 0)
+            socket.setReceiveBufferSize(receiveBufferSize);
         socket.setTcpNoDelay(true);
         try {
             channel.connect(address);

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -251,7 +251,8 @@ private[kafka] class Acceptor(val host: String,
         new InetSocketAddress(host, port)
     val serverChannel = ServerSocketChannel.open()
     serverChannel.configureBlocking(false)
-    serverChannel.socket().setReceiveBufferSize(recvBufferSize)
+    if(recvBufferSize > 0)
+      serverChannel.socket().setReceiveBufferSize(recvBufferSize)
     try {
       serverChannel.socket.bind(socketAddress)
       info("Awaiting socket connections on %s:%d.".format(socketAddress.getHostName, port))
@@ -272,7 +273,8 @@ private[kafka] class Acceptor(val host: String,
       connectionQuotas.inc(socketChannel.socket().getInetAddress)
       socketChannel.configureBlocking(false)
       socketChannel.socket().setTcpNoDelay(true)
-      socketChannel.socket().setSendBufferSize(sendBufferSize)
+      if(sendBufferSize > 0 )
+        socketChannel.socket().setSendBufferSize(sendBufferSize)
 
       debug("Accepted connection from %s on %s. sendBufferSize [actual|requested]: [%d|%d] recvBufferSize [actual|requested]: [%d|%d]"
             .format(socketChannel.socket.getInetAddress, socketChannel.socket.getLocalSocketAddress,


### PR DESCRIPTION
KAFKA-724: Allow automatic socket.send.buffer from operating system 
If socket.receive.buffer.bytes/socket.send.buffer.bytes set to non-zero/-1, the OS defaults work.Do not explicitly set buffers.
