### PR TITLE
HOTFIX: call consumer.poll() even when no task is assigned

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -265,22 +265,29 @@ public class StreamThread extends Thread {
                     sensors.pollTimeSensor.record(endPoll - startPoll);
                 }
 
-                // try to process one record from each task
                 totalNumBuffered = 0;
-                requiresPoll = false;
 
-                for (StreamTask task : tasks.values()) {
-                    long startProcess = time.milliseconds();
+                if (!tasks.isEmpty()) {
+                    // try to process one record from each task
+                    requiresPoll = false;
 
-                    totalNumBuffered += task.process();
-                    requiresPoll = requiresPoll || task.requiresPoll();
+                    for (StreamTask task : tasks.values()) {
+                        long startProcess = time.milliseconds();
 
-                    sensors.processTimeSensor.record(time.milliseconds() - startProcess);
+                        totalNumBuffered += task.process();
+                        requiresPoll = requiresPoll || task.requiresPoll();
+
+                        sensors.processTimeSensor.record(time.milliseconds() - startProcess);
+                    }
+
+                    maybePunctuate();
+                    maybeCommit();
+                } else {
+                    // even when no task is assigned, we must poll to get a task.
+                    requiresPoll = true;
                 }
 
-                maybePunctuate();
                 maybeClean();
-                maybeCommit();
             }
         } catch (Exception e) {
             throw new KafkaException(e);


### PR DESCRIPTION
StreamThread should keep calling consumer.poll() even when no task is assigned. This is necessary to get a task.

@guozhangwang 
