### PR TITLE
KAFKA-2851 Using random file names for local kdc files to avoid conflicts.

### DIFF
--- a/tests/kafkatest/services/security/minikdc.py
+++ b/tests/kafkatest/services/security/minikdc.py
@@ -21,6 +21,7 @@ from tempfile import mkstemp
 from shutil import move
 from os import remove, close
 from io import open
+import uuid
 
 class MiniKdc(Service):
 
@@ -35,8 +36,8 @@ class MiniKdc(Service):
     KEYTAB_FILE = "/mnt/minikdc/keytab"
     KRB5CONF_FILE = "/mnt/minikdc/krb5.conf"
     LOG_FILE = "/mnt/minikdc/minikdc.log"
-    LOCAL_KEYTAB_FILE = "/tmp/keytab"
-    LOCAL_KRB5CONF_FILE = "/tmp/krb5.conf"
+    LOCAL_KEYTAB_FILE = "/tmp/" + str(uuid.uuid4().get_hex()) + "_keytab"
+    LOCAL_KRB5CONF_FILE = "/tmp/" + str(uuid.uuid4().get_hex()) + "_krb5.conf"
 
     def __init__(self, context, kafka_nodes, extra_principals = ""):
         super(MiniKdc, self).__init__(context, 1)


### PR DESCRIPTION
I originally tried to solve the problem by using tempfile, and creating and using scp() utility method that created a random local temp file every time it was called. However, it required passing miniKdc object to SecurityConfig setup_node which looked very invasive, since many tests use this method. Here is the PR for that, which I think we will close: https://github.com/apache/kafka/pull/609

This change is the least invasive change to solve conflicts between multiple tests jobs. 
