### PR TITLE
KAFKA-2643: Run mirror maker ducktape tests with SSL and SASL

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -66,6 +66,7 @@ class KafkaService(JmxMixin, Service):
         self.interbroker_security_protocol = interbroker_security_protocol
         self.sasl_mechanism = sasl_mechanism
         self.topics = topics
+        self.minikdc = None
 
         for node in self.nodes:
             node.version = version
@@ -77,10 +78,9 @@ class KafkaService(JmxMixin, Service):
 
     def start(self):
         if self.security_config.has_sasl_kerberos:
-            self.minikdc = MiniKdc(self.context, self.nodes)
-            self.minikdc.start()
-        else:
-            self.minikdc = None
+            if self.minikdc is None:
+                self.minikdc = MiniKdc(self.context, self.nodes)
+                self.minikdc.start()
         Service.start(self)
 
         # Create topics if necessary

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -56,15 +56,15 @@ class VerifiableProducer(BackgroundThreadService):
             node.version = version
         self.acked_values = []
         self.not_acked_values = []
-
         self.prop_file = ""
-        self.security_config = kafka.security_config.client_config(self.prop_file)
-        self.prop_file += str(self.security_config)
+
 
     def _worker(self, idx, node):
         node.account.ssh("mkdir -p %s" % VerifiableProducer.PERSISTENT_ROOT, allow_fail=False)
 
         # Create and upload log properties
+        self.security_config = self.kafka.security_config.client_config(self.prop_file)
+        self.prop_file += str(self.security_config)
         log_config = self.render('tools_log4j.properties', log_file=VerifiableProducer.LOG_FILE)
         node.account.create_file(VerifiableProducer.LOG4J_CONFIG, log_config)
 


### PR DESCRIPTION
Run tests with SSL, SASL_PLAINTEXT and SASL_SSL. Same security protocol is used for source and target Kafka.
