### PR TITLE
KAFKA-2477: Fix a race condition between log append and fetch that causes OffsetOutOfRangeException.

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -471,8 +471,7 @@ class Log(val dir: File,
     trace("Reading %d bytes from offset %d in log %s of length %d bytes".format(maxLength, startOffset, name, size))
 
     // Because we don't use lock for reading, the synchronization is a little bit tricky.
-    // We first create a few local variables to avoid race conditions with updates to the log. The order matters here.
-    // We can allow currentLastEntry to have a newer value than currentNextOffsetMetadata but not vice versa.
+    // We create the local variables to avoid race conditions with updates to the log.
     val currentNextOffsetMetadata = nextOffsetMetadata
     val next = currentNextOffsetMetadata.messageOffset
     if(startOffset == next)
@@ -495,7 +494,7 @@ class Log(val dir: File,
       val maxPosition = {
         if (entry == segments.lastEntry) {
           val exposedPos = nextOffsetMetadata.relativePositionInSegment.toLong
-          // Check the segment again in case a new segment has just rolled rolled out
+          // Check the segment again in case a new segment has just rolled out.
           if (entry != segments.lastEntry)
             // New log segment has rolled out, we can read up to the file end.
             entry.getValue.size

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -641,12 +641,14 @@ class Log(val dir: File,
       val prev = addSegment(segment)
       if(prev != null)
         throw new KafkaException("Trying to roll a new log segment for topic partition %s with start offset %d while it already exists.".format(name, newOffset))
-      
+      // We need to update the segment base offset and append position data of the metadata when log rolls.
+      // The next offset should not change.
+      updateLogEndOffset(nextOffsetMetadata.messageOffset)
       // schedule an asynchronous flush of the old segment
       scheduler.schedule("flush-log", () => flush(newOffset), delay = 0L)
       
       info("Rolled new log segment for '" + name + "' in %.0f ms.".format((System.nanoTime - start) / (1000.0*1000.0)))
-      
+
       segment
     }
   }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -486,8 +486,8 @@ class Log(val dir: File,
     // continue to read from successive segments until we get some messages or we reach the end of the log
     while(entry != null) {
       val maxPosition = {
-        if (entry == segments.lastEntry())
-          Option(nextOffsetMetadata.relativePositionInSegment.toLong)
+        if (entry == segments.lastEntry)
+          Some(nextOffsetMetadata.relativePositionInSegment.toLong)
         else
           None
       }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -470,30 +470,39 @@ class Log(val dir: File,
   def read(startOffset: Long, maxLength: Int, maxOffset: Option[Long] = None): FetchDataInfo = {
     trace("Reading %d bytes from offset %d in log %s of length %d bytes".format(maxLength, startOffset, name, size))
 
-    // check if the offset is valid and in range
-    val next = nextOffsetMetadata.messageOffset
-    if(startOffset == next)
-      return FetchDataInfo(nextOffsetMetadata, MessageSet.Empty)
-    
+    // We first create a few local variables to avoid race conditions with updates to the log. The order matters here.
+    // We can allow currentLastEntry to have a newer value than currentNextOffsetMetadata but not vice versa.
+    val currentNextOffsetMetadata = nextOffsetMetadata
+    val currentNext = currentNextOffsetMetadata.messageOffset
+    val currentLastEntry = segments.lastEntry
+
+    if(startOffset == currentNext)
+      return FetchDataInfo(currentNextOffsetMetadata, MessageSet.Empty)
+
     var entry = segments.floorEntry(startOffset)
-      
+
     // attempt to read beyond the log end offset is an error
-    if(startOffset > next || entry == null)
-      throw new OffsetOutOfRangeException("Request for offset %d but we only have log segments in the range %d to %d.".format(startOffset, segments.firstKey, next))
+    if(startOffset > currentNext || entry == null)
+      throw new OffsetOutOfRangeException(("Request for offset %d but we only have log segments in the range %d " +
+        "to %d.").format(startOffset, segments.firstKey, currentNext))
     
-    // do the read on the segment with a base offset less than the target offset
+    // Do the read on the segment with a base offset less than the target offset
     // but if that segment doesn't contain any messages with an offset greater than that
     // continue to read from successive segments until we get some messages or we reach the end of the log
+    // Note that at this point startOffset < currentNext. There are three cases:
+    // 1. No new log segment is created after we created local variable currentNextOffsetMetadata and currentLastEntry
+    // 2. A new log segment is created after we created local variable currentNextOffsetMetadata but before we created
+    //    currentLastEntry. i.e currentLastEntry is actually newer than currentNextOffsetMetadata
+    // 3. A new log segment is created after we created currentNextOffsetMetadata and currentLastEntry.
+    // In all three cases, reading will start from currentLastEntry or older segments, but not the newly rolled segment.
+    // In case (2) and (3), if the reading starts from the currentLastEntry, it might be reading a little conservatively
+    // because we capped the reading up to currentNextOffsetMetadata.relativePositionInSegment even though the log
+    // segment being read is no longer the active log segment. But it is fine because later reading will see updated
+    // messages.
     while(entry != null) {
       val maxPosition = {
-        if (entry == segments.lastEntry) {
-          val exposedPos = nextOffsetMetadata.relativePositionInSegment.toLong
-          // Check the segment again in case a new segment has just rolled rolled out
-          if (entry != segments.lastEntry)
-            // New log segment has rolled out, we can read up to the file end.
-            entry.getValue.size
-          else
-            exposedPos
+        if (entry == currentLastEntry) {
+          currentNextOffsetMetadata.relativePositionInSegment.toLong
         } else {
           entry.getValue.size
         }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -484,15 +484,14 @@ class Log(val dir: File,
     // do the read on the segment with a base offset less than the target offset
     // but if that segment doesn't contain any messages with an offset greater than that
     // continue to read from successive segments until we get some messages or we reach the end of the log
-    val maxAvailableOffset = nextOffsetMetadata.messageOffset
     while(entry != null) {
-      val maxOffsetOpt = {
+      val maxPosition = {
         if (entry == segments.lastEntry())
-          Option(Math.min(maxAvailableOffset, maxOffset.getOrElse(Long.MaxValue)))
+          Option(nextOffsetMetadata.relativePositionInSegment.toLong)
         else
-          maxOffset
+          None
       }
-      val fetchInfo = entry.getValue.read(startOffset, maxOffsetOpt, maxLength)
+      val fetchInfo = entry.getValue.read(startOffset, maxOffset, maxLength, maxPosition)
       if(fetchInfo == null) {
         entry = segments.higherEntry(entry.getKey)
       } else {

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -151,7 +151,7 @@ class LogSegment(val log: FileMessageSet,
               logSize // the max offset is off the end of the log, use the end of the file
             else
               mapping.position
-          min(endPosition - startPosition.position, maxSize) 
+          min(min(maxPosition, endPosition) - startPosition.position, maxSize).toInt
         }
       }
     FetchDataInfo(offsetMetadata, log.read(startPosition.position, length))

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -112,13 +112,13 @@ class LogSegment(val log: FileMessageSet,
    * @param startOffset A lower bound on the first offset to include in the message set we read
    * @param maxSize The maximum number of bytes to include in the message set we read
    * @param maxOffset An optional maximum offset for the message set we read
-   * @param maxPosition The maximum position in the log segment that should be exposed for read.
+   * @param maxPosition An optional maximum position in the log segment that should be exposed for read.
    * 
    * @return The fetched data and the offset metadata of the first message whose offset is >= startOffset,
    *         or null if the startOffset is larger than the largest offset in this log
    */
   @threadsafe
-  def read(startOffset: Long, maxOffset: Option[Long], maxSize: Int, maxPosition: Option[Long] = None): FetchDataInfo = {
+  def read(startOffset: Long, maxOffset: Option[Long], maxSize: Int, maxPosition: Long = size): FetchDataInfo = {
     if(maxSize < 0)
       throw new IllegalArgumentException("Invalid max size for log read (%d)".format(maxSize))
 
@@ -140,7 +140,7 @@ class LogSegment(val log: FileMessageSet,
       maxOffset match {
         case None =>
           // no max offset, just read until the max position
-          (maxPosition.getOrElse(size) - startPosition.position).toInt
+          min((maxPosition - startPosition.position).toInt, maxSize)
         case Some(offset) => {
           // there is a max offset, translate it to a file position and use that to calculate the max read size
           if(offset < startOffset)


### PR DESCRIPTION
Tried two fixes. I prefer the second approach because it saves an additional offset search.
