### PR TITLE
KAFKA-2718: Prevent temp directory being reused in parallel test runs

### DIFF
--- a/core/src/test/scala/other/kafka/StressTestLog.scala
+++ b/core/src/test/scala/other/kafka/StressTestLog.scala
@@ -32,7 +32,7 @@ object StressTestLog {
   val running = new AtomicBoolean(true)
   
   def main(args: Array[String]) {
-    val dir = TestUtils.tempPartitionLogDir(TestUtils.tempDir())
+    val dir = TestUtils.randomPartitionLogDir(TestUtils.tempDir())
     val time = new MockTime
     val logProprties = new Properties()
     logProprties.put(LogConfig.SegmentBytesProp, 64*1024*1024: java.lang.Integer)

--- a/core/src/test/scala/other/kafka/StressTestLog.scala
+++ b/core/src/test/scala/other/kafka/StressTestLog.scala
@@ -32,7 +32,7 @@ object StressTestLog {
   val running = new AtomicBoolean(true)
   
   def main(args: Array[String]) {
-    val dir = TestUtils.tempDir()
+    val dir = TestUtils.tempPartitionLogDir(TestUtils.tempDir())
     val time = new MockTime
     val logProprties = new Properties()
     logProprties.put(LogConfig.SegmentBytesProp, 64*1024*1024: java.lang.Integer)

--- a/core/src/test/scala/unit/kafka/log/BrokerCompressionTest.scala
+++ b/core/src/test/scala/unit/kafka/log/BrokerCompressionTest.scala
@@ -35,14 +35,9 @@ import scala.collection.JavaConversions._
 class BrokerCompressionTest(messageCompression: String, brokerCompression: String) extends JUnitSuite {
 
   val tmpDir = TestUtils.tempDir()
-  var logDir: File = null
+  val logDir = TestUtils.tempPartitionLogDir(tmpDir)
   val time = new MockTime(0)
   val logConfig = LogConfig()
-
-  @Before
-  def setUp() {
-    logDir = TestUtils.tempPartitionLogDir(tmpDir)
-  }
 
   @After
   def tearDown() {

--- a/core/src/test/scala/unit/kafka/log/BrokerCompressionTest.scala
+++ b/core/src/test/scala/unit/kafka/log/BrokerCompressionTest.scala
@@ -34,18 +34,19 @@ import scala.collection.JavaConversions._
 @RunWith(value = classOf[Parameterized])
 class BrokerCompressionTest(messageCompression: String, brokerCompression: String) extends JUnitSuite {
 
+  val tmpDir = TestUtils.tempDir()
   var logDir: File = null
   val time = new MockTime(0)
   val logConfig = LogConfig()
 
   @Before
   def setUp() {
-    logDir = TestUtils.tempDir()
+    logDir = TestUtils.tempPartitionLogDir(tmpDir)
   }
 
   @After
   def tearDown() {
-    CoreUtils.rm(logDir)
+    CoreUtils.rm(tmpDir)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/BrokerCompressionTest.scala
+++ b/core/src/test/scala/unit/kafka/log/BrokerCompressionTest.scala
@@ -35,7 +35,7 @@ import scala.collection.JavaConversions._
 class BrokerCompressionTest(messageCompression: String, brokerCompression: String) extends JUnitSuite {
 
   val tmpDir = TestUtils.tempDir()
-  val logDir = TestUtils.tempPartitionLogDir(tmpDir)
+  val logDir = TestUtils.randomPartitionLogDir(tmpDir)
   val time = new MockTime(0)
   val logConfig = LogConfig()
 

--- a/core/src/test/scala/unit/kafka/log/CleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/CleanerTest.scala
@@ -38,7 +38,7 @@ import scala.collection._
 class CleanerTest extends JUnitSuite {
   
   val tmpdir = TestUtils.tempDir()
-  val dir = TestUtils.tempPartitionLogDir(tmpdir)
+  val dir = TestUtils.randomPartitionLogDir(tmpdir)
   val logProps = new Properties()
   logProps.put(LogConfig.SegmentBytesProp, 1024: java.lang.Integer)
   logProps.put(LogConfig.SegmentIndexBytesProp, 1024: java.lang.Integer)

--- a/core/src/test/scala/unit/kafka/log/CleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/CleanerTest.scala
@@ -37,7 +37,8 @@ import scala.collection._
  */
 class CleanerTest extends JUnitSuite {
   
-  val dir = TestUtils.tempDir()
+  val tmpdir = TestUtils.tempDir()
+  val dir = TestUtils.tempPartitionLogDir(tmpdir)
   val logProps = new Properties()
   logProps.put(LogConfig.SegmentBytesProp, 1024: java.lang.Integer)
   logProps.put(LogConfig.SegmentIndexBytesProp, 1024: java.lang.Integer)
@@ -48,7 +49,7 @@ class CleanerTest extends JUnitSuite {
   
   @After
   def teardown() {
-    CoreUtils.rm(dir)
+    CoreUtils.rm(tmpdir)
   }
   
   /**

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -31,7 +31,7 @@ import kafka.server.KafkaConfig
 class LogTest extends JUnitSuite {
   
   val tmpDir = TestUtils.tempDir()
-  val logDir = TestUtils.tempPartitionLogDir(tmpDir)
+  val logDir = TestUtils.randomPartitionLogDir(tmpDir)
   val time = new MockTime(0)
   var config: KafkaConfig = null
   val logConfig = LogConfig()  

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -30,6 +30,7 @@ import kafka.server.KafkaConfig
 
 class LogTest extends JUnitSuite {
   
+  val tmpDir = TestUtils.tempDir()
   var logDir: File = null
   val time = new MockTime(0)
   var config: KafkaConfig = null
@@ -37,14 +38,14 @@ class LogTest extends JUnitSuite {
 
   @Before
   def setUp() {
-    logDir = TestUtils.tempDir()
+    logDir = TestUtils.tempPartitionLogDir(tmpDir)
     val props = TestUtils.createBrokerConfig(0, "127.0.0.1:1", port = -1)
     config = KafkaConfig.fromProps(props)
   }
 
   @After
   def tearDown() {
-    CoreUtils.rm(logDir)
+    CoreUtils.rm(tmpDir)
   }
   
   def createEmptyLogs(dir: File, offsets: Int*) {

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -31,14 +31,13 @@ import kafka.server.KafkaConfig
 class LogTest extends JUnitSuite {
   
   val tmpDir = TestUtils.tempDir()
-  var logDir: File = null
+  val logDir = TestUtils.tempPartitionLogDir(tmpDir)
   val time = new MockTime(0)
   var config: KafkaConfig = null
   val logConfig = LogConfig()  
 
   @Before
   def setUp() {
-    logDir = TestUtils.tempPartitionLogDir(tmpDir)
     val props = TestUtils.createBrokerConfig(0, "127.0.0.1:1", port = -1)
     config = KafkaConfig.fromProps(props)
   }


### PR DESCRIPTION
Use Files.createTempDirectory to avoid reuse, for log directories create a new temp directory as parent
