### PR TITLE
KAFKA-2825, KAFKA-2851: Controller failover tests added to ducktape replication tests and fix to temp dir

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -164,7 +164,7 @@ class KafkaService(JmxMixin, Service):
         node.account.create_file(KafkaService.CONFIG_FILE, prop_file)
         node.account.create_file(self.LOG4J_CONFIG, self.render('log4j.properties', log_dir=KafkaService.OPERATIONAL_LOG_DIR))
 
-        self.security_config.setup_node(node)
+        self.security_config.setup_node(node, self.minikdc)
 
         cmd = self.start_cmd(node)
         self.logger.debug("Attempting to start KafkaService on %s with command: %s" % (str(node.account), cmd))

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -318,24 +318,29 @@ class KafkaService(JmxMixin, Service):
         self.stop_node(node, clean_shutdown)
         self.start_node(node)
 
-    def leader(self, topic, partition=0):
-        """ Get the leader replica for the given topic and partition.
-        """
+    def query_zookeeper(self, zk_path):
+        """ Get info from zookeeper """
         kafka_dir = KAFKA_TRUNK
-        cmd = "/opt/%s/bin/kafka-run-class.sh kafka.tools.ZooKeeperMainWrapper -server %s " %\
-              (kafka_dir, self.zk.connect_setting())
-        cmd += "get /brokers/topics/%s/partitions/%d/state" % (topic, partition)
+        cmd = "/opt/%s/bin/kafka-run-class.sh kafka.tools.ZooKeeperMainWrapper -server %s get %s" % \
+              (kafka_dir, self.zk.connect_setting(), zk_path)
         self.logger.debug(cmd)
 
         node = self.zk.nodes[0]
-        self.logger.debug("Querying zookeeper to find leader replica for topic %s: \n%s" % (cmd, topic))
-        partition_state = None
+        result = None
         for line in node.account.ssh_capture(cmd):
             # loop through all lines in the output, but only hold on to the first match
-            if partition_state is None:
+            if result is None:
                 match = re.match("^({.+})$", line)
                 if match is not None:
-                    partition_state = match.groups()[0]
+                    result = match.groups()[0]
+        return result
+
+    def leader(self, topic, partition=0):
+        """ Get the leader replica for the given topic and partition.
+        """
+        self.logger.debug("Querying zookeeper to find leader replica for topic: \n%s" % (topic))
+        zk_path = "/brokers/topics/%s/partitions/%d/state" % (topic, partition)
+        partition_state = self.query_zookeeper(zk_path)
 
         if partition_state is None:
             raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
@@ -359,3 +364,19 @@ class KafkaService(JmxMixin, Service):
             raise ValueError("We are retrieving bootstrap servers for the port: %s which is not currently open. - " % str(port_mapping))
 
         return ','.join([node.account.hostname + ":" + str(port_mapping.number) for node in self.nodes])
+
+    def controller(self):
+        """ Get the controller ID
+        """
+        self.logger.debug("Querying zookeeper to find controller broker")
+        controller_info = self.query_zookeeper("/controller")
+
+        if controller_info is None:
+            raise Exception("Error finding controller info")
+
+        controller_info = json.loads(controller_info)
+        self.logger.debug(controller_info)
+
+        controller_idx = int(controller_info["brokerid"])
+        self.logger.info("Controller's ID: %d" % (controller_idx))
+        return self.get_node(controller_idx)

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -318,29 +318,12 @@ class KafkaService(JmxMixin, Service):
         self.stop_node(node, clean_shutdown)
         self.start_node(node)
 
-    def query_zookeeper(self, zk_path):
-        """ Get info from zookeeper """
-        kafka_dir = KAFKA_TRUNK
-        cmd = "/opt/%s/bin/kafka-run-class.sh kafka.tools.ZooKeeperMainWrapper -server %s get %s" % \
-              (kafka_dir, self.zk.connect_setting(), zk_path)
-        self.logger.debug(cmd)
-
-        node = self.zk.nodes[0]
-        result = None
-        for line in node.account.ssh_capture(cmd):
-            # loop through all lines in the output, but only hold on to the first match
-            if result is None:
-                match = re.match("^({.+})$", line)
-                if match is not None:
-                    result = match.groups()[0]
-        return result
-
     def leader(self, topic, partition=0):
         """ Get the leader replica for the given topic and partition.
         """
         self.logger.debug("Querying zookeeper to find leader replica for topic: \n%s" % (topic))
         zk_path = "/brokers/topics/%s/partitions/%d/state" % (topic, partition)
-        partition_state = self.query_zookeeper(zk_path)
+        partition_state = self.zk.query(zk_path)
 
         if partition_state is None:
             raise Exception("Error finding partition state for topic %s and partition %d." % (topic, partition))
@@ -366,10 +349,10 @@ class KafkaService(JmxMixin, Service):
         return ','.join([node.account.hostname + ":" + str(port_mapping.number) for node in self.nodes])
 
     def controller(self):
-        """ Get the controller ID
+        """ Get the controller node
         """
         self.logger.debug("Querying zookeeper to find controller broker")
-        controller_info = self.query_zookeeper("/controller")
+        controller_info = self.zk.query("/controller")
 
         if controller_info is None:
             raise Exception("Error finding controller info")

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -50,7 +50,6 @@ class MiniKdc(Service):
         try:
             self.local_temp_dir = tempfile.mkdtemp(dir=self.local_temp_dir)
             self.logger.debug("Created temporary local directory %s" % (self.local_temp_dir))
-            # os.chmod(self.local_temp_dir, 0755)
         except OSError as e:
             raise Exception("Failed to create temporary tocal directory for $s and %s files: %s" % (self.LOCAL_KEYTAB_FILENAME, self.LOCAL_KRB5CONF_FILENAME, e.strerror))
 
@@ -77,6 +76,4 @@ class MiniKdc(Service):
     def clean_node(self, node):
         node.account.kill_process("apacheds", clean_shutdown=False, allow_fail=False)
         node.account.ssh("rm -rf " + MiniKdc.WORK_DIR, allow_fail=False)
-
-
 

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -63,7 +63,6 @@ class MiniKdc(Service):
         self.logger.info("Stopping %s on %s" % (type(self).__name__, node.account.hostname))
         node.account.kill_process("apacheds", allow_fail=False)
 
-
     def clean_node(self, node):
         node.account.kill_process("apacheds", clean_shutdown=False, allow_fail=False)
         node.account.ssh("rm -rf " + MiniKdc.WORK_DIR, allow_fail=False)

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -46,16 +46,6 @@ class MiniKdc(Service):
         self.logger.info("minikdc.properties")
         self.logger.info(props_file)
 
-        # create local temp dir where we will store keytab and krb5conf files
-        try:
-            self.local_temp_dir = tempfile.mkdtemp(dir=self.local_temp_dir)
-            self.logger.debug("Created temporary local directory %s" % (self.local_temp_dir))
-        except OSError as e:
-            raise Exception("Failed to create temporary tocal directory for $s and %s files: %s" % (self.LOCAL_KEYTAB_FILENAME, self.LOCAL_KRB5CONF_FILENAME, e.strerror))
-
-        self.local_keytab_file = os.path.join(self.local_temp_dir, self.LOCAL_KEYTAB_FILENAME)
-        self.local_krb5conf_file = os.path.join(self.local_temp_dir, self.LOCAL_KRB5CONF_FILENAME)
-
         kafka_principals = ' '.join(['kafka/' + kafka_node.account.hostname for kafka_node in self.kafka_nodes])
         principals = 'client ' + kafka_principals + self.extra_principals
         self.logger.info("Starting MiniKdc with principals " + principals)
@@ -72,6 +62,7 @@ class MiniKdc(Service):
     def stop_node(self, node):
         self.logger.info("Stopping %s on %s" % (type(self).__name__, node.account.hostname))
         node.account.kill_process("apacheds", allow_fail=False)
+
 
     def clean_node(self, node):
         node.account.kill_process("apacheds", clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -17,10 +17,6 @@ from ducktape.services.service import Service
 from kafkatest.services.kafka.directory import kafka_dir
 
 import os
-from tempfile import mkstemp
-from shutil import move
-from os import remove, close
-from io import open
 
 class MiniKdc(Service):
 
@@ -35,24 +31,11 @@ class MiniKdc(Service):
     KEYTAB_FILE = "/mnt/minikdc/keytab"
     KRB5CONF_FILE = "/mnt/minikdc/krb5.conf"
     LOG_FILE = "/mnt/minikdc/minikdc.log"
-    LOCAL_KEYTAB_FILE = "/tmp/keytab"
-    LOCAL_KRB5CONF_FILE = "/tmp/krb5.conf"
 
     def __init__(self, context, kafka_nodes, extra_principals = ""):
         super(MiniKdc, self).__init__(context, 1)
         self.kafka_nodes = kafka_nodes
         self.extra_principals = extra_principals
-
-    def replace_in_file(self, file_path, pattern, subst):
-        fh, abs_path = mkstemp()
-        with open(abs_path, 'w') as new_file:
-            with open(file_path) as old_file:
-                for line in old_file:
-                    new_file.write(line.replace(pattern, subst))
-        close(fh)
-        remove(file_path)
-        move(abs_path, file_path)
-
 
     def start_node(self, node):
 
@@ -75,12 +58,6 @@ class MiniKdc(Service):
             node.account.ssh(cmd)
             monitor.wait_until("MiniKdc Running", timeout_sec=60, backoff_sec=1, err_msg="MiniKdc didn't finish startup")
 
-        node.account.scp_from(MiniKdc.KEYTAB_FILE, MiniKdc.LOCAL_KEYTAB_FILE)
-        node.account.scp_from(MiniKdc.KRB5CONF_FILE, MiniKdc.LOCAL_KRB5CONF_FILE)
-
-        #KDC is set to bind openly (via 0.0.0.0). Change krb5.conf to hold the specific KDC address
-        self.replace_in_file(MiniKdc.LOCAL_KRB5CONF_FILE, '0.0.0.0', node.account.hostname)
-
     def stop_node(self, node):
         self.logger.info("Stopping %s on %s" % (type(self).__name__, node.account.hostname))
         node.account.kill_process("apacheds", allow_fail=False)
@@ -88,9 +65,6 @@ class MiniKdc(Service):
     def clean_node(self, node):
         node.account.kill_process("apacheds", clean_shutdown=False, allow_fail=False)
         node.account.ssh("rm -rf " + MiniKdc.WORK_DIR, allow_fail=False)
-        if os.path.exists(MiniKdc.LOCAL_KEYTAB_FILE):
-            os.remove(MiniKdc.LOCAL_KEYTAB_FILE)
-        if os.path.exists(MiniKdc.LOCAL_KRB5CONF_FILE):
-            os.remove(MiniKdc.LOCAL_KRB5CONF_FILE)
+
 
 

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -16,6 +16,7 @@
 import os
 import subprocess
 from ducktape.template import TemplateRenderer
+from kafkatest.utils.remote_account import scp
 from kafkatest.services.security.minikdc import MiniKdc
 
 class Keytool(object):
@@ -127,8 +128,8 @@ class SecurityConfig(TemplateRenderer):
             jaas_conf = self.render(jaas_conf_file,  node=node, is_ibm_jdk=is_ibm_jdk)
             node.account.create_file(SecurityConfig.JAAS_CONF_PATH, jaas_conf)
             if self.has_sasl_kerberos:
-                node.account.scp_to(miniKdc.local_keytab_file, SecurityConfig.KEYTAB_PATH)
-                node.account.scp_to(miniKdc.local_krb5conf_file, SecurityConfig.KRB5CONF_PATH)
+                scp(miniKdc.nodes[0], MiniKdc.KEYTAB_FILE, node, SecurityConfig.KEYTAB_PATH)
+                scp(miniKdc.nodes[0], MiniKdc.KRB5CONF_FILE, node, SecurityConfig.KRB5CONF_PATH)
 
     def clean_node(self, node):
         if self.security_protocol != SecurityConfig.PLAINTEXT:

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -128,6 +128,8 @@ class SecurityConfig(TemplateRenderer):
             jaas_conf = self.render(jaas_conf_file,  node=node, is_ibm_jdk=is_ibm_jdk)
             node.account.create_file(SecurityConfig.JAAS_CONF_PATH, jaas_conf)
             if self.has_sasl_kerberos:
+                if miniKdc is None:
+                    raise Exception("miniKdc must be not None when has_sasl_kerberos is true")
                 scp(miniKdc.nodes[0], MiniKdc.KEYTAB_FILE, node, SecurityConfig.KEYTAB_PATH)
                 #KDC is set to bind openly (via 0.0.0.0). Change krb5.conf to hold the specific KDC address
                 scp(miniKdc.nodes[0], MiniKdc.KRB5CONF_FILE, node, SecurityConfig.KRB5CONF_PATH, '0.0.0.0', miniKdc.nodes[0].account.hostname)

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -129,7 +129,8 @@ class SecurityConfig(TemplateRenderer):
             node.account.create_file(SecurityConfig.JAAS_CONF_PATH, jaas_conf)
             if self.has_sasl_kerberos:
                 scp(miniKdc.nodes[0], MiniKdc.KEYTAB_FILE, node, SecurityConfig.KEYTAB_PATH)
-                scp(miniKdc.nodes[0], MiniKdc.KRB5CONF_FILE, node, SecurityConfig.KRB5CONF_PATH)
+                #KDC is set to bind openly (via 0.0.0.0). Change krb5.conf to hold the specific KDC address
+                scp(miniKdc.nodes[0], MiniKdc.KRB5CONF_FILE, node, SecurityConfig.KRB5CONF_PATH, '0.0.0.0', miniKdc.nodes[0].account.hostname)
 
     def clean_node(self, node):
         if self.security_protocol != SecurityConfig.PLAINTEXT:

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -110,7 +110,7 @@ class SecurityConfig(TemplateRenderer):
     def client_config(self, template_props=""):
         return SecurityConfig(self.security_protocol, sasl_mechanism=self.sasl_mechanism, template_props=template_props)
 
-    def setup_node(self, node):
+    def setup_node(self, node, miniKdc=None):
         if self.has_ssl:
             node.account.ssh("mkdir -p %s" % SecurityConfig.CONFIG_DIR, allow_fail=False)
             node.account.scp_to(SecurityConfig.ssl_stores['ssl.keystore.location'], SecurityConfig.KEYSTORE_PATH)
@@ -127,8 +127,8 @@ class SecurityConfig(TemplateRenderer):
             jaas_conf = self.render(jaas_conf_file,  node=node, is_ibm_jdk=is_ibm_jdk)
             node.account.create_file(SecurityConfig.JAAS_CONF_PATH, jaas_conf)
             if self.has_sasl_kerberos:
-                node.account.scp_to(MiniKdc.LOCAL_KEYTAB_FILE, SecurityConfig.KEYTAB_PATH)
-                node.account.scp_to(MiniKdc.LOCAL_KRB5CONF_FILE, SecurityConfig.KRB5CONF_PATH)
+                node.account.scp_to(miniKdc.local_keytab_file, SecurityConfig.KEYTAB_PATH)
+                node.account.scp_to(miniKdc.local_krb5conf_file, SecurityConfig.KRB5CONF_PATH)
 
     def clean_node(self, node):
         if self.security_protocol != SecurityConfig.PLAINTEXT:

--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -16,10 +16,11 @@
 
 from ducktape.services.service import Service
 
-from kafkatest.services.kafka.directory import kafka_dir
+from kafkatest.services.kafka.directory import kafka_dir, KAFKA_TRUNK
 
 import subprocess
 import time
+import re
 
 
 class ZookeeperService(Service):
@@ -83,3 +84,19 @@ class ZookeeperService(Service):
 
     def connect_setting(self):
         return ','.join([node.account.hostname + ':2181' for node in self.nodes])
+
+    def query(self, path):
+        kafka_dir = KAFKA_TRUNK
+        cmd = "/opt/%s/bin/kafka-run-class.sh kafka.tools.ZooKeeperMainWrapper -server %s get %s" % \
+              (kafka_dir, self.connect_setting(), path)
+        self.logger.debug(cmd)
+
+        node = self.nodes[0]
+        result = None
+        for line in node.account.ssh_capture(cmd):
+            # loop through all lines in the output, but only hold on to the first match
+            if result is None:
+                match = re.match("^({.+})$", line)
+                if match is not None:
+                    result = match.groups()[0]
+        return result

--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -86,6 +86,9 @@ class ZookeeperService(Service):
         return ','.join([node.account.hostname + ':2181' for node in self.nodes])
 
     def query(self, path):
+        """
+        Queries zookeeper for data associated with 'path' and returns all fields in the schema
+        """
         kafka_dir = KAFKA_TRUNK
         cmd = "/opt/%s/bin/kafka-run-class.sh kafka.tools.ZooKeeperMainWrapper -server %s get %s" % \
               (kafka_dir, self.connect_setting(), path)

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -124,8 +124,11 @@ class ReplicationTest(ProduceConsumeValidateTest):
 
 
     @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
-            broker_type=["leader", "controller"],
+            broker_type=["leader"],
             security_protocol=["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"])
+    @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
+            broker_type=["controller"],
+            security_protocol=["PLAINTEXT", "SASL_SSL"])
     def test_replication_with_broker_failure(self, failure_mode, security_protocol, broker_type):
         """Replication tests.
         These tests verify that replication provides simple durability guarantees by checking that data acked by

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -26,40 +26,56 @@ from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 import signal
 
 
-def clean_shutdown(test):
-    """Discover leader node for our topic and shut it down cleanly."""
-    test.kafka.signal_leader(test.topic, partition=0, sig=signal.SIGTERM)
+def broker_node(test, broker_type):
+    """ Discover node of requested type. For leader type, discovers leader for our topic and partition 0
+    """
+    if broker_type == "leader":
+        node = test.kafka.leader(test.topic, partition=0)
+    elif broker_type == "controller":
+        node = test.kafka.controller()
+    else:
+        raise Exception("Unexpected broker type %s." % (broker_type))
+
+    return node
 
 
-def hard_shutdown(test):
-    """Discover leader node for our topic and shut it down with a hard kill."""
-    test.kafka.signal_leader(test.topic, partition=0, sig=signal.SIGKILL)
+def clean_shutdown(test, broker_type):
+    """Discover broker node of requested type and shut it down cleanly.
+    """
+    node = broker_node(test, broker_type)
+    test.kafka.signal_node(node, sig=signal.SIGTERM)
 
 
-def clean_bounce(test):
-    """Chase the leader of one partition and restart it cleanly."""
+def hard_shutdown(test, broker_type):
+    """Discover broker node of requested type and shut it down with a hard kill."""
+    node = broker_node(test, broker_type)
+    test.kafka.signal_node(node, sig=signal.SIGKILL)
+
+
+def clean_bounce(test, broker_type):
+    """Chase the broker node of requested type and restart it cleanly."""
     for i in range(5):
-        prev_leader_node = test.kafka.leader(topic=test.topic, partition=0)
-        test.kafka.restart_node(prev_leader_node, clean_shutdown=True)
+        prev_broker_node = broker_node(test, broker_type)
+        test.kafka.restart_node(prev_broker_node, clean_shutdown=True)
 
 
-def hard_bounce(test):
+def hard_bounce(test, broker_type):
     """Chase the leader and restart it with a hard kill."""
     for i in range(5):
-        prev_leader_node = test.kafka.leader(topic=test.topic, partition=0)
-        test.kafka.signal_node(prev_leader_node, sig=signal.SIGKILL)
+        prev_broker_node = broker_node(test, broker_type)
+        test.kafka.signal_node(prev_broker_node, sig=signal.SIGKILL)
 
         # Since this is a hard kill, we need to make sure the process is down and that
-        # zookeeper and the broker cluster have registered the loss of the leader.
-        # Waiting for a new leader to be elected on the topic-partition is a reasonable heuristic for this.
+        # zookeeper and the broker cluster have registered the loss of the leader/controller.
+        # Waiting for a new leader for the topic-partition/controller to be elected is a reasonable heuristic for this.
 
-        def leader_changed():
-            current_leader = test.kafka.leader(topic=test.topic, partition=0)
-            return current_leader is not None and current_leader != prev_leader_node
+        def role_reassigned():
+            current_elected_broker = broker_node(test, broker_type)
+            return current_elected_broker is not None and current_elected_broker != prev_broker_node
 
-        wait_until(lambda: len(test.kafka.pids(prev_leader_node)) == 0, timeout_sec=5)
-        wait_until(leader_changed, timeout_sec=10, backoff_sec=.5)
-        test.kafka.start_node(prev_leader_node)
+        wait_until(lambda: len(test.kafka.pids(prev_broker_node)) == 0, timeout_sec=5)
+        wait_until(role_reassigned, timeout_sec=10, backoff_sec=.5)
+        test.kafka.start_node(prev_broker_node)
 
 failures = {
     "clean_shutdown": clean_shutdown,
@@ -108,8 +124,9 @@ class ReplicationTest(ProduceConsumeValidateTest):
 
 
     @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
+            broker_type=["leader", "controller"],
             security_protocol=["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"])
-    def test_replication_with_broker_failure(self, failure_mode, security_protocol):
+    def test_replication_with_broker_failure(self, failure_mode, security_protocol, broker_type):
         """Replication tests.
         These tests verify that replication provides simple durability guarantees by checking that data acked by
         brokers is still available for consumption in the face of various failure scenarios.
@@ -129,4 +146,4 @@ class ReplicationTest(ProduceConsumeValidateTest):
         self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, consumer_timeout_ms=60000, message_validator=is_int)
         self.kafka.start()
         
-        self.run_produce_consume_validate(core_test_action=lambda: failures[failure_mode](self))
+        self.run_produce_consume_validate(core_test_action=lambda: failures[failure_mode](self, broker_type))

--- a/tests/kafkatest/utils/remote_account.py
+++ b/tests/kafkatest/utils/remote_account.py
@@ -15,6 +15,7 @@
 
 import os
 import tempfile
+import shutil
 
 def file_exists(node, file):
     """Quick and dirty check for existence of remote file."""
@@ -41,18 +42,15 @@ def scp(source_node, source_path, target_node, target_path):
     :param target_node: destination node
     :param target_path: path on the destination node to copy to
     """
-    local_temp_dir = "/tmp"
     try:
-        local_temp_dir = tempfile.mkdtemp(dir=local_temp_dir)
+        local_temp_dir = tempfile.mkdtemp(dir="/tmp")
     except OSError as e:
         raise Exception("Failed to create temporary local directory to scp %s to %s: %s" % (source_path, target_path, e.strerror))
 
     local_temp_file = os.path.join(local_temp_dir, "tmpfile")
-    source_node.account.scp_from(source_path, local_temp_file)
-    target_node.account.scp_to(local_temp_file, target_path)
 
-    # clean up temp dir/file
-    if os.path.exists(local_temp_file):
-        os.remove(local_temp_file)
-    if os.path.exists(local_temp_dir):
-        os.removedirs(local_temp_dir)
+    try:
+        source_node.account.scp_from(source_path, local_temp_file)
+        target_node.account.scp_to(local_temp_file, target_path)
+    finally:
+        shutil.rmtree(local_temp_dir, ignore_errors=True)

--- a/tests/kafkatest/utils/remote_account.py
+++ b/tests/kafkatest/utils/remote_account.py
@@ -19,7 +19,6 @@ from shutil import move, rmtree
 from os import remove, close
 from io import open
 
-
 def file_exists(node, file):
     """Quick and dirty check for existence of remote file."""
     try:
@@ -67,7 +66,7 @@ def scp(source_node, source_path, target_node, target_path, pattern=None, subst=
         source_node.account.scp_from(source_path, local_temp_file)
         if pattern is not None:
             if subst is None:
-                raise Exception("Substitute string must be specified if pattern is speficied")
+                raise Exception("Substitute string must be specified if pattern is specified")
             replace_in_file(local_temp_file, pattern, subst)
         target_node.account.scp_to(local_temp_file, target_path)
     finally:

--- a/tests/kafkatest/utils/remote_account.py
+++ b/tests/kafkatest/utils/remote_account.py
@@ -45,7 +45,7 @@ def scp(source_node, source_path, target_node, target_path):
     try:
         local_temp_dir = tempfile.mkdtemp(dir=local_temp_dir)
     except OSError as e:
-        raise Exception("Failed to create temporary local directory to scp $s to %s: %s" % (source_path, target_path, e.strerror))
+        raise Exception("Failed to create temporary local directory to scp %s to %s: %s" % (source_path, target_path, e.strerror))
 
     local_temp_file = os.path.join(local_temp_dir, "tmpfile")
     source_node.account.scp_from(source_path, local_temp_file)

--- a/tests/kafkatest/utils/remote_account.py
+++ b/tests/kafkatest/utils/remote_account.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 
 def file_exists(node, file):
     """Quick and dirty check for existence of remote file."""
@@ -30,3 +32,27 @@ def line_count(node, file):
         raise Exception("Expected single line of output from wc -l")
 
     return int(out[0].strip().split(" ")[0])
+
+def scp(source_node, source_path, target_node, target_path):
+    """ Copy file from source node to destination node. Uses a temporary file
+    on local node, since there is no mechanism to copy directly between two remote nodes.
+    :param source_node: source node to copy from
+    :param source_path: path on the source node to copy from
+    :param target_node: destination node
+    :param target_path: path on the destination node to copy to
+    """
+    local_temp_dir = "/tmp"
+    try:
+        local_temp_dir = tempfile.mkdtemp(dir=local_temp_dir)
+    except OSError as e:
+        raise Exception("Failed to create temporary local directory to scp $s to %s: %s" % (source_path, target_path, e.strerror))
+
+    local_temp_file = os.path.join(local_temp_dir, "tmpfile")
+    source_node.account.scp_from(source_path, local_temp_file)
+    target_node.account.scp_to(local_temp_file, target_path)
+
+    # clean up temp dir/file
+    if os.path.exists(local_temp_file):
+        os.remove(local_temp_file)
+    if os.path.exists(local_temp_dir):
+        os.removedirs(local_temp_dir)

--- a/tests/kafkatest/utils/remote_account.py
+++ b/tests/kafkatest/utils/remote_account.py
@@ -15,7 +15,10 @@
 
 import os
 import tempfile
-import shutil
+from shutil import move, rmtree
+from os import remove, close
+from io import open
+
 
 def file_exists(node, file):
     """Quick and dirty check for existence of remote file."""
@@ -34,9 +37,20 @@ def line_count(node, file):
 
     return int(out[0].strip().split(" ")[0])
 
-def scp(source_node, source_path, target_node, target_path):
-    """ Copy file from source node to destination node. Uses a temporary file
-    on local node, since there is no mechanism to copy directly between two remote nodes.
+def replace_in_file(file_path, pattern, subst):
+    fh, abs_path = tempfile.mkstemp()
+    with open(abs_path, 'w') as new_file:
+        with open(file_path) as old_file:
+            for line in old_file:
+                new_file.write(line.replace(pattern, subst))
+    close(fh)
+    remove(file_path)
+    move(abs_path, file_path)
+
+def scp(source_node, source_path, target_node, target_path, pattern=None, subst=None):
+    """ Copy file from source node to destination node. Optionally, replaces 'pattern' with 'subst' while
+    copying a file. Uses a temporary file on local node, since there is no mechanism to copy directly
+    between two remote nodes.
     :param source_node: source node to copy from
     :param source_path: path on the source node to copy from
     :param target_node: destination node
@@ -51,6 +65,10 @@ def scp(source_node, source_path, target_node, target_path):
 
     try:
         source_node.account.scp_from(source_path, local_temp_file)
+        if pattern is not None:
+            if subst is None:
+                raise Exception("Substitute string must be specified if pattern is speficied")
+            replace_in_file(local_temp_file, pattern, subst)
         target_node.account.scp_to(local_temp_file, target_path)
     finally:
-        shutil.rmtree(local_temp_dir, ignore_errors=True)
+        rmtree(local_temp_dir, ignore_errors=True)


### PR DESCRIPTION
I closed an original pull request that contained previous comments by Geoff (which are already addressed here), because I got into bad rebase situation. So, I created a new branch and cherry-picked my commits + merged with Ben's changes to fix MiniKDC tests to run on Virtual Box. That change was conflicting with my changes, where I was copying MiniKDC files with new scp method, and temp file was created inside that method. To merge Ben's changes, I added two optional parameters to scp(): 'pattern' and 'subst' to optionally substitute string while spp'ing files, which is needed for krb5.conf file.
