### PR TITLE
Exclude conflicting zookeeper version from 'com.101tec:zkclient' dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,9 @@ project(':core') {
     compile project(':log4j-appender')
     compile "org.scala-lang:scala-library:$scalaVersion"
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
-    compile 'com.101tec:zkclient:0.5'
+    compile ('com.101tec:zkclient:0.5') {
+      exclude group: 'org.apache.zookeeper', module: 'zookeeper'
+    }
     compile 'com.yammer.metrics:metrics-core:2.2.0'
     compile 'net.sf.jopt-simple:jopt-simple:3.2'
     if (scalaVersion.startsWith('2.11')) {


### PR DESCRIPTION
'com.101tec:zkclient:0.5' package brings in a dependency on older zookeper version: `3.4.4`

This causes conflicts if consumers of kafka jar are trying to use `maven-enforcer` plugin.
This plugin ensures there are no conflicts in your dependency clojure.
