### PR TITLE
KAFKA-3175 : Topic not accessible after deletion even when delete.topic.enable is disabled

### DIFF
--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -75,8 +75,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
   // register topic and partition change listeners
   def registerListeners() {
     registerTopicChangeListener()
-    if(controller.config.deleteTopicEnable)
-      registerDeleteTopicListener()
+    registerDeleteTopicListener()
   }
 
   // de-register topic and partition change listeners
@@ -456,7 +455,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
      * @throws Exception On any error.
      */
     @throws(classOf[Exception])
-    def handleChildChange(parentPath : String, children : java.util.List[String]) {
+    def handleChildChange(parentPath: String, children: java.util.List[String]) {
       inLock(controllerContext.controllerLock) {
         var topicsToBeDeleted = {
           import JavaConversions._
@@ -469,19 +468,26 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
           nonExistentTopics.foreach(topic => zkUtils.deletePathRecursive(getDeleteTopicPath(topic)))
         }
         topicsToBeDeleted --= nonExistentTopics
-        if(topicsToBeDeleted.nonEmpty) {
-          info("Starting topic deletion for topics " + topicsToBeDeleted.mkString(","))
-          // mark topic ineligible for deletion if other state changes are in progress
-          topicsToBeDeleted.foreach { topic =>
-            val preferredReplicaElectionInProgress =
-              controllerContext.partitionsUndergoingPreferredReplicaElection.map(_.topic).contains(topic)
-            val partitionReassignmentInProgress =
-              controllerContext.partitionsBeingReassigned.keySet.map(_.topic).contains(topic)
-            if(preferredReplicaElectionInProgress || partitionReassignmentInProgress)
-              controller.deleteTopicManager.markTopicIneligibleForDeletion(Set(topic))
+        if(controller.config.deleteTopicEnable) {
+          if(topicsToBeDeleted.nonEmpty) {
+            info("Starting topic deletion for topics " + topicsToBeDeleted.mkString(","))
+            // mark topic ineligible for deletion if other state changes are in progress
+            topicsToBeDeleted.foreach { topic =>
+              val preferredReplicaElectionInProgress =
+                controllerContext.partitionsUndergoingPreferredReplicaElection.map(_.topic).contains(topic)
+              val partitionReassignmentInProgress =
+                controllerContext.partitionsBeingReassigned.keySet.map(_.topic).contains(topic)
+              if(preferredReplicaElectionInProgress || partitionReassignmentInProgress)
+                controller.deleteTopicManager.markTopicIneligibleForDeletion(Set(topic))
+            }
+            // add topic to deletion list
+            controller.deleteTopicManager.enqueueTopicsForDeletion(topicsToBeDeleted)
           }
-          // add topic to deletion list
-          controller.deleteTopicManager.enqueueTopicsForDeletion(topicsToBeDeleted)
+        } else {
+          // If delete topic is disabled remove entries under zookeeper path : /admin/delete_topics
+          for(topic <- topicsToBeDeleted) {
+            controller.deleteTopicManager.cleanZkStateForDeleteTopic(topic)
+          }
         }
       }
     }

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -454,7 +454,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
      * @throws Exception On any error.
      */
     @throws(classOf[Exception])
-    def handleChildChange(parentPath: String, children: java.util.List[String]) {
+    def handleChildChange(parentPath : String, children : java.util.List[String]) {
       inLock(controllerContext.controllerLock) {
         var topicsToBeDeleted = {
           import JavaConversions._
@@ -467,8 +467,8 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
           nonExistentTopics.foreach(topic => zkUtils.deletePathRecursive(getDeleteTopicPath(topic)))
         }
         topicsToBeDeleted --= nonExistentTopics
-        if(controller.config.deleteTopicEnable) {
-          if(topicsToBeDeleted.nonEmpty) {
+        if (controller.config.deleteTopicEnable) {
+          if (topicsToBeDeleted.nonEmpty) {
             info("Starting topic deletion for topics " + topicsToBeDeleted.mkString(","))
             // mark topic ineligible for deletion if other state changes are in progress
             topicsToBeDeleted.foreach { topic =>
@@ -476,7 +476,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
                 controllerContext.partitionsUndergoingPreferredReplicaElection.map(_.topic).contains(topic)
               val partitionReassignmentInProgress =
                 controllerContext.partitionsBeingReassigned.keySet.map(_.topic).contains(topic)
-              if(preferredReplicaElectionInProgress || partitionReassignmentInProgress)
+              if (preferredReplicaElectionInProgress || partitionReassignmentInProgress)
                 controller.deleteTopicManager.markTopicIneligibleForDeletion(Set(topic))
             }
             // add topic to deletion list
@@ -484,8 +484,10 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
           }
         } else {
           // If delete topic is disabled remove entries under zookeeper path : /admin/delete_topics
-          for(topic <- topicsToBeDeleted) {
-            controller.deleteTopicManager.cleanZkStateForDeleteTopic(topic)
+          for (topic <- topicsToBeDeleted) {
+            info("Removing " + getDeleteTopicPath(topic) + " since delete topic is disabled")
+            val zkUtils = controllerContext.zkUtils
+            zkUtils.zkClient.delete(getDeleteTopicPath(topic))
           }
         }
       }

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -86,8 +86,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
         zkUtils.zkClient.unsubscribeDataChanges(getTopicPath(topic), listener)
     }
     partitionModificationsListeners.clear()
-    if(controller.config.deleteTopicEnable)
-      deregisterDeleteTopicListener()
+    deregisterDeleteTopicListener()
   }
 
   /**

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -87,8 +87,16 @@ class TopicDeletionManager(controller: KafkaController,
   var deleteTopicsThread: DeleteTopicsThread = null
   val isDeleteTopicEnabled = controller.config.deleteTopicEnable
   val topicsToBeDeleted: mutable.Set[String] = mutable.Set.empty[String]
-  if (isDeleteTopicEnabled)
+  if (isDeleteTopicEnabled) {
     topicsToBeDeleted ++= initialTopicsToBeDeleted
+  }
+  else {
+    // if delete topic is disabled clean the topic entries under /admin/delete_topics
+    for (topic <- initialTopicsToBeDeleted) {
+      cleanZkStateForDeleteTopic(topic)
+    }
+  }
+
   val partitionsToBeDeleted: mutable.Set[TopicAndPartition] = topicsToBeDeleted.flatMap(controllerContext.partitionsForTopic)
 
   /**

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -90,7 +90,9 @@ class TopicDeletionManager(controller: KafkaController,
     // if delete topic is disabled clean the topic entries under /admin/delete_topics
     val zkUtils = controllerContext.zkUtils
     for (topic <- initialTopicsToBeDeleted) {
-      zkUtils.zkClient.delete(getDeleteTopicPath(topic))
+      val deleteTopicPath = getDeleteTopicPath(topic)
+      info("Removing " + deleteTopicPath + " since delete topic is disabled")
+      zkUtils.zkClient.delete(deleteTopicPath)
     }
     mutable.Set.empty[String]
   }

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -87,16 +87,14 @@ class TopicDeletionManager(controller: KafkaController,
   var deleteTopicsThread: DeleteTopicsThread = null
   val isDeleteTopicEnabled = controller.config.deleteTopicEnable
   val topicsToBeDeleted: mutable.Set[String] = mutable.Set.empty[String]
-  if (isDeleteTopicEnabled) {
+  if(isDeleteTopicEnabled) {
     topicsToBeDeleted ++= initialTopicsToBeDeleted
-  }
-  else {
+  } else {
     // if delete topic is disabled clean the topic entries under /admin/delete_topics
-    for (topic <- initialTopicsToBeDeleted) {
+    for(topic <- initialTopicsToBeDeleted) {
       cleanZkStateForDeleteTopic(topic)
     }
   }
-
   val partitionsToBeDeleted: mutable.Set[TopicAndPartition] = topicsToBeDeleted.flatMap(controllerContext.partitionsForTopic)
 
   /**

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -277,10 +277,10 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     servers.foreach(_.shutdown())
   }
 
-  private def createTestTopicAndCluster(topic: String, deleteTopicEnabled: String = "true"): Seq[KafkaServer] = {
+  private def createTestTopicAndCluster(topic: String, deleteTopicEnabled: Boolean = true): Seq[KafkaServer] = {
 
     val brokerConfigs = TestUtils.createBrokerConfigs(3, zkConnect, false)
-    brokerConfigs.foreach(p => p.setProperty("delete.topic.enable", deleteTopicEnabled)
+    brokerConfigs.foreach(p => p.setProperty("delete.topic.enable", deleteTopicEnabled.toString)
     )
     createTestTopicAndCluster(topic,brokerConfigs)
   }
@@ -314,7 +314,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     val topic = topicAndPartition.topic
 
     // creating a cluster with "delete.topic.enable" = "false"
-    val servers = createTestTopicAndCluster(topic, "false")
+    val servers = createTestTopicAndCluster(topic, false)
 
     // mark the topic for deletion
     AdminUtils.deleteTopic(zkUtils, "test")

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -309,7 +309,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
   }
 
   @Test
-  def testDeleteWhenDeleteTopicIsDisabled() {
+  def testDisableDeleteTopic() {
     val topicAndPartition = TopicAndPartition("test", 0)
     val topic = topicAndPartition.topic
 
@@ -321,12 +321,11 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     TestUtils.waitUntilTrue(() => !zkUtils.pathExists(getDeleteTopicPath(topic)),
       "Admin path /admin/delete_topic/%s path not deleted even if deleteTopic is disabled".format(topic))
     // verify that topic test is untouched
-    TestUtils.waitUntilTrue(() => servers.forall(_.getLogManager().getLog(topicAndPartition).isDefined),
-      "Replicas for topic test not created")
+    assertTrue(servers.forall(_.getLogManager().getLog(topicAndPartition).isDefined))
     // test the topic path exists
-    assertTrue("Topic test mistakenly deleted", zkUtils.pathExists(getTopicPath(topic)))
+    assertTrue("Topic path disappeared", zkUtils.pathExists(getTopicPath(topic)))
     // topic test should have a leader
-    val leaderIdOpt = TestUtils.waitUntilLeaderIsElectedOrChanged(zkUtils, topic, 0, 1000)
+    val leaderIdOpt = zkUtils.getLeaderForPartition(topic, 0)
     assertTrue("Leader should exist for topic test", leaderIdOpt.isDefined)
     servers.foreach(_.shutdown())
   }

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -312,10 +312,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
   def testDisableDeleteTopic() {
     val topicAndPartition = TopicAndPartition("test", 0)
     val topic = topicAndPartition.topic
-
-    // creating a cluster with "delete.topic.enable" = "false"
-    val servers = createTestTopicAndCluster(topic, false)
-
+    val servers = createTestTopicAndCluster(topic, deleteTopicEnabled = false)
     // mark the topic for deletion
     AdminUtils.deleteTopic(zkUtils, "test")
     TestUtils.waitUntilTrue(() => !zkUtils.pathExists(getDeleteTopicPath(topic)),


### PR DESCRIPTION
Remove topics under /admin/delete_topics path in zk if deleteTopic is disabled. The topic should never be enqueued for deletion.
