### PR TITLE
KAFKA-2801: Process any remaining data in SSL network read buffer after handshake

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -440,7 +440,7 @@ public class SslTransportLayer implements TransportLayer {
             netReadBuffer = Utils.ensureCapacity(netReadBuffer, netReadBufferSize());
             if (netReadBuffer.remaining() > 0) {
                 int netread = socketChannel.read(netReadBuffer);
-                if (netread == 0) return netread;
+                if (netread == 0 && netReadBuffer.position() == 0) return netread;
                 else if (netread < 0) throw new EOFException("EOF during read");
             }
             do {


### PR DESCRIPTION
Process any remaining data in the network read buffer in `SslTransportLayer` when `read()` is invoked. On handshake completion, there could be application data ready to be processed that was read into `netReadBuffer` during handshake processing. `read()` is already invoked from `Selector` after handshake completion, but data already read into the `netReadBuffer` was not being processed. This PR adds a check for remaining data and continues with processing data if data is available.
