### PR TITLE
KAFKA-2203: Getting Java8 to relax about javadoc and let our build pass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,14 @@ subprojects {
 
   sourceCompatibility = 1.7
 
+  if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+        // disable the crazy super-strict doclint tool in Java 8
+        //noinspection SpellCheckingInspection
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+  }
+
   uploadArchives {
     repositories {
       signing {


### PR DESCRIPTION
This patch is different than the one attached to the JIRA - I'm applying the new javadoc rules to all subprojects while the one in the JIRA applies only to "clients". We need this since Copycat  has the same issues.
