### PR TITLE
MINOR: Do not collect zk persistent data by default

### DIFF
--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -30,7 +30,7 @@ class ZookeeperService(Service):
             "collect_default": True},
         "zk_data": {
             "path": "/mnt/zookeeper",
-            "collect_default": True}
+            "collect_default": False}
     }
 
     def __init__(self, context, num_nodes):


### PR DESCRIPTION
In system tests zookeeper service, it is overkill and space-intensive to collect zookeeper data logs by default. This minor patch turns off default collection.
