### PR TITLE
MINOR: Quota's equals() is buggy.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Quota.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Quota.java
@@ -65,6 +65,6 @@ public final class Quota {
         if (!(obj instanceof Quota))
             return false;
         Quota that = (Quota) obj;
-        return (that.bound == this.bound) && (this.upper == this.upper);
+        return (that.bound == this.bound) && (that.upper == this.upper);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -35,6 +35,10 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
 import org.apache.kafka.common.utils.MockTime;
 import org.junit.Test;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class MetricsTest {
 
@@ -272,6 +276,18 @@ public class MetricsTest {
         } catch (QuotaViolationException e) {
             // this is good
         }
+    }
+
+    @Test
+    public void testQuotasEquality() {
+        final Quota quota1 = Quota.lessThan(10.5);
+        final Quota quota2 = Quota.moreThan(10.5);
+
+        assertFalse(quota1.equals(quota2));
+
+        Quota quota3 = Quota.moreThan(10.5);
+
+        assertTrue(quota2.equals(quota3));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -283,11 +283,11 @@ public class MetricsTest {
         final Quota quota1 = Quota.lessThan(10.5);
         final Quota quota2 = Quota.moreThan(10.5);
 
-        assertFalse(quota1.equals(quota2));
+        assertFalse("Quota with different upper values shouldn't be equal", quota1.equals(quota2));
 
-        Quota quota3 = Quota.moreThan(10.5);
+        final Quota quota3 = Quota.moreThan(10.5);
 
-        assertTrue(quota2.equals(quota3));
+        assertTrue("Quota with same upper and bound values should be equal", quota2.equals(quota3));
     }
 
     @Test


### PR DESCRIPTION
It compares upper bound with itself.
