### PR TITLE
MINOR: ConsumerRecords are organized per topic partition

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRecords.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 /**
  * A container that holds the list {@link ConsumerRecord} per partition for a
- * particular topic. There is one for every topic returned by a
- * {@link Consumer#poll(long)} operation.
+ * particular topic. There is one {@link ConsumerRecord} list for every topic
+ * partition returned by a {@link Consumer#poll(long)} operation.
  */
 public class ConsumerRecords<K, V> implements Iterable<ConsumerRecord<K, V>> {
     public static final ConsumerRecords<Object, Object> EMPTY =


### PR DESCRIPTION
ConsumerRecords has records organized per topic partition, not per topic as ConsumerRecords javadoc suggested.
