### PR TITLE
KAFKA-873, KAFKA-2079: curator + exhibitor integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ TAGS
 .gradle
 kafka.ipr
 kafka.iws
+core/data
+gradle/wrapper

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,9 @@ project(':core') {
     compile project(':clients')
     compile "org.scala-lang:scala-library:$scalaVersion"
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
-    compile 'com.101tec:zkclient:0.3'
+    compile 'com.101tec:zkclient:0.4'
+    compile 'org.apache.curator:curator-framework:2.7.1'
+    compile 'com.netflix.curator:curator-x-zkclient-bridge:3.0.0'
     compile 'com.yammer.metrics:metrics-core:2.2.0'
     compile 'net.sf.jopt-simple:jopt-simple:3.2'
 

--- a/core/src/main/scala/kafka/consumer/ZookeeperConsumerConnector.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperConsumerConnector.scala
@@ -167,8 +167,9 @@ private[kafka] class ZookeeperConsumerConnector(val config: ConsumerConfig,
   }
 
   private def connectZk() {
-    info("Connecting to zookeeper instance at " + config.zkConnect)
-    zkClient = new ZkClient(config.zkConnect, config.zkSessionTimeoutMs, config.zkConnectionTimeoutMs, ZKStringSerializer)
+    info("Connecting to zookeeper instance at " + config.zkConnect +
+      (if (!config.exhibitorHosts.isEmpty) " (" + config.exhibitorHosts + ")" else ""))
+    zkClient = ZkUtils.bridgeCurator(config, ZkUtils.makeCuratorClient(config))
   }
 
   // Blocks until the offset manager is located and a channel is established to it.
@@ -489,6 +490,9 @@ private[kafka] class ZookeeperConsumerConnector(val config: ConsumerConfig,
       // The child change watchers will be set inside rebalance when we read the children list.
     }
 
+    @throws(classOf[Exception])
+    def handleSessionEstablishmentError(error: Throwable): Unit = {
+    }
   }
 
   class ZKTopicPartitionChangeListener(val loadBalancerListener: ZKRebalancerListener)

--- a/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
@@ -93,6 +93,10 @@ class ZookeeperTopicEventWatcher(val zkClient: ZkClient,
         }
       }
     }
+
+    @throws(classOf[Exception])
+    def handleSessionEstablishmentError(error: Throwable): Unit = {
+    }
   }
 }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1109,6 +1109,10 @@ class KafkaController(val config : KafkaConfig, zkClient: ZkClient, val brokerSt
         controllerElector.elect
       }
     }
+
+    @throws(classOf[Exception])
+    def handleSessionEstablishmentError(error: Throwable): Unit = {
+    }
   }
 
   private def checkAndTriggerPartitionRebalance(): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaHealthcheck.scala
+++ b/core/src/main/scala/kafka/server/KafkaHealthcheck.scala
@@ -82,6 +82,10 @@ class KafkaHealthcheck(private val brokerId: Int,
       info("done re-registering broker")
       info("Subscribing to %s path to watch for new topics".format(ZkUtils.BrokerTopicsPath))
     }
+
+    @throws(classOf[Exception])
+    def handleSessionEstablishmentError(error: Throwable): Unit = {
+    }
   }
 
 }


### PR DESCRIPTION
My motivation for introducing curator to kafka was to get optional exhibitor support, however I noticed this  is also a solution to ticket KAFKA-873 (https://issues.apache.org/jira/browse/KAFKA-873).

Structurally I believe the code is sound, however some tests are blocking which I believe is duet o races related to in-memory Zookeeper but not entirely sure. Am looking into it and testing outside of in-memory ZK, as well. But would love comments/discussion on this PR. I imagine exhibitor support is something that many are interested in, especially those of us in AWS & cloud environments.

Some notes on this PR:
-- A ZkClient-Curator bridge is used so that Kafka code continues to use the ZkClient abstraction
-- Exhibitor support implemented here is _optional_ (enabled if and only if exhibitor is configured in Kafka server or consumer configuration)
