### PR TITLE
KAFKA-2419; Garbage collect unused sensors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -17,7 +17,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.CopyOnWriteMap;
@@ -282,8 +285,9 @@ public class Metrics implements Closeable {
                 // There is however a minor race condition here. Assume we have a parent sensor P and child sensor C.
                 // Calling record on C would cause a record on P as well.
                 // So expiration time for P == C1. If the record on P happens via C just after P is removed,
-                // that remove will cause C to also get removed
-                // Since the expiration time is typically high it is not expected to be a significant concern and thus not worth optimizing
+                // that will cause C to also get removed.
+                // Since the expiration time is typically high it is not expected to be a significant concern
+                // and thus not necessary to optimize
                 synchronized (sensorEntry.getValue()) {
                     if (sensorEntry.getValue().hasExpired()) {
                         log.debug("Removing expired sensor {}", sensorEntry.getKey());

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -284,7 +284,7 @@ public class Metrics implements Closeable {
                 // removeSensor also locks the sensor object. This is fine because synchronized is reentrant
                 // There is however a minor race condition here. Assume we have a parent sensor P and child sensor C.
                 // Calling record on C would cause a record on P as well.
-                // So expiration time for P == C1. If the record on P happens via C just after P is removed,
+                // So expiration time for P == expiration time for C. If the record on P happens via C just after P is removed,
                 // that will cause C to also get removed.
                 // Since the expiration time is typically high it is not expected to be a significant concern
                 // and thus not necessary to optimize

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -279,6 +279,11 @@ public class Metrics implements Closeable {
         public void run() {
             for (Map.Entry<String, Sensor> sensorEntry : sensors.entrySet()) {
                 // removeSensor also locks the sensor object. This is fine because synchronized is reentrant
+                // There is however a minor race condition here. Assume we have a parent sensor P and child sensor C.
+                // Calling record on C would cause a record on P as well.
+                // So expiration time for P == C1. If the record on P happens via C just after P is removed,
+                // that remove will cause C to also get removed
+                // Since the expiration time is typically high it is not expected to be a significant concern and thus not worth optimizing
                 synchronized (sensorEntry.getValue()) {
                     if (sensorEntry.getValue().hasExpired()) {
                         log.debug("Removing expired sensor {}", sensorEntry.getKey());

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -39,9 +39,9 @@ public final class Sensor {
     private final MetricConfig config;
     private final Time time;
     private volatile long lastRecordTime;
-    private final long expireInactiveSensorTimeMillis;
+    private final long inactiveSensorExpirationTimeMs;
 
-    Sensor(Metrics registry, String name, Sensor[] parents, MetricConfig config, Time time, long expireInactiveSensorTimeSeconds) {
+    Sensor(Metrics registry, String name, Sensor[] parents, MetricConfig config, Time time, long inactiveSensorExpirationTimeSeconds) {
         super();
         this.registry = registry;
         this.name = Utils.notNull(name);
@@ -50,7 +50,7 @@ public final class Sensor {
         this.stats = new ArrayList<>();
         this.config = config;
         this.time = time;
-        this.expireInactiveSensorTimeMillis = TimeUnit.MILLISECONDS.convert(expireInactiveSensorTimeSeconds, TimeUnit.SECONDS);
+        this.inactiveSensorExpirationTimeMs = TimeUnit.MILLISECONDS.convert(inactiveSensorExpirationTimeSeconds, TimeUnit.SECONDS);
         this.lastRecordTime = time.milliseconds();
         checkForest(new HashSet<Sensor>());
     }
@@ -184,7 +184,7 @@ public final class Sensor {
      *        false otherwise
      */
     public boolean isExpired() {
-        return (time.milliseconds() - this.lastRecordTime) > this.expireInactiveSensorTimeMillis;
+        return (time.milliseconds() - this.lastRecordTime) > this.inactiveSensorExpirationTimeMs;
     }
 
     synchronized List<KafkaMetric> metrics() {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.CompoundStat.NamedMeasurable;
@@ -37,16 +38,20 @@ public final class Sensor {
     private final List<KafkaMetric> metrics;
     private final MetricConfig config;
     private final Time time;
+    private volatile long lastRecordTime;
+    private final long expireInactiveSensorTimeMillis;
 
-    Sensor(Metrics registry, String name, Sensor[] parents, MetricConfig config, Time time) {
+    Sensor(Metrics registry, String name, Sensor[] parents, MetricConfig config, Time time, long expireInactiveSensorTimeSeconds) {
         super();
         this.registry = registry;
         this.name = Utils.notNull(name);
         this.parents = parents == null ? new Sensor[0] : parents;
-        this.metrics = new ArrayList<KafkaMetric>();
-        this.stats = new ArrayList<Stat>();
+        this.metrics = new ArrayList<>();
+        this.stats = new ArrayList<>();
         this.config = config;
         this.time = time;
+        this.expireInactiveSensorTimeMillis = TimeUnit.MILLISECONDS.convert(expireInactiveSensorTimeSeconds, TimeUnit.SECONDS);
+        this.lastRecordTime = time.milliseconds();
         checkForest(new HashSet<Sensor>());
     }
 
@@ -91,6 +96,7 @@ public final class Sensor {
      *         bound
      */
     public void record(double value, long timeMs) {
+        this.lastRecordTime = time.milliseconds();
         synchronized (this) {
             // increment all the stats
             for (int i = 0; i < this.stats.size(); i++)
@@ -171,6 +177,14 @@ public final class Sensor {
         this.registry.registerMetric(metric);
         this.metrics.add(metric);
         this.stats.add(stat);
+    }
+
+    /**
+     * Return true if the Sensor is eligible for removal due to inactivity.
+     *        false otherwise
+     */
+    public boolean isExpired() {
+        return (time.milliseconds() - this.lastRecordTime) > this.expireInactiveSensorTimeMillis;
     }
 
     synchronized List<KafkaMetric> metrics() {

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -183,7 +183,7 @@ public final class Sensor {
      * Return true if the Sensor is eligible for removal due to inactivity.
      *        false otherwise
      */
-    public boolean isExpired() {
+    public boolean hasExpired() {
         return (time.milliseconds() - this.lastRecordTime) > this.inactiveSensorExpirationTimeMs;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CoordinatorTest.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -109,6 +110,11 @@ public class CoordinatorTest {
                 defaultOffsetCommitCallback,
                 autoCommitEnabled,
                 autoCommitIntervalMs);
+    }
+
+    @After
+    public void teardown() {
+        this.metrics.close();
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,7 +84,8 @@ public class FetcherTest {
 
     private MemoryRecords records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
     private Fetcher<byte[], byte[]> fetcher = createFetcher(subscriptions, metrics);
-    private Fetcher<byte[], byte[]> fetcherNoAutoReset = createFetcher(subscriptionsNoAutoReset, new Metrics(time));
+    private Metrics fetcherMetrics = new Metrics(time);
+    private Fetcher<byte[], byte[]> fetcherNoAutoReset = createFetcher(subscriptionsNoAutoReset, fetcherMetrics);
 
     @Before
     public void setup() throws Exception {
@@ -95,6 +97,12 @@ public class FetcherTest {
         records.append(3L, "key".getBytes(), "value-3".getBytes());
         records.close();
         records.flip();
+    }
+
+    @After
+    public void teardown() {
+        this.metrics.close();
+        this.fetcherMetrics.close();
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -42,7 +42,7 @@ public class BufferPoolTest {
 
     @After
     public void teardown() {
-      this.metrics.close();
+        this.metrics.close();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
+import org.junit.After;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -38,6 +39,11 @@ public class BufferPoolTest {
     private final long maxBlockTimeMs =  2000;
     String metricGroup = "TestMetrics";
     Map<String, String> metricTags = new LinkedHashMap<String, String>();
+
+    @After
+    public void teardown() {
+      this.metrics.close();
+    }
 
     /**
      * Test the simple non-blocking allocation paths

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
+import org.junit.After;
 import org.junit.Test;
 
 public class RecordAccumulatorTest {
@@ -66,6 +67,11 @@ public class RecordAccumulatorTest {
     private Metrics metrics = new Metrics(time);
     Map<String, String> metricTags = new LinkedHashMap<String, String>();
     private final long maxBlockTimeMs = 1000;
+
+    @After
+    public void teardown() {
+        this.metrics.close();
+    }
 
     @Test
     public void testFull() throws Exception {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -123,16 +123,15 @@ public class SenderTest {
         Metrics m = new Metrics();
         try {
             Sender sender = new Sender(client,
-                    metadata,
-                    this.accumulator,
-                    MAX_REQUEST_SIZE,
-                    ACKS_ALL,
-                    maxRetries,
-                    REQUEST_TIMEOUT_MS,
-                    m,
-                    time,
-                    "clientId",
-                    REQUEST_TIMEOUT);
+                                       metadata,
+                                       this.accumulator,
+                                       MAX_REQUEST_SIZE,
+                                       ACKS_ALL,
+                                       maxRetries,
+                                       m,
+                                       time,
+                                       "clientId",
+                                       REQUEST_TIMEOUT);
             // do a successful retry
             Future<RecordMetadata> future = accumulator.append(tp, "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
             sender.run(time.milliseconds()); // connect

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -36,6 +36,7 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -76,6 +77,11 @@ public class SenderTest {
         metricTags.put("client-id", CLIENT_ID);
     }
 
+    @After
+    public void tearDown() {
+        this.metrics.close();
+    }
+
     @Test
     public void testSimple() throws Exception {
         long offset = 0;
@@ -114,44 +120,50 @@ public class SenderTest {
     public void testRetries() throws Exception {
         // create a sender with retries = 1
         int maxRetries = 1;
-        Sender sender = new Sender(client,
-                                   metadata,
-                                   this.accumulator,
-                                   MAX_REQUEST_SIZE,
-                                   ACKS_ALL,
-                                   maxRetries,
-                                   new Metrics(),
-                                   time,
-                                   "clientId",
-                                   REQUEST_TIMEOUT);
-        // do a successful retry
-        Future<RecordMetadata> future = accumulator.append(tp, "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
-        sender.run(time.milliseconds()); // connect
-        sender.run(time.milliseconds()); // send produce request
-        assertEquals(1, client.inFlightRequestCount());
-        client.disconnect(client.requests().peek().request().destination());
-        assertEquals(0, client.inFlightRequestCount());
-        sender.run(time.milliseconds()); // receive error
-        sender.run(time.milliseconds()); // reconnect
-        sender.run(time.milliseconds()); // resend
-        assertEquals(1, client.inFlightRequestCount());
-        long offset = 0;
-        client.respond(produceResponse(tp, offset, Errors.NONE.code(), 0));
-        sender.run(time.milliseconds());
-        assertTrue("Request should have retried and completed", future.isDone());
-        assertEquals(offset, future.get().offset());
-
-        // do an unsuccessful retry
-        future = accumulator.append(tp, "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
-        sender.run(time.milliseconds()); // send produce request
-        for (int i = 0; i < maxRetries + 1; i++) {
+        Metrics m = new Metrics();
+        try {
+            Sender sender = new Sender(client,
+                    metadata,
+                    this.accumulator,
+                    MAX_REQUEST_SIZE,
+                    ACKS_ALL,
+                    maxRetries,
+                    REQUEST_TIMEOUT_MS,
+                    m,
+                    time,
+                    "clientId",
+                    REQUEST_TIMEOUT);
+            // do a successful retry
+            Future<RecordMetadata> future = accumulator.append(tp, "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
+            sender.run(time.milliseconds()); // connect
+            sender.run(time.milliseconds()); // send produce request
+            assertEquals(1, client.inFlightRequestCount());
             client.disconnect(client.requests().peek().request().destination());
+            assertEquals(0, client.inFlightRequestCount());
             sender.run(time.milliseconds()); // receive error
             sender.run(time.milliseconds()); // reconnect
             sender.run(time.milliseconds()); // resend
+            assertEquals(1, client.inFlightRequestCount());
+            long offset = 0;
+            client.respond(produceResponse(tp, offset, Errors.NONE.code(), 0));
+            sender.run(time.milliseconds());
+            assertTrue("Request should have retried and completed", future.isDone());
+            assertEquals(offset, future.get().offset());
+
+            // do an unsuccessful retry
+            future = accumulator.append(tp, "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
+            sender.run(time.milliseconds()); // send produce request
+            for (int i = 0; i < maxRetries + 1; i++) {
+                client.disconnect(client.requests().peek().request().destination());
+                sender.run(time.milliseconds()); // receive error
+                sender.run(time.milliseconds()); // reconnect
+                sender.run(time.milliseconds()); // resend
+            }
+            sender.run(time.milliseconds());
+            completedWithError(future, Errors.NETWORK_EXCEPTION);
+        } finally {
+            m.close();
         }
-        sender.run(time.milliseconds());
-        completedWithError(future, Errors.NETWORK_EXCEPTION);
     }
 
     private void completedWithError(Future<RecordMetadata> future, Errors error) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/JmxReporterTest.java
@@ -26,12 +26,16 @@ public class JmxReporterTest {
     @Test
     public void testJmxRegistration() throws Exception {
         Metrics metrics = new Metrics();
-        metrics.addReporter(new JmxReporter());
-        Sensor sensor = metrics.sensor("kafka.requests");
-        sensor.add(new MetricName("pack.bean1.avg", "grp1"), new Avg());
-        sensor.add(new MetricName("pack.bean2.total", "grp2"), new Total());
-        Sensor sensor2 = metrics.sensor("kafka.blah");
-        sensor2.add(new MetricName("pack.bean1.some", "grp1"), new Total());
-        sensor2.add(new MetricName("pack.bean2.some", "grp1"), new Total());
+        try {
+            metrics.addReporter(new JmxReporter());
+            Sensor sensor = metrics.sensor("kafka.requests");
+            sensor.add(new MetricName("pack.bean1.avg", "grp1"), new Avg());
+            sensor.add(new MetricName("pack.bean2.total", "grp2"), new Total());
+            Sensor sensor2 = metrics.sensor("kafka.blah");
+            sensor2.add(new MetricName("pack.bean1.some", "grp1"), new Total());
+            sensor2.add(new MetricName("pack.bean2.some", "grp1"), new Total());
+        } finally {
+            metrics.close();
+        }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/SSLSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SSLSelectorTest.java
@@ -34,11 +34,6 @@ import org.junit.Test;
  */
 public class SSLSelectorTest extends SelectorTest {
 
-    private static final int BUFFER_SIZE = 4 * 1024;
-
-    private EchoServer server;
-    private Selector selector;
-    private ChannelBuilder channelBuilder;
     private Metrics metrics;
 
     @Before
@@ -56,7 +51,7 @@ public class SSLSelectorTest extends SelectorTest {
         this.channelBuilder = new SSLChannelBuilder(SSLFactory.Mode.CLIENT);
         this.channelBuilder.configure(sslClientConfigs);
         this.metrics = new Metrics();
-        this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
+        this.selector = new Selector(5000, metrics, time, "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
     }
 
     @After

--- a/clients/src/test/java/org/apache/kafka/common/network/SSLSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SSLSelectorTest.java
@@ -34,6 +34,13 @@ import org.junit.Test;
  */
 public class SSLSelectorTest extends SelectorTest {
 
+    private static final int BUFFER_SIZE = 4 * 1024;
+
+    private EchoServer server;
+    private Selector selector;
+    private ChannelBuilder channelBuilder;
+    private Metrics metrics;
+
     @Before
     public void setup() throws Exception {
         File trustStoreFile = File.createTempFile("truststore", ".jks");
@@ -48,6 +55,7 @@ public class SSLSelectorTest extends SelectorTest {
 
         this.channelBuilder = new SSLChannelBuilder(SSLFactory.Mode.CLIENT);
         this.channelBuilder.configure(sslClientConfigs);
+        this.metrics = new Metrics();
         this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
     }
 
@@ -55,6 +63,7 @@ public class SSLSelectorTest extends SelectorTest {
     public void teardown() throws Exception {
         this.selector.close();
         this.server.close();
+        this.metrics.close();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -44,6 +44,7 @@ public class SelectorTest {
     protected Time time;
     protected Selectable selector;
     protected ChannelBuilder channelBuilder;
+    private Metrics metrics;
 
     @Before
     public void setup() throws Exception {
@@ -54,13 +55,15 @@ public class SelectorTest {
         this.time = new MockTime();
         this.channelBuilder = new PlaintextChannelBuilder();
         this.channelBuilder.configure(configs);
-        this.selector = new Selector(5000, new Metrics(), time, "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
+        this.metrics = new Metrics();
+        this.selector = new Selector(5000, this.metrics, time, "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
     }
 
     @After
     public void teardown() throws Exception {
         this.selector.close();
         this.server.close();
+        this.metrics.close();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/test/MetricsBench.java
+++ b/clients/src/test/java/org/apache/kafka/test/MetricsBench.java
@@ -29,23 +29,27 @@ public class MetricsBench {
     public static void main(String[] args) {
         long iters = Long.parseLong(args[0]);
         Metrics metrics = new Metrics();
-        Sensor parent = metrics.sensor("parent");
-        Sensor child = metrics.sensor("child", parent);
-        for (Sensor sensor : Arrays.asList(parent, child)) {
-            sensor.add(new MetricName(sensor.name() + ".avg", "grp1"), new Avg());
-            sensor.add(new MetricName(sensor.name() + ".count", "grp1"), new Count());
-            sensor.add(new MetricName(sensor.name() + ".max", "grp1"), new Max());
-            sensor.add(new Percentiles(1024,
-                                       0.0,
-                                       iters,
-                                       BucketSizing.CONSTANT,
-                                       new Percentile(new MetricName(sensor.name() + ".median", "grp1"), 50.0),
-                                       new Percentile(new MetricName(sensor.name() +  ".p_99", "grp1"), 99.0)));
+        try {
+            Sensor parent = metrics.sensor("parent");
+            Sensor child = metrics.sensor("child", parent);
+            for (Sensor sensor : Arrays.asList(parent, child)) {
+                sensor.add(new MetricName(sensor.name() + ".avg", "grp1"), new Avg());
+                sensor.add(new MetricName(sensor.name() + ".count", "grp1"), new Count());
+                sensor.add(new MetricName(sensor.name() + ".max", "grp1"), new Max());
+                sensor.add(new Percentiles(1024,
+                        0.0,
+                        iters,
+                        BucketSizing.CONSTANT,
+                        new Percentile(new MetricName(sensor.name() + ".median", "grp1"), 50.0),
+                        new Percentile(new MetricName(sensor.name() +  ".p_99", "grp1"), 99.0)));
+            }
+            long start = System.nanoTime();
+            for (int i = 0; i < iters; i++)
+                parent.record(i);
+            double ellapsed = (System.nanoTime() - start) / (double) iters;
+            System.out.println(String.format("%.2f ns per metric recording.", ellapsed));
+        } finally {
+            metrics.close();
         }
-        long start = System.nanoTime();
-        for (int i = 0; i < iters; i++)
-            parent.record(i);
-        double ellapsed = (System.nanoTime() - start) / (double) iters;
-        System.out.println(String.format("%.2f ns per metric recording.", ellapsed));
     }
 }

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -58,7 +58,7 @@ object ClientQuotaManagerConfig {
   val DefaultQuotaWindowSizeSeconds = 1
   val MaxThrottleTimeSeconds = 30
   // Purge sensors after 1 hour of inactivity
-  val expireInactiveSensorTimeSeconds = 3600
+  val inactiveSensorExpirationTimeSeconds  = 3600
 }
 
 /**
@@ -200,7 +200,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
           // create the throttle time sensor also. Use default metric config
           throttleTimeSensor = metrics.sensor(throttleTimeSensorName,
                                               null,
-                                              ClientQuotaManagerConfig.expireInactiveSensorTimeSeconds)
+                                              ClientQuotaManagerConfig.inactiveSensorExpirationTimeSeconds)
           throttleTimeSensor.add(new MetricName("throttle-time",
                                                 apiKey,
                                                 "Tracking average throttle-time per client",
@@ -209,7 +209,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
 
           quotaSensor = metrics.sensor(quotaSensorName,
                                        getQuotaMetricConfig(quota(clientId)),
-                                       ClientQuotaManagerConfig.expireInactiveSensorTimeSeconds)
+                                       ClientQuotaManagerConfig.inactiveSensorExpirationTimeSeconds)
           quotaSensor.add(clientRateMetricName(clientId), new Rate())
         }
       } finally {

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -57,6 +57,8 @@ object ClientQuotaManagerConfig {
   val DefaultNumQuotaSamples = 11
   val DefaultQuotaWindowSizeSeconds = 1
   val MaxThrottleTimeSeconds = 30
+  // Purge sensors after 5 minutes of inactivity
+  val expireInactiveSensorTimeSeconds = 300
 }
 
 /**
@@ -195,14 +197,19 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
       try {
         quotaSensor = metrics.getSensor(quotaSensorName)
         if (quotaSensor == null) {
-          // create the throttle time sensor also
-          throttleTimeSensor = metrics.sensor(throttleTimeSensorName)
+          // create the throttle time sensor also. Use default metric config
+          throttleTimeSensor = metrics.sensor(throttleTimeSensorName,
+                                              null,
+                                              ClientQuotaManagerConfig.expireInactiveSensorTimeSeconds)
           throttleTimeSensor.add(new MetricName("throttle-time",
                                                 apiKey,
                                                 "Tracking average throttle-time per client",
                                                 "client-id",
                                                 clientId), new Avg())
-          quotaSensor = metrics.sensor(quotaSensorName, getQuotaMetricConfig(quota(clientId)))
+
+          quotaSensor = metrics.sensor(quotaSensorName,
+                                       getQuotaMetricConfig(quota(clientId)),
+                                       ClientQuotaManagerConfig.expireInactiveSensorTimeSeconds)
           quotaSensor.add(clientRateMetricName(clientId), new Rate())
         }
       } finally {

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -58,7 +58,7 @@ object ClientQuotaManagerConfig {
   val DefaultQuotaWindowSizeSeconds = 1
   val MaxThrottleTimeSeconds = 30
   // Purge sensors after 1 hour of inactivity
-  val inactiveSensorExpirationTimeSeconds  = 3600
+  val InactiveSensorExpirationTimeSeconds  = 3600
 }
 
 /**
@@ -200,7 +200,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
           // create the throttle time sensor also. Use default metric config
           throttleTimeSensor = metrics.sensor(throttleTimeSensorName,
                                               null,
-                                              ClientQuotaManagerConfig.inactiveSensorExpirationTimeSeconds)
+                                              ClientQuotaManagerConfig.InactiveSensorExpirationTimeSeconds)
           throttleTimeSensor.add(new MetricName("throttle-time",
                                                 apiKey,
                                                 "Tracking average throttle-time per client",
@@ -209,7 +209,7 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
 
           quotaSensor = metrics.sensor(quotaSensorName,
                                        getQuotaMetricConfig(quota(clientId)),
-                                       ClientQuotaManagerConfig.inactiveSensorExpirationTimeSeconds)
+                                       ClientQuotaManagerConfig.InactiveSensorExpirationTimeSeconds)
           quotaSensor.add(clientRateMetricName(clientId), new Rate())
         }
       } finally {

--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -57,8 +57,8 @@ object ClientQuotaManagerConfig {
   val DefaultNumQuotaSamples = 11
   val DefaultQuotaWindowSizeSeconds = 1
   val MaxThrottleTimeSeconds = 30
-  // Purge sensors after 5 minutes of inactivity
-  val expireInactiveSensorTimeSeconds = 300
+  // Purge sensors after 1 hour of inactivity
+  val expireInactiveSensorTimeSeconds = 3600
 }
 
 /**

--- a/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerFailoverTest.scala
@@ -41,6 +41,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   val msgQueueSize = 1
   val topic = "topic1"
   val overridingProps = new Properties()
+  val metrics = new Metrics()
   overridingProps.put(KafkaConfig.NumPartitionsProp, numParts.toString)
 
   override def generateConfigs() = TestUtils.createBrokerConfigs(numNodes, zkConnect)
@@ -54,6 +55,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   @After
   override def tearDown() {
     super.tearDown()
+    this.metrics.close()
   }
 
   /**
@@ -83,7 +85,7 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
     // Replace channel manager with our mock manager
     controller.kafkaController.controllerContext.controllerChannelManager.shutdown()
     val channelManager = new MockChannelManager(controller.kafkaController.controllerContext, 
-                                                  controller.kafkaController.config)
+                                                  controller.kafkaController.config, metrics)
     channelManager.startup()
     controller.kafkaController.controllerContext.controllerChannelManager = channelManager
     channelManager.shrinkBlockingQueue(0)
@@ -149,8 +151,8 @@ class ControllerFailoverTest extends KafkaServerTestHarness with Logging {
   }
 }
 
-class MockChannelManager(private val controllerContext: ControllerContext, config: KafkaConfig)
-  extends ControllerChannelManager(controllerContext, config, new SystemTime, new Metrics) {
+class MockChannelManager(private val controllerContext: ControllerContext, config: KafkaConfig, metrics: Metrics)
+  extends ControllerChannelManager(controllerContext, config, new SystemTime, metrics) {
 
   def stopSendThread(brokerId: Int) {
     val requestThread = brokerStateInfo(brokerId).requestSendThread

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -54,32 +54,37 @@ class HighwatermarkPersistenceTest {
     // create kafka scheduler
     val scheduler = new KafkaScheduler(2)
     scheduler.startup
+    val metrics = new Metrics
     // create replica manager
-    val replicaManager = new ReplicaManager(configs.head, new Metrics, new MockTime, new JMockTime, zkClient, scheduler,
+    val replicaManager = new ReplicaManager(configs.head, metrics, new MockTime, new JMockTime, zkClient, scheduler,
       logManagers(0), new AtomicBoolean(false))
     replicaManager.startup()
-    replicaManager.checkpointHighWatermarks()
-    var fooPartition0Hw = hwmFor(replicaManager, topic, 0)
-    assertEquals(0L, fooPartition0Hw)
-    val partition0 = replicaManager.getOrCreatePartition(topic, 0)
-    // create leader and follower replicas
-    val log0 = logManagers(0).createLog(TopicAndPartition(topic, 0), LogConfig())
-    val leaderReplicaPartition0 = new Replica(configs.head.brokerId, partition0, SystemTime, 0, Some(log0))
-    partition0.addReplicaIfNotExists(leaderReplicaPartition0)
-    val followerReplicaPartition0 = new Replica(configs.last.brokerId, partition0, SystemTime)
-    partition0.addReplicaIfNotExists(followerReplicaPartition0)
-    replicaManager.checkpointHighWatermarks()
-    fooPartition0Hw = hwmFor(replicaManager, topic, 0)
-    assertEquals(leaderReplicaPartition0.highWatermark.messageOffset, fooPartition0Hw)
-    // set the high watermark for local replica
-    partition0.getReplica().get.highWatermark = new LogOffsetMetadata(5L)
-    replicaManager.checkpointHighWatermarks()
-    fooPartition0Hw = hwmFor(replicaManager, topic, 0)
-    assertEquals(leaderReplicaPartition0.highWatermark.messageOffset, fooPartition0Hw)
-    EasyMock.verify(zkClient)
-
-    // shutdown the replica manager upon test completion
-    replicaManager.shutdown(false)
+    try {
+      replicaManager.checkpointHighWatermarks()
+      var fooPartition0Hw = hwmFor(replicaManager, topic, 0)
+      assertEquals(0L, fooPartition0Hw)
+      val partition0 = replicaManager.getOrCreatePartition(topic, 0)
+      // create leader and follower replicas
+      val log0 = logManagers(0).createLog(TopicAndPartition(topic, 0), LogConfig())
+      val leaderReplicaPartition0 = new Replica(configs.head.brokerId, partition0, SystemTime, 0, Some(log0))
+      partition0.addReplicaIfNotExists(leaderReplicaPartition0)
+      val followerReplicaPartition0 = new Replica(configs.last.brokerId, partition0, SystemTime)
+      partition0.addReplicaIfNotExists(followerReplicaPartition0)
+      replicaManager.checkpointHighWatermarks()
+      fooPartition0Hw = hwmFor(replicaManager, topic, 0)
+      assertEquals(leaderReplicaPartition0.highWatermark.messageOffset, fooPartition0Hw)
+      // set the high watermark for local replica
+      partition0.getReplica().get.highWatermark = new LogOffsetMetadata(5L)
+      replicaManager.checkpointHighWatermarks()
+      fooPartition0Hw = hwmFor(replicaManager, topic, 0)
+      assertEquals(leaderReplicaPartition0.highWatermark.messageOffset, fooPartition0Hw)
+      EasyMock.verify(zkClient)
+    } finally {
+      // shutdown the replica manager upon test completion
+      replicaManager.shutdown(false)
+      metrics.close()
+      scheduler.shutdown()
+    }
   }
 
   @Test
@@ -92,56 +97,60 @@ class HighwatermarkPersistenceTest {
     // create kafka scheduler
     val scheduler = new KafkaScheduler(2)
     scheduler.startup
+    val metrics = new Metrics
     // create replica manager
-    val replicaManager = new ReplicaManager(configs.head, new Metrics, new MockTime(), new JMockTime, zkClient,
+    val replicaManager = new ReplicaManager(configs.head, metrics, new MockTime(), new JMockTime, zkClient,
       scheduler, logManagers(0), new AtomicBoolean(false))
     replicaManager.startup()
-    replicaManager.checkpointHighWatermarks()
-    var topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
-    assertEquals(0L, topic1Partition0Hw)
-    val topic1Partition0 = replicaManager.getOrCreatePartition(topic1, 0)
-    // create leader log
-    val topic1Log0 = logManagers(0).createLog(TopicAndPartition(topic1, 0), LogConfig())
-    // create a local replica for topic1
-    val leaderReplicaTopic1Partition0 = new Replica(configs.head.brokerId, topic1Partition0, SystemTime, 0, Some(topic1Log0))
-    topic1Partition0.addReplicaIfNotExists(leaderReplicaTopic1Partition0)
-    replicaManager.checkpointHighWatermarks()
-    topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
-    assertEquals(leaderReplicaTopic1Partition0.highWatermark.messageOffset, topic1Partition0Hw)
-    // set the high watermark for local replica
-    topic1Partition0.getReplica().get.highWatermark = new LogOffsetMetadata(5L)
-    replicaManager.checkpointHighWatermarks()
-    topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
-    assertEquals(5L, leaderReplicaTopic1Partition0.highWatermark.messageOffset)
-    assertEquals(5L, topic1Partition0Hw)
-    // add another partition and set highwatermark
-    val topic2Partition0 = replicaManager.getOrCreatePartition(topic2, 0)
-    // create leader log
-    val topic2Log0 = logManagers(0).createLog(TopicAndPartition(topic2, 0), LogConfig())
-    // create a local replica for topic2
-    val leaderReplicaTopic2Partition0 =  new Replica(configs.head.brokerId, topic2Partition0, SystemTime, 0, Some(topic2Log0))
-    topic2Partition0.addReplicaIfNotExists(leaderReplicaTopic2Partition0)
-    replicaManager.checkpointHighWatermarks()
-    var topic2Partition0Hw = hwmFor(replicaManager, topic2, 0)
-    assertEquals(leaderReplicaTopic2Partition0.highWatermark.messageOffset, topic2Partition0Hw)
-    // set the highwatermark for local replica
-    topic2Partition0.getReplica().get.highWatermark = new LogOffsetMetadata(15L)
-    assertEquals(15L, leaderReplicaTopic2Partition0.highWatermark.messageOffset)
-    // change the highwatermark for topic1
-    topic1Partition0.getReplica().get.highWatermark = new LogOffsetMetadata(10L)
-    assertEquals(10L, leaderReplicaTopic1Partition0.highWatermark.messageOffset)
-    replicaManager.checkpointHighWatermarks()
-    // verify checkpointed hw for topic 2
-    topic2Partition0Hw = hwmFor(replicaManager, topic2, 0)
-    assertEquals(15L, topic2Partition0Hw)
-    // verify checkpointed hw for topic 1
-    topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
-    assertEquals(10L, topic1Partition0Hw)
-    EasyMock.verify(zkClient)
-
-    // shutdown the replica manager upon test completion
-    replicaManager.shutdown(false)
-
+    try {
+      replicaManager.checkpointHighWatermarks()
+      var topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
+      assertEquals(0L, topic1Partition0Hw)
+      val topic1Partition0 = replicaManager.getOrCreatePartition(topic1, 0)
+      // create leader log
+      val topic1Log0 = logManagers(0).createLog(TopicAndPartition(topic1, 0), LogConfig())
+      // create a local replica for topic1
+      val leaderReplicaTopic1Partition0 = new Replica(configs.head.brokerId, topic1Partition0, SystemTime, 0, Some(topic1Log0))
+      topic1Partition0.addReplicaIfNotExists(leaderReplicaTopic1Partition0)
+      replicaManager.checkpointHighWatermarks()
+      topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
+      assertEquals(leaderReplicaTopic1Partition0.highWatermark.messageOffset, topic1Partition0Hw)
+      // set the high watermark for local replica
+      topic1Partition0.getReplica().get.highWatermark = new LogOffsetMetadata(5L)
+      replicaManager.checkpointHighWatermarks()
+      topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
+      assertEquals(5L, leaderReplicaTopic1Partition0.highWatermark.messageOffset)
+      assertEquals(5L, topic1Partition0Hw)
+      // add another partition and set highwatermark
+      val topic2Partition0 = replicaManager.getOrCreatePartition(topic2, 0)
+      // create leader log
+      val topic2Log0 = logManagers(0).createLog(TopicAndPartition(topic2, 0), LogConfig())
+      // create a local replica for topic2
+      val leaderReplicaTopic2Partition0 =  new Replica(configs.head.brokerId, topic2Partition0, SystemTime, 0, Some(topic2Log0))
+      topic2Partition0.addReplicaIfNotExists(leaderReplicaTopic2Partition0)
+      replicaManager.checkpointHighWatermarks()
+      var topic2Partition0Hw = hwmFor(replicaManager, topic2, 0)
+      assertEquals(leaderReplicaTopic2Partition0.highWatermark.messageOffset, topic2Partition0Hw)
+      // set the highwatermark for local replica
+      topic2Partition0.getReplica().get.highWatermark = new LogOffsetMetadata(15L)
+      assertEquals(15L, leaderReplicaTopic2Partition0.highWatermark.messageOffset)
+      // change the highwatermark for topic1
+      topic1Partition0.getReplica().get.highWatermark = new LogOffsetMetadata(10L)
+      assertEquals(10L, leaderReplicaTopic1Partition0.highWatermark.messageOffset)
+      replicaManager.checkpointHighWatermarks()
+      // verify checkpointed hw for topic 2
+      topic2Partition0Hw = hwmFor(replicaManager, topic2, 0)
+      assertEquals(15L, topic2Partition0Hw)
+      // verify checkpointed hw for topic 1
+      topic1Partition0Hw = hwmFor(replicaManager, topic1, 0)
+      assertEquals(10L, topic1Partition0Hw)
+      EasyMock.verify(zkClient)
+    } finally {
+      // shutdown the replica manager upon test completion
+      replicaManager.shutdown(false)
+      metrics.close()
+      scheduler.shutdown()
+    }
   }
 
   def hwmFor(replicaManager: ReplicaManager, topic: String, partition: Int): Long = {

--- a/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
@@ -58,6 +58,7 @@ class IsrExpirationTest {
   @After
   def tearDown() {
     replicaManager.shutdown(false)
+    metrics.close()
   }
 
   /*

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -104,6 +104,6 @@ class ReplicaManagerTest {
       metrics.close()
     }
 
-    TestUtils.verifyNonDaemonThreadsStatus
+    TestUtils.verifyNonDaemonThreadsStatus(this.getClass.getName)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
@@ -123,6 +123,7 @@ class SimpleFetchTest {
   @After
   def tearDown() {
     replicaManager.shutdown(false)
+    metrics.close()
   }
 
   /**


### PR DESCRIPTION
As discussed in KAFKA-2419 - I've added a time based sensor retention config to Sensor. Sensors that have not been "recorded" for 'n' seconds are eligible for expiration.

In addition to the time based retention, I've also altered several tests to close the Metrics and scheduler objects since they can cause leaks while running tests. This causes TestUtils.verifyNonDaemonThreadStatus to fail.
