### PR TITLE
Log the real exception which triggered a reconnect

### DIFF
--- a/core/src/main/scala/kafka/consumer/SimpleConsumer.scala
+++ b/core/src/main/scala/kafka/consumer/SimpleConsumer.scala
@@ -90,7 +90,7 @@ class SimpleConsumer(val host: String,
         case e: AsynchronousCloseException =>
           throw e
         case e : Throwable =>
-          info("Reconnect due to socket error: %s".format(e.toString))
+          info("Reconnect due to error:", e)
           // retry once
           try {
             reconnect()


### PR DESCRIPTION
The commit here improves the logging in SimpleConsumer to log the real reason why a reconnect was attempted. Relates to https://issues.apache.org/jira/browse/KAFKA-2221.

The same patch was submitted a while back but wasn't merged because SimpleConsumer was considered deprecated and users' aren't expected to use it. However, more and more users in the user mailing list are running into this log message but have no way to understand what the root cause is. So IMO, this change still adds value  to such users who are using SimpleConsumer.
