### PR TITLE
KAFKA-3179 Fix seek on compressed messages

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -560,10 +560,10 @@ public class Fetcher<K, V> {
                 List<ConsumerRecord<K, V>> parsed = new ArrayList<>();
                 for (LogEntry logEntry : records) {
                     // Skip the messages earlier than current position.
-                    if (logEntry.offset() < position)
-                        continue;
-                    parsed.add(parseRecord(tp, logEntry));
-                    bytes += logEntry.size();
+                    if (logEntry.offset() >= position) {
+                        parsed.add(parseRecord(tp, logEntry));
+                        bytes += logEntry.size();
+                    }
                 }
 
                 if (!parsed.isEmpty()) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -559,6 +559,9 @@ public class Fetcher<K, V> {
                 MemoryRecords records = MemoryRecords.readableRecords(buffer);
                 List<ConsumerRecord<K, V>> parsed = new ArrayList<>();
                 for (LogEntry logEntry : records) {
+                    // Skip the messages earlier than current position.
+                    if (logEntry.offset() < position)
+                        continue;
                     parsed.add(parseRecord(tp, logEntry));
                     bytes += logEntry.size();
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -464,7 +464,8 @@ public class FetcherTest {
 
         // normal fetch
         for (int i = 1; i < 4; i++) {
-            // We need to make sure the message offset grows.
+            // We need to make sure the message offset grows. Otherwise they will be considered as already consumed
+            // and filtered out by consumer.
             if (i > 1) {
                 this.records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
                 for (int v = 0; v < 3; v++) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -467,9 +467,9 @@ public class FetcherTest {
             // We need to make sure the message offset grows.
             if (i > 1) {
                 this.records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
-                this.records.append((long) i * 3, "key".getBytes(), "value-0".getBytes());
-                this.records.append((long) i * 3 + 1, "key".getBytes(), "value-1".getBytes());
-                this.records.append((long) i * 3 + 2, "key".getBytes(), "value-2".getBytes());
+                for (int v = 0; v < 3; v++) {
+                    this.records.append((long) i * 3 + v, "key".getBytes(), String.format("value-%d", v).getBytes());
+                }
                 this.records.close();
             }
             fetcher.initFetches(cluster);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -467,9 +467,9 @@ public class FetcherTest {
             // We need to make sure the message offset grows.
             if (i > 1) {
                 this.records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
-                this.records.append((long) i * 3, "key".getBytes(), "value-1".getBytes());
-                this.records.append((long) i * 3 + 1, "key".getBytes(), "value-2".getBytes());
-                this.records.append((long) i * 3 + 2, "key".getBytes(), "value-3".getBytes());
+                this.records.append((long) i * 3, "key".getBytes(), "value-0".getBytes());
+                this.records.append((long) i * 3 + 1, "key".getBytes(), "value-1".getBytes());
+                this.records.append((long) i * 3 + 2, "key".getBytes(), "value-2".getBytes());
                 this.records.close();
             }
             fetcher.initFetches(cluster);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -464,8 +464,15 @@ public class FetcherTest {
 
         // normal fetch
         for (int i = 1; i < 4; i++) {
+            // We need to make sure the message offset grows.
+            if (i > 1) {
+                this.records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
+                this.records.append((long) i * 3, "key".getBytes(), "value-1".getBytes());
+                this.records.append((long) i * 3 + 1, "key".getBytes(), "value-2".getBytes());
+                this.records.append((long) i * 3 + 2, "key".getBytes(), "value-3".getBytes());
+                this.records.close();
+            }
             fetcher.initFetches(cluster);
-
             client.prepareResponse(fetchResponse(this.records.buffer(), Errors.NONE.code(), 100L, 100 * i));
             consumerClient.poll(0);
             records = fetcher.fetchedRecords().get(tp);

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -279,18 +279,22 @@ abstract class BaseConsumerTest extends IntegrationTestHarness with Logging {
   }
 
   protected def sendRecords(numRecords: Int, tp: TopicPartition) {
-    sendRecords(this.producers(0), numRecords, tp)
-    this.producers(0).flush()
+    sendRecords(numRecords, tp, None)
   }
 
-  protected def sendCompressedRecords(numRecords: Int, tp: TopicPartition) {
-    val producerProps = new Properties()
-    producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")
-    producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, Long.MaxValue.toString)
-    val producer = TestUtils.createNewProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
-      retries = 0, lingerMs = Long.MaxValue, props = Some(producerProps))
-    sendRecords(producer, numRecords, tp)
-    producer.close()
+  protected def sendRecords(numRecords: Int, tp: TopicPartition, codec: Option[String] = None) {
+    if (!codec.isDefined) {
+      sendRecords(this.producers(0), numRecords, tp)
+      this.producers(0).flush()
+    } else {
+      val producerProps = new Properties()
+      producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, codec.get)
+      producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, Long.MaxValue.toString)
+      val producer = TestUtils.createNewProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
+        retries = 0, lingerMs = Long.MaxValue, props = Some(producerProps))
+      sendRecords(producer, numRecords, tp)
+      producer.close()
+    }
   }
 
   private def sendRecords(producer: Producer[Array[Byte], Array[Byte]], numRecords: Int, tp: TopicPartition) {

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -281,16 +281,15 @@ abstract class BaseConsumerTest extends IntegrationTestHarness with Logging {
 
   protected def sendRecords(producer: Producer[Array[Byte], Array[Byte]],
                             numRecords: Int,
-                            tp: TopicPartition,
-                            startingKeyAndValueIndex: Int = 0) {
-    (startingKeyAndValueIndex until numRecords + startingKeyAndValueIndex).foreach { i =>
+                            tp: TopicPartition) {
+    (0 until numRecords).foreach { i =>
       producer.send(new ProducerRecord(tp.topic(), tp.partition(), s"key $i".getBytes, s"value $i".getBytes))
     }
     producer.flush()
   }
 
   protected def consumeAndVerifyRecords(consumer: Consumer[Array[Byte], Array[Byte]], numRecords: Int, startingOffset: Int,
-                                      startingKeyAndValueIndex: Int = 0) {
+                                      startingKeyAndValueIndex: Int = 0, tp: TopicPartition = tp) {
     val records = new ArrayList[ConsumerRecord[Array[Byte], Array[Byte]]]()
     val maxIters = numRecords * 300
     var iters = 0
@@ -304,8 +303,8 @@ abstract class BaseConsumerTest extends IntegrationTestHarness with Logging {
     for (i <- 0 until numRecords) {
       val record = records.get(i)
       val offset = startingOffset + i
-      assertEquals(topic, record.topic())
-      assertEquals(part, record.partition())
+      assertEquals(tp.topic(), record.topic())
+      assertEquals(tp.partition(), record.partition())
       assertEquals(offset.toLong, record.offset())
       val keyAndValueIndex = startingKeyAndValueIndex + i
       assertEquals(s"key $keyAndValueIndex", new String(record.key()))

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -281,15 +281,15 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     consumeAndVerifyRecords(consumer, numRecords = 1, startingOffset = 0)
 
     // Test seek non-compressed message
-    val quarter = totalRecords / 2
-    consumer.seek(tp, quarter)
-    assertEquals(quarter, consumer.position(tp))
-    consumeAndVerifyRecords(consumer, numRecords = 1, startingOffset = quarter.toInt, startingKeyAndValueIndex = quarter.toInt)
+    val midOfNonCompressedMessages = totalRecords / 2
+    consumer.seek(tp, midOfNonCompressedMessages)
+    assertEquals(midOfNonCompressedMessages, consumer.position(tp))
+    consumeAndVerifyRecords(consumer, numRecords = 1, startingOffset = midOfNonCompressedMessages.toInt, startingKeyAndValueIndex = midOfNonCompressedMessages.toInt)
     // Test seek compressed message
-    val threeQuarters = totalRecords + totalRecords / 2
-    consumer.seek(tp, threeQuarters)
-    assertEquals(threeQuarters, consumer.position(tp))
-    consumeAndVerifyRecords(consumer, numRecords = 1, startingOffset = threeQuarters.toInt, startingKeyAndValueIndex = threeQuarters.toInt)
+    val midOfCompressedMessages = totalRecords + totalRecords / 2
+    consumer.seek(tp, midOfCompressedMessages)
+    assertEquals(midOfCompressedMessages, consumer.position(tp))
+    consumeAndVerifyRecords(consumer, numRecords = 1, startingOffset = midOfCompressedMessages.toInt, startingKeyAndValueIndex = midOfCompressedMessages.toInt)
   }
 
   private def sendCompressedMessages(numRecords: Int, tp: TopicPartition, startingKeyAndValueIndex: Int) {
@@ -299,6 +299,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val producer = TestUtils.createNewProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
         retries = 0, lingerMs = Long.MaxValue, props = Some(producerProps))
     sendRecords(producer, numRecords, tp, startingKeyAndValueIndex)
+    producer.close()
   }
 
   def testPositionAndCommit() {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -266,7 +266,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def testSeek() {
     val consumer = this.consumers(0)
     val totalRecords = 50L
-    sendRecords(totalRecords.toInt)
+    sendCompressedRecords(totalRecords.toInt, tp)
     consumer.assign(List(tp).asJava)
 
     consumer.seekToEnd(tp)


### PR DESCRIPTION
The fix itself is simple. 

Some explanation on unit tests. Currently we the vast majority of unit test is running with uncompressed messages.  I was initially thinking about run all the tests using compressed messages. But it seems uncompressed messages are necessary in a many test cases because we need the bytes sent and appended to the log to be predictable. In most of other cases, it does not matter whether the message is compressed or not, and compression will slow down the unit test. So I just added one method in the BaseConsumerTest to send compressed messages whenever we need it. 
