### PR TITLE
KAFKA-3022: Deduplicate common project configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ def jersey_version = '2.22.1'
 
 allprojects {
   apply plugin: 'idea'
+  apply plugin: 'eclipse'
   repositories {
     mavenCentral()
   }
@@ -83,9 +84,9 @@ if (new File('.git').exists()) {
 
 subprojects {
   apply plugin: 'java'
-  apply plugin: 'eclipse'
   apply plugin: 'maven'
   apply plugin: 'signing'
+  apply plugin: 'checkstyle'
 
   sourceCompatibility = 1.7
 
@@ -129,8 +130,12 @@ subprojects {
     }
   }
 
-  tasks.withType(Test) {
+  test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    testLogging {
+      events "passed", "skipped", "failed"
+      exceptionFormat = 'full'
+    }
   }
 
   jar {
@@ -138,11 +143,25 @@ subprojects {
     from '../NOTICE'
   }
 
-  task srcJar(type:Jar) {
+  task srcJar(type: Jar) {
     classifier = 'sources'
     from '../LICENSE'
     from '../NOTICE'
-    from sourceSets.main.java
+    from sourceSets.main.allSource
+  }
+
+  task testJar(type: Jar) {
+    classifier = 'test'
+    from '../LICENSE'
+    from '../NOTICE'
+    from sourceSets.test.output
+  }
+
+  task testSrcJar(type: Jar, dependsOn: testJar) {
+    classifier = 'test-sources'
+    from '../LICENSE'
+    from '../NOTICE'
+    from sourceSets.test.allSource
   }
 
   task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -158,18 +177,17 @@ subprojects {
 
   artifacts {
     archives srcJar
+    archives testJar
+    archives testSrcJar
     archives javadocJar
   }
 
   plugins.withType(ScalaPlugin) {
-    //source jar should also contain scala source:
-    srcJar.from sourceSets.main.scala
-
     task scaladocJar(type:Jar) {
       classifier = 'scaladoc'
       from '../LICENSE'
       from '../NOTICE'
-      from scaladoc
+      from scaladoc.destinationDir
     }
 
     //documentation task should also trigger building scala doc jar
@@ -188,6 +206,12 @@ subprojects {
       jvmArgs = ['-XX:MaxPermSize=512m', '-Xss2m']
     }
   }
+
+  checkstyle {
+    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
+  }
+  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 for ( sv in ['2_10', '2_11'] ) {
@@ -259,7 +283,6 @@ project(':core') {
   println "Building project 'core' with Scala version $resolvedScalaVersion"
 
   apply plugin: 'scala'
-  apply plugin: 'checkstyle'
   archivesBaseName = "kafka_${baseScalaVersion}"
 
   dependencies {
@@ -367,22 +390,6 @@ project(':core') {
     )
   }
 
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat = 'full'
-    }
-  }
-
-  artifacts {
-    archives testJar
-  }
-
   tasks.create(name: "copyDependantTestLibs", type: Copy) {
     from (configurations.testRuntime) {
       include('*.jar')
@@ -391,29 +398,27 @@ project(':core') {
   }
 
   checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
   }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':examples') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "kafka-examples"
 
   dependencies {
     compile project(':core')
   }
 
+  testJar {
+    enabled = false
+  }
+
   checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
   }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':clients') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "kafka-clients"
 
   dependencies {
@@ -469,18 +474,6 @@ project(':clients') {
     delete "$buildDir/kafka/"
   }
 
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat = 'full'
-    }
-  }
-
   javadoc {
     include "**/org/apache/kafka/clients/consumer/*"
     include "**/org/apache/kafka/clients/producer/*"
@@ -488,24 +481,9 @@ project(':clients') {
     include "**/org/apache/kafka/common/errors/*"
     include "**/org/apache/kafka/common/serialization/*"
   }
-
-  artifacts {
-    archives testJar
-  }
-
-  configurations {
-    archives.extendsFrom (testCompile)
-  }
-
-  checkstyle {
-     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-     configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-  }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':tools') {
-    apply plugin: 'checkstyle'
     archivesBaseName = "kafka-tools"
 
     dependencies {
@@ -517,18 +495,6 @@ project(':tools') {
 
         testCompile "$junit"
         testCompile project(path: ':clients', configuration: 'archives')
-    }
-
-    task testJar(type: Jar) {
-        classifier = 'test'
-        from sourceSets.test.output
-    }
-
-    test {
-        testLogging {
-            events "passed", "skipped", "failed"
-            exceptionFormat = 'full'
-        }
     }
 
     javadoc {
@@ -548,24 +514,9 @@ project(':tools') {
     jar {
         dependsOn 'copyDependantLibs'
     }
-
-    artifacts {
-        archives testJar
-    }
-
-    configurations {
-        archives.extendsFrom (testCompile)
-    }
-
-    checkstyle {
-        configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-    }
-    test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':streams') {
-    apply plugin: 'checkstyle'
     archivesBaseName = "kafka-streams"
 
     dependencies {
@@ -577,18 +528,6 @@ project(':streams') {
 
         testCompile "$junit"
         testCompile project(path: ':clients', configuration: 'archives')
-    }
-
-    task testJar(type: Jar) {
-        classifier = 'test'
-        from sourceSets.test.output
-    }
-
-    test {
-        testLogging {
-            events "passed", "skipped", "failed"
-            exceptionFormat = 'full'
-        }
     }
 
     javadoc {
@@ -608,24 +547,9 @@ project(':streams') {
     jar {
         dependsOn 'copyDependantLibs'
     }
-
-    artifacts {
-      archives testJar
-    }
-
-    configurations {
-      archives.extendsFrom (testCompile)
-    }
-
-    checkstyle {
-        configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-        configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-    }
-    test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':log4j-appender') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "kafka-log4j-appender"
 
   dependencies {
@@ -636,31 +560,12 @@ project(':log4j-appender') {
     testCompile project(path: ':clients', configuration: 'archives')
   }
 
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-        events "passed", "skipped", "failed"
-        exceptionFormat = 'full'
-    }
-  }
-
   javadoc {
     include "**/org/apache/kafka/log4jappender/*"
   }
-
-  checkstyle {
-     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-     configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-  }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':connect:api') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "connect-api"
 
   dependencies {
@@ -669,18 +574,6 @@ project(':connect:api') {
 
     testCompile "$junit"
     testRuntime "$slf4jlog4j"
-  }
-
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-      events "passed", "skipped", "failed"
-      exceptionFormat = 'full'
-    }
   }
 
   javadoc {
@@ -701,24 +594,9 @@ project(':connect:api') {
   jar {
     dependsOn copyDependantLibs
   }
-
-  artifacts {
-    archives testJar
-  }
-
-  configurations {
-    archives.extendsFrom (testCompile)
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-  }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':connect:json') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "connect-json"
 
   dependencies {
@@ -731,18 +609,6 @@ project(':connect:json') {
     testCompile "$powermock"
     testCompile "$powermock_easymock"
     testRuntime "$slf4jlog4j"
-  }
-
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-      events "passed", "skipped", "failed"
-      exceptionFormat = 'full'
-    }
   }
 
   javadoc {
@@ -763,24 +629,9 @@ project(':connect:json') {
   jar {
     dependsOn copyDependantLibs
   }
-
-  artifacts {
-    archives testJar
-  }
-
-  configurations {
-    archives.extendsFrom(testCompile)
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-  }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }
 
 project(':connect:runtime') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "connect-runtime"
 
   dependencies {
@@ -803,18 +654,6 @@ project(':connect:runtime') {
     testRuntime project(":connect:json")
   }
 
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-      events "passed", "skipped", "failed"
-      exceptionFormat = 'full'
-    }
-  }
-
   javadoc {
     enabled = false
   }
@@ -834,20 +673,6 @@ project(':connect:runtime') {
     dependsOn copyDependantLibs
   }
 
-  artifacts {
-    archives testJar
-  }
-
-  configurations {
-    archives.extendsFrom(testCompile)
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-  }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
-
   tasks.create(name: "genConnectConfigDocs", dependsOn:jar, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.apache.kafka.connect.runtime.distributed.DistributedConfig'
@@ -856,7 +681,6 @@ project(':connect:runtime') {
 }
 
 project(':connect:file') {
-  apply plugin: 'checkstyle'
   archivesBaseName = "connect-file"
 
   dependencies {
@@ -870,18 +694,6 @@ project(':connect:file') {
     testRuntime "$slf4jlog4j"
   }
 
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from sourceSets.test.output
-  }
-
-  test {
-    testLogging {
-      events "passed", "skipped", "failed"
-      exceptionFormat = 'full'
-    }
-  }
-
   javadoc {
     enabled = false
   }
@@ -900,18 +712,4 @@ project(':connect:file') {
   jar {
     dependsOn copyDependantLibs
   }
-
-  artifacts {
-    archives testJar
-  }
-
-  configurations {
-    archives.extendsFrom(testCompile)
-  }
-
-  checkstyle {
-    configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
-  }
-  test.dependsOn('checkstyleMain', 'checkstyleTest')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -150,20 +150,6 @@ subprojects {
     from sourceSets.main.allSource
   }
 
-  task testJar(type: Jar) {
-    classifier = 'test'
-    from '../LICENSE'
-    from '../NOTICE'
-    from sourceSets.test.output
-  }
-
-  task testSrcJar(type: Jar, dependsOn: testJar) {
-    classifier = 'test-sources'
-    from '../LICENSE'
-    from '../NOTICE'
-    from sourceSets.test.allSource
-  }
-
   task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier 'javadoc'
     from '../LICENSE'
@@ -177,9 +163,28 @@ subprojects {
 
   artifacts {
     archives srcJar
-    archives testJar
-    archives testSrcJar
     archives javadocJar
+  }
+
+  if(!sourceSets.test.allSource.isEmpty()) {
+    task testJar(type: Jar) {
+      classifier = 'test'
+      from '../LICENSE'
+      from '../NOTICE'
+      from sourceSets.test.output
+    }
+
+    task testSrcJar(type: Jar, dependsOn: testJar) {
+      classifier = 'test-sources'
+      from '../LICENSE'
+      from '../NOTICE'
+      from sourceSets.test.allSource
+    }
+
+    artifacts {
+      archives testJar
+      archives testSrcJar
+    }
   }
 
   plugins.withType(ScalaPlugin) {
@@ -407,10 +412,6 @@ project(':examples') {
 
   dependencies {
     compile project(':core')
-  }
-
-  testJar {
-    enabled = false
   }
 
   checkstyle {


### PR DESCRIPTION
- Move testJar to subprojects config
- Move CheckStyle to subprojects config
- Move testLogging to subprojects config
- Add testSourceJar in subprojects config
- Minor cleanup
