### PR TITLE
KAFKA-2468: SIGINT during Kafka server startup can leave server deadlocked

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServerStartable.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerStartable.scala
@@ -17,7 +17,6 @@
 
 package kafka.server
 
-import kafka.common.AppInfo
 import kafka.utils.Logging
 
 
@@ -43,7 +42,8 @@ class KafkaServerStartable(val serverConfig: KafkaConfig) extends Logging {
     catch {
       case e: Throwable =>
         fatal("Fatal error during KafkaServerStable shutdown. Prepare to halt", e)
-        System.exit(1)
+        // Calling exit() can lead to deadlock as exit() can be called multiple times. Force exit.
+        Runtime.getRuntime.halt(1)
     }
   }
 


### PR DESCRIPTION
As we handle exceptions or invalid states in Kafka server by shutting it down, there is no reason to use exit() and not halt() in shutdown itself.
