### PR TITLE
KAFKA-2755: NPE thrown while handling DescribeGroup request for non-e…

### DIFF
--- a/core/src/main/scala/kafka/coordinator/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/GroupCoordinator.scala
@@ -662,13 +662,13 @@ class GroupCoordinator(val brokerId: Int,
 
 object GroupCoordinator {
 
-  val EmptyGroup = GroupSummary(NoState, NoProtocolType, NoProtocol, NoMembers)
-  val DeadGroup = GroupSummary(Dead.toString, NoProtocolType, NoProtocol, NoMembers)
-  val NoMembers = List[MemberSummary]()
   val NoState = ""
   val NoProtocolType = ""
   val NoProtocol = ""
   val NoLeader = ""
+  val NoMembers = List[MemberSummary]()
+  val EmptyGroup = GroupSummary(NoState, NoProtocolType, NoProtocol, NoMembers)
+  val DeadGroup = GroupSummary(Dead.toString, NoProtocolType, NoProtocol, NoMembers)
 
   // TODO: we store both group metadata and offset data here despite the topic name being offsets only
   val GroupMetadataTopicName = "__consumer_offsets"

--- a/core/src/test/scala/integration/kafka/api/AdminClientTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientTest.scala
@@ -111,4 +111,15 @@ class AdminClientTest extends IntegrationTestHarness with Logging {
       assertEquals(Set(tp, tp2), partitions.toSet)
   }
 
+  @Test
+  def testDescribeConsumerGroupForNonExistentGroup() {
+    val nonExistentGroup = "non" + groupId
+    try {
+      client.describeConsumerGroup(nonExistentGroup)
+      fail("Should have failed for non existent group.")
+    } catch {
+      case ex: IllegalArgumentException => // Pass
+      case _: Throwable => fail("Should have failed for non existent group with IllegalArgumentException.")
+    }
+  }
 }


### PR DESCRIPTION
…xistent consumer group
