### PR TITLE
KAFKA-2658: Add PLAIN mechanism to SASL implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -307,6 +307,7 @@ public class ConsumerConfig extends AbstractConfig {
                                 .define(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, Type.DOUBLE, SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, Importance.LOW, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC)
                                 .define(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER, Type.DOUBLE, SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_JITTER, Importance.LOW, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER_DOC)
                                 .define(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN, Type.LONG, SaslConfigs.DEFAULT_KERBEROS_MIN_TIME_BEFORE_RELOGIN, Importance.LOW, SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC)
+                                .define(SaslConfigs.SASL_MECHANISM, Type.STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, Importance.MEDIUM, SaslConfigs.SASL_MECHANISM_DOC)
                                 .define(REQUEST_TIMEOUT_MS_CONFIG,
                                         Type.INT,
                                         40 * 1000,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -285,6 +285,7 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, Type.DOUBLE, SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, Importance.LOW, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC)
                                 .define(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER, Type.DOUBLE, SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_JITTER, Importance.LOW, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER_DOC)
                                 .define(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN, Type.LONG, SaslConfigs.DEFAULT_KERBEROS_MIN_TIME_BEFORE_RELOGIN, Importance.LOW, SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC)
+                                .define(SaslConfigs.SASL_MECHANISM, Type.STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, Importance.MEDIUM, SaslConfigs.SASL_MECHANISM_DOC)
                                 /* default is set to be a bit lower than the server default (10 min), to avoid both client and server closing connection at same time */
                                 .define(CONNECTIONS_MAX_IDLE_MS_CONFIG, Type.LONG, 9 * 60 * 1000, Importance.MEDIUM, CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_DOC)
                                 .define(PARTITIONER_CLASS_CONFIG, Type.CLASS, "org.apache.kafka.clients.producer.internals.DefaultPartitioner", Importance.MEDIUM, PARTITIONER_CLASS_DOC);

--- a/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
@@ -16,10 +16,17 @@ package org.apache.kafka.common.config;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.kafka.common.security.authenticator.SaslMechanism;
+
 public class SaslConfigs {
     /*
      * NOTE: DO NOT CHANGE EITHER CONFIG NAMES AS THESE ARE PART OF THE PUBLIC API AND CHANGE WILL BREAK USER CODE.
      */
+    
+    public static final String SASL_MECHANISM = "sasl.mechanism";
+    public static final String SASL_MECHANISM_DOC = "The sasl mechanism. "
+        + "Default will be GSSAPI";
+    public static final String DEFAULT_SASL_MECHANISM = SaslMechanism.GSSAPI.mechanismName();
 
     public static final String SASL_KERBEROS_SERVICE_NAME = "sasl.kerberos.service.name";
     public static final String SASL_KERBEROS_SERVICE_NAME_DOC = "The Kerberos principal name that Kafka runs as. "

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -58,7 +58,9 @@ public class SaslChannelBuilder implements ChannelBuilder {
         try {
             this.configs = configs;
             String mechanismName = (String) this.configs.get(SaslConfigs.SASL_MECHANISM);
-            mechanism = mechanismName == null ? SaslMechanism.GSSAPI : SaslMechanism.fromMechanismName(mechanismName);
+            if (mechanismName == null)
+                throw new IllegalArgumentException("SASL mechanism not specified.");
+            mechanism = SaslMechanism.fromMechanismName(mechanismName);
             this.loginManager = LoginManager.acquireLoginManager(loginType, mechanism, configs);
             this.principalBuilder = (PrincipalBuilder) Utils.newInstance((Class<?>) configs.get(SslConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG));
             this.principalBuilder.configure(configs);

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/Login.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/Login.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.authenticator;
+
+import javax.security.auth.Subject;
+
+
+/**
+ * Login interface that enables different implementation classes for each SASL mechanism.
+ */
+public interface Login {
+    
+    public SaslMechanism mechanism();
+
+    public Subject subject();
+    
+    public void startThreadIfNeeded();
+
+    public void shutdown();
+
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -51,7 +51,7 @@ public class LoginManager {
         switch (mechanism) {
             case GSSAPI:
                 login = new KerberosLogin(loginContext, configs);
-                this.serviceName = getServiceName(loginContext, configs);
+                this.serviceName = findServiceName(loginContext, configs);
                 login.startThreadIfNeeded();
                 break;
             case PLAIN:
@@ -65,7 +65,7 @@ public class LoginManager {
         }
     }
 
-    private static String getServiceName(String loginContext, Map<String, ?> configs) throws IOException {
+    private static String findServiceName(String loginContext, Map<String, ?> configs) throws IOException {
         String jaasServiceName = JaasUtils.jaasConfig(loginContext, JaasUtils.SERVICE_NAME);
         String configServiceName = (String) configs.get(SaslConfigs.SASL_KERBEROS_SERVICE_NAME);
         if (jaasServiceName != null && configServiceName != null && jaasServiceName != configServiceName) {

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslMechanism.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslMechanism.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.authenticator;
+
+import org.apache.kafka.common.config.ConfigException;
+
+/**
+ * Sasl mechanisms
+ */
+public enum SaslMechanism {
+    GSSAPI("GSSAPI"),
+    PLAIN("PLAIN");
+
+    private final String mechanismName;
+
+    SaslMechanism(String mechanismName) {
+        this.mechanismName = mechanismName;
+    }
+
+    public String mechanismName() {
+        return mechanismName;
+    }
+    
+    public static SaslMechanism fromMechanismName(String mechanismName) {
+        SaslMechanism mechanism = null;
+        for (SaslMechanism m : values()) {
+            if (m.mechanismName.equals(mechanismName)) {
+                mechanism = m;
+                break;
+            }
+        }
+        if (mechanism == null)
+            throw new ConfigException("Unsupported SASL mechanism " + mechanismName);
+        return mechanism;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainLogin.java
@@ -40,11 +40,11 @@ import java.util.Map;
 public class PlainLogin implements Login, CallbackHandler {
     private static final Logger log = LoggerFactory.getLogger(PlainLogin.class);
     
-    private LoginContext loginContext;
-    private Subject subject;
+    private final LoginContext loginContext;
     
     public PlainLogin(final String loginContextName, Map<String, ?> configs) throws LoginException {
-        this.loginContext = login(loginContextName);
+        loginContext = new LoginContext(loginContextName, this);
+        loginContext.login();
     }
     
     @Override
@@ -54,7 +54,7 @@ public class PlainLogin implements Login, CallbackHandler {
 
     @Override
     public Subject subject() {
-        return loginContext != null ? loginContext.getSubject() : subject;
+        return loginContext.getSubject();
     }
     
     @Override
@@ -64,16 +64,6 @@ public class PlainLogin implements Login, CallbackHandler {
     @Override
     public void shutdown() {
     }
-
-    private synchronized LoginContext login(final String loginContextName) throws LoginException {
-        if (subject == null) {
-            loginContext = new LoginContext(loginContextName, this);
-            loginContext.login();
-        }
-        log.info("Successfully logged in.");
-        return loginContext;
-    }
-
     
     @Override
     public void handle(Callback[] callbacks) throws UnsupportedCallbackException {

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainLogin.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.plain;
+
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.Subject;
+
+import org.apache.kafka.common.security.authenticator.Login;
+import org.apache.kafka.common.security.authenticator.SaslMechanism;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Login for PLAIN authentication using username/password.
+ */
+public class PlainLogin implements Login, CallbackHandler {
+    private static final Logger log = LoggerFactory.getLogger(PlainLogin.class);
+    
+    private LoginContext loginContext;
+    private Subject subject;
+    
+    public PlainLogin(final String loginContextName, Map<String, ?> configs) throws LoginException {
+        this.loginContext = login(loginContextName);
+    }
+    
+    @Override
+    public SaslMechanism mechanism() {
+        return SaslMechanism.PLAIN;
+    }
+
+    @Override
+    public Subject subject() {
+        return loginContext != null ? loginContext.getSubject() : subject;
+    }
+    
+    @Override
+    public void startThreadIfNeeded() {       
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    private synchronized LoginContext login(final String loginContextName) throws LoginException {
+        if (subject == null) {
+            loginContext = new LoginContext(loginContextName, this);
+            loginContext.login();
+        }
+        log.info("Successfully logged in.");
+        return loginContext;
+    }
+
+    
+    @Override
+    public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
+        for (Callback callback : callbacks) {
+            if (callback instanceof NameCallback) {
+                NameCallback nc = (NameCallback) callback;
+                nc.setName(nc.getDefaultName());
+            } else if (callback instanceof PasswordCallback) {
+                // Call `setPassword` once we support obtaining a password from the user and update message below
+                log.warn("Could not login: the client is being asked for a password, but the Kafka" +
+                         " client code does not currently support obtaining a password from the user." +
+                         " Configure password using JaaS config.");
+            } else {
+                throw new UnsupportedCallbackException(callback, "Unexpected callback for SASL/PLAIN");
+            }
+        }
+    }
+    
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainLoginModule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainLoginModule.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.plain;
+
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+public class PlainLoginModule implements LoginModule {
+    
+    private static final String USERNAME_CONFIG = "username";
+    private static final String PASSWORD_CONFIG = "password";
+    
+    static {
+        PlainSaslServerProvider.initialize();
+    }
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+        String username = (String) options.get(USERNAME_CONFIG);
+        if (username != null)
+            subject.getPublicCredentials().add(username);
+        String password = (String) options.get(PASSWORD_CONFIG);
+        if (password != null)
+            subject.getPrivateCredentials().add(password);
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return false;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServer.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.plain;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+import org.apache.kafka.common.network.LoginType;
+import org.apache.kafka.common.security.JaasUtils;
+import org.apache.kafka.common.security.authenticator.SaslMechanism;
+
+/**
+ * Simple SaslServer implementation for SASL/PLAIN. In order to make this implementation
+ * fully pluggable, authentication of username/password is fully contained within the
+ * server implementation.
+ * <p>
+ * Valid users with passwords are specified in the Jaas configuration file. Each user
+ * is specified with user_<username> as key and <password> as value. This is consistent
+ * with Zookeeper Digest-MD5 implementation.
+ * <p>
+ * This implementation is provided as a sample and for testing. In production systems,
+ * this can be easily replaced with a different implementation that does not require 
+ * clear passwords to be stored on disk.
+ *
+ */
+public class PlainSaslServer implements SaslServer {
+    
+    private static final String JAAS_USER_PREFIX = "user_";
+    
+    private boolean complete;
+    private String authorizationID;
+
+    public PlainSaslServer(CallbackHandler callbackHandler) {
+    }
+
+    @Override
+    public byte[] evaluateResponse(byte[] response) throws SaslException {
+        /*
+         * Message format (from https://tools.ietf.org/html/rfc4616):
+         * 
+         * message   = [authzid] UTF8NUL authcid UTF8NUL passwd
+         * authcid   = 1*SAFE ; MUST accept up to 255 octets
+         * authzid   = 1*SAFE ; MUST accept up to 255 octets
+         * passwd    = 1*SAFE ; MUST accept up to 255 octets
+         * UTF8NUL   = %x00 ; UTF-8 encoded NUL character
+         * 
+         * SAFE      = UTF1 / UTF2 / UTF3 / UTF4
+         *                ;; any UTF-8 encoded Unicode character except NUL
+         */
+        
+        
+        String[] tokens;        
+        try {
+            tokens = new String(response, "UTF-8").split("\u0000");
+        } catch (UnsupportedEncodingException e) {
+            throw new SaslException("UTF-8 encoding not supported", e);
+        }
+        if (tokens.length != 3)
+            throw new SaslException("Invalid SASL/PLAIN response");
+        authorizationID = tokens[0];
+        String username = tokens[1];
+        String password = tokens[2];
+        
+        
+        if (username.length() == 0) {
+            throw new SaslException("Authentication failed: username not specified");
+        }
+        if (password.length() == 0) {
+            throw new SaslException("Authentication failed: password not specified");
+        }
+        if (authorizationID.length() == 0)
+            authorizationID = username;
+
+        try {
+            String expectedPassword = JaasUtils.jaasConfig(LoginType.SERVER.contextName(), JAAS_USER_PREFIX + username);
+            if (!password.equals(expectedPassword)) {
+                throw new SaslException("Authentication failed: Invalid username or password");
+            }
+        } catch (IOException e) {
+            throw new SaslException("Authentication failed: " + e, e);
+        }
+        complete = true;
+        return new byte[0];
+    }
+
+    @Override
+    public String getAuthorizationID() {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return authorizationID;
+    }
+
+    @Override
+    public String getMechanismName() {
+        return SaslMechanism.PLAIN.mechanismName();
+    }
+
+    @Override
+    public Object getNegotiatedProperty(String propName) {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return null;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return complete;
+    }
+
+    @Override
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return Arrays.copyOfRange(incoming, offset, offset + len);
+    }
+
+    @Override
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return Arrays.copyOfRange(outgoing, offset, offset + len);
+    }
+    
+
+    @Override
+    public void dispose() throws SaslException {
+    }
+    
+    public static class PlainSaslServerFactory implements SaslServerFactory {
+
+        @Override
+        public SaslServer createSaslServer(String mechanism, String protocol, String serverName, Map<String, ?> props, CallbackHandler cbh)
+            throws SaslException {
+            
+            if (!SaslMechanism.PLAIN.mechanismName().equals(mechanism)) {
+                throw new SaslException("Mechanism not supported: " + mechanism);
+            }
+            return new PlainSaslServer(cbh);
+        }
+
+        @Override
+        public String[] getMechanismNames(Map<String, ?> props) {
+            String noPlainText = (String) props.get(Sasl.POLICY_NOPLAINTEXT);
+            if ("true".equals(noPlainText))
+                return new String[]{SaslMechanism.PLAIN.mechanismName()};
+            else
+                return new String[]{};
+        }
+        
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServerProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServerProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.plain;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.apache.kafka.common.security.authenticator.SaslMechanism;
+import org.apache.kafka.common.security.plain.PlainSaslServer.PlainSaslServerFactory;
+
+public class PlainSaslServerProvider extends Provider {
+
+    private static final long serialVersionUID = 1L;
+    
+    protected PlainSaslServerProvider() {
+        super("Simple SASL/PLAIN Server Provider", 1.0, "Simple SASL/PLAIN Server Provider for Kafka");
+        super.put("SaslServerFactory." + SaslMechanism.PLAIN.mechanismName(), PlainSaslServerFactory.class.getName());
+    }
+    
+    public static void initialize() {
+        Security.addProvider(new PlainSaslServerProvider());
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.kafka.common.network;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.io.IOException;
+import java.io.File;
+import java.nio.ByteBuffer;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.TestSslUtils;
+import org.apache.kafka.test.TestUtils;
+
+/**
+ * Common utility functions used by transport layer and authenticator tests.
+ */
+
+public class NetworkTestUtils {
+    
+    
+    public static NioEchoServer createEchoServer(SecurityProtocol securityProtocol, Map<String, Object> saslServerConfigs) throws Exception {
+        NioEchoServer server = new NioEchoServer(securityProtocol, saslServerConfigs, "localhost");
+        server.start();
+        return server;
+    }  
+
+    public static void checkClientConnection(Selector selector, String node, int minMessageSize, int messageCount) throws Exception {
+
+        String prefix = TestUtils.randomString(minMessageSize);
+        int requests = 0;
+        int responses = 0;
+        // wait for handshake to finish
+        while (!selector.isChannelReady(node)) {
+            selector.poll(1000L);
+        }
+        selector.send(new NetworkSend(node, ByteBuffer.wrap((prefix + "-0").getBytes())));
+        requests++;
+        while (responses < messageCount) {
+            selector.poll(0L);
+            assertEquals("No disconnects should have occurred.", 0, selector.disconnected().size());
+
+            for (NetworkReceive receive : selector.completedReceives()) {
+                assertEquals(prefix + "-" + responses, new String(Utils.toArray(receive.payload())));
+                responses++;
+            }
+
+            for (int i = 0; i < selector.completedSends().size() && requests < messageCount && selector.isChannelReady(node); i++, requests++) {
+                selector.send(new NetworkSend(node, ByteBuffer.wrap((prefix + "-" + requests).getBytes())));
+            }
+        }
+    }
+    
+    public static void waitForChannelClose(Selector selector, String node) throws IOException {
+        boolean closed = false;
+        for (int i = 0; i < 30; i++) {
+            selector.poll(1000L);
+            if (selector.channel(node) == null) {
+                closed = true;
+                break;
+            }
+        }
+        assertTrue(closed);
+    }
+    
+    public static class CertStores {
+        
+        Map<String, Object> sslConfig;
+        
+        public CertStores(boolean server) throws Exception {
+            String name = server ? "server" : "client";
+            Mode mode = server ? Mode.SERVER : Mode.CLIENT;
+            File truststoreFile = File.createTempFile(name + "TS", ".jks");
+            sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name);
+            sslConfig.put(SslConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, Class.forName(SslConfigs.DEFAULT_PRINCIPAL_BUILDER_CLASS));
+        }
+       
+        public Map<String, Object> getTrustingConfig(CertStores truststoreConfig) {
+            Map<String, Object> config = new HashMap<String, Object>(sslConfig);
+            config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreConfig.sslConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+            config.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, truststoreConfig.sslConfig.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+            config.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, truststoreConfig.sslConfig.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG));
+            return config;
+        }
+        
+        public Map<String, Object> getUntrustingConfig() {
+            return sslConfig;
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -35,8 +35,8 @@ import org.apache.kafka.test.TestUtils;
 public class NetworkTestUtils {
     
     
-    public static NioEchoServer createEchoServer(SecurityProtocol securityProtocol, Map<String, Object> saslServerConfigs) throws Exception {
-        NioEchoServer server = new NioEchoServer(securityProtocol, saslServerConfigs, "localhost");
+    public static NioEchoServer createEchoServer(SecurityProtocol securityProtocol, Map<String, Object> serverConfigs) throws Exception {
+        NioEchoServer server = new NioEchoServer(securityProtocol, serverConfigs, "localhost");
         server.start();
         return server;
     }  

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -35,7 +35,8 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.utils.MockTime;
 
-// Non-blocking EchoServer implementation that uses SslTransportLayer
+// Non-blocking EchoServer implementation that uses ChannelBuilder to create channels
+// with the configured security protocol.
 public class NioEchoServer extends Thread {
     public final int port;
     private final ServerSocketChannel serverSocketChannel;

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.network;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.utils.MockTime;
+
+// Non-blocking EchoServer implementation that uses SslTransportLayer
+public class NioEchoServer extends Thread {
+    public final int port;
+    private final ServerSocketChannel serverSocketChannel;
+    private final List<SocketChannel> newChannels;
+    private final List<SocketChannel> socketChannels;
+    private final AcceptorThread acceptorThread;
+    private final Selector selector;
+    private final ConcurrentLinkedQueue<NetworkSend> inflightSends = new ConcurrentLinkedQueue<NetworkSend>();
+
+    public NioEchoServer(SecurityProtocol securityProtocol, Map<String, ?> configs, String serverHost) throws Exception {
+        serverSocketChannel = ServerSocketChannel.open();
+        serverSocketChannel.configureBlocking(false);
+        serverSocketChannel.socket().bind(new InetSocketAddress(serverHost, 0));
+        this.port = serverSocketChannel.socket().getLocalPort();
+        this.socketChannels = Collections.synchronizedList(new ArrayList<SocketChannel>());
+        this.newChannels = Collections.synchronizedList(new ArrayList<SocketChannel>());
+        ChannelBuilder channelBuilder = ChannelBuilders.create(securityProtocol, Mode.SERVER, LoginType.SERVER, configs);
+        this.selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
+        setName("echoserver");
+        setDaemon(true);
+        acceptorThread = new AcceptorThread();
+    }
+
+    @Override
+    public void run() {
+        try {
+            acceptorThread.start();
+            while (serverSocketChannel.isOpen()) {
+                selector.poll(1000);
+                for (SocketChannel socketChannel : newChannels) {
+                    String id = id(socketChannel);
+                    selector.register(id, socketChannel);
+                    socketChannels.add(socketChannel);
+                }
+                newChannels.clear();
+                while (true) {
+                    NetworkSend send = inflightSends.peek();
+                    if (send != null && !selector.channel(send.destination()).hasSend()) {
+                        send = inflightSends.poll();
+                        selector.send(send);
+                    } else
+                        break;
+                }
+                List<NetworkReceive> completedReceives = selector.completedReceives();
+                for (NetworkReceive rcv : completedReceives) {
+                    NetworkSend send = new NetworkSend(rcv.source(), rcv.payload());
+                    if (!selector.channel(send.destination()).hasSend())
+                        selector.send(send);
+                    else
+                        inflightSends.add(send);
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+    
+    private String id(SocketChannel channel) {
+        return channel.socket().getLocalAddress().getHostAddress() + ":" + channel.socket().getLocalPort() + "-" +
+                channel.socket().getInetAddress().getHostAddress() + ":" + channel.socket().getPort();
+    }
+
+    public void closeConnections() throws IOException {
+        for (SocketChannel channel : socketChannels)
+            channel.close();
+        socketChannels.clear();
+    }
+
+    public void close() throws IOException, InterruptedException {
+        this.serverSocketChannel.close();
+        closeConnections();
+        acceptorThread.interrupt();
+        acceptorThread.join();
+        interrupt();
+        join();
+    }
+    
+    private class AcceptorThread extends Thread {
+        public AcceptorThread() throws IOException {
+            setName("acceptor");
+        }
+        public void run() {
+            try {
+
+                java.nio.channels.Selector acceptSelector = java.nio.channels.Selector.open();
+                serverSocketChannel.register(acceptSelector, SelectionKey.OP_ACCEPT);
+                while (serverSocketChannel.isOpen()) {
+                    if (acceptSelector.select(1000) > 0) {
+                        Iterator<SelectionKey> it = acceptSelector.selectedKeys().iterator();
+                        while (it.hasNext()) {
+                            SelectionKey key = it.next();
+                            if (key.isAcceptable()) {
+                                SocketChannel socketChannel = ((ServerSocketChannel) key.channel()).accept();
+                                socketChannel.configureBlocking(false);
+                                newChannels.add(socketChannel);
+                                selector.wakeup();
+                            }
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SaslAuthenticatorTest.java
@@ -73,8 +73,8 @@ public class SaslAuthenticatorTest {
         String node = "0";
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
         TestJaasConfig.createPlainConfig("myuser", "mypassword", "user_myuser", "mypassword");
-        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
-        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        createConfig(saslClientConfigs, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, SaslMechanism.PLAIN);
         
         server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
         createSelector(securityProtocol, saslClientConfigs);
@@ -89,8 +89,8 @@ public class SaslAuthenticatorTest {
         String node = "0";
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_PLAINTEXT;
         TestJaasConfig.createPlainConfig("myuser", "mypassword", "user_myuser", "mypassword");
-        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
-        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        createConfig(saslClientConfigs, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, SaslMechanism.PLAIN);
         
         server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
         createSelector(securityProtocol, saslClientConfigs);
@@ -105,8 +105,8 @@ public class SaslAuthenticatorTest {
         String node = "0";
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
         TestJaasConfig.createPlainConfig("myuser", "invalidpassword", "user_myuser", "mypassword");
-        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
-        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        createConfig(saslClientConfigs, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, SaslMechanism.PLAIN);
         
         server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
         createSelector(securityProtocol, saslClientConfigs);
@@ -120,8 +120,8 @@ public class SaslAuthenticatorTest {
     public void testMissingUsernameSaslPlain() throws Exception {
         String node = "0";
         TestJaasConfig.createPlainConfig(null, "mypassword", "user_myuser", "mypassword");
-        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
-        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        createConfig(saslClientConfigs, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, SaslMechanism.PLAIN);
 
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
         server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
@@ -139,8 +139,8 @@ public class SaslAuthenticatorTest {
     public void testMissingPasswordSaslPlain() throws Exception {
         String node = "0";
         TestJaasConfig.createPlainConfig("myuser", null, "user_myuser", "mypassword");
-        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
-        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        createConfig(saslClientConfigs, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, SaslMechanism.PLAIN);
 
         SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
         server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
@@ -162,7 +162,7 @@ public class SaslAuthenticatorTest {
     }
 
     
-    private void createConfig(Map<String, Object> config, boolean isServer, SaslMechanism mechanism) throws Exception {
+    private void createConfig(Map<String, Object> config, SaslMechanism mechanism) throws Exception {
         config.put(SslConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, Class.forName(SslConfigs.DEFAULT_PRINCIPAL_BUILDER_CLASS));
         config.put(SaslConfigs.SASL_MECHANISM, mechanism.mechanismName());        
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SaslAuthenticatorTest.java
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.kafka.common.network;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.net.InetSocketAddress;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
+import javax.security.auth.login.Configuration;
+
+import static org.junit.Assert.fail;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.authenticator.SaslMechanism;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for the Sasl authenticator. These use a test harness that runs a simple socket server that echos back responses.
+ */
+
+public class SaslAuthenticatorTest {
+
+    private static final int BUFFER_SIZE = 4 * 1024;
+
+    private NioEchoServer server;
+    private Selector selector;
+    private ChannelBuilder channelBuilder;
+    private NetworkTestUtils.CertStores serverCertStores;
+    private NetworkTestUtils.CertStores clientCertStores;
+    private Map<String, Object> saslClientConfigs;
+    private Map<String, Object> saslServerConfigs;
+    
+    @Before
+    public void setup() throws Exception {
+        serverCertStores = new NetworkTestUtils.CertStores(true);
+        clientCertStores = new NetworkTestUtils.CertStores(false);
+        saslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
+        saslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
+    }
+
+    @After
+    public void teardown() throws Exception {
+        if (server != null)
+            this.server.close();
+        if (selector != null)
+            this.selector.close();
+    }
+    
+    @Test
+    public void testValidSaslPlain_Ssl() throws Exception {
+        String node = "0";
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
+        TestJaasConfig.createPlainConfig("myuser", "mypassword", "user_myuser", "mypassword");
+        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        
+        server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
+        createSelector(securityProtocol, saslClientConfigs);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port);
+        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
+    }
+    
+    @Test
+    public void testValidSaslPlain_Plaintext() throws Exception {
+        String node = "0";
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_PLAINTEXT;
+        TestJaasConfig.createPlainConfig("myuser", "mypassword", "user_myuser", "mypassword");
+        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        
+        server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
+        createSelector(securityProtocol, saslClientConfigs);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port);
+        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
+    }
+    
+    @Test
+    public void testInvalidSaslPlain() throws Exception {
+        String node = "0";
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
+        TestJaasConfig.createPlainConfig("myuser", "invalidpassword", "user_myuser", "mypassword");
+        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+        
+        server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
+        createSelector(securityProtocol, saslClientConfigs);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port);
+        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+
+        NetworkTestUtils.waitForChannelClose(selector, node);
+    }
+
+    @Test
+    public void testMissingUsernameSaslPlain() throws Exception {
+        String node = "0";
+        TestJaasConfig.createPlainConfig(null, "mypassword", "user_myuser", "mypassword");
+        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
+        server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
+        createSelector(securityProtocol, saslClientConfigs);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port);
+        try {
+            selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+            fail("SASL/PLAIN channel created without username");
+        } catch (KafkaException e) {
+            // Expected exception
+        }
+    }
+    
+    @Test
+    public void testMissingPasswordSaslPlain() throws Exception {
+        String node = "0";
+        TestJaasConfig.createPlainConfig("myuser", null, "user_myuser", "mypassword");
+        createConfig(saslClientConfigs, false, SaslMechanism.PLAIN);
+        createConfig(saslServerConfigs, true, SaslMechanism.PLAIN);
+
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
+        server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
+        createSelector(securityProtocol, saslClientConfigs);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port);
+        try {
+            selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+            fail("SASL/PLAIN channel created without password");
+        } catch (KafkaException e) {
+            // Expected exception
+        }
+    }
+
+    private void createSelector(SecurityProtocol securityProtocol, Map<String, Object> saslClientConfigs) {
+        
+        this.channelBuilder = new SaslChannelBuilder(Mode.CLIENT, LoginType.CLIENT, securityProtocol);
+        this.channelBuilder.configure(saslClientConfigs);
+        this.selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
+    }
+
+    
+    private void createConfig(Map<String, Object> config, boolean isServer, SaslMechanism mechanism) throws Exception {
+        config.put(SslConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, Class.forName(SslConfigs.DEFAULT_PRINCIPAL_BUILDER_CLASS));
+        config.put(SaslConfigs.SASL_MECHANISM, mechanism.mechanismName());        
+    }
+    
+    private static class TestJaasConfig extends Configuration {
+        
+        private HashMap<String, AppConfigurationEntry[]> entryMap = new HashMap<String, AppConfigurationEntry[]>();
+        
+        public static TestJaasConfig createPlainConfig(String clientUsername, String clientPassword, String...serverUsernamesAndPasswords) {
+            TestJaasConfig config = new TestJaasConfig();
+            config.createEntry("KafkaClient", PlainLoginModule.class.getName(), "username", clientUsername, "password", clientPassword);
+            config.createEntry("KafkaServer", PlainLoginModule.class.getName(), serverUsernamesAndPasswords);
+            Configuration.setConfiguration(config);
+            return config;
+        }
+        
+        public void createEntry(String name, String loginModule, String...optionNamesAndValues) {
+            HashMap<String, Object> options = new HashMap<String, Object>();
+            AppConfigurationEntry entry = new AppConfigurationEntry(loginModule, LoginModuleControlFlag.REQUIRED, options);
+            for (int i = 0; i < optionNamesAndValues.length; i += 2) {
+                String value =  optionNamesAndValues[i + 1];
+                if (value != null)
+                    options.put(optionNamesAndValues[i], value);
+            }
+            entryMap.put(name, new AppConfigurationEntry[]{entry});
+        }
+
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+            return entryMap.get(name);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -12,26 +12,16 @@
  */
 package org.apache.kafka.common.network;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.io.IOException;
-import java.io.File;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
-import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 
 import javax.net.ssl.SSLContext;
@@ -39,12 +29,10 @@ import javax.net.ssl.SSLEngine;
 
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.test.TestSslUtils;
-import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,23 +40,24 @@ import org.junit.Test;
 /**
  * Tests for the SSL transport layer. These use a test harness that runs a simple socket server that echos back responses.
  */
+
 public class SslTransportLayerTest {
 
     private static final int BUFFER_SIZE = 4 * 1024;
 
-    private SslEchoServer server;
+    private NioEchoServer server;
     private Selector selector;
     private ChannelBuilder channelBuilder;
-    private CertStores serverCertStores;
-    private CertStores clientCertStores;
+    private NetworkTestUtils.CertStores serverCertStores;
+    private NetworkTestUtils.CertStores clientCertStores;
     private Map<String, Object> sslClientConfigs;
     private Map<String, Object> sslServerConfigs;
 
     @Before
     public void setup() throws Exception {
         // Create certificates for use by client and server. Add server cert to client truststore and vice versa.
-        serverCertStores = new CertStores(true);
-        clientCertStores = new CertStores(false);
+        serverCertStores = new NetworkTestUtils.CertStores(true);
+        clientCertStores = new NetworkTestUtils.CertStores(false);
         sslServerConfigs = serverCertStores.getTrustingConfig(clientCertStores);
         sslClientConfigs = clientCertStores.getTrustingConfig(serverCertStores);
 
@@ -92,13 +81,13 @@ public class SslTransportLayerTest {
     @Test
     public void testValidEndpointIdentification() throws Exception {
         String node = "0";
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -110,14 +99,14 @@ public class SslTransportLayerTest {
     public void testInvalidEndpointIdentification() throws Exception {
         String node = "0";
         String serverHost = InetAddress.getLocalHost().getHostAddress();
-        server = new SslEchoServer(sslServerConfigs, serverHost);
+        server = new NioEchoServer(SecurityProtocol.SSL, sslServerConfigs, serverHost);
         server.start();
         sslClientConfigs.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "HTTPS");
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress(serverHost, server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        waitForChannelClose(node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
     }
     
     /**
@@ -128,14 +117,14 @@ public class SslTransportLayerTest {
     public void testEndpointIdentificationDisabled() throws Exception {
         String node = "0";
         String serverHost = InetAddress.getLocalHost().getHostAddress();
-        server = new SslEchoServer(sslServerConfigs, serverHost);
+        server = new NioEchoServer(SecurityProtocol.SSL, sslServerConfigs, serverHost);
         server.start();
         sslClientConfigs.remove(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress(serverHost, server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -146,12 +135,12 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationRequiredValidProvided() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -163,12 +152,12 @@ public class SslTransportLayerTest {
         String node = "0";
         sslServerConfigs = serverCertStores.getUntrustingConfig();
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        createEchoServer(sslServerConfigs);        
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);        
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        waitForChannelClose(node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
     }
     
     /**
@@ -179,7 +168,7 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationRequiredNotProvided() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         
         sslClientConfigs.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
         sslClientConfigs.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
@@ -188,7 +177,7 @@ public class SslTransportLayerTest {
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        waitForChannelClose(node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
     }
     
     /**
@@ -200,12 +189,12 @@ public class SslTransportLayerTest {
         String node = "0";
         sslServerConfigs = serverCertStores.getUntrustingConfig();
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
-        createEchoServer(sslServerConfigs);      
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);      
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -216,7 +205,7 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationDisabledNotProvided() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "none");
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         
         sslClientConfigs.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
         sslClientConfigs.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
@@ -225,7 +214,7 @@ public class SslTransportLayerTest {
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -236,12 +225,12 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationRequestedValidProvided() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -252,7 +241,7 @@ public class SslTransportLayerTest {
     public void testClientAuthenticationRequestedNotProvided() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "requested");
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         
         sslClientConfigs.remove(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
         sslClientConfigs.remove(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG);
@@ -261,7 +250,7 @@ public class SslTransportLayerTest {
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 100, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
     }
     
     /**
@@ -302,12 +291,12 @@ public class SslTransportLayerTest {
     public void testInvalidKeyPassword() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "invalid");
-        createEchoServer(sslServerConfigs);        
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);        
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        waitForChannelClose(node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
     }
     
     /**
@@ -317,14 +306,14 @@ public class SslTransportLayerTest {
     public void testUnsupportedTLSVersion() throws Exception {
         String node = "0";
         sslServerConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.2"));
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         
         sslClientConfigs.put(SslConfigs.SSL_ENABLED_PROTOCOLS_CONFIG, Arrays.asList("TLSv1.1"));
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        waitForChannelClose(node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
     }
     
     /**
@@ -335,14 +324,14 @@ public class SslTransportLayerTest {
         String node = "0";
         String[] cipherSuites = SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites();
         sslServerConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[0]));
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         
         sslClientConfigs.put(SslConfigs.SSL_CIPHER_SUITES_CONFIG, Arrays.asList(cipherSuites[1]));
         createSelector(sslClientConfigs);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        waitForChannelClose(node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
     }
 
     /**
@@ -351,12 +340,12 @@ public class SslTransportLayerTest {
     @Test
     public void testNetReadBufferResize() throws Exception {
         String node = "0";
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         createSelector(sslClientConfigs, 10, null, null);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 64000, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 64000, 10);
     }
     
     /**
@@ -365,12 +354,12 @@ public class SslTransportLayerTest {
     @Test
     public void testNetWriteBufferResize() throws Exception {
         String node = "0";
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         createSelector(sslClientConfigs, null, 10, null);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 64000, 10);
+        NetworkTestUtils.checkClientConnection(selector, node, 64000, 10);
     }
 
     /**
@@ -379,55 +368,12 @@ public class SslTransportLayerTest {
     @Test
     public void testApplicationBufferResize() throws Exception {
         String node = "0";
-        createEchoServer(sslServerConfigs);
+        server = NetworkTestUtils.createEchoServer(SecurityProtocol.SSL, sslServerConfigs);
         createSelector(sslClientConfigs, null, null, 10);
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        testClientConnection(node, 64000, 10);
-    }
-
-    private void testClientConnection(String node, int minMessageSize, int messageCount) throws Exception {
-
-        String prefix = TestUtils.randomString(minMessageSize);
-        int requests = 0;
-        int responses = 0;
-        // wait for handshake to finish
-        while (!selector.isChannelReady(node)) {
-            selector.poll(1000L);
-        }
-        selector.send(new NetworkSend(node, ByteBuffer.wrap((prefix + "-0").getBytes())));
-        requests++;
-        while (responses < messageCount) {
-            selector.poll(0L);
-            assertEquals("No disconnects should have occurred.", 0, selector.disconnected().size());
-
-            for (NetworkReceive receive : selector.completedReceives()) {
-                assertEquals(prefix + "-" + responses, new String(Utils.toArray(receive.payload())));
-                responses++;
-            }
-
-            for (int i = 0; i < selector.completedSends().size() && requests < messageCount && selector.isChannelReady(node); i++, requests++) {
-                selector.send(new NetworkSend(node, ByteBuffer.wrap((prefix + "-" + requests).getBytes())));
-            }
-        }
-    }
-    
-    private void waitForChannelClose(String node) throws IOException {
-        boolean closed = false;
-        for (int i = 0; i < 30; i++) {
-            selector.poll(1000L);
-            if (selector.channel(node) == null) {
-                closed = true;
-                break;
-            }
-        }
-        assertTrue(closed);
-    }
-    
-    private void createEchoServer(Map<String, Object> sslServerConfigs) throws Exception {
-        server = new SslEchoServer(sslServerConfigs, "localhost");
-        server.start();
+        NetworkTestUtils.checkClientConnection(selector, node, 64000, 10);
     }
     
     private void createSelector(Map<String, Object> sslClientConfigs) {
@@ -453,34 +399,9 @@ public class SslTransportLayerTest {
         this.channelBuilder.configure(sslClientConfigs);
         this.selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
     }
-    
-    private static class CertStores {
-        
-        Map<String, Object> sslConfig;
-        
-        CertStores(boolean server) throws Exception {
-            String name = server ? "server" : "client";
-            Mode mode = server ? Mode.SERVER : Mode.CLIENT;
-            File truststoreFile = File.createTempFile(name + "TS", ".jks");
-            sslConfig = TestSslUtils.createSslConfig(!server, true, mode, truststoreFile, name);
-            sslConfig.put(SslConfigs.PRINCIPAL_BUILDER_CLASS_CONFIG, Class.forName(SslConfigs.DEFAULT_PRINCIPAL_BUILDER_CLASS));
-        }
-       
-        private Map<String, Object> getTrustingConfig(CertStores truststoreConfig) {
-            Map<String, Object> config = new HashMap<String, Object>(sslConfig);
-            config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, truststoreConfig.sslConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
-            config.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, truststoreConfig.sslConfig.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG));
-            config.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, truststoreConfig.sslConfig.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG));
-            return config;
-        }
-        
-        private Map<String, Object> getUntrustingConfig() {
-            return sslConfig;
-        }
-    }
 
     /**
-     * SSLTransportLayer with overrides for packet and application buffer size to test buffer resize
+     * SslTransportLayer with overrides for packet and application buffer size to test buffer resize
      * code path. The overridden buffer size starts with a small value and increases in size when the buffer
      * size is retrieved to handle overflow/underflow, until the actual session buffer size is reached.
      */
@@ -490,8 +411,8 @@ public class SslTransportLayerTest {
         private final ResizeableBufferSize netWriteBufSize;
         private final ResizeableBufferSize appBufSize;
 
-        public TestSslTransportLayer(String channelId, SelectionKey key, SSLEngine sslEngine,
-                                     Integer netReadBufSize, Integer netWriteBufSize, Integer appBufSize) throws IOException {
+        public TestSslTransportLayer(String channelId, SelectionKey key, SSLEngine sslEngine, 
+                Integer netReadBufSize, Integer netWriteBufSize, Integer appBufSize) throws IOException {
             super(channelId, key, sslEngine, false);
             this.netReadBufSize = new ResizeableBufferSize(netReadBufSize);
             this.netWriteBufSize = new ResizeableBufferSize(netWriteBufSize);
@@ -501,7 +422,7 @@ public class SslTransportLayerTest {
         @Override
         protected int netReadBufferSize() {
             ByteBuffer netReadBuffer = netReadBuffer();
-            // netReadBufferSize() is invoked in SSLTransportLayer.read() prior to the read
+            // netReadBufferSize() is invoked in SslTransportLayer.read() prior to the read
             // operation. To avoid the read buffer being expanded too early, increase buffer size
             // only when read buffer is full. This ensures that BUFFER_UNDERFLOW is always
             // triggered in testNetReadBufferResize().
@@ -535,117 +456,7 @@ public class SslTransportLayerTest {
             }
         }
     }
-    
-    // Non-blocking EchoServer implementation that uses SSLTransportLayer
-    private class SslEchoServer extends Thread {
-        private final int port;
-        private final ServerSocketChannel serverSocketChannel;
-        private final List<SocketChannel> newChannels;
-        private final List<SocketChannel> socketChannels;
-        private final AcceptorThread acceptorThread;
-        private SslFactory sslFactory;
-        private final Selector selector;
-        private final ConcurrentLinkedQueue<NetworkSend> inflightSends = new ConcurrentLinkedQueue<NetworkSend>();
-
-        public SslEchoServer(Map<String, ?> configs, String serverHost) throws Exception {
-            this.sslFactory = new SslFactory(Mode.SERVER);
-            this.sslFactory.configure(configs);
-            serverSocketChannel = ServerSocketChannel.open();
-            serverSocketChannel.configureBlocking(false);
-            serverSocketChannel.socket().bind(new InetSocketAddress(serverHost, 0));
-            this.port = serverSocketChannel.socket().getLocalPort();
-            this.socketChannels = Collections.synchronizedList(new ArrayList<SocketChannel>());
-            this.newChannels = Collections.synchronizedList(new ArrayList<SocketChannel>());
-            SslChannelBuilder channelBuilder = new SslChannelBuilder(Mode.SERVER);
-            channelBuilder.configure(sslServerConfigs);
-            this.selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", new LinkedHashMap<String, String>(), channelBuilder);
-            setName("echoserver");
-            setDaemon(true);
-            acceptorThread = new AcceptorThread();
-        }
-
-        @Override
-        public void run() {
-            try {
-                acceptorThread.start();
-                while (serverSocketChannel.isOpen()) {
-                    selector.poll(1000);
-                    for (SocketChannel socketChannel : newChannels) {
-                        String id = id(socketChannel);
-                        selector.register(id, socketChannel);
-                        socketChannels.add(socketChannel);
-                    }
-                    newChannels.clear();
-                    while (true) {
-                        NetworkSend send = inflightSends.peek();
-                        if (send != null && !selector.channel(send.destination()).hasSend()) {
-                            send = inflightSends.poll();
-                            selector.send(send);
-                        } else
-                            break;
-                    }
-                    List<NetworkReceive> completedReceives = selector.completedReceives();
-                    for (NetworkReceive rcv : completedReceives) {
-                        NetworkSend send = new NetworkSend(rcv.source(), rcv.payload());
-                        if (!selector.channel(send.destination()).hasSend())
-                            selector.send(send);
-                        else
-                            inflightSends.add(send);
-                    }
-                }
-            } catch (IOException e) {
-                // ignore
-            }
-        }
-        
-        private String id(SocketChannel channel) {
-            return channel.socket().getLocalAddress().getHostAddress() + ":" + channel.socket().getLocalPort() + "-" +
-                    channel.socket().getInetAddress().getHostAddress() + ":" + channel.socket().getPort();
-        }
-
-        public void closeConnections() throws IOException {
-            for (SocketChannel channel : socketChannels)
-                channel.close();
-            socketChannels.clear();
-        }
-
-        public void close() throws IOException, InterruptedException {
-            this.serverSocketChannel.close();
-            closeConnections();
-            acceptorThread.interrupt();
-            acceptorThread.join();
-            interrupt();
-            join();
-        }
-        
-        private class AcceptorThread extends Thread {
-            public AcceptorThread() throws IOException {
-                setName("acceptor");
-            }
-            public void run() {
-                try {
-
-                    java.nio.channels.Selector acceptSelector = java.nio.channels.Selector.open();
-                    serverSocketChannel.register(acceptSelector, SelectionKey.OP_ACCEPT);
-                    while (serverSocketChannel.isOpen()) {
-                        if (acceptSelector.select(1000) > 0) {
-                            Iterator<SelectionKey> it = acceptSelector.selectedKeys().iterator();
-                            while (it.hasNext()) {
-                                SelectionKey key = it.next();
-                                if (key.isAcceptable()) {
-                                    SocketChannel socketChannel = ((ServerSocketChannel) key.channel()).accept();
-                                    socketChannel.configureBlocking(false);
-                                    newChannels.add(socketChannel);
-                                    selector.wakeup();
-                                }
-                            }
-                        }
-                    }
-                } catch (IOException e) {
-                    // ignore
-                }
-            }
-        }
-    }
 
 }
+
+

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -169,6 +169,7 @@ object Defaults {
   val SslClientAuth = SslClientAuthNone
 
   /** ********* Sasl configuration ***********/
+  val SaslMechanism = SaslConfigs.DEFAULT_SASL_MECHANISM
   val SaslKerberosKinitCmd = SaslConfigs.DEFAULT_KERBEROS_KINIT_CMD
   val SaslKerberosTicketRenewWindowFactor = SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_WINDOW_FACTOR
   val SaslKerberosTicketRenewJitter = SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_JITTER
@@ -323,6 +324,7 @@ object KafkaConfig {
   val SslClientAuthProp = SslConfigs.SSL_CLIENT_AUTH_CONFIG
 
   /** ********* SASL Configuration ****************/
+  val SaslMechanismProp = SaslConfigs.SASL_MECHANISM
   val SaslKerberosServiceNameProp = SaslConfigs.SASL_KERBEROS_SERVICE_NAME
   val SaslKerberosKinitCmdProp = SaslConfigs.SASL_KERBEROS_KINIT_CMD
   val SaslKerberosTicketRenewWindowFactorProp = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR
@@ -498,6 +500,7 @@ object KafkaConfig {
   val SslClientAuthDoc = SslConfigs.SSL_CLIENT_AUTH_DOC
 
   /** ********* Sasl Configuration ****************/
+  val SaslMechanismDoc = SaslConfigs.SASL_MECHANISM_DOC
   val SaslKerberosServiceNameDoc = SaslConfigs.SASL_KERBEROS_SERVICE_NAME_DOC
   val SaslKerberosKinitCmdDoc = SaslConfigs.SASL_KERBEROS_KINIT_CMD_DOC
   val SaslKerberosTicketRenewWindowFactorDoc = SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC
@@ -662,6 +665,7 @@ object KafkaConfig {
       .define(SslCipherSuitesProp, LIST, MEDIUM, SslCipherSuitesDoc, false)
 
       /** ********* Sasl Configuration ****************/
+      .define(SaslMechanismProp, STRING, MEDIUM, SaslMechanismDoc, false)
       .define(SaslKerberosServiceNameProp, STRING, MEDIUM, SaslKerberosServiceNameDoc, false)
       .define(SaslKerberosKinitCmdProp, STRING, Defaults.SaslKerberosKinitCmd, MEDIUM, SaslKerberosKinitCmdDoc)
       .define(SaslKerberosTicketRenewWindowFactorProp, DOUBLE, Defaults.SaslKerberosTicketRenewWindowFactor, MEDIUM, SaslKerberosTicketRenewWindowFactorDoc)
@@ -831,6 +835,7 @@ case class KafkaConfig (props: java.util.Map[_, _]) extends AbstractConfig(Kafka
   val sslCipher = getList(KafkaConfig.SslCipherSuitesProp)
 
   /** ********* Sasl Configuration **************/
+  val saslMechanism = getString(KafkaConfig.SaslMechanismProp)
   val saslKerberosServiceName = getString(KafkaConfig.SaslKerberosServiceNameProp)
   val saslKerberosKinitCmd = getString(KafkaConfig.SaslKerberosKinitCmdProp)
   val saslKerberosTicketRenewWindowFactor = getDouble(KafkaConfig.SaslKerberosTicketRenewWindowFactorProp)

--- a/core/src/test/resources/kafka_saslplain_jaas.conf
+++ b/core/src/test/resources/kafka_saslplain_jaas.conf
@@ -1,0 +1,25 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  */
+KafkaClient {
+	org.apache.kafka.common.security.plain.PlainLoginModule required
+	username="client"
+	password="clientpassword";
+};
+
+KafkaServer {
+	org.apache.kafka.common.security.plain.PlainLoginModule required
+	username="server"
+	password="serverpassword"
+	user_server="serverpassword"
+	user_client="clientpassword";
+};

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -38,7 +38,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
     val numServers = 2
     overridingProps.put(KafkaConfig.NumPartitionsProp, 4.toString)
     TestUtils.createBrokerConfigs(numServers, zkConnect, false, interBrokerSecurityProtocol = Some(securityProtocol),
-      trustStoreFile = trustStoreFile).map(KafkaConfig.fromProps(_, overridingProps))
+      trustStoreFile = trustStoreFile, saslMechanism = saslMechanism).map(KafkaConfig.fromProps(_, overridingProps))
   }
 
   private var consumer1: SimpleConsumer = null
@@ -65,7 +65,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
   }
 
   private def createProducer(brokerList: String, retries: Int = 0, lingerMs: Long = 0, props: Option[Properties] = None): KafkaProducer[Array[Byte],Array[Byte]] =
-    TestUtils.createNewProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
+    TestUtils.createNewProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile, saslMechanism = saslMechanism,
       retries = retries, lingerMs = lingerMs, props = props)
 
   /**

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -46,7 +46,7 @@ trait IntegrationTestHarness extends KafkaServerTestHarness {
 
   override def generateConfigs() = {
     val cfgs = TestUtils.createBrokerConfigs(serverCount, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
-      trustStoreFile = trustStoreFile)
+      trustStoreFile = trustStoreFile, saslMechanism = saslMechanism)
     cfgs.foreach(_.putAll(serverConfig))
     cfgs.map(KafkaConfig.fromProps)
   }
@@ -57,11 +57,11 @@ trait IntegrationTestHarness extends KafkaServerTestHarness {
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArraySerializer])
     producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArraySerializer])
-    producerConfig.putAll(TestUtils.producerSecurityConfigs(securityProtocol, trustStoreFile))
+    producerConfig.putAll(TestUtils.producerSecurityConfigs(securityProtocol, trustStoreFile, saslMechanism))
     consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArrayDeserializer])
     consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArrayDeserializer])
-    consumerConfig.putAll(TestUtils.consumerSecurityConfigs(securityProtocol, trustStoreFile))
+    consumerConfig.putAll(TestUtils.consumerSecurityConfigs(securityProtocol, trustStoreFile, saslMechanism))
     for (i <- 0 until producerCount)
       producers += new KafkaProducer(producerConfig)
     for (i <- 0 until consumerCount) {

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslConsumerTest.scala
@@ -1,0 +1,48 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  */
+package kafka.api
+
+import java.io.File
+import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.JaasUtils
+import org.junit.After
+import org.junit.Before
+import javax.security.auth.login.Configuration
+import org.apache.kafka.common.config.SaslConfigs
+import kafka.zk.ZooKeeperTestHarness
+
+class SaslPlainSslConsumerTest extends BaseConsumerTest with ZooKeeperTestHarness {
+  override protected def securityProtocol = SecurityProtocol.SASL_SSL
+  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))    
+  this.serverConfig.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN") 
+  
+  @Before
+  override def setUp() {
+    // Clean-up global configuration set by other tests
+    Configuration.setConfiguration(null)
+    val jaasFileUrl = Thread.currentThread().getContextClassLoader.getResource("kafka_saslplain_jaas.conf")
+    if (jaasFileUrl == null)
+      throw new IllegalStateException("Could not load `kafka_saslplain_jaas.conf`, make sure it is in the classpath")
+    System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, jaasFileUrl.getPath)
+    super.setUp
+    this.producerConfig.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN")
+    this.consumerConfig.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN")
+  }
+
+  @After
+  override def tearDown() {
+    super.tearDown
+    System.clearProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)
+    Configuration.setConfiguration(null)
+  }
+}

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslConsumerTest.scala
@@ -20,11 +20,12 @@ import org.junit.Before
 import javax.security.auth.login.Configuration
 import org.apache.kafka.common.config.SaslConfigs
 import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslPlainSslConsumerTest extends BaseConsumerTest with ZooKeeperTestHarness {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))    
-  this.serverConfig.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN") 
+  override protected def saslMechanism = Some(SaslMechanism.PLAIN)
   
   @Before
   override def setUp() {
@@ -35,8 +36,6 @@ class SaslPlainSslConsumerTest extends BaseConsumerTest with ZooKeeperTestHarnes
       throw new IllegalStateException("Could not load `kafka_saslplain_jaas.conf`, make sure it is in the classpath")
     System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, jaasFileUrl.getPath)
     super.setUp
-    this.producerConfig.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN")
-    this.consumerConfig.setProperty(SaslConfigs.SASL_MECHANISM, "PLAIN")
   }
 
   @After

--- a/core/src/test/scala/integration/kafka/api/SaslPlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlaintextConsumerTest.scala
@@ -13,7 +13,9 @@
 package kafka.api
 
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslPlaintextConsumerTest extends BaseConsumerTest with SaslTestHarness {
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
+  override protected def saslMechanism = Some(SaslMechanism.GSSAPI)
 }

--- a/core/src/test/scala/integration/kafka/api/SaslSslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslConsumerTest.scala
@@ -13,10 +13,11 @@
 package kafka.api
 
 import java.io.File
-
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslSslConsumerTest extends BaseConsumerTest with SaslTestHarness {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  override protected def saslMechanism = Some(SaslMechanism.GSSAPI)
 }

--- a/core/src/test/scala/integration/kafka/api/SaslTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslTestHarness.scala
@@ -19,7 +19,7 @@ import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.hadoop.minikdc.MiniKdc
 import org.apache.kafka.common.security.JaasUtils
-import org.apache.kafka.common.security.kerberos.LoginManager
+import org.apache.kafka.common.security.authenticator.LoginManager
 import org.junit.{After, Before}
 
 trait SaslTestHarness extends ZooKeeperTestHarness {

--- a/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
@@ -19,7 +19,6 @@ package kafka.integration
 
 import java.io.File
 import java.nio.ByteBuffer
-
 import kafka.admin.AdminUtils
 import kafka.api.{TopicMetadataRequest, TopicMetadataResponse}
 import kafka.client.ClientUtils
@@ -32,6 +31,7 @@ import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.junit.Assert._
 import org.junit.{Test, After, Before}
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 abstract class BaseTopicMetadataTest extends ZooKeeperTestHarness {
   private var server1: KafkaServer = null
@@ -42,12 +42,13 @@ abstract class BaseTopicMetadataTest extends ZooKeeperTestHarness {
   // This should be defined if `securityProtocol` uses SSL (eg SSL, SASL_SSL)
   protected def trustStoreFile: Option[File]
   protected def securityProtocol: SecurityProtocol
+  protected def saslMechanism: Option[SaslMechanism]
 
   @Before
   override def setUp() {
     super.setUp()
     val props = createBrokerConfigs(numConfigs, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
-      trustStoreFile = trustStoreFile)
+      trustStoreFile = trustStoreFile, saslMechanism = saslMechanism)
     val configs: Seq[KafkaConfig] = props.map(KafkaConfig.fromProps)
     adHocConfigs = configs.takeRight(configs.size - 1) // Started and stopped by individual test cases
     server1 = TestUtils.createServer(configs.head)

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -19,15 +19,14 @@ package kafka.integration
 
 import java.io.File
 import java.util.Arrays
-
 import kafka.common.KafkaException
 import kafka.server._
 import kafka.utils.{CoreUtils, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.junit.{After, Before}
-
 import scala.collection.mutable.Buffer
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 /**
  * A test harness that brings up some number of broker nodes
@@ -54,6 +53,7 @@ trait KafkaServerTestHarness extends ZooKeeperTestHarness {
 
   protected def securityProtocol: SecurityProtocol = SecurityProtocol.PLAINTEXT
   protected def trustStoreFile: Option[File] = None
+  protected def saslMechanism: Option[SaslMechanism] = None
 
   @Before
   override def setUp() {

--- a/core/src/test/scala/unit/kafka/integration/PlaintextTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/PlaintextTopicMetadataTest.scala
@@ -22,5 +22,6 @@ import org.apache.kafka.common.protocol.SecurityProtocol
 class PlaintextTopicMetadataTest extends BaseTopicMetadataTest {
   protected def securityProtocol = SecurityProtocol.PLAINTEXT
   protected def trustStoreFile = None
+  protected def saslMechanism = None
 }
 

--- a/core/src/test/scala/unit/kafka/integration/SaslPlaintextTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/SaslPlaintextTopicMetadataTest.scala
@@ -19,8 +19,10 @@ package kafka.integration
 
 import kafka.api.SaslTestHarness
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslPlaintextTopicMetadataTest extends BaseTopicMetadataTest with SaslTestHarness {
   protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
   protected def trustStoreFile = None
+  protected def saslMechanism = Some(SaslMechanism.GSSAPI)
 }

--- a/core/src/test/scala/unit/kafka/integration/SaslSslTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/SaslSslTopicMetadataTest.scala
@@ -18,11 +18,12 @@
 package kafka.integration
 
 import java.io.File
-
 import kafka.api.SaslTestHarness
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslSslTopicMetadataTest extends BaseTopicMetadataTest with SaslTestHarness {
   protected def securityProtocol = SecurityProtocol.SASL_SSL
   protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  protected def saslMechanism = Some(SaslMechanism.GSSAPI)
 }

--- a/core/src/test/scala/unit/kafka/integration/SslTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/SslTopicMetadataTest.scala
@@ -24,4 +24,5 @@ import org.apache.kafka.common.protocol.SecurityProtocol
 class SslTopicMetadataTest extends BaseTopicMetadataTest {
   protected def securityProtocol = SecurityProtocol.SSL
   protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  protected def saslMechanism = None
 }

--- a/core/src/test/scala/unit/kafka/server/BaseReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseReplicaFetchTest.scala
@@ -18,7 +18,6 @@
 package kafka.server
 
 import java.io.File
-
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.junit.{Test, After, Before}
 import kafka.zk.ZooKeeperTestHarness
@@ -27,6 +26,7 @@ import kafka.producer.KeyedMessage
 import kafka.serializer.StringEncoder
 import kafka.utils.{TestUtils}
 import kafka.common._
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 abstract class BaseReplicaFetchTest extends ZooKeeperTestHarness  {
   var brokers: Seq[KafkaServer] = null
@@ -36,12 +36,13 @@ abstract class BaseReplicaFetchTest extends ZooKeeperTestHarness  {
   // This should be defined if `securityProtocol` uses SSL (eg SSL, SASL_SSL)
   protected def trustStoreFile: Option[File]
   protected def securityProtocol: SecurityProtocol
+  protected def saslMechanism: Option[SaslMechanism]
 
   @Before
   override def setUp() {
     super.setUp()
     val props = createBrokerConfigs(2, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
-      trustStoreFile = trustStoreFile)
+      trustStoreFile = trustStoreFile, saslMechanism = saslMechanism)
     brokers = props.map(KafkaConfig.fromProps).map(TestUtils.createServer(_))
   }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -508,6 +508,7 @@ class KafkaConfigTest {
         case KafkaConfig.SslCipherSuitesProp => // ignore string
 
         //Sasl Configs
+        case KafkaConfig.SaslMechanismProp => // ignore string
         case KafkaConfig.SaslKerberosServiceNameProp => // ignore string
         case KafkaConfig.SaslKerberosKinitCmdProp =>
         case KafkaConfig.SaslKerberosTicketRenewWindowFactorProp =>

--- a/core/src/test/scala/unit/kafka/server/PlaintextReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/PlaintextReplicaFetchTest.scala
@@ -22,4 +22,5 @@ import org.apache.kafka.common.protocol.SecurityProtocol
 class PlaintextReplicaFetchTest extends BaseReplicaFetchTest {
   protected def securityProtocol = SecurityProtocol.PLAINTEXT
   protected def trustStoreFile = None
+  protected def saslMechanism = None
 }

--- a/core/src/test/scala/unit/kafka/server/SaslPlaintextReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslPlaintextReplicaFetchTest.scala
@@ -19,8 +19,10 @@ package kafka.server
 
 import kafka.api.SaslTestHarness
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslPlaintextReplicaFetchTest extends BaseReplicaFetchTest with SaslTestHarness {
   protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
   protected def trustStoreFile = None
+  protected def saslMechanism = Some(SaslMechanism.GSSAPI)
 }

--- a/core/src/test/scala/unit/kafka/server/SaslSslReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslSslReplicaFetchTest.scala
@@ -18,11 +18,12 @@
 package kafka.server
 
 import java.io.File
-
 import kafka.api.SaslTestHarness
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SaslSslReplicaFetchTest extends BaseReplicaFetchTest with SaslTestHarness {
   protected def securityProtocol = SecurityProtocol.SASL_SSL
   protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  protected def saslMechanism = Some(SaslMechanism.GSSAPI)
 }

--- a/core/src/test/scala/unit/kafka/server/SslReplicaFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SslReplicaFetchTest.scala
@@ -18,10 +18,11 @@
 package kafka.server
 
 import java.io.File
-
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.security.authenticator.SaslMechanism
 
 class SslReplicaFetchTest extends BaseReplicaFetchTest {
   protected def securityProtocol = SecurityProtocol.SSL
   protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+  protected def saslMechanism = None
 }


### PR DESCRIPTION
Implementation and unit tests for SASL/PLAIN. A simple login module and SaslServer implementation for PLAIN mechanism are included in the implementation, but these can be replaced to integrate with authentication servers.
