### PR TITLE
MINOR: flush record collector after local state flush

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -245,11 +245,11 @@ public class StreamTask implements Punctuator {
      * Commit the current task state
      */
     public void commit() {
-        // 1) flush produced records in the downstream and change logs of local states
-        recordCollector.flush();
-
-        // 2) flush local state
+        // 1) flush local state
         stateMgr.flush();
+
+        // 2) flush produced records in the downstream and change logs of local states
+        recordCollector.flush();
 
         // 3) commit consumed offsets if it is dirty already
         if (commitOffsetNeeded) {


### PR DESCRIPTION
@guozhangwang 
Fix the order of flushing. Undoing the change I did sometime ago.
