### PR TITLE
MINOR: kafkatest add manifest

### DIFF
--- a/tests/MANIFEST.in
+++ b/tests/MANIFEST.in
@@ -1,1 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 recursive-include kafkatest/services/templates *.properties

--- a/tests/MANIFEST.in
+++ b/tests/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include kafkatest/services/templates *.properties

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -174,7 +174,6 @@ class ConsoleConsumer(BackgroundThreadService):
             if self.message_validator is not None:
                 msg = self.message_validator(msg)
             if msg is not None:
-                self.logger.debug("consumed a message: " + str(msg))
                 self.messages_consumed[idx].append(msg)
 
     def start_node(self, node):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,11 +17,12 @@
 from setuptools import find_packages, setup
 
 setup(name="kafkatest",
-      version="0.8.3-SNAPSHOT",
+      version="0.8.3.dev0",
       description="Apache Kafka System Tests",
       author="Apache Kafka",
       platforms=["any"], 
       license="apache2.0",
       packages=find_packages(),
-      requires=["ducktape(==0.3.0)"]
+      include_package_data=True,
+      install_requires=["ducktape==0.3.2"]
       )

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -17,11 +17,12 @@
 from setuptools import find_packages, setup
 
 setup(name="kafkatest",
-      version="0.8.3-SNAPSHOT",
+      version="0.8.3.dev0",
       description="Apache Kafka System Tests",
       author="Apache Kafka",
       platforms=["any"], 
       license="apache2.0",
       packages=find_packages(),
-      requires=["ducktape(==0.3.1)"]
+      include_package_data=True,
+      install_requires=["ducktape==0.3.2"]
       )


### PR DESCRIPTION
This patch makes it possible to publish kafkatest (system test package) to pypi and use it as a library in other projects by:
- including necessary static resources with the package
- renaming the version to conform w/PEP 440, since python packaging tools reject the current version name
