### PR TITLE
KAFKA-2669; Fix LogCleanerIntegrationTest

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -152,12 +152,9 @@ class LogCleaner(val config: CleanerConfig,
    * For testing, a way to know when work has completed. This method blocks until the
    * cleaner has processed up to the given offset on the specified topic/partition
    */
-  def awaitCleaned(topic: String, part: Int, offset: Long, timeout: Long = 30000L): Unit = {
-    while(true) {
-      val cleanedOffset = cleanerManager.allCleanerCheckpoints.get(TopicAndPartition(topic, part))
-      if (cleanedOffset == None || cleanedOffset.get < offset) Thread.sleep(10)
-      else return
-    }
+  def awaitCleaned(topic: String, part: Int, offset: Long): Unit = {
+    while (cleanerManager.allCleanerCheckpoints.get(TopicAndPartition(topic, part)).fold(true)(_ < offset))
+      Thread.sleep(10)
   }
   
   /**

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -163,10 +163,11 @@ class LogCleaner(val config: CleanerConfig,
     def isCleaned = cleanerManager.allCleanerCheckpoints.get(TopicAndPartition(topic, part)).fold(false)(_ >= offset)
     var remainingWaitMs = maxWaitMs
     while (!isCleaned && remainingWaitMs > 0) {
-      Thread.sleep(math.min(100, remainingWaitMs))
-      remainingWaitMs -= 100
+      val sleepTime = math.min(100, remainingWaitMs)
+      Thread.sleep(sleepTime)
+      remainingWaitMs -= sleepTime
     }
-    return isCleaned
+    isCleaned
   }
   
   /**

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -164,7 +164,7 @@ class LogCleaner(val config: CleanerConfig,
     var remainingWaitMs = maxWaitMs
     while (!isCleaned && remainingWaitMs > 0) {
       Thread.sleep(math.min(100, remainingWaitMs))
-      remainingWaitMs = math.max(0, remainingWaitMs - 100)
+      remainingWaitMs -= 100
     }
     return isCleaned
   }

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -153,8 +153,11 @@ class LogCleaner(val config: CleanerConfig,
    * cleaner has processed up to the given offset on the specified topic/partition
    */
   def awaitCleaned(topic: String, part: Int, offset: Long, timeout: Long = 30000L): Unit = {
-    while(!cleanerManager.allCleanerCheckpoints.contains(TopicAndPartition(topic, part)))
-      Thread.sleep(10)
+    while(true) {
+      val cleanedOffset = cleanerManager.allCleanerCheckpoints.get(TopicAndPartition(topic, part))
+      if (cleanedOffset == None || cleanedOffset.get < offset) Thread.sleep(10)
+      else return
+    }
   }
   
   /**

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -239,7 +239,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     writeDups(numKeys = 100, numDups = 3,log)
 
     // wait for cleaner to clean
-   server.logManager.cleaner.awaitCleaned(topicName,0,0)
+   server.logManager.cleaner.awaitCleaned(topicName, 0, 0)
 
     // delete topic
     AdminUtils.deleteTopic(zkClient, "test")

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -56,9 +56,12 @@ class LogCleanerIntegrationTest(compressionCodec: String) {
     val startSize = log.size
     cleaner.startup()
 
-    val lastCleaned = log.activeSegment.baseOffset
+    val firstDirty = log.activeSegment.baseOffset
     // wait until we clean up to base_offset of active segment - minDirtyMessages
-    cleaner.awaitCleaned("log", 0, lastCleaned)
+    cleaner.awaitCleaned("log", 0, firstDirty)
+
+    val lastCleaned = cleaner.cleanerManager.allCleanerCheckpoints.get(TopicAndPartition("log", 0)).get
+    assertTrue("log cleaner should have processed up to offset " + firstDirty, lastCleaned >= firstDirty);
     
     val read = readFromLog(log)
     assertEquals("Contents of the map shouldn't change.", appends.toMap, read.toMap)
@@ -66,8 +69,12 @@ class LogCleanerIntegrationTest(compressionCodec: String) {
 
     // write some more stuff and validate again
     val appends2 = appends ++ writeDups(numKeys = 100, numDups = 3, log, CompressionCodec.getCompressionCodec(compressionCodec))
-    val lastCleaned2 = log.activeSegment.baseOffset
-    cleaner.awaitCleaned("log", 0, lastCleaned2)
+    val firstDirty2 = log.activeSegment.baseOffset
+    cleaner.awaitCleaned("log", 0, firstDirty2)
+
+    val lastCleaned2 = cleaner.cleanerManager.allCleanerCheckpoints.get(TopicAndPartition("log", 0)).get
+    assertTrue("log cleaner should have processed up to offset " + firstDirty2, lastCleaned2 >= firstDirty2);
+
     val read2 = readFromLog(log)
     assertEquals("Contents of the map shouldn't change.", appends2.toMap, read2.toMap)
 
@@ -82,7 +89,6 @@ class LogCleanerIntegrationTest(compressionCodec: String) {
 
     // we expect partition 0 to be gone
     assert(!checkpoints.contains(topics(0)))
-    
     cleaner.shutdown()
   }
 
@@ -111,6 +117,7 @@ class LogCleanerIntegrationTest(compressionCodec: String) {
     
   @After
   def teardown() {
+    time.scheduler.shutdown()
     CoreUtils.rm(logDir)
   }
   

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -43,6 +43,7 @@ class MockScheduler(val time: Time) extends Scheduler {
   
   def shutdown() {
     this synchronized {
+      tasks.foreach(_.fun())
       tasks.clear()
     }
   }


### PR DESCRIPTION
LogCleanerIntegrationTest calls LogCleaner.awaitCleaned() to wait until cleaner has processed up to given offset. However, existing awaitCleaned() implementation doesn't wait for this. This patch fix the problem.
