### PR TITLE
MINOR: Increment ducktape dependency

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -30,5 +30,5 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.3.8", "requests>=2.5.0"]
+      install_requires=["ducktape==0.3.9", "requests>=2.5.0"]
       )

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -30,5 +30,5 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.3.9", "requests>=2.5.0"]
+      install_requires=["ducktape==0.3.10", "requests>=2.5.0"]
       )


### PR DESCRIPTION
Pin kafka system tests to a newer version of ducktape.

Ran in branch builder; only one preexisting (transient) failure:
http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2016-02-01--001.1454333721--confluentinc--increment-ducktape-dependency--a40f474/report.html
