### PR TITLE
KAFKA-2361: unit test failure in ProducerFailureHandlingTest.testNotE…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
@@ -18,7 +18,7 @@
 package kafka.api
 
 import kafka.common.Topic
-import org.apache.kafka.common.errors.{InvalidTopicException,NotEnoughReplicasException}
+import org.apache.kafka.common.errors.{NotEnoughReplicasAfterAppendException, InvalidTopicException, NotEnoughReplicasException}
 import org.scalatest.junit.JUnit3Suite
 import org.junit.Test
 import org.junit.Assert._
@@ -351,8 +351,11 @@ class ProducerFailureHandlingTest extends JUnit3Suite with KafkaServerTestHarnes
       fail("Expected exception when producing to topic with fewer brokers than min.insync.replicas")
     } catch {
       case e: ExecutionException =>
-        if (!e.getCause.isInstanceOf[NotEnoughReplicasException]) {
-          fail("Expected NotEnoughReplicasException when producing to topic with fewer brokers than min.insync.replicas")
+        if (!e.getCause.isInstanceOf[NotEnoughReplicasException]  &&
+          !e.getCause.isInstanceOf[NotEnoughReplicasAfterAppendException] &&
+          !e.getCause.isInstanceOf[TimeoutException]) {
+          fail("Expected NotEnoughReplicasException or NotEnoughReplicasAfterAppendException when producing to topic " +
+            "with fewer brokers than min.insync.replicas, but saw " + e.getCause)
         }
     }
 


### PR DESCRIPTION
the same issue stated at https://issues.apache.org/jira/browse/KAFKA-1999, but on branch 0.8.2, still not fixed @junrao 
