### PR TITLE
KAFKA-2824: MiniKDC based tests don't run in VirtualBox

### DIFF
--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -91,7 +91,7 @@ class MiniKdc(Service):
         node.account.ssh("rm -rf " + MiniKdc.WORK_DIR, allow_fail=False)
         if os.path.exists(MiniKdc.LOCAL_KEYTAB_FILE):
             os.remove(MiniKdc.LOCAL_KEYTAB_FILE)
-        # if os.path.exists(MiniKdc.LOCAL_KRB5CONF_FILE):
-        #     os.remove(MiniKdc.LOCAL_KRB5CONF_FILE)
+        if os.path.exists(MiniKdc.LOCAL_KRB5CONF_FILE):
+            os.remove(MiniKdc.LOCAL_KRB5CONF_FILE)
 
 

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -17,7 +17,12 @@ from ducktape.services.service import Service
 from kafkatest.services.kafka.directory import kafka_dir
 
 import os
-
+from tempfile import mkstemp
+from shutil import move
+from os import remove, close
+import tempfile
+import shutil
+from io import open
 
 class MiniKdc(Service):
 
@@ -38,6 +43,16 @@ class MiniKdc(Service):
     def __init__(self, context, kafka_nodes):
         super(MiniKdc, self).__init__(context, 1)
         self.kafka_nodes = kafka_nodes
+
+    def replace_in_file(self, file_path, pattern, subst):
+        fh, abs_path = mkstemp()
+        with open(abs_path, 'w') as new_file:
+            with open(file_path) as old_file:
+                for line in old_file:
+                    new_file.write(line.replace(pattern, subst))
+        close(fh)
+        remove(file_path)
+        move(abs_path, file_path)
 
 
     def start_node(self, node):
@@ -60,9 +75,12 @@ class MiniKdc(Service):
         with node.account.monitor_log(MiniKdc.LOG_FILE) as monitor:
             node.account.ssh(cmd)
             monitor.wait_until("MiniKdc Running", timeout_sec=60, backoff_sec=1, err_msg="MiniKdc didn't finish startup")
+
         node.account.scp_from(MiniKdc.KEYTAB_FILE, MiniKdc.LOCAL_KEYTAB_FILE)
         node.account.scp_from(MiniKdc.KRB5CONF_FILE, MiniKdc.LOCAL_KRB5CONF_FILE)
 
+        #KDC is set to bind openly (via 0.0.0.0). Change krb5.conf to hold the specific KDC address
+        self.replace_in_file(MiniKdc.LOCAL_KRB5CONF_FILE, '0.0.0.0', node.account.hostname)
 
     def stop_node(self, node):
         self.logger.info("Stopping %s on %s" % (type(self).__name__, node.account.hostname))
@@ -73,7 +91,7 @@ class MiniKdc(Service):
         node.account.ssh("rm -rf " + MiniKdc.WORK_DIR, allow_fail=False)
         if os.path.exists(MiniKdc.LOCAL_KEYTAB_FILE):
             os.remove(MiniKdc.LOCAL_KEYTAB_FILE)
-        if os.path.exists(MiniKdc.LOCAL_KRB5CONF_FILE):
-            os.remove(MiniKdc.LOCAL_KRB5CONF_FILE)
+        # if os.path.exists(MiniKdc.LOCAL_KRB5CONF_FILE):
+        #     os.remove(MiniKdc.LOCAL_KRB5CONF_FILE)
 
 

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -20,8 +20,6 @@ import os
 from tempfile import mkstemp
 from shutil import move
 from os import remove, close
-import tempfile
-import shutil
 from io import open
 
 class MiniKdc(Service):

--- a/tests/kafkatest/services/security/templates/minikdc.properties
+++ b/tests/kafkatest/services/security/templates/minikdc.properties
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kdc.bind.address={{ node.account.hostname }}
+kdc.bind.address=0.0.0.0
 


### PR DESCRIPTION
This is a hack which works. Is there a better way?

Build (v2) of the replication_test.py running here: http://jenkins.confluent.io/job/kafka_system_tests_branch_builder/185/
