### PR TITLE
Kafka 2902 streaming config use get base consumer configs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamingConfig.java
@@ -222,7 +222,7 @@ public class StreamingConfig extends AbstractConfig {
     }
 
     public Map<String, Object> getConsumerConfigs(StreamThread streamThread) {
-        Map<String, Object> props = getRestoreConsumerConfigs();
+        Map<String, Object> props = getBaseConsumerConfigs();
         props.put(StreamingConfig.NUM_STANDBY_REPLICAS_CONFIG, getInt(StreamingConfig.NUM_STANDBY_REPLICAS_CONFIG));
         props.put(StreamingConfig.InternalConfig.STREAM_THREAD_INSTANCE, streamThread);
         props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, KafkaStreamingPartitionAssignor.class.getName());

--- a/streams/src/test/java/org/apache/kafka/streams/StreamingConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamingConfigTest.java
@@ -1,0 +1,57 @@
+package org.apache.kafka.streams;
+
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.examples.WallclockTimestampExtractor;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Properties;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
+import static org.hamcrest.CoreMatchers.is;
+
+
+/**
+ * Created by bbejeck on 11/27/15.
+ * Test for StreamingConfig
+ */
+public class StreamingConfigTest {
+
+    private Properties props = new Properties();
+    private StreamingConfig streamingConfig;
+    private StreamThread streamThreadPlaceHolder = null;
+
+
+    @Before
+    public void setUp() {
+        props.put(StreamingConfig.CLIENT_ID_CONFIG, "Example-Processor-Job");
+        props.put("group.id","test-consumer-group");
+        props.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(StreamingConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(StreamingConfig.VALUE_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        props.put(StreamingConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
+        streamingConfig = new StreamingConfig(props);
+    }
+
+
+
+    @Test
+    public void testGetConsumerConfigs() throws Exception {
+        Map<String,Object> returnedProps = streamingConfig.getConsumerConfigs(streamThreadPlaceHolder);
+        assertThat(returnedProps.get("group.id"),is("test-consumer-group"));
+
+    }
+
+    @Test
+    public void testGetRestoreConsumerConfigs() throws Exception {
+        Map<String,Object> returnedProps = streamingConfig.getRestoreConsumerConfigs();
+        assertNull(returnedProps.get("group.id"));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/StreamingConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamingConfigTest.java
@@ -32,10 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 
-/**
- * Created by bbejeck on 11/27/15.
- * Test for StreamingConfig
- */
+
 public class StreamingConfigTest {
 
     private Properties props = new Properties();

--- a/streams/src/test/java/org/apache/kafka/streams/StreamingConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamingConfigTest.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.streams;
 
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -11,9 +28,8 @@ import org.junit.Test;
 
 import java.util.Map;
 import java.util.Properties;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.CoreMatchers.is;
 
 
 /**
@@ -30,7 +46,7 @@ public class StreamingConfigTest {
     @Before
     public void setUp() {
         props.put(StreamingConfig.CLIENT_ID_CONFIG, "Example-Processor-Job");
-        props.put("group.id","test-consumer-group");
+        props.put("group.id", "test-consumer-group");
         props.put(StreamingConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         props.put(StreamingConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(StreamingConfig.VALUE_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
@@ -44,14 +60,14 @@ public class StreamingConfigTest {
 
     @Test
     public void testGetConsumerConfigs() throws Exception {
-        Map<String,Object> returnedProps = streamingConfig.getConsumerConfigs(streamThreadPlaceHolder);
-        assertThat(returnedProps.get("group.id"),is("test-consumer-group"));
+        Map<String, Object> returnedProps = streamingConfig.getConsumerConfigs(streamThreadPlaceHolder);
+        assertEquals(returnedProps.get("group.id"), "test-consumer-group");
 
     }
 
     @Test
     public void testGetRestoreConsumerConfigs() throws Exception {
-        Map<String,Object> returnedProps = streamingConfig.getRestoreConsumerConfigs();
+        Map<String, Object> returnedProps = streamingConfig.getRestoreConsumerConfigs();
         assertNull(returnedProps.get("group.id"));
     }
 }


### PR DESCRIPTION
Changes made for using getBaseConsumerConfigs from StreamingConfig.getConsumerConfigs.
