### PR TITLE
KAFKA-2698: Add paused() method to o.a.k.c.c.Consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -142,6 +142,11 @@ public interface Consumer<K, V> extends Closeable {
     public void pause(TopicPartition... partitions);
 
     /**
+     * @see KafkaConsumer#paused()
+     */
+    public Set<TopicPartition> paused();
+
+    /**
      * @see KafkaConsumer#resume(TopicPartition...)
      */
     public void resume(TopicPartition... partitions);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1129,6 +1129,21 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     }
 
     /**
+     * Get the set of partitions that were previously paused by a call to {@link #pause(TopicPartition...)}.
+     *
+     * @return The set of paused partitions
+     */
+    @Override
+    public Set<TopicPartition> paused() {
+        acquire();
+        try {
+            return Collections.unmodifiableSet(subscriptions.pausedPartitions());
+        } finally {
+            release();
+        }
+    }
+
+    /**
      * Resume any partitions which have been paused with {@link #pause(TopicPartition...)}. New calls to
      * {@link #poll(long)} will return records from these partitions if there are any to be fetched.
      * If the partitions were not previously paused, this method is a no-op.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -199,6 +199,18 @@ public class SubscriptionState {
         return this.subscription;
     }
 
+    public Set<TopicPartition> pausedPartitions() {
+        HashSet<TopicPartition> paused = new HashSet<>();
+        for (Map.Entry<TopicPartition, TopicPartitionState> entry : assignment.entrySet()) {
+            final TopicPartition tp = entry.getKey();
+            final TopicPartitionState state = entry.getValue();
+            if (state.paused) {
+                paused.add(tp);
+            }
+        }
+        return paused;
+    }
+
     /**
      * Get the subscription for the group. For the leader, this will include the union of the
      * subscriptions of all group members. For followers, it is just that member's subscription.

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -54,13 +54,7 @@ public class KafkaConsumerTest {
 
     @Test
     public void testSubscription() {
-        Properties props = new Properties();
-        props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testSubscription");
-        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
-        props.setProperty(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
-
-        KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<byte[], byte[]>(
-            props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+        KafkaConsumer<byte[], byte[]> consumer = newConsumer();
 
         consumer.subscribe(Collections.singletonList(topic));
         Assert.assertEquals(Collections.singleton(topic), consumer.subscription());
@@ -77,5 +71,33 @@ public class KafkaConsumerTest {
         consumer.unsubscribe();
         Assert.assertTrue(consumer.subscription().isEmpty());
         Assert.assertTrue(consumer.assignment().isEmpty());
+    }
+
+    @Test
+    public void testPause() {
+        KafkaConsumer<byte[], byte[]> consumer = newConsumer();
+
+        consumer.assign(Collections.singletonList(tp0));
+        Assert.assertEquals(Collections.singleton(tp0), consumer.assignment());
+        Assert.assertTrue(consumer.paused().isEmpty());
+
+        consumer.pause(tp0);
+        Assert.assertEquals(Collections.singleton(tp0), consumer.paused());
+
+        consumer.resume(tp0);
+        Assert.assertTrue(consumer.paused().isEmpty());
+
+        consumer.unsubscribe();
+        Assert.assertTrue(consumer.paused().isEmpty());
+    }
+
+    private KafkaConsumer<byte[], byte[]> newConsumer() {
+        Properties props = new Properties();
+        props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "my.consumer");
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
+
+        return new KafkaConsumer<byte[], byte[]>(
+            props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
     }
 }


### PR DESCRIPTION
As per KAFKA-2698, this adds a `paused()` method to the Consumer interface such that client code can query Consumer implementations for paused partitions.

Somewhat new to the code base but I understand this may require a KIP given this changes APIs: is this required even for backward-compatible changes like this?
