### PR TITLE
KAFKA-2779: Close SSL socket channel on remote connection close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -137,11 +137,9 @@ public class SslTransportLayer implements TransportLayer {
 
     /**
     * Sends a SSL close message and closes socketChannel.
-    * @throws IOException if an I/O error occurs
-    * @throws IOException if there is data on the outgoing network buffer and we are unable to flush it
     */
     @Override
-    public void close() throws IOException {
+    public void close() {
         if (closing) return;
         closing = true;
         sslEngine.closeOutbound();
@@ -159,10 +157,15 @@ public class SslTransportLayer implements TransportLayer {
             }
             netWriteBuffer.flip();
             flush(netWriteBuffer);
-            socketChannel.socket().close();
-            socketChannel.close();
         } catch (IOException ie) {
             log.warn("Failed to send SSL Close message ", ie);
+        } finally {
+            try {
+                socketChannel.socket().close();
+                socketChannel.close();
+            } catch (IOException e) {
+                log.warn("Failed to close SSL socket channel: " + e);
+            }
         }
         key.attach(null);
         key.cancel();


### PR DESCRIPTION
Close socket channel in finally block to avoid file descriptor leak when remote end closes the connection
