### PR TITLE
MINOR: Add secondary constructor that takes only `props` in `KafkaConfig`

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -707,6 +707,8 @@ object KafkaConfig {
 
 class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends AbstractConfig(KafkaConfig.configDef, props, doLog) {
 
+  def this(props: java.util.Map[_, _]) = this(props, true)
+
   /** ********* Zookeeper Configuration ***********/
   val zkConnect: String = getString(KafkaConfig.ZkConnectProp)
   val zkSessionTimeoutMs: Int = getInt(KafkaConfig.ZkSessionTimeoutMsProp)


### PR DESCRIPTION
This fixes a compatibility break for users that use `new KafkaConfig(map)`
instead of `KafkaConfig(map)`.
