### PR TITLE
KAFKA-3103; Transient Failure in testIsrAfterBrokerShutDownAndJoinsBack

### DIFF
--- a/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/BaseTopicMetadataTest.scala
@@ -201,7 +201,7 @@ abstract class BaseTopicMetadataTest extends ZooKeeperTestHarness {
                                 2000, 0)
         metadata.topicsMetadata.nonEmpty &&
           metadata.topicsMetadata.head.partitionsMetadata.nonEmpty &&
-          expectedIsr == metadata.topicsMetadata.head.partitionsMetadata.head.isr
+          expectedIsr.sortBy(_.id) == metadata.topicsMetadata.head.partitionsMetadata.head.isr.sortBy(_.id)
       },
         "Topic metadata is not correctly updated for broker " + x + ".\n" +
         "Expected ISR: " + expectedIsr + "\n" +


### PR DESCRIPTION
All three defects have the same root cause. 

Root cause is ClientUtils.fetchTopicMetadata returns the BrokerEndPoints in a non-deterministic order, so we need to sort the expected endpoints and the received endpoints so we can correctly compare them.
