### PR TITLE
KAFKA-2654: optimize unnecessary poll(0) away

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
@@ -154,6 +154,11 @@ public class PartitionGroup {
         return recordQueue.size();
     }
 
+    public int topQueueSize() {
+        RecordQueue recordQueue = queuesByTime.peek();
+        return (recordQueue == null) ? 0 : recordQueue.size();
+    }
+
     public int numBuffered() {
         return totalBuffered;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -64,6 +64,8 @@ public class StreamTask implements Punctuator {
     private StampedRecord currRecord = null;
     private ProcessorNode currNode = null;
 
+    private boolean requiresPoll = true;
+
     /**
      * Create {@link StreamTask} with its assigned partitions
      *
@@ -173,8 +175,12 @@ public class StreamTask implements Punctuator {
             StampedRecord record = partitionGroup.nextRecord(recordInfo);
 
             // if there is no record to process, return immediately
-            if (record == null)
+            if (record == null) {
+                requiresPoll = true;
                 return 0;
+            }
+
+            requiresPoll = false;
 
             try {
                 // process the record by passing to the source node of the topology
@@ -196,6 +202,11 @@ public class StreamTask implements Punctuator {
                 // decreased to the threshold, we can then resume the consumption on this partition
                 if (partitionGroup.numBuffered(partition) == this.maxBufferedSize) {
                     consumer.resume(partition);
+                    requiresPoll = true;
+                }
+
+                if (partitionGroup.topQueueSize() <= this.maxBufferedSize) {
+                    requiresPoll = true;
                 }
             } finally {
                 this.currRecord = null;
@@ -204,6 +215,10 @@ public class StreamTask implements Punctuator {
 
             return partitionGroup.numBuffered();
         }
+    }
+
+    public boolean requiresPoll() {
+        return requiresPoll;
     }
 
     /**


### PR DESCRIPTION
@guozhangwang 
This change aims to remove unnecessary `consumer.poll(0)` calls.
- `once` after some partition is resumed
- whenever the size of the top queue in any task is below `BUFFERED_RECORDS_PER_PARTITION_CONFIG`
