### PR TITLE
KAFKA-2384; Encode/decode to utf-8 for commit title IO in kafka-merge-pr.py

### DIFF
--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -381,7 +381,7 @@ def main():
     url = pr["url"]
 
     pr_title = pr["title"]
-    commit_title = raw_input("Commit title [%s]: " % pr_title)
+    commit_title = raw_input("Commit title [%s]: " % pr_title.encode("utf-8")).decode("utf-8")
     if commit_title == "":
         commit_title = pr_title
 


### PR DESCRIPTION
This fix should be fine for Linux and OS X. Not sure about Windows though. This is a very specific fix for new functionality added in KAFKA-2384. There are other places where a similar error could occur, but are less likely.

The script doesn't really support Unicode input at the moment.
