### PR TITLE
MINOR: MemoryRecords.sizeInBytes throws NPE when non-writable.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MemoryRecords.java
@@ -145,7 +145,7 @@ public class MemoryRecords implements Records {
         if (writable) {
             return compressor.buffer().position();
         } else {
-            return compressor.buffer().limit();
+            return buffer.limit();
         }
     }
 


### PR DESCRIPTION
I just noticed that `MemoryRecords.sizeInBytes` throws NPE when MemoryRecords is non-writable. `compressor` is explicitly set to null when `writable` is false (L56) at the construction time, for instance when `MemoryRecords.readableRecords` is used.

@guozhangwang Could you take a look when you have time?
