### PR TITLE
KAFKA-3152; kafka-acl doesn't allow space in principal name (backport to 0.9.0)

### DIFF
--- a/bin/kafka-acls.sh
+++ b/bin/kafka-acls.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.AclCommand $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.AclCommand "$@"

--- a/bin/kafka-configs.sh
+++ b/bin/kafka-configs.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConfigCommand $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConfigCommand "$@"

--- a/bin/kafka-console-consumer.sh
+++ b/bin/kafka-console-consumer.sh
@@ -18,4 +18,4 @@ if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleConsumer $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleConsumer "$@"

--- a/bin/kafka-console-producer.sh
+++ b/bin/kafka-console-producer.sh
@@ -17,4 +17,4 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleProducer $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsoleProducer "$@"

--- a/bin/kafka-consumer-groups.sh
+++ b/bin/kafka-consumer-groups.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConsumerGroupCommand $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConsumerGroupCommand "$@"

--- a/bin/kafka-consumer-offset-checker.sh
+++ b/bin/kafka-consumer-offset-checker.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsumerOffsetChecker $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsumerOffsetChecker "$@"

--- a/bin/kafka-consumer-perf-test.sh
+++ b/bin/kafka-consumer-perf-test.sh
@@ -17,4 +17,4 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsumerPerformance $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.ConsumerPerformance "$@"

--- a/bin/kafka-mirror-maker.sh
+++ b/bin/kafka-mirror-maker.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.MirrorMaker $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.MirrorMaker "$@"

--- a/bin/kafka-preferred-replica-election.sh
+++ b/bin/kafka-preferred-replica-election.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.PreferredReplicaLeaderElectionCommand $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.PreferredReplicaLeaderElectionCommand "$@"

--- a/bin/kafka-producer-perf-test.sh
+++ b/bin/kafka-producer-perf-test.sh
@@ -17,4 +17,4 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance $@
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.ProducerPerformance "$@"

--- a/bin/kafka-reassign-partitions.sh
+++ b/bin/kafka-reassign-partitions.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ReassignPartitionsCommand $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.ReassignPartitionsCommand "$@"

--- a/bin/kafka-replay-log-producer.sh
+++ b/bin/kafka-replay-log-producer.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ReplayLogProducer $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.ReplayLogProducer "$@"

--- a/bin/kafka-replica-verification.sh
+++ b/bin/kafka-replica-verification.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.ReplicaVerificationTool $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.ReplicaVerificationTool "$@"

--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -41,4 +41,4 @@ case $COMMAND in
     ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka $@
+exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"

--- a/bin/kafka-simple-consumer-shell.sh
+++ b/bin/kafka-simple-consumer-shell.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.tools.SimpleConsumerShell $@
+exec $(dirname $0)/kafka-run-class.sh kafka.tools.SimpleConsumerShell "$@"

--- a/bin/kafka-topics.sh
+++ b/bin/kafka-topics.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.TopicCommand $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.TopicCommand "$@"

--- a/bin/kafka-verifiable-consumer.sh
+++ b/bin/kafka-verifiable-consumer.sh
@@ -17,4 +17,4 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer $@
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableConsumer "$@"

--- a/bin/kafka-verifiable-producer.sh
+++ b/bin/kafka-verifiable-producer.sh
@@ -17,4 +17,4 @@
 if [ "x$KAFKA_HEAP_OPTS" = "x" ]; then
     export KAFKA_HEAP_OPTS="-Xmx512M"
 fi
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer $@
+exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.tools.VerifiableProducer "$@"

--- a/bin/zookeeper-security-migration.sh
+++ b/bin/zookeeper-security-migration.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ZkSecurityMigrator $@
+exec $(dirname $0)/kafka-run-class.sh kafka.admin.ZkSecurityMigrator "$@"

--- a/bin/zookeeper-server-start.sh
+++ b/bin/zookeeper-server-start.sh
@@ -41,5 +41,4 @@ case $COMMAND in
      ;;
 esac
 
-exec $base_dir/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain $@
-
+exec $base_dir/kafka-run-class.sh $EXTRA_ARGS org.apache.zookeeper.server.quorum.QuorumPeerMain "$@"

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -52,7 +52,7 @@ object AclCommand {
         listAcl(opts)
     } catch {
       case e: Throwable =>
-        println(s"Error while executing topic Acl command ${e.getMessage}")
+        println(s"Error while executing ACL command: ${e.getMessage}")
         println(Utils.stackTrace(e))
         System.exit(-1)
     }
@@ -79,11 +79,11 @@ object AclCommand {
       val resourceToAcl = getResourceToAcls(opts)
 
       if (resourceToAcl.values.exists(_.isEmpty))
-        CommandLineUtils.printUsageAndDie(opts.parser, "You must specify one of: --allow-principal, --deny-principal when trying to add acls.")
+        CommandLineUtils.printUsageAndDie(opts.parser, "You must specify one of: --allow-principal, --deny-principal when trying to add ACLs.")
 
       for ((resource, acls) <- resourceToAcl) {
         val acls = resourceToAcl(resource)
-        println(s"Adding following acls for resource: $resource $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
+        println(s"Adding ACLs for resource `${resource}`: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
         authorizer.addAcls(acls, resource)
       }
 
@@ -97,10 +97,10 @@ object AclCommand {
 
       for ((resource, acls) <- resourceToAcl) {
         if (acls.isEmpty) {
-          if (confirmAction(s"Are you sure you want to delete all acls for resource: $resource y/n?"))
+          if (confirmAction(s"Are you sure you want to delete all ACLs for resource `${resource}`? (y/n)"))
             authorizer.removeAcls(resource)
         } else {
-          if (confirmAction(s"Are you sure you want to remove acls: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline from resource $resource y/n?"))
+          if (confirmAction(s"Are you sure you want to remove ACLs: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline from resource `${resource}`? (y/n)"))
             authorizer.removeAcls(acls, resource)
         }
       }
@@ -119,14 +119,14 @@ object AclCommand {
         resources.map(resource => (resource -> authorizer.getAcls(resource)))
 
       for ((resource, acls) <- resourceToAcls)
-        println(s"Following is list of acls for resource: $resource $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
+        println(s"Current ACLs for resource `${resource}`: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline")
     }
   }
 
   private def getResourceToAcls(opts: AclCommandOptions): Map[Resource, Set[Acl]] = {
     var resourceToAcls = Map.empty[Resource, Set[Acl]]
 
-    //if none of the --producer or --consumer options are specified , just construct acls from CLI options.
+    //if none of the --producer or --consumer options are specified , just construct ACLs from CLI options.
     if (!opts.options.has(opts.producerOpt) && !opts.options.has(opts.consumerOpt)) {
       resourceToAcls ++= getCliResourceToAcls(opts)
     }
@@ -267,22 +267,22 @@ object AclCommand {
       .describedAs("authorizer-properties")
       .ofType(classOf[String])
 
-    val topicOpt = parser.accepts("topic", "topic to which acls should be added or removed. " +
-      "A value of * indicates acl should apply to all topics.")
+    val topicOpt = parser.accepts("topic", "topic to which ACLs should be added or removed. " +
+      "A value of * indicates ACL should apply to all topics.")
       .withRequiredArg
       .describedAs("topic")
       .ofType(classOf[String])
 
-    val clusterOpt = parser.accepts("cluster", "Add/Remove cluster acls.")
-    val groupOpt = parser.accepts("group", "Consumer Group to which the acls should be added or removed. " +
-      "A value of * indicates the acls should apply to all groups.")
+    val clusterOpt = parser.accepts("cluster", "Add/Remove cluster ACLs.")
+    val groupOpt = parser.accepts("group", "Consumer Group to which the ACLs should be added or removed. " +
+      "A value of * indicates the ACLs should apply to all groups.")
       .withRequiredArg
       .describedAs("group")
       .ofType(classOf[String])
 
-    val addOpt = parser.accepts("add", "Indicates you are trying to add acls.")
-    val removeOpt = parser.accepts("remove", "Indicates you are trying to remove acls.")
-    val listOpt = parser.accepts("list", "List acls for the specified resource, use --topic <topic> or --group <group> or --cluster to specify a resource.")
+    val addOpt = parser.accepts("add", "Indicates you are trying to add ACLs.")
+    val removeOpt = parser.accepts("remove", "Indicates you are trying to remove ACLs.")
+    val listOpt = parser.accepts("list", "List ACLs for the specified resource, use --topic <topic> or --group <group> or --cluster to specify a resource.")
 
     val operationsOpt = parser.accepts("operation", "Operation that is being allowed or denied. Valid operation names are: " + Newline +
       Operation.values.map("\t" + _).mkString(Newline) + Newline)
@@ -296,10 +296,10 @@ object AclCommand {
       .describedAs("allow-principal")
       .ofType(classOf[String])
 
-    val denyPrincipalsOpt = parser.accepts("deny-principal", "principal is in principalType: name format. " +
+    val denyPrincipalsOpt = parser.accepts("deny-principal", "principal is in principalType:name format. " +
       "By default anyone not added through --allow-principal is denied access. " +
       "You only need to use this option as negation to already allowed set. " +
-      "For example if you wanted to allow access to all users in the system but not test-user you can define an acl that " +
+      "For example if you wanted to allow access to all users in the system but not test-user you can define an ACL that " +
       "allows access to User:* and specify --deny-principal=User:test@EXAMPLE.COM. " +
       "AND PLEASE REMEMBER DENY RULES TAKES PRECEDENCE OVER ALLOW RULES.")
       .withRequiredArg
@@ -318,11 +318,11 @@ object AclCommand {
       .describedAs("deny-host")
       .ofType(classOf[String])
 
-    val producerOpt = parser.accepts("producer", "Convenience option to add/remove acls for producer role. " +
-      "This will generate acls that allows WRITE,DESCRIBE on topic and CREATE on cluster. ")
+    val producerOpt = parser.accepts("producer", "Convenience option to add/remove ACLs for producer role. " +
+      "This will generate ACLs that allows WRITE,DESCRIBE on topic and CREATE on cluster. ")
 
-    val consumerOpt = parser.accepts("consumer", "Convenience option to add/remove acls for consumer role. " +
-      "This will generate acls that allows READ,DESCRIBE on topic and READ on group.")
+    val consumerOpt = parser.accepts("consumer", "Convenience option to add/remove ACLs for consumer role. " +
+      "This will generate ACLs that allows READ,DESCRIBE on topic and READ on group.")
 
     val helpOpt = parser.accepts("help", "Print usage information.")
 


### PR DESCRIPTION
This is a backport of the trunk PR and it excludes the test
changes due to conflicts and the fact that the changes
were not directly related to the bug in the end
(it was something we did not test for, but the non-shell code
was already correct).

Details:
- Add quotes to `$` in shell scripts
  This is necessary for correct processing of quotes in the
  user command.
- Minor improvements to AclCommand messages
