### PR TITLE
KAFKA-2948: Remove unused topics from producer metadata set

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -182,7 +182,9 @@ public final class Metadata {
     }
 
     /**
-     * Updates cluster metadata and handles topic expiry.
+     * Updates cluster metadata and handles topic expiry. This can
+     * be used for initializing the metadata cluster.
+     * See {@link #update(Cluster, long, Collection)} for details.
      */
     public synchronized void update(Cluster cluster, long now) {
         update(cluster, now, Collections.<String>emptyList());
@@ -228,7 +230,7 @@ public final class Metadata {
      * Record an attempt to update the metadata that failed. We need to keep track of this
      * to avoid retrying immediately. Removes unknown topics from metadata if expiry is enabled.
      */
-    public synchronized void handleFailedUpdate(long now, Collection<String> unknownTopics) {
+    public synchronized void failedUpdate(long now, Collection<String> unknownTopics) {
         this.lastRefreshMs = now;
         if (topicExpiryEnabled)
             topics.keySet().removeAll(unknownTopics);

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -15,9 +15,13 @@ package org.apache.kafka.clients;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
@@ -32,10 +36,17 @@ import org.slf4j.LoggerFactory;
  * 
  * Metadata is maintained for only a subset of topics, which can be added to over time. When we request metadata for a
  * topic we don't have any metadata for it will trigger a metadata update.
+ * <p>
+ * If topic expiry is enabled for the metadata, any topic that is unknown or has not been used within the expiry
+ * period is removed from the metadata refresh set after an update. Consumers disable topic expiry since they explicitly
+ * manage topics while producers rely on topic expiry to limit the refresh set.
  */
 public final class Metadata {
 
     private static final Logger log = LoggerFactory.getLogger(Metadata.class);
+
+    public static final long TOPIC_EXPIRY_MILLIS = 5 * 60 * 1000;
+    private static final Long TOPIC_EXPIRY_NEEDS_UPDATE = -1L;
 
     private final long refreshBackoffMs;
     private final long metadataExpireMs;
@@ -44,9 +55,11 @@ public final class Metadata {
     private long lastSuccessfulRefreshMs;
     private Cluster cluster;
     private boolean needUpdate;
-    private final Set<String> topics;
+    /* Topics with expiry time */
+    private final Map<String, Long> topics;
     private final List<Listener> listeners;
     private boolean needMetadataForAllTopics;
+    private boolean topicExpiryEnabled;
 
     /**
      * Create a metadata instance with reasonable defaults
@@ -55,21 +68,27 @@ public final class Metadata {
         this(100L, 60 * 60 * 1000L);
     }
 
+    public Metadata(long refreshBackoffMs, long metadataExpireMs) {
+        this(refreshBackoffMs, metadataExpireMs, false);
+    }
+
     /**
      * Create a new Metadata instance
      * @param refreshBackoffMs The minimum amount of time that must expire between metadata refreshes to avoid busy
      *        polling
      * @param metadataExpireMs The maximum amount of time that metadata can be retained without refresh
+     * @param topicExpiryEnabled If true, enable expiry of unused topics
      */
-    public Metadata(long refreshBackoffMs, long metadataExpireMs) {
+    public Metadata(long refreshBackoffMs, long metadataExpireMs, boolean topicExpiryEnabled) {
         this.refreshBackoffMs = refreshBackoffMs;
         this.metadataExpireMs = metadataExpireMs;
+        this.topicExpiryEnabled = topicExpiryEnabled;
         this.lastRefreshMs = 0L;
         this.lastSuccessfulRefreshMs = 0L;
         this.version = 0;
         this.cluster = Cluster.empty();
         this.needUpdate = false;
-        this.topics = new HashSet<String>();
+        this.topics = new HashMap<>();
         this.listeners = new ArrayList<>();
         this.needMetadataForAllTopics = false;
     }
@@ -82,10 +101,10 @@ public final class Metadata {
     }
 
     /**
-     * Add the topic to maintain in the metadata
+     * Add the topic to maintain in the metadata.
      */
     public synchronized void add(String topic) {
-        topics.add(topic);
+        topics.put(topic, TOPIC_EXPIRY_NEEDS_UPDATE);
     }
 
     /**
@@ -135,21 +154,22 @@ public final class Metadata {
     }
 
     /**
-     * Replace the current set of topics maintained to the one provided
+     * Replace the current set of topics maintained to the one provided.
      * @param topics
      */
     public synchronized void setTopics(Collection<String> topics) {
-        if (!this.topics.containsAll(topics))
+        if (!this.topics.keySet().containsAll(topics))
             requestUpdate();
         this.topics.clear();
-        this.topics.addAll(topics);
+        for (String topic : topics)
+            this.topics.put(topic, TOPIC_EXPIRY_NEEDS_UPDATE);
     }
 
     /**
      * Get the list of topics we are currently maintaining metadata for
      */
     public synchronized Set<String> topics() {
-        return new HashSet<String>(this.topics);
+        return new HashSet<>(this.topics.keySet());
     }
 
     /**
@@ -158,7 +178,7 @@ public final class Metadata {
      * @return true if the topic exists, false otherwise
      */
     public synchronized boolean containsTopic(String topic) {
-        return this.topics.contains(topic);
+        return this.topics.containsKey(topic);
     }
 
     /**
@@ -170,6 +190,20 @@ public final class Metadata {
         this.lastSuccessfulRefreshMs = now;
         this.version += 1;
 
+        if (topicExpiryEnabled) {
+            // Handle expiry of topics from the metadata refresh set.
+            for (Iterator<Map.Entry<String, Long>> it = topics.entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry<String, Long> entry = it.next();
+                Long expireMs = entry.getValue();
+                if (expireMs == TOPIC_EXPIRY_NEEDS_UPDATE)
+                    entry.setValue(now + TOPIC_EXPIRY_MILLIS);
+                else if (expireMs <= now) {
+                    it.remove();
+                    log.debug("Removing unused topic from the metadata list: " + entry.getKey());
+                }
+            }
+        }
+
         for (Listener listener: listeners)
             listener.onMetadataUpdate(cluster);
 
@@ -178,6 +212,15 @@ public final class Metadata {
 
         notifyAll();
         log.debug("Updated cluster metadata version {} to {}", this.version, this.cluster);
+    }
+
+    /**
+     * If expiry is enabled, remove the unknown topic from the metadata refresh set to
+     * avoid further metadata requests for deleted topics which are not in use.
+     */
+    public synchronized void handleUnknownTopic(String topic) {
+        if (topicExpiryEnabled)
+            topics.remove(topic);
     }
 
     /**
@@ -251,9 +294,9 @@ public final class Metadata {
         List<Node> nodes = Collections.emptyList();
         if (cluster != null) {
             unauthorizedTopics.addAll(cluster.unauthorizedTopics());
-            unauthorizedTopics.retainAll(this.topics);
+            unauthorizedTopics.retainAll(this.topics.keySet());
 
-            for (String topic : this.topics) {
+            for (String topic : this.topics.keySet()) {
                 partitionInfos.addAll(cluster.partitionsForTopic(topic));
             }
             nodes = cluster.nodes();

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -607,6 +607,8 @@ public class NetworkClient implements KafkaClient {
                 log.trace("Ignoring empty metadata response with correlation id {}.", header.correlationId());
                 this.metadata.failedUpdate(now);
             }
+            for (String topic : response.topicsByError(Errors.UNKNOWN_TOPIC_OR_PARTITION))
+                this.metadata.handleUnknownTopic(topic);
         }
 
         /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -607,7 +607,7 @@ public class NetworkClient implements KafkaClient {
                 this.metadata.update(cluster, now, unknownTopics);
             } else {
                 log.trace("Ignoring empty metadata response with correlation id {}.", header.correlationId());
-                this.metadata.handleFailedUpdate(now, unknownTopics);
+                this.metadata.failedUpdate(now, unknownTopics);
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -599,15 +598,14 @@ public class NetworkClient implements KafkaClient {
             Map<String, Errors> errors = response.errors();
             if (!errors.isEmpty())
                 log.warn("Error while fetching metadata with correlation id {} : {}", header.correlationId(), errors);
-            Collection<String> unknownTopics = response.topicsByError(Errors.UNKNOWN_TOPIC_OR_PARTITION);
 
             // don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
             // created which means we will get errors and no nodes until it exists
             if (cluster.nodes().size() > 0) {
-                this.metadata.update(cluster, now, unknownTopics);
+                this.metadata.update(cluster, now);
             } else {
                 log.trace("Ignoring empty metadata response with correlation id {}.", header.correlationId());
-                this.metadata.failedUpdate(now, unknownTopics);
+                this.metadata.failedUpdate(now);
             }
         }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -520,9 +520,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         long remainingWaitMs = maxWaitMs;
         while (metadata.fetch().partitionsForTopic(topic) == null) {
             log.trace("Requesting metadata update for topic {}.", topic);
-            // Add the topic to metadata before requesting update to ensure that the topic is included
-            // in the metadata topic list since unknown topics are removed from the metadata
-            this.metadata.add(topic);
             int version = metadata.requestUpdate();
             sender.wakeup();
             metadata.awaitUpdate(version, remainingWaitMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -299,7 +299,7 @@ public final class RecordAccumulator {
     public ReadyCheckResult ready(Cluster cluster, long nowMs) {
         Set<Node> readyNodes = new HashSet<>();
         long nextReadyCheckDelayMs = Long.MAX_VALUE;
-        boolean unknownLeadersExist = false;
+        Set<String> unknownLeaderTopics = new HashSet<>();
 
         boolean exhausted = this.free.queued() > 0;
         for (Map.Entry<TopicPartition, Deque<RecordBatch>> entry : this.batches.entrySet()) {
@@ -307,10 +307,10 @@ public final class RecordAccumulator {
             Deque<RecordBatch> deque = entry.getValue();
 
             Node leader = cluster.leaderFor(part);
-            if (leader == null) {
-                unknownLeadersExist = true;
-            } else if (!readyNodes.contains(leader) && !muted.contains(part)) {
-                synchronized (deque) {
+            synchronized (deque) {
+                if (leader == null && !deque.isEmpty()) {
+                    unknownLeaderTopics.add(part.topic());
+                } else if (!readyNodes.contains(leader) && !muted.contains(part)) {
                     RecordBatch batch = deque.peekFirst();
                     if (batch != null) {
                         boolean backingOff = batch.attempts > 0 && batch.lastAttemptMs + retryBackoffMs > nowMs;
@@ -333,7 +333,7 @@ public final class RecordAccumulator {
             }
         }
 
-        return new ReadyCheckResult(readyNodes, nextReadyCheckDelayMs, unknownLeadersExist);
+        return new ReadyCheckResult(readyNodes, nextReadyCheckDelayMs, unknownLeaderTopics);
     }
 
     /**
@@ -549,12 +549,12 @@ public final class RecordAccumulator {
     public final static class ReadyCheckResult {
         public final Set<Node> readyNodes;
         public final long nextReadyCheckDelayMs;
-        public final boolean unknownLeadersExist;
+        public final Set<String> unknownLeaderTopics;
 
-        public ReadyCheckResult(Set<Node> readyNodes, long nextReadyCheckDelayMs, boolean unknownLeadersExist) {
+        public ReadyCheckResult(Set<Node> readyNodes, long nextReadyCheckDelayMs, Set<String> unknownLeaderTopics) {
             this.readyNodes = readyNodes;
             this.nextReadyCheckDelayMs = nextReadyCheckDelayMs;
-            this.unknownLeadersExist = unknownLeadersExist;
+            this.unknownLeaderTopics = unknownLeaderTopics;
         }
     }
     

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -309,6 +309,8 @@ public final class RecordAccumulator {
             Node leader = cluster.leaderFor(part);
             synchronized (deque) {
                 if (leader == null && !deque.isEmpty()) {
+                    // This is a partition for which leader is not known, but messages are available to send.
+                    // Note that entries are currently not removed from batches when deque is empty.
                     unknownLeaderTopics.add(part.topic());
                 } else if (!readyNodes.contains(leader) && !muted.contains(part)) {
                     RecordBatch batch = deque.peekFirst();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -177,10 +177,8 @@ public class Sender implements Runnable {
         // if there are any partitions whose leaders are not known yet, force metadata update
         if (!result.unknownLeaderTopics.isEmpty()) {
             // The set of topics with unknown leader contains topics with leader election pending as well as
-            // topics which returned UNKNOWN_TOPIC_OR_PARTITION. The latter are removed from the metadata to
-            // avoid unnecessary metadata fetch for deleted topics which are no longer in use. Add the topic
-            // again to metadata to ensure it is included and request metadata update, since there are messages
-            // to send to the topic.
+            // topics which may have expired. Add the topic again to metadata to ensure it is included
+            //  and request metadata update, since there are messages to send to the topic.
             for (String topic : result.unknownLeaderTopics)
                 this.metadata.add(topic);
             this.metadata.requestUpdate();

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -236,6 +236,18 @@ public class MetadataResponse extends AbstractRequestResponse {
     }
 
     /**
+     * Returns the set of topics with the specified error
+     */
+    public Set<String> topicsByError(Errors error) {
+        Set<String> errorTopics = new HashSet<>();
+        for (TopicMetadata metadata : topicMetadata) {
+            if (metadata.error == error)
+                errorTopics.add(metadata.topic());
+        }
+        return errorTopics;
+    }
+
+    /**
      * Get a snapshot of the cluster metadata from this response
      * @return the cluster snapshot
      */
@@ -256,7 +268,7 @@ public class MetadataResponse extends AbstractRequestResponse {
             }
         }
 
-        return new Cluster(this.brokers, partitions, unauthorizedTopics);
+        return new Cluster(this.brokers, partitions, topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataResponse.java
@@ -252,7 +252,6 @@ public class MetadataResponse extends AbstractRequestResponse {
      * @return the cluster snapshot
      */
     public Cluster cluster() {
-        Set<String> unauthorizedTopics = new HashSet<>();
         List<PartitionInfo> partitions = new ArrayList<>();
         for (TopicMetadata metadata : topicMetadata) {
             if (metadata.error == Errors.NONE) {
@@ -263,8 +262,6 @@ public class MetadataResponse extends AbstractRequestResponse {
                             partitionMetadata.leader,
                             partitionMetadata.replicas.toArray(new Node[0]),
                             partitionMetadata.isr.toArray(new Node[0])));
-            } else if (metadata.error == Errors.TOPIC_AUTHORIZATION_FAILED) {
-                unauthorizedTopics.add(metadata.topic);
             }
         }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -111,7 +111,7 @@ public class MetadataTest {
         metadata.update(Cluster.empty(), time);
 
         assertEquals(100, metadata.timeToNextUpdate(1000));
-        metadata.failedUpdate(1100);
+        metadata.handleFailedUpdate(1100, Collections.<String>emptyList());
 
         assertEquals(100, metadata.timeToNextUpdate(1100));
         assertEquals(100, metadata.lastSuccessfulUpdate());
@@ -230,7 +230,7 @@ public class MetadataTest {
         metadata.add("topic3");
         metadata.update(TestUtils.singletonCluster("topic3", 1), time);
         assertTrue("Topic expired even though in use", metadata.containsTopic("topic3"));
-        metadata.handleUnknownTopic("topic3");
+        metadata.update(TestUtils.singletonCluster("topic3", 1), time, Collections.singleton("topic3"));
         assertFalse("Unknown topic not deleted", metadata.containsTopic("topic3"));
 
         // Test that topics added using setTopics expire
@@ -269,7 +269,7 @@ public class MetadataTest {
         metadata.add("topic3");
         metadata.update(TestUtils.singletonCluster("topic3", 1), time);
         assertTrue("Topic expired even though in use", metadata.containsTopic("topic3"));
-        metadata.handleUnknownTopic("topic3");
+        metadata.update(TestUtils.singletonCluster("topic3", 1), time, Collections.singleton("topic3"));
         assertTrue("Unknown topic deleted when expiry disabled", metadata.containsTopic("topic3"));
 
         // Test that topics added using setTopics don't expire

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -204,6 +204,83 @@ public class MetadataTest {
             new HashSet<>(Arrays.asList("topic", "topic1")), topics);
     }
 
+    @Test
+    public void testTopicExpiry() throws Exception {
+        metadata = new Metadata(refreshBackoffMs, metadataExpireMs, true);
+
+        // Test that topic is expired if not used within the expiry interval
+        long time = 0;
+        metadata.add("topic1");
+        metadata.update(Cluster.empty(), time);
+        time += Metadata.TOPIC_EXPIRY_MILLIS;
+        metadata.update(Cluster.empty(), time);
+        assertFalse("Unused topic not expired", metadata.containsTopic("topic1"));
+
+        // Test that topic is not expired if used within the expiry interval
+        metadata.add("topic2");
+        metadata.update(Cluster.empty(), time);
+        for (int i = 0; i < 3; i++) {
+            time += Metadata.TOPIC_EXPIRY_MILLIS / 2;
+            metadata.update(Cluster.empty(), time);
+            assertTrue("Topic expired even though in use", metadata.containsTopic("topic2"));
+            metadata.add("topic2");
+        }
+
+        // Test that a topic that is unknown is expired
+        metadata.add("topic3");
+        metadata.update(TestUtils.singletonCluster("topic3", 1), time);
+        assertTrue("Topic expired even though in use", metadata.containsTopic("topic3"));
+        metadata.handleUnknownTopic("topic3");
+        assertFalse("Unknown topic not deleted", metadata.containsTopic("topic3"));
+
+        // Test that topics added using setTopics expire
+        HashSet<String> topics = new HashSet<>();
+        topics.add("topic4");
+        metadata.setTopics(topics);
+        metadata.update(Cluster.empty(), time);
+        time += Metadata.TOPIC_EXPIRY_MILLIS;
+        metadata.update(Cluster.empty(), time);
+        assertFalse("Unused topic not expired", metadata.containsTopic("topic4"));
+    }
+
+    @Test
+    public void testNonExpiringMetadata() throws Exception {
+        metadata = new Metadata(refreshBackoffMs, metadataExpireMs, false);
+
+        // Test that topic is not expired if not used within the expiry interval
+        long time = 0;
+        metadata.add("topic1");
+        metadata.update(Cluster.empty(), time);
+        time += Metadata.TOPIC_EXPIRY_MILLIS;
+        metadata.update(Cluster.empty(), time);
+        assertTrue("Unused topic expired when expiry disabled", metadata.containsTopic("topic1"));
+
+        // Test that topic is not expired if used within the expiry interval
+        metadata.add("topic2");
+        metadata.update(Cluster.empty(), time);
+        for (int i = 0; i < 3; i++) {
+            time += Metadata.TOPIC_EXPIRY_MILLIS / 2;
+            metadata.update(Cluster.empty(), time);
+            assertTrue("Topic expired even though in use", metadata.containsTopic("topic2"));
+            metadata.add("topic2");
+        }
+
+        // Test that a topic that is unknown is not expired
+        metadata.add("topic3");
+        metadata.update(TestUtils.singletonCluster("topic3", 1), time);
+        assertTrue("Topic expired even though in use", metadata.containsTopic("topic3"));
+        metadata.handleUnknownTopic("topic3");
+        assertTrue("Unknown topic deleted when expiry disabled", metadata.containsTopic("topic3"));
+
+        // Test that topics added using setTopics dont expire
+        HashSet<String> topics = new HashSet<>();
+        topics.add("topic4");
+        metadata.setTopics(topics);
+        time += metadataExpireMs * 2;
+        metadata.update(Cluster.empty(), time);
+        assertTrue("Unused topic expired when expiry disabled", metadata.containsTopic("topic4"));
+    }
+
     private Thread asyncFetch(final String topic) {
         Thread thread = new Thread() {
             public void run() {

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -111,7 +111,7 @@ public class MetadataTest {
         metadata.update(Cluster.empty(), time);
 
         assertEquals(100, metadata.timeToNextUpdate(1000));
-        metadata.failedUpdate(1100, Collections.<String>emptyList());
+        metadata.failedUpdate(1100);
 
         assertEquals(100, metadata.timeToNextUpdate(1100));
         assertEquals(100, metadata.lastSuccessfulUpdate());
@@ -226,13 +226,6 @@ public class MetadataTest {
             metadata.add("topic2");
         }
 
-        // Test that a topic that is unknown is expired
-        metadata.add("topic3");
-        metadata.update(TestUtils.singletonCluster("topic3", 1), time);
-        assertTrue("Topic expired even though in use", metadata.containsTopic("topic3"));
-        metadata.update(TestUtils.singletonCluster("topic3", 1), time, Collections.singleton("topic3"));
-        assertFalse("Unknown topic not deleted", metadata.containsTopic("topic3"));
-
         // Test that topics added using setTopics expire
         HashSet<String> topics = new HashSet<>();
         topics.add("topic4");
@@ -264,13 +257,6 @@ public class MetadataTest {
             assertTrue("Topic expired even though in use", metadata.containsTopic("topic2"));
             metadata.add("topic2");
         }
-
-        // Test that a topic that is unknown is not expired
-        metadata.add("topic3");
-        metadata.update(TestUtils.singletonCluster("topic3", 1), time);
-        assertTrue("Topic expired even though in use", metadata.containsTopic("topic3"));
-        metadata.update(TestUtils.singletonCluster("topic3", 1), time, Collections.singleton("topic3"));
-        assertTrue("Unknown topic deleted when expiry disabled", metadata.containsTopic("topic3"));
 
         // Test that topics added using setTopics don't expire
         HashSet<String> topics = new HashSet<>();

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -111,7 +111,7 @@ public class MetadataTest {
         metadata.update(Cluster.empty(), time);
 
         assertEquals(100, metadata.timeToNextUpdate(1000));
-        metadata.handleFailedUpdate(1100, Collections.<String>emptyList());
+        metadata.failedUpdate(1100, Collections.<String>emptyList());
 
         assertEquals(100, metadata.timeToNextUpdate(1100));
         assertEquals(100, metadata.lastSuccessfulUpdate());

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -212,7 +212,7 @@ public class MetadataTest {
         long time = 0;
         metadata.add("topic1");
         metadata.update(Cluster.empty(), time);
-        time += Metadata.TOPIC_EXPIRY_MILLIS;
+        time += Metadata.TOPIC_EXPIRY_MS;
         metadata.update(Cluster.empty(), time);
         assertFalse("Unused topic not expired", metadata.containsTopic("topic1"));
 
@@ -220,7 +220,7 @@ public class MetadataTest {
         metadata.add("topic2");
         metadata.update(Cluster.empty(), time);
         for (int i = 0; i < 3; i++) {
-            time += Metadata.TOPIC_EXPIRY_MILLIS / 2;
+            time += Metadata.TOPIC_EXPIRY_MS / 2;
             metadata.update(Cluster.empty(), time);
             assertTrue("Topic expired even though in use", metadata.containsTopic("topic2"));
             metadata.add("topic2");
@@ -238,7 +238,7 @@ public class MetadataTest {
         topics.add("topic4");
         metadata.setTopics(topics);
         metadata.update(Cluster.empty(), time);
-        time += Metadata.TOPIC_EXPIRY_MILLIS;
+        time += Metadata.TOPIC_EXPIRY_MS;
         metadata.update(Cluster.empty(), time);
         assertFalse("Unused topic not expired", metadata.containsTopic("topic4"));
     }
@@ -251,7 +251,7 @@ public class MetadataTest {
         long time = 0;
         metadata.add("topic1");
         metadata.update(Cluster.empty(), time);
-        time += Metadata.TOPIC_EXPIRY_MILLIS;
+        time += Metadata.TOPIC_EXPIRY_MS;
         metadata.update(Cluster.empty(), time);
         assertTrue("Unused topic expired when expiry disabled", metadata.containsTopic("topic1"));
 
@@ -259,7 +259,7 @@ public class MetadataTest {
         metadata.add("topic2");
         metadata.update(Cluster.empty(), time);
         for (int i = 0; i < 3; i++) {
-            time += Metadata.TOPIC_EXPIRY_MILLIS / 2;
+            time += Metadata.TOPIC_EXPIRY_MS / 2;
             metadata.update(Cluster.empty(), time);
             assertTrue("Topic expired even though in use", metadata.containsTopic("topic2"));
             metadata.add("topic2");
@@ -272,7 +272,7 @@ public class MetadataTest {
         metadata.handleUnknownTopic("topic3");
         assertTrue("Unknown topic deleted when expiry disabled", metadata.containsTopic("topic3"));
 
-        // Test that topics added using setTopics dont expire
+        // Test that topics added using setTopics don't expire
         HashSet<String> topics = new HashSet<>();
         topics.add("topic4");
         metadata.setTopics(topics);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1114,7 +1114,7 @@ public class ConsumerCoordinatorTest {
     }
 
     @Test
-    public void testMetadataTopicExpiry() {
+    public void testMetadataTopicsExpiryDisabled() {
         final String consumerId = "consumer";
 
         subscriptions.subscribe(Arrays.asList(topicName), rebalanceListener);
@@ -1132,7 +1132,7 @@ public class ConsumerCoordinatorTest {
 
         metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
         assertTrue("Topic not found in metadata", metadata.containsTopic(topicName));
-        time.sleep(Metadata.TOPIC_EXPIRY_MILLIS * 2);
+        time.sleep(Metadata.TOPIC_EXPIRY_MS * 2);
         metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
         assertTrue("Topic expired", metadata.containsTopic(topicName));
         metadata.handleUnknownTopic(topicName);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1130,17 +1130,17 @@ public class ConsumerCoordinatorTest {
         client.prepareResponse(syncGroupResponse(Arrays.asList(tp), Errors.NONE.code()));
         coordinator.ensurePartitionAssignment();
 
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.<String>emptyList());
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
         assertTrue("Topic not found in metadata", metadata.containsTopic(topicName));
         time.sleep(Metadata.TOPIC_EXPIRY_MS * 2);
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.<String>emptyList());
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
         assertTrue("Topic expired", metadata.containsTopic(topicName));
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.singleton(topicName));
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
         metadata.update(Cluster.empty(), time.milliseconds());
         assertTrue("Topic expired", metadata.containsTopic(topicName));
 
         assertTrue(subscriptions.partitionAssignmentNeeded());
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.<String>emptyList());
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
         assertTrue(subscriptions.partitionAssignmentNeeded());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1130,17 +1130,17 @@ public class ConsumerCoordinatorTest {
         client.prepareResponse(syncGroupResponse(Arrays.asList(tp), Errors.NONE.code()));
         coordinator.ensurePartitionAssignment();
 
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.<String>emptyList());
         assertTrue("Topic not found in metadata", metadata.containsTopic(topicName));
         time.sleep(Metadata.TOPIC_EXPIRY_MS * 2);
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.<String>emptyList());
         assertTrue("Topic expired", metadata.containsTopic(topicName));
-        metadata.handleUnknownTopic(topicName);
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.singleton(topicName));
         metadata.update(Cluster.empty(), time.milliseconds());
         assertTrue("Topic expired", metadata.containsTopic(topicName));
 
         assertTrue(subscriptions.partitionAssignmentNeeded());
-        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds());
+        metadata.update(TestUtils.singletonCluster(topicName, 2), time.milliseconds(), Collections.<String>emptyList());
         assertTrue(subscriptions.partitionAssignmentNeeded());
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -13,8 +13,8 @@
 package org.apache.kafka.clients.producer.internals;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Collections;
@@ -60,7 +60,7 @@ public class SenderTest {
     private MockTime time = new MockTime();
     private MockClient client = new MockClient(time);
     private int batchSize = 16 * 1024;
-    private Metadata metadata = new Metadata(0, Long.MAX_VALUE);
+    private Metadata metadata = new Metadata(0, Long.MAX_VALUE, true);
     private Cluster cluster = TestUtils.singletonCluster("test", 1);
     private Metrics metrics = null;
     private RecordAccumulator accumulator = null;
@@ -226,7 +226,42 @@ public class SenderTest {
         } finally {
             m.close();
         }
+    }
 
+    /**
+     * Tests that topics are added to the metadata list when messages are available to send
+     * and expired if not used during a metadata refresh interval.
+     */
+    @Test
+    public void testMetadataTopicExpiry() throws Exception {
+        long offset = 0;
+        metadata.update(Cluster.empty(), time.milliseconds());
+
+        Future<RecordMetadata> future = accumulator.append(tp, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
+        sender.run(time.milliseconds());
+        assertTrue("Topic not added to metadata", metadata.containsTopic(tp.topic()));
+        metadata.update(cluster, time.milliseconds());
+        sender.run(time.milliseconds());  // send produce request
+        client.respond(produceResponse(tp, offset++, Errors.NONE.code(), 0));
+        sender.run(time.milliseconds());
+        assertEquals("Request completed.", 0, (long) client.inFlightRequestCount());
+        sender.run(time.milliseconds());
+        assertTrue("Request should be completed", future.isDone());
+
+        assertTrue("Topic not retained in metadata list", metadata.containsTopic(tp.topic()));
+        time.sleep(Metadata.TOPIC_EXPIRY_MILLIS);
+        metadata.update(Cluster.empty(), time.milliseconds());
+        assertFalse("Unused topic has not been expired", metadata.containsTopic(tp.topic()));
+        future = accumulator.append(tp, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
+        sender.run(time.milliseconds());
+        assertTrue("Topic not added to metadata", metadata.containsTopic(tp.topic()));
+        metadata.update(cluster, time.milliseconds());
+        sender.run(time.milliseconds());  // send produce request
+        client.respond(produceResponse(tp, offset++, Errors.NONE.code(), 0));
+        sender.run(time.milliseconds());
+        assertEquals("Request completed.", 0, (long) client.inFlightRequestCount());
+        sender.run(time.milliseconds());
+        assertTrue("Request should be completed", future.isDone());
     }
 
     private void completedWithError(Future<RecordMetadata> future, Errors error) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -244,12 +244,12 @@ public class SenderTest {
         sender.run(time.milliseconds());  // send produce request
         client.respond(produceResponse(tp, offset++, Errors.NONE.code(), 0));
         sender.run(time.milliseconds());
-        assertEquals("Request completed.", 0, (long) client.inFlightRequestCount());
+        assertEquals("Request completed.", 0, client.inFlightRequestCount());
         sender.run(time.milliseconds());
         assertTrue("Request should be completed", future.isDone());
 
         assertTrue("Topic not retained in metadata list", metadata.containsTopic(tp.topic()));
-        time.sleep(Metadata.TOPIC_EXPIRY_MILLIS);
+        time.sleep(Metadata.TOPIC_EXPIRY_MS);
         metadata.update(Cluster.empty(), time.milliseconds());
         assertFalse("Unused topic has not been expired", metadata.containsTopic(tp.topic()));
         future = accumulator.append(tp, time.milliseconds(), "key".getBytes(), "value".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
@@ -259,7 +259,7 @@ public class SenderTest {
         sender.run(time.milliseconds());  // send produce request
         client.respond(produceResponse(tp, offset++, Errors.NONE.code(), 0));
         sender.run(time.milliseconds());
-        assertEquals("Request completed.", 0, (long) client.inFlightRequestCount());
+        assertEquals("Request completed.", 0, client.inFlightRequestCount());
         sender.run(time.milliseconds());
         assertTrue("Request should be completed", future.isDone());
     }


### PR DESCRIPTION
If no messages are sent to a topic during the last refresh interval or if UNKNOWN_TOPIC_OR_PARTITION error is received, remove the topic from the metadata list. Topics are added to the list on the next attempt to send a message to the topic.
