### PR TITLE
MINOR: Restore `SslConsumerTest` which was accidentally deleted in client-side assignment commit

### DIFF
--- a/core/src/test/scala/integration/kafka/api/SslConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslConsumerTest.scala
@@ -1,0 +1,22 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  */
+package kafka.api
+
+import java.io.File
+
+import org.apache.kafka.common.protocol.SecurityProtocol
+
+class SslConsumerTest extends BaseConsumerTest {
+  override protected def securityProtocol = SecurityProtocol.SSL
+  override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+}


### PR DESCRIPTION
Probably happened while resolving conflicts, commit: 86eb74d9236c586af5889fe79f4b9e066c9c2af3
