### PR TITLE
MINOR: Reorder StreamThread shutdown sequence

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -335,9 +335,6 @@ public class ProcessorStateManager {
             checkpoint.write(checkpointOffsets);
         }
 
-        // un-assign the change log partition
-        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
-
         // release the state directory directoryLock
         directoryLock.release();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -261,20 +261,16 @@ public class StreamThread extends Thread {
     private void shutdown() {
         log.info("Shutting down stream thread [" + this.getName() + "]");
 
-        // We need to first remove the tasks before shutting down the underlying clients
-        // as they may be required in the previous steps; and exceptions should not
-        // prevent this call from going through all shutdown steps.
         try {
             commitAll();
         } catch (Throwable e) {
             // already logged in commitAll()
         }
-        try {
-            removeStreamTasks();
-            removeStandbyTasks();
-        } catch (Throwable e) {
-            // already logged in removeStreamTasks() and removeStandbyTasks()
-        }
+
+        // We need to first close the underlying clients before closing the state
+        // manager, for example we need to make sure producer's message sends
+        // have all been acked before the state manager records
+        // changelog sent offsets
         try {
             producer.close();
         } catch (Throwable e) {
@@ -289,6 +285,14 @@ public class StreamThread extends Thread {
             restoreConsumer.close();
         } catch (Throwable e) {
             log.error("Failed to close restore consumer in thread [" + this.getName() + "]: ", e);
+        }
+
+        // Exceptions should not prevent this call from going through all shutdown steps
+        try {
+            removeStreamTasks();
+            removeStandbyTasks();
+        } catch (Throwable e) {
+            // already logged in removeStreamTasks() and removeStandbyTasks()
         }
 
         log.info("Stream thread shutdown complete [" + this.getName() + "]");


### PR DESCRIPTION
We need to close producer first before closing tasks to make sure all messages are acked and hence checkpoint offsets are updated before closing tasks and their state. It was re-ordered mistakenly before.
