### PR TITLE
KAFKA-3087: Fix retention.ms property documentation in config docs

### DIFF
--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -109,7 +109,7 @@ object LogConfig {
   val FlushIntervalDoc = "The number of messages that can be written to the log before a flush is forced"
   val FlushMsDoc = "The amount of time the log can have dirty data before a flush is forced"
   val RetentionSizeDoc = "The approximate total number of bytes this log can use"
-  val RetentionMsDoc = "The approximate maximum age of the last segment that is retained"
+  val RetentionMsDoc = "The approximate maximum number of milli seconds of the last segment that is retained."
   val MaxIndexSizeDoc = "The maximum size of an index file"
   val MaxMessageSizeDoc = "The maximum size of a message"
   val IndexIntervalDoc = "The approximate number of bytes between index entries"

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -109,7 +109,7 @@ object LogConfig {
   val FlushIntervalDoc = "The number of messages that can be written to the log before a flush is forced"
   val FlushMsDoc = "The amount of time the log can have dirty data before a flush is forced"
   val RetentionSizeDoc = "The approximate total number of bytes this log can use"
-  val RetentionMsDoc = "The approximate maximum number of milli seconds of the last segment that is retained."
+  val RetentionMsDoc = "The approximate maximum number of milliseconds of the last segment that is retained"
   val MaxIndexSizeDoc = "The maximum size of an index file"
   val MaxMessageSizeDoc = "The maximum size of a message"
   val IndexIntervalDoc = "The approximate number of bytes between index entries"

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -119,7 +119,7 @@ The following are the topic-level configurations. The server's default configura
       <td>retention.ms</td>
       <td>7 days</td>
       <td>log.retention.ms</td>
-      <td>This configuration controls the maximum number of milli seconds we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data.</td>
+      <td>This configuration controls the maximum number of milliseconds we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data.</td>
     </tr>
     <tr>
       <td>segment.bytes</td>

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -118,8 +118,8 @@ The following are the topic-level configurations. The server's default configura
     <tr>
       <td>retention.ms</td>
       <td>7 days</td>
-      <td>log.retention.minutes</td>
-      <td>This configuration controls the maximum time we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data.</td>
+      <td>log.retention.ms</td>
+      <td>This configuration controls the maximum number of milli seconds we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data.</td>
     </tr>
     <tr>
       <td>segment.bytes</td>


### PR DESCRIPTION
Log retention settings can be set it in broker and some properties can be overriden at topic level. 
|Property |Default|Server Default property| Description|
|retention.ms|7 days|log.retention.minutes|This configuration controls the maximum time we will retain a log before we will discard old log segments to free up space if we are using the "delete" retention policy. This represents an SLA on how soon consumers must read their data.|

But retention.ms is in milli seconds not in minutes. So corresponding _Server Default property_ should be _log.retention.ms_ instead of _log.retention.minutes_.
