### PR TITLE
MINOR: Fix building from subproject directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,19 +312,19 @@ project(':core') {
   tasks.create(name: "genProducerConfigDocs", dependsOn:jar, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.apache.kafka.clients.producer.ProducerConfig'
-    standardOutput = new File('docs/producer_config.html').newOutputStream()
+    standardOutput = new File("$rootDir/docs/producer_config.html").newOutputStream()
   }
 
   tasks.create(name: "genConsumerConfigDocs", dependsOn:jar, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.apache.kafka.clients.consumer.ConsumerConfig'
-    standardOutput = new File('docs/consumer_config.html').newOutputStream()
+    standardOutput = new File("$rootDir/docs/consumer_config.html").newOutputStream()
   }
 
   tasks.create(name: "genKafkaConfigDocs", dependsOn:jar, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'kafka.server.KafkaConfig'
-    standardOutput = new File('docs/kafka_config.html').newOutputStream()
+    standardOutput = new File("$rootDir/docs/kafka_config.html").newOutputStream()
   }
 
   task siteDocsTar(dependsOn: ['genProducerConfigDocs', 'genConsumerConfigDocs', 'genKafkaConfigDocs', ':connect:runtime:genConnectConfigDocs'], type: Tar) {
@@ -488,6 +488,7 @@ project(':clients') {
 
   checkstyle {
      configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+     configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
@@ -547,6 +548,7 @@ project(':tools') {
 
     checkstyle {
         configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
     }
     test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
@@ -604,6 +606,7 @@ project(':streams') {
 
     checkstyle {
         configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
     }
     test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
@@ -638,6 +641,7 @@ project(':log4j-appender') {
 
   checkstyle {
      configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+     configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
@@ -695,6 +699,7 @@ project(':connect:api') {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
@@ -756,6 +761,7 @@ project(':connect:json') {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
@@ -825,13 +831,14 @@ project(':connect:runtime') {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 
   tasks.create(name: "genConnectConfigDocs", dependsOn:jar, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.apache.kafka.connect.runtime.distributed.DistributedConfig'
-    standardOutput = new File('docs/connect_config.html').newOutputStream()
+    standardOutput = new File("$rootDir/docs/connect_config.html").newOutputStream()
   }
 }
 
@@ -891,6 +898,7 @@ project(':connect:file') {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
 }

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN" 
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
      "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 <!--
 // Licensed to the Apache Software Foundation (ASF) under one or more
@@ -9,9 +9,9 @@
 // The ASF licenses this file to You under the Apache License, Version 2.0
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
-// 
+//
 //    http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,7 +67,7 @@
 
     <!-- dependencies -->
     <module name="ImportControl">
-      <property name="file" value="${basedir}/checkstyle/import-control.xml"/>
+      <property name="file" value="${importControlFile}"/>
     </module>
 
     <!-- whitespace -->


### PR DESCRIPTION
This patch fixes some releative paths so bulding from a subproject directory like ($rootDir/core) will not fail
