### PR TITLE
KAFKA-2719: Use wildcard classpath for dependant-libs

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -31,9 +31,10 @@ if [ -z "$SCALA_BINARY_VERSION" ]; then
 fi
 
 # run ./gradlew copyDependantLibs to get all dependant jars in a local dir
-for file in $base_dir/core/build/dependant-libs-${SCALA_VERSION}*/*.jar;
+shopt -s nullglob
+for dir in $base_dir/core/build/dependant-libs-${SCALA_VERSION}*;
 do
-  CLASSPATH=$CLASSPATH:$file
+  CLASSPATH=$CLASSPATH:$dir/*
 done
 
 for file in $base_dir/examples/build/libs//kafka-examples*.jar;
@@ -66,17 +67,20 @@ do
   CLASSPATH=$CLASSPATH:$file
 done
 
-for file in $base_dir/tools/build/dependant-libs-${SCALA_VERSION}*/*.jar;
+for dir in $base_dir/tools/build/dependant-libs-${SCALA_VERSION}*;
 do
-  CLASSPATH=$CLASSPATH:$file
+  CLASSPATH=$CLASSPATH:$dir/*
 done
 
 for cc_pkg in "api" "runtime" "file" "json"
 do
-  for file in $base_dir/copycat/${cc_pkg}/build/libs/copycat-${cc_pkg}*.jar $base_dir/copycat/${cc_pkg}/build/dependant-libs/*.jar;
+  for file in $base_dir/copycat/${cc_pkg}/build/libs/copycat-${cc_pkg}*.jar;
   do
     CLASSPATH=$CLASSPATH:$file
   done
+  if [ -d "$base_dir/copycat/${cc_pkg}/build/dependant-libs" ] ; then
+    CLASSPATH=$CLASSPATH:$base_dir/copycat/${cc_pkg}/build/dependant-libs/*
+  fi
 done
 
 # classpath addition for release
@@ -89,6 +93,7 @@ for file in $base_dir/core/build/libs/kafka_${SCALA_BINARY_VERSION}*.jar;
 do
   CLASSPATH=$CLASSPATH:$file
 done
+shopt -u nullglob
 
 # JMX settings
 if [ -z "$KAFKA_JMX_OPTS" ]; then

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -84,10 +84,7 @@ do
 done
 
 # classpath addition for release
-for file in $base_dir/libs/*.jar;
-do
-  CLASSPATH=$CLASSPATH:$file
-done
+CLASSPATH=$CLASSPATH:$base_dir/libs/*
 
 for file in $base_dir/core/build/libs/kafka_${SCALA_BINARY_VERSION}*.jar;
 do


### PR DESCRIPTION
PR switches to wildcard classpath for dependant libs to restrict the length of classpath, thereby reducing command line length.
