### PR TITLE
MINOR: Add property to configure showing of standard streams in Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Please note for this to work you should create/update `~/.gradle/gradle.properti
     signing.password=
     signing.secretKeyRingFile=
 
-### Install the jars to the local Maven repository ###
+### Installing the jars to the local Maven repository ###
     ./gradlew install
 
 ### Building the test jar ###

--- a/README.md
+++ b/README.md
@@ -115,11 +115,17 @@ Please note for this to work you should create/update `~/.gradle/gradle.properti
 ### Running checkstyle on the java code ###
     ./gradlew checkstyleMain checkstyleTest
 
-### Limit the number of processes for each task ###
-    ./gradlew -Dorg.gradle.project.maxParallelForks=1 test
-
 This will most commonly be useful for automated builds where the full resources of the host running the build and tests
 may not be dedicated to Kafka's build.
+
+### Common build options ###
+
+The following options should be set with a `-D` switch, for example `./gradlew -Dorg.gradle.project.maxParallelForms=1 test`.
+
+* `org.gradle.project.mavenUrl`: sets the URL of the maven deployment repository (`file://path/to/repo` can be used to point to a local repository).
+* `org.gradle.project.maxParallelForks`: limits the maximum number of processes for each task.
+* `org.gradle.project.showStandardStreams`: shows standard out and standard error of the test JVM(s) on the console.
+* `org.gradle.project.skipSigning`: skips signing of artifacts.
 
 ### Running in Vagrant ###
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Please note for this to work you should create/update `~/.gradle/gradle.properti
     signing.password=
     signing.secretKeyRingFile=
 
-### Publishing the jars without signing to a local repository ###
-    ./gradlew -Dorg.gradle.project.skipSigning=true -Dorg.gradle.project.mavenUrl=file://path/to/repo uploadArchivesAll
+### Install the jars to the local Maven repository ###
+    ./gradlew install
 
 ### Building the test jar ###
     ./gradlew testJar

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Please note for this to work you should create/update `~/.gradle/gradle.properti
     signing.secretKeyRingFile=
 
 ### Installing the jars to the local Maven repository ###
-    ./gradlew install
+    ./gradlew installAll
 
 ### Building the test jar ###
     ./gradlew testJar

--- a/build.gradle
+++ b/build.gradle
@@ -47,17 +47,18 @@ allprojects {
 }
 
 ext {
-    gradleVersion = "2.10"
-    buildVersionFileName = "kafka-version.properties"
+  gradleVersion = "2.10"
+  buildVersionFileName = "kafka-version.properties"
 
-    userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
+  userMaxForks = project.hasProperty('maxParallelForks') ? maxParallelForks.toInteger() : null
 
-    skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
-    shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
+  skipSigning = project.hasProperty('skipSigning') && skipSigning.toBoolean()
+  shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
 
-    mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
-    mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
-    mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
+  mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
+  mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
+  mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
+
 }
 
 apply from: file('wrapper.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ ext {
   mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
   mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
 
+  userShowStandardStreams = project.hasProperty("showStandardStreams") ? showStandardStreams : null
+
 }
 
 apply from: file('wrapper.gradle')
@@ -135,6 +137,7 @@ subprojects {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
     testLogging {
       events "passed", "skipped", "failed"
+      showStandardStreams = userShowStandardStreams ?: false
       exceptionFormat = 'full'
     }
   }


### PR DESCRIPTION
This is handy when debugging certain kinds of Jenkins failures.
