### PR TITLE
KAFKA-3049: VerifiableProperties does not respect 'default' properties of underlying java.util.Properties instance

### DIFF
--- a/core/src/main/scala/kafka/utils/VerifiableProperties.scala
+++ b/core/src/main/scala/kafka/utils/VerifiableProperties.scala
@@ -29,7 +29,7 @@ class VerifiableProperties(val props: Properties) extends Logging {
   def this() = this(new Properties)
 
   def containsKey(name: String): Boolean = {
-    props.containsKey(name)
+    props.getProperty(name) != null
   }
 
   def getProperty(name: String): String = {

--- a/core/src/test/scala/kafka/utils/VerifiablePropertiesTest.scala
+++ b/core/src/test/scala/kafka/utils/VerifiablePropertiesTest.scala
@@ -1,0 +1,49 @@
+package kafka.utils
+
+import java.util.Properties
+import org.junit.Assert._
+import org.junit.Test
+
+class VerifiablePropertiesTest {
+
+  @Test
+  def testContainsKeyWithoutDefaults() {
+    val props = new Properties
+    props.setProperty("foo", "bar")
+    props.setProperty("baz", "qux")
+    val vProps = new VerifiableProperties(props)
+    assertTrue(vProps.containsKey("foo"))
+    assertTrue(vProps.containsKey("baz"))
+    assertEquals(vProps.getString("foo"), "bar")
+    assertEquals(vProps.getString("baz"), "qux")
+  }
+
+  @Test
+  def testContainsKeyWithDefaults() {
+    val baseProps = new Properties
+    baseProps.setProperty("zookeeper.connect", "localhost:2181")
+    baseProps.setProperty("zookeeper.connection.timeout.ms", "2000")
+    val props1 = new Properties(baseProps)
+    props1.setProperty("group.id", "test-1")
+    val props2 = new Properties(baseProps)
+    props2.setProperty("group.id", "test-2")
+    val vProps1 = new VerifiableProperties(props1)
+    val vProps2 = new VerifiableProperties(props2)
+    assertTrue(vProps1.containsKey("zookeeper.connect"))
+    assertTrue(vProps1.containsKey("group.id"))
+    assertTrue(vProps2.containsKey("zookeeper.connect"))
+    assertTrue(vProps2.containsKey("group.id"))
+  }
+
+  @Test
+  def testInheritanceOfDefaults() {
+   val baseProps = new Properties
+    baseProps.setProperty("zookeeper.connect", "localhost:2181")
+    baseProps.setProperty("zookeeper.connection.timeout.ms", "2000")
+    val props = new Properties(baseProps)
+    props.setProperty("group.id", "test-1")
+    val vProps = new VerifiableProperties(props)
+    assertEquals(vProps.getString("zookeeper.connect"), "localhost:2181")
+    assertEquals(vProps.getString("group.id"), "test-1")
+  }
+}


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/KAFKA-3049 for more information.

An alternative solution can be found at: https://github.com/apache/kafka/compare/trunk...jeffreyolchovy:KAFKA-3049_immutable-property-names.
