### PR TITLE
validate configuration while parsing ConfigDef

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -118,8 +118,10 @@ public class ConfigDef {
         Map<String, Object> values = new HashMap<String, Object>();
         for (ConfigKey key : configKeys.values()) {
             Object value;
-            if (props.containsKey(key.name))
+            if (props.containsKey(key.name)){
                 value = parseType(key.name, props.get(key.name), key.type);
+                if(key.validator!=null) key.validator.ensureValid(key.name,value);
+            }
             else if (key.defaultValue == NO_DEFAULT_VALUE)
                 throw new ConfigException("Missing required configuration \"" + key.name + "\" which has no default value.");
             else


### PR DESCRIPTION
In java client, configDef class's parse() function should return parsed and validated values (if validator is present) but it does not validate the configuration. e.g. i can create a KafkaProducer instance with a negative value for batch.size and then it throws NullPointerException while sending which is hard to debug.

This commit fix that
