### PR TITLE
KAFKA-2605: Replace 'catch: Throwable' clauses with 'NonFatal'

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -22,6 +22,8 @@ import metrics.KafkaMetricsReporter
 import server.{KafkaConfig, KafkaServerStartable, KafkaServer}
 import utils.{Utils, Logging}
 
+import scala.util.control.NonFatal
+
 object Kafka extends Logging {
 
   def main(args: Array[String]): Unit = {
@@ -47,7 +49,7 @@ object Kafka extends Logging {
       kafkaServerStartable.awaitShutdown
     }
     catch {
-      case e: Throwable => fatal(e)
+      case NonFatal(e) => fatal(e)
     }
     System.exit(0)
   }

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -23,6 +23,7 @@ import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import kafka.common.{TopicAndPartition, AdminCommandFailedException}
 import collection._
 import mutable.ListBuffer
+import scala.util.control.NonFatal
 
 object PreferredReplicaLeaderElectionCommand extends Logging {
 
@@ -64,7 +65,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
       preferredReplicaElectionCommand.moveLeaderToPreferredReplica()
       println("Successfully started preferred replica election for partitions %s".format(partitionsForPreferredReplicaElection))
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         println("Failed to start preferred replica election")
         println(Utils.stackTrace(e))
     } finally {
@@ -109,7 +110,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
           PreferredReplicaLeaderElectionCommand.parsePreferredReplicaElectionData(ZkUtils.readData(zkClient, zkPath)._1)
         throw new AdminOperationException("Preferred replica leader election currently in progress for " +
           "%s. Aborting operation".format(partitionsUndergoingPreferredReplicaElection))
-      case e2: Throwable => throw new AdminOperationException(e2.toString)
+      case NonFatal(e2) => throw new AdminOperationException(e2.toString)
     }
   }
 }
@@ -121,7 +122,7 @@ class PreferredReplicaLeaderElectionCommand(zkClient: ZkClient, partitions: scal
       val validPartitions = partitions.filter(p => validatePartition(zkClient, p.topic, p.partition))
       PreferredReplicaLeaderElectionCommand.writePreferredReplicaElectionData(zkClient, validPartitions)
     } catch {
-      case e: Throwable => throw new AdminCommandFailedException("Admin command failed", e)
+      case NonFatal(e) => throw new AdminCommandFailedException("Admin command failed", e)
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -23,6 +23,8 @@ import org.I0Itec.zkclient.ZkClient
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import kafka.common.{TopicAndPartition, AdminCommandFailedException}
 
+import scala.util.control.NonFatal
+
 object ReassignPartitionsCommand extends Logging {
 
   def main(args: Array[String]): Unit = {
@@ -46,7 +48,7 @@ object ReassignPartitionsCommand extends Logging {
       else if (opts.options.has(opts.executeOpt))
         executeAssignment(zkClient, opts)
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         println("Partitions reassignment failed due to " + e.getMessage)
         println(Utils.stackTrace(e))
     } finally {
@@ -215,7 +217,7 @@ class ReassignPartitionsCommand(zkClient: ZkClient, partitions: collection.Map[T
         val partitionsBeingReassigned = ZkUtils.getPartitionsBeingReassigned(zkClient)
         throw new AdminCommandFailedException("Partition reassignment currently in " +
         "progress for %s. Aborting operation".format(partitionsBeingReassigned))
-      case e: Throwable => error("Admin command failed", e); false
+      case NonFatal(e) => error("Admin command failed", e); false
     }
   }
 

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -31,6 +31,8 @@ import kafka.consumer.Whitelist
 import kafka.server.OffsetManager
 import org.apache.kafka.common.utils.Utils.formatAddress
 
+import scala.util.control.NonFatal
+
 
 object TopicCommand {
 
@@ -62,7 +64,7 @@ object TopicCommand {
       else if(opts.options.has(opts.deleteOpt))
         deleteTopic(zkClient, opts)
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         println("Error while executing topic command " + e.getMessage)
         println(Utils.stackTrace(e))
     } finally {
@@ -146,7 +148,7 @@ object TopicCommand {
       } catch {
         case e: ZkNodeExistsException =>
           println("Topic %s is already marked for deletion.".format(topic))
-        case e2: Throwable =>
+        case NonFatal(e2) =>
           throw new AdminOperationException("Error while deleting topic %s".format(topic))
       }    
     }

--- a/core/src/main/scala/kafka/client/ClientUtils.scala
+++ b/core/src/main/scala/kafka/client/ClientUtils.scala
@@ -23,7 +23,8 @@ import kafka.producer._
 import kafka.common.{ErrorMapping, KafkaException}
 import kafka.utils.{Utils, Logging}
 import java.util.Properties
-import util.Random
+ import scala.util.control.NonFatal
+ import util.Random
  import kafka.network.BlockingChannel
  import kafka.utils.ZkUtils._
  import org.I0Itec.zkclient.ZkClient
@@ -59,7 +60,7 @@ object ClientUtils extends Logging{
         fetchMetaDataSucceeded = true
       }
       catch {
-        case e: Throwable =>
+        case NonFatal(e) =>
           warn("Fetching topic metadata with correlation id %d for topics [%s] from broker [%s] failed"
             .format(correlationId, topics, shuffledBrokers(i).toString), e)
           t = e

--- a/core/src/main/scala/kafka/cluster/Broker.scala
+++ b/core/src/main/scala/kafka/cluster/Broker.scala
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer
 import kafka.common.{KafkaException, BrokerNotAvailableException}
 import org.apache.kafka.common.utils.Utils._
 
+import scala.util.control.NonFatal
+
 /**
  * A Kafka broker
  */
@@ -43,7 +45,7 @@ object Broker {
           throw new BrokerNotAvailableException("Broker id %d does not exist".format(id))
       }
     } catch {
-      case t: Throwable => throw new KafkaException("Failed to parse the broker info from zookeeper: " + brokerInfoString, t)
+      case NonFatal(t) => throw new KafkaException("Failed to parse the broker info from zookeeper: " + brokerInfoString, t)
     }
   }
 

--- a/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
@@ -32,6 +32,8 @@ import kafka.common.TopicAndPartition
 import kafka.client.ClientUtils
 import java.util.concurrent.atomic.AtomicInteger
 
+import scala.util.control.NonFatal
+
 /**
  *  Usage:
  *  Once ConsumerFetcherManager is created, startConnections() and stopAllConnections() can be called repeatedly
@@ -81,7 +83,7 @@ class ConsumerFetcherManager(private val consumerIdString: String,
           }
         }
       } catch {
-        case t: Throwable => {
+        case NonFatal(t) => {
             if (!isRunning.get())
               throw t /* If this thread is stopped, propagate this exception to kill the thread. */
             else
@@ -97,7 +99,7 @@ class ConsumerFetcherManager(private val consumerIdString: String,
             topicAndPartition -> BrokerAndInitialOffset(broker, partitionMap(topicAndPartition).getFetchOffset())}
         )
       } catch {
-        case t: Throwable => {
+        case NonFatal(t) => {
           if (!isRunning.get())
             throw t /* If this thread is stopped, propagate this exception to kill the thread. */
           else {

--- a/core/src/main/scala/kafka/consumer/SimpleConsumer.scala
+++ b/core/src/main/scala/kafka/consumer/SimpleConsumer.scala
@@ -23,6 +23,8 @@ import kafka.utils._
 import kafka.common.{ErrorMapping, TopicAndPartition}
 import org.apache.kafka.common.utils.Utils._
 
+import scala.util.control.NonFatal
+
 /**
  * A consumer of kafka messages
  */
@@ -70,7 +72,7 @@ class SimpleConsumer(val host: String,
         blockingChannel.send(request)
         response = blockingChannel.receive()
       } catch {
-        case e : Throwable =>
+        case NonFatal(e) =>
           info("Reconnect due to socket error: %s".format(e.toString))
           // retry once
           try {
@@ -78,7 +80,7 @@ class SimpleConsumer(val host: String,
             blockingChannel.send(request)
             response = blockingChannel.receive()
           } catch {
-            case e: Throwable =>
+            case NonFatal(e) =>
               disconnect()
               throw e
           }

--- a/core/src/main/scala/kafka/consumer/TopicCount.scala
+++ b/core/src/main/scala/kafka/consumer/TopicCount.scala
@@ -22,6 +22,8 @@ import org.I0Itec.zkclient.ZkClient
 import kafka.utils.{Json, ZKGroupDirs, ZkUtils, Logging, Utils}
 import kafka.common.KafkaException
 
+import scala.util.control.NonFatal
+
 private[kafka] trait TopicCount {
 
   def getConsumerThreadIdsPerTopic: Map[String, Set[ConsumerThreadId]]
@@ -76,7 +78,7 @@ private[kafka] object TopicCount extends Logging {
         case None => throw new KafkaException("error constructing TopicCount : " + topicCountString)
       }
     } catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         error("error parsing consumer json string " + topicCountString, e)
         throw e
     }

--- a/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
@@ -22,6 +22,8 @@ import kafka.utils.{ZkUtils, ZKStringSerializer, Logging}
 import org.I0Itec.zkclient.{IZkStateListener, IZkChildListener, ZkClient}
 import org.apache.zookeeper.Watcher.Event.KeeperState
 
+import scala.util.control.NonFatal
+
 class ZookeeperTopicEventWatcher(val zkClient: ZkClient,
     val eventHandler: TopicEventHandler[String]) extends Logging {
 
@@ -70,7 +72,7 @@ class ZookeeperTopicEventWatcher(val zkClient: ZkClient,
           }
         }
         catch {
-          case e: Throwable =>
+          case NonFatal(e) =>
             error("error in handling child changes", e)
         }
       }

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -26,6 +26,8 @@ import org.apache.log4j.Logger
 import kafka.controller.Callbacks._
 import kafka.utils.Utils._
 
+import scala.util.control.NonFatal
+
 /**
  * This class represents the state machine for replicas. It defines the states that a replica can be in, and
  * transitions to move the replica to another legal state. The different states that a replica can be in are -
@@ -114,7 +116,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
         replicas.foreach(r => handleStateChange(r, targetState, callbacks))
         brokerRequestBatch.sendRequestsToBrokers(controller.epoch, controllerContext.correlationId.getAndIncrement)
       }catch {
-        case e: Throwable => error("Error while moving some replicas to %s state".format(targetState), e)
+        case NonFatal(e) => error("Error while moving some replicas to %s state".format(targetState), e)
       }
     }
   }
@@ -272,7 +274,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
       }
     }
     catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         stateChangeLogger.error("Controller %d epoch %d initiated state change of replica %d for partition [%s,%d] from %s to %s failed"
                                   .format(controllerId, controller.epoch, replicaId, topic, partition, currState, targetState), t)
     }
@@ -372,7 +374,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
               if(deadBrokerIds.size > 0)
                 controller.onBrokerFailure(deadBrokerIds.toSeq)
             } catch {
-              case e: Throwable => error("Error while handling broker changes", e)
+              case NonFatal(e) => error("Error while handling broker changes", e)
             }
           }
         }

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -25,6 +25,8 @@ import kafka.common.{TopicAndPartition, KafkaException}
 import kafka.server.{RecoveringFromUncleanShutdown, BrokerState, OffsetCheckpoint}
 import java.util.concurrent.{Executors, ExecutorService, ExecutionException, Future}
 
+import scala.util.control.NonFatal
+
 /**
  * The entry point to the kafka log management subsystem. The log manager is responsible for log creation, retrieval, and cleaning.
  * All read and write operations are delegated to the individual log instances.
@@ -478,7 +480,7 @@ class LogManager(val logDirs: Array[File],
         if(timeSinceLastFlush >= log.config.flushMs)
           log.flush
       } catch {
-        case e: Throwable =>
+        case NonFatal(e) =>
           error("Error flushing topic " + topicAndPartition.topic, e)
       }
     }

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -27,6 +27,8 @@ import kafka.utils._
 import kafka.utils.Utils.inLock
 import kafka.common.InvalidOffsetException
 
+import scala.util.control.NonFatal
+
 /**
  * An index that maps offsets to physical file locations for a particular log segment. This index may be sparse:
  * that is it may not hold an entry for all messages in the log.
@@ -300,7 +302,7 @@ class OffsetIndex(@volatile var file: File, val baseOffset: Long, val maxIndexSi
       if(m.isInstanceOf[sun.nio.ch.DirectBuffer])
         (m.asInstanceOf[sun.nio.ch.DirectBuffer]).cleaner().clean()
     } catch {
-      case t: Throwable => warn("Error when freeing index buffer", t)
+      case NonFatal(t) => warn("Error when freeing index buffer", t)
     }
   }
   

--- a/core/src/main/scala/kafka/network/BlockingChannel.scala
+++ b/core/src/main/scala/kafka/network/BlockingChannel.scala
@@ -22,6 +22,8 @@ import java.nio.channels._
 import kafka.utils.{nonthreadsafe, Logging}
 import kafka.api.RequestOrResponse
 
+import scala.util.control.NonFatal
+
 
 object BlockingChannel{
   val UseDefaultBufferSize = -1
@@ -72,7 +74,7 @@ class BlockingChannel( val host: String,
                          connectTimeoutMs))
 
       } catch {
-        case e: Throwable => disconnect()
+        case NonFatal(e) => disconnect()
       }
     }
   }

--- a/core/src/main/scala/kafka/network/BoundedByteBufferReceive.scala
+++ b/core/src/main/scala/kafka/network/BoundedByteBufferReceive.scala
@@ -21,6 +21,8 @@ import java.nio._
 import java.nio.channels._
 import kafka.utils._
 
+import scala.util.control.NonFatal
+
 /**
  * Represents a communication between the client and server
  * 
@@ -82,7 +84,7 @@ private[kafka] class BoundedByteBufferReceive(val maxSize: Int) extends Receive 
       case e: OutOfMemoryError =>
         error("OOME with size " + size, e)
         throw e
-      case e2: Throwable =>
+      case NonFatal(e2) =>
         throw e2
     }
     buffer

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -31,6 +31,8 @@ import kafka.metrics.KafkaMetricsGroup
 import kafka.utils._
 import com.yammer.metrics.core.{Gauge, Meter}
 
+import scala.util.control.NonFatal
+
 /**
  * An NIO socket server. The threading model is
  *   1 Acceptor thread that handles new connections
@@ -229,7 +231,7 @@ private[kafka] class Acceptor(val host: String,
             // round robin to the next processor thread
             currentProcessor = (currentProcessor + 1) % processors.length
           } catch {
-            case e: Throwable => error("Error while accepting connection", e)
+            case NonFatal(e) => error("Error while accepting connection", e)
           }
         }
       }
@@ -351,7 +353,7 @@ private[kafka] class Processor(val id: Int,
             } case e: InvalidRequestException => {
               info("Closing socket connection to %s due to invalid request: %s".format(channelFor(key).socket.getInetAddress, e.getMessage))
               close(key)
-            } case e: Throwable => {
+            } case NonFatal(e) => {
               error("Closing socket for " + channelFor(key).socket.getInetAddress + " because of error", e)
               close(key)
             }

--- a/core/src/main/scala/kafka/producer/SyncProducer.scala
+++ b/core/src/main/scala/kafka/producer/SyncProducer.scala
@@ -24,6 +24,8 @@ import java.util.Random
 
 import org.apache.kafka.common.utils.Utils._
 
+import scala.util.control.NonFatal
+
 object SyncProducer {
   val RequestKey: Short = 0
   val randomGenerator = new Random
@@ -80,7 +82,7 @@ class SyncProducer(val config: SyncProducerConfig) extends Logging {
           // no way to tell if write succeeded. Disconnect and re-throw exception to let client handle retry
           disconnect()
           throw e
-        case e: Throwable => throw e
+        case NonFatal(e) => throw e
       }
       response
     }

--- a/core/src/main/scala/kafka/producer/async/ProducerSendThread.scala
+++ b/core/src/main/scala/kafka/producer/async/ProducerSendThread.scala
@@ -24,6 +24,8 @@ import kafka.producer.KeyedMessage
 import kafka.metrics.KafkaMetricsGroup
 import com.yammer.metrics.core.Gauge
 
+import scala.util.control.NonFatal
+
 class ProducerSendThread[K,V](val threadName: String,
                               val queue: BlockingQueue[KeyedMessage[K,V]],
                               val handler: EventHandler[K,V],
@@ -44,7 +46,7 @@ class ProducerSendThread[K,V](val threadName: String,
     try {
       processEvents
     }catch {
-      case e: Throwable => error("Error in sending events: ", e)
+      case NonFatal(e) => error("Error in sending events: ", e)
     }finally {
       shutdownLatch.countDown
     }
@@ -104,7 +106,7 @@ class ProducerSendThread[K,V](val threadName: String,
       if(size > 0)
         handler.handle(events)
     }catch {
-      case e: Throwable => error("Error in handling batch of " + size + " events", e)
+      case NonFatal(e) => error("Error in handling batch of " + size + " events", e)
     }
   }
 

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -23,6 +23,8 @@ import kafka.metrics.KafkaMetricsGroup
 import java.util.concurrent.TimeUnit
 import com.yammer.metrics.core.Meter
 
+import scala.util.control.NonFatal
+
 /**
  * A thread that answers kafka requests.
  */
@@ -58,7 +60,7 @@ class KafkaRequestHandler(id: Int,
         trace("Kafka request handler %d on broker %d handling request %s".format(id, brokerId, req))
         apis.handle(req)
       } catch {
-        case e: Throwable => error("Exception when handling request", e)
+        case NonFatal(e) => error("Exception when handling request", e)
       }
     }
   }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -34,6 +34,8 @@ import kafka.network.{Receive, BlockingChannel, SocketServer}
 import kafka.metrics.KafkaMetricsGroup
 import com.yammer.metrics.core.Gauge
 
+import scala.util.control.NonFatal
+
 /**
  * Represents the lifecycle of a single Kafka broker. Handles all functionality required
  * to start up and shutdown a single Kafka node.
@@ -129,7 +131,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime) extends Logg
       info("started")
     }
     catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         fatal("Fatal error during KafkaServer startup. Prepare to shutdown", e)
         shutdown()
         throw e
@@ -293,7 +295,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime) extends Logg
       }
     }
     catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         fatal("Fatal error during KafkaServer shutdown.", e)
         throw e
     }

--- a/core/src/main/scala/kafka/server/KafkaServerStartable.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerStartable.scala
@@ -20,6 +20,8 @@ package kafka.server
 import kafka.common.AppInfo
 import kafka.utils.Logging
 
+import scala.util.control.NonFatal
+
 
 class KafkaServerStartable(val serverConfig: KafkaConfig) extends Logging {
   private val server = new KafkaServer(serverConfig)
@@ -30,7 +32,7 @@ class KafkaServerStartable(val serverConfig: KafkaConfig) extends Logging {
       AppInfo.registerInfo()
     }
     catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         fatal("Fatal error during KafkaServerStartable startup. Prepare to shutdown", e)
         // KafkaServer already calls shutdown() internally, so this is purely for logging & the exit code
         System.exit(1)
@@ -42,7 +44,7 @@ class KafkaServerStartable(val serverConfig: KafkaConfig) extends Logging {
       server.shutdown()
     }
     catch {
-      case e: Throwable =>
+      case NonFatal(e) =>
         fatal("Fatal error during KafkaServerStable shutdown. Prepare to halt", e)
         System.exit(1)
     }

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -26,6 +26,8 @@ import kafka.common.{ErrorMapping, ReplicaNotAvailableException, LeaderNotAvaila
 import kafka.common.TopicAndPartition
 import kafka.controller.KafkaController.StateChangeLogger
 
+import scala.util.control.NonFatal
+
 /**
  *  A cache for the state (e.g., current leader) of each partition. This cache is updated through
  *  UpdateMetadataRequest from the controller. Every broker maintains the same cache, asynchronously.
@@ -67,7 +69,7 @@ private[server] class MetadataCache {
                     isr.filterNot(isrInfo.map(_.id).contains(_)).mkString(","))
                 new PartitionMetadata(partitionId, leaderInfo, replicaInfo, isrInfo, ErrorMapping.NoError)
               } catch {
-                case e: Throwable =>
+                case NonFatal(e) =>
                   debug("Error while fetching metadata for %s. Possible cause: %s".format(topicPartition, e.getMessage))
                   new PartitionMetadata(partitionId, leaderInfo, replicaInfo, isrInfo,
                     ErrorMapping.codeFor(e.getClass.asInstanceOf[Class[Throwable]]))

--- a/core/src/main/scala/kafka/server/OffsetManager.scala
+++ b/core/src/main/scala/kafka/server/OffsetManager.scala
@@ -41,6 +41,8 @@ import java.util.concurrent.TimeUnit
 import com.yammer.metrics.core.Gauge
 import org.I0Itec.zkclient.ZkClient
 
+import scala.util.control.NonFatal
+
 
 /**
  * Configuration settings for in-built offset management
@@ -148,7 +150,7 @@ class OffsetManager(val config: OffsetManagerConfig,
           tombstones.size
         }
         catch {
-          case t: Throwable =>
+          case NonFatal(t) =>
             error("Failed to mark %d stale offsets for deletion in %s.".format(messages.size, appendPartition), t)
             // ignore and continue
             0
@@ -302,7 +304,7 @@ class OffsetManager(val config: OffsetManagerConfig,
         }
       }
       catch {
-        case t: Throwable =>
+        case NonFatal(t) =>
           error("Error in loading offsets from " + topicPartition, t)
       }
       finally {

--- a/core/src/main/scala/kafka/server/ZookeeperLeaderElector.scala
+++ b/core/src/main/scala/kafka/server/ZookeeperLeaderElector.scala
@@ -24,6 +24,8 @@ import org.I0Itec.zkclient.IZkDataListener
 import kafka.controller.ControllerContext
 import kafka.controller.KafkaController
 
+import scala.util.control.NonFatal
+
 /**
  * This class handles zookeeper based leader election based on an ephemeral path. The election module does not handle
  * session expiration, instead it assumes the caller will handle it by probably try to re-elect again. If the existing
@@ -89,7 +91,7 @@ class ZookeeperLeaderElector(controllerContext: ControllerContext,
         else
           warn("A leader has been elected but just resigned, this will result in another round of election")
 
-      case e2: Throwable =>
+      case NonFatal(e2) =>
         error("Error while electing or becoming leader on broker %d".format(brokerId), e2)
         resign()
     }

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -29,6 +29,8 @@ import kafka.utils._
 import kafka.metrics.KafkaMetricsReporter
 import kafka.consumer.{Blacklist,Whitelist,ConsumerConfig,Consumer}
 
+import scala.util.control.NonFatal
+
 /**
  * Consumer that dumps messages out to standard out.
  *
@@ -168,7 +170,7 @@ object ConsoleConsumer extends Logging {
           formatter.writeTo(messageAndTopic.key, messageAndTopic.message, System.out)
           numMessages += 1
         } catch {
-          case e: Throwable =>
+          case NonFatal(e) =>
             if (skipMessageOnError)
               error("Error processing message, skipping this message: ", e)
             else
@@ -184,7 +186,7 @@ object ConsoleConsumer extends Logging {
         }
       }
     } catch {
-      case e: Throwable => error("Error processing message, stopping consumer: ", e)
+      case NonFatal(e) => error("Error processing message, stopping consumer: ", e)
     }
     System.err.println("Consumed %d messages".format(numMessages))
     System.out.flush()
@@ -208,7 +210,7 @@ object ConsoleConsumer extends Logging {
       val zk = new ZkClient(zkUrl, 30*1000,30*1000, ZKStringSerializer);
       zk.exists(path)
     } catch {
-      case _: Throwable => false
+      case NonFatal(_) => false
     }
   }
 }

--- a/core/src/main/scala/kafka/tools/ConsumerOffsetChecker.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerOffsetChecker.scala
@@ -31,6 +31,8 @@ import kafka.api.PartitionOffsetRequestInfo
 import scala.Some
 import org.I0Itec.zkclient.exception.ZkNoNodeException
 
+import scala.util.control.NonFatal
+
 object ConsumerOffsetChecker extends Logging {
 
   private val consumerMap: mutable.Map[Int, Option[SimpleConsumer]] = mutable.Map()
@@ -54,7 +56,7 @@ object ConsumerOffsetChecker extends Logging {
           throw new BrokerNotAvailableException("Broker id %d does not exist".format(bid))
       }
     } catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         println("Could not parse broker info due to " + t.getCause)
         None
     }
@@ -204,7 +206,7 @@ object ConsumerOffsetChecker extends Logging {
         }
     }
     catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         println("Exiting due to: %s.".format(t.getMessage))
     }
     finally {

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -27,6 +27,8 @@ import java.util.{ Random, Properties }
 import kafka.consumer._
 import java.text.SimpleDateFormat
 
+import scala.util.control.NonFatal
+
 /**
  * Performance test for the full zookeeper consumer
  */
@@ -171,7 +173,7 @@ object ConsumerPerformance {
         case _: InterruptedException =>
         case _: ClosedByInterruptException =>
         case _: ConsumerTimeoutException =>
-        case e: Throwable => e.printStackTrace()
+        case NonFatal(e) => e.printStackTrace()
       }
       totalMessagesRead.addAndGet(messagesRead)
       totalBytesRead.addAndGet(bytesRead)

--- a/core/src/main/scala/kafka/tools/ImportZkOffsets.scala
+++ b/core/src/main/scala/kafka/tools/ImportZkOffsets.scala
@@ -23,6 +23,8 @@ import joptsimple._
 import kafka.utils.{Logging, ZkUtils,ZKStringSerializer, CommandLineUtils}
 import org.I0Itec.zkclient.ZkClient
 
+import scala.util.control.NonFatal
+
 
 /**
  *  A utility that updates the offset of broker partitions in ZK.
@@ -99,7 +101,7 @@ object ImportZkOffsets extends Logging {
       try {
         ZkUtils.updatePersistentPath(zkClient, partition, offset.toString)
       } catch {
-        case e: Throwable => e.printStackTrace()
+        case NonFatal(e) => e.printStackTrace()
       }
     }
   }

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -32,6 +32,8 @@ import scala.collection.JavaConversions._
 
 import joptsimple.OptionParser
 
+import scala.util.control.NonFatal
+
 object MirrorMaker extends Logging {
 
   private var connectors: Seq[ZookeeperConsumerConnector] = null
@@ -153,7 +155,7 @@ object MirrorMaker extends Logging {
     try {
       streams = connectors.map(_.createMessageStreamsByFilter(filterSpec, numStreams, new DefaultDecoder(), new DefaultDecoder())).flatten
     } catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         fatal("Unable to create stream - shutting down mirror maker.")
         connectors.foreach(_.shutdown)
     }
@@ -261,7 +263,7 @@ object MirrorMaker extends Logging {
           mirrorDataChannel.put(data)
         }
       } catch {
-        case e: Throwable => {
+        case NonFatal(e) => {
           fatal("Stream unexpectedly exited.", e)
           isCleanShutdown = false
         }
@@ -309,7 +311,7 @@ object MirrorMaker extends Logging {
           producer.send(data.topic(), data.key(), data.value())
         }
       } catch {
-        case t: Throwable => {
+        case NonFatal(t) => {
           fatal("Producer thread failure due to ", t)
           isCleanShutdown = false
         }

--- a/core/src/main/scala/kafka/tools/ProducerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ProducerPerformance.scala
@@ -31,6 +31,8 @@ import java.math.BigInteger
 
 import org.apache.log4j.Logger
 
+import scala.util.control.NonFatal
+
 /**
  * Load test for the producer
  */
@@ -266,14 +268,14 @@ object ProducerPerformance extends Logging {
                 Thread.sleep(config.messageSendGapMs)
             })
         } catch {
-          case e: Throwable => error("Error when sending message " + new String(message), e)
+          case NonFatal(e) => error("Error when sending message " + new String(message), e)
         }
         i += 1
       }
       try {
         producer.close()
       } catch {
-        case e: Throwable => error("Error when closing producer", e)
+        case NonFatal(e) => error("Error when closing producer", e)
       }
       totalBytesSent.addAndGet(bytesSent)
       totalMessagesSent.addAndGet(nSends)

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -31,6 +31,8 @@ import kafka.common.{ErrorMapping, TopicAndPartition}
 import kafka.utils._
 import kafka.consumer.{ConsumerConfig, Whitelist, SimpleConsumer}
 
+import scala.util.control.NonFatal
+
 /**
  *  For verifying the consistency among replicas.
  *
@@ -306,7 +308,7 @@ private class ReplicaBuffer(expectedReplicasPerTopicAndPartition: Map[TopicAndPa
             } else
               isMessageInAllReplicas = false
           } catch {
-            case t: Throwable =>
+            case NonFatal(t) =>
               throw new RuntimeException("Error in processing replica %d in partition %s at offset %d."
               .format(replicaId, topicAndPartition, fetchOffsetMap.get(topicAndPartition)), t)
           }
@@ -362,7 +364,7 @@ private class ReplicaFetcher(name: String, sourceBroker: Broker, topicAndPartiti
     try {
       response = simpleConsumer.fetch(fetchRequest)
     } catch {
-      case t: Throwable =>
+      case NonFatal(t) =>
         if (!isRunning.get)
           throw t
     }

--- a/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
@@ -26,6 +26,8 @@ import kafka.cluster.Broker
 import scala.collection.JavaConversions._
 import kafka.common.TopicAndPartition
 
+import scala.util.control.NonFatal
+
 /**
  * Command line program to dump out messages to standard out using the simple consumer
  */
@@ -173,7 +175,7 @@ object SimpleConsumerShell extends Logging {
         startingOffset = simpleConsumer.earliestOrLatestOffset(TopicAndPartition(topic, partitionId), startingOffset,
                                                                Request.DebuggingConsumerId)
       } catch {
-        case t: Throwable =>
+        case NonFatal(t) =>
           System.err.println("Error in getting earliest or latest offset due to: " + Utils.stackTrace(t))
           System.exit(1)
       } finally {
@@ -216,7 +218,7 @@ object SimpleConsumerShell extends Logging {
                 formatter.writeTo(key, if(message.isNull) null else Utils.readBytes(message.payload), System.out)
                 numMessagesConsumed += 1
               } catch {
-                case e: Throwable =>
+                case NonFatal(e) =>
                   if (skipMessageOnError)
                     error("Error processing message, skipping this message: ", e)
                   else
@@ -232,7 +234,7 @@ object SimpleConsumerShell extends Logging {
             }
           }
         } catch {
-          case e: Throwable =>
+          case NonFatal(e) =>
             error("Error consuming topic, partition, replica (%s, %d, %d) with offset [%d]".format(topic, partitionId, replicaId, offset), e)
         }finally {
           info("Consumed " + numMessagesConsumed + " messages")

--- a/core/src/main/scala/kafka/tools/VerifyConsumerRebalance.scala
+++ b/core/src/main/scala/kafka/tools/VerifyConsumerRebalance.scala
@@ -21,6 +21,8 @@ import joptsimple.OptionParser
 import org.I0Itec.zkclient.ZkClient
 import kafka.utils.{Logging, ZKGroupTopicDirs, ZkUtils, ZKStringSerializer, CommandLineUtils}
 
+import scala.util.control.NonFatal
+
 object VerifyConsumerRebalance extends Logging {
   def main(args: Array[String]) {
     val parser = new OptionParser()
@@ -59,7 +61,7 @@ object VerifyConsumerRebalance extends Logging {
         else
           println("Rebalance operation failed !")
       } catch {
-        case e2: Throwable => error("Error while verifying current rebalancing operation", e2)
+        case NonFatal(e2) => error("Error while verifying current rebalancing operation", e2)
       }
     }
     finally {

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -20,6 +20,7 @@ package kafka.utils
 import java.util.concurrent._
 import atomic._
 import collection.mutable.HashMap
+import scala.util.control.NonFatal
 
 /**
  * A scheduler for running jobs
@@ -98,7 +99,7 @@ class KafkaScheduler(val threads: Int,
         trace("Begining execution of scheduled task '%s'.".format(name))
         fun()
       } catch {
-        case t: Throwable => error("Uncaught exception in scheduled task '" + name +"'", t)
+        case NonFatal(t) => error("Uncaught exception in scheduled task '" + name +"'", t)
       } finally {
         trace("Completed execution of scheduled task '%s'.".format(name))
       }

--- a/core/src/main/scala/kafka/utils/Mx4jLoader.scala
+++ b/core/src/main/scala/kafka/utils/Mx4jLoader.scala
@@ -21,6 +21,8 @@ package kafka.utils
 import java.lang.management.ManagementFactory
 import javax.management.ObjectName
 
+import scala.util.control.NonFatal
+
 /**
  * If mx4j-tools is in the classpath call maybeLoad to load the HTTP interface of mx4j.
  *
@@ -64,7 +66,7 @@ object Mx4jLoader extends Logging {
 	  case e: ClassNotFoundException => {
         info("Will not load MX4J, mx4j-tools.jar is not in the classpath");
       }
-      case e: Throwable => {
+      case NonFatal(e) => {
         warn("Could not start register mbean in JMX", e);
       }
     }

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -20,6 +20,8 @@ package kafka.utils
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.CountDownLatch
 
+import scala.util.control.NonFatal
+
 abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean = true)
         extends Thread(name) with Logging {
   this.setDaemon(false)
@@ -60,7 +62,7 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
         doWork()
       }
     } catch{
-      case e: Throwable =>
+      case NonFatal(e) =>
         if(isRunning.get())
           error("Error due to ", e)
     }

--- a/core/src/main/scala/kafka/utils/Utils.scala
+++ b/core/src/main/scala/kafka/utils/Utils.scala
@@ -30,6 +30,8 @@ import java.util.Properties
 import kafka.common.KafkaException
 import kafka.common.KafkaStorageException
 
+import scala.util.control.NonFatal
+
 
 /**
  * General helper functions!
@@ -171,7 +173,7 @@ object Utils extends Logging {
     try {
       action
     } catch {
-      case e: Throwable => log(e.getMessage(), e)
+      case NonFatal(e) => log(e.getMessage(), e)
     }
   }
   

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -34,6 +34,7 @@ import scala.Some
 import kafka.controller.LeaderIsrAndControllerEpoch
 import kafka.common.TopicAndPartition
 import scala.collection
+import scala.util.control.NonFatal
 
 object ZkUtils extends Logging {
   val ConsumersPath = "/consumers"
@@ -243,7 +244,7 @@ object ZkUtils extends Logging {
           storedData = readData(client, path)._1
         } catch {
           case e1: ZkNoNodeException => // the node disappeared; treat as if node existed and let caller handles this
-          case e2: Throwable => throw e2
+          case NonFatal(e2) => throw e2
         }
         if (storedData == null || storedData != data) {
           info("conflict in " + path + " data: " + data + " stored data: " + storedData)
@@ -253,7 +254,7 @@ object ZkUtils extends Logging {
           info(path + " exists with value " + data + " during connection loss; this is ok")
         }
       }
-      case e2: Throwable => throw e2
+      case NonFatal(e2) => throw e2
     }
   }
 
@@ -293,7 +294,7 @@ object ZkUtils extends Logging {
             case None => // the node disappeared; retry creating the ephemeral node immediately
           }
         }
-        case e2: Throwable => throw e2
+        case NonFatal(e2) => throw e2
       }
     }
   }
@@ -332,10 +333,10 @@ object ZkUtils extends Logging {
         } catch {
           case e: ZkNodeExistsException =>
             client.writeData(path, data)
-          case e2: Throwable => throw e2
+          case NonFatal(e2) => throw e2
         }
       }
-      case e2: Throwable => throw e2
+      case NonFatal(e2) => throw e2
     }
   }
 
@@ -401,7 +402,7 @@ object ZkUtils extends Logging {
         createParentPath(client, path)
         client.createEphemeral(path, data)
       }
-      case e2: Throwable => throw e2
+      case NonFatal(e2) => throw e2
     }
   }
 
@@ -413,7 +414,7 @@ object ZkUtils extends Logging {
         // this can happen during a connection loss event, return normally
         info(path + " deleted during connection loss; this is ok")
         false
-      case e2: Throwable => throw e2
+      case NonFatal(e2) => throw e2
     }
   }
 
@@ -424,7 +425,7 @@ object ZkUtils extends Logging {
       case e: ZkNoNodeException =>
         // this can happen during a connection loss event, return normally
         info(path + " deleted during connection loss; this is ok")
-      case e2: Throwable => throw e2
+      case NonFatal(e2) => throw e2
     }
   }
 
@@ -434,7 +435,7 @@ object ZkUtils extends Logging {
       zk.deleteRecursive(dir)
       zk.close()
     } catch {
-      case _: Throwable => // swallow
+      case NonFatal(_) => // swallow
     }
   }
 
@@ -451,7 +452,7 @@ object ZkUtils extends Logging {
                       } catch {
                         case e: ZkNoNodeException =>
                           (None, stat)
-                        case e2: Throwable => throw e2
+                        case NonFatal(e2) => throw e2
                       }
     dataAndStat
   }
@@ -469,7 +470,7 @@ object ZkUtils extends Logging {
       client.getChildren(path)
     } catch {
       case e: ZkNoNodeException => return Nil
-      case e2: Throwable => throw e2
+      case NonFatal(e2) => throw e2
     }
   }
 
@@ -631,7 +632,7 @@ object ZkUtils extends Logging {
           case nne: ZkNoNodeException =>
             ZkUtils.createPersistentPath(zkClient, zkPath, jsonData)
             debug("Created path %s with %s for partition reassignment".format(zkPath, jsonData))
-          case e2: Throwable => throw new AdminOperationException(e2.toString)
+          case NonFatal(e2) => throw new AdminOperationException(e2.toString)
         }
     }
   }


### PR DESCRIPTION
'catch: Throwable' will catch VirtualMachineError, ThreadDeath, InterruptedException, LinkageError, ControlThrowable, NotImplementedError; we don't want to catch those kind of error
