### PR TITLE
MINOR: Fix homophone typo in Design documentation

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -27,7 +27,7 @@ It also meant the system would have to handle low-latency delivery to handle mor
 <p>
 We wanted to support partitioned, distributed, real-time processing of these feeds to create new, derived feeds. This motivated our partitioning and consumer model.
 <p>
-Finally in cases where the stream is fed into other data systems for serving we new the system would have to be able to guarantee fault-tolerance in the presence of machine failures.
+Finally in cases where the stream is fed into other data systems for serving we knew the system would have to be able to guarantee fault-tolerance in the presence of machine failures.
 <p>
 Supporting these uses led use to a design with a number of unique elements, more akin to a database log then a traditional messaging system. We will outline some elements of the design in the following sections.
 


### PR DESCRIPTION
Noticed that there was a small typo in section 4.1 of the Design documentation on the [website](https://kafka.apache.org/documentation.html#majordesignelements) ('new' vs. 'knew'). This patch corrects that.
