### PR TITLE
KAFKA-2811: add standby tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
@@ -54,6 +54,10 @@ public class StreamingConfig extends AbstractConfig {
     public static final String NUM_STREAM_THREADS_CONFIG = "num.stream.threads";
     private static final String NUM_STREAM_THREADS_DOC = "The number of threads to execute stream processing.";
 
+    /** <code>num.stream.threads</code> */
+    public static final String NUM_STANDBY_REPLICAS_CONFIG = "num.standby.replicas";
+    private static final String NUM_STANDBY_REPLICAS_DOC = "The number of standby replicas.";
+
     /** <code>buffered.records.per.partition</code> */
     public static final String BUFFERED_RECORDS_PER_PARTITION_CONFIG = "buffered.records.per.partition";
     private static final String BUFFERED_RECORDS_PER_PARTITION_DOC = "The maximum number of records to buffer per partition.";
@@ -136,6 +140,11 @@ public class StreamingConfig extends AbstractConfig {
                                         1,
                                         Importance.LOW,
                                         NUM_STREAM_THREADS_DOC)
+                                .define(NUM_STANDBY_REPLICAS_CONFIG,
+                                        Type.INT,
+                                        0,
+                                        Importance.LOW,
+                                        NUM_STANDBY_REPLICAS_DOC)
                                 .define(BUFFERED_RECORDS_PER_PARTITION_CONFIG,
                                         Type.INT,
                                         1000,
@@ -214,6 +223,7 @@ public class StreamingConfig extends AbstractConfig {
 
     public Map<String, Object> getConsumerConfigs(StreamThread streamThread) {
         Map<String, Object> props = getConsumerConfigs();
+        props.put(StreamingConfig.NUM_STANDBY_REPLICAS_CONFIG, getInt(StreamingConfig.NUM_STANDBY_REPLICAS_CONFIG));
         props.put(StreamingConfig.InternalConfig.STREAM_THREAD_INSTANCE, streamThread);
         props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, KafkaStreamingPartitionAssignor.class.getName());
         return props;

--- a/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
@@ -56,7 +56,7 @@ public class StreamingConfig extends AbstractConfig {
 
     /** <code>num.stream.threads</code> */
     public static final String NUM_STANDBY_REPLICAS_CONFIG = "num.standby.replicas";
-    private static final String NUM_STANDBY_REPLICAS_DOC = "The number of standby replicas.";
+    private static final String NUM_STANDBY_REPLICAS_DOC = "The number of standby replicas for each task.";
 
     /** <code>buffered.records.per.partition</code> */
     public static final String BUFFERED_RECORDS_PER_PARTITION_CONFIG = "buffered.records.per.partition";

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
+import org.apache.kafka.streams.processor.TaskId;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+public abstract class AbstractTask {
+    protected final TaskId id;
+    protected final ProcessorTopology topology;
+    protected final ProcessorStateManager stateMgr;
+    protected final Set<TopicPartition> partitions;
+    protected ProcessorContext processorContext;
+
+    protected AbstractTask(TaskId id,
+                           Consumer<byte[], byte[]> restoreConsumer,
+                           ProcessorTopology topology,
+                           StreamingConfig config,
+                           Set<TopicPartition> partitions) {
+        this.id = id;
+        this.topology = topology;
+        this.partitions = partitions;
+
+        // create the processor state manager
+        try {
+            File stateFile = new File(config.getString(StreamingConfig.STATE_DIR_CONFIG), id.toString());
+            // if partitions is null, this is a standby task
+            this.stateMgr = new ProcessorStateManager(id.partition, stateFile, restoreConsumer, partitions == null);
+        } catch (IOException e) {
+            throw new KafkaException("Error while creating the state manager", e);
+        }
+    }
+
+    protected void initializeStateStores() {
+        for (StateStoreSupplier stateStoreSupplier : this.topology.stateStoreSuppliers()) {
+            StateStore store = stateStoreSupplier.get();
+            store.init(this.processorContext);
+        }
+    }
+
+    public final TaskId id() {
+        return id;
+    }
+
+    public final Set<TopicPartition> partitions() {
+        return this.partitions;
+    }
+
+    public final ProcessorTopology topology() {
+        return topology;
+    }
+
+    public final ProcessorContext context() {
+        return processorContext;
+    }
+
+    public abstract void commit();
+
+    public void close() {
+        try {
+            stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
+        } catch (IOException e) {
+            throw new KafkaException("Error while closing the state manager in processor context", e);
+        }
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -35,6 +35,7 @@ import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ProcessorStateManager {
@@ -51,13 +52,17 @@ public class ProcessorStateManager {
     private final Consumer<byte[], byte[]> restoreConsumer;
     private final Map<TopicPartition, Long> restoredOffsets;
     private final Map<TopicPartition, Long> checkpointedOffsets;
+    private final boolean isStandby;
+    private final Map<String, StateRestoreCallback> restoreCallbacks; // used for standby tasks
 
-    public ProcessorStateManager(int partition, File baseDir, Consumer<byte[], byte[]> restoreConsumer) throws IOException {
+    public ProcessorStateManager(int partition, File baseDir, Consumer<byte[], byte[]> restoreConsumer, boolean isStandby) throws IOException {
         this.partition = partition;
         this.baseDir = baseDir;
         this.stores = new HashMap<>();
         this.restoreConsumer = restoreConsumer;
         this.restoredOffsets = new HashMap<>();
+        this.isStandby = isStandby;
+        this.restoreCallbacks = isStandby ? new HashMap<String, StateRestoreCallback>() : null;
 
         // create the state directory for this task if missing (we won't create the parent directory)
         createStateDirectory(baseDir);
@@ -103,8 +108,6 @@ public class ProcessorStateManager {
         if (this.stores.containsKey(store.name()))
             throw new IllegalArgumentException("Store " + store.name() + " has already been registered.");
 
-        // ---- register the store ---- //
-
         // check that the underlying change log topic exist or not
         if (restoreConsumer.listTopics().containsKey(store.name())) {
             boolean partitionNotFound = true;
@@ -124,48 +127,94 @@ public class ProcessorStateManager {
 
         this.stores.put(store.name(), store);
 
+        if (isStandby) {
+            if (store.persistent())
+                restoreCallbacks.put(store.name(), stateRestoreCallback);
+        } else {
+            restore(store, stateRestoreCallback);
+        }
+    }
+
+    private void restore(StateStore store, StateRestoreCallback stateRestoreCallback) {
+
+        if (store == null)
+            throw new IllegalArgumentException("Store " + store.name() + " has not been registered.");
+
         // ---- try to restore the state from change-log ---- //
 
         // subscribe to the store's partition
-        TopicPartition storePartition = new TopicPartition(store.name(), partition);
         if (!restoreConsumer.subscription().isEmpty()) {
             throw new IllegalStateException("Restore consumer should have not subscribed to any partitions beforehand");
         }
+        TopicPartition storePartition = new TopicPartition(store.name(), partition);
         restoreConsumer.assign(Collections.singletonList(storePartition));
 
-        // calculate the end offset of the partition
-        // TODO: this is a bit hacky to first seek then position to get the end offset
-        restoreConsumer.seekToEnd(storePartition);
-        long endOffset = restoreConsumer.position(storePartition);
+        try {
+            // calculate the end offset of the partition
+            // TODO: this is a bit hacky to first seek then position to get the end offset
+            restoreConsumer.seekToEnd(storePartition);
+            long endOffset = restoreConsumer.position(storePartition);
 
-        // restore from the checkpointed offset of the change log if it is persistent and the offset exists;
-        // restore the state from the beginning of the change log otherwise
-        if (checkpointedOffsets.containsKey(storePartition) && store.persistent()) {
-            restoreConsumer.seek(storePartition, checkpointedOffsets.get(storePartition));
-        } else {
-            restoreConsumer.seekToBeginning(storePartition);
-        }
-
-        // restore its state from changelog records; while restoring the log end offset
-        // should not change since it is only written by this thread.
-        while (true) {
-            for (ConsumerRecord<byte[], byte[]> record : restoreConsumer.poll(100).records(storePartition)) {
-                stateRestoreCallback.restore(record.key(), record.value());
+            // restore from the checkpointed offset of the change log if it is persistent and the offset exists;
+            // restore the state from the beginning of the change log otherwise
+            if (checkpointedOffsets.containsKey(storePartition) && store.persistent()) {
+                restoreConsumer.seek(storePartition, checkpointedOffsets.get(storePartition));
+            } else {
+                restoreConsumer.seekToBeginning(storePartition);
             }
 
-            if (restoreConsumer.position(storePartition) == endOffset) {
-                break;
-            } else if (restoreConsumer.position(storePartition) > endOffset) {
-                throw new IllegalStateException("Log end offset should not change while restoring");
-            }
-        }
+            // restore its state from changelog records; while restoring the log end offset
+            // should not change since it is only written by this thread.
+            while (true) {
+                for (ConsumerRecord<byte[], byte[]> record : restoreConsumer.poll(100).records(storePartition)) {
+                    stateRestoreCallback.restore(record.key(), record.value());
+                }
 
+                if (restoreConsumer.position(storePartition) == endOffset) {
+                    break;
+                } else if (restoreConsumer.position(storePartition) > endOffset) {
+                    throw new IllegalStateException("Log end offset should not change while restoring");
+                }
+            }
+
+            // record the restored offset for its change log partition
+            long newOffset = restoreConsumer.position(storePartition);
+            restoredOffsets.put(storePartition, newOffset);
+        } finally {
+            // un-assign the change log partition
+            restoreConsumer.assign(Collections.<TopicPartition>emptyList());
+        }
+    }
+
+    public Map<TopicPartition, Long> changeLogOffsets() {
+        Map<TopicPartition, Long> partitionsAndOffsets = new HashMap<>();
+
+        for (Map.Entry<String, StateRestoreCallback> entry : restoreCallbacks.entrySet()) {
+            String storeName = entry.getKey();
+            TopicPartition storePartition = new TopicPartition(storeName, partition);
+
+            long offset = -1;
+            if (restoredOffsets.containsKey(storePartition)) {
+                restoredOffsets.get(storePartition);
+            } else if (checkpointedOffsets.containsKey(storePartition)) {
+                checkpointedOffsets.get(storePartition);
+            }
+
+            partitionsAndOffsets.put(new TopicPartition(storeName, partition), offset);
+        }
+        return partitionsAndOffsets;
+    }
+
+    public void updateStandbyStates(TopicPartition storePartition, List<ConsumerRecord<byte[], byte[]>> records) {
+        // restore states from changelog records
+        StateRestoreCallback restoreCallback = restoreCallbacks.get(storePartition.topic());
+
+        for (ConsumerRecord<byte[], byte[]> record : records) {
+            restoreCallback.restore(record.key(), record.value());
+        }
         // record the restored offset for its change log partition
         long newOffset = restoreConsumer.position(storePartition);
         restoredOffsets.put(storePartition, newOffset);
-
-        // un-assign the change log partition
-        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
     }
 
     public StateStore getStore(String name) {
@@ -223,6 +272,9 @@ public class ProcessorStateManager {
             OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(this.baseDir, CHECKPOINT_FILE_NAME));
             checkpoint.write(checkpointOffsets);
         }
+
+        // un-assign the change log partition
+        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
 
         // release the state directory directoryLock
         directoryLock.release();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.StreamingMetrics;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TaskId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class StandbyContextImpl implements ProcessorContext, RecordCollector.Supplier {
+
+    private static final Logger log = LoggerFactory.getLogger(StandbyContextImpl.class);
+
+    private final TaskId id;
+    private final StreamingMetrics metrics;
+    private final ProcessorStateManager stateMgr;
+
+    private final Serializer<?> keySerializer;
+    private final Serializer<?> valSerializer;
+    private final Deserializer<?> keyDeserializer;
+    private final Deserializer<?> valDeserializer;
+
+    private boolean initialized;
+
+    public StandbyContextImpl(TaskId id,
+                              StreamingConfig config,
+                              ProcessorStateManager stateMgr,
+                              StreamingMetrics metrics) {
+        this.id = id;
+        this.metrics = metrics;
+        this.stateMgr = stateMgr;
+
+        this.keySerializer = config.keySerializer();
+        this.valSerializer = config.valueSerializer();
+        this.keyDeserializer = config.keyDeserializer();
+        this.valDeserializer = config.valueDeserializer();
+
+        this.initialized = false;
+    }
+
+    public void initialized() {
+        this.initialized = true;
+    }
+
+    public TaskId id() {
+        return id;
+    }
+
+    public ProcessorStateManager getStateMgr() {
+        return stateMgr;
+    }
+
+    @Override
+    public RecordCollector recordCollector() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Serializer<?> keySerializer() {
+        return this.keySerializer;
+    }
+
+    @Override
+    public Serializer<?> valueSerializer() {
+        return this.valSerializer;
+    }
+
+    @Override
+    public Deserializer<?> keyDeserializer() {
+        return this.keyDeserializer;
+    }
+
+    @Override
+    public Deserializer<?> valueDeserializer() {
+        return this.valDeserializer;
+    }
+
+    @Override
+    public File stateDir() {
+        return stateMgr.baseDir();
+    }
+
+    @Override
+    public StreamingMetrics metrics() {
+        return metrics;
+    }
+
+    @Override
+    public void register(StateStore store, StateRestoreCallback stateRestoreCallback) {
+        if (initialized)
+            throw new KafkaException("Can only create state stores during initialization.");
+
+        stateMgr.register(store, stateRestoreCallback);
+    }
+
+    @Override
+    public StateStore getStateStore(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String topic() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int partition() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long offset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long timestamp() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K, V> void forward(K key, V value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K, V> void forward(K key, V value, int childIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void commit() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void schedule(long interval) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -38,7 +38,7 @@ public class StandbyTask extends AbstractTask {
 
     private static final Logger log = LoggerFactory.getLogger(StandbyTask.class);
 
-    private final Map<TopicPartition, Long> changeLogStartOffsets;
+    private final Map<TopicPartition, Long> checkpointedOffsets;
 
     /**
      * Create {@link StandbyTask} with its assigned partitions
@@ -63,15 +63,15 @@ public class StandbyTask extends AbstractTask {
 
         ((StandbyContextImpl) this.processorContext).initialized();
 
-        this.changeLogStartOffsets = Collections.unmodifiableMap(stateMgr.changeLogOffsets());
+        this.checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointedOffsets());
     }
 
-    public Map<TopicPartition, Long> changeLogStartOffsets() {
-        return changeLogStartOffsets;
+    public Map<TopicPartition, Long> checkpointedOffsets() {
+        return checkpointedOffsets;
     }
 
     public Collection<TopicPartition> changeLogPartitions() {
-        return changeLogStartOffsets.keySet();
+        return checkpointedOffsets.keySet();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.StreamingMetrics;
+import org.apache.kafka.streams.processor.TaskId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A StandbyTask
+ */
+public class StandbyTask extends AbstractTask {
+
+    private static final Logger log = LoggerFactory.getLogger(StandbyTask.class);
+
+    private final Map<TopicPartition, Long> changeLogStartOffsets;
+
+    /**
+     * Create {@link StandbyTask} with its assigned partitions
+     *
+     * @param id                    the ID of this task
+     * @param restoreConsumer       the instance of {@link Consumer} used when restoring state
+     * @param topology              the instance of {@link ProcessorTopology}
+     * @param config                the {@link StreamingConfig} specified by the user
+     * @param metrics               the {@link StreamingMetrics} created by the thread
+     */
+    public StandbyTask(TaskId id,
+                       Consumer<byte[], byte[]> restoreConsumer,
+                       ProcessorTopology topology,
+                       StreamingConfig config,
+                       StreamingMetrics metrics) {
+        super(id, restoreConsumer, topology, config, null);
+
+        // initialize the topology with its own context
+        this.processorContext = new StandbyContextImpl(id, config, stateMgr, metrics);
+
+        initializeStateStores();
+
+        ((StandbyContextImpl) this.processorContext).initialized();
+
+        this.changeLogStartOffsets = Collections.unmodifiableMap(stateMgr.changeLogOffsets());
+    }
+
+    public Map<TopicPartition, Long> changeLogStartOffsets() {
+        return changeLogStartOffsets;
+    }
+
+    public Collection<TopicPartition> changeLogPartitions() {
+        return changeLogStartOffsets.keySet();
+    }
+
+    /**
+     * Updates a state store using records from one change log partition
+     */
+    public void update(TopicPartition partition, List<ConsumerRecord<byte[], byte[]>> records) {
+        stateMgr.updateStandbyStates(partition, records);
+    }
+
+    public void commit() {
+        stateMgr.flush();
+    }
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -78,7 +78,8 @@ public class StreamThread extends Thread {
     protected final Consumer<byte[], byte[]> restoreConsumer;
 
     private final AtomicBoolean running;
-    private final Map<TaskId, StreamTask> tasks;
+    private final Map<TaskId, StreamTask> activeTasks;
+    private final Map<TaskId, StandbyTask> standbyTasks;
     private final Set<TaskId> prevTasks;
     private final String clientId;
     private final Time time;
@@ -96,14 +97,15 @@ public class StreamThread extends Thread {
     final ConsumerRebalanceListener rebalanceListener = new ConsumerRebalanceListener() {
         @Override
         public void onPartitionsAssigned(Collection<TopicPartition> assignment) {
-            addPartitions(assignment);
+            addStreamTasks(assignment);
+            addStandbyTasks();
             lastClean = time.milliseconds(); // start the cleaning cycle
         }
 
         @Override
         public void onPartitionsRevoked(Collection<TopicPartition> assignment) {
             commitAll();
-            removePartitions();
+            removeAllTasks();
             lastClean = Long.MAX_VALUE; // stop the cleaning cycle until partitions are assigned
         }
     };
@@ -141,7 +143,8 @@ public class StreamThread extends Thread {
         this.restoreConsumer = (restoreConsumer != null) ? restoreConsumer : createRestoreConsumer();
 
         // initialize the task list
-        this.tasks = new HashMap<>();
+        this.activeTasks = new HashMap<>();
+        this.standbyTasks = new HashMap<>();
         this.prevTasks = new HashSet<>();
 
         // read in task specific config values
@@ -208,7 +211,7 @@ public class StreamThread extends Thread {
     }
 
     public Map<TaskId, StreamTask> tasks() {
-        return Collections.unmodifiableMap(tasks);
+        return Collections.unmodifiableMap(activeTasks);
     }
 
     private void shutdown() {
@@ -236,7 +239,7 @@ public class StreamThread extends Thread {
             log.error("Failed to close restore consumer in thread [" + this.getName() + "]: ", e);
         }
         try {
-            removePartitions();
+            removeAllTasks();
         } catch (Throwable e) {
             // already logged in removePartition()
         }
@@ -261,7 +264,7 @@ public class StreamThread extends Thread {
                     ConsumerRecords<byte[], byte[]> records = consumer.poll(totalNumBuffered == 0 ? this.pollTimeMs : 0);
 
                     if (!records.isEmpty()) {
-                        for (StreamTask task : tasks.values()) {
+                        for (StreamTask task : activeTasks.values()) {
                             for (TopicPartition partition : task.partitions()) {
                                 task.addRecords(partition, records.records(partition));
                             }
@@ -274,11 +277,11 @@ public class StreamThread extends Thread {
 
                 totalNumBuffered = 0;
 
-                if (!tasks.isEmpty()) {
+                if (!activeTasks.isEmpty()) {
                     // try to process one record from each task
                     requiresPoll = false;
 
-                    for (StreamTask task : tasks.values()) {
+                    for (StreamTask task : activeTasks.values()) {
                         long startProcess = time.milliseconds();
 
                         totalNumBuffered += task.process();
@@ -294,10 +297,26 @@ public class StreamThread extends Thread {
                     requiresPoll = true;
                 }
 
+                if (!standbyTasks.isEmpty()) {
+                    updateStandbyTasks();
+                }
+
                 maybeClean();
             }
         } catch (Exception e) {
             throw new KafkaException(e);
+        }
+    }
+
+    private void updateStandbyTasks() {
+        ConsumerRecords<byte[], byte[]> records = restoreConsumer.poll(0);
+
+        if (!records.isEmpty()) {
+            for (StandbyTask task : standbyTasks.values()) {
+                for (TopicPartition partition : task.changeLogPartitions()) {
+                    task.update(partition, records.records(partition));
+                }
+            }
         }
     }
 
@@ -316,7 +335,7 @@ public class StreamThread extends Thread {
     }
 
     private void maybePunctuate() {
-        for (StreamTask task : tasks.values()) {
+        for (StreamTask task : activeTasks.values()) {
             try {
                 long now = time.milliseconds();
 
@@ -324,7 +343,7 @@ public class StreamThread extends Thread {
                     sensors.punctuateTimeSensor.record(time.milliseconds() - now);
 
             } catch (Exception e) {
-                log.error("Failed to commit task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
+                log.error("Failed to commit active task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
                 throw e;
             }
         }
@@ -339,12 +358,12 @@ public class StreamThread extends Thread {
             commitAll();
             lastCommit = now;
         } else {
-            for (StreamTask task : tasks.values()) {
+            for (StreamTask task : activeTasks.values()) {
                 try {
                     if (task.commitNeeded())
                         commitOne(task, time.milliseconds());
                 } catch (Exception e) {
-                    log.error("Failed to commit task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
+                    log.error("Failed to commit active task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
                     throw e;
                 }
             }
@@ -355,24 +374,22 @@ public class StreamThread extends Thread {
      * Commit the states of all its tasks
      */
     private void commitAll() {
-        for (StreamTask task : tasks.values()) {
-            try {
-                commitOne(task, time.milliseconds());
-            } catch (Exception e) {
-                log.error("Failed to commit task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
-                throw e;
-            }
+        for (StreamTask task : activeTasks.values()) {
+            commitOne(task, time.milliseconds());
+        }
+        for (StandbyTask task : standbyTasks.values()) {
+            commitOne(task, time.milliseconds());
         }
     }
 
     /**
-     * Commit the state of a task
+     * Commit the state of an task
      */
-    private void commitOne(StreamTask task, long now) {
+    private void commitOne(AbstractTask task, long now) {
         try {
             task.commit();
         } catch (Exception e) {
-            log.error("Failed to commit task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
+            log.error("Failed to commit " + task.getClass().getSimpleName() + " #" + task.id() + " in thread [" + this.getName() + "]: ", e);
             throw e;
         }
 
@@ -426,7 +443,7 @@ public class StreamThread extends Thread {
      * Returns ids of tasks that were being executed before the rebalance.
      */
     public Set<TaskId> prevTasks() {
-        return prevTasks;
+        return Collections.unmodifiableSet(prevTasks);
     }
 
     /**
@@ -467,7 +484,7 @@ public class StreamThread extends Thread {
         return new StreamTask(id, consumer, producer, restoreConsumer, partitionsForTask, topology, config, sensors);
     }
 
-    private void addPartitions(Collection<TopicPartition> assignment) {
+    private void addStreamTasks(Collection<TopicPartition> assignment) {
 
         HashMap<TaskId, Set<TopicPartition>> partitionsForTask = new HashMap<>();
 
@@ -486,9 +503,9 @@ public class StreamThread extends Thread {
         // create the tasks
         for (TaskId taskId : partitionsForTask.keySet()) {
             try {
-                tasks.put(taskId, createStreamTask(taskId, partitionsForTask.get(taskId)));
+                activeTasks.put(taskId, createStreamTask(taskId, partitionsForTask.get(taskId)));
             } catch (Exception e) {
-                log.error("Failed to create a task #" + taskId + " in thread [" + this.getName() + "]: ", e);
+                log.error("Failed to create an active task #" + taskId + " in thread [" + this.getName() + "]: ", e);
                 throw e;
             }
         }
@@ -496,23 +513,65 @@ public class StreamThread extends Thread {
         lastClean = time.milliseconds();
     }
 
-    private void removePartitions() {
+    private void removeAllTasks() {
 
         // TODO: change this clearing tasks behavior
-        for (StreamTask task : tasks.values()) {
-            log.info("Removing task {}", task.id());
-            try {
-                task.close();
-            } catch (Exception e) {
-                log.error("Failed to close a task #" + task.id() + " in thread [" + this.getName() + "]: ", e);
-                throw e;
-            }
-            sensors.taskDestructionSensor.record();
+        for (StreamTask task : activeTasks.values()) {
+            closeOne(task);
         }
-        prevTasks.clear();
-        prevTasks.addAll(tasks.keySet());
 
-        tasks.clear();
+        for (StandbyTask task : standbyTasks.values()) {
+            closeOne(task);
+        }
+        // un-assign the change log partitions
+        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
+
+        prevTasks.clear();
+        prevTasks.addAll(activeTasks.keySet());
+
+        activeTasks.clear();
+        standbyTasks.clear();
+    }
+
+    private void closeOne(AbstractTask task) {
+        log.info("Removing a task {}", task.id());
+        try {
+            task.close();
+        } catch (Exception e) {
+            log.error("Failed to close a " + task.getClass().getSimpleName() + " #" + task.id() + " in thread [" + this.getName() + "]: ", e);
+            throw e;
+        }
+        sensors.taskDestructionSensor.record();
+    }
+
+    protected StandbyTask createStandbyTask(TaskId id) {
+        sensors.taskCreationSensor.record();
+
+        ProcessorTopology topology = builder.build(id.topicGroupId);
+
+        return new StandbyTask(id, restoreConsumer, topology, config, sensors);
+    }
+
+    private void addStandbyTasks() {
+        Map<TopicPartition, Long> changeLogStartOffsets = new HashMap<>();
+
+        for (TaskId taskId : partitionGrouper.standbyTasks()) {
+            StandbyTask task = createStandbyTask(taskId);
+            standbyTasks.put(taskId, task);
+            changeLogStartOffsets.putAll(task.changeLogStartOffsets());
+        }
+
+        restoreConsumer.assign(new ArrayList<>(changeLogStartOffsets.keySet()));
+
+        for (Map.Entry<TopicPartition, Long> entry : changeLogStartOffsets.entrySet()) {
+            TopicPartition partition = entry.getKey();
+            long offset = entry.getValue();
+            if (offset >= 0) {
+                restoreConsumer.seek(partition, offset);
+            } else {
+                restoreConsumer.seekToBeginning(partition);
+            }
+        }
     }
 
     private void ensureCopartitioning(Collection<Set<String>> copartitionGroups) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -546,17 +546,17 @@ public class StreamThread extends Thread {
     }
 
     private void addStandbyTasks() {
-        Map<TopicPartition, Long> changeLogStartOffsets = new HashMap<>();
+        Map<TopicPartition, Long> checkpointedOffsets = new HashMap<>();
 
         for (TaskId taskId : partitionGrouper.standbyTasks()) {
             StandbyTask task = createStandbyTask(taskId);
             standbyTasks.put(taskId, task);
-            changeLogStartOffsets.putAll(task.changeLogStartOffsets());
+            checkpointedOffsets.putAll(task.checkpointedOffsets());
         }
 
-        restoreConsumer.assign(new ArrayList<>(changeLogStartOffsets.keySet()));
+        restoreConsumer.assign(new ArrayList<>(checkpointedOffsets.keySet()));
 
-        for (Map.Entry<TopicPartition, Long> entry : changeLogStartOffsets.entrySet()) {
+        for (Map.Entry<TopicPartition, Long> entry : checkpointedOffsets.entrySet()) {
             TopicPartition partition = entry.getKey();
             long offset = entry.getValue();
             if (offset >= 0) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -385,7 +385,7 @@ public class StreamThread extends Thread {
     }
 
     /**
-     * Commit the state of an task
+     * Commit the state of a task
      */
     private void commitOne(AbstractTask task, long now) {
         try {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertFalse;
 
 public class ProcessorStateManagerTest {
 
-    private class MockRestoreConsumer  extends MockConsumer<byte[], byte[]> {
+    public static class MockRestoreConsumer extends MockConsumer<byte[], byte[]> {
         private final Serializer<Integer> serializer = new IntegerSerializer();
 
         public TopicPartition assignedPartition = null;
@@ -79,7 +79,7 @@ public class ProcessorStateManagerTest {
             recordBuffer.clear();
         }
 
-        // buffer a record (we cannot use addRecord because we need to add records before asigning a partition)
+        // buffer a record (we cannot use addRecord because we need to add records before assigning a partition)
         public void bufferRecord(ConsumerRecord<Integer, Integer> record) {
             recordBuffer.add(
                 new ConsumerRecord<>(record.topic(), record.partition(), record.offset(),
@@ -186,7 +186,7 @@ public class ProcessorStateManagerTest {
             FileLock lock;
 
             // the state manager locks the directory
-            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, new MockRestoreConsumer());
+            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, new MockRestoreConsumer(), false);
 
             try {
                 // this should not get the lock
@@ -215,7 +215,7 @@ public class ProcessorStateManagerTest {
         try {
             MockStateStoreSupplier.MockStateStore mockStateStore = new MockStateStoreSupplier.MockStateStore("mockStore", false);
 
-            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, new MockRestoreConsumer());
+            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, new MockRestoreConsumer(), false);
             try {
                 stateMgr.register(mockStateStore, mockStateStore.stateRestoreCallback);
             } finally {
@@ -243,7 +243,7 @@ public class ProcessorStateManagerTest {
 
             MockStateStoreSupplier.MockStateStore persistentStore = new MockStateStoreSupplier.MockStateStore("persistentStore", true); // persistent store
 
-            ProcessorStateManager stateMgr = new ProcessorStateManager(2, baseDir, restoreConsumer);
+            ProcessorStateManager stateMgr = new ProcessorStateManager(2, baseDir, restoreConsumer, false);
             try {
                 restoreConsumer.reset();
 
@@ -291,7 +291,7 @@ public class ProcessorStateManagerTest {
 
             MockStateStoreSupplier.MockStateStore nonPersistentStore = new MockStateStoreSupplier.MockStateStore("nonPersistentStore", false); // non persistent store
 
-            ProcessorStateManager stateMgr = new ProcessorStateManager(2, baseDir, restoreConsumer);
+            ProcessorStateManager stateMgr = new ProcessorStateManager(2, baseDir, restoreConsumer, false);
             try {
                 restoreConsumer.reset();
 
@@ -331,7 +331,7 @@ public class ProcessorStateManagerTest {
 
             MockStateStoreSupplier.MockStateStore mockStateStore = new MockStateStoreSupplier.MockStateStore("mockStore", false);
 
-            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, restoreConsumer);
+            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, restoreConsumer, false);
             try {
                 stateMgr.register(mockStateStore, mockStateStore.stateRestoreCallback);
 
@@ -372,7 +372,7 @@ public class ProcessorStateManagerTest {
             MockStateStoreSupplier.MockStateStore persistentStore = new MockStateStoreSupplier.MockStateStore("persistentStore", true);
             MockStateStoreSupplier.MockStateStore nonPersistentStore = new MockStateStoreSupplier.MockStateStore("nonPersistentStore", false);
 
-            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, restoreConsumer);
+            ProcessorStateManager stateMgr = new ProcessorStateManager(1, baseDir, restoreConsumer, false);
             try {
                 // make sure the checkpoint file is deleted
                 assertFalse(checkpointFile.exists());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -235,11 +234,13 @@ public class ProcessorStateManagerTest {
             checkpoint.write(Collections.singletonMap(new TopicPartition("persistentStore", 2), lastCheckpointedOffset));
 
             MockRestoreConsumer restoreConsumer = new MockRestoreConsumer();
-            restoreConsumer.updatePartitions("persistentStore", Arrays.asList(
+            restoreConsumer.updatePartitions("persistentStore", Utils.mkList(
                     new PartitionInfo("persistentStore", 1, Node.noNode(), new Node[0], new Node[0]),
                     new PartitionInfo("persistentStore", 2, Node.noNode(), new Node[0], new Node[0])
             ));
-            restoreConsumer.updateEndOffsets(Collections.singletonMap(new TopicPartition("persistentStore", 2), 13L));
+
+            TopicPartition partition = new TopicPartition("persistentStore", 2);
+            restoreConsumer.updateEndOffsets(Collections.singletonMap(partition, 13L));
 
             MockStateStoreSupplier.MockStateStore persistentStore = new MockStateStoreSupplier.MockStateStore("persistentStore", true); // persistent store
 
@@ -248,8 +249,9 @@ public class ProcessorStateManagerTest {
                 restoreConsumer.reset();
 
                 ArrayList<Integer> expectedKeys = new ArrayList<>();
+                long offset = -1L;
                 for (int i = 1; i <= 3; i++) {
-                    long offset = (long) i;
+                    offset = (long) i;
                     int key = i * 10;
                     expectedKeys.add(key);
                     restoreConsumer.bufferRecord(
@@ -283,11 +285,13 @@ public class ProcessorStateManagerTest {
             checkpoint.write(Collections.singletonMap(new TopicPartition("persistentStore", 2), lastCheckpointedOffset));
 
             MockRestoreConsumer restoreConsumer = new MockRestoreConsumer();
-            restoreConsumer.updatePartitions("nonPersistentStore", Arrays.asList(
+            restoreConsumer.updatePartitions("nonPersistentStore", Utils.mkList(
                     new PartitionInfo("nonPersistentStore", 1, Node.noNode(), new Node[0], new Node[0]),
                     new PartitionInfo("nonPersistentStore", 2, Node.noNode(), new Node[0], new Node[0])
             ));
-            restoreConsumer.updateEndOffsets(Collections.singletonMap(new TopicPartition("persistentStore", 2), 13L));
+
+            TopicPartition partition = new TopicPartition("persistentStore", 2);
+            restoreConsumer.updateEndOffsets(Collections.singletonMap(partition, 13L));
 
             MockStateStoreSupplier.MockStateStore nonPersistentStore = new MockStateStoreSupplier.MockStateStore("nonPersistentStore", false); // non persistent store
 
@@ -296,8 +300,9 @@ public class ProcessorStateManagerTest {
                 restoreConsumer.reset();
 
                 ArrayList<Integer> expectedKeys = new ArrayList<>();
+                long offset = -1L;
                 for (int i = 1; i <= 3; i++) {
-                    long offset = (long) (i + 100);
+                    offset = (long) (i + 100);
                     int key = i;
                     expectedKeys.add(i);
                     restoreConsumer.bufferRecord(
@@ -312,9 +317,61 @@ public class ProcessorStateManagerTest {
                 assertTrue(restoreConsumer.seekToBeginingCalled);
                 assertTrue(restoreConsumer.seekToEndCalled);
                 assertEquals(expectedKeys, nonPersistentStore.keys);
+
             } finally {
                 stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
             }
+        } finally {
+            Utils.delete(baseDir);
+        }
+    }
+
+    @Test
+    public void testChangeLogOffsets() throws IOException {
+        File baseDir = Files.createTempDirectory("test").toFile();
+        try {
+            long lastCheckpointedOffset = 10L;
+            OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(baseDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));
+            checkpoint.write(Collections.singletonMap(new TopicPartition("store1", 0), lastCheckpointedOffset));
+
+            MockRestoreConsumer restoreConsumer = new MockRestoreConsumer();
+            restoreConsumer.updatePartitions("store1", Utils.mkList(
+                    new PartitionInfo("store1", 0, Node.noNode(), new Node[0], new Node[0])
+            ));
+            restoreConsumer.updatePartitions("store2", Utils.mkList(
+                    new PartitionInfo("store2", 0, Node.noNode(), new Node[0], new Node[0])
+            ));
+
+            TopicPartition partition1 = new TopicPartition("store1", 0);
+            TopicPartition partition2 = new TopicPartition("store2", 0);
+
+            Map<TopicPartition, Long> endOffsets = new HashMap<>();
+            endOffsets.put(partition1, 13L);
+            endOffsets.put(partition2, 17L);
+            restoreConsumer.updateEndOffsets(endOffsets);
+
+            MockStateStoreSupplier.MockStateStore store1 = new MockStateStoreSupplier.MockStateStore("store1", true);
+            MockStateStoreSupplier.MockStateStore store2 = new MockStateStoreSupplier.MockStateStore("store2", true);
+
+            ProcessorStateManager stateMgr = new ProcessorStateManager(0, baseDir, restoreConsumer, true); // standby
+            try {
+                restoreConsumer.reset();
+
+                stateMgr.register(store1, store1.stateRestoreCallback);
+                stateMgr.register(store2, store2.stateRestoreCallback);
+
+                Map<TopicPartition, Long> changeLogOffsets = stateMgr.checkpointedOffsets();
+
+                assertEquals(2, changeLogOffsets.size());
+                assertTrue(changeLogOffsets.containsKey(partition1));
+                assertTrue(changeLogOffsets.containsKey(partition2));
+                assertEquals(lastCheckpointedOffset, (long) changeLogOffsets.get(partition1));
+                assertEquals(-1L, (long) changeLogOffsets.get(partition2));
+
+            } finally {
+                stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
+            }
+
         } finally {
             Utils.delete(baseDir);
         }
@@ -325,7 +382,7 @@ public class ProcessorStateManagerTest {
         File baseDir = Files.createTempDirectory("test").toFile();
         try {
             MockRestoreConsumer restoreConsumer = new MockRestoreConsumer();
-            restoreConsumer.updatePartitions("mockStore", Arrays.asList(
+            restoreConsumer.updatePartitions("mockStore", Utils.mkList(
                     new PartitionInfo("mockStore", 1, Node.noNode(), new Node[0], new Node[0])
             ));
 
@@ -356,10 +413,10 @@ public class ProcessorStateManagerTest {
             oldCheckpoint.write(Collections.<TopicPartition, Long>emptyMap());
 
             MockRestoreConsumer restoreConsumer = new MockRestoreConsumer();
-            restoreConsumer.updatePartitions("persistentStore", Arrays.asList(
+            restoreConsumer.updatePartitions("persistentStore", Utils.mkList(
                     new PartitionInfo("persistentStore", 1, Node.noNode(), new Node[0], new Node[0])
             ));
-            restoreConsumer.updatePartitions("nonPersistentStore", Arrays.asList(
+            restoreConsumer.updatePartitions("nonPersistentStore", Utils.mkList(
                     new PartitionInfo("nonPersistentStore", 1, Node.noNode(), new Node[0], new Node[0])
             ));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -85,6 +85,7 @@ public class StandbyTaskTest {
 
     @Before
     public void setup() {
+        restoreStateConsumer.reset();
         restoreStateConsumer.updatePartitions("store1", Utils.mkList(
                 new PartitionInfo("store1", 0, Node.noNode(), new Node[0], new Node[0]),
                 new PartitionInfo("store1", 1, Node.noNode(), new Node[0], new Node[0]),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.StreamingConfig;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.OffsetCheckpoint;
+import org.apache.kafka.test.MockStateStoreSupplier;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+public class StandbyTaskTest {
+
+    private final TaskId taskId = new TaskId(0, 1);
+
+    private final Serializer<Integer> intSerializer = new IntegerSerializer();
+
+    private final TopicPartition partition1 = new TopicPartition("store1", 1);
+    private final TopicPartition partition2 = new TopicPartition("store2", 1);
+
+    private final ProcessorTopology topology = new ProcessorTopology(
+            Collections.<ProcessorNode>emptyList(),
+            Collections.<String, SourceNode>emptyMap(),
+            Utils.<StateStoreSupplier>mkList(
+                    new MockStateStoreSupplier(partition1.topic(), false),
+                    new MockStateStoreSupplier(partition2.topic(), true)
+            )
+    );
+
+
+    private StreamingConfig createConfig(final File baseDir) throws Exception {
+        return new StreamingConfig(new Properties() {
+            {
+                setProperty(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+                setProperty(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+                setProperty(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
+                setProperty(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+                setProperty(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "org.apache.kafka.test.MockTimestampExtractor");
+                setProperty(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:2171");
+                setProperty(StreamingConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3");
+                setProperty(StreamingConfig.STATE_DIR_CONFIG, baseDir.getCanonicalPath());
+            }
+        });
+    }
+
+    private final ProcessorStateManagerTest.MockRestoreConsumer restoreStateConsumer = new ProcessorStateManagerTest.MockRestoreConsumer();
+
+    private final byte[] recordValue = intSerializer.serialize(null, 10);
+    private final byte[] recordKey = intSerializer.serialize(null, 1);
+
+    @Before
+    public void setup() {
+        restoreStateConsumer.updatePartitions("store1", Utils.mkList(
+                new PartitionInfo("store1", 0, Node.noNode(), new Node[0], new Node[0]),
+                new PartitionInfo("store1", 1, Node.noNode(), new Node[0], new Node[0]),
+                new PartitionInfo("store1", 2, Node.noNode(), new Node[0], new Node[0])
+        ));
+
+        restoreStateConsumer.updatePartitions("store2", Utils.mkList(
+                new PartitionInfo("store2", 0, Node.noNode(), new Node[0], new Node[0]),
+                new PartitionInfo("store2", 1, Node.noNode(), new Node[0], new Node[0]),
+                new PartitionInfo("store2", 2, Node.noNode(), new Node[0], new Node[0])
+        ));
+    }
+
+    @Test
+    public void testStorePartitions() throws Exception {
+        File baseDir = Files.createTempDirectory("test").toFile();
+        try {
+            StreamingConfig config = createConfig(baseDir);
+            StandbyTask task = new StandbyTask(taskId, restoreStateConsumer, topology, config, null);
+
+            assertEquals(Utils.mkSet(partition2), new HashSet<>(task.changeLogPartitions()));
+
+        } finally {
+            Utils.delete(baseDir);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = Exception.class)
+    public void testUpdateNonPersistentStore() throws Exception {
+        File baseDir = Files.createTempDirectory("test").toFile();
+        try {
+            StreamingConfig config = createConfig(baseDir);
+            StandbyTask task = new StandbyTask(taskId, restoreStateConsumer, topology, config, null);
+
+            restoreStateConsumer.assign(new ArrayList<>(task.changeLogPartitions()));
+
+            task.update(partition1,
+                    records(new ConsumerRecord<>(partition1.topic(), partition1.partition(), 10, recordKey, recordValue))
+            );
+
+        } finally {
+            Utils.delete(baseDir);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUpdate() throws Exception {
+        File baseDir = Files.createTempDirectory("test").toFile();
+        try {
+            StreamingConfig config = createConfig(baseDir);
+            StandbyTask task = new StandbyTask(taskId, restoreStateConsumer, topology, config, null);
+
+            restoreStateConsumer.assign(new ArrayList<>(task.changeLogPartitions()));
+
+            for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
+                    new ConsumerRecord<>(partition2.topic(), partition2.partition(), 10, 1, 100),
+                    new ConsumerRecord<>(partition2.topic(), partition2.partition(), 20, 2, 100),
+                    new ConsumerRecord<>(partition2.topic(), partition2.partition(), 30, 3, 100))) {
+                restoreStateConsumer.bufferRecord(record);
+            }
+
+            for (Map.Entry<TopicPartition, Long> entry : task.changeLogStartOffsets().entrySet()) {
+                TopicPartition partition = entry.getKey();
+                long offset = entry.getValue();
+                if (offset >= 0) {
+                    restoreStateConsumer.seek(partition, offset);
+                } else {
+                    restoreStateConsumer.seekToBeginning(partition);
+                }
+            }
+
+            task.update(partition2, restoreStateConsumer.poll(100).records(partition2));
+
+            StandbyContextImpl context = (StandbyContextImpl) task.context();
+            MockStateStoreSupplier.MockStateStore store1 =
+                    (MockStateStoreSupplier.MockStateStore) context.getStateMgr().getStore(partition1.topic());
+            MockStateStoreSupplier.MockStateStore store2 =
+                    (MockStateStoreSupplier.MockStateStore) context.getStateMgr().getStore(partition2.topic());
+
+            assertEquals(Collections.emptyList(), store1.keys);
+            assertEquals(Utils.mkList(1, 2, 3), store2.keys);
+
+            task.close();
+
+            File taskDir = new File(baseDir, taskId.toString());
+            OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(taskDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));
+            Map<TopicPartition, Long> offsets = checkpoint.read();
+
+            assertEquals(1, offsets.size());
+            assertEquals(new Long(30L + 1L), offsets.get(partition2));
+
+        } finally {
+            Utils.delete(baseDir);
+        }
+    }
+
+    private List<ConsumerRecord<byte[], byte[]>> records(ConsumerRecord<byte[], byte[]>... recs) {
+        return Arrays.asList(recs);
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -148,7 +148,7 @@ public class StandbyTaskTest {
                 restoreStateConsumer.bufferRecord(record);
             }
 
-            for (Map.Entry<TopicPartition, Long> entry : task.changeLogStartOffsets().entrySet()) {
+            for (Map.Entry<TopicPartition, Long> entry : task.checkpointedOffsets().entrySet()) {
                 TopicPartition partition = entry.getKey();
                 long offset = entry.getValue();
                 if (offset >= 0) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -167,7 +167,7 @@ public class StreamThreadTest {
             }
         };
 
-        initPartitionGrouper(thread);
+        initPartitionGrouper(config, thread);
 
         ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
 
@@ -292,7 +292,7 @@ public class StreamThreadTest {
                 }
             };
 
-            initPartitionGrouper(thread);
+            initPartitionGrouper(config, thread);
 
             ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
 
@@ -414,7 +414,7 @@ public class StreamThreadTest {
                 }
             };
 
-            initPartitionGrouper(thread);
+            initPartitionGrouper(config, thread);
 
             ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
 
@@ -467,13 +467,11 @@ public class StreamThreadTest {
         }
     }
 
-    private void initPartitionGrouper(StreamThread thread) {
+    private void initPartitionGrouper(StreamingConfig config, StreamThread thread) {
 
         KafkaStreamingPartitionAssignor partitionAssignor = new KafkaStreamingPartitionAssignor();
 
-        partitionAssignor.configure(
-                Collections.singletonMap(StreamingConfig.InternalConfig.STREAM_THREAD_INSTANCE, thread)
-        );
+        partitionAssignor.configure(config.getConsumerConfigs(thread));
 
         Map<String, PartitionAssignor.Assignment> assignments =
                 partitionAssignor.assign(metadata, Collections.singletonMap("client", subscription));


### PR DESCRIPTION
@guozhangwang 
- added a new config param "num.standby.replicas" (the default value is 0).
- added a new abstract class AbstractTask
- added StandbyTask as a subclass of AbstractTask
- modified StreamTask to a subclass of AbstractTask
- StreamThread
  - standby tasks are created by calling StreamThread.addStandbyTask() from onPartitionsAssigned()
  - standby tasks are destroyed by calling StreamThread.removeStandbyTasks() from onPartitionRevoked()
  - In addStandbyTasks(), change log partitions are assigned to restoreConsumer.
  - In removeStandByTasks(), change log partitions are removed from restoreConsumer.
  - StreamThread polls change log records using restoreConsumer in the runLoop with timeout=0.
  - If records are returned, StreamThread calls StandbyTask.update and pass records to each standby tasks.
