### PR TITLE
MINOR: Fixes version lookup exception.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ProtoUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ProtoUtils.java
@@ -27,7 +27,7 @@ public class ProtoUtils {
         if (apiKey < 0 || apiKey > schemas.length)
             throw new IllegalArgumentException("Invalid api key: " + apiKey);
         Schema[] versions = schemas[apiKey];
-        if (version < 0 || version > versions.length)
+        if (version < 0 || version > latestVersion(apiKey))
             throw new IllegalArgumentException("Invalid version for API key " + apiKey + ": " + version);
         if (versions[version] == null)
             throw new IllegalArgumentException("Unsupported version for API key " + apiKey + ": " + version);

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.protocol;
+
+import org.junit.Test;
+
+public class ProtoUtilsTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void schemaVersionOutOfRange() {
+        ProtoUtils.requestSchema(ApiKeys.PRODUCE.id, Protocol.REQUESTS[ApiKeys.PRODUCE.id].length);
+    }
+}


### PR DESCRIPTION
Given a schema with 2 versions (0 and 1), if you pass in a version of `2` you will get an `OutOfBoundsException` instead of an `IllegalArgumentException`.

This fixes the problem by changing the check from `>` to `>=`, which will now return true in the given scenario.
