### PR TITLE
KAFKA-2899: (trivial) Log unexpected exceptions thrown when reading local log

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -556,7 +556,7 @@ class ReplicaManager(val config: KafkaConfig,
           case e: Throwable =>
             BrokerTopicStats.getBrokerTopicStats(topic).failedFetchRequestRate.mark()
             BrokerTopicStats.getBrokerAllTopicsStats().failedFetchRequestRate.mark()
-            error("Error processing fetch operation on partition [%s,%d] offset %d".format(topic, partition, offset))
+            error("Error processing fetch operation on partition [%s,%d] offset %d".format(topic, partition, offset), e)
             LogReadResult(FetchDataInfo(LogOffsetMetadata.UnknownOffsetMetadata, MessageSet.Empty), -1L, fetchSize, false, Some(e))
         }
       (TopicAndPartition(topic, partition), partitionDataAndOffsetInfo)


### PR DESCRIPTION
Currently we don't log exceptions raised when reading from the local log which makes tracking down the cause of problems a bit tricky. 
