### PR TITLE
KAFKA-2562: update kafka scripts to use new tools/code

### DIFF
--- a/bin/kafka-producer-perf-test.sh
+++ b/bin/kafka-producer-perf-test.sh
@@ -17,4 +17,4 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ProducerPerformance $@
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance $@

--- a/bin/windows/kafka-producer-perf-test.bat
+++ b/bin/windows/kafka-producer-perf-test.bat
@@ -16,5 +16,5 @@ rem limitations under the License.
 
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M
-%~dp0kafka-run-class.bat kafka.tools.ProducerPerformance %*
+%~dp0kafka-run-class.bat org.apache.kafka.tools.ProducerPerformance %*
 EndLocal

--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ project(':core') {
 
   dependencies {
     compile project(':clients')
-    compile project(':log4j-appender')
+    compile "$slf4jlog4j"
     compile "org.scala-lang:scala-library:$scalaVersion"
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
     compile 'com.101tec:zkclient:0.6'
@@ -316,6 +316,9 @@ project(':core') {
     from(configurations.runtime) { into("libs/") }
     from(configurations.archives.artifacts.files) { into("libs/") }
     from(project.siteDocsTar) { into("site-docs/") }
+    from(project(':log4j-appender').jar) { into("libs/") }
+    from(project(':tools').jar) { into("libs/") }
+    from(project(':tools').configurations.runtime) { into("libs/") }
   }
 
   jar {

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -54,7 +54,7 @@ class ProducerPerformanceService(JmxMixin, PerformanceService):
             'kafka_directory': kafka_dir(node)
             })
         cmd = "JMX_PORT=%(jmx_port)d /opt/%(kafka_directory)s/bin/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance " \
-              "--topic %(topic)s --num_records %(num_records)d --record_size %(record_size)d --throughput %(throughput)d --producer_props bootstrap.servers=%(bootstrap_servers)s client.id=%(client_id)s" % args
+              "--topic %(topic)s --num-records %(num_records)d --record-size %(record_size)d --throughput %(throughput)d --producer-props bootstrap.servers=%(bootstrap_servers)s client.id=%(client_id)s" % args
 
         self.security_config.setup_node(node)
         if self.security_protocol == SecurityConfig.SSL:

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -46,6 +46,7 @@ class ProducerPerformanceService(JmxMixin, PerformanceService):
 
     def _worker(self, idx, node):
         args = self.args.copy()
+<<<<<<< HEAD
         args.update({
             'bootstrap_servers': self.kafka.bootstrap_servers(),
             'jmx_port': self.jmx_port,
@@ -53,7 +54,7 @@ class ProducerPerformanceService(JmxMixin, PerformanceService):
             'kafka_directory': kafka_dir(node)
             })
         cmd = "JMX_PORT=%(jmx_port)d /opt/%(kafka_directory)s/bin/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance " \
-              "%(topic)s %(num_records)d %(record_size)d %(throughput)d bootstrap.servers=%(bootstrap_servers)s client.id=%(client_id)s" % args
+              "--topic %(topic)s --num_records %(num_records)d --record_size %(record_size)d --throughput %(throughput)d --producer_props bootstrap.servers=%(bootstrap_servers)s client.id=%(client_id)s" % args
 
         self.security_config.setup_node(node)
         if self.security_protocol == SecurityConfig.SSL:

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -46,7 +46,6 @@ class ProducerPerformanceService(JmxMixin, PerformanceService):
 
     def _worker(self, idx, node):
         args = self.args.copy()
-<<<<<<< HEAD
         args.update({
             'bootstrap_servers': self.kafka.bootstrap_servers(),
             'jmx_port': self.jmx_port,

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -31,8 +31,7 @@ public class ProducerPerformance {
         ArgumentParser parser = argParser();
 
         try {
-            Namespace res;
-            res = parser.parseArgs(args);
+            Namespace res = parser.parseArgs(args);
 
             /* parse args */
             String topicName = res.getString("topic");

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -35,10 +35,10 @@ public class ProducerPerformance {
 
             /* parse args */
             String topicName = res.getString("topic");
-            long numRecords = res.getLong("num_records");
-            int recordSize = res.getInt("record_size");
+            long numRecords = res.getLong("numRecords");
+            int recordSize = res.getInt("recordSize");
             int throughput = res.getInt("throughput");
-            List<String> producerProps = res.getList("producer_props");
+            List<String> producerProps = res.getList("producerConfig");
 
             Properties props = new Properties();
             if (producerProps != null)
@@ -97,22 +97,24 @@ public class ProducerPerformance {
                 .action(store())
                 .required(true)
                 .type(String.class)
-                .metavar("TOPIC_NAME")
+                .metavar("TOPIC")
                 .help("produce messages to this topic");
 
-        parser.addArgument("--num_records")
+        parser.addArgument("--num-records")
                 .action(store())
                 .required(true)
                 .type(Long.class)
-                .metavar("NUM_RECORDS")
-                .help("number messages to produce");
+                .metavar("NUM-RECORDS")
+                .dest("numRecords")
+                .help("number of messages to produce");
 
-        parser.addArgument("--record_size")
+        parser.addArgument("--record-size")
                 .action(store())
                 .required(true)
                 .type(Integer.class)
-                .metavar("RECORD_SIZE")
-                .help("message size is bytes");
+                .metavar("RECORD-SIZE")
+                .dest("recordSize")
+                .help("message size in bytes");
 
         parser.addArgument("--throughput")
                 .action(store())
@@ -121,12 +123,13 @@ public class ProducerPerformance {
                 .metavar("THROUGHPUT")
                 .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
 
-        parser.addArgument("--producer_props")
+        parser.addArgument("--producer-props")
                  .nargs("+")
                  .required(true)
-                 .metavar("PROP_NAME=PROP_VALUE")
+                 .metavar("PROP-NAME=PROP-VALUE")
                  .type(String.class)
-                 .help("kafka producer related configuaration properties like bootstrap.servers etc..");
+                 .dest("producerConfig")
+                 .help("kafka producer related configuaration properties like bootstrap.servers,client.id etc..");
 
         return parser;
     }

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -3,67 +3,133 @@
  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.apache.kafka.tools;
 
+import static net.sourceforge.argparse4j.impl.Arguments.store;
+
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.apache.kafka.clients.producer.*;
 
 public class ProducerPerformance {
 
     public static void main(String[] args) throws Exception {
-        if (args.length < 4) {
-            System.err.println("USAGE: java " + ProducerPerformance.class.getName() +
-                               " topic_name num_records record_size target_records_sec [prop_name=prop_value]*");
-            System.exit(1);
-        }
+        ArgumentParser parser = argParser();
 
-        /* parse args */
-        String topicName = args[0];
-        long numRecords = Long.parseLong(args[1]);
-        int recordSize = Integer.parseInt(args[2]);
-        int throughput = Integer.parseInt(args[3]);
+        try {
+            Namespace res;
+            res = parser.parseArgs(args);
 
-        Properties props = new Properties();
-        for (int i = 4; i < args.length; i++) {
-            String[] pieces = args[i].split("=");
-            if (pieces.length != 2)
-                throw new IllegalArgumentException("Invalid property: " + args[i]);
-            props.put(pieces[0], pieces[1]);
-        }
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
-        KafkaProducer<byte[], byte[]> producer = new KafkaProducer<byte[], byte[]>(props);
+            /* parse args */
+            String topicName = res.getString("topic");
+            long numRecords = res.getLong("num_records");
+            int recordSize = res.getInt("record_size");
+            int throughput = res.getInt("throughput");
+            List<String> producerProps = res.getList("producer_props");
 
-        /* setup perf test */
-        byte[] payload = new byte[recordSize];
-        Arrays.fill(payload, (byte) 1);
-        ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[], byte[]>(topicName, payload);
-        Stats stats = new Stats(numRecords, 5000);
-        long startMs = System.currentTimeMillis();
+            Properties props = new Properties();
+            if (producerProps != null)
+                for (String prop : producerProps) {
+                    String[] pieces = prop.split("=");
+                    if (pieces.length != 2)
+                        throw new IllegalArgumentException("Invalid property: " + prop);
+                    props.put(pieces[0], pieces[1]);
+                }
 
-        ThroughputThrottler throttler = new ThroughputThrottler(throughput, startMs);
-        for (int i = 0; i < numRecords; i++) {
-            long sendStartMs = System.currentTimeMillis();
-            Callback cb = stats.nextCompletion(sendStartMs, payload.length, stats);
-            producer.send(record, cb);
+            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+            KafkaProducer<byte[], byte[]> producer = new KafkaProducer<byte[], byte[]>(props);
 
-            if (throttler.shouldThrottle(i, sendStartMs)) {
-                throttler.throttle();
+            /* setup perf test */
+            byte[] payload = new byte[recordSize];
+            Arrays.fill(payload, (byte) 1);
+            ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[], byte[]>(topicName, payload);
+            Stats stats = new Stats(numRecords, 5000);
+            long startMs = System.currentTimeMillis();
+
+            ThroughputThrottler throttler = new ThroughputThrottler(throughput, startMs);
+            for (int i = 0; i < numRecords; i++) {
+                long sendStartMs = System.currentTimeMillis();
+                Callback cb = stats.nextCompletion(sendStartMs, payload.length, stats);
+                producer.send(record, cb);
+
+                if (throttler.shouldThrottle(i, sendStartMs)) {
+                    throttler.throttle();
+                }
+            }
+
+            /* print final results */
+            producer.close();
+            stats.printTotal();
+        } catch (ArgumentParserException e) {
+            if (args.length == 0) {
+                parser.printHelp();
+                System.exit(0);
+            } else {
+                parser.handleError(e);
+                System.exit(1);
             }
         }
 
-        /* print final results */
-        producer.close();
-        stats.printTotal();
+    }
+
+    /** Get the command-line argument parser. */
+    private static ArgumentParser argParser() {
+        ArgumentParser parser = ArgumentParsers
+                .newArgumentParser("producer-performance")
+                .defaultHelp(true)
+                .description("This tool is used to verify the producer performance.");
+
+        parser.addArgument("--topic")
+                .action(store())
+                .required(true)
+                .type(String.class)
+                .metavar("TOPIC_NAME")
+                .help("produce messages to this topic");
+
+        parser.addArgument("--num_records")
+                .action(store())
+                .required(true)
+                .type(Long.class)
+                .metavar("NUM_RECORDS")
+                .help("number messages to produce");
+
+        parser.addArgument("--record_size")
+                .action(store())
+                .required(true)
+                .type(Integer.class)
+                .metavar("RECORD_SIZE")
+                .help("message size is bytes");
+
+        parser.addArgument("--throughput")
+                .action(store())
+                .required(true)
+                .type(Integer.class)
+                .metavar("THROUGHPUT")
+                .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
+
+        parser.addArgument("--producer_props")
+                 .nargs("+")
+                 .required(true)
+                 .metavar("PROP_NAME=PROP_VALUE")
+                 .type(String.class)
+                 .help("kafka producer related configuaration properties like bootstrap.servers etc..");
+
+        return parser;
     }
 
     private static class Stats {


### PR DESCRIPTION
Updated  kafka-producer-perf-test.sh to use org.apache.kafka.clients.tools.ProducerPerformance. 
Updated build.gradle to add kafka-tools-0.9.0.0-SNAPSHOT.jar to kafka/libs  folder.
