### PR TITLE
KAFKA-3161: Fixed ProducerConfig/ConsumerConfig so that defaults are used in java.util.Properties

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -323,8 +323,7 @@ public class ConsumerConfig extends AbstractConfig {
     public static Properties addDeserializerToConfig(Properties properties,
                                                      Deserializer<?> keyDeserializer,
                                                      Deserializer<?> valueDeserializer) {
-        Properties newProperties = new Properties();
-        newProperties.putAll(properties);
+        Properties newProperties = new Properties(properties);
         if (keyDeserializer != null)
             newProperties.put(KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getClass().getName());
         if (valueDeserializer != null)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -302,8 +302,7 @@ public class ProducerConfig extends AbstractConfig {
 
     public static Properties addSerializerToConfig(Properties properties,
                                                    Serializer<?> keySerializer, Serializer<?> valueSerializer) {
-        Properties newProperties = new Properties();
-        newProperties.putAll(properties);
+        Properties newProperties = new Properties(properties);
         if (keySerializer != null)
             newProperties.put(KEY_SERIALIZER_CLASS_CONFIG, keySerializer.getClass().getName());
         if (valueSerializer != null)

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/ConsumerConfigTest.java
@@ -42,25 +42,33 @@ public class ConsumerConfigTest {
         properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClassName);
         properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClassName);
         Properties newProperties = ConsumerConfig.addDeserializerToConfig(properties, null, null);
-        assertEquals(newProperties.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClassName);
-        assertEquals(newProperties.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClassName);
+        assertEquals(keyDeserializerClassName, newProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClassName, newProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
-        properties.clear();
+        properties = new Properties();
         properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClassName);
         newProperties = ConsumerConfig.addDeserializerToConfig(properties, keyDeserializer, null);
-        assertEquals(newProperties.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClassName);
-        assertEquals(newProperties.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClassName);
+        assertEquals(keyDeserializerClassName, newProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClassName, newProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
-        properties.clear();
+        properties = new Properties();
         properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClassName);
         newProperties = ConsumerConfig.addDeserializerToConfig(properties, null, valueDeserializer);
-        assertEquals(newProperties.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClassName);
-        assertEquals(newProperties.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClassName);
+        assertEquals(keyDeserializerClassName, newProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClassName, newProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
-        properties.clear();
+        properties = new Properties();
         newProperties = ConsumerConfig.addDeserializerToConfig(properties, keyDeserializer, valueDeserializer);
-        assertEquals(newProperties.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClassName);
-        assertEquals(newProperties.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClassName);
+        assertEquals(keyDeserializerClassName, newProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClassName, newProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+
+        Properties defaultProps = new Properties();
+        defaultProps.setProperty("foo", "bar");
+        properties = new Properties(defaultProps);
+        newProperties = ConsumerConfig.addDeserializerToConfig(properties, keyDeserializer, valueDeserializer);
+        assertEquals(keyDeserializerClassName, newProperties.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClassName, newProperties.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+        assertEquals("bar", newProperties.getProperty("foo"));
     }
 
     @Test
@@ -69,24 +77,24 @@ public class ConsumerConfigTest {
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
         Map<String, Object> newConfigs = ConsumerConfig.addDeserializerToConfig(configs, null, null);
-        assertEquals(newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClass);
-        assertEquals(newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClass);
+        assertEquals(keyDeserializerClass, newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClass, newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
         configs.clear();
         configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass);
         newConfigs = ConsumerConfig.addDeserializerToConfig(configs, keyDeserializer, null);
-        assertEquals(newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClass);
-        assertEquals(newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClass);
+        assertEquals(keyDeserializerClass, newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClass, newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
         configs.clear();
         configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass);
         newConfigs = ConsumerConfig.addDeserializerToConfig(configs, null, valueDeserializer);
-        assertEquals(newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClass);
-        assertEquals(newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClass);
+        assertEquals(keyDeserializerClass, newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClass, newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
         configs.clear();
         newConfigs = ConsumerConfig.addDeserializerToConfig(configs, keyDeserializer, valueDeserializer);
-        assertEquals(newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG), keyDeserializerClass);
-        assertEquals(newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG), valueDeserializerClass);
+        assertEquals(keyDeserializerClass, newConfigs.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+        assertEquals(valueDeserializerClass, newConfigs.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
     }
 }

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -37,8 +37,6 @@ trait IntegrationTestHarness extends KafkaServerTestHarness {
   val producerCount: Int
   val consumerCount: Int
   val serverCount: Int
-  lazy val producerConfig = new Properties
-  lazy val consumerConfig = new Properties
   lazy val serverConfig = new Properties
 
   val consumers = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
@@ -51,17 +49,16 @@ trait IntegrationTestHarness extends KafkaServerTestHarness {
     cfgs.map(KafkaConfig.fromProps)
   }
 
+  lazy val producerConfig = new Properties(TestUtils.producerSecurityConfigs(securityProtocol, trustStoreFile))
+  lazy val consumerConfig = new Properties(TestUtils.consumerSecurityConfigs(securityProtocol, trustStoreFile))
+
   @Before
   override def setUp() {
-    val producerSecurityProps = TestUtils.producerSecurityConfigs(securityProtocol, trustStoreFile)
-    val consumerSecurityProps = TestUtils.consumerSecurityConfigs(securityProtocol, trustStoreFile)
     super.setUp()
-    producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArraySerializer])
-    producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArraySerializer])
-    producerConfig.putAll(producerSecurityProps)
-    consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArrayDeserializer])
-    consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[org.apache.kafka.common.serialization.ByteArrayDeserializer])
-    consumerConfig.putAll(consumerSecurityProps)
+    producerConfig.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
+    producerConfig.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
+    consumerConfig.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+    consumerConfig.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
     for (i <- 0 until producerCount)
       producers += TestUtils.createNewProducer(brokerList,
                                                securityProtocol = this.securityProtocol,


### PR DESCRIPTION
This impacts the ProducerConfig and ConsumerConfig.  I added a unit test to reflect the new case.  While running unit tests I found that the order for assertEquals(<expected>, <actual>) were backwards - I fixed this.

This is my original work to be licensed to the kafka product (Instructions 5d).
