### PR TITLE
MINOR: Add new build target for system test libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,8 @@ subprojects {
 
   task docsJar(dependsOn: javadocJar)
 
+  task systemTestLibs(dependsOn: jar)
+
   artifacts {
     archives srcJar
     archives javadocJar

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,7 @@ https://cwiki.apache.org/confluence/display/KAFKA/tutorial+-+set+up+and+run+Kafk
        
         $ git checkout $BRANCH
         $ gradle  # (only if necessary)
-        $ ./gradlew jar
+        $ ./gradlew systemTestLibs
      
 * Run the system tests using ducktape:
 


### PR DESCRIPTION
KAFKA-2644 adds MiniKdc for system tests and hence needs a target to collect all MiniKdc jars. At the moment, system tests run `gradlew jar`. Replacing that with `gradlew systemTestLibs` will enable kafka jars and test dependency jars to be built and copied into appropriate locations. Submitting this as a separate PR so that the new target can be added to the build scripts that run system tests before KAFKA-2644 is committed. A separate target for system test artifacts will allow dependency changes to be made in future without breaking test runs.
