### PR TITLE
KAFKA-3166; Disable SSL client authentication for SASL_SSL security protocol (backport)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -66,8 +66,9 @@ public class SaslChannelBuilder implements ChannelBuilder {
                 kerberosShortNamer = KerberosShortNamer.fromUnparsedRules(defaultRealm, principalToLocalRules);
 
             if (this.securityProtocol == SecurityProtocol.SASL_SSL) {
-                this.sslFactory = new SslFactory(mode);
-                this.sslFactory.configure(this.configs);
+                // Disable SSL client authentication as we are using SASL authentication
+                this.sslFactory = new SslFactory(mode, "none");
+                this.sslFactory.configure(configs);
             }
         } catch (Exception e) {
             throw new KafkaException(e);

--- a/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/ssl/SslFactory.java
@@ -33,6 +33,9 @@ import java.util.Map;
 
 public class SslFactory implements Configurable {
 
+    private final Mode mode;
+    private final String clientAuthConfigOverride;
+
     private String protocol;
     private String provider;
     private String kmfAlgorithm;
@@ -46,10 +49,14 @@ public class SslFactory implements Configurable {
     private SSLContext sslContext;
     private boolean needClientAuth;
     private boolean wantClientAuth;
-    private final Mode mode;
 
     public SslFactory(Mode mode) {
+        this(mode, null);
+    }
+
+    public SslFactory(Mode mode, String clientAuthConfigOverride) {
         this.mode = mode;
+        this.clientAuthConfigOverride = clientAuthConfigOverride;
     }
 
     @Override
@@ -70,7 +77,9 @@ public class SslFactory implements Configurable {
         if (endpointIdentification != null)
             this.endpointIdentification = endpointIdentification;
 
-        String clientAuthConfig = (String) configs.get(SslConfigs.SSL_CLIENT_AUTH_CONFIG);
+        String clientAuthConfig = clientAuthConfigOverride;
+        if (clientAuthConfig == null)
+            clientAuthConfig = (String) configs.get(SslConfigs.SSL_CLIENT_AUTH_CONFIG);
         if (clientAuthConfig != null) {
             if (clientAuthConfig.equals("required"))
                 this.needClientAuth = true;


### PR DESCRIPTION
Backport of https://github.com/apache/kafka/pull/827 to 0.9.0 that only includes the essential code changes (excluded the test changes due to conflicts).
