### PR TITLE
Ignore gradle wrapper download directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 target/
 build/
 .gradle/
+gradle/wrapper/
 lib_managed/
 src_managed/
 project/boot/


### PR DESCRIPTION
This patch adds gradle wrapper download directory to .gitignore
