### PR TITLE
MINOR: Expose ReplicaManager gauges

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -122,7 +122,7 @@ class ReplicaManager(val config: KafkaConfig,
   val delayedFetchPurgatory = new DelayedOperationPurgatory[DelayedFetch](
     purgatoryName = "Fetch", config.brokerId, config.fetchPurgatoryPurgeIntervalRequests)
 
-  newGauge(
+  val leaderCount = newGauge(
     "LeaderCount",
     new Gauge[Int] {
       def value = {
@@ -130,13 +130,13 @@ class ReplicaManager(val config: KafkaConfig,
       }
     }
   )
-  newGauge(
+  val partitionCount = newGauge(
     "PartitionCount",
     new Gauge[Int] {
       def value = allPartitions.size
     }
   )
-  newGauge(
+  val underReplicatedPartitions = newGauge(
     "UnderReplicatedPartitions",
     new Gauge[Int] {
       def value = underReplicatedPartitionCount()


### PR DESCRIPTION
There are several gauges in core that are registered but cannot be accessed programmatically. For example, gauges "LeaderCount", "PartitionCount", "UnderReplicatedParittions" are all registered in ReplicaManager.scala but there is no way to access them programmatically if one has access to the kafka.server object. Other metrics,  such as isrExpandRate (also in ReplicaManager.scala) can be accessed. The solution here is trivial, add a var <variable name> in front of newGauge, as shown below
val partitionCount newGauge(
     "PartitionCount",
     new Gauge[Int] {
       def value = allPartitions.size
     }
)
