### PR TITLE
MINOR: Fixed ConsumerRecord constructor javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecord.java
@@ -24,11 +24,12 @@ public final class ConsumerRecord<K, V> {
     private final V value;
 
     /**
-     * Create a record with no key
-     * 
+     * Creates a record to be received from a specified topic and partition
+     *
      * @param topic The topic this record is received from
      * @param partition The partition of the topic this record is received from
      * @param offset The offset of this record in the corresponding Kafka partition
+     * @param key The key of the record, if one exists (null is allowed)
      * @param value The record contents
      */
     public ConsumerRecord(String topic, int partition, long offset, K key, V value) {


### PR DESCRIPTION
Refactoring of ConsumerRecord made in https://github.com/apache/kafka/commit/0699ff2ce60abb466cab5315977a224f1a70a4da#diff-fafe8d3a3942f3c6394927881a9389b2 left ConsumerRecord constructor javadoc inconsistent with implementation.

This patch fixes ConsumerRecord constructor javadoc to be inline with implementation.
