### PR TITLE
Fix for KAFKA-2446

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -38,7 +38,7 @@ object ConfigCommand {
     val opts = new ConfigCommandOptions(args)
 
     if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(opts.parser, "Add/Remove entity (topic/client) configs")
+      CommandLineUtils.printUsageAndDie(opts.parser, "Add/Remove entity (topics/clients) configs")
 
     opts.checkArgs()
 
@@ -122,7 +122,7 @@ object ConfigCommand {
             .ofType(classOf[String])
     val alterOpt = parser.accepts("alter", "Alter the configuration for the entity.")
     val describeOpt = parser.accepts("describe", "List configs for the given entity.")
-    val entityType = parser.accepts("entity-type", "Type of entity (topic/client)")
+    val entityType = parser.accepts("entity-type", "Type of entity (topics/clients)")
             .withRequiredArg
             .ofType(classOf[String])
     val entityName = parser.accepts("entity-name", "Name of entity (topic name/client id)")

--- a/core/src/main/scala/kafka/server/DynamicConfigManager.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfigManager.scala
@@ -32,8 +32,8 @@ import org.I0Itec.zkclient.{IZkChildListener, ZkClient}
  * Represents all the entities that can be configured via ZK
  */
 object ConfigType {
-  val Topic = "topic"
-  val Client = "client"
+  val Topic = "topics"
+  val Client = "clients"
 }
 
 /**

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -28,14 +28,14 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     // Should parse correctly
     var createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
                                                      "--entity-name", "x",
-                                                     "--entity-type", "client",
+                                                     "--entity-type", "clients",
                                                      "--describe"))
     createOpts.checkArgs()
 
     // For --alter and added config
     createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
                                                 "--entity-name", "x",
-                                                "--entity-type", "client",
+                                                "--entity-type", "clients",
                                                 "--alter",
                                                 "--added-config", "a=b,c=d"))
     createOpts.checkArgs()
@@ -43,7 +43,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     // For alter and deleted config
     createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
                                                 "--entity-name", "x",
-                                                "--entity-type", "client",
+                                                "--entity-type", "clients",
                                                 "--alter",
                                                 "--deleted-config", "a,b,c"))
     createOpts.checkArgs()
@@ -51,7 +51,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     // For alter and both added, deleted config
     createOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
                                                 "--entity-name", "x",
-                                                "--entity-type", "client",
+                                                "--entity-type", "clients",
                                                 "--alter",
                                                 "--added-config", "a=b,c=d",
                                                 "--deleted-config", "a"))


### PR DESCRIPTION
This bug was introduced while committing KAFKA-2205. Basically, the path for topic overrides was renamed to "topic" from "topics". However, this causes existing topic config overrides to break because they will not be read from ZK anymore since the path is different.

https://reviews.apache.org/r/34554/
