### PR TITLE
KAFKA-2607: Review `Time` interface and its usage

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -418,7 +418,7 @@ class Partition(val topic: String,
     val leaderLogEndOffset = leaderReplica.logEndOffset
     val candidateReplicas = inSyncReplicas - leaderReplica
 
-    val laggingReplicas = candidateReplicas.filter(r => (time.milliseconds - r.lastCaughtUpTimeMs) > maxLagMs)
+    val laggingReplicas = candidateReplicas.filter(r => (time.relativeMilliseconds - r.lastCaughtUpTimeMs) > maxLagMs)
     if(laggingReplicas.size > 0)
       debug("Lagging replicas for partition %s are %s".format(TopicAndPartition(topic, partitionId), laggingReplicas.map(_.brokerId).mkString(",")))
 

--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -45,7 +45,7 @@ class Replica(val brokerId: Int,
     }
   }
 
-  private[this] val lastCaughtUpTimeMsUnderlying = new AtomicLong(time.milliseconds)
+  private[this] val lastCaughtUpTimeMsUnderlying = new AtomicLong(time.relativeMilliseconds)
 
   def lastCaughtUpTimeMs = lastCaughtUpTimeMsUnderlying.get()
 
@@ -57,7 +57,7 @@ class Replica(val brokerId: Int,
      * This means that the replica is fully caught up.
      */
     if(logReadResult.isReadFromLogEnd) {
-      lastCaughtUpTimeMsUnderlying.set(time.milliseconds)
+      lastCaughtUpTimeMsUnderlying.set(time.relativeMilliseconds)
     }
   }
 

--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -84,7 +84,7 @@ class ZkNodeChangeNotificationListener(private val zkUtils: ZkUtils,
     if (notifications.nonEmpty) {
       info(s"Processing notification(s) to $seqNodeRoot")
       try {
-        val now = time.milliseconds
+        val now = time.absoluteMilliseconds
         for (notification <- notifications) {
           val changeId = changeNumber(notification)
           if (changeId > lastExecutedChange) {

--- a/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
@@ -40,7 +40,7 @@ import java.util.concurrent.atomic.AtomicInteger
 class ConsumerFetcherManager(private val consumerIdString: String,
                              private val config: ConsumerConfig,
                              private val zkUtils : ZkUtils)
-        extends AbstractFetcherManager("ConsumerFetcherManager-%d".format(SystemTime.milliseconds),
+        extends AbstractFetcherManager("ConsumerFetcherManager-%d".format(SystemTime.absoluteMilliseconds),
                                        config.clientId, config.numConsumerFetchers) {
   private var partitionMap: immutable.Map[TopicAndPartition, PartitionTopicInfo] = null
   private var cluster: Cluster = null

--- a/core/src/main/scala/kafka/consumer/ZookeeperConsumerConnector.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperConsumerConnector.scala
@@ -271,7 +271,7 @@ private[kafka] class ZookeeperConsumerConnector(val config: ConsumerConfig,
 
   private def registerConsumerInZK(dirs: ZKGroupDirs, consumerIdString: String, topicCount: TopicCount) {
     info("begin registering consumer " + consumerIdString + " in ZK")
-    val timestamp = SystemTime.milliseconds.toString
+    val timestamp = SystemTime.absoluteMilliseconds.toString
     val consumerRegistrationInfo = Json.encode(Map("version" -> 1, "subscription" -> topicCount.getTopicCountMap, "pattern" -> topicCount.pattern,
                                                   "timestamp" -> timestamp))
     val zkWatchedEphemeral = new ZKCheckedEphemeral(dirs.

--- a/core/src/main/scala/kafka/coordinator/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/GroupCoordinator.scala
@@ -563,7 +563,7 @@ class GroupCoordinator(val brokerId: Int,
    */
   private def completeAndScheduleNextHeartbeatExpiration(group: GroupMetadata, member: MemberMetadata) {
     // complete current heartbeat expectation
-    member.latestHeartbeat = SystemTime.milliseconds
+    member.latestHeartbeat = SystemTime.absoluteMilliseconds
     val memberKey = MemberKey(member.groupId, member.memberId)
     heartbeatPurgatory.checkAndComplete(memberKey)
 

--- a/core/src/main/scala/kafka/coordinator/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/GroupMetadataManager.scala
@@ -358,7 +358,7 @@ class GroupMetadataManager(val brokerId: Int,
         }
       }
 
-      val startMs = SystemTime.milliseconds
+      val startMs = SystemTime.relativeMilliseconds
       try {
         replicaManager.logManager.getLog(topicPartition) match {
           case Some(log) =>
@@ -437,7 +437,7 @@ class GroupMetadataManager(val brokerId: Int,
 
             if (!shuttingDown.get())
               info("Finished loading offsets from %s in %d milliseconds."
-                .format(topicPartition, SystemTime.milliseconds - startMs))
+                .format(topicPartition, SystemTime.relativeMilliseconds - startMs))
           case None =>
             warn("No log found for " + topicPartition)
         }
@@ -532,7 +532,7 @@ class GroupMetadataManager(val brokerId: Int,
 
   private def deleteExpiredOffsets() {
     debug("Collecting expired offsets.")
-    val startMs = SystemTime.milliseconds
+    val startMs = SystemTime.absoluteMilliseconds
 
     val numExpiredOffsetsRemoved = inWriteLock(offsetExpireLock) {
       val expiredOffsets = offsetsCache.filter { case (groupTopicPartition, offsetAndMetadata) =>
@@ -580,7 +580,7 @@ class GroupMetadataManager(val brokerId: Int,
       }.sum
     }
 
-    info("Removed %d expired offsets in %d milliseconds.".format(numExpiredOffsetsRemoved, SystemTime.milliseconds - startMs))
+    info("Removed %d expired offsets in %d milliseconds.".format(numExpiredOffsetsRemoved, SystemTime.absoluteMilliseconds - startMs))
   }
 
   private def getHighWatermark(partitionId: Int): Long = {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -659,11 +659,11 @@ private case class CleanerStats(time: Time = SystemTime) {
   }
 
   def indexDone() {
-    mapCompleteTime = time.milliseconds
+    mapCompleteTime = time.relativeMilliseconds
   }
 
   def allDone() {
-    endTime = time.milliseconds
+    endTime = time.relativeMilliseconds
   }
   
   def elapsedSecs = (endTime - startTime)/1000.0
@@ -671,7 +671,7 @@ private case class CleanerStats(time: Time = SystemTime) {
   def elapsedIndexSecs = (mapCompleteTime - startTime)/1000.0
   
   def clear() {
-    startTime = time.milliseconds
+    startTime = time.absoluteMilliseconds
     mapCompleteTime = -1L
     endTime = -1L
     bytesRead = 0L

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -293,6 +293,7 @@ class LogManager(val logDirs: Array[File],
 
   /**
    *  Delete all data in a partition and start the log at the new offset
+ *
    *  @param newOffset The new offset to start the log with
    */
   def truncateFullyAndStartAt(topicAndPartition: TopicAndPartition, newOffset: Long) {
@@ -417,7 +418,7 @@ class LogManager(val logDirs: Array[File],
   private def cleanupExpiredSegments(log: Log): Int = {
     if (log.config.retentionMs < 0)
       return 0
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     log.deleteOldSegments(startMs - _.lastModified > log.config.retentionMs)
   }
 
@@ -446,13 +447,13 @@ class LogManager(val logDirs: Array[File],
   def cleanupLogs() {
     debug("Beginning log cleanup...")
     var total = 0
-    val startMs = time.milliseconds
+    val startMs = time.absoluteMilliseconds
     for(log <- allLogs; if !log.config.compact) {
       debug("Garbage collecting '" + log.name + "'")
       total += cleanupExpiredSegments(log) + cleanupSegmentsToMaintainSize(log)
     }
     debug("Log cleanup completed. " + total + " files deleted in " +
-                  (time.milliseconds - startMs) / 1000 + " seconds")
+                  (time.absoluteMilliseconds - startMs) / 1000 + " seconds")
   }
 
   /**
@@ -482,7 +483,7 @@ class LogManager(val logDirs: Array[File],
 
     for ((topicAndPartition, log) <- logs) {
       try {
-        val timeSinceLastFlush = time.milliseconds - log.lastFlushTime
+        val timeSinceLastFlush = time.absoluteMilliseconds - log.lastFlushTime
         debug("Checking if flush is needed on " + topicAndPartition.topic + " flush interval  " + log.config.flushMs +
               " last flushed " + log.lastFlushTime + " time since last flush: " + timeSinceLastFlush)
         if(timeSinceLastFlush >= log.config.flushMs)

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -48,7 +48,7 @@ class LogSegment(val log: FileMessageSet,
                  val rollJitterMs: Long,
                  time: Time) extends Logging {
 
-  var created = time.milliseconds
+  var created = time.absoluteMilliseconds
 
   /* the number of bytes since we last added an entry in the offset index */
   private var bytesSinceLastIndexEntry = 0
@@ -219,7 +219,7 @@ class LogSegment(val log: FileMessageSet,
     index.resize(index.maxIndexSize)
     val bytesTruncated = log.truncateTo(mapping.position)
     if(log.sizeInBytes == 0)
-      created = time.milliseconds
+      created = time.absoluteMilliseconds
     bytesSinceLastIndexEntry = 0
     bytesTruncated
   }

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -101,7 +101,7 @@ object RequestChannel extends Logging {
     trace("Processor %d received request : %s".format(processor, requestDesc(true)))
 
     def updateRequestMetrics() {
-      val endTimeMs = SystemTime.milliseconds
+      val endTimeMs = SystemTime.absoluteMilliseconds
       // In some corner cases, apiLocalCompleteTimeMs may not be set when the request completes if the remote
       // processing time is really small. This value is set in KafkaApis from a request handling thread.
       // This may be read in a network thread before the actual update happens in KafkaApis which will cause us to
@@ -149,7 +149,7 @@ object RequestChannel extends Logging {
   }
 
   case class Response(processor: Int, request: Request, responseSend: Send, responseAction: ResponseAction) {
-    request.responseCompleteTimeMs = SystemTime.milliseconds
+    request.responseCompleteTimeMs = SystemTime.absoluteMilliseconds
 
     def this(processor: Int, request: Request, responseSend: Send) =
       this(processor, request, responseSend, if (responseSend == null) NoOpAction else SendAction)
@@ -229,7 +229,7 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
   def receiveResponse(processor: Int): RequestChannel.Response = {
     val response = responseQueues(processor).poll()
     if (response != null)
-      response.request.responseDequeueTimeMs = SystemTime.milliseconds
+      response.request.responseDequeueTimeMs = SystemTime.absoluteMilliseconds
     response
   }
 

--- a/core/src/main/scala/kafka/producer/async/DefaultEventHandler.scala
+++ b/core/src/main/scala/kafka/producer/async/DefaultEventHandler.scala
@@ -66,11 +66,11 @@ class DefaultEventHandler[K,V](config: ProducerConfig,
     while (remainingRetries > 0 && outstandingProduceRequests.size > 0) {
       topicMetadataToRefresh ++= outstandingProduceRequests.map(_.topic)
       if (topicMetadataRefreshInterval >= 0 &&
-          SystemTime.milliseconds - lastTopicMetadataRefreshTime > topicMetadataRefreshInterval) {
+          SystemTime.absoluteMilliseconds - lastTopicMetadataRefreshTime > topicMetadataRefreshInterval) {
         CoreUtils.swallowError(brokerPartitionInfo.updateInfo(topicMetadataToRefresh.toSet, correlationId.getAndIncrement))
         sendPartitionPerTopicCache.clear()
         topicMetadataToRefresh.clear
-        lastTopicMetadataRefreshTime = SystemTime.milliseconds
+        lastTopicMetadataRefreshTime = SystemTime.absoluteMilliseconds
       }
       outstandingProduceRequests = dispatchSerializedData(outstandingProduceRequests)
       if (outstandingProduceRequests.size > 0) {

--- a/core/src/main/scala/kafka/server/DynamicConfigManager.scala
+++ b/core/src/main/scala/kafka/server/DynamicConfigManager.scala
@@ -100,7 +100,7 @@ class DynamicConfigManager(private val zkUtils: ZkUtils,
   private def processConfigChanges(notifications: Seq[String]) {
     if (notifications.size > 0) {
       info("Processing config change notification(s)...")
-      val now = time.milliseconds
+      val now = time.absoluteMilliseconds
       for (notification <- notifications) {
         val changeId = changeNumber(notification)
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -111,7 +111,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           error("Error when handling request %s".format(request.body), e)
         }
     } finally
-      request.apiLocalCompleteTimeMs = SystemTime.milliseconds
+      request.apiLocalCompleteTimeMs = SystemTime.absoluteMilliseconds
   }
 
   def handleLeaderAndIsrRequest(request: RequestChannel.Request) {
@@ -284,7 +284,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       //   - If v1 and no explicit commit timestamp is provided we use default expiration timestamp.
       //   - If v1 and explicit commit timestamp is provided we calculate retention from that explicit commit timestamp
       //   - If v2 we use the default expiration timestamp
-      val currentTimestamp = SystemTime.milliseconds
+      val currentTimestamp = SystemTime.absoluteMilliseconds
       val defaultExpireTimestamp = offsetRetention + currentTimestamp
       val offsetData = authorizedRequestInfo.mapValues(offsetAndMetadata =>
         offsetAndMetadata.copy(
@@ -374,7 +374,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
 
       // When this callback is triggered, the remote API call has completed
-      request.apiRemoteCompleteTimeMs = SystemTime.milliseconds
+      request.apiRemoteCompleteTimeMs = SystemTime.absoluteMilliseconds
 
       quotaManagers(ApiKeys.PRODUCE.id).recordAndMaybeThrottle(
         request.header.clientId,
@@ -441,7 +441,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
 
       // When this callback is triggered, the remote API call has completed
-      request.apiRemoteCompleteTimeMs = SystemTime.milliseconds
+      request.apiRemoteCompleteTimeMs = SystemTime.absoluteMilliseconds
 
       // Do not throttle replication traffic
       if (fetchRequest.isFromFollower) {
@@ -556,7 +556,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     for(i <- 0 until segsArray.length)
       offsetTimeArray(i) = (segsArray(i).baseOffset, segsArray(i).lastModified)
     if (segsArray.last.size > 0)
-      offsetTimeArray(segsArray.length) = (log.logEndOffset, SystemTime.milliseconds)
+      offsetTimeArray(segsArray.length) = (log.logEndOffset, SystemTime.absoluteMilliseconds)
 
     var startIndex = -1
     timestamp match {

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -44,9 +44,9 @@ class KafkaRequestHandler(id: Int,
           // Since meter is calculated as total_recorded_value / time_window and
           // time_window is independent of the number of threads, each recorded idle
           // time should be discounted by # threads.
-          val startSelectTime = SystemTime.nanoseconds
+          val startSelectTime = SystemTime.relativeNanoseconds
           req = requestChannel.receiveRequest(300)
-          val idleTime = SystemTime.nanoseconds - startSelectTime
+          val idleTime = SystemTime.relativeNanoseconds - startSelectTime
           aggregateIdleMeter.mark(idleTime / totalHandlerThreads)
         }
 
@@ -55,7 +55,7 @@ class KafkaRequestHandler(id: Int,
             id, brokerId))
           return
         }
-        req.requestDequeueTimeMs = SystemTime.milliseconds
+        req.requestDequeueTimeMs = SystemTime.absoluteMilliseconds
         trace("Kafka request handler %d on broker %d handling request %s".format(id, brokerId, req))
         apis.handle(req)
       } catch {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -325,9 +325,9 @@ class ReplicaManager(val config: KafkaConfig,
                      responseCallback: Map[TopicPartition, PartitionResponse] => Unit) {
 
     if (isValidRequiredAcks(requiredAcks)) {
-      val sTime = SystemTime.milliseconds
+      val sTime = SystemTime.absoluteMilliseconds
       val localProduceResults = appendToLocalLog(internalTopicsAllowed, messagesPerPartition, requiredAcks)
-      debug("Produce to local log in %d ms".format(SystemTime.milliseconds - sTime))
+      debug("Produce to local log in %d ms".format(SystemTime.absoluteMilliseconds - sTime))
 
       val produceStatus = localProduceResults.map { case (topicPartition, result) =>
         topicPartition ->

--- a/core/src/main/scala/kafka/server/ZookeeperLeaderElector.scala
+++ b/core/src/main/scala/kafka/server/ZookeeperLeaderElector.scala
@@ -59,7 +59,7 @@ class ZookeeperLeaderElector(controllerContext: ControllerContext,
   }
 
   def elect: Boolean = {
-    val timestamp = SystemTime.milliseconds.toString
+    val timestamp = SystemTime.absoluteMilliseconds.toString
     val electString = Json.encode(Map("version" -> 1, "brokerid" -> brokerId, "timestamp" -> timestamp))
    
    leaderId = getControllerID 

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -59,7 +59,7 @@ object ReplicaVerificationTool extends Logging {
   val dateFormat = new SimpleDateFormat(dateFormatString)
 
   def getCurrentTimeString() = {
-    ReplicaVerificationTool.dateFormat.format(new Date(SystemTime.milliseconds))
+    ReplicaVerificationTool.dateFormat.format(new Date(SystemTime.absoluteMilliseconds))
   }
 
   def main(args: Array[String]): Unit = {
@@ -205,7 +205,7 @@ private class ReplicaBuffer(expectedReplicasPerTopicAndPartition: Map[TopicAndPa
   private val messageSetCache = new Pool[TopicAndPartition, Pool[Int, FetchResponsePartitionData]]
   private val fetcherBarrier = new AtomicReference(new CountDownLatch(expectedNumFetchers))
   private val verificationBarrier = new AtomicReference(new CountDownLatch(1))
-  @volatile private var lastReportTime = SystemTime.milliseconds
+  @volatile private var lastReportTime = SystemTime.absoluteMilliseconds
   private var maxLag: Long = -1L
   private var offsetWithMaxLag: Long = -1L
   private var maxLagTopicAndPartition: TopicAndPartition = null
@@ -326,7 +326,7 @@ private class ReplicaBuffer(expectedReplicasPerTopicAndPartition: Map[TopicAndPa
       }
       fetchResponsePerReplica.clear()
     }
-    val currentTimeMs = SystemTime.milliseconds
+    val currentTimeMs = SystemTime.absoluteMilliseconds
     if (currentTimeMs - lastReportTime > reportInterval) {
       println(ReplicaVerificationTool.dateFormat.format(new Date(currentTimeMs)) + ": max lag is "
         + maxLag + " for partition " + maxLagTopicAndPartition + " at offset " + offsetWithMaxLag

--- a/core/src/main/scala/kafka/tools/SimpleConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerPerformance.scala
@@ -53,7 +53,7 @@ object SimpleConsumerPerformance {
       ))
     var offset: Long = consumer.getOffsetsBefore(request).partitionErrorAndOffsets(topicAndPartition).offsets.head
 
-    val startMs = System.currentTimeMillis
+    val startMs = SystemTime.relativeMilliseconds
     var done = false
     var totalBytesRead = 0L
     var totalMessagesRead = 0L
@@ -96,7 +96,7 @@ object SimpleConsumerPerformance {
             (totalBytesRead*1.0)/(1024*1024), totalMBRead/elapsed,
             totalMessagesRead, (totalMessagesRead-lastMessagesRead)/elapsed))
         }
-        lastReportTime = SystemTime.milliseconds
+        lastReportTime = SystemTime.relativeMilliseconds
         lastBytesRead = totalBytesRead
         lastMessagesRead = totalMessagesRead
         consumedInterval = 0

--- a/core/src/main/scala/kafka/utils/ByteBoundedBlockingQueue.scala
+++ b/core/src/main/scala/kafka/utils/ByteBoundedBlockingQueue.scala
@@ -43,17 +43,17 @@ class ByteBoundedBlockingQueue[E] (val queueNumMessageCapacity: Int, val queueBy
    */
   def offer(e: E, timeout: Long, unit: TimeUnit = TimeUnit.MICROSECONDS): Boolean = {
     if (e == null) throw new NullPointerException("Putting null element into queue.")
-    val startTime = SystemTime.nanoseconds
+    val startTime = SystemTime.relativeNanoseconds
     val expireTime = startTime + unit.toNanos(timeout)
     putLock synchronized {
-      var timeoutNanos = expireTime - SystemTime.nanoseconds
+      var timeoutNanos = expireTime - SystemTime.relativeNanoseconds
       while (currentByteSize.get() >= queueByteCapacity && timeoutNanos > 0) {
         // ensure that timeoutNanos > 0, otherwise (per javadoc) we have to wait until the next notify
         putLock.wait(timeoutNanos / 1000000, (timeoutNanos % 1000000).toInt)
-        timeoutNanos = expireTime - SystemTime.nanoseconds
+        timeoutNanos = expireTime - SystemTime.relativeNanoseconds
       }
       // only proceed if queue has capacity and not timeout
-      timeoutNanos = expireTime - SystemTime.nanoseconds
+      timeoutNanos = expireTime - SystemTime.relativeNanoseconds
       if (currentByteSize.get() < queueByteCapacity && timeoutNanos > 0) {
         val success = queue.offer(e, timeoutNanos, TimeUnit.NANOSECONDS)
         // only increase queue byte size if put succeeds

--- a/core/src/main/scala/kafka/utils/DelayedItem.scala
+++ b/core/src/main/scala/kafka/utils/DelayedItem.scala
@@ -22,7 +22,7 @@ import scala.math._
 
 class DelayedItem(delayMs: Long) extends Delayed with Logging {
 
-  private val dueMs = SystemTime.milliseconds + delayMs
+  private val dueMs = SystemTime.relativeMilliseconds + delayMs
 
   def this(delay: Long, unit: TimeUnit) = this(unit.toMillis(delay))
 
@@ -30,7 +30,7 @@ class DelayedItem(delayMs: Long) extends Delayed with Logging {
    * The remaining delay time
    */
   def getDelay(unit: TimeUnit): Long = {
-    unit.convert(max(dueMs - SystemTime.milliseconds, 0), TimeUnit.MILLISECONDS)
+    unit.convert(max(dueMs - SystemTime.relativeMilliseconds, 0), TimeUnit.MILLISECONDS)
   }
 
   def compareTo(d: Delayed): Int = {

--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -42,14 +42,14 @@ class Throttler(val desiredRatePerSec: Double,
   
   private val lock = new Object
   private val meter = newMeter(metricName, units, TimeUnit.SECONDS)
-  private var periodStartNs: Long = time.nanoseconds
+  private var periodStartNs: Long = time.relativeNanoseconds
   private var observedSoFar: Double = 0.0
   
   def maybeThrottle(observed: Double) {
     meter.mark(observed.toLong)
     lock synchronized {
       observedSoFar += observed
-      val now = time.nanoseconds
+      val now = time.relativeNanoseconds
       val elapsedNs = now - periodStartNs
       // if we have completed an interval AND we have observed something, maybe
       // we should take a little nap

--- a/core/src/main/scala/kafka/utils/Time.scala
+++ b/core/src/main/scala/kafka/utils/Time.scala
@@ -40,9 +40,11 @@ object Time {
  */
 trait Time {
   
-  def milliseconds: Long
+  def absoluteMilliseconds: Long
 
-  def nanoseconds: Long
+  def relativeMilliseconds: Long
+
+  def relativeNanoseconds: Long
 
   def sleep(ms: Long)
 }
@@ -51,10 +53,29 @@ trait Time {
  * The normal system implementation of time functions
  */
 object SystemTime extends Time {
-  
-  def milliseconds: Long = System.currentTimeMillis
-  
-  def nanoseconds: Long = System.nanoTime
+
+  /**
+    * Returns the number of milliseconds since midnight UTC on 1/1/1970 based on the operating system's clock.
+    *
+    * This value is likely less precise than relative time.
+    */
+  def absoluteMilliseconds: Long = System.currentTimeMillis
+
+  /**
+    * Returns the current value of the JVM's high resolution time source rounded down to milliseconds.
+    *
+    * This time value can only be used for measuring elapsed time within the JVM from which it is generated.
+    * This time value has no relation to the "wall-clock" time.
+    */
+  def relativeMilliseconds: Long = relativeNanoseconds / Time.NsPerMs
+
+  /**
+    * Returns the current value of the JVM's high resolution time source in nanoseconds.
+    *
+    * This time value can only be used for measuring elapsed time within the JVM from which it is generated.
+    * This time value has no relation to the "wall-clock" time.
+    */
+  def relativeNanoseconds: Long = System.nanoTime
   
   def sleep(ms: Long): Unit = Thread.sleep(ms)
   

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -275,7 +275,7 @@ class ZkUtils(val zkClient: ZkClient,
    */
   def registerBrokerInZk(id: Int, host: String, port: Int, advertisedEndpoints: immutable.Map[SecurityProtocol, EndPoint], jmxPort: Int) {
     val brokerIdPath = BrokerIdsPath + "/" + id
-    val timestamp = SystemTime.milliseconds.toString
+    val timestamp = SystemTime.absoluteMilliseconds.toString
 
     val brokerInfo = Json.encode(Map("version" -> 2, "host" -> host, "port" -> port, "endpoints"->advertisedEndpoints.values.map(_.connectionString).toArray, "jmx_port" -> jmxPort, "timestamp" -> timestamp))
     registerBrokerInZk(brokerIdPath, brokerInfo)

--- a/core/src/main/scala/kafka/utils/timer/TimerTaskList.scala
+++ b/core/src/main/scala/kafka/utils/timer/TimerTaskList.scala
@@ -117,7 +117,7 @@ private[timer] class TimerTaskList(taskCounter: AtomicInteger) extends Delayed {
   }
 
   def getDelay(unit: TimeUnit): Long = {
-    unit.convert(max(getExpiration - SystemTime.milliseconds, 0), TimeUnit.MILLISECONDS)
+    unit.convert(max(getExpiration - SystemTime.absoluteMilliseconds, 0), TimeUnit.MILLISECONDS)
   }
 
   def compareTo(d: Delayed): Int = {

--- a/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
+++ b/core/src/test/scala/other/kafka/TestPurgatoryPerformance.scala
@@ -276,7 +276,7 @@ object TestPurgatoryPerformance {
 
     private class Scheduled(val operation: FakeOperation) extends Delayed {
       def getDelay(unit: TimeUnit): Long = {
-        unit.convert(max(operation.completesAt - SystemTime.milliseconds, 0), TimeUnit.MILLISECONDS)
+        unit.convert(max(operation.completesAt - SystemTime.absoluteMilliseconds, 0), TimeUnit.MILLISECONDS)
       }
 
       def compareTo(d: Delayed): Int = {

--- a/core/src/test/scala/unit/kafka/api/RequestResponseSerializationTest.scala
+++ b/core/src/test/scala/unit/kafka/api/RequestResponseSerializationTest.scala
@@ -156,7 +156,7 @@ object SerializationTestUtils {
   def createTestOffsetCommitRequestV2: OffsetCommitRequest = {
     new OffsetCommitRequest(
       groupId = "group 1",
-      retentionMs = SystemTime.milliseconds,
+      retentionMs = SystemTime.absoluteMilliseconds,
       requestInfo=collection.immutable.Map(
       TopicAndPartition(topic1, 0) -> OffsetAndMetadata(42L, "some metadata"),
       TopicAndPartition(topic1, 1) -> OffsetAndMetadata(100L, OffsetMetadata.NoMetadata)
@@ -168,8 +168,8 @@ object SerializationTestUtils {
       versionId = 1,
       groupId = "group 1",
       requestInfo = collection.immutable.Map(
-      TopicAndPartition(topic1, 0) -> OffsetAndMetadata(42L, "some metadata", SystemTime.milliseconds),
-      TopicAndPartition(topic1, 1) -> OffsetAndMetadata(100L, OffsetMetadata.NoMetadata, SystemTime.milliseconds)
+      TopicAndPartition(topic1, 0) -> OffsetAndMetadata(42L, "some metadata", SystemTime.absoluteMilliseconds),
+      TopicAndPartition(topic1, 1) -> OffsetAndMetadata(100L, OffsetMetadata.NoMetadata, SystemTime.absoluteMilliseconds)
     ))
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -94,7 +94,7 @@ class LogManagerTest {
     }
     assertTrue("There should be more than one segment now.", log.numberOfSegments > 1)
 
-    log.logSegments.foreach(_.log.file.setLastModified(time.milliseconds))
+    log.logSegments.foreach(_.log.file.setLastModified(time.absoluteMilliseconds))
 
     time.sleep(maxLogAgeMs + 1)
     assertEquals("Now there should only be only one segment in the index.", 1, log.numberOfSegments)

--- a/core/src/test/scala/unit/kafka/producer/ProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/producer/ProducerTest.scala
@@ -304,7 +304,7 @@ class ProducerTest extends ZooKeeperTestHarness with Logging{
     // any requests should be accepted and queue up, but not handled
     server1.requestHandlerPool.shutdown()
 
-    val t1 = SystemTime.milliseconds
+    val t1 = SystemTime.absoluteMilliseconds
     try {
       // this message should be assigned to partition 0 whose leader is on broker 0, but
       // broker 0 will not response within timeoutMs millis.
@@ -315,7 +315,7 @@ class ProducerTest extends ZooKeeperTestHarness with Logging{
     } finally {
       producer.close()
     }
-    val t2 = SystemTime.milliseconds
+    val t2 = SystemTime.absoluteMilliseconds
 
     // make sure we don't wait fewer than timeoutMs
     assertTrue((t2-t1) >= timeoutMs)

--- a/core/src/test/scala/unit/kafka/producer/SyncProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/producer/SyncProducerTest.scala
@@ -44,7 +44,7 @@ class SyncProducerTest extends KafkaServerTestHarness {
 
 
     val producer = new SyncProducer(new SyncProducerConfig(props))
-    val firstStart = SystemTime.milliseconds
+    val firstStart = SystemTime.relativeMilliseconds
     try {
       val response = producer.send(TestUtils.produceRequest("test", 0,
         new ByteBufferMessageSet(compressionCodec = NoCompressionCodec, messages = new Message(messageBytes)), acks = 1))
@@ -52,9 +52,9 @@ class SyncProducerTest extends KafkaServerTestHarness {
     } catch {
       case e: Exception => Assert.fail("Unexpected failure sending message to broker. " + e.getMessage)
     }
-    val firstEnd = SystemTime.milliseconds
+    val firstEnd = SystemTime.relativeMilliseconds
     Assert.assertTrue((firstEnd-firstStart) < 500)
-    val secondStart = SystemTime.milliseconds
+    val secondStart = SystemTime.relativeMilliseconds
     try {
       val response = producer.send(TestUtils.produceRequest("test", 0,
         new ByteBufferMessageSet(compressionCodec = NoCompressionCodec, messages = new Message(messageBytes)), acks = 1))
@@ -62,7 +62,7 @@ class SyncProducerTest extends KafkaServerTestHarness {
     } catch {
       case e: Exception => Assert.fail("Unexpected failure sending message to broker. " + e.getMessage)
     }
-    val secondEnd = SystemTime.milliseconds
+    val secondEnd = SystemTime.relativeMilliseconds
     Assert.assertTrue((secondEnd-secondStart) < 500)
     try {
       val response = producer.send(TestUtils.produceRequest("test", 0,
@@ -204,7 +204,7 @@ class SyncProducerTest extends KafkaServerTestHarness {
     // any requests should be accepted and queue up, but not handled
     server.requestHandlerPool.shutdown()
 
-    val t1 = SystemTime.milliseconds
+    val t1 = SystemTime.relativeMilliseconds
     try {
       producer.send(request)
       Assert.fail("Should have received timeout exception since request handling is stopped.")
@@ -212,7 +212,7 @@ class SyncProducerTest extends KafkaServerTestHarness {
       case e: SocketTimeoutException => /* success */
       case e: Throwable => Assert.fail("Unexpected exception when expecting timeout: " + e)
     }
-    val t2 = SystemTime.milliseconds
+    val t2 = SystemTime.relativeMilliseconds
     // make sure we don't wait fewer than timeoutMs for a response
     Assert.assertTrue((t2-t1) >= timeoutMs)
   }

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -152,7 +152,7 @@ class LogOffsetTest extends ZooKeeperTestHarness {
       log.append(new ByteBufferMessageSet(NoCompressionCodec, message))
     log.flush()
 
-    val now = time.milliseconds + 30000 // pretend it is the future to avoid race conditions with the fs
+    val now = time.absoluteMilliseconds + 30000 // pretend it is the future to avoid race conditions with the fs
 
     val offsets = server.apis.fetchOffsets(logManager, new TopicPartition(topic, part), now, 10)
     assertEquals(Seq(20L, 18L, 15L, 12L, 9L, 6L, 3L, 0L), offsets)

--- a/core/src/test/scala/unit/kafka/server/OffsetCommitTest.scala
+++ b/core/src/test/scala/unit/kafka/server/OffsetCommitTest.scala
@@ -256,7 +256,7 @@ class OffsetCommitTest extends ZooKeeperTestHarness {
     // committed offset should expire
     val commitRequest2 = OffsetCommitRequest(
       groupId = group,
-      requestInfo = immutable.Map(topicPartition -> OffsetAndMetadata(3L, "metadata", SystemTime.milliseconds - 2*24*60*60*1000L)),
+      requestInfo = immutable.Map(topicPartition -> OffsetAndMetadata(3L, "metadata", SystemTime.absoluteMilliseconds - 2*24*60*60*1000L)),
       versionId = 1
     )
     assertEquals(Errors.NONE.code, simpleConsumer.commitOffsets(commitRequest2).commitStatus.get(topicPartition).get)

--- a/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockScheduler.scala
@@ -55,7 +55,7 @@ class MockScheduler(val time: Time) extends Scheduler {
    */
   def tick() {
     this synchronized {
-      val now = time.milliseconds
+      val now = time.absoluteMilliseconds
       while(!tasks.isEmpty && tasks.head.nextExecution <= now) {
         /* pop and execute the task with the lowest next execution time */
         val curr = tasks.dequeue
@@ -71,7 +71,7 @@ class MockScheduler(val time: Time) extends Scheduler {
   
   def schedule(name: String, fun: ()=>Unit, delay: Long = 0, period: Long = -1, unit: TimeUnit = TimeUnit.MILLISECONDS) {
     this synchronized {
-      tasks += MockTask(name, fun, time.milliseconds + delay, period = period)
+      tasks += MockTask(name, fun, time.absoluteMilliseconds + delay, period = period)
       tick()
     }
   }

--- a/core/src/test/scala/unit/kafka/utils/MockTime.scala
+++ b/core/src/test/scala/unit/kafka/utils/MockTime.scala
@@ -34,9 +34,12 @@ class MockTime(@volatile private var currentMs: Long) extends Time {
   
   def this() = this(System.currentTimeMillis)
   
-  def milliseconds: Long = currentMs
+  def absoluteMilliseconds: Long = currentMs
 
-  def nanoseconds: Long = 
+
+  override def relativeMilliseconds: Long = currentMs
+
+  def relativeNanoseconds: Long =
     TimeUnit.NANOSECONDS.convert(currentMs, TimeUnit.MILLISECONDS)
 
   def sleep(ms: Long) {
@@ -44,6 +47,6 @@ class MockTime(@volatile private var currentMs: Long) extends Time {
     scheduler.tick()
   }
   
-  override def toString() = "MockTime(%d)".format(milliseconds)
+  override def toString() = "MockTime(%d)".format(absoluteMilliseconds)
 
 }


### PR DESCRIPTION
This change adds some documentation and changes some calls from using absolute time to relative time.

Since I am new to the Kafka codebase I will mark the locations where I made the change from absolute to relative times to make it easier for reviewers to find any bugs that I might have introduced.
