### PR TITLE
KAFKA-2718: Add logging to investigate intermittent unit test failures

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
+++ b/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
@@ -37,6 +37,8 @@ class EmbeddedZookeeper() {
   factory.startup(zookeeper)
   val port = zookeeper.getClientPort()
 
+  println("Starting embedded zookeeper on port " + port + " using directories " + snapshotDir + "," + logDir)
+
   def shutdown() {
     CoreUtils.swallow(zookeeper.shutdown())
     CoreUtils.swallow(factory.shutdown())


### PR DESCRIPTION
Print port and directories used by zookeeper in unit tests to figure out which may be causing conflict.
