### PR TITLE
MINOR: Update system test MANIFEST.in

### DIFF
--- a/tests/MANIFEST.in
+++ b/tests/MANIFEST.in
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-recursive-include kafkatest *.properties
+recursive-include kafkatest */templates/*

--- a/tests/MANIFEST.in
+++ b/tests/MANIFEST.in
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-recursive-include kafkatest/services/templates *.properties
+recursive-include kafkatest *.properties


### PR DESCRIPTION
@ewencp 
Some *.properties files were missing from `kafkatest` package. This update makes `kafkatest` services once again useable by external dependencies

I've tested this change on aws with confluent system tests
