### PR TITLE
KAFKA-3119: Adding -daemon option to zookeeper-server-start.sh USAGE, similar to kafka-server-start.sh

### DIFF
--- a/bin/zookeeper-server-start.sh
+++ b/bin/zookeeper-server-start.sh
@@ -16,7 +16,7 @@
 
 if [ $# -lt 1 ];
 then
-	echo "USAGE: $0 zookeeper.properties"
+	echo "USAGE: $0 [-daemon] zookeeper.properties"
 	exit 1
 fi
 base_dir=$(dirname $0)


### PR DESCRIPTION
Output after fix:
# satul# ./kafka-server-start.sh

USAGE: ./kafka-server-start.sh [-daemon] server.properties
# satul# ./zookeeper-server-start.sh

USAGE: ./zookeeper-server-start.sh [-daemon] zookeeper.properties
