### PR TITLE
KAFKA-2815: Fix KafkaStreamingPartitionAssignorTest.testSubscription

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/KafkaStreamingPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/KafkaStreamingPartitionAssignorTest.java
@@ -171,6 +171,7 @@ public class KafkaStreamingPartitionAssignorTest {
 
         PartitionAssignor.Subscription subscription = partitionAssignor.subscription(Utils.mkSet("topic1", "topic2"));
 
+        Collections.sort(subscription.topics());
         assertEquals(Utils.mkList("topic1", "topic2"), subscription.topics());
 
         Set<TaskId> standbyTasks = new HashSet<>(cachedTasks);


### PR DESCRIPTION
Fails when order of elements is incorrect
