### PR TITLE
KAFKA-2928: system test: fix version sanity checks

### DIFF
--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -23,4 +23,4 @@
 # Instead, in trunk, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 0.9.0.0-SNAPSHOT, this should be something like "0.9.0.0.dev0"
-__version__ = '0.9.0.0.dev0'
+__version__ = '0.9.1.0.dev0'


### PR DESCRIPTION
Fixed version sanity checks by updated kafkatest version to match kafka version
