### PR TITLE
KAFKA-2457; StackOverflowError during builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ subprojects {
 
     configure(scalaCompileOptions.forkOptions) {
       memoryMaximumSize = '1g'
-      jvmArgs = ['-XX:MaxPermSize=512m']
+      jvmArgs = ['-XX:MaxPermSize=512m -Xss2m']
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ group=org.apache.kafka
 version=0.8.3-SNAPSHOT
 scalaVersion=2.10.5
 task=build
-org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m
+org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m -Xss2m


### PR DESCRIPTION
The default is typically `1m` for 64-bit machines and the Scala compiler sometimes needs more than this.
