### PR TITLE
KAFKA-2726: Fix port collision between ntpdate and ntp daemon

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -74,6 +74,7 @@ fi
 chmod a+rwx /mnt
 
 # Run ntpdate once to sync to ntp servers
-ntpdate pool.ntp.org
+# use -u option to avoid port collision in case ntp daemon is already running
+ntpdate -u pool.ntp.org
 # Install ntp daemon - it will automatically start on boot
 apt-get -y install ntp


### PR DESCRIPTION
@gwenshap Can you take a quick look? I have verified the change allows successful `vagrant provision` even with ntp daemon already running on the vm.
