### PR TITLE
MINOR: Fix syntax used for comment in JAAS config file

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -206,7 +206,7 @@ Apache Kafka allows clients to connect over SSL. By default SSL is disabled but 
         principal="kafka/kafka1.hostname.com@EXAMPLE.COM";
     };
 
-    # Zookeeper client authentication
+    // Zookeeper client authentication
     Client {
        com.sun.security.auth.module.Krb5LoginModule required
        useKeyTab=true


### PR DESCRIPTION
Simple fix, but important because the incorrect syntax causes the server not to start.
