### PR TITLE
MINOR: Tuned timeout parameter to reduce chance of transient failure

### DIFF
--- a/tests/kafkatest/tests/mirror_maker_test.py
+++ b/tests/kafkatest/tests/mirror_maker_test.py
@@ -47,7 +47,7 @@ class TestMirrorMakerService(ProduceConsumeValidateTest):
                                         whitelist=self.topic, offset_commit_interval_ms=1000)
         # This will consume from target kafka cluster
         self.consumer = ConsoleConsumer(test_context, num_nodes=1, kafka=self.target_kafka, topic=self.topic,
-                                        message_validator=is_int, consumer_timeout_ms=15000)
+                                        message_validator=is_int, consumer_timeout_ms=60000)
 
     def setUp(self):
         # Source cluster


### PR DESCRIPTION
Increased timeout in downstream consumer doing validation step. This addresses a transient failure case in mirror maker tests with mirror maker failover.
