### PR TITLE
KAFKA-2170, KAFKA-1194: Fixes for Windows

### DIFF
--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -20,6 +20,7 @@ package kafka.log
 import java.io._
 import java.nio._
 import java.nio.channels._
+import java.nio.file._
 import java.util.concurrent.atomic._
 
 import kafka.utils._
@@ -309,19 +310,20 @@ object FileMessageSet
   def openChannel(file: File, mutable: Boolean, fileAlreadyExists: Boolean = false, initFileSize: Int = 0, preallocate: Boolean = false): FileChannel = {
     if (mutable) {
       if (fileAlreadyExists)
-        new RandomAccessFile(file, "rw").getChannel()
+        FileChannel.open(file.toPath, StandardOpenOption.WRITE, StandardOpenOption.READ)
       else {
         if (preallocate) {
           val randomAccessFile = new RandomAccessFile(file, "rw")
           randomAccessFile.setLength(initFileSize)
-          randomAccessFile.getChannel()
+          randomAccessFile.close
+          FileChannel.open(file.toPath, StandardOpenOption.WRITE, StandardOpenOption.READ)
         }
         else
-          new RandomAccessFile(file, "rw").getChannel()
+          FileChannel.open(file.toPath, StandardOpenOption.WRITE, StandardOpenOption.READ, StandardOpenOption.CREATE)
       }
     }
     else
-      new FileInputStream(file).getChannel()
+      FileChannel.open(file.toPath, StandardOpenOption.READ)
   }
 }
 

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -329,6 +329,10 @@ class LogTest extends JUnitSuite {
 
       // cleanup the log
       log.delete()
+
+      // Run the timer to ensure the async delete tasks triggered by
+      // deleteOldSegments have run prior to the next loop.
+      time.sleep(log.config.fileDeleteDelayMs + 1)
     }
   }
 
@@ -787,6 +791,8 @@ class LogTest extends JUnitSuite {
       log = new Log(logDir, config, recoveryPoint, time.scheduler, time)
       assertEquals(numMessages, log.logEndOffset)
       assertEquals("Messages in the log after recovery should be the same.", messages, log.logSegments.flatMap(_.log.iterator.toList))
+
+      log.close()
       CoreUtils.rm(logDir)
     }
   }


### PR DESCRIPTION
This branch fixes several Windows specific issues, both in the code and in the tests.  With these changes the whole test suite passes on my Windows machine.  I found the following issues that were relevant in Jira: KAFKA-2170 and KAFKA-1194, but there may be some others.  I also have a branch with these changes done against 0.8.2.1 if there's any interest in merging to the 0.8 series.
