### PR TITLE
KAFKA-2805

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -216,7 +216,6 @@ public final class RecordAccumulator {
                 Iterator<RecordBatch> batchIterator = dq.iterator();
                 while (batchIterator.hasNext()) {
                     RecordBatch batch = batchIterator.next();
-                    Node leader = cluster.leaderFor(topicAndPartition);
                     // check if the batch is expired
                     if (batch.maybeExpire(requestTimeout, now, this.lingerMs)) {
                         expiredBatches.add(batch);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -217,17 +217,15 @@ public final class RecordAccumulator {
                 while (batchIterator.hasNext()) {
                     RecordBatch batch = batchIterator.next();
                     Node leader = cluster.leaderFor(topicAndPartition);
-                    if (leader == null) {
-                        // check if the batch is expired
-                        if (batch.maybeExpire(requestTimeout, now, this.lingerMs)) {
-                            expiredBatches.add(batch);
-                            count++;
-                            batchIterator.remove();
-                            deallocate(batch);
-                        } else {
-                            if (!batch.inRetry()) {
-                                break;
-                            }
+                    // check if the batch is expired
+                    if (batch.maybeExpire(requestTimeout, now, this.lingerMs)) {
+                        expiredBatches.add(batch);
+                        count++;
+                        batchIterator.remove();
+                        deallocate(batch);
+                    } else {
+                        if (!batch.inRetry()) {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Removed the check for expiring only those batches whose metadata is unavailable. Now the batches will be expired irrespective of whether the leader is available or not, as soon as it reaches the requestimeout threshold.
