### PR TITLE
MINOR: Remove copyDependantTestLibs from jar dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -437,10 +437,6 @@ project(':core') {
     duplicatesStrategy 'exclude'
   }
 
-  systemTestLibs {
-    dependsOn testJar
-  }
-
   task genProtocolErrorDocs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.apache.kafka.common.protocol.Errors'
@@ -538,7 +534,7 @@ project(':core') {
     duplicatesStrategy 'exclude'
   }
 
-  systemTestLibs.dependsOn('jar', 'copyDependantTestLibs')
+  systemTestLibs.dependsOn('jar', 'testJar', 'copyDependantTestLibs')
 
   checkstyle {
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]

--- a/build.gradle
+++ b/build.gradle
@@ -521,7 +521,7 @@ project(':core') {
   }
 
   jar {
-    dependsOn('copyDependantLibs', 'copyDependantTestLibs')
+    dependsOn('copyDependantLibs')
   }
 
   jar.manifest {
@@ -537,6 +537,8 @@ project(':core') {
     into "$buildDir/dependant-testlibs"
     duplicatesStrategy 'exclude'
   }
+
+  systemTestLibs.dependsOn('jar', 'copyDependantTestLibs')
 
   checkstyle {
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]


### PR DESCRIPTION
_copyDependantTestLibs_ was added temporarily as a dependency of _jar_ task to enable SASL system tests to be run with MiniKdc without changing the automated system test runs which run _gradlew clean jar_. Since the build target _systemTestLibs_ is already in Kafka build.gradle, the Confluent automated test runs can now run _gradlew clean systemTestLibs_ instead. This PR provides the final change to remove _copyDependantTestLibs_ from the _jar_ task. This should be committed only after the Confluent automated sytem test build script is updated, to avoid breaking any builds.
