### PR TITLE
KAFKA-2820: Remove log threshold on appender in tools-log4j.properties

### DIFF
--- a/tests/kafkatest/services/performance/templates/tools_log4j.properties
+++ b/tests/kafkatest/services/performance/templates/tools_log4j.properties
@@ -19,7 +19,6 @@ log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File={{ log_file }}
 log4j.appender.FILE.ImmediateFlush=true
-log4j.appender.FILE.Threshold=debug
 # Set the append to false, overwrite
 log4j.appender.FILE.Append=false
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout

--- a/tests/kafkatest/services/templates/connect_log4j.properties
+++ b/tests/kafkatest/services/templates/connect_log4j.properties
@@ -21,7 +21,6 @@ log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File={{ log_file }}
 log4j.appender.FILE.ImmediateFlush=true
-log4j.appender.FILE.Threshold=debug
 log4j.appender.FILE.Append=true
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n

--- a/tests/kafkatest/services/templates/tools_log4j.properties
+++ b/tests/kafkatest/services/templates/tools_log4j.properties
@@ -19,7 +19,6 @@ log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File={{ log_file }}
 log4j.appender.FILE.ImmediateFlush=true
-log4j.appender.FILE.Threshold=debug
 # Set the append to true
 log4j.appender.FILE.Append=true
 log4j.appender.FILE.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Removed a config in tools-log4j.properties which prevented certain service classes from logging at TRACE level.
