### PR TITLE
MINOR: Update LinkedIn JVM tuning settings

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -397,8 +397,9 @@ LinkedIn is currently running JDK 1.8 u5 (looking to upgrade to a newer version)
 
 LinkedIn's tuning looks like this:
 <pre>
--Xms4g -Xmx4g -XX:PermSize=48m -XX:MaxPermSize=48m -XX:+UseG1GC
+-Xmx6g -Xms6g -XX:MetaspaceSize=96m -XX:+UseG1GC
 -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M
+-XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80
 </pre>
 
 For reference, here are the stats on one of LinkedIn's busiest clusters (at peak):


### PR DESCRIPTION
This is a follow-up as the previous update was missing some changes.
