### PR TITLE
MINOR: Remove unused imports from tests whose packages were fixed

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AdminClientTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientTest.scala
@@ -17,7 +17,6 @@
 package kafka.api
 
 import kafka.admin.AdminClient
-import kafka.api.IntegrationTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.{TestUtils, Logging}
 import org.apache.kafka.clients.consumer.ConsumerConfig

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -19,7 +19,6 @@ package kafka.admin
 import java.io.StringReader
 import java.util.Properties
 
-import kafka.admin.AclCommand
 import kafka.security.auth._
 import kafka.server.KafkaConfig
 import kafka.utils.{Logging, TestUtils}

--- a/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
@@ -16,7 +16,6 @@
  */
 package kafka.security.auth
 
-import kafka.security.auth._
 import kafka.utils.Json
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.{Test, Assert}

--- a/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
@@ -17,7 +17,6 @@
 package kafka.security.auth
 
 import kafka.common.{KafkaException}
-import kafka.security.auth.{Operation, Read}
 import org.junit.{Test, Assert}
 import org.scalatest.junit.JUnitSuite
 

--- a/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
@@ -17,7 +17,6 @@
 package kafka.security.auth
 
 import kafka.common.KafkaException
-import kafka.security.auth.{Allow, PermissionType}
 import org.junit.{Test, Assert}
 import org.scalatest.junit.JUnitSuite
 

--- a/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
@@ -17,7 +17,6 @@
 package kafka.security.auth
 
 import kafka.common.KafkaException
-import kafka.security.auth.{ResourceType, Topic}
 import org.junit.{Test, Assert}
 import org.scalatest.junit.JUnitSuite
 

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -20,7 +20,6 @@ package kafka.tools
 import java.io.FileOutputStream
 
 import kafka.consumer.{BaseConsumer, BaseConsumerRecord}
-import kafka.tools.{ConsoleConsumer, MessageFormatter}
 import kafka.utils.TestUtils
 import org.easymock.EasyMock
 import org.junit.Assert._


### PR DESCRIPTION
I missed this when reviewing:

https://github.com/apache/kafka/commit/a58b459bddd5b1dcab224b53cda0196e947a5b09
