### PR TITLE
KAFKA-2694: Task Id

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SlidingWindowSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SlidingWindowSupplier.java
@@ -83,7 +83,7 @@ public class SlidingWindowSupplier<K, V> implements WindowSupplier<K, V> {
         @Override
         public void init(ProcessorContext context) {
             this.context = context;
-            this.partition = context.id();
+            this.partition = context.id().partition;
             SlidingWindowRegistryCallback restoreFunc = new SlidingWindowRegistryCallback();
             context.register(this, restoreFunc);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
@@ -35,7 +35,7 @@ public class DefaultPartitionGrouper extends PartitionGrouper {
         Map<TaskId, Set<TopicPartition>> groups = new HashMap<>();
 
         for (Map.Entry<Integer, Set<String>> entry : topicGroups.entrySet()) {
-            Integer taskGroupId = entry.getKey();
+            Integer topicGroupId = entry.getKey();
             Set<String> topicGroup = entry.getValue();
 
             int maxNumPartitions = maxNumPartitions(metadata, topicGroup);
@@ -48,7 +48,7 @@ public class DefaultPartitionGrouper extends PartitionGrouper {
                         group.add(new TopicPartition(topic, partitionId));
                     }
                 }
-                groups.put(new TaskId(taskGroupId, partitionId), Collections.unmodifiableSet(group));
+                groups.put(new TaskId(topicGroupId, partitionId), Collections.unmodifiableSet(group));
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/PartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/PartitionGrouper.java
@@ -21,14 +21,12 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.internals.KafkaStreamingPartitionAssignor;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public abstract class PartitionGrouper {
 
-    protected Collection<Set<String>> topicGroups;
+    protected Map<Integer, Set<String>> topicGroups;
 
     private KafkaStreamingPartitionAssignor partitionAssignor = null;
 
@@ -38,9 +36,9 @@ public abstract class PartitionGrouper {
      * @param metadata
      * @return a map of task ids to groups of partitions
      */
-    public abstract Map<Integer, List<TopicPartition>> partitionGroups(Cluster metadata);
+    public abstract Map<TaskId, Set<TopicPartition>> partitionGroups(Cluster metadata);
 
-    public void topicGroups(Collection<Set<String>> topicGroups) {
+    public void topicGroups(Map<Integer, Set<String>> topicGroups) {
         this.topicGroups = topicGroups;
     }
 
@@ -48,7 +46,7 @@ public abstract class PartitionGrouper {
         this.partitionAssignor = partitionAssignor;
     }
 
-    public Set<Integer> taskIds(TopicPartition partition) {
+    public Set<TaskId> taskIds(TopicPartition partition) {
         return partitionAssignor.taskIds(partition);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -30,7 +30,7 @@ public interface ProcessorContext {
      *
      * @return the task id
      */
-    int id();
+    TaskId id();
 
     /**
      * Returns the key serializer

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -19,16 +19,16 @@ package org.apache.kafka.streams.processor;
 
 public class TaskId {
 
-    public final int taskGroupId;
+    public final int topicGroupId;
     public final int partition;
 
-    public TaskId(int taskGroupId, int partition) {
-        this.taskGroupId = taskGroupId;
+    public TaskId(int topicGroupId, int partition) {
+        this.topicGroupId = topicGroupId;
         this.partition = partition;
     }
 
     public String toString() {
-        return taskGroupId + "_" + partition;
+        return topicGroupId + "_" + partition;
     }
 
     public static TaskId parse(String string) {
@@ -36,10 +36,10 @@ public class TaskId {
         if (index <= 0 || index + 1 >= string.length()) throw new TaskIdFormatException();
 
         try {
-            int taskGroupId = Integer.parseInt(string.substring(0, index));
+            int topicGroupId = Integer.parseInt(string.substring(0, index));
             int partition = Integer.parseInt(string.substring(index + 1));
 
-            return new TaskId(taskGroupId, partition);
+            return new TaskId(topicGroupId, partition);
         } catch (Exception e) {
             throw new TaskIdFormatException();
         }
@@ -49,7 +49,7 @@ public class TaskId {
     public boolean equals(Object o) {
         if (o instanceof TaskId) {
             TaskId other = (TaskId) o;
-            return other.taskGroupId == this.taskGroupId && other.partition == this.partition;
+            return other.topicGroupId == this.topicGroupId && other.partition == this.partition;
         } else {
             return false;
         }
@@ -57,7 +57,7 @@ public class TaskId {
 
     @Override
     public int hashCode() {
-        long n = ((long) taskGroupId << 32) | (long) partition;
+        long n = ((long) topicGroupId << 32) | (long) partition;
         return (int) (n % 0xFFFFFFFFL);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskId.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor;
+
+public class TaskId {
+
+    public final int taskGroupId;
+    public final int partition;
+
+    public TaskId(int taskGroupId, int partition) {
+        this.taskGroupId = taskGroupId;
+        this.partition = partition;
+    }
+
+    public String toString() {
+        return taskGroupId + "_" + partition;
+    }
+
+    public static TaskId parse(String string) {
+        int index = string.indexOf('_');
+        if (index <= 0 || index + 1 >= string.length()) throw new TaskIdFormatException();
+
+        try {
+            int taskGroupId = Integer.parseInt(string.substring(0, index));
+            int partition = Integer.parseInt(string.substring(index + 1));
+
+            return new TaskId(taskGroupId, partition);
+        } catch (Exception e) {
+            throw new TaskIdFormatException();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof TaskId) {
+            TaskId other = (TaskId) o;
+            return other.taskGroupId == this.taskGroupId && other.partition == this.partition;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        long n = ((long) taskGroupId << 32) | (long) partition;
+        return (int) (n % 0xFFFFFFFFL);
+    }
+
+    public static class TaskIdFormatException extends RuntimeException {
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -265,7 +265,7 @@ public class TopologyBuilder {
 
         if (nodeGroups == null) {
             nodeGroups = nodeGroups();
-        } else if (nodeGroups.equals(nodeGroups())) {
+        } else if (!nodeGroups.equals(nodeGroups())) {
             throw new TopologyException("topology has mutated");
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/KafkaStreamingPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/KafkaStreamingPartitionAssignor.java
@@ -90,7 +90,7 @@ public class KafkaStreamingPartitionAssignor implements PartitionAssignor, Confi
             buf.putInt(1);
             // encode task ids
             for (TaskId id : ids) {
-                buf.putInt(id.taskGroupId);
+                buf.putInt(id.topicGroupId);
                 buf.putInt(id.partition);
             }
             buf.rewind();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/KafkaStreamingPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/KafkaStreamingPartitionAssignor.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.StreamingConfig;
 import org.apache.kafka.streams.processor.PartitionGrouper;
+import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,7 @@ public class KafkaStreamingPartitionAssignor implements PartitionAssignor, Confi
     private static final Logger log = LoggerFactory.getLogger(KafkaStreamingPartitionAssignor.class);
 
     private PartitionGrouper partitionGrouper;
-    private Map<TopicPartition, Set<Integer>> partitionToTaskIds;
+    private Map<TopicPartition, Set<TaskId>> partitionToTaskIds;
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -67,29 +68,30 @@ public class KafkaStreamingPartitionAssignor implements PartitionAssignor, Confi
 
     @Override
     public Map<String, Assignment> assign(Cluster metadata, Map<String, Subscription> subscriptions) {
-        Map<Integer, List<TopicPartition>> partitionGroups = partitionGrouper.partitionGroups(metadata);
+        Map<TaskId, Set<TopicPartition>> partitionGroups = partitionGrouper.partitionGroups(metadata);
 
         String[] clientIds = subscriptions.keySet().toArray(new String[subscriptions.size()]);
-        Integer[] taskIds = partitionGroups.keySet().toArray(new Integer[partitionGroups.size()]);
+        TaskId[] taskIds = partitionGroups.keySet().toArray(new TaskId[partitionGroups.size()]);
 
         Map<String, Assignment> assignment = new HashMap<>();
 
         for (int i = 0; i < clientIds.length; i++) {
             List<TopicPartition> partitions = new ArrayList<>();
-            List<Integer> ids = new ArrayList<>();
+            List<TaskId> ids = new ArrayList<>();
             for (int j = i; j < taskIds.length; j += clientIds.length) {
-                Integer taskId = taskIds[j];
+                TaskId taskId = taskIds[j];
                 for (TopicPartition partition : partitionGroups.get(taskId)) {
                     partitions.add(partition);
                     ids.add(taskId);
                 }
             }
-            ByteBuffer buf = ByteBuffer.allocate(4 + ids.size() * 4);
+            ByteBuffer buf = ByteBuffer.allocate(4 + ids.size() * 8);
             //version
             buf.putInt(1);
             // encode task ids
-            for (Integer id : ids) {
-                buf.putInt(id);
+            for (TaskId id : ids) {
+                buf.putInt(id.taskGroupId);
+                buf.putInt(id.partition);
             }
             buf.rewind();
             assignment.put(clientIds[i], new Assignment(partitions, buf));
@@ -104,19 +106,19 @@ public class KafkaStreamingPartitionAssignor implements PartitionAssignor, Confi
         ByteBuffer data = assignment.userData();
         data.rewind();
 
-        Map<TopicPartition, Set<Integer>> partitionToTaskIds = new HashMap<>();
+        Map<TopicPartition, Set<TaskId>> partitionToTaskIds = new HashMap<>();
 
         // check version
         int version = data.getInt();
         if (version == 1) {
             for (TopicPartition partition : partitions) {
-                Set<Integer> taskIds = partitionToTaskIds.get(partition);
+                Set<TaskId> taskIds = partitionToTaskIds.get(partition);
                 if (taskIds == null) {
                     taskIds = new HashSet<>();
                     partitionToTaskIds.put(partition, taskIds);
                 }
                 // decode a task id
-                taskIds.add(data.getInt());
+                taskIds.add(new TaskId(data.getInt(), data.getInt()));
             }
         } else {
             KafkaException ex = new KafkaException("unknown assignment data version: " + version);
@@ -126,7 +128,7 @@ public class KafkaStreamingPartitionAssignor implements PartitionAssignor, Confi
         this.partitionToTaskIds = partitionToTaskIds;
     }
 
-    public Set<Integer> taskIds(TopicPartition partition) {
+    public Set<TaskId> taskIds(TopicPartition partition) {
         return partitionToTaskIds.get(partition);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -25,8 +25,8 @@ import org.apache.kafka.streams.StreamingMetrics;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
-
 import org.apache.kafka.streams.processor.TaskId;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 
+import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
 
     private static final Logger log = LoggerFactory.getLogger(ProcessorContextImpl.class);
 
-    private final int id;
+    private final TaskId id;
     private final StreamTask task;
     private final StreamingMetrics metrics;
     private final RecordCollector collector;
@@ -49,7 +50,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
     private boolean initialized;
 
     @SuppressWarnings("unchecked")
-    public ProcessorContextImpl(int id,
+    public ProcessorContextImpl(TaskId id,
                                 StreamTask task,
                                 StreamingConfig config,
                                 RecordCollector collector,
@@ -78,8 +79,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
         this.initialized = true;
     }
 
-    @Override
-    public int id() {
+    public TaskId id() {
         return id;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.StreamingConfig;
 import org.apache.kafka.streams.StreamingMetrics;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,7 @@ public class StreamTask implements Punctuator {
 
     private static final Logger log = LoggerFactory.getLogger(StreamTask.class);
 
-    private final int id;
+    private final TaskId id;
     private final int maxBufferedSize;
 
     private final Consumer consumer;
@@ -78,7 +79,7 @@ public class StreamTask implements Punctuator {
      * @param config                the {@link StreamingConfig} specified by the user
      * @param metrics               the {@link StreamingMetrics} created by the thread
      */
-    public StreamTask(int id,
+    public StreamTask(TaskId id,
                       Consumer<byte[], byte[]> consumer,
                       Producer<byte[], byte[]> producer,
                       Consumer<byte[], byte[]> restoreConsumer,
@@ -116,8 +117,8 @@ public class StreamTask implements Punctuator {
 
         // create the processor state manager
         try {
-            File stateFile = new File(config.getString(StreamingConfig.STATE_DIR_CONFIG), Integer.toString(id));
-            this.stateMgr = new ProcessorStateManager(id, stateFile, restoreConsumer);
+            File stateFile = new File(config.getString(StreamingConfig.STATE_DIR_CONFIG), id.toString());
+            this.stateMgr = new ProcessorStateManager(id.partition, stateFile, restoreConsumer);
         } catch (IOException e) {
             throw new KafkaException("Error while creating the state manager", e);
         }
@@ -138,7 +139,7 @@ public class StreamTask implements Punctuator {
         this.processorContext.initialized();
     }
 
-    public int id() {
+    public TaskId id() {
         return id;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/MeteredKeyValueStore.java
@@ -73,7 +73,7 @@ public class MeteredKeyValueStore<K, V> implements KeyValueStore<K, V> {
         this.restoreTime = this.metrics.addLatencySensor(metricGrp, name, "restore", "store-name", name);
 
         this.topic = name;
-        this.partition = context.id();
+        this.partition = context.id().partition;
 
         this.context = context;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBKeyValueStore.java
@@ -81,7 +81,7 @@ public class RocksDBKeyValueStore<K, V> extends MeteredKeyValueStore<K, V> {
 
         public RocksDBStore(String name, ProcessorContext context, Serdes<K, V> serdes) {
             this.topic = name;
-            this.partition = context.id();
+            this.partition = context.id().partition;
             this.context = context;
             this.serdes = serdes;
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/DefaultPartitionGrouperTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/DefaultPartitionGrouperTest.java
@@ -47,7 +47,7 @@ public class DefaultPartitionGrouperTest {
     @Test
     public void testGrouping() {
         PartitionGrouper grouper = new DefaultPartitionGrouper();
-        int taskGroupId;
+        int topicGroupId;
         Map<TaskId, Set<TopicPartition>> expected;
         Map<Integer, Set<String>> topicGroups;
 
@@ -57,13 +57,13 @@ public class DefaultPartitionGrouperTest {
         grouper.topicGroups(topicGroups);
 
         expected = new HashMap<>();
-        taskGroupId = 0;
-        expected.put(new TaskId(taskGroupId, 0), mkSet(new TopicPartition("topic1", 0)));
-        expected.put(new TaskId(taskGroupId, 1), mkSet(new TopicPartition("topic1", 1)));
-        expected.put(new TaskId(taskGroupId, 2), mkSet(new TopicPartition("topic1", 2)));
-        taskGroupId++;
-        expected.put(new TaskId(taskGroupId, 0), mkSet(new TopicPartition("topic2", 0)));
-        expected.put(new TaskId(taskGroupId, 1), mkSet(new TopicPartition("topic2", 1)));
+        topicGroupId = 0;
+        expected.put(new TaskId(topicGroupId, 0), mkSet(new TopicPartition("topic1", 0)));
+        expected.put(new TaskId(topicGroupId, 1), mkSet(new TopicPartition("topic1", 1)));
+        expected.put(new TaskId(topicGroupId, 2), mkSet(new TopicPartition("topic1", 2)));
+        topicGroupId++;
+        expected.put(new TaskId(topicGroupId, 0), mkSet(new TopicPartition("topic2", 0)));
+        expected.put(new TaskId(topicGroupId, 1), mkSet(new TopicPartition("topic2", 1)));
 
         assertEquals(expected, grouper.partitionGroups(metadata));
 
@@ -72,10 +72,10 @@ public class DefaultPartitionGrouperTest {
         grouper.topicGroups(topicGroups);
 
         expected = new HashMap<>();
-        taskGroupId = 0;
-        expected.put(new TaskId(taskGroupId, 0), mkSet(new TopicPartition("topic1", 0), new TopicPartition("topic2", 0)));
-        expected.put(new TaskId(taskGroupId, 1), mkSet(new TopicPartition("topic1", 1), new TopicPartition("topic2", 1)));
-        expected.put(new TaskId(taskGroupId, 2), mkSet(new TopicPartition("topic1", 2)));
+        topicGroupId = 0;
+        expected.put(new TaskId(topicGroupId, 0), mkSet(new TopicPartition("topic1", 0), new TopicPartition("topic2", 0)));
+        expected.put(new TaskId(topicGroupId, 1), mkSet(new TopicPartition("topic1", 1), new TopicPartition("topic2", 1)));
+        expected.put(new TaskId(topicGroupId, 2), mkSet(new TopicPartition("topic1", 2)));
 
         assertEquals(expected, grouper.partitionGroups(metadata));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/DefaultPartitionGrouperTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/DefaultPartitionGrouperTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import static org.apache.kafka.common.utils.Utils.mkList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import org.junit.Test;
 
@@ -29,6 +28,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,28 +47,35 @@ public class DefaultPartitionGrouperTest {
     @Test
     public void testGrouping() {
         PartitionGrouper grouper = new DefaultPartitionGrouper();
-        int taskId;
-        Map<Integer, List<TopicPartition>> expected;
+        int taskGroupId;
+        Map<TaskId, Set<TopicPartition>> expected;
+        Map<Integer, Set<String>> topicGroups;
 
-        grouper.topicGroups(mkList(mkSet("topic1"), mkSet("topic2")));
+        topicGroups = new HashMap<>();
+        topicGroups.put(0, mkSet("topic1"));
+        topicGroups.put(1, mkSet("topic2"));
+        grouper.topicGroups(topicGroups);
 
         expected = new HashMap<>();
-        taskId = 0;
-        expected.put(taskId++, mkList(new TopicPartition("topic1", 0)));
-        expected.put(taskId++, mkList(new TopicPartition("topic1", 1)));
-        expected.put(taskId++, mkList(new TopicPartition("topic1", 2)));
-        expected.put(taskId++, mkList(new TopicPartition("topic2", 0)));
-        expected.put(taskId,   mkList(new TopicPartition("topic2", 1)));
+        taskGroupId = 0;
+        expected.put(new TaskId(taskGroupId, 0), mkSet(new TopicPartition("topic1", 0)));
+        expected.put(new TaskId(taskGroupId, 1), mkSet(new TopicPartition("topic1", 1)));
+        expected.put(new TaskId(taskGroupId, 2), mkSet(new TopicPartition("topic1", 2)));
+        taskGroupId++;
+        expected.put(new TaskId(taskGroupId, 0), mkSet(new TopicPartition("topic2", 0)));
+        expected.put(new TaskId(taskGroupId, 1), mkSet(new TopicPartition("topic2", 1)));
 
         assertEquals(expected, grouper.partitionGroups(metadata));
 
-        grouper.topicGroups(mkList(mkSet("topic1", "topic2")));
+        topicGroups = new HashMap<>();
+        topicGroups.put(0, mkSet("topic1", "topic2"));
+        grouper.topicGroups(topicGroups);
 
         expected = new HashMap<>();
-        taskId = 0;
-        expected.put(taskId++, mkList(new TopicPartition("topic1", 0), new TopicPartition("topic2", 0)));
-        expected.put(taskId++, mkList(new TopicPartition("topic1", 1), new TopicPartition("topic2", 1)));
-        expected.put(taskId,   mkList(new TopicPartition("topic1", 2)));
+        taskGroupId = 0;
+        expected.put(new TaskId(taskGroupId, 0), mkSet(new TopicPartition("topic1", 0), new TopicPartition("topic2", 0)));
+        expected.put(new TaskId(taskGroupId, 1), mkSet(new TopicPartition("topic1", 1), new TopicPartition("topic2", 1)));
+        expected.put(new TaskId(taskGroupId, 2), mkSet(new TopicPartition("topic1", 2)));
 
         assertEquals(expected, grouper.partitionGroups(metadata));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -25,8 +25,10 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TopologyBuilderTest {
@@ -121,14 +123,27 @@ public class TopologyBuilderTest {
 
         builder.addProcessor("processor-3", new MockProcessorSupplier(), "source-3", "source-4");
 
-        Collection<Set<String>> topicGroups = builder.topicGroups();
+        Map<Integer, Set<String>> topicGroups = builder.topicGroups();
+
+        Map<Integer, Set<String>> expectedTopicGroups = new HashMap<>();
+        expectedTopicGroups.put(0, set("topic-1", "topic-1x", "topic-2"));
+        expectedTopicGroups.put(1, set("topic-3", "topic-4"));
+        expectedTopicGroups.put(2, set("topic-5"));
 
         assertEquals(3, topicGroups.size());
-        assertEquals(mkSet(mkSet("topic-1", "topic-1x", "topic-2"), mkSet("topic-3", "topic-4"), mkSet("topic-5")), new HashSet<>(topicGroups));
+        assertEquals(expectedTopicGroups, topicGroups);
 
         Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
 
         assertEquals(mkSet(mkSet("topic-1", "topic-1x", "topic-2")), new HashSet<>(copartitionGroups));
+    }
+
+    private <T> Set<T> set(T... items) {
+        Set<T> set = new HashSet<>();
+        for (T item : items) {
+            set.add(item);
+        }
+        return set;
     }
 
     private <T> List<T> list(T... elems) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.test.MockSourceNode;
 import org.junit.Test;
 import org.junit.Before;
@@ -98,7 +99,7 @@ public class StreamTaskTest {
         File baseDir = Files.createTempDirectory("test").toFile();
         try {
             StreamingConfig config = createConfig(baseDir);
-            StreamTask task = new StreamTask(0, consumer, producer, restoreStateConsumer, partitions, topology, config, null);
+            StreamTask task = new StreamTask(new TaskId(0, 0), consumer, producer, restoreStateConsumer, partitions, topology, config, null);
 
             task.addRecords(partition1, records(
                     new ConsumerRecord<>(partition1.topic(), partition1.partition(), 10, recordKey, recordValue),
@@ -149,7 +150,7 @@ public class StreamTaskTest {
         File baseDir = Files.createTempDirectory("test").toFile();
         try {
             StreamingConfig config = createConfig(baseDir);
-            StreamTask task = new StreamTask(1, consumer, producer, restoreStateConsumer, partitions, topology, config, null);
+            StreamTask task = new StreamTask(new TaskId(1, 1), consumer, producer, restoreStateConsumer, partitions, topology, config, null);
 
             task.addRecords(partition1, records(
                     new ConsumerRecord<>(partition1.topic(), partition1.partition(), 10, recordKey, recordValue),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamingConfig;
 import org.apache.kafka.streams.processor.PartitionGrouper;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.junit.Test;
@@ -81,11 +82,11 @@ public class StreamThreadTest {
     PartitionAssignor.Subscription subscription = new PartitionAssignor.Subscription(Arrays.asList("topic1", "topic2", "topic3"));
 
     // task0 is unused
-    private final int task1 = 1;
-    private final int task2 = 2;
-    // task3 is unused
-    private final int task4 = 4;
-    private final int task5 = 5;
+    private final TaskId task1 = new TaskId(0, 1);
+    private final TaskId task2 = new TaskId(0, 2);
+    private final TaskId task3 = new TaskId(0, 3);
+    private final TaskId task4 = new TaskId(1, 1);
+    private final TaskId task5 = new TaskId(1, 2);
 
     private Properties configProps() {
         return new Properties() {
@@ -104,7 +105,7 @@ public class StreamThreadTest {
     private static class TestStreamTask extends StreamTask {
         public boolean committed = false;
 
-        public TestStreamTask(int id,
+        public TestStreamTask(TaskId id,
                               Consumer<byte[], byte[]> consumer,
                               Producer<byte[], byte[]> producer,
                               Consumer<byte[], byte[]> restoreConsumer,
@@ -140,7 +141,7 @@ public class StreamThreadTest {
 
         StreamThread thread = new StreamThread(builder, config, producer, consumer, mockRestoreConsumer, "test", new Metrics(), new SystemTime()) {
             @Override
-            protected StreamTask createStreamTask(int id, Collection<TopicPartition> partitionsForTask) {
+            protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
                 return new TestStreamTask(id, consumer, producer, mockRestoreConsumer, partitionsForTask, builder.build(), config);
             }
         };
@@ -240,9 +241,9 @@ public class StreamThreadTest {
 
             StreamingConfig config = new StreamingConfig(props);
 
-            File stateDir1 = new File(baseDir, "1");
-            File stateDir2 = new File(baseDir, "2");
-            File stateDir3 = new File(baseDir, "3");
+            File stateDir1 = new File(baseDir, task1.toString());
+            File stateDir2 = new File(baseDir, task2.toString());
+            File stateDir3 = new File(baseDir, task3.toString());
             File extraDir = new File(baseDir, "X");
             stateDir1.mkdir();
             stateDir2.mkdir();
@@ -264,7 +265,7 @@ public class StreamThreadTest {
                 }
 
                 @Override
-                protected StreamTask createStreamTask(int id, Collection<TopicPartition> partitionsForTask) {
+                protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
                     return new TestStreamTask(id, consumer, producer, mockRestoreConsumer, partitionsForTask, builder.build(), config);
                 }
             };
@@ -385,7 +386,7 @@ public class StreamThreadTest {
                 }
 
                 @Override
-                protected StreamTask createStreamTask(int id, Collection<TopicPartition> partitionsForTask) {
+                protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
                     return new TestStreamTask(id, consumer, producer, mockRestoreConsumer, partitionsForTask, builder.build(), config);
                 }
             };

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.StreamingMetrics;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.test.MockProcessorContext;
 
@@ -245,8 +246,8 @@ public class KeyValueStoreTestDriver<K, V> {
         this.context = new MockProcessorContext(null, serdes.keySerializer(), serdes.keyDeserializer(), serdes.valueSerializer(),
                 serdes.valueDeserializer(), recordCollector) {
             @Override
-            public int id() {
-                return 1;
+            public TaskId id() {
+                return new TaskId(0, 1);
             }
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -23,6 +23,7 @@ import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 
 import java.io.File;
@@ -82,8 +83,8 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
     }
 
     @Override
-    public int id() {
-        return 0;
+    public TaskId id() {
+        return new TaskId(0, 0);
     }
 
     @Override


### PR DESCRIPTION
@guozhangwang 
- A task id is now a class, `TaskId`, that has a topic group id and a partition id fields.
- `TopologyBuilder` assigns a topic group id to a topic group. Related methods are changed accordingly.
- A state store uses the partition id part of the task id as the change log partition id.
