### PR TITLE
KAFKA-2796 add support for reassignment partition to specified logdir

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -552,6 +552,10 @@ public class Protocol {
     public static final Schema[] LEAVE_GROUP_REQUEST = new Schema[] {LEAVE_GROUP_REQUEST_V0};
     public static final Schema[] LEAVE_GROUP_RESPONSE = new Schema[] {LEAVE_GROUP_RESPONSE_V0};
 
+    public static final Schema REPLICA_AND_LOGDIR_V0 =
+            new Schema(new Field("replica", STRING, "the replica id."),
+                       new Field("log_dir", STRING, "the log dir"));
+
     /* Leader and ISR api */
     public static final Schema LEADER_AND_ISR_REQUEST_PARTITION_STATE_V0 =
             new Schema(new Field("topic", STRING, "Topic name."),
@@ -561,7 +565,8 @@ public class Protocol {
                        new Field("leader_epoch", INT32, "The leader epoch."),
                        new Field("isr", new ArrayOf(INT32), "The in sync replica ids."),
                        new Field("zk_version", INT32, "The ZK version."),
-                       new Field("replicas", new ArrayOf(INT32), "The replica ids."));
+                       new Field("replicas", new ArrayOf(INT32), "The replica ids."),
+                       new Field("replica_logdirs", new ArrayOf(REPLICA_AND_LOGDIR_V0), "the replica logdirs"));
 
     public static final Schema LEADER_AND_ISR_REQUEST_LIVE_LEADER_V0 =
             new Schema(new Field("id", INT32, "The broker id."),

--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrRequest.java
@@ -36,16 +36,32 @@ public class LeaderAndIsrRequest extends AbstractRequest {
         public final List<Integer> isr;
         public final int zkVersion;
         public final Set<Integer> replicas;
+        public final Map<String, String> replicaLogDirs;
 
-        public PartitionState(int controllerEpoch, int leader, int leaderEpoch, List<Integer> isr, int zkVersion, Set<Integer> replicas) {
+        public PartitionState(int controllerEpoch, int leader,
+                              int leaderEpoch, List<Integer> isr,
+                              int zkVersion, Set<Integer> replicas) {
             this.controllerEpoch = controllerEpoch;
             this.leader = leader;
             this.leaderEpoch = leaderEpoch;
             this.isr = isr;
             this.zkVersion = zkVersion;
             this.replicas = replicas;
+            this.replicaLogDirs = new HashMap<String, String>();
         }
 
+        public PartitionState(int controllerEpoch, int leader,
+                              int leaderEpoch, List<Integer> isr,
+                              int zkVersion, Set<Integer> replicas,
+                              Map<String, String> replicaLogDirs) {
+            this.controllerEpoch = controllerEpoch;
+            this.leader = leader;
+            this.leaderEpoch = leaderEpoch;
+            this.isr = isr;
+            this.zkVersion = zkVersion;
+            this.replicas = replicas;
+            this.replicaLogDirs = replicaLogDirs;
+        }
     }
 
     public static final class EndPoint {
@@ -75,6 +91,11 @@ public class LeaderAndIsrRequest extends AbstractRequest {
     private static final String ISR_KEY_NAME = "isr";
     private static final String ZK_VERSION_KEY_NAME = "zk_version";
     private static final String REPLICAS_KEY_NAME = "replicas";
+    private static final String REPLICA_LOGDIRS_KEY_NAME = "replica_logdirs";
+
+    // replica_logdirs key names
+    private static final String REPLICA_ID_KEY_NAME = "replica";
+    private static final String LOG_DIR_KEY_NAME = "log_dir";
 
     // live_leaders key names
     private static final String END_POINT_ID_KEY_NAME = "id";
@@ -105,6 +126,14 @@ public class LeaderAndIsrRequest extends AbstractRequest {
             partitionStateData.set(ISR_KEY_NAME, partitionState.isr.toArray());
             partitionStateData.set(ZK_VERSION_KEY_NAME, partitionState.zkVersion);
             partitionStateData.set(REPLICAS_KEY_NAME, partitionState.replicas.toArray());
+            List<Struct> replicaLogDirs = new ArrayList<>(partitionState.replicaLogDirs.size());
+            for (Map.Entry<String, String> dirEntry : partitionState.replicaLogDirs.entrySet()) {
+                Struct replicaLogDir = partitionStateData.instance(REPLICA_LOGDIRS_KEY_NAME);
+                replicaLogDir.set(REPLICA_ID_KEY_NAME, dirEntry.getKey());
+                replicaLogDir.set(LOG_DIR_KEY_NAME, dirEntry.getValue());
+                replicaLogDirs.add(replicaLogDir);
+            }
+            partitionStateData.set(REPLICA_LOGDIRS_KEY_NAME, replicaLogDirs.toArray());
             partitionStatesData.add(partitionStateData);
         }
         struct.set(PARTITION_STATES_KEY_NAME, partitionStatesData.toArray());
@@ -149,7 +178,13 @@ public class LeaderAndIsrRequest extends AbstractRequest {
             for (Object r : replicasArray)
                 replicas.add((Integer) r);
 
-            PartitionState partitionState = new PartitionState(controllerEpoch, leader, leaderEpoch, isr, zkVersion, replicas);
+            Object[] replicaLogDirsArray = partitionStateData.getArray(REPLICA_LOGDIRS_KEY_NAME);
+            HashMap<String, String> replicaLogDirs = new HashMap<>();
+            for (Object logDirObj : replicaLogDirsArray) {
+                Struct logDir = (Struct) logDirObj;
+                replicaLogDirs.put(logDir.getString(REPLICA_ID_KEY_NAME), logDir.getString(LOG_DIR_KEY_NAME));
+            }
+            PartitionState partitionState = new PartitionState(controllerEpoch, leader, leaderEpoch, isr, zkVersion, replicas, replicaLogDirs);
             partitionStates.put(new TopicPartition(topic, partition), partitionState);
 
         }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -113,6 +113,7 @@ public class RequestResponseTest {
             Method deserializer = req.getClass().getDeclaredMethod("parse", ByteBuffer.class, Integer.TYPE);
             deserialized = (AbstractRequestResponse) deserializer.invoke(null, buffer, version);
         }
+
         assertEquals("The original and deserialized of " + req.getClass().getSimpleName() + " should be the same.", req, deserialized);
         assertEquals("The original and deserialized of " + req.getClass().getSimpleName() + " should have the same hashcode.",
                 req.hashCode(), deserialized.hashCode());
@@ -323,12 +324,14 @@ public class RequestResponseTest {
         Map<TopicPartition, LeaderAndIsrRequest.PartitionState> partitionStates = new HashMap<>();
         List<Integer> isr = Arrays.asList(1, 2);
         List<Integer> replicas = Arrays.asList(1, 2, 3, 4);
+        Map<String, String> replicaDirs = new HashMap<String, String>();
+        replicaDirs.put("1", "/data1/kafka_data");
         partitionStates.put(new TopicPartition("topic5", 105),
                 new LeaderAndIsrRequest.PartitionState(0, 2, 1, new ArrayList<>(isr), 2, new HashSet<>(replicas)));
         partitionStates.put(new TopicPartition("topic5", 1),
-                new LeaderAndIsrRequest.PartitionState(1, 1, 1, new ArrayList<>(isr), 2, new HashSet<>(replicas)));
+                new LeaderAndIsrRequest.PartitionState(1, 1, 1, new ArrayList<>(isr), 2, new HashSet<>(replicas), replicaDirs));
         partitionStates.put(new TopicPartition("topic20", 1),
-                new LeaderAndIsrRequest.PartitionState(1, 0, 1, new ArrayList<>(isr), 2, new HashSet<>(replicas)));
+                new LeaderAndIsrRequest.PartitionState(1, 0, 1, new ArrayList<>(isr), 2, new HashSet<>(replicas), replicaDirs));
 
         Set<LeaderAndIsrRequest.EndPoint> leaders = new HashSet<>(Arrays.asList(
                 new LeaderAndIsrRequest.EndPoint(0, "test0", 1223),

--- a/core/src/main/scala/kafka/api/LeaderAndIsrRequest.scala
+++ b/core/src/main/scala/kafka/api/LeaderAndIsrRequest.scala
@@ -56,13 +56,16 @@ object PartitionStateInfo {
     val zkVersion = buffer.getInt
     val replicationFactor = buffer.getInt
     val replicas = for(i <- 0 until replicationFactor) yield buffer.getInt
+    val replicaDirsSize = buffer.getInt
+    val replicaDirs = for(i <- 0 until replicaDirsSize) yield readShortString(buffer) -> readShortString(buffer)
     PartitionStateInfo(LeaderIsrAndControllerEpoch(LeaderAndIsr(leader, leaderEpoch, isr.toList, zkVersion), controllerEpoch),
-                       replicas.toSet)
+                       replicas.toSet, replicaDirs.toMap)
   }
 }
 
 case class PartitionStateInfo(leaderIsrAndControllerEpoch: LeaderIsrAndControllerEpoch,
-                              allReplicas: Set[Int]) {
+                              allReplicas: Set[Int],
+                              replicaDirs: scala.collection.Map[String, String] = Map.empty) {
   def replicationFactor = allReplicas.size
 
   def writeTo(buffer: ByteBuffer) {
@@ -74,10 +77,15 @@ case class PartitionStateInfo(leaderIsrAndControllerEpoch: LeaderIsrAndControlle
     buffer.putInt(leaderIsrAndControllerEpoch.leaderAndIsr.zkVersion)
     buffer.putInt(replicationFactor)
     allReplicas.foreach(buffer.putInt(_))
+    buffer.putInt(replicaDirs.size)
+    for ((key, value) <- replicaDirs) {
+      writeShortString(buffer, key)
+      writeShortString(buffer, value)
+    }
   }
 
   def sizeInBytes(): Int = {
-    val size =
+    var size =
       4 /* epoch of the controller that elected the leader */ +
       4 /* leader broker id */ +
       4 /* leader epoch */ +
@@ -85,7 +93,10 @@ case class PartitionStateInfo(leaderIsrAndControllerEpoch: LeaderIsrAndControlle
       4 * leaderIsrAndControllerEpoch.leaderAndIsr.isr.size /* replicas in isr */ +
       4 /* zk version */ +
       4 /* replication factor */ +
-      allReplicas.size * 4
+      allReplicas.size * 4 +
+      4 /* number of replicaDirs */
+      for ((key, value) <- replicaDirs)
+        size += 2 + key.length + 2 + value.length
     size
   }
   
@@ -93,7 +104,9 @@ case class PartitionStateInfo(leaderIsrAndControllerEpoch: LeaderIsrAndControlle
     val partitionStateInfo = new StringBuilder
     partitionStateInfo.append("(LeaderAndIsrInfo:" + leaderIsrAndControllerEpoch.toString)
     partitionStateInfo.append(",ReplicationFactor:" + replicationFactor + ")")
-    partitionStateInfo.append(",AllReplicas:" + allReplicas.mkString(",") + ")")
+    partitionStateInfo.append(",AllReplicas:" + allReplicas.mkString(","))
+    partitionStateInfo.append(",ReplicaDirs:{" + replicaDirs.map(p => p._1 + ":" + p._2).toSeq.mkString(",") + "}")
+    partitionStateInfo.append(")")
     partitionStateInfo.toString()
   }
 }

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -269,12 +269,13 @@ class ControllerBrokerRequestBatch(controller: KafkaController) extends  Logging
 
   def addLeaderAndIsrRequestForBrokers(brokerIds: Seq[Int], topic: String, partition: Int,
                                        leaderIsrAndControllerEpoch: LeaderIsrAndControllerEpoch,
-                                       replicas: Seq[Int], callback: AbstractRequestResponse => Unit = null) {
+                                       replicas: Seq[Int], replicaDirs : scala.collection.Map[String,String] = Map.empty,
+                                       callback: AbstractRequestResponse => Unit = null) {
     val topicPartition = new TopicPartition(topic, partition)
 
     brokerIds.filter(_ >= 0).foreach { brokerId =>
       val result = leaderAndIsrRequestMap.getOrElseUpdate(brokerId, mutable.Map.empty)
-      result.put(topicPartition, PartitionStateInfo(leaderIsrAndControllerEpoch, replicas.toSet))
+      result.put(topicPartition, PartitionStateInfo(leaderIsrAndControllerEpoch, replicas.toSet, replicaDirs))
     }
 
     addUpdateMetadataRequestForBrokers(controllerContext.liveOrShuttingDownBrokerIds.toSeq,
@@ -356,13 +357,16 @@ class ControllerBrokerRequestBatch(controller: KafkaController) extends  Logging
         }
         val partitionStates = partitionStateInfos.map { case (topicPartition, partitionStateInfo) =>
           val LeaderIsrAndControllerEpoch(leaderIsr, controllerEpoch) = partitionStateInfo.leaderIsrAndControllerEpoch
+          val replicaDirs = partitionStateInfo.replicaDirs.map{ case (brokerId, logDir) => brokerId -> logDir}
+
           val partitionState = new LeaderAndIsrRequest.PartitionState(controllerEpoch, leaderIsr.leader,
             leaderIsr.leaderEpoch, leaderIsr.isr.map(Integer.valueOf).asJava, leaderIsr.zkVersion,
-            partitionStateInfo.allReplicas.map(Integer.valueOf).asJava
+            partitionStateInfo.allReplicas.map(Integer.valueOf).asJava, replicaDirs.asJava
           )
           topicPartition -> partitionState
         }
         val leaderAndIsrRequest = new LeaderAndIsrRequest(controllerId, controllerEpoch, partitionStates.asJava, leaders.asJava)
+        stateChangeLogger.trace(leaderAndIsrRequest.toString)
         controller.sendRequest(broker, ApiKeys.LEADER_AND_ISR, None, leaderAndIsrRequest, null)
       }
       leaderAndIsrRequestMap.clear()

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -342,7 +342,7 @@ class LogManager(val logDirs: Array[File],
    * Create a log for the given topic and the given partition
    * If the log already exists, just return a copy of the existing log
    */
-  def createLog(topicAndPartition: TopicAndPartition, config: LogConfig): Log = {
+  def createLog(topicAndPartition: TopicAndPartition, config: LogConfig, logDir: String = null): Log = {
     logCreationOrDeletionLock synchronized {
       var log = logs.get(topicAndPartition)
       
@@ -351,7 +351,11 @@ class LogManager(val logDirs: Array[File],
         return log
       
       // if not, create it
-      val dataDir = nextLogDir()
+      var dataDir: File = null
+      if (logDir != null && !logDir.isEmpty)
+        dataDir = new File(logDir)
+      else
+        dataDir = nextLogDir()
       val dir = new File(dataDir, topicAndPartition.topic + "-" + topicAndPartition.partition)
       dir.mkdirs()
       log = new Log(dir, 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -770,7 +770,10 @@ class ReplicaManager(val config: KafkaConfig,
               partition.topic, partition.partitionId, newLeaderBrokerId))
             // Create the local replica even if the leader is unavailable. This is required to ensure that we include
             // the partition's high watermark in the checkpoint file (see KAFKA-1647)
-            partition.getOrCreateReplica()
+            partitionStateInfo.replicaDirs.get(localBrokerId.toString) match {
+              case Some(logDir) => partition.getOrCreateReplicaWithFixedDir(logDir.asInstanceOf[String])
+              case _ => partition.getOrCreateReplica()
+            }
         }
       }
 

--- a/core/src/test/scala/unit/kafka/api/RequestResponseSerializationTest.scala
+++ b/core/src/test/scala/unit/kafka/api/RequestResponseSerializationTest.scala
@@ -43,6 +43,7 @@ object SerializationTestUtils {
   private val topic2 = "test2"
   private val leader1 = 0
   private val isr1 = List(0, 1, 2)
+  private val isrDirs1 = Map(("0","/data1/kafka_data2/"), ("2","/data10/kafka_data10/"))
   private val leader2 = 0
   private val isr2 = List(0, 2, 3)
   private val partitionDataFetchResponse0 = new FetchResponsePartitionData(messages = new ByteBufferMessageSet(new Message("first message".getBytes)))
@@ -123,7 +124,7 @@ object SerializationTestUtils {
   def createTestLeaderAndIsrRequest() : LeaderAndIsrRequest = {
     val leaderAndIsr1 = new LeaderIsrAndControllerEpoch(new LeaderAndIsr(leader1, 1, isr1, 1), 1)
     val leaderAndIsr2 = new LeaderIsrAndControllerEpoch(new LeaderAndIsr(leader2, 1, isr2, 2), 1)
-    val map = Map(((topic1, 0), PartitionStateInfo(leaderAndIsr1, isr1.toSet)),
+    val map = Map(((topic1, 0), PartitionStateInfo(leaderAndIsr1, isr1.toSet, isrDirs1)),
                   ((topic2, 0), PartitionStateInfo(leaderAndIsr2, isr2.toSet)))
     new LeaderAndIsrRequest(map.toMap, collection.immutable.Set[BrokerEndPoint](), 0, 1, 0, "")
   }


### PR DESCRIPTION
  Currently when creating a log, the directory is chosen by calculating the number of partitions
in each directory and then choosing the data directory with the fewest partitions.
    However, the sizes of different TopicParitions are very different, which lead to usage vary greatly between different logDirs. And usually each logDir corresponds to a disk, so the disk usage between different disks is very imbalance .
    The possible solution is to reassign partitions in high-usage logDirs to low-usage logDirs.  I change the format of /admin/reassign_partitions，add replicaDirs field.  At reassigning Partitions, when broker’s LogManager.createLog() is invoked , if replicaDir is specified ,  the specified logDir will be chosen, otherwise the logDir with the fewest partitions will be chosen.

the old /admin/reassign_partitions:

```
  {"version":1,
   "partitions": 
   [
     {
       "topic" : "Foo",
       "partition": 1,
       "replicas": [1, 2, 3]
     }
   ]
  }
```

the new /admin/reassign_partitions:

```
  {"version":1,
   "partitions": 
   [
     {
       "topic" : "Foo",
       "partition": 1,
       "replicas": [1, 2, 3],
       "replicaDirs": {"1":"/data1/kafka_data",  "3":"/data10/kakfa_data" }
     }
   ]
  }
```
