### PR TITLE
MINOR: Added to .gitignore Kafka server logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ kafka.ipr
 kafka.iws
 .vagrant
 Vagrantfile.local
+/logs
 
 config/server-*
 config/zookeeper-*


### PR DESCRIPTION
When running Kafka server from sources, logs directory gets created in root of repository, and kafka server logs end up there. Currently that directory is not ignored by git.

This change adds root logs directory to .gitignore so that Kafka server logs are ignored and do not get tracked by git.
