### PR TITLE
KAFKA-2597: Add to .gitignore the Eclipse IDE directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ patch-process/*
 .idea
 .svn
 .classpath
+/.metadata
+/.recommenders
 *~
 *#
 .#*


### PR DESCRIPTION
The `.metadata` and `.recommenders` keep IDE workspace state and should not be committed.
