### PR TITLE
KAFKA-2555: Infinite recursive function call when call commitSync in …

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Coordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Coordinator.java
@@ -134,7 +134,6 @@ public final class Coordinator {
     public Map<TopicPartition, OffsetAndMetadata> fetchCommittedOffsets(Set<TopicPartition> partitions) {
         while (true) {
             ensureCoordinatorKnown();
-            ensurePartitionAssignment();
 
             // contact coordinator to fetch committed offsets
             RequestFuture<Map<TopicPartition, OffsetAndMetadata>> future = sendOffsetFetchRequest(partitions);
@@ -368,9 +367,11 @@ public final class Coordinator {
     }
 
     public void commitOffsetsSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+        if (offsets.isEmpty())
+            return;
+
         while (true) {
             ensureCoordinatorKnown();
-            ensurePartitionAssignment();
 
             RequestFuture<Void> future = sendOffsetCommitRequest(offsets);
             client.poll(future);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Coordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Coordinator.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.IllegalGenerationException;
+import org.apache.kafka.common.errors.UnknownConsumerIdException;
 import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -196,7 +198,10 @@ public final class Coordinator {
             client.poll(future);
 
             if (future.failed()) {
-                if (!future.isRetriable())
+                if (future.exception() instanceof UnknownConsumerIdException
+                    || future.exception() instanceof IllegalGenerationException)
+                    continue;
+                else if (!future.isRetriable())
                     throw future.exception();
                 Utils.sleep(retryBackoffMs);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Coordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Coordinator.java
@@ -198,8 +198,7 @@ public final class Coordinator {
             client.poll(future);
 
             if (future.failed()) {
-                if (future.exception() instanceof UnknownConsumerIdException
-                    || future.exception() instanceof IllegalGenerationException)
+                if (future.exception() instanceof UnknownConsumerIdException)
                     continue;
                 else if (!future.isRetriable())
                     throw future.exception();

--- a/clients/src/main/java/org/apache/kafka/common/errors/IllegalGenerationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/IllegalGenerationException.java
@@ -12,7 +12,7 @@
  */
 package org.apache.kafka.common.errors;
 
-public class IllegalGenerationException extends RetriableException {
+public class IllegalGenerationException extends ApiException {
     private static final long serialVersionUID = 1L;
 
     public IllegalGenerationException() {

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnknownConsumerIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnknownConsumerIdException.java
@@ -12,7 +12,7 @@
  */
 package org.apache.kafka.common.errors;
 
-public class UnknownConsumerIdException extends RetriableException {
+public class UnknownConsumerIdException extends ApiException {
     private static final long serialVersionUID = 1L;
 
     public UnknownConsumerIdException() {


### PR DESCRIPTION
@hachikuji @ewencp I found this problem when adding new consumer to mirror maker which commits offset in the rebalance callback. It is not clear to me why we are triggering rebalance for commitSync() and fetchCommittedOffset(). Can you help review to see if I miss something?

Regarding commitSync, After each poll() the partitions will be either assigned to a consumer or it will be already revoked. As long as user is using internal offset map, the offset map will always be valid. i.e. the offset map will always only contain the assigned partitions when commitSync is called. Hence there is no need to trigger a rebalance in commitSync().

The same guarantee also apply to fetchCommittedOffset(), isn't the only requirement is to ensure we know the coordinator?

Another related issue is that today the IllegalGenerationIdException is a bit confusing. When we receive an IllegalGenerationIdException from heartbeat, we need to use that same generation Id to commit offset and the coordinator will take it. So the generation ID was not really illegal. I will file a ticket for this issue.
