### PR TITLE
MINOR: MockClient's disconnect() method has two bugs

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -77,10 +77,6 @@ public class MockClient implements KafkaClient {
         return true;
     }
 
-    public Set<Integer> ready() {
-        return ready;
-    }
-
     @Override
     public long connectionDelay(Node node, long now) {
         return 0;

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -77,6 +77,10 @@ public class MockClient implements KafkaClient {
         return true;
     }
 
+    public Set<Integer> ready() {
+        return ready;
+    }
+
     @Override
     public long connectionDelay(Node node, long now) {
         return 0;

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -87,16 +87,15 @@ public class MockClient implements KafkaClient {
         return false;
     }
 
-    public void disconnect(String node) {
-        Iterator<ClientRequest> iter = requests.iterator();
-        while (iter.hasNext()) {
+    public void disconnect(String nodeId) {
+        for (Iterator<ClientRequest> iter = requests.iterator(); iter.hasNext(); ) {
             ClientRequest request = iter.next();
-            if (request.request().destination() == node) {
+            if (request.request().destination().equals(nodeId)) {
                 responses.add(new ClientResponse(request, time.milliseconds(), true, null));
                 iter.remove();
             }
         }
-        ready.remove(node);
+        ready.remove(Integer.valueOf(nodeId));
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -14,6 +14,7 @@ package org.apache.kafka.clients.producer.internals;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
@@ -128,8 +129,10 @@ public class SenderTest {
         sender.run(time.milliseconds()); // connect
         sender.run(time.milliseconds()); // send produce request
         assertEquals(1, client.inFlightRequestCount());
+        assertFalse(client.ready().isEmpty());
         client.disconnect(client.requests().peek().request().destination());
         assertEquals(0, client.inFlightRequestCount());
+        assertTrue(client.ready().isEmpty());
         sender.run(time.milliseconds()); // receive error
         sender.run(time.milliseconds()); // reconnect
         sender.run(time.milliseconds()); // resend


### PR DESCRIPTION
 (and a prospetive refactoring)
- First, it compares Strings using `==` instead of `equals()`
- Second, it tries to remove a String from a Set<Integer>. As disconnect() method is only called by a single method on SenderTest then it's safe to refactor it to make it both explicit that its argument is a node id and perform a Integer.valueOf() before trying to remove from `ready`.
- Third, not a bug, but the Iterator logic can be simplified, shrinking the scope of the Iterator without changing the logic.
