### PR TITLE
KAFKA-2822: DescribeConsumerGroup now returns empty list for non-exis…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AdminClientTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientTest.scala
@@ -113,12 +113,6 @@ class AdminClientTest extends IntegrationTestHarness with Logging {
   @Test
   def testDescribeConsumerGroupForNonExistentGroup() {
     val nonExistentGroup = "non" + groupId
-    try {
-      client.describeConsumerGroup(nonExistentGroup)
-      fail("Should have failed for non existent group.")
-    } catch {
-      case ex: IllegalArgumentException => // Pass
-      case _: Throwable => fail("Should have failed for non existent group with IllegalArgumentException.")
-    }
+    assertTrue("Expected empty ConsumerSummary list", client.describeConsumerGroup(nonExistentGroup).isEmpty)
   }
 }


### PR DESCRIPTION
…tent group, it used to throw IllegalArgumentException
