### PR TITLE
KAFKA-2624: Change log message position

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -153,9 +153,9 @@ class ReplicaFetcherThread(name: String,
         Runtime.getRuntime.halt(1)
       }
 
-      replicaMgr.logManager.truncateTo(Map(topicAndPartition -> leaderEndOffset))
       warn("Replica %d for partition %s reset its fetch offset from %d to current leader %d's latest offset %d"
         .format(brokerConfig.brokerId, topicAndPartition, replica.logEndOffset.messageOffset, sourceBroker.id, leaderEndOffset))
+      replicaMgr.logManager.truncateTo(Map(topicAndPartition -> leaderEndOffset))
       leaderEndOffset
     } else {
       /**


### PR DESCRIPTION
Log warning message before truncating log in order to
display right offset value for the truncated log.
