### PR TITLE
KAFKA-2999: Errors enum should be a 1 to 1 mapping of error codes and…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/InconsistentGroupProtocolException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InconsistentGroupProtocolException.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class InconsistentGroupProtocolException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public InconsistentGroupProtocolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InconsistentGroupProtocolException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidCommitOffsetSizeException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidCommitOffsetSizeException.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class InvalidCommitOffsetSizeException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidCommitOffsetSizeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidCommitOffsetSizeException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidGroupIdException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidGroupIdException.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class InvalidGroupIdException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidGroupIdException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidGroupIdException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidSessionTimeoutException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidSessionTimeoutException.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class InvalidSessionTimeoutException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidSessionTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidSessionTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -28,8 +28,12 @@ import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupCoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.GroupLoadInProgressException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
+import org.apache.kafka.common.errors.InconsistentGroupProtocolException;
+import org.apache.kafka.common.errors.InvalidCommitOffsetSizeException;
 import org.apache.kafka.common.errors.InvalidFetchSizeException;
+import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidRequiredAcksException;
+import org.apache.kafka.common.errors.InvalidSessionTimeoutException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.NetworkException;
@@ -105,17 +109,17 @@ public enum Errors {
     ILLEGAL_GENERATION(22,
             new IllegalGenerationException("Specified group generation id is not valid.")),
     INCONSISTENT_GROUP_PROTOCOL(23,
-            new ApiException("The group member's supported protocols are incompatible with those of existing members.")),
+            new InconsistentGroupProtocolException("The group member's supported protocols are incompatible with those of existing members.")),
     INVALID_GROUP_ID(24,
-            new ApiException("The configured groupId is invalid")),
+            new InvalidGroupIdException("The configured groupId is invalid")),
     UNKNOWN_MEMBER_ID(25,
             new UnknownMemberIdException("The coordinator is not aware of this member.")),
     INVALID_SESSION_TIMEOUT(26,
-            new ApiException("The session timeout is not within an acceptable range.")),
+            new InvalidSessionTimeoutException("The session timeout is not within an acceptable range.")),
     REBALANCE_IN_PROGRESS(27,
             new RebalanceInProgressException("The group is rebalancing, so a rejoin is needed.")),
     INVALID_COMMIT_OFFSET_SIZE(28,
-            new ApiException("The committing offset data size is not valid")),
+            new InvalidCommitOffsetSizeException("The committing offset data size is not valid")),
     TOPIC_AUTHORIZATION_FAILED(29,
             new TopicAuthorizationException("Topic authorization failed.")),
     GROUP_AUTHORIZATION_FAILED(30,

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.protocol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.kafka.common.errors.ApiException;
+import org.junit.Test;
+
+public class ErrorsTest {
+
+    @Test
+    public void testUniqueErrorCodes() {
+        Set<Short> codeSet = new HashSet<>();
+        for (Errors error : Errors.values()) {
+            codeSet.add(error.code());
+        }
+        assertEquals("Error codes must be unique", codeSet.size(), Errors.values().length);
+    }
+
+    @Test
+    public void testUniqueExceptions() {
+        Set<Class> exceptionSet = new HashSet<>();
+        for (Errors error : Errors.values()) {
+            if(error != Errors.NONE)
+                exceptionSet.add(error.exception().getClass());
+        }
+        assertEquals("Exceptions must be unique", exceptionSet.size(), Errors.values().length - 1); // Ignore NONE
+    }
+
+    @Test
+    public void testExceptionsAreNotGeneric() {
+        for (Errors error : Errors.values()) {
+            if(error != Errors.NONE)
+                assertNotEquals("Generic ApiException should not be used", error.exception().getClass(), ApiException.class);
+        }
+    }
+
+    @Test
+    public void testNoneException() {
+        assertNull("The NONE error should not have an exception", Errors.NONE.exception());
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ErrorsTest.java
@@ -41,7 +41,7 @@ public class ErrorsTest {
     public void testUniqueExceptions() {
         Set<Class> exceptionSet = new HashSet<>();
         for (Errors error : Errors.values()) {
-            if(error != Errors.NONE)
+            if (error != Errors.NONE)
                 exceptionSet.add(error.exception().getClass());
         }
         assertEquals("Exceptions must be unique", exceptionSet.size(), Errors.values().length - 1); // Ignore NONE
@@ -50,7 +50,7 @@ public class ErrorsTest {
     @Test
     public void testExceptionsAreNotGeneric() {
         for (Errors error : Errors.values()) {
-            if(error != Errors.NONE)
+            if (error != Errors.NONE)
                 assertNotEquals("Generic ApiException should not be used", error.exception().getClass(), ApiException.class);
         }
     }


### PR DESCRIPTION
… exceptions
