### PR TITLE
KAFKA-3166; Disable SSL client authentication for SASL_SSL security protocol

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -66,8 +66,9 @@ public class SaslChannelBuilder implements ChannelBuilder {
                 kerberosShortNamer = KerberosShortNamer.fromUnparsedRules(defaultRealm, principalToLocalRules);
 
             if (this.securityProtocol == SecurityProtocol.SASL_SSL) {
-                this.sslFactory = new SslFactory(mode);
-                this.sslFactory.configure(this.configs);
+                // Disable SSL client authentication as we are using SASL authentication
+                this.sslFactory = new SslFactory(mode, "none");
+                this.sslFactory.configure(configs);
             }
         } catch (Exception e) {
             throw new KafkaException(e);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -38,6 +38,9 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class SslFactory implements Configurable {
 
+    private final Mode mode;
+    private final String clientAuthConfigOverride;
+
     private String protocol;
     private String provider;
     private String kmfAlgorithm;
@@ -51,10 +54,14 @@ public class SslFactory implements Configurable {
     private SSLContext sslContext;
     private boolean needClientAuth;
     private boolean wantClientAuth;
-    private final Mode mode;
 
     public SslFactory(Mode mode) {
+        this(mode, null);
+    }
+
+    public SslFactory(Mode mode, String clientAuthConfigOverride) {
         this.mode = mode;
+        this.clientAuthConfigOverride = clientAuthConfigOverride;
     }
 
     @Override
@@ -75,7 +82,9 @@ public class SslFactory implements Configurable {
         if (endpointIdentification != null)
             this.endpointIdentification = endpointIdentification;
 
-        String clientAuthConfig = (String) configs.get(SslConfigs.SSL_CLIENT_AUTH_CONFIG);
+        String clientAuthConfig = clientAuthConfigOverride;
+        if (clientAuthConfig == null)
+            clientAuthConfig = (String) configs.get(SslConfigs.SSL_CLIENT_AUTH_CONFIG);
         if (clientAuthConfig != null) {
             if (clientAuthConfig.equals("required"))
                 this.needClientAuth = true;

--- a/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestSslUtils.java
@@ -199,18 +199,18 @@ public class TestSslUtils {
     public static  Map<String, Object> createSslConfig(boolean useClientCert, boolean trustStore, Mode mode, File trustStoreFile, String certAlias, String host)
         throws IOException, GeneralSecurityException {
         Map<String, X509Certificate> certs = new HashMap<>();
-        File keyStoreFile;
+        File keyStoreFile = null;
         Password password = mode == Mode.SERVER ? new Password("ServerPassword") : new Password("ClientPassword");
 
         Password trustStorePassword = new Password("TrustStorePassword");
 
-        if (useClientCert) {
+        if (mode == Mode.CLIENT && useClientCert) {
             keyStoreFile = File.createTempFile("clientKS", ".jks");
             KeyPair cKP = generateKeyPair("RSA");
             X509Certificate cCert = generateCertificate("CN=" + host + ", O=A client", cKP, 30, "SHA1withRSA");
             createKeyStore(keyStoreFile.getPath(), password, "client", cKP.getPrivate(), cCert);
             certs.put(certAlias, cCert);
-        } else {
+        } else if (mode == Mode.SERVER) {
             keyStoreFile = File.createTempFile("serverKS", ".jks");
             KeyPair sKP = generateKeyPair("RSA");
             X509Certificate sCert = generateCertificate("CN=" + host + ", O=A server", sKP, 30,

--- a/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
@@ -16,10 +16,17 @@
   */
 package kafka.api
 
+import kafka.server.KafkaConfig
 import org.apache.kafka.common.protocol.SecurityProtocol
 
 class SaslSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override val clientPrincipal = "client"
   override val kafkaPrincipal = "kafka"
+
+  // Configure brokers to require SSL client authentication in order to verify that SASL_SSL works correctly even if the
+  // client doesn't have a keystore. We want to cover the scenario where a broker requires either SSL client
+  // authentication or SASL authentication with SSL as the transport layer (but not both).
+  serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
+
 }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -443,7 +443,7 @@ object TestUtils extends Logging {
                               certAlias: String): Properties = {
     val props = new Properties
     if (usesSslTransportLayer(securityProtocol))
-      props.putAll(sslConfigs(mode, true, trustStoreFile, certAlias))
+      props.putAll(sslConfigs(mode, securityProtocol == SecurityProtocol.SSL, trustStoreFile, certAlias))
     props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name)
     props
   }


### PR DESCRIPTION
Also:
- Fixed a bug in `createSslConfig` where we were always generating a
  keystore even if `useClientCert` was false and `mode` was `Mode.CLIENT`.
- Pass `numRecords` to `consumerRecords` and other clean-ups (formatting and scaladoc).
