### PR TITLE
KAFKA-1595; Remove deprecated and slower scala JSON parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,7 @@ project(':core') {
     compile 'com.101tec:zkclient:0.5'
     compile 'com.yammer.metrics:metrics-core:2.2.0'
     compile 'net.sf.jopt-simple:jopt-simple:3.2'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.5.4'
 
     testCompile 'junit:junit:4.6'
     testCompile 'org.easymock:easymock:3.0'

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -236,10 +236,10 @@ object ConsumerGroupCommand {
       ZkUtils.readDataMaybeNull(zkClient, ZkUtils.BrokerIdsPath + "/" + brokerId)._1 match {
         case Some(brokerInfoString) =>
           Json.parseFull(brokerInfoString) match {
-            case Some(m) =>
-              val brokerInfo = m.asInstanceOf[Map[String, Any]]
-              val host = brokerInfo.get("host").get.asInstanceOf[String]
-              val port = brokerInfo.get("port").get.asInstanceOf[Int]
+            case Some(js) =>
+              val brokerInfo = js.asJsonObject
+              val host = brokerInfo("host").to[String]
+              val port = brokerInfo("port").to[Int]
               Some(new SimpleConsumer(host, port, 10000, 100000, "ConsumerGroupCommand"))
             case None =>
               throw new BrokerNotAvailableException("Broker id %d does not exist".format(brokerId))

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -75,20 +75,19 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
 
   def parsePreferredReplicaElectionData(jsonString: String): immutable.Set[TopicAndPartition] = {
     Json.parseFull(jsonString) match {
-      case Some(m) =>
-        m.asInstanceOf[Map[String, Any]].get("partitions") match {
+      case Some(js) =>
+        js.asJsonObject.get("partitions") match {
           case Some(partitionsList) =>
-            val partitionsRaw = partitionsList.asInstanceOf[List[Map[String, Any]]]
+            val partitionsRaw = partitionsList.asJsonArray.iterator.map(_.asJsonObject)
             val partitions = partitionsRaw.map { p =>
-              val topic = p.get("topic").get.asInstanceOf[String]
-              val partition = p.get("partition").get.asInstanceOf[Int]
+              val topic = p("topic").to[String]
+              val partition = p("partition").to[Int]
               TopicAndPartition(topic, partition)
-            }
+            }.toBuffer
             val duplicatePartitions = CoreUtils.duplicates(partitions)
-            val partitionsSet = partitions.toSet
             if (duplicatePartitions.nonEmpty)
               throw new AdminOperationException("Preferred replica election data contains duplicate partitions: %s".format(duplicatePartitions.mkString(",")))
-            partitionsSet
+            partitions.toSet
           case None => throw new AdminOperationException("Preferred replica election data is empty")
         }
       case None => throw new AdminOperationException("Preferred replica election data is empty")

--- a/core/src/main/scala/kafka/cluster/Broker.scala
+++ b/core/src/main/scala/kafka/cluster/Broker.scala
@@ -60,20 +60,20 @@ object Broker {
       throw new BrokerNotAvailableException("Broker id %s does not exist".format(id))
     try {
       Json.parseFull(brokerInfoString) match {
-        case Some(m) =>
-          val brokerInfo = m.asInstanceOf[Map[String, Any]]
-          val version = brokerInfo("version").asInstanceOf[Int]
+        case Some(js) =>
+          val brokerInfo = js.asJsonObject
+          val version = brokerInfo("version").to[Int]
           val endpoints = version match {
             case 1 =>
-              val host = brokerInfo("host").asInstanceOf[String]
-              val port = brokerInfo("port").asInstanceOf[Int]
+              val host = brokerInfo("host").to[String]
+              val port = brokerInfo("port").to[Int]
               Map(SecurityProtocol.PLAINTEXT -> new EndPoint(host, port, SecurityProtocol.PLAINTEXT))
             case 2 =>
-              val listeners = brokerInfo("endpoints").asInstanceOf[List[String]]
-              listeners.map(listener => {
+              val listeners = brokerInfo("endpoints").to[Seq[String]]
+              listeners.map { listener =>
                 val ep = EndPoint.createEndPoint(listener)
                 (ep.protocolType, ep)
-              }).toMap
+              }.toMap
             case _ => throw new KafkaException("Unknown version of broker registration. Only versions 1 and 2 are supported." + brokerInfoString)
           }
           new Broker(id, endpoints)

--- a/core/src/main/scala/kafka/consumer/TopicCount.scala
+++ b/core/src/main/scala/kafka/consumer/TopicCount.scala
@@ -63,14 +63,14 @@ private[kafka] object TopicCount extends Logging {
     var topMap: Map[String, Int] = null
     try {
       Json.parseFull(topicCountString) match {
-        case Some(m) =>
-          val consumerRegistrationMap = m.asInstanceOf[Map[String, Any]]
+        case Some(js) =>
+          val consumerRegistrationMap = js.asJsonObject
           consumerRegistrationMap.get("pattern") match {
-            case Some(pattern) => subscriptionPattern = pattern.asInstanceOf[String]
+            case Some(pattern) => subscriptionPattern = pattern.to[String]
             case None => throw new KafkaException("error constructing TopicCount : " + topicCountString)
           }
           consumerRegistrationMap.get("subscription") match {
-            case Some(sub) => topMap = sub.asInstanceOf[Map[String, Int]]
+            case Some(sub) => topMap = sub.to[Map[String, Int]]
             case None => throw new KafkaException("error constructing TopicCount : " + topicCountString)
           }
         case None => throw new KafkaException("error constructing TopicCount : " + topicCountString)

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -130,9 +130,7 @@ object KafkaController extends Logging {
   def parseControllerId(controllerInfoString: String): Int = {
     try {
       Json.parseFull(controllerInfoString) match {
-        case Some(m) =>
-          val controllerInfo = m.asInstanceOf[Map[String, Any]]
-          return controllerInfo.get("brokerid").get.asInstanceOf[Int]
+        case Some(js) => js.asJsonObject("brokerid").to[Int]
         case None => throw new KafkaException("Failed to parse the controller info json [%s].".format(controllerInfoString))
       }
     } catch {
@@ -140,9 +138,8 @@ object KafkaController extends Logging {
         // It may be due to an incompatible controller register version
         warn("Failed to parse the controller info as json. "
           + "Probably this controller is still using the old format [%s] to store the broker id in zookeeper".format(controllerInfoString))
-        try {
-          return controllerInfoString.toInt
-        } catch {
+        try controllerInfoString.toInt
+        catch {
           case t: Throwable => throw new KafkaException("Failed to parse the controller info: " + controllerInfoString + ". This is neither the new or the old format.", t)
         }
     }

--- a/core/src/main/scala/kafka/tools/ConsumerOffsetChecker.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerOffsetChecker.scala
@@ -42,10 +42,10 @@ object ConsumerOffsetChecker extends Logging {
       ZkUtils.readDataMaybeNull(zkClient, ZkUtils.BrokerIdsPath + "/" + bid)._1 match {
         case Some(brokerInfoString) =>
           Json.parseFull(brokerInfoString) match {
-            case Some(m) =>
-              val brokerInfo = m.asInstanceOf[Map[String, Any]]
-              val host = brokerInfo.get("host").get.asInstanceOf[String]
-              val port = brokerInfo.get("port").get.asInstanceOf[Int]
+            case Some(js) =>
+              val brokerInfo = js.asJsonObject
+              val host = brokerInfo("host").to[String]
+              val port = brokerInfo("port").to[Int]
               Some(new SimpleConsumer(host, port, 10000, 100000, "ConsumerOffsetChecker"))
             case None =>
               throw new BrokerNotAvailableException("Broker id %d does not exist".format(bid))

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -50,15 +50,14 @@ object Json {
       case n: Number => n.toString
       case m: Map[_, _] => 
         "{" + 
-          m.map(elem => 
-            elem match {
-            case t: Tuple2[_,_] => encode(t._1) + ":" + encode(t._2)
-            case _ => throw new IllegalArgumentException("Invalid map element (" + elem + ") in " + obj)
-          }).mkString(",") + 
-      "}"
+          m.map {
+            case (k, v) => encode(k) + ":" + encode(v)
+            case elem => throw new IllegalArgumentException("Invalid map element (" + elem + ") in " + obj)
+          }.mkString(",") +
+        "}"
       case a: Array[_] => encode(a.toSeq)
       case i: Iterable[_] => "[" + i.map(encode).mkString(",") + "]"
-      case other: AnyRef => throw new IllegalArgumentException("Unknown arguement of type " + other.getClass + ": " + other)
+      case other: AnyRef => throw new IllegalArgumentException("Unknown argument of type " + other.getClass + ": " + other)
     }
   }
 

--- a/core/src/main/scala/kafka/utils/ReplicationUtils.scala
+++ b/core/src/main/scala/kafka/utils/ReplicationUtils.scala
@@ -77,12 +77,12 @@ object ReplicationUtils extends Logging {
 
   private def parseLeaderAndIsr(leaderAndIsrStr: String, path: String, stat: Stat)
       : Option[LeaderIsrAndControllerEpoch] = {
-    Json.parseFull(leaderAndIsrStr).flatMap {m =>
-      val leaderIsrAndEpochInfo = m.asInstanceOf[Map[String, Any]]
-      val leader = leaderIsrAndEpochInfo.get("leader").get.asInstanceOf[Int]
-      val epoch = leaderIsrAndEpochInfo.get("leader_epoch").get.asInstanceOf[Int]
-      val isr = leaderIsrAndEpochInfo.get("isr").get.asInstanceOf[List[Int]]
-      val controllerEpoch = leaderIsrAndEpochInfo.get("controller_epoch").get.asInstanceOf[Int]
+    Json.parseFull(leaderAndIsrStr).flatMap { js =>
+      val leaderIsrAndEpochInfo = js.asJsonObject
+      val leader = leaderIsrAndEpochInfo("leader").to[Int]
+      val epoch = leaderIsrAndEpochInfo("leader_epoch").to[Int]
+      val isr = leaderIsrAndEpochInfo("isr").to[List[Int]]
+      val controllerEpoch = leaderIsrAndEpochInfo("controller_epoch").to[Int]
       val zkPathVersion = stat.getVersion
       debug("Leader %d, Epoch %d, Isr %s, Zk path version %d for leaderAndIsrPath %s".format(leader, epoch,
         isr.toString(), zkPathVersion, path))

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -34,6 +34,7 @@ import kafka.controller.ReassignedPartitionsContext
 import kafka.controller.KafkaController
 import kafka.controller.LeaderIsrAndControllerEpoch
 import kafka.common.TopicAndPartition
+import kafka.utils.Json._
 
 object ZkUtils extends Logging {
   val ConsumersPath = "/consumers"
@@ -99,16 +100,10 @@ object ZkUtils extends Logging {
   }
 
   def getLeaderForPartition(zkClient: ZkClient, topic: String, partition: Int): Option[Int] = {
-    val leaderAndIsrOpt = readDataMaybeNull(zkClient, getTopicPartitionLeaderAndIsrPath(topic, partition))._1
-    leaderAndIsrOpt match {
-      case Some(leaderAndIsr) =>
-        Json.parseFull(leaderAndIsr) match {
-          case Some(m) =>
-            Some(m.asInstanceOf[Map[String, Any]].get("leader").get.asInstanceOf[Int])
-          case None => None
-        }
-      case None => None
-    }
+    for {
+      leaderAndIsr <- readDataMaybeNull(zkClient, getTopicPartitionLeaderAndIsrPath(topic, partition))._1
+      json <- Json.parseFull(leaderAndIsr)
+    } yield json.asJsonObject("leader").to[Int]
   }
 
   /**
@@ -122,7 +117,7 @@ object ZkUtils extends Logging {
       case Some(leaderAndIsr) =>
         Json.parseFull(leaderAndIsr) match {
           case None => throw new NoEpochForPartitionException("No epoch, leaderAndISR data for partition [%s,%d] is invalid".format(topic, partition))
-          case Some(m) => m.asInstanceOf[Map[String, Any]].get("leader_epoch").get.asInstanceOf[Int]
+          case Some(js) => js.asJsonObject("leader_epoch").to[Int]
         }
       case None => throw new NoEpochForPartitionException("No epoch, ISR path for partition [%s,%d] is empty"
         .format(topic, partition))
@@ -145,7 +140,7 @@ object ZkUtils extends Logging {
     leaderAndIsrOpt match {
       case Some(leaderAndIsr) =>
         Json.parseFull(leaderAndIsr) match {
-          case Some(m) => m.asInstanceOf[Map[String, Any]].get("isr").get.asInstanceOf[Seq[Int]]
+          case Some(js) => js.asJsonObject("isr").to[Seq[Int]]
           case None => Seq.empty[Int]
         }
       case None => Seq.empty[Int]
@@ -156,21 +151,13 @@ object ZkUtils extends Logging {
    * Gets the assigned replicas (AR) for a specific topic and partition
    */
   def getReplicasForPartition(zkClient: ZkClient, topic: String, partition: Int): Seq[Int] = {
-    val jsonPartitionMapOpt = readDataMaybeNull(zkClient, getTopicPath(topic))._1
-    jsonPartitionMapOpt match {
-      case Some(jsonPartitionMap) =>
-        Json.parseFull(jsonPartitionMap) match {
-          case Some(m) => m.asInstanceOf[Map[String, Any]].get("partitions") match {
-            case Some(replicaMap) => replicaMap.asInstanceOf[Map[String, Seq[Int]]].get(partition.toString) match {
-              case Some(seq) => seq
-              case None => Seq.empty[Int]
-            }
-            case None => Seq.empty[Int]
-          }
-          case None => Seq.empty[Int]
-        }
-      case None => Seq.empty[Int]
-    }
+    val seqOpt = for {
+      jsonPartitionMap <- readDataMaybeNull(zkClient, getTopicPath(topic))._1
+      js <- Json.parseFull(jsonPartitionMap)
+      replicaMap <- js.asJsonObject.get("partitions")
+      seq <- replicaMap.asJsonObject.get(partition.toString)
+    } yield seq.to[Seq[Int]]
+    seqOpt.getOrElse(Seq.empty)
   }
 
   /**
@@ -536,22 +523,15 @@ object ZkUtils extends Logging {
   def getReplicaAssignmentForTopics(zkClient: ZkClient, topics: Seq[String]): mutable.Map[TopicAndPartition, Seq[Int]] = {
     val ret = new mutable.HashMap[TopicAndPartition, Seq[Int]]
     topics.foreach { topic =>
-      val jsonPartitionMapOpt = readDataMaybeNull(zkClient, getTopicPath(topic))._1
-      jsonPartitionMapOpt match {
-        case Some(jsonPartitionMap) =>
-          Json.parseFull(jsonPartitionMap) match {
-            case Some(m) => m.asInstanceOf[Map[String, Any]].get("partitions") match {
-              case Some(repl)  =>
-                val replicaMap = repl.asInstanceOf[Map[String, Seq[Int]]]
-                for((partition, replicas) <- replicaMap){
-                  ret.put(TopicAndPartition(topic, partition.toInt), replicas)
-                  debug("Replicas assigned to topic [%s], partition [%s] are [%s]".format(topic, partition, replicas))
-                }
-              case None =>
+      readDataMaybeNull(zkClient, getTopicPath(topic))._1.foreach { jsonPartitionMap =>
+        Json.parseFull(jsonPartitionMap).foreach { js =>
+          js.asJsonObject.get("partitions").foreach { repl =>
+            repl.asJsonObject.iterator.foreach { case (partition, replicas) =>
+              ret.put(TopicAndPartition(topic, partition.toInt), replicas.to[Seq[Int]])
+              debug("Replicas assigned to topic [%s], partition [%s] are [%s]".format(topic, partition, replicas))
             }
-            case None =>
           }
-        case None =>
+        }
       }
     }
     ret
@@ -559,21 +539,13 @@ object ZkUtils extends Logging {
 
   def getPartitionAssignmentForTopics(zkClient: ZkClient, topics: Seq[String]): mutable.Map[String, collection.Map[Int, Seq[Int]]] = {
     val ret = new mutable.HashMap[String, Map[Int, Seq[Int]]]()
-    topics.foreach{ topic =>
-      val jsonPartitionMapOpt = readDataMaybeNull(zkClient, getTopicPath(topic))._1
-      val partitionMap = jsonPartitionMapOpt match {
-        case Some(jsonPartitionMap) =>
-          Json.parseFull(jsonPartitionMap) match {
-            case Some(m) => m.asInstanceOf[Map[String, Any]].get("partitions") match {
-              case Some(replicaMap) =>
-                val m1 = replicaMap.asInstanceOf[Map[String, Seq[Int]]]
-                m1.map(p => (p._1.toInt, p._2))
-              case None => Map[Int, Seq[Int]]()
-            }
-            case None => Map[Int, Seq[Int]]()
-          }
-        case None => Map[Int, Seq[Int]]()
-      }
+    topics.foreach { topic =>
+      val partitionMapOpt = for {
+        jsonPartitionMap <- readDataMaybeNull(zkClient, getTopicPath(topic))._1
+        js <- Json.parseFull(jsonPartitionMap)
+        replicaMap <- js.asJsonObject.get("partitions")
+      } yield replicaMap.asJsonObject.iterator.map { case (k, v) => (k.toInt, v.to[Seq[Int]]) }.toMap
+      val partitionMap = partitionMapOpt.getOrElse(Map.empty)
       debug("Partition map for /brokers/topics/%s is %s".format(topic, partitionMap))
       ret += (topic -> partitionMap)
     }
@@ -602,21 +574,16 @@ object ZkUtils extends Logging {
 
   // Parses without deduplicating keys so the the data can be checked before allowing reassignment to proceed
   def parsePartitionReassignmentDataWithoutDedup(jsonData: String): Seq[(TopicAndPartition, Seq[Int])] = {
-    Json.parseFull(jsonData) match {
-      case Some(m) =>
-        m.asInstanceOf[Map[String, Any]].get("partitions") match {
-          case Some(partitionsSeq) =>
-            partitionsSeq.asInstanceOf[Seq[Map[String, Any]]].map(p => {
-              val topic = p.get("topic").get.asInstanceOf[String]
-              val partition = p.get("partition").get.asInstanceOf[Int]
-              val newReplicas = p.get("replicas").get.asInstanceOf[Seq[Int]]
-              TopicAndPartition(topic, partition) -> newReplicas
-            })
-          case None =>
-            Seq.empty
-        }
-      case None =>
-        Seq.empty
+    for {
+      js <- Json.parseFull(jsonData).toSeq
+      partitionsSeq <- js.asJsonObject.get("partitions").toSeq
+      p <- partitionsSeq.asJsonArray.iterator
+    } yield {
+      val partitionFields = p.asJsonObject
+      val topic = partitionFields("topic").to[String]
+      val partition = partitionFields("partition").to[Int]
+      val newReplicas = partitionFields("replicas").to[Seq[Int]]
+      TopicAndPartition(topic, partition) -> newReplicas
     }
   }
 
@@ -625,21 +592,11 @@ object ZkUtils extends Logging {
   }
 
   def parseTopicsData(jsonData: String): Seq[String] = {
-    var topics = List.empty[String]
-    Json.parseFull(jsonData) match {
-      case Some(m) =>
-        m.asInstanceOf[Map[String, Any]].get("topics") match {
-          case Some(partitionsSeq) =>
-            val mapPartitionSeq = partitionsSeq.asInstanceOf[Seq[Map[String, Any]]]
-            mapPartitionSeq.foreach(p => {
-              val topic = p.get("topic").get.asInstanceOf[String]
-              topics ++= List(topic)
-            })
-          case None =>
-        }
-      case None =>
-    }
-    topics
+    for {
+      js <- Json.parseFull(jsonData).toSeq
+      partitionsSeq <- js.asJsonObject.get("topics").toSeq
+      p <- partitionsSeq.asJsonArray.iterator
+    } yield p.asJsonObject("topic").to[String]
   }
 
   def getPartitionReassignmentZkData(partitionsToBeReassigned: Map[TopicAndPartition, Seq[Int]]): String = {

--- a/core/src/main/scala/kafka/utils/json/DecodeJson.scala
+++ b/core/src/main/scala/kafka/utils/json/DecodeJson.scala
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils.json
+
+import scala.collection._
+import JavaConverters._
+import generic.CanBuildFrom
+
+import com.fasterxml.jackson.databind.{JsonMappingException, JsonNode}
+
+trait DecodeJson[T] {
+
+  def decodeEither(node: JsonNode): Either[String, T]
+
+  def decode(node: JsonNode): T =
+    decodeEither(node) match {
+      case Right(x) => x
+      case Left(x) => throw new JsonMappingException(x)
+    }
+
+}
+
+object DecodeJson {
+
+  implicit object DecodeBoolean extends DecodeJson[Boolean] {
+    def decodeEither(node: JsonNode): Either[String, Boolean] =
+      if (node.isBoolean) Right(node.booleanValue) else Left("Expected `Boolean` value, received " + node)
+  }
+
+  implicit object DecodeDouble extends DecodeJson[Double] {
+    def decodeEither(node: JsonNode): Either[String, Double] =
+      if (node.isDouble || node.isLong || node.isInt)
+        Right(node.doubleValue)
+      else Left("Expected `Double` value, received " + node)
+  }
+
+  implicit object DecodeInt extends DecodeJson[Int] {
+    def decodeEither(node: JsonNode): Either[String, Int] =
+      if (node.isInt) Right(node.intValue) else Left("Expected `Int` value, received " + node)
+  }
+
+  implicit object DecodeLong extends DecodeJson[Long] {
+    def decodeEither(node: JsonNode): Either[String, Long] =
+      if (node.isLong || node.isInt) Right(node.longValue) else Left("Expected `Long` value, received " + node)
+  }
+
+  implicit object DecodeString extends DecodeJson[String] {
+    def decodeEither(node: JsonNode): Either[String, String] =
+      if (node.isTextual) Right(node.textValue) else Left("Expected `String` value, received " + node)
+  }
+
+  implicit def decodeOption[E](implicit decodeJson: DecodeJson[E]): DecodeJson[Option[E]] = new DecodeJson[Option[E]] {
+    def decodeEither(node: JsonNode): Either[String, Option[E]] = {
+      if (node.isNull) Right(None)
+      else decodeJson.decodeEither(node).right.map(Some(_))
+    }
+  }
+
+  implicit def decodeSeq[E, S[+T] <: Seq[E]](implicit decodeJson: DecodeJson[E], cbf: CanBuildFrom[Nothing, E, S[E]]): DecodeJson[S[E]] = new DecodeJson[S[E]] {
+    def decodeEither(node: JsonNode): Either[String, S[E]] = {
+      if (node.isArray)
+        decodeIterator(node.elements.asScala)(decodeJson.decodeEither)
+      else Left("Expected JSON array, received " + node)
+    }
+  }
+
+  implicit def decodeMap[V, M[K, +V] <: Map[K, V]](implicit decodeJson: DecodeJson[V], cbf: CanBuildFrom[Nothing, (String, V), M[String, V]]): DecodeJson[M[String, V]] = new DecodeJson[M[String, V]] {
+    def decodeEither(node: JsonNode): Either[String, M[String, V]] = {
+      if (node.isObject)
+        decodeIterator(node.fields.asScala)(e => decodeJson.decodeEither(e.getValue).right.map(v => (e.getKey, v)))(cbf)
+      else Left("Expected JSON object, received " + node)
+    }
+  }
+
+  private def decodeIterator[S, T, C](it: Iterator[S])(f: S => Either[String, T])(implicit cbf: CanBuildFrom[Nothing, T, C]): Either[String, C] = {
+    val result = cbf()
+    while (it.hasNext) {
+      f(it.next) match {
+        case Right(x) => result += x
+        case Left(x) => return Left(x)
+      }
+    }
+    Right(result.result())
+  }
+
+}

--- a/core/src/main/scala/kafka/utils/json/JsonArray.scala
+++ b/core/src/main/scala/kafka/utils/json/JsonArray.scala
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils.json
+
+import scala.collection.{Iterator, JavaConverters}
+import JavaConverters._
+
+import com.fasterxml.jackson.databind.node.ArrayNode
+
+class JsonArray private[json] (protected val node: ArrayNode) extends JsonValue {
+  def iterator: Iterator[JsonValue] = node.elements.asScala.map(JsonValue(_))
+}

--- a/core/src/main/scala/kafka/utils/json/JsonObject.scala
+++ b/core/src/main/scala/kafka/utils/json/JsonObject.scala
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils.json
+
+import com.fasterxml.jackson.databind.JsonMappingException
+
+import scala.collection.JavaConverters._
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+
+import scala.collection.Iterator
+
+class JsonObject private[json] (protected val node: ObjectNode) extends JsonValue {
+
+  def apply(name: String): JsonValue =
+    get(name).getOrElse(throw new JsonMappingException("No such field exists: `" + name + "`"))
+
+  def get(name: String): Option[JsonValue] = Option(node.get(name)).map(JsonValue(_))
+
+  def iterator: Iterator[(String, JsonValue)] = node.fields.asScala.map { entry =>
+    (entry.getKey, JsonValue(entry.getValue))
+  }
+
+}

--- a/core/src/main/scala/kafka/utils/json/JsonValue.scala
+++ b/core/src/main/scala/kafka/utils/json/JsonValue.scala
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils.json
+
+import scala.collection._
+
+import com.fasterxml.jackson.databind.{JsonMappingException, JsonNode}
+import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
+
+trait JsonValue {
+
+  protected def node: JsonNode
+
+  def to[T](implicit decodeJson: DecodeJson[T]): T = decodeJson.decode(node)
+
+  def toEither[T](implicit decodeJson: DecodeJson[T]): Either[String, T] = decodeJson.decodeEither(node)
+
+  def asJsonObject: JsonObject =
+    asJsonObjectOption.getOrElse(throw new JsonMappingException("Expected JSON object, received " + node))
+
+  def asJsonObjectOption: Option[JsonObject] = this match {
+    case j: JsonObject => Some(j)
+    case _ => node match {
+      case n: ObjectNode => Some(new JsonObject(n))
+      case _ => None
+    }
+  }
+
+  def asJsonArray: JsonArray =
+    asJsonArrayOption.getOrElse(throw new JsonMappingException("Expected JSON array, received " + node))
+
+  def asJsonArrayOption: Option[JsonArray] = this match {
+    case j: JsonArray => Some(j)
+    case _ => node match {
+      case n: ArrayNode => Some(new JsonArray(n))
+      case _ => None
+    }
+  }
+
+  override def hashCode: Int = node.hashCode
+
+  override def equals(a: Any): Boolean = a match {
+    case a: JsonValue => node == a.node
+    case _ => false
+  }
+
+  override def toString: String = node.toString
+
+}
+
+object JsonValue {
+
+  def apply(node: JsonNode): JsonValue = node match {
+    case n: ObjectNode => new JsonObject(n)
+    case n: ArrayNode => new JsonArray(n)
+    case _ => new BasicJsonValue(node)
+  }
+
+  private class BasicJsonValue private[json] (protected val node: JsonNode) extends JsonValue
+
+}

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -22,6 +22,14 @@ import org.junit.{Test, After, Before}
 class JsonTest {
 
   @Test
+  def testJsonParse() {
+    assertEquals(Json.parseFull("{}"), Some(Map()))
+    assertEquals(Json.parseFull("""{"foo":"bar"s}"""), None)
+    assertEquals(Json.parseFull("""{"foo":"bar", "is_enabled":true}"""), Some(Map("foo" -> "bar", "is_enabled" -> true)))
+    assertEquals(Json.parseFull("[1, 2, 3]"), Some(List(1, 2, 3)))
+  }
+
+  @Test
   def testJsonEncoding() {
     assertEquals("null", Json.encode(null))
     assertEquals("1", Json.encode(1))

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -16,17 +16,32 @@
  */
 package kafka.utils
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node._
 import junit.framework.Assert._
-import org.junit.{Test, After, Before}
+import kafka.utils.json.JsonValue
+import org.junit.Test
+import scala.collection.JavaConverters._
 
 class JsonTest {
 
   @Test
   def testJsonParse() {
-    assertEquals(Json.parseFull("{}"), Some(Map()))
+    val jnf = JsonNodeFactory.instance
+
+    assertEquals(Json.parseFull("{}"), Some(JsonValue(new ObjectNode(jnf))))
+
     assertEquals(Json.parseFull("""{"foo":"bar"s}"""), None)
-    assertEquals(Json.parseFull("""{"foo":"bar", "is_enabled":true}"""), Some(Map("foo" -> "bar", "is_enabled" -> true)))
-    assertEquals(Json.parseFull("[1, 2, 3]"), Some(List(1, 2, 3)))
+
+    val objectNode = new ObjectNode(
+      jnf,
+      Map[String, JsonNode]("foo" -> new TextNode("bar"), "is_enabled" -> BooleanNode.TRUE).asJava
+    )
+    assertEquals(Json.parseFull("""{"foo":"bar", "is_enabled":true}"""), Some(JsonValue(objectNode)))
+
+    val arrayNode = new ArrayNode(jnf)
+    Vector(1, 2, 3).map(new IntNode(_)).foreach(arrayNode.add)
+    assertEquals(Json.parseFull("[1, 2, 3]"), Some(JsonValue(arrayNode)))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/json/JsonValueTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/json/JsonValueTest.scala
@@ -205,6 +205,7 @@ class JsonValueTest {
     assertTo[Option[Int]](None, _("null"))
     assertTo[Option[Int]](Some(1234), _("int"))
     assertToFails[Option[String]](_("int"))
+    assertToFails[Option[String]](_("long"))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/utils/json/JsonValueTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/json/JsonValueTest.scala
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils.json
+
+import com.fasterxml.jackson.databind.{ObjectMapper, JsonMappingException}
+import org.junit.Test
+import org.junit.Assert._
+
+import kafka.utils.Json
+
+class JsonValueTest {
+
+  val json = """
+    |{
+    |  "boolean": false,
+    |  "int": 1234,
+    |  "long": 3000000000,
+    |  "double": 16.244355,
+    |  "string": "string",
+    |  "number_as_string": "123",
+    |  "array": [4.0, 11.1, 44.5],
+    |  "object": {
+    |    "a": true,
+    |    "b": false
+    |  },
+    |  "null": null
+    |}
+   """.stripMargin
+
+  private def parse(s: String): JsonValue =
+    Json.parseFull(s).getOrElse(sys.error("Failed to parse json: " + s))
+
+  private def assertTo[T: DecodeJson](expected: T, jsonValue: JsonObject => JsonValue): Unit = {
+    val parsed = jsonValue(parse(json).asJsonObject)
+    assertEquals(Right(expected), parsed.toEither[T])
+    assertEquals(expected, parsed.to[T])
+  }
+
+  private def assertToFails[T: DecodeJson](jsonValue: JsonObject => JsonValue): Unit = {
+    val parsed = jsonValue(parse(json).asJsonObject)
+    assertTrue(parsed.toEither[T].isLeft)
+    assertThrow[JsonMappingException](parsed.to[T])
+  }
+
+  def assertThrow[E <: Throwable : Manifest](body: => Unit): Unit = {
+    import scala.util.control.Exception._
+    val klass = manifest[E].runtimeClass
+    catchingPromiscuously(klass).opt(body).foreach { _ =>
+      fail("Expected `" + klass + "` to be thrown, but no exception was thrown")
+    }
+  }
+
+  @Test
+  def testAsJsonObject: Unit = {
+    val parsed = parse(json).asJsonObject
+    val obj = parsed("object")
+    assertEquals(obj, obj.asJsonObject)
+    assertThrow[JsonMappingException](parsed("array").asJsonObject)
+  }
+
+  @Test
+  def testAsJsonObjectOption: Unit = {
+    val parsed = parse(json).asJsonObject
+    assertTrue(parsed("object").asJsonObjectOption.isDefined)
+    assertEquals(None, parsed("array").asJsonObjectOption)
+  }
+
+  @Test
+  def testAsJsonArray: Unit = {
+    val parsed = parse(json).asJsonObject
+    val array = parsed("array")
+    assertEquals(array, array.asJsonArray)
+    assertThrow[JsonMappingException](parsed("object").asJsonArray)
+  }
+
+  @Test
+  def testAsJsonArrayOption: Unit = {
+    val parsed = parse(json).asJsonObject
+    assertTrue(parsed("array").asJsonArrayOption.isDefined)
+    assertEquals(None, parsed("object").asJsonArrayOption)
+  }
+
+  @Test
+  def testJsonObjectGet: Unit = {
+    val parsed = parse(json).asJsonObject
+    assertEquals(Some(parse("""{"a":true,"b":false}""")), parsed.get("object"))
+    assertEquals(None, parsed.get("aaaaa"))
+  }
+
+  @Test
+  def testJsonObjectApply: Unit = {
+    val parsed = parse(json).asJsonObject
+    assertEquals(parse("""{"a":true,"b":false}"""), parsed("object"))
+    assertThrow[JsonMappingException](parsed("aaaaaaaa"))
+  }
+
+  @Test
+  def testJsonObjectIterator: Unit = {
+    assertEquals(
+      Vector("a" -> parse("true"), "b" -> parse("false")),
+      parse(json).asJsonObject("object").asJsonObject.iterator.toVector
+    )
+  }
+
+  @Test
+  def testJsonArrayIterator: Unit = {
+    assertEquals(Vector("4.0", "11.1", "44.5").map(parse), parse(json).asJsonObject("array").asJsonArray.iterator.toVector)
+  }
+
+  @Test
+  def testJsonValueEquals: Unit = {
+
+    assertEquals(parse(json), parse(json))
+
+    assertEquals(parse("""{"blue": true, "red": false}"""), parse("""{"red": false, "blue": true}"""))
+    assertFalse(parse("""{"blue": true, "red": true}""") == parse("""{"red": false, "blue": true}"""))
+
+    assertEquals(parse("""[1, 2, 3]"""), parse("""[1, 2, 3]"""))
+    assertFalse(parse("""[1, 2, 3]""") == parse("""[2, 1, 3]"""))
+
+    assertEquals(parse("1344"), parse("1344"))
+    assertFalse(parse("1344") == parse("144"))
+
+  }
+
+  @Test
+  def testJsonValueHashCode: Unit = {
+    assertEquals(new ObjectMapper().readTree(json).hashCode, parse(json).hashCode)
+  }
+
+  @Test
+  def testJsonValueToString: Unit = {
+    val js = """{"boolean":false,"int":1234,"array":[4.0,11.1,44.5],"object":{"a":true,"b":false}}"""
+    assertEquals(js, parse(js).toString)
+  }
+
+  @Test
+  def testDecodeBoolean: Unit = {
+    assertTo[Boolean](false, _("boolean"))
+    assertToFails[Boolean](_("int"))
+  }
+
+  @Test
+  def testDecodeString: Unit = {
+    assertTo[String]("string", _("string"))
+    assertTo[String]("123", _("number_as_string"))
+    assertToFails[String](_("int"))
+    assertToFails[String](_("array"))
+  }
+
+  @Test
+  def testDecodeInt: Unit = {
+    assertTo[Int](1234, _("int"))
+    assertToFails[Int](_("long"))
+  }
+
+  @Test
+  def testDecodeLong: Unit = {
+    assertTo[Long](3000000000L, _("long"))
+    assertTo[Long](1234, _("int"))
+    assertToFails[Long](_("string"))
+  }
+
+  @Test
+  def testDecodeDouble: Unit = {
+    assertTo[Double](16.244355, _("double"))
+    assertTo[Double](1234.0, _("int"))
+    assertTo[Double](3000000000L, _("long"))
+    assertToFails[Double](_("string"))
+  }
+
+  @Test
+  def testDecodeSeq: Unit = {
+    assertTo[Seq[Double]](Seq(4.0, 11.1, 44.5), _("array"))
+    assertToFails[Seq[Double]](_("string"))
+    assertToFails[Seq[Double]](_("object"))
+    assertToFails[Seq[String]](_("array"))
+  }
+
+  @Test
+  def testDecodeMap: Unit = {
+    assertTo[Map[String, Boolean]](Map("a" -> true, "b" -> false), _("object"))
+    assertToFails[Map[String, Int]](_("object"))
+    assertToFails[Map[String, String]](_("object"))
+    assertToFails[Map[String, Double]](_("array"))
+  }
+
+  @Test
+  def testDecodeOption: Unit = {
+    assertTo[Option[Int]](None, _("null"))
+    assertTo[Option[Int]](Some(1234), _("int"))
+    assertToFails[Option[String]](_("int"))
+  }
+
+}


### PR DESCRIPTION
A thin wrapper over Jackson's Tree Model API is used as the replacement. This wrapper
increases safety while providing a simple, but powerful API through the usage of the
`DecodeJson` type class. Even though this has a maintenance cost, it makes the API
much more convenient from Scala. A number of tests were added to verify the
behaviour of this wrapper.

The Scala module for Jackson doesn't provide any help for our current usage, so we don't
depend on it.

An attempt has been made to maintain the existing behaviour regarding when exceptions
are thrown. There are a number of cases where `JsonMappingException` will be thrown
instead of `ClassCastException`, however. It is expected that users would not try to catch
`ClassCastException`.
