### PR TITLE
KAFKA-2289: KafkaProducer logs erroneous warning on startup

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -256,6 +256,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         Serializer.class);
                 this.keySerializer.configure(config.originals(), true);
             } else {
+                config.use(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG);
                 this.keySerializer = keySerializer;
             }
             if (valueSerializer == null) {
@@ -263,6 +264,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         Serializer.class);
                 this.valueSerializer.configure(config.originals(), false);
             } else {
+                config.use(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG);
                 this.valueSerializer = valueSerializer;
             }
             config.logUnused();

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -51,10 +51,14 @@ public class AbstractConfig {
     }
 
     protected Object get(String key) {
+        use(key);
+        return values.get(key);
+    }
+
+    public void use(String key) {
         if (!values.containsKey(key))
             throw new ConfigException(String.format("Unknown configuration '%s'", key));
         used.add(key);
-        return values.get(key);
     }
 
     public Short getShort(String key) {


### PR DESCRIPTION
This change fixes the problem.
