### PR TITLE
KAFKA-3157 - Mirror maker doesn't commit offset

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -536,9 +536,11 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
           throw new ConsumerTimeoutException
       }
 
-      val record = recordIter.next
+      val record = recordIter.next()
       val tp = new TopicPartition(record.topic, record.partition)
+
       offsets.put(tp, record.offset + 1)
+      
       BaseConsumerRecord(record.topic, record.partition, record.offset, record.key, record.value)
     }
 

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -540,7 +540,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       val tp = new TopicPartition(record.topic, record.partition)
 
       offsets.put(tp, record.offset + 1)
-      
+
       BaseConsumerRecord(record.topic, record.partition, record.offset, record.key, record.value)
     }
 

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -527,13 +527,15 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       }
     }
 
-    // New consumer always hasNext
-    override def hasData = true
+    override def hasData : Boolean = {
+      if (recordIter == null || !recordIter.hasNext) {
+        recordIter = consumer.poll(1000).iterator
+      }
+
+      recordIter.hasNext
+    }
 
     override def receive() : BaseConsumerRecord = {
-      while (recordIter == null || !recordIter.hasNext)
-        recordIter = consumer.poll(1000).iterator
-
       val record = recordIter.next()
       val tp = new TopicPartition(record.topic, record.partition)
 


### PR DESCRIPTION
Mirror maker doesn't commit offset with new consumer enabled when data volume is low. This is caused by infinite loop in `receive()` which would never jump out of loop if no data coming
