### PR TITLE
KAFKA-3138: 0.9.0 docs still say that log compaction doesn't work on compressed topics.

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -351,7 +351,6 @@ Further cleaner configurations are described <a href="/documentation.html#broker
 
 <ol>
   <li>You cannot configure yet how much log is retained without compaction (the "head" of the log).  Currently all segments are eligible except for the last segment, i.e. the one currently being written to.</li>
-  <li>Log compaction is not yet compatible with compressed topics.</li>
 </ol>
 <h3><a id="design_quotas" href="#design_quotas">4.9 Quotas</a></h3>
 <p>


### PR DESCRIPTION
Log compaction is supported on compressed topics as of 0.9.0, so update the docs to reflect that.
