### PR TITLE
MINOR: Introduce `installAll` and accept major as well as full Scala version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ The release file can be found inside ./core/build/distributions/.
 
 ### Running a task on a particular version of Scala (either 2.10.6 or 2.11.7) ###
 #### (If building a jar with a version other than 2.10, need to set SCALA_BINARY_VERSION variable or change it in bin/kafka-run-class.sh to run quick start.) ####
-    ./gradlew -PscalaVersion=2.11.7 jar
-    ./gradlew -PscalaVersion=2.11.7 test
-    ./gradlew -PscalaVersion=2.11.7 releaseTarGz
+You can pass either the major version (eg 2.11) or the full version (eg 2.11.7):
+    ./gradlew -PscalaVersion=2.11 jar
+    ./gradlew -PscalaVersion=2.11 test
+    ./gradlew -PscalaVersion=2.11 releaseTarGz
 
 ### Running a task for a specific project ###
 This is for 'core', 'examples' and 'clients'

--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ subprojects {
   }
 }
 
-for ( sv in ['2_10_6', '2_11_7'] ) {
+for ( sv in ['2_10', '2_11'] ) {
   String svInDot = sv.replaceAll( "_", ".")
 
   tasks.create(name: "jar_core_${sv}", type: GradleBuild) {
@@ -217,6 +217,12 @@ for ( sv in ['2_10_6', '2_11_7'] ) {
     startParameter.projectProperties = [scalaVersion: "${svInDot}"]
   }
 
+  tasks.create(name: "install_${sv}", type: GradleBuild) {
+    buildFile = './build.gradle'
+    tasks = ['install']
+    startParameter.projectProperties = [scalaVersion: "${svInDot}"]
+  }
+
   tasks.create(name: "releaseTarGz_${sv}", type: GradleBuild) {
     buildFile = './build.gradle'
     tasks = ['releaseTarGz']
@@ -234,22 +240,23 @@ def connectPkgs = ['connect:api', 'connect:runtime', 'connect:json', 'connect:fi
 def pkgs = ['clients', 'examples', 'log4j-appender', 'tools', 'streams'] + connectPkgs
 
 tasks.create(name: "jarConnect", dependsOn: connectPkgs.collect { it + ":jar" }) {}
-tasks.create(name: "jarAll", dependsOn: ['jar_core_2_10_6', 'jar_core_2_11_7'] + pkgs.collect { it + ":jar" }) { }
+tasks.create(name: "jarAll", dependsOn: ['jar_core_2_10', 'jar_core_2_11'] + pkgs.collect { it + ":jar" }) { }
 
-tasks.create(name: "srcJarAll", dependsOn: ['srcJar_2_10_6', 'srcJar_2_11_7'] + pkgs.collect { it + ":srcJar" }) { }
+tasks.create(name: "srcJarAll", dependsOn: ['srcJar_2_10', 'srcJar_2_11'] + pkgs.collect { it + ":srcJar" }) { }
 
-tasks.create(name: "docsJarAll", dependsOn: ['docsJar_2_10_6', 'docsJar_2_11_7'] + pkgs.collect { it + ":docsJar" }) { }
+tasks.create(name: "docsJarAll", dependsOn: ['docsJar_2_10', 'docsJar_2_11'] + pkgs.collect { it + ":docsJar" }) { }
 
 tasks.create(name: "testConnect", dependsOn: connectPkgs.collect { it + ":test" }) {}
-tasks.create(name: "testAll", dependsOn: ['test_core_2_10_6', 'test_core_2_11_7'] + pkgs.collect { it + ":test" }) { }
+tasks.create(name: "testAll", dependsOn: ['test_core_2_10', 'test_core_2_11'] + pkgs.collect { it + ":test" }) { }
 
-tasks.create(name: "releaseTarGzAll", dependsOn: ['releaseTarGz_2_10_6', 'releaseTarGz_2_11_7']) {
-}
+tasks.create(name: "installAll", dependsOn: ['install_2_10', 'install_2_11'] + pkgs.collect { it + ":install" }) { }
 
-tasks.create(name: "uploadArchivesAll", dependsOn: ['uploadCoreArchives_2_10_6', 'uploadCoreArchives_2_11_7'] + pkgs.collect { it + ":uploadArchives" }) { }
+tasks.create(name: "releaseTarGzAll", dependsOn: ['releaseTarGz_2_10', 'releaseTarGz_2_11']) { }
+
+tasks.create(name: "uploadArchivesAll", dependsOn: ['uploadCoreArchives_2_10', 'uploadCoreArchives_2_11'] + pkgs.collect { it + ":uploadArchives" }) { }
 
 project(':core') {
-  println "Building project 'core' with Scala version $scalaVersion"
+  println "Building project 'core' with Scala version $resolvedScalaVersion"
 
   apply plugin: 'scala'
   archivesBaseName = "kafka_${baseScalaVersion}"
@@ -257,12 +264,12 @@ project(':core') {
   dependencies {
     compile project(':clients')
     compile "$slf4jlog4j"
-    compile "org.scala-lang:scala-library:$scalaVersion"
+    compile "org.scala-lang:scala-library:$resolvedScalaVersion"
     compile 'org.apache.zookeeper:zookeeper:3.4.6'
     compile 'com.101tec:zkclient:0.7'
     compile 'com.yammer.metrics:metrics-core:2.2.0'
     compile 'net.sf.jopt-simple:jopt-simple:4.9'
-    if (scalaVersion.startsWith('2.11')) {
+    if (baseScalaVersion == '2.11') {
       compile 'org.scala-lang.modules:scala-xml_2.11:1.0.4'
       compile 'org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4'
     }
@@ -299,7 +306,7 @@ project(':core') {
     from (configurations.runtime) {
       exclude('kafka-clients*')
     }
-    into "$buildDir/dependant-libs-${scalaVersion}"
+    into "$buildDir/dependant-libs-${resolvedScalaVersion}"
   }
 
   tasks.create(name: "genProducerConfigDocs", dependsOn:jar, type: JavaExec) {
@@ -523,7 +530,7 @@ project(':tools') {
         from (configurations.runtime) {
             exclude('kafka-clients*')
         }
-        into "$buildDir/dependant-libs-${scalaVersion}"
+        into "$buildDir/dependant-libs-${resolvedScalaVersion}"
     }
 
     jar {
@@ -580,7 +587,7 @@ project(':streams') {
         from (configurations.runtime) {
             exclude('kafka-clients*')
         }
-        into "$buildDir/dependant-libs-${scalaVersion}"
+        into "$buildDir/dependant-libs-${resolvedScalaVersion}"
     }
 
     jar {

--- a/scala.gradle
+++ b/scala.gradle
@@ -13,14 +13,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+ext.defaultScala210Version = '2.10.6'
+ext.defaultScala211Version = '2.11.7'
 if (!hasProperty('scalaVersion')) {
-  ext.scalaVersion = '2.10.6'
+  ext.scalaVersion = defaultScala210Version
 }
-ext.defaultScalaVersion = '2.10.6'
+ext.defaultScalaVersion = defaultScala210Version
+
 if (scalaVersion.startsWith('2.10')) {
     ext.baseScalaVersion = '2.10'
+    setResolvedScalaVersion(defaultScala210Version)
 } else if (scalaVersion.startsWith('2.11')) {
     ext.baseScalaVersion = '2.11'
+    setResolvedScalaVersion(defaultScala211Version)
 } else {
     ext.baseScalaVersion = scalaVersion
 }
+
+def setResolvedScalaVersion(defaultFullScalaVersion) {
+    if (scalaVersion == ext.baseScalaVersion) {
+        ext.resolvedScalaVersion = defaultFullScalaVersion
+    }
+    else {
+        ext.resolvedScalaVersion = scalaVersion
+    }
+}
+


### PR DESCRIPTION
We can take advantage of the fact that major Scala versions are binary compatible (since 2.10) to make the build a little more user-friendly.
