### PR TITLE
KAFKA-2851 Using random dir under /temp for local kdc files to avoid conflicts.

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -164,7 +164,7 @@ class KafkaService(JmxMixin, Service):
         node.account.create_file(KafkaService.CONFIG_FILE, prop_file)
         node.account.create_file(self.LOG4J_CONFIG, self.render('log4j.properties', log_dir=KafkaService.OPERATIONAL_LOG_DIR))
 
-        self.security_config.setup_node(node)
+        self.security_config.setup_node(node, self.minikdc)
 
         cmd = self.start_cmd(node)
         self.logger.debug("Attempting to start KafkaService on %s with command: %s" % (str(node.account), cmd))

--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -17,10 +17,6 @@ from ducktape.services.service import Service
 from kafkatest.services.kafka.directory import kafka_dir
 
 import os
-from tempfile import mkstemp
-from shutil import move
-from os import remove, close
-from io import open
 
 class MiniKdc(Service):
 
@@ -35,24 +31,11 @@ class MiniKdc(Service):
     KEYTAB_FILE = "/mnt/minikdc/keytab"
     KRB5CONF_FILE = "/mnt/minikdc/krb5.conf"
     LOG_FILE = "/mnt/minikdc/minikdc.log"
-    LOCAL_KEYTAB_FILE = "/tmp/keytab"
-    LOCAL_KRB5CONF_FILE = "/tmp/krb5.conf"
 
     def __init__(self, context, kafka_nodes, extra_principals = ""):
         super(MiniKdc, self).__init__(context, 1)
         self.kafka_nodes = kafka_nodes
         self.extra_principals = extra_principals
-
-    def replace_in_file(self, file_path, pattern, subst):
-        fh, abs_path = mkstemp()
-        with open(abs_path, 'w') as new_file:
-            with open(file_path) as old_file:
-                for line in old_file:
-                    new_file.write(line.replace(pattern, subst))
-        close(fh)
-        remove(file_path)
-        move(abs_path, file_path)
-
 
     def start_node(self, node):
 
@@ -75,11 +58,6 @@ class MiniKdc(Service):
             node.account.ssh(cmd)
             monitor.wait_until("MiniKdc Running", timeout_sec=60, backoff_sec=1, err_msg="MiniKdc didn't finish startup")
 
-        node.account.scp_from(MiniKdc.KEYTAB_FILE, MiniKdc.LOCAL_KEYTAB_FILE)
-        node.account.scp_from(MiniKdc.KRB5CONF_FILE, MiniKdc.LOCAL_KRB5CONF_FILE)
-
-        #KDC is set to bind openly (via 0.0.0.0). Change krb5.conf to hold the specific KDC address
-        self.replace_in_file(MiniKdc.LOCAL_KRB5CONF_FILE, '0.0.0.0', node.account.hostname)
 
     def stop_node(self, node):
         self.logger.info("Stopping %s on %s" % (type(self).__name__, node.account.hostname))
@@ -88,9 +66,6 @@ class MiniKdc(Service):
     def clean_node(self, node):
         node.account.kill_process("apacheds", clean_shutdown=False, allow_fail=False)
         node.account.ssh("rm -rf " + MiniKdc.WORK_DIR, allow_fail=False)
-        if os.path.exists(MiniKdc.LOCAL_KEYTAB_FILE):
-            os.remove(MiniKdc.LOCAL_KEYTAB_FILE)
-        if os.path.exists(MiniKdc.LOCAL_KRB5CONF_FILE):
-            os.remove(MiniKdc.LOCAL_KRB5CONF_FILE)
+
 
 

--- a/tests/kafkatest/utils/remote_account.py
+++ b/tests/kafkatest/utils/remote_account.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
+from shutil import move, rmtree
+from os import remove, close
+from io import open
 
 def file_exists(node, file):
     """Quick and dirty check for existence of remote file."""
@@ -30,3 +35,39 @@ def line_count(node, file):
         raise Exception("Expected single line of output from wc -l")
 
     return int(out[0].strip().split(" ")[0])
+
+def replace_in_file(file_path, pattern, subst):
+    fh, abs_path = tempfile.mkstemp()
+    with open(abs_path, 'w') as new_file:
+        with open(file_path) as old_file:
+            for line in old_file:
+                new_file.write(line.replace(pattern, subst))
+    close(fh)
+    remove(file_path)
+    move(abs_path, file_path)
+
+def scp(source_node, source_path, target_node, target_path, pattern=None, subst=None):
+    """ Copy file from source node to destination node. Optionally, replaces 'pattern' with 'subst' while
+    copying a file. Uses a temporary file on local node, since there is no mechanism to copy directly
+    between two remote nodes.
+    :param source_node: source node to copy from
+    :param source_path: path on the source node to copy from
+    :param target_node: destination node
+    :param target_path: path on the destination node to copy to
+    """
+    try:
+        local_temp_dir = tempfile.mkdtemp(dir="/tmp")
+    except OSError as e:
+        raise Exception("Failed to create temporary local directory to scp %s to %s: %s" % (source_path, target_path, e.strerror))
+
+    local_temp_file = os.path.join(local_temp_dir, "tmpfile")
+
+    try:
+        source_node.account.scp_from(source_path, local_temp_file)
+        if pattern is not None:
+            if subst is None:
+                raise Exception("Substitute string must be specified if pattern is specified")
+            replace_in_file(local_temp_file, pattern, subst)
+        target_node.account.scp_to(local_temp_file, target_path)
+    finally:
+        rmtree(local_temp_dir, ignore_errors=True)


### PR DESCRIPTION
when multiple test jobs are running.

I manually separated changes for KAFKA-2851 from this PR:  https://github.com/apache/kafka/pull/570 which also had KAFKA-2825 changes.
