### PR TITLE
MINOR: Fixed javadoc for committed return value

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -963,7 +963,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * consumer hasn't yet initialized it's cache of committed offsets.
      * 
      * @param partition The partition to check
-     * @return The last committed offset or null if no offset has been committed
+     * @return The last committed offset
      * @throws NoOffsetForPartitionException If no offset has ever been committed by any process for the given
      *             partition.
      */


### PR DESCRIPTION
If no offset has been committed, then committed method does not return (null) value, instead NoOffsetForPartitionException is thrown in that case.
