### PR TITLE
KAFKA-2975

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -627,6 +627,7 @@ public class NetworkClient implements KafkaClient {
             // check if any topics metadata failed to get updated
             if (response.errors().size() > 0) {
                 log.warn("Error while fetching metadata with correlation id {} : {}", header.correlationId(), response.errors());
+                requestUpdate();
             }
             // don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
             // created which means we will get errors and no nodes until it exists


### PR DESCRIPTION
The newtorkClient should request a metadata update after it gets an error in the handleResponse().

Currently in data pipeline,
1) Lets say Mirror Maker requestTimeout is set to 2 min and metadataExpiry is set to 5 min
2) We delete a topic, the Mirror Maker get UNKNOWN_TOPIC_PARTITION and tries torefresh its Metadata.
3) It gets LeaderNotAvailableException, may be because the topic is not created yet.
4) Now its metadata does not have any information about that topic.
5) It will wait for 5 min to do the next refresh.
6) In the mean time the batches sitting in the accumulator will expire and the mirror makers die to avoid data loss.

To overcome this we need to refresh the metadata after 3).

Well there is an alternative solution to have the metadataExpiry set to be less then requestTimeout, but this will mean we make more metadataRequest over the wire in normal scenario as well.
