### PR TITLE
KAFKA-2309; ISR shrink rate not updated on LeaderAndIsr request with shrunk ISR

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -178,6 +178,8 @@ class Partition(val topic: String,
 
       // If the ISR size received from a LeaderAndIsrRequest is smaller than the existing ISR size,
       // mark the isrShrinkRate meter. For example: This can happen if one of the followers is shutdown.
+      // Note that this metric is not triggered on follower -> leader transition
+      // because the inSyncReplicas.size is always zero on a follower
       if (newInSyncReplicas.size < inSyncReplicas.size) replicaManager.isrShrinkRate.mark()
 
       // remove assigned replicas that have been removed by the controller

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -86,9 +86,6 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
                                                     oldLeaderOpt = if(leader1.get == 0) None else leader1)
     val leaderEpoch2 = zkUtils.getEpochForPartition(topic, partitionId)
 
-    // A LeaderAndIsrRequest with a smaller isr should cause the isrShrinkRate meter to be counted
-    assertEquals("Isr must have shrunk on the replica", 1, servers.head.replicaManager.isrShrinkRate.count())
-
     debug("Leader is elected to be: %s".format(leader1.getOrElse(-1)))
     debug("leader Epoc: " + leaderEpoch2)
     assertEquals("Leader must move to broker 0", 0, leader2.getOrElse(-1))

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -85,6 +85,10 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
     val leader2 = waitUntilLeaderIsElectedOrChanged(zkUtils, topic, partitionId,
                                                     oldLeaderOpt = if(leader1.get == 0) None else leader1)
     val leaderEpoch2 = zkUtils.getEpochForPartition(topic, partitionId)
+
+    // A LeaderAndIsrRequest with a smaller isr should cause the isrShrinkRate meter to be counted
+    assertEquals("Isr must have shrunk on the replica", 1, servers.head.replicaManager.isrShrinkRate.count())
+
     debug("Leader is elected to be: %s".format(leader1.getOrElse(-1)))
     debug("leader Epoc: " + leaderEpoch2)
     assertEquals("Leader must move to broker 0", 0, leader2.getOrElse(-1))

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -85,7 +85,6 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
     val leader2 = waitUntilLeaderIsElectedOrChanged(zkUtils, topic, partitionId,
                                                     oldLeaderOpt = if(leader1.get == 0) None else leader1)
     val leaderEpoch2 = zkUtils.getEpochForPartition(topic, partitionId)
-
     debug("Leader is elected to be: %s".format(leader1.getOrElse(-1)))
     debug("leader Epoc: " + leaderEpoch2)
     assertEquals("Leader must move to broker 0", 0, leader2.getOrElse(-1))


### PR DESCRIPTION
Currently, a LeaderAndIsrRequest does not mark the isrShrinkRate if the received ISR is smaller than the existing ISR. This can happen if one of the replicas is shut down.
