### PR TITLE
Should stop offset backing store in Copycat Worker's stop method

### DIFF
--- a/copycat/runtime/src/main/java/org/apache/kafka/copycat/runtime/Worker.java
+++ b/copycat/runtime/src/main/java/org/apache/kafka/copycat/runtime/Worker.java
@@ -132,7 +132,7 @@ public class Worker {
         long timeoutMs = limit - time.milliseconds();
         sourceTaskOffsetCommitter.close(timeoutMs);
 
-        offsetBackingStore.start();
+        offsetBackingStore.stop();
 
         log.info("Worker stopped");
     }


### PR DESCRIPTION
@ewencp @gwenshap This is a trivial bug fix
