### PR TITLE
KAFKA-2718: Avoid reusing temporary directories in core unit tests

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -95,7 +95,10 @@ object TestUtils extends Logging {
    */
   def tempRelativeDir(parent: String): File = {
     new File(parent).mkdirs()
-    val f: File = Iterator.continually(new File(parent, "kafka-" + random.nextInt(1000000))).find(_.mkdir()).get
+    val attempts = 1000
+    val f = Iterator.continually(new File(parent, "kafka-" + random.nextInt(1000000)))
+                    .take(attempts).find(_.mkdir())
+                    .getOrElse(sys.error(s"Failed to create directory after $attempts attempts"))
     f.deleteOnExit()
 
     Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -85,8 +85,20 @@ object TestUtils extends Logging {
    * Create a temporary directory
    */
   def tempDir(): File = {
-    val f = new File(IoTmpDir, "kafka-" + random.nextInt(1000000))
-    f.mkdirs()
+    tempRelativeDir(IoTmpDir)
+  }
+
+  def tempTopic(): String = "testTopic" + random.nextInt(1000000)
+
+  /**
+   * Create a temporary relative directory
+   */
+  def tempRelativeDir(parent: String): File = {
+    new File(parent).mkdirs()
+    var f: File = null
+    do {
+      f = new File(parent, "kafka-" + random.nextInt(1000000))
+    } while (!f.mkdir())
     f.deleteOnExit()
 
     Runtime.getRuntime().addShutdownHook(new Thread() {
@@ -98,17 +110,6 @@ object TestUtils extends Logging {
     f
   }
 
-  def tempTopic(): String = "testTopic" + random.nextInt(1000000)
-
-  /**
-   * Create a temporary relative directory
-   */
-  def tempRelativeDir(parent: String): File = {
-    val f = new File(parent, "kafka-" + random.nextInt(1000000))
-    f.mkdirs()
-    f.deleteOnExit()
-    f
-  }
 
   /**
    * Create a temporary file

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -95,10 +95,7 @@ object TestUtils extends Logging {
    */
   def tempRelativeDir(parent: String): File = {
     new File(parent).mkdirs()
-    var f: File = null
-    do {
-      f = new File(parent, "kafka-" + random.nextInt(1000000))
-    } while (!f.mkdir())
+    val f: File = Iterator.continually(new File(parent, "kafka-" + random.nextInt(1000000))).find(_.mkdir()).get
     f.deleteOnExit()
 
     Runtime.getRuntime().addShutdownHook(new Thread() {


### PR DESCRIPTION
Retry to find new directory and cleanup on exit.
