### PR TITLE
KAFKA-1911

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -147,7 +147,7 @@ class Partition(val topic: String,
       inSyncReplicas = Set.empty[Replica]
       leaderReplicaIdOpt = None
       try {
-        logManager.deleteLog(TopicAndPartition(topic, partitionId))
+        logManager.markLogForDeletion(TopicAndPartition(topic, partitionId))
         removePartitionMetrics()
       } catch {
         case e: IOException =>

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -200,8 +200,10 @@ class Log(@volatile var dir: File,
           }
         }
         else {
-          error("Could not find index file corresponding to log file %s, rebuilding index...".format(segment.log.file.getAbsolutePath))
-          segment.recover(config.maxMessageSize)
+          if (!dir.getAbsolutePath.endsWith(Log.DeleteDirSuffix)) {
+            recoverLog()
+            activeSegment.index.resize(config.maxIndexSize)
+          }
         }
         segments.put(start, segment)
       }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -98,7 +98,9 @@ class Log(@volatile var dir: File,
 
   /* the actual segments of the log */
   private val segments: ConcurrentNavigableMap[java.lang.Long, LogSegment] = new ConcurrentSkipListMap[java.lang.Long, LogSegment]
-  loadSegments()
+  if (!dir.getAbsolutePath.endsWith(Log.DeleteDirSuffix)) {
+    loadSegments()
+  }
 
   /* Calculate the offset of the next message */
   @volatile var nextOffsetMetadata = new LogOffsetMetadata(activeSegment.nextOffset(), activeSegment.baseOffset, activeSegment.size.toInt)
@@ -240,11 +242,9 @@ class Log(@volatile var dir: File,
                                      initFileSize = this.initFileSize(),
                                      preallocate = config.preallocate))
     } else {
-      if (!dir.getAbsolutePath.endsWith(Log.DeleteDirSuffix)) {
         recoverLog()
         // reset the index size of the currently active log segment to allow more entries
         activeSegment.index.resize(config.maxIndexSize)
-      }
     }
 
   }
@@ -925,7 +925,7 @@ object Log {
   val CleanShutdownFile = ".kafka_cleanshutdown"
 
   /** a directory that is scheduled to be deleted */
-  val DeleteDirSuffix = ".delete"
+  val DeleteDirSuffix = "-delete"
 
   /**
    * Make log segment file name from offset bytes. All this does is pad out the offset number with zeros
@@ -966,10 +966,10 @@ object Log {
     if (name == null || name.isEmpty || !name.contains('-')) {
       throwException(dir)
     }
-    val index = name.lastIndexOf('-')
+    val index = name.indexOf('-')
     val topic: String = name.substring(0, index)
     val partition = if(name.endsWith(DeleteDirSuffix)) {
-      val partitionIndex = name.indexOf(".")
+      val partitionIndex = name.lastIndexOf("-")
       name.substring(index + 1, partitionIndex)
     } else {
       name.substring(index + 1)

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -964,7 +964,7 @@ object Log {
     if (name == null || name.isEmpty || !name.contains('-')) {
       throwException(dir)
     }
-    val index = name.indexOf('-')
+    val index = name.lastIndexOf('-')
     val topic: String = name.substring(0, index)
     val partition = if(name.endsWith(DeleteDirSuffix)) {
       val partitionIndex = name.indexOf(".")

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -200,10 +200,8 @@ class Log(@volatile var dir: File,
           }
         }
         else {
-          if (!dir.getAbsolutePath.endsWith(Log.DeleteDirSuffix)) {
-            recoverLog()
-            activeSegment.index.resize(config.maxIndexSize)
-          }
+          error("Could not find index file corresponding to log file %s, rebuilding index...".format(segment.log.file.getAbsolutePath))
+          segment.recover(config.maxMessageSize)
         }
         segments.put(start, segment)
       }
@@ -242,9 +240,11 @@ class Log(@volatile var dir: File,
                                      initFileSize = this.initFileSize(),
                                      preallocate = config.preallocate))
     } else {
-      recoverLog()
-      // reset the index size of the currently active log segment to allow more entries
-      activeSegment.index.resize(config.maxIndexSize)
+      if (!dir.getAbsolutePath.endsWith(Log.DeleteDirSuffix)) {
+        recoverLog()
+        // reset the index size of the currently active log segment to allow more entries
+        activeSegment.index.resize(config.maxIndexSize)
+      }
     }
 
   }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -567,19 +567,20 @@ class Log(@volatile var dir: File,
   def deleteOldSegments(predicate: LogSegment => Boolean): Int = {
     // find any segments that match the user-supplied predicate UNLESS it is the final segment
     // and it is empty (since we would just end up re-creating it
-    val lastSegment = activeSegment
-    val deletable = logSegments.takeWhile(s => predicate(s) && (s.baseOffset != lastSegment.baseOffset || s.size > 0))
-    val numToDelete = deletable.size
-    if(numToDelete > 0) {
-      lock synchronized {
+    lock synchronized {
+      val lastSegment = activeSegment
+      val deletable = logSegments.takeWhile(s => predicate(s) && (s.baseOffset != lastSegment.baseOffset || s.size > 0))
+      val numToDelete = deletable.size
+      if(numToDelete > 0) {
         // we must always have at least one segment, so if we are going to delete all the segments, create a new one first
         if(segments.size == numToDelete)
           roll()
         // remove the segments for lookups
         deletable.foreach(deleteSegment(_))
-      }
+       }
+
+      numToDelete
     }
-    numToDelete
   }
 
   /**

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -19,7 +19,6 @@ package kafka.log
 
 import java.io._
 import java.nio.file.{StandardCopyOption, Files, Paths, Path}
-;
 import java.util.concurrent.TimeUnit
 
 import kafka.utils._

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -154,12 +154,15 @@ class LogManager(val logDirs: Array[File],
           val logRecoveryPoint = recoveryPoints.getOrElse(topicPartition, 0L)
 
           val current = new Log(logDir, config, logRecoveryPoint, scheduler, time)
-          val previous = this.logs.put(topicPartition, current)
-
-          if (previous != null) {
-            throw new IllegalArgumentException(
-              "Duplicate log directories found: %s, %s!".format(
-              current.dir.getAbsolutePath, previous.dir.getAbsolutePath))
+          if (logDir.getName.endsWith(Log.DeleteDirSuffix)) {
+            this.logsToBeDeleted += current
+          } else {
+            val previous = this.logs.put(topicPartition, current)
+            if (previous != null) {
+              throw new IllegalArgumentException(
+                "Duplicate log directories found: %s, %s!".format(
+                  current.dir.getAbsolutePath, previous.dir.getAbsolutePath))
+            }
           }
         }
       }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -233,7 +233,7 @@ class ReplicaManager(val config: KafkaConfig,
           val topicAndPartition = TopicAndPartition(topic, partitionId)
 
           if(logManager.getLog(topicAndPartition).isDefined) {
-              logManager.deleteLog(topicAndPartition)
+              logManager.markLogForDeletion(topicAndPartition)
           }
         }
         stateChangeLogger.trace("Broker %d ignoring stop replica (delete=%s) for partition [%s,%d] as replica doesn't exist on broker"

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -233,7 +233,7 @@ class ReplicaManager(val config: KafkaConfig,
           val topicAndPartition = TopicAndPartition(topic, partitionId)
 
           if(logManager.getLog(topicAndPartition).isDefined) {
-              logManager.markLogForDeletion(topicAndPartition)
+              logManager.asyncDelete(topicAndPartition)
           }
         }
         stateChangeLogger.trace("Broker %d ignoring stop replica (delete=%s) for partition [%s,%d] as replica doesn't exist on broker"


### PR DESCRIPTION
Made delete topic on brokers async.
This patch renames the directory (Topic-Partition) to (Topic-Partition.UUID.delete) on calling markForDeletion and then delete it asynchronously.

I need to update the test cases for this patch. 
