### PR TITLE
MINOR: Introduce `producer.config` property to `ConsoleProducer`

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -28,6 +28,7 @@ import java.io._
 
 import joptsimple._
 import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.utils.Utils
 
 object ConsoleProducer {
 
@@ -76,10 +77,7 @@ object ConsoleProducer {
   }
 
   def getOldProducerProps(config: ProducerConfig): Properties = {
-
-    val props = new Properties
-
-    props.putAll(config.extraProducerProps)
+    val props = producerProps(config)
 
     props.put("metadata.broker.list", config.brokerList)
     props.put("compression.codec", config.compressionCodec)
@@ -101,11 +99,17 @@ object ConsoleProducer {
     props
   }
 
-  def getNewProducerProps(config: ProducerConfig): Properties = {
-
-    val props = new Properties
-
+  private def producerProps(config: ProducerConfig): Properties = {
+    val props =
+      if (config.options.has(config.producerConfigOpt))
+        Utils.loadProps(config.options.valueOf(config.producerConfigOpt))
+      else new Properties
     props.putAll(config.extraProducerProps)
+    props
+  }
+
+  def getNewProducerProps(config: ProducerConfig): Properties = {
+    val props = producerProps(config)
 
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokerList)
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec)
@@ -237,6 +241,10 @@ object ConsoleProducer {
             .withRequiredArg
             .describedAs("producer_prop")
             .ofType(classOf[String])
+    val producerConfigOpt = parser.accepts("producer.config", "Producer config properties file.")
+      .withRequiredArg
+      .describedAs("config file")
+      .ofType(classOf[String])
     val useOldProducerOpt = parser.accepts("old-producer", "Use the old producer implementation.")
 
     val options = parser.parse(args : _*)

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -241,7 +241,7 @@ object ConsoleProducer {
             .withRequiredArg
             .describedAs("producer_prop")
             .ofType(classOf[String])
-    val producerConfigOpt = parser.accepts("producer.config", "Producer config properties file.")
+    val producerConfigOpt = parser.accepts("producer.config", s"Producer config properties file. Note that $producerPropertyOpt takes precedence over this config.")
       .withRequiredArg
       .describedAs("config file")
       .ofType(classOf[String])


### PR DESCRIPTION
This makes it easier to pass security properties in the same way
to `ConsoleConsumer` and `ConsoleProducer`.
