### PR TITLE
KAFKA-2748: Ensure sink tasks commit offsets upon rebalance and rewind if the SinkTask flush fails.

### DIFF
--- a/copycat/runtime/src/main/java/org/apache/kafka/copycat/runtime/WorkerSinkTask.java
+++ b/copycat/runtime/src/main/java/org/apache/kafka/copycat/runtime/WorkerSinkTask.java
@@ -149,7 +149,6 @@ class WorkerSinkTask implements WorkerTask {
     /**
      * Starts an offset commit by flushing outstanding messages from the task and then starting
      * the write commit. This should only be invoked by the WorkerSinkTaskThread.
-     * @returns true if synchronous and successful or asynchronous, false if synchronous and failed
      **/
     public void commitOffsets(boolean sync, final int seqno) {
         log.info("{} Committing offsets", this);

--- a/copycat/runtime/src/main/java/org/apache/kafka/copycat/runtime/WorkerSinkTaskThread.java
+++ b/copycat/runtime/src/main/java/org/apache/kafka/copycat/runtime/WorkerSinkTaskThread.java
@@ -54,7 +54,7 @@ class WorkerSinkTaskThread extends ShutdownableThread {
             iteration();
         }
         // Make sure any uncommitted data has committed
-        task.commitOffsets(task.time().milliseconds(), true, -1, false);
+        task.commitOffsets(true, -1);
     }
 
     public void iteration() {
@@ -67,7 +67,7 @@ class WorkerSinkTaskThread extends ShutdownableThread {
                 commitSeqno += 1;
                 commitStarted = now;
             }
-            task.commitOffsets(now, false, commitSeqno, true);
+            task.commitOffsets(false, commitSeqno);
             nextCommit += task.workerConfig().getLong(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG);
         }
 


### PR DESCRIPTION
Also fix the incorrect consumer group ID setting which was giving each task its
own group instead of one for the entire sink connector.
