### PR TITLE
KAFKA-2642: Run replication tests with SSL and SASL clients

### DIFF
--- a/tests/kafkatest/tests/compatibility_test.py
+++ b/tests/kafkatest/tests/compatibility_test.py
@@ -32,7 +32,7 @@ class ClientCompatibilityTest(Test):
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, version=LATEST_0_8_2, topics={self.topic: {
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,
-                                                                    "min.insync.replicas": 2}})
+                                                                    'configs': {"min.insync.replicas": 2}}})
         self.zk.start()
         self.kafka.start()
 

--- a/tests/kafkatest/tests/quota_test.py
+++ b/tests/kafkatest/tests/quota_test.py
@@ -50,7 +50,7 @@ class QuotaTest(Test):
         self.kafka = KafkaService(test_context, num_nodes=1, zk=self.zk,
                                   security_protocol='PLAINTEXT',
                                   interbroker_security_protocol='PLAINTEXT',
-                                  topics={self.topic: {'partitions': 6, 'replication-factor': 1, 'min.insync.replicas': 1}},
+                                  topics={self.topic: {'partitions': 6, 'replication-factor': 1, 'configs': {'min.insync.replicas': 1}}},
                                   quota_config=self.quota_config,
                                   jmx_object_names=['kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec',
                                                     'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec'],

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -95,7 +95,7 @@ class ReplicationTest(ProduceConsumeValidateTest):
                                                                     "replication-factor": 3,
                                                                     "min.insync.replicas": 2}
                                                                 })
-        self.producer_throughput = 10000
+        self.producer_throughput = 1000
         self.num_producers = 1
         self.num_consumers = 1
 

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -93,7 +93,7 @@ class ReplicationTest(ProduceConsumeValidateTest):
         self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,
-                                                                    "min.insync.replicas": 2}
+                                                                    'configs': {"min.insync.replicas": 2}}
                                                                 })
         self.producer_throughput = 1000
         self.num_producers = 1

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -123,10 +123,11 @@ class ReplicationTest(ProduceConsumeValidateTest):
             - Validate that every acked message was consumed
         """
 
-        self.kafka.security_protocol = 'PLAINTEXT'
+        self.kafka.security_protocol = security_protocol
         self.kafka.interbroker_security_protocol = security_protocol
+        new_consumer = False if  self.kafka.security_protocol == "PLAINTEXT" else True
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka, self.topic, throughput=self.producer_throughput)
-        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, consumer_timeout_ms=60000, message_validator=is_int)
+        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, new_consumer=new_consumer, consumer_timeout_ms=60000, message_validator=is_int)
         self.kafka.start()
         
         self.run_produce_consume_validate(core_test_action=lambda: failures[failure_mode](self))

--- a/tests/kafkatest/tests/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/security_rolling_upgrade_test.py
@@ -40,7 +40,7 @@ class TestSecurityRollingUpgrade(ProduceConsumeValidateTest):
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
             "partitions": 3,
             "replication-factor": 3,
-            "min.insync.replicas": 2}})
+            'configs': {"min.insync.replicas": 2}}})
         self.zk.start()
 
         #reduce replica.lag.time.max.ms due to KAFKA-2827

--- a/tests/kafkatest/tests/upgrade_test.py
+++ b/tests/kafkatest/tests/upgrade_test.py
@@ -33,7 +33,7 @@ class TestUpgrade(ProduceConsumeValidateTest):
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, version=LATEST_0_8_2, topics={self.topic: {
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,
-                                                                    "min.insync.replicas": 2}})
+                                                                    'configs': {"min.insync.replicas": 2}}})
         self.zk.start()
         self.kafka.start()
 


### PR DESCRIPTION
For SSL and SASL replication tests, set security protocol for clients as well.
