### PR TITLE
KAFKA-2722: Improve ISR change propagation.

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1354,8 +1354,10 @@ class IsrChangeNotificationListener(controller: KafkaController) extends IZkChil
       val childrenAsScala: mutable.Buffer[String] = currentChildren.asScala
       try {
         val topicAndPartitions: immutable.Set[TopicAndPartition] = childrenAsScala.map(x => getTopicAndPartition(x)).flatten.toSet
-        controller.updateLeaderAndIsrCache(topicAndPartitions)
-        processUpdateNotifications(topicAndPartitions)
+        if (topicAndPartitions.nonEmpty) {
+          controller.updateLeaderAndIsrCache(topicAndPartitions)
+          processUpdateNotifications(topicAndPartitions)
+        }
       } finally {
         // delete processed children
         childrenAsScala.map(x => controller.controllerContext.zkUtils.deletePath(

--- a/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
@@ -210,7 +210,7 @@ abstract class BaseTopicMetadataTest extends ZooKeeperTestHarness {
                                 metadata.topicsMetadata.head.partitionsMetadata.nonEmpty)
                               metadata.topicsMetadata.head.partitionsMetadata.head.isr
                             else
-                              ""), 6000L)
+                              ""), 7000L)
     })
   }
 

--- a/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
@@ -210,7 +210,7 @@ abstract class BaseTopicMetadataTest extends ZooKeeperTestHarness {
                                 metadata.topicsMetadata.head.partitionsMetadata.nonEmpty)
                               metadata.topicsMetadata.head.partitionsMetadata.head.isr
                             else
-                              ""), 7000L)
+                              ""), 8000L)
     })
   }
 


### PR DESCRIPTION
The patch has two changes:
1. fixed a bug in controller that it sends UpdateMetadataRequest of all the partitions in the cluster.
2. Uses the following rules to propagate ISR change: 1) if there are ISR changes pending propagation and the last ISR change is more than five seconds ago, propagate the changes. 2) if there is ISR change at T in the recent five seconds, delay the propagation until T + 5s. 3) if the last propagation is more than 1 min ago, ignore rule No.2 and propagate ISR change if there are changes pending propagation.

This algorithm avoids a fixed configuration of ISR propagation interval as we discussed about in KIP-29.
