### PR TITLE
KAFKA-2858; Introduce `SimplePrincipal` and use it in the authentication layer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -29,7 +29,7 @@ import java.nio.channels.SelectionKey;
 
 import java.security.Principal;
 
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SimplePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ public class PlaintextTransportLayer implements TransportLayer {
     private static final Logger log = LoggerFactory.getLogger(PlaintextTransportLayer.class);
     private final SelectionKey key;
     private final SocketChannel socketChannel;
-    private final Principal principal = KafkaPrincipal.ANONYMOUS;
+    private final Principal principal = SimplePrincipal.ANONYMOUS;
 
     public PlaintextTransportLayer(SelectionKey key) throws IOException {
         this.key = key;

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -35,7 +35,7 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.SimplePrincipal;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -637,7 +637,7 @@ public class SslTransportLayer implements TransportLayer {
             return sslEngine.getSession().getPeerPrincipal();
         } catch (SSLPeerUnverifiedException se) {
             log.warn("SSL peer is not authenticated, returning ANONYMOUS instead");
-            return KafkaPrincipal.ANONYMOUS;
+            return SimplePrincipal.ANONYMOUS;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/DefaultPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/DefaultPrincipalBuilder.java
@@ -24,8 +24,7 @@ import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.network.Authenticator;
 import org.apache.kafka.common.KafkaException;
 
-/** DefaultPrincipalBuilder which return transportLayer's peer Principal **/
-
+/** DefaultPrincipalBuilder which return transportLayer's peer Principal */
 public class DefaultPrincipalBuilder implements PrincipalBuilder {
 
     public void configure(Map<String, ?> configs) {}

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/KafkaPrincipal.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/KafkaPrincipal.java
@@ -18,13 +18,19 @@ package org.apache.kafka.common.security.auth;
 
 import java.security.Principal;
 
+/**
+ * An implementation of `Principal` that contains a `name` and a `principalType`, which is used on the authorization
+ * layer by the broker.
+ *
+ * @see SimplePrincipal
+ */
 public class KafkaPrincipal implements Principal {
     public static final String SEPARATOR = ":";
     public static final String USER_TYPE = "User";
     public final static KafkaPrincipal ANONYMOUS = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "ANONYMOUS");
 
-    private String principalType;
-    private String name;
+    private final String principalType;
+    private final String name;
 
     public KafkaPrincipal(String principalType, String name) {
         if (principalType == null || name == null) {
@@ -46,6 +52,13 @@ public class KafkaPrincipal implements Principal {
         }
 
         return new KafkaPrincipal(split[0], split[1]);
+    }
+
+    /**
+     * Returns a KafkaPrincipal with `USER_TYPE` and with the same name as `principal`.
+     */
+    public static KafkaPrincipal fromPrincipal(Principal principal) {
+        return new KafkaPrincipal(USER_TYPE, principal.getName());
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/SimplePrincipal.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/SimplePrincipal.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.auth;
+
+import java.security.Principal;
+
+/**
+ * Simple implementation of `Principal` that contains a `name` and is used on the authentication layer by clients
+ * and broker.
+ *
+ * @see KafkaPrincipal
+ */
+public class SimplePrincipal implements Principal {
+
+    public final static Principal ANONYMOUS = new SimplePrincipal("ANONYMOUS");
+
+    private final String name;
+
+    public SimplePrincipal(String name) {
+        if (name == null)
+            throw new IllegalArgumentException("name can not be null");
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SimplePrincipal)) return false;
+        SimplePrincipal that = (SimplePrincipal) o;
+        return name.equals(that.name);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -44,10 +44,10 @@ import org.apache.kafka.common.network.Authenticator;
 import org.apache.kafka.common.network.NetworkSend;
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.TransportLayer;
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.PrincipalBuilder;
 import org.apache.kafka.common.KafkaException;
 
+import org.apache.kafka.common.security.auth.SimplePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,7 +174,7 @@ public class SaslClientAuthenticator implements Authenticator {
     }
 
     public Principal principal() {
-        return new KafkaPrincipal(KafkaPrincipal.USER_TYPE, clientPrincipalName);
+        return new SimplePrincipal(clientPrincipalName);
     }
 
     public boolean complete() {

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -34,6 +34,7 @@ import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslException;
 
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.security.auth.SimplePrincipal;
 import org.apache.kafka.common.security.kerberos.KerberosName;
 import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
 import org.ietf.jgss.GSSContext;
@@ -45,7 +46,6 @@ import org.ietf.jgss.Oid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.network.Authenticator;
 import org.apache.kafka.common.network.NetworkSend;
 import org.apache.kafka.common.network.NetworkReceive;
@@ -173,7 +173,7 @@ public class SaslServerAuthenticator implements Authenticator {
     }
 
     public Principal principal() {
-        return new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID());
+        return new SimplePrincipal(saslServer.getAuthorizationID());
     }
 
     public boolean complete() {

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -421,8 +421,7 @@ private[kafka] class Processor(val id: Int,
         selector.completedReceives.asScala.foreach { receive =>
           try {
             val channel = selector.channel(receive.source)
-            val session = RequestChannel.Session(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, channel.principal.getName),
-              channel.socketAddress)
+            val session = RequestChannel.Session(KafkaPrincipal.fromPrincipal(channel.principal), channel.socketAddress)
             val req = RequestChannel.Request(processor = id, connectionId = receive.source, session = session, buffer = receive.payload, startTimeMs = time.milliseconds, securityProtocol = protocol)
             requestChannel.sendRequest(req)
             selector.mute(receive.source)


### PR DESCRIPTION
This makes it clear that we only support a principal name at the
authentication layer (principalType is only used at the authorization
layer).
