### PR TITLE
KAFKA-2706: make state stores first class citizens in the processor topology

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.DefaultPartitionGrouper;
 import org.apache.kafka.streams.processor.PartitionGrouper;
 import org.apache.kafka.streams.processor.internals.KafkaStreamingPartitionAssignor;
@@ -243,6 +245,22 @@ public class StreamingConfig extends AbstractConfig {
         props.remove(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG);
 
         return props;
+    }
+
+    public Serializer keySerializer() {
+        return getConfiguredInstance(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, Serializer.class);
+    }
+
+    public Serializer valueSerializer() {
+        return getConfiguredInstance(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serializer.class);
+    }
+
+    public Deserializer keyDeserializer() {
+        return getConfiguredInstance(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+    }
+
+    public Deserializer valueDeserializer() {
+        return getConfiguredInstance(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
     }
 
     public static void main(String[] args) {

--- a/streams/src/main/java/org/apache/kafka/streams/examples/ProcessorJob.java
+++ b/streams/src/main/java/org/apache/kafka/streams/examples/ProcessorJob.java
@@ -45,10 +45,11 @@ public class ProcessorJob {
                 private KeyValueStore<String, Integer> kvStore;
 
                 @Override
+                @SuppressWarnings("unchecked")
                 public void init(ProcessorContext context) {
                     this.context = context;
                     this.context.schedule(1000);
-                    this.kvStore = Stores.create("local-state", context).withStringKeys().withIntegerValues().inMemory().build();
+                    this.kvStore = (KeyValueStore<String, Integer>) context.getStateStore("local-state");
                 }
 
                 @Override
@@ -103,6 +104,8 @@ public class ProcessorJob {
         builder.addSource("SOURCE", new StringDeserializer(), new StringDeserializer(), "topic-source");
 
         builder.addProcessor("PROCESS", new MyProcessorSupplier(), "SOURCE");
+        builder.addStateStore(Stores.create("local-state", config).withStringKeys().withIntegerValues().inMemory().build());
+        builder.connectProcessorAndStateStores("local-state", "PROCESS");
 
         builder.addSink("SINK", "topic-sink", new StringSerializer(), new IntegerSerializer(), "PROCESS");
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -154,24 +154,27 @@ public interface KStream<K, V> {
      * Applies a stateful transformation to all elements in this stream.
      *
      * @param transformerSupplier the class of TransformerDef
+     * @param stateStoreNames the names of the state store used by the processor
      * @return KStream
      */
-    <K1, V1> KStream<K1, V1> transform(TransformerSupplier<K, V, KeyValue<K1, V1>> transformerSupplier);
+    <K1, V1> KStream<K1, V1> transform(TransformerSupplier<K, V, KeyValue<K1, V1>> transformerSupplier, String... stateStoreNames);
 
     /**
      * Applies a stateful transformation to all values in this stream.
      *
      * @param valueTransformerSupplier the class of TransformerDef
+     * @param stateStoreNames the names of the state store used by the processor
      * @return KStream
      */
-    <R> KStream<K, R> transformValues(ValueTransformerSupplier<V, R> valueTransformerSupplier);
+    <R> KStream<K, R> transformValues(ValueTransformerSupplier<V, R> valueTransformerSupplier, String... stateStoreNames);
 
     /**
      * Processes all elements in this stream by applying a processor.
      *
      * @param processorSupplier the supplier of the Processor to use
+     * @param stateStoreNames the names of the state store used by the processor
      * @return the new stream containing the processed output
      */
-    void process(ProcessorSupplier<K, V> processorSupplier);
+    void process(ProcessorSupplier<K, V> processorSupplier, String... stateStoreNames);
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -201,27 +201,30 @@ public class KStreamImpl<K, V> implements KStream<K, V> {
     }
 
     @Override
-    public <K1, V1> KStream<K1, V1> transform(TransformerSupplier<K, V, KeyValue<K1, V1>> transformerSupplier) {
+    public <K1, V1> KStream<K1, V1> transform(TransformerSupplier<K, V, KeyValue<K1, V1>> transformerSupplier, String... stateStoreNames) {
         String name = TRANSFORM_NAME + INDEX.getAndIncrement();
 
         topology.addProcessor(name, new KStreamTransform<>(transformerSupplier), this.name);
+        topology.connectProcessorAndStateStores(name, stateStoreNames);
 
         return new KStreamImpl<>(topology, name, null);
     }
 
     @Override
-    public <V1> KStream<K, V1> transformValues(ValueTransformerSupplier<V, V1> valueTransformerSupplier) {
+    public <V1> KStream<K, V1> transformValues(ValueTransformerSupplier<V, V1> valueTransformerSupplier, String... stateStoreNames) {
         String name = TRANSFORMVALUES_NAME + INDEX.getAndIncrement();
 
         topology.addProcessor(name, new KStreamTransformValues<>(valueTransformerSupplier), this.name);
+        topology.connectProcessorAndStateStores(name, stateStoreNames);
 
         return new KStreamImpl<>(topology, name, sourceNodes);
     }
 
     @Override
-    public void process(final ProcessorSupplier<K, V> processorSupplier) {
+    public void process(final ProcessorSupplier<K, V> processorSupplier, String... stateStoreNames) {
         String name = PROCESSOR_NAME + INDEX.getAndIncrement();
 
         topology.addProcessor(name, processorSupplier, this.name);
+        topology.connectProcessorAndStateStores(name, stateStoreNames);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateStoreSupplier.java
@@ -17,41 +17,9 @@
 
 package org.apache.kafka.streams.processor;
 
-/**
- * A storage engine for managing state maintained by a stream processor.
- *
- * <p>
- * This interface does not specify any query capabilities, which, of course,
- * would be query engine specific. Instead it just specifies the minimum
- * functionality required to reload a storage engine from its changelog as well
- * as basic lifecycle management.
- * </p>
- */
-public interface StateStore {
+public interface StateStoreSupplier {
 
-    /**
-     * The name of this store.
-     * @return the storage name
-     */
     String name();
 
-    /**
-     * Initializes this state store
-     */
-    void init(ProcessorContext context);
-
-    /**
-     * Flush any cached data
-     */
-    void flush();
-
-    /**
-     * Close the storage engine
-     */
-    void close();
-
-    /**
-     * If the storage is persistent
-     */
-    boolean persistent();
+    StateStore get();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -310,9 +310,8 @@ public class TopologyBuilder {
         if (iter.hasNext()) {
             String user = iter.next();
             nodeGrouper.unite(user, processorName);
-        } else {
-            users.add(processorName);
         }
+        users.add(processorName);
 
         NodeFactory factory = nodeFactories.get(processorName);
         if (factory instanceof ProcessorNodeFactory) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -33,6 +33,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,16 +50,18 @@ import java.util.Set;
  */
 public class TopologyBuilder {
 
-    // list of node factories in a topological order
-    private final ArrayList<NodeFactory> nodeFactories = new ArrayList<>();
+    // node factories in a topological order
+    private final LinkedHashMap<String, NodeFactory> nodeFactories = new LinkedHashMap<>();
 
-    private final Set<String> nodeNames = new HashSet<>();
     private final Set<String> sourceTopicNames = new HashSet<>();
 
     private final QuickUnion<String> nodeGrouper = new QuickUnion<>();
     private final List<Set<String>> copartitionSourceGroups = new ArrayList<>();
     private final HashMap<String, String[]> nodeToTopics = new HashMap<>();
     private Map<Integer, Set<String>> nodeGroups = null;
+
+    private Map<String, StateStoreSupplier> stateStores = new HashMap<>();
+    private Map<String, Set<String>> stateStoreUsers = new HashMap();
 
     private interface NodeFactory {
         ProcessorNode build();
@@ -67,6 +71,7 @@ public class TopologyBuilder {
         public final String[] parents;
         private final String name;
         private final ProcessorSupplier supplier;
+        private final Set<String> stateStoreNames = new HashSet<>();
 
         public ProcessorNodeFactory(String name, String[] parents, ProcessorSupplier supplier) {
             this.name = name;
@@ -74,9 +79,13 @@ public class TopologyBuilder {
             this.supplier = supplier;
         }
 
+        public void addStateStore(String stateStoreName) {
+            stateStoreNames.add(stateStoreName);
+        }
+
         @Override
         public ProcessorNode build() {
-            return new ProcessorNode(name, supplier.get());
+            return new ProcessorNode(name, supplier.get(), stateStoreNames);
         }
     }
 
@@ -155,7 +164,7 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      */
     public final TopologyBuilder addSource(String name, Deserializer keyDeserializer, Deserializer valDeserializer, String... topics) {
-        if (nodeNames.contains(name))
+        if (nodeFactories.containsKey(name))
             throw new TopologyException("Processor " + name + " is already added.");
 
         for (String topic : topics) {
@@ -165,8 +174,7 @@ public class TopologyBuilder {
             sourceTopicNames.add(topic);
         }
 
-        nodeNames.add(name);
-        nodeFactories.add(new SourceNodeFactory(name, topics, keyDeserializer, valDeserializer));
+        nodeFactories.put(name, new SourceNodeFactory(name, topics, keyDeserializer, valDeserializer));
         nodeToTopics.put(name, topics.clone());
         nodeGrouper.add(name);
 
@@ -204,7 +212,7 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      */
     public final TopologyBuilder addSink(String name, String topic, Serializer keySerializer, Serializer valSerializer, String... parentNames) {
-        if (nodeNames.contains(name))
+        if (nodeFactories.containsKey(name))
             throw new TopologyException("Processor " + name + " is already added.");
 
         if (parentNames != null) {
@@ -212,14 +220,13 @@ public class TopologyBuilder {
                 if (parent.equals(name)) {
                     throw new TopologyException("Processor " + name + " cannot be a parent of itself.");
                 }
-                if (!nodeNames.contains(parent)) {
+                if (!nodeFactories.containsKey(parent)) {
                     throw new TopologyException("Parent processor " + parent + " is not added yet.");
                 }
             }
         }
 
-        nodeNames.add(name);
-        nodeFactories.add(new SinkNodeFactory(name, parentNames, topic, keySerializer, valSerializer));
+        nodeFactories.put(name, new SinkNodeFactory(name, parentNames, topic, keySerializer, valSerializer));
         return this;
     }
 
@@ -233,7 +240,7 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      */
     public final TopologyBuilder addProcessor(String name, ProcessorSupplier supplier, String... parentNames) {
-        if (nodeNames.contains(name))
+        if (nodeFactories.containsKey(name))
             throw new TopologyException("Processor " + name + " is already added.");
 
         if (parentNames != null) {
@@ -241,17 +248,78 @@ public class TopologyBuilder {
                 if (parent.equals(name)) {
                     throw new TopologyException("Processor " + name + " cannot be a parent of itself.");
                 }
-                if (!nodeNames.contains(parent)) {
+                if (!nodeFactories.containsKey(parent)) {
                     throw new TopologyException("Parent processor " + parent + " is not added yet.");
                 }
             }
         }
 
-        nodeNames.add(name);
-        nodeFactories.add(new ProcessorNodeFactory(name, parentNames, supplier));
+        nodeFactories.put(name, new ProcessorNodeFactory(name, parentNames, supplier));
         nodeGrouper.add(name);
         nodeGrouper.unite(name, parentNames);
         return this;
+    }
+
+    /**
+     * Adds a state store
+     *
+     * @param supplier the supplier used to obtain this state store {@link StateStore} instance
+     * @return this builder instance so methods can be chained together; never null
+     */
+    public final TopologyBuilder addStateStore(StateStoreSupplier supplier, String... processorNames) {
+        if (stateStores.containsKey(supplier.name())) {
+            throw new TopologyException("StateStore " + supplier.name() + " is already added.");
+        }
+        stateStores.put(supplier.name(), supplier);
+        stateStoreUsers.put(supplier.name(), new HashSet<String>());
+
+        if (processorNames != null) {
+            for (String processorName : processorNames) {
+                connectProcessorAndStateStore(processorName, supplier.name());
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Connects the processor and the state stores
+     *
+     * @param processorName the name of the processor
+     * @param stateStoreNames the names of state stores that the processor uses
+     * @return this builder instance so methods can be chained together; never null
+     */
+    public final TopologyBuilder connectProcessorAndStateStores(String processorName, String... stateStoreNames) {
+        if (stateStoreNames != null) {
+            for (String stateStoreName : stateStoreNames) {
+                connectProcessorAndStateStore(processorName, stateStoreName);
+            }
+        }
+
+        return this;
+    }
+
+    private void connectProcessorAndStateStore(String processorName, String stateStoreName) {
+        if (!stateStores.containsKey(stateStoreName))
+            throw new TopologyException("StateStore " + stateStoreName + " is not added yet.");
+        if (!nodeFactories.containsKey(processorName))
+            throw new TopologyException("Processor " + processorName + " is not added yet.");
+
+        Set<String> users = stateStoreUsers.get(stateStoreName);
+        Iterator<String> iter = users.iterator();
+        if (iter.hasNext()) {
+            String user = iter.next();
+            nodeGrouper.unite(user, processorName);
+        } else {
+            users.add(processorName);
+        }
+
+        NodeFactory factory = nodeFactories.get(processorName);
+        if (factory instanceof ProcessorNodeFactory) {
+            ((ProcessorNodeFactory) factory).addStateStore(stateStoreName);
+        } else {
+            throw new TopologyException("cannot connect a state store " + stateStoreName + " to a source node or a sink node.");
+        }
     }
 
     /**
@@ -301,7 +369,7 @@ public class TopologyBuilder {
         }
 
         // Go through non-source nodes
-        for (String nodeName : Utils.sorted(nodeNames)) {
+        for (String nodeName : Utils.sorted(nodeFactories.keySet())) {
             if (!nodeToTopics.containsKey(nodeName)) {
                 String root = nodeGrouper.root(nodeName);
                 Set<String> nodeGroup = rootToNodeGroup.get(root);
@@ -357,10 +425,11 @@ public class TopologyBuilder {
         List<ProcessorNode> processorNodes = new ArrayList<>(nodeFactories.size());
         Map<String, ProcessorNode> processorMap = new HashMap<>();
         Map<String, SourceNode> topicSourceMap = new HashMap<>();
+        Map<String, StateStoreSupplier> stateStoreMap = new HashMap<>();
 
         try {
             // create processor nodes in a topological order ("nodeFactories" is already topologically sorted)
-            for (NodeFactory factory : nodeFactories) {
+            for (NodeFactory factory : nodeFactories.values()) {
                 ProcessorNode node = factory.build();
                 processorNodes.add(node);
                 processorMap.put(node.name(), node);
@@ -368,6 +437,11 @@ public class TopologyBuilder {
                 if (factory instanceof ProcessorNodeFactory) {
                     for (String parent : ((ProcessorNodeFactory) factory).parents) {
                         processorMap.get(parent).addChild(node);
+                    }
+                    for (String stateStoreName : ((ProcessorNodeFactory) factory).stateStoreNames) {
+                        if (!stateStoreMap.containsKey(stateStoreName)) {
+                            stateStoreMap.put(stateStoreName, stateStores.get(stateStoreName));
+                        }
                     }
                 } else if (factory instanceof SourceNodeFactory) {
                     for (String topic : ((SourceNodeFactory) factory).topics) {
@@ -385,7 +459,7 @@ public class TopologyBuilder {
             throw new KafkaException("ProcessorNode construction failed: this should not happen.");
         }
 
-        return new ProcessorTopology(processorNodes, topicSourceMap);
+        return new ProcessorTopology(processorNodes, topicSourceMap, new ArrayList<>(stateStoreMap.values()));
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -70,17 +70,21 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
         this.initialized = false;
     }
 
-    @Override
-    public RecordCollector recordCollector() {
-        return this.collector;
-    }
-
     public void initialized() {
         this.initialized = true;
     }
 
     public TaskId id() {
         return id;
+    }
+
+    public ProcessorStateManager getStateMgr() {
+        return stateMgr;
+    }
+
+    @Override
+    public RecordCollector recordCollector() {
+        return this.collector;
     }
 
     @Override
@@ -133,11 +137,6 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
 
         return stateMgr.getStore(name);
     }
-
-    public ProcessorStateManager getStateMgr() {
-        return stateMgr;
-    }
-
 
     @Override
     public String topic() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -134,7 +134,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
         return stateMgr.getStore(name);
     }
 
-    ProcessorStateManager getStateMgr() {
+    public ProcessorStateManager getStateMgr() {
         return stateMgr;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -62,10 +62,10 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
         this.collector = collector;
         this.stateMgr = stateMgr;
 
-        this.keySerializer = config.getConfiguredInstance(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, Serializer.class);
-        this.valSerializer = config.getConfiguredInstance(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, Serializer.class);
-        this.keyDeserializer = config.getConfiguredInstance(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
-        this.valDeserializer = config.getConfiguredInstance(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, Deserializer.class);
+        this.keySerializer = config.keySerializer();
+        this.valSerializer = config.valueSerializer();
+        this.keyDeserializer = config.keyDeserializer();
+        this.valDeserializer = config.valueDeserializer();
 
         this.initialized = false;
     }
@@ -123,8 +123,21 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
 
     @Override
     public StateStore getStateStore(String name) {
+        ProcessorNode node = task.node();
+
+        if (node == null)
+            throw new KafkaException("accessing from an unknown node");
+
+        if (!node.stateStores.contains(name))
+            throw new KafkaException("Processor " + node.name() + " has no access to StateStore " + name);
+
         return stateMgr.getStore(name);
     }
+
+    ProcessorStateManager getStateMgr() {
+        return stateMgr;
+    }
+
 
     @Override
     public String topic() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class ProcessorNode<K, V> {
 
@@ -30,14 +31,17 @@ public class ProcessorNode<K, V> {
     private final String name;
     private final Processor<K, V> processor;
 
+    public final Set<String> stateStores;
+
     public ProcessorNode(String name) {
-        this(name, null);
+        this(name, null, null);
     }
 
-    public ProcessorNode(String name, Processor<K, V> processor) {
+    public ProcessorNode(String name, Processor<K, V> processor, Set<String> stateStores) {
         this.name = name;
         this.processor = processor;
         this.children = new ArrayList<>();
+        this.stateStores = stateStores;
     }
 
     public final String name() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.streams.processor.internals;
 
+import org.apache.kafka.streams.processor.StateStoreSupplier;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -27,11 +29,14 @@ public class ProcessorTopology {
 
     private final List<ProcessorNode> processorNodes;
     private final Map<String, SourceNode> sourceByTopics;
+    private final List<StateStoreSupplier> stateStoreSuppliers;
 
     public ProcessorTopology(List<ProcessorNode> processorNodes,
-                             Map<String, SourceNode> sourceByTopics) {
+                             Map<String, SourceNode> sourceByTopics,
+                             List<StateStoreSupplier> stateStoreSuppliers) {
         this.processorNodes = Collections.unmodifiableList(processorNodes);
         this.sourceByTopics = Collections.unmodifiableMap(sourceByTopics);
+        this.stateStoreSuppliers = Collections.unmodifiableList(stateStoreSuppliers);
     }
 
     public Set<String> sourceTopics() {
@@ -48,6 +53,10 @@ public class ProcessorTopology {
 
     public List<ProcessorNode> processors() {
         return processorNodes;
+    }
+
+    public List<StateStoreSupplier> stateStoreSuppliers() {
+        return stateStoreSuppliers;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.StreamingConfig;
 import org.apache.kafka.streams.StreamingMetrics;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.slf4j.Logger;
@@ -125,6 +127,12 @@ public class StreamTask implements Punctuator {
 
         // initialize the topology with its own context
         this.processorContext = new ProcessorContextImpl(id, this, config, recordCollector, stateMgr, metrics);
+
+        // initialize the state stores
+        for (StateStoreSupplier stateStoreSupplier : this.topology.stateStoreSuppliers()) {
+            StateStore store = stateStoreSupplier.get();
+            store.init(this.processorContext);
+        }
 
         // initialize the task by initializing all its processor nodes in the topology
         for (ProcessorNode node : this.topology.processors()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/Serdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Serdes.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.StreamingConfig;
 
 final class Serdes<K, V> {
 
@@ -64,7 +64,7 @@ final class Serdes<K, V> {
 
     /**
      * Create a context for serialization using the specified serializers and deserializers.
-     * 
+     *
      * @param topic the name of the topic
      * @param keySerializer the serializer for keys; may not be null
      * @param keyDeserializer the deserializer for keys; may not be null
@@ -83,47 +83,44 @@ final class Serdes<K, V> {
 
     /**
      * Create a context for serialization using the specified serializers and deserializers, or if any of them are null the
-     * corresponding {@link ProcessorContext}'s default serializer or deserializer, which
+     * corresponding {@link StreamingConfig}'s serializer or deserializer, which
      * <em>must</em> match the key and value types used as parameters for this object.
-     * 
+     *
      * @param topic the name of the topic
-     * @param keySerializer the serializer for keys; may be null if the {@link ProcessorContext#keySerializer() default
+     * @param keySerializer the serializer for keys; may be null if the {@link StreamingConfig#keySerializer() default
      *            key serializer} should be used
-     * @param keyDeserializer the deserializer for keys; may be null if the {@link ProcessorContext#keyDeserializer() default
+     * @param keyDeserializer the deserializer for keys; may be null if the {@link StreamingConfig#keyDeserializer() default
      *            key deserializer} should be used
-     * @param valueSerializer the serializer for values; may be null if the {@link ProcessorContext#valueSerializer() default
+     * @param valueSerializer the serializer for values; may be null if the {@link StreamingConfig#valueSerializer() default
      *            value serializer} should be used
-     * @param valueDeserializer the deserializer for values; may be null if the {@link ProcessorContext#valueDeserializer()
+     * @param valueDeserializer the deserializer for values; may be null if the {@link StreamingConfig#valueDeserializer()
      *            default value deserializer} should be used
-     * @param context the processing context
+     * @param config the streaming config
      */
     @SuppressWarnings("unchecked")
     public Serdes(String topic,
             Serializer<K> keySerializer, Deserializer<K> keyDeserializer,
             Serializer<V> valueSerializer, Deserializer<V> valueDeserializer,
-            ProcessorContext context) {
+            StreamingConfig config) {
         this.topic = topic;
-        this.keySerializer = keySerializer != null ? keySerializer : (Serializer<K>) context.keySerializer();
-        this.keyDeserializer = keyDeserializer != null ? keyDeserializer : (Deserializer<K>) context.keyDeserializer();
-        this.valueSerializer = valueSerializer != null ? valueSerializer : (Serializer<V>) context.valueSerializer();
-        this.valueDeserializer = valueDeserializer != null ? valueDeserializer : (Deserializer<V>) context.valueDeserializer();
+
+        this.keySerializer = keySerializer != null ? keySerializer : config.keySerializer();
+        this.keyDeserializer = keyDeserializer != null ? keyDeserializer : config.keyDeserializer();
+        this.valueSerializer = valueSerializer != null ? valueSerializer : config.valueSerializer();
+        this.valueDeserializer = valueDeserializer != null ? valueDeserializer : config.valueDeserializer();
     }
 
     /**
-     * Create a context for serialization using the {@link ProcessorContext}'s default serializers and deserializers, which
+     * Create a context for serialization using the {@link StreamingConfig}'s serializers and deserializers, which
      * <em>must</em> match the key and value types used as parameters for this object.
-     * 
+     *
      * @param topic the name of the topic
-     * @param context the processing context
+     * @param config the streaming config
      */
     @SuppressWarnings("unchecked")
     public Serdes(String topic,
-            ProcessorContext context) {
-        this.topic = topic;
-        this.keySerializer = (Serializer<K>) context.keySerializer();
-        this.keyDeserializer = (Deserializer<K>) context.keyDeserializer();
-        this.valueSerializer = (Serializer<V>) context.valueSerializer();
-        this.valueDeserializer = (Deserializer<V>) context.valueDeserializer();
+                  StreamingConfig config) {
+        this(topic, null, null, null, null, config);
     }
 
     public Deserializer<K> keyDeserializer() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 
 import static org.apache.kafka.common.utils.Utils.mkSet;
 import org.apache.kafka.test.MockProcessorSupplier;
+import org.apache.kafka.test.MockStateStoreSupplier;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -106,6 +107,55 @@ public class TopologyBuilderTest {
         assertEquals(3, builder.sourceTopics().size());
     }
 
+    @Test(expected = TopologyException.class)
+    public void testAddStateStoreWithNonExistingProcessor() {
+        final TopologyBuilder builder = new TopologyBuilder();
+
+        builder.addStateStore(new MockStateStoreSupplier("store", false), "no-such-processsor");
+    }
+
+    @Test(expected = TopologyException.class)
+    public void testAddStateStoreWithSource() {
+        final TopologyBuilder builder = new TopologyBuilder();
+
+        builder.addSource("source-1", "topic-1");
+        builder.addStateStore(new MockStateStoreSupplier("store", false), "source-1");
+    }
+
+    @Test(expected = TopologyException.class)
+    public void testAddStateStoreWithSink() {
+        final TopologyBuilder builder = new TopologyBuilder();
+
+        builder.addSink("sink-1", "topic-1");
+        builder.addStateStore(new MockStateStoreSupplier("store", false), "sink-1");
+    }
+
+    @Test(expected = TopologyException.class)
+    public void testAddStateStoreWithDuplicates() {
+        final TopologyBuilder builder = new TopologyBuilder();
+
+        builder.addStateStore(new MockStateStoreSupplier("store", false));
+        builder.addStateStore(new MockStateStoreSupplier("store", false));
+    }
+
+    @Test
+    public void testAddStateStore() {
+        final TopologyBuilder builder = new TopologyBuilder();
+        List<StateStoreSupplier> suppliers;
+
+        StateStoreSupplier supplier = new MockStateStoreSupplier("store-1", false);
+        builder.addStateStore(supplier);
+        suppliers = builder.build().stateStoreSuppliers();
+        assertEquals(0, suppliers.size());
+
+        builder.addSource("source-1", "topic-1");
+        builder.addProcessor("processor-1", new MockProcessorSupplier(), "source-1");
+        builder.connectProcessorAndStateStores("processor-1", "store-1");
+        suppliers = builder.build().stateStoreSuppliers();
+        assertEquals(1, suppliers.size());
+        assertEquals(supplier.name(), suppliers.get(0).name());
+    }
+
     @Test
     public void testTopicGroups() {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -136,6 +186,35 @@ public class TopologyBuilderTest {
         Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
 
         assertEquals(mkSet(mkSet("topic-1", "topic-1x", "topic-2")), new HashSet<>(copartitionGroups));
+    }
+
+    @Test
+    public void testTopicGroupsByStateStore() {
+        final TopologyBuilder builder = new TopologyBuilder();
+
+        builder.addSource("source-1", "topic-1", "topic-1x");
+        builder.addSource("source-2", "topic-2");
+        builder.addSource("source-3", "topic-3");
+        builder.addSource("source-4", "topic-4");
+        builder.addSource("source-5", "topic-5");
+
+        builder.addProcessor("processor-1", new MockProcessorSupplier(), "source-1");
+        builder.addProcessor("processor-2", new MockProcessorSupplier(), "source-2");
+        builder.addStateStore(new MockStateStoreSupplier("strore-1", false), "processor-1", "processor-2");
+
+        builder.addProcessor("processor-3", new MockProcessorSupplier(), "source-3");
+        builder.addProcessor("processor-4", new MockProcessorSupplier(), "source-4");
+        builder.addStateStore(new MockStateStoreSupplier("strore-2", false), "processor-3", "processor-4");
+
+        Map<Integer, Set<String>> topicGroups = builder.topicGroups();
+
+        Map<Integer, Set<String>> expectedTopicGroups = new HashMap<>();
+        expectedTopicGroups.put(0, set("topic-1", "topic-1x", "topic-2"));
+        expectedTopicGroups.put(1, set("topic-3", "topic-4"));
+        expectedTopicGroups.put(2, set("topic-5"));
+
+        assertEquals(3, topicGroups.size());
+        assertEquals(expectedTopicGroups, topicGroups);
     }
 
     private <T> Set<T> set(T... items) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -24,16 +24,11 @@ import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.StateRestoreCallback;
-import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.StateStoreSupplier;
 import org.apache.kafka.streams.state.OffsetCheckpoint;
+import org.apache.kafka.test.MockStateStoreSupplier;
 import org.junit.Test;
 
 import java.io.File;
@@ -54,69 +49,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 public class ProcessorStateManagerTest {
-
-    private static class MockStateStoreSupplier implements StateStoreSupplier {
-        private final String name;
-        private final boolean persistent;
-
-        public MockStateStoreSupplier(String name, boolean persistent) {
-            this.name = name;
-            this.persistent = persistent;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-        @Override
-        public StateStore get() {
-            return new MockStateStore(name, persistent);
-        }
-    }
-
-    private static class MockStateStore implements StateStore {
-        private final String name;
-        private final boolean persistent;
-
-        public boolean initialized = false;
-        public boolean flushed = false;
-        public boolean closed = false;
-        public final ArrayList<Integer> keys = new ArrayList<>();
-
-        public MockStateStore(String name, boolean persistent) {
-            this.name = name;
-            this.persistent = persistent;
-        }
-        @Override
-        public String name() {
-            return name;
-        }
-        @Override
-        public void init(ProcessorContext context) {
-            initialized = true;
-        }
-        @Override
-        public void flush() {
-            flushed = true;
-        }
-        @Override
-        public void close() {
-            closed = true;
-        }
-        @Override
-        public boolean persistent() {
-            return persistent;
-        }
-
-        public final StateRestoreCallback stateRestoreCallback = new StateRestoreCallback() {
-            private final Deserializer<Integer> deserializer = new IntegerDeserializer();
-
-            @Override
-            public void restore(byte[] key, byte[] value) {
-                keys.add(deserializer.deserialize("", key));
-            }
-        };
-    }
 
     private class MockRestoreConsumer  extends MockConsumer<byte[], byte[]> {
         private final Serializer<Integer> serializer = new IntegerSerializer();
@@ -281,7 +213,7 @@ public class ProcessorStateManagerTest {
     public void testNoTopic() throws IOException {
         File baseDir = Files.createTempDirectory("test").toFile();
         try {
-            MockStateStore mockStateStore = new MockStateStore("mockStore", false);
+            MockStateStoreSupplier.MockStateStore mockStateStore = new MockStateStoreSupplier.MockStateStore("mockStore", false);
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, new MockRestoreConsumer());
             try {
@@ -309,7 +241,7 @@ public class ProcessorStateManagerTest {
             ));
             restoreConsumer.updateEndOffsets(Collections.singletonMap(new TopicPartition("persistentStore", 2), 13L));
 
-            MockStateStore persistentStore = new MockStateStore("persistentStore", true); // persistent store
+            MockStateStoreSupplier.MockStateStore persistentStore = new MockStateStoreSupplier.MockStateStore("persistentStore", true); // persistent store
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(2, baseDir, restoreConsumer);
             try {
@@ -357,7 +289,7 @@ public class ProcessorStateManagerTest {
             ));
             restoreConsumer.updateEndOffsets(Collections.singletonMap(new TopicPartition("persistentStore", 2), 13L));
 
-            MockStateStore nonPersistentStore = new MockStateStore("nonPersistentStore", false); // non persistent store
+            MockStateStoreSupplier.MockStateStore nonPersistentStore = new MockStateStoreSupplier.MockStateStore("nonPersistentStore", false); // non persistent store
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(2, baseDir, restoreConsumer);
             try {
@@ -397,7 +329,7 @@ public class ProcessorStateManagerTest {
                     new PartitionInfo("mockStore", 1, Node.noNode(), new Node[0], new Node[0])
             ));
 
-            MockStateStore mockStateStore = new MockStateStore("mockStore", false);
+            MockStateStoreSupplier.MockStateStore mockStateStore = new MockStateStoreSupplier.MockStateStore("mockStore", false);
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, restoreConsumer);
             try {
@@ -437,8 +369,8 @@ public class ProcessorStateManagerTest {
             ackedOffsets.put(new TopicPartition("nonPersistentStore", 1), 456L);
             ackedOffsets.put(new TopicPartition("otherTopic", 1), 789L);
 
-            MockStateStore persistentStore = new MockStateStore("persistentStore", true);
-            MockStateStore nonPersistentStore = new MockStateStore("nonPersistentStore", false);
+            MockStateStoreSupplier.MockStateStore persistentStore = new MockStateStoreSupplier.MockStateStore("persistentStore", true);
+            MockStateStoreSupplier.MockStateStore nonPersistentStore = new MockStateStoreSupplier.MockStateStore("nonPersistentStore", false);
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, restoreConsumer);
             try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -39,7 +39,6 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StateUtils;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.MockProcessorSupplier;
-import org.apache.kafka.test.ProcessorTopologyTestDriver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,7 +82,7 @@ public class ProcessorTopologyTest {
         }
         driver = null;
     }
-    
+
     @Test
     public void testTopologyMetadata() {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -203,6 +202,10 @@ public class ProcessorTopologyTest {
     protected TopologyBuilder createStatefulTopology(String storeName) {
         return new TopologyBuilder().addSource("source", STRING_DESERIALIZER, STRING_DESERIALIZER, INPUT_TOPIC)
                                     .addProcessor("processor", define(new StatefulProcessor(storeName)), "source")
+                                    .addStateStore(
+                                            Stores.create(storeName, config).withStringKeys().withStringValues().inMemory().build(),
+                                            "processor"
+                                    )
                                     .addSink("counts", OUTPUT_TOPIC_1, "processor");
     }
 
@@ -262,9 +265,10 @@ public class ProcessorTopologyTest {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         public void init(ProcessorContext context) {
             super.init(context);
-            store = Stores.create(storeName, context).withStringKeys().withStringValues().inMemory().build();
+            store = (KeyValueStore<String, String>) context.getStateStore(storeName);
         }
 
         @Override
@@ -281,7 +285,7 @@ public class ProcessorTopologyTest {
             }
             context().forward(Long.toString(streamTime), count);
         }
-        
+
         @Override
         public void close() {
             store.close();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StateUtils;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.MockProcessorSupplier;
+import org.apache.kafka.test.ProcessorTopologyTestDriver;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTestDriver.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.test;
+package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -32,8 +32,6 @@ import org.apache.kafka.streams.StreamingMetrics;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
-import org.apache.kafka.streams.processor.internals.ProcessorTopology;
-import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.ArrayList;
@@ -266,7 +264,7 @@ public class ProcessorTopologyTestDriver {
      * @see #getKeyValueStore(String)
      */
     public StateStore getStateStore(String name) {
-        return task.context().getStateStore(name);
+        return ((ProcessorContextImpl) task.context()).getStateMgr().getStore(name);
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/PunctuationQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/PunctuationQueueTest.java
@@ -30,7 +30,7 @@ public class PunctuationQueueTest {
     @Test
     public void testPunctuationInterval() {
         TestProcessor processor = new TestProcessor();
-        ProcessorNode<String, String> node = new ProcessorNode<>("test", processor);
+        ProcessorNode<String, String> node = new ProcessorNode<>("test", processor, null);
         PunctuationQueue queue = new PunctuationQueue();
 
         PunctuationSchedule sched = new PunctuationSchedule(node, 100L);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.test.MockSourceNode;
 import org.junit.Test;
@@ -37,6 +38,7 @@ import org.junit.Before;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Properties;
@@ -57,13 +59,15 @@ public class StreamTaskTest {
     private final MockSourceNode source1 = new MockSourceNode<>(intDeserializer, intDeserializer);
     private final MockSourceNode source2 = new MockSourceNode<>(intDeserializer, intDeserializer);
     private final ProcessorTopology topology = new ProcessorTopology(
-        Arrays.asList((ProcessorNode) source1, (ProcessorNode) source2),
-        new HashMap<String, SourceNode>() {
-            {
-                put("topic1", source1);
-                put("topic2", source2);
-            }
-        });
+            Arrays.asList((ProcessorNode) source1, (ProcessorNode) source2),
+            new HashMap<String, SourceNode>() {
+                {
+                    put("topic1", source1);
+                    put("topic2", source2);
+                }
+            },
+            Collections.<StateStoreSupplier>emptyList()
+    );
 
     private StreamingConfig createConfig(final File baseDir) throws Exception {
         return new StreamingConfig(new Properties() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/AbstractKeyValueStoreTest.java
@@ -21,20 +21,22 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import org.apache.kafka.streams.StreamingConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.junit.Test;
 
 public abstract class AbstractKeyValueStoreTest {
 
-    protected abstract <K, V> KeyValueStore<K, V> createKeyValueStore(ProcessorContext context,
+    protected abstract <K, V> KeyValueStore<K, V> createKeyValueStore(StreamingConfig config,
+                                                                      ProcessorContext context,
                                                                       Class<K> keyClass, Class<V> valueClass,
                                                                       boolean useContextSerdes);
-    
+
     @Test
     public void testPutGetRange() {
         // Create the test driver ...
         KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create();
-        KeyValueStore<Integer, String> store = createKeyValueStore(driver.context(), Integer.class, String.class, false);
+        KeyValueStore<Integer, String> store = createKeyValueStore(driver.config(), driver.context(), Integer.class, String.class, false);
         try {
 
             // Verify that the store reads and writes correctly ...
@@ -100,7 +102,7 @@ public abstract class AbstractKeyValueStoreTest {
     public void testPutGetRangeWithDefaultSerdes() {
         // Create the test driver ...
         KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create(Integer.class, String.class);
-        KeyValueStore<Integer, String> store = createKeyValueStore(driver.context(), Integer.class, String.class, true);
+        KeyValueStore<Integer, String> store = createKeyValueStore(driver.config(), driver.context(), Integer.class, String.class, true);
         try {
 
             // Verify that the store reads and writes correctly ...
@@ -150,7 +152,7 @@ public abstract class AbstractKeyValueStoreTest {
 
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
-        KeyValueStore<Integer, String> store = createKeyValueStore(driver.context(), Integer.class, String.class, false);
+        KeyValueStore<Integer, String> store = createKeyValueStore(driver.config(), driver.context(), Integer.class, String.class, false);
         try {
             // Verify that the store's contents were properly restored ...
             assertEquals(0, driver.checkForRestoredEntries(store));
@@ -176,7 +178,7 @@ public abstract class AbstractKeyValueStoreTest {
 
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
-        KeyValueStore<Integer, String> store = createKeyValueStore(driver.context(), Integer.class, String.class, true);
+        KeyValueStore<Integer, String> store = createKeyValueStore(driver.config(), driver.context(), Integer.class, String.class, true);
         try {
             // Verify that the store's contents were properly restored ...
             assertEquals(0, driver.checkForRestoredEntries(store));

--- a/streams/src/test/java/org/apache/kafka/streams/state/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/InMemoryKeyValueStoreTest.java
@@ -18,21 +18,33 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.StreamingConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
 
 public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     @SuppressWarnings("unchecked")
     @Override
-    protected <K, V> KeyValueStore<K, V> createKeyValueStore(ProcessorContext context, Class<K> keyClass, Class<V> valueClass,
-                                                             boolean useContextSerdes) {
+    protected <K, V> KeyValueStore<K, V> createKeyValueStore(
+            StreamingConfig config,
+            ProcessorContext context,
+            Class<K> keyClass, Class<V> valueClass,
+            boolean useContextSerdes) {
+
+        StateStoreSupplier supplier;
         if (useContextSerdes) {
             Serializer<K> keySer = (Serializer<K>) context.keySerializer();
             Deserializer<K> keyDeser = (Deserializer<K>) context.keyDeserializer();
             Serializer<V> valSer = (Serializer<V>) context.valueSerializer();
             Deserializer<V> valDeser = (Deserializer<V>) context.valueDeserializer();
-            return Stores.create("my-store", context).withKeys(keySer, keyDeser).withValues(valSer, valDeser).inMemory().build();
+            supplier = Stores.create("my-store", config).withKeys(keySer, keyDeser).withValues(valSer, valDeser).inMemory().build();
+        } else {
+            supplier = Stores.create("my-store", config).withKeys(keyClass).withValues(valueClass).inMemory().build();
         }
-        return Stores.create("my-store", context).withKeys(keyClass).withValues(valueClass).inMemory().build();
+
+        KeyValueStore<K, V> store = (KeyValueStore<K, V>) supplier.get();
+        store.init(context);
+        return store;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/InMemoryLRUCacheStoreTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
 import org.junit.Test;
 
 public class InMemoryLRUCacheStoreTest {
@@ -29,10 +30,12 @@ public class InMemoryLRUCacheStoreTest {
     public void testPutGetRange() {
         // Create the test driver ...
         KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create();
-        KeyValueStore<Integer, String> store = Stores.create("my-store", driver.context())
+        StateStoreSupplier supplier = Stores.create("my-store", driver.config())
                                                      .withIntegerKeys().withStringValues()
                                                      .inMemory().maxEntries(3)
                                                      .build();
+        KeyValueStore<Integer, String> store = (KeyValueStore<Integer, String>) supplier.get();
+        store.init(driver.context());
 
         // Verify that the store reads and writes correctly, keeping only the last 2 entries ...
         store.put(0, "zero");
@@ -79,11 +82,13 @@ public class InMemoryLRUCacheStoreTest {
         Deserializer<Integer> keyDeser = (Deserializer<Integer>) driver.context().keyDeserializer();
         Serializer<String> valSer = (Serializer<String>) driver.context().valueSerializer();
         Deserializer<String> valDeser = (Deserializer<String>) driver.context().valueDeserializer();
-        KeyValueStore<Integer, String> store = Stores.create("my-store", driver.context())
+        StateStoreSupplier supplier = Stores.create("my-store", driver.config())
                                                      .withKeys(keySer, keyDeser)
                                                      .withValues(valSer, valDeser)
                                                      .inMemory().maxEntries(3)
                                                      .build();
+        KeyValueStore<Integer, String> store = (KeyValueStore<Integer, String>) supplier.get();
+        store.init(driver.context());
 
         // Verify that the store reads and writes correctly, keeping only the last 2 entries ...
         store.put(0, "zero");
@@ -133,10 +138,12 @@ public class InMemoryLRUCacheStoreTest {
 
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
-        KeyValueStore<Integer, String> store = Stores.create("my-store", driver.context())
+        StateStoreSupplier supplier = Stores.create("my-store", driver.config())
                                                      .withIntegerKeys().withStringValues()
                                                      .inMemory().maxEntries(3)
                                                      .build();
+        KeyValueStore<Integer, String> store = (KeyValueStore<Integer, String>) supplier.get();
+        store.init(driver.context());
 
         // Verify that the store's contents were properly restored ...
         assertEquals(0, driver.checkForRestoredEntries(store));

--- a/streams/src/test/java/org/apache/kafka/test/MockStateStoreSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockStateStoreSupplier.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.test;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
+
+import java.util.ArrayList;
+
+public class MockStateStoreSupplier implements StateStoreSupplier {
+    private final String name;
+    private final boolean persistent;
+
+    public MockStateStoreSupplier(String name, boolean persistent) {
+        this.name = name;
+        this.persistent = persistent;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public StateStore get() {
+        return new MockStateStore(name, persistent);
+    }
+
+    public static class MockStateStore implements StateStore {
+        private final String name;
+        private final boolean persistent;
+
+        public boolean initialized = false;
+        public boolean flushed = false;
+        public boolean closed = false;
+        public final ArrayList<Integer> keys = new ArrayList<>();
+
+        public MockStateStore(String name, boolean persistent) {
+            this.name = name;
+            this.persistent = persistent;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public void init(ProcessorContext context) {
+            context.register(this, stateRestoreCallback);
+            initialized = true;
+        }
+
+        @Override
+        public void flush() {
+            flushed = true;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        @Override
+        public boolean persistent() {
+            return persistent;
+        }
+
+        public final StateRestoreCallback stateRestoreCallback = new StateRestoreCallback() {
+            private final Deserializer<Integer> deserializer = new IntegerDeserializer();
+
+            @Override
+            public void restore(byte[] key, byte[] value) {
+                keys.add(deserializer.deserialize("", key));
+            }
+        };
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.processor.internals;
+package org.apache.kafka.test;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -32,6 +32,9 @@ import org.apache.kafka.streams.StreamingMetrics;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
+import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.ProcessorTopology;
+import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.state.KeyValueStore;
 
 import java.util.ArrayList;


### PR DESCRIPTION
- Added StateStoreSupplier
- StateStore
  - Added init(ProcessorContext context) method
- TopologyBuilder
  - Added addStateStore(StateStoreSupplier supplier, String... processNames)
  - Added connectProessorAndStateStores(String processorName, String... stateStoreNames)
    - This is for the case processors are not created when a store is added to the topology. (used by KStream)
- KStream
  - add stateStoreNames to process(), transform(), transformValues().
- Refactored existing state stores to implement StateStoreSupplier

@guozhangwang 
