### PR TITLE
KAFKA-3197 Fix producer sending records out of order

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -287,7 +287,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             this.sender = new Sender(client,
                     this.metadata,
                     this.accumulator,
-                    // We treat max.in.flight.request.per.connection as user expects reordering protection.
                     config.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION) == 1,
                     config.getInt(ProducerConfig.MAX_REQUEST_SIZE_CONFIG),
                     (short) parseAcks(config.getString(ProducerConfig.ACKS_CONFIG)),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -287,7 +287,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             this.sender = new Sender(client,
                     this.metadata,
                     this.accumulator,
-                    config.getBoolean(ProducerConfig.SEND_IN_ORDER_CONFIG),
+                    // We treat max.in.flight.request.per.connection as user expects reordering protection.
+                    config.getInt(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION) == 1,
                     config.getInt(ProducerConfig.MAX_REQUEST_SIZE_CONFIG),
                     (short) parseAcks(config.getString(ProducerConfig.ACKS_CONFIG)),
                     config.getInt(ProducerConfig.RETRIES_CONFIG),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -287,6 +287,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             this.sender = new Sender(client,
                     this.metadata,
                     this.accumulator,
+                    config.getBoolean(ProducerConfig.SEND_IN_ORDER_CONFIG),
                     config.getInt(ProducerConfig.MAX_REQUEST_SIZE_CONFIG),
                     (short) parseAcks(config.getString(ProducerConfig.ACKS_CONFIG)),
                     config.getInt(ProducerConfig.RETRIES_CONFIG),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -260,14 +260,20 @@ public final class RecordAccumulator {
      * partition will be ready; Also return the flag for whether there are any unknown leaders for the accumulated
      * partition batches.
      * <p>
-     * A destination node is ready to send data if ANY one of its partition is not backing off the send and is not muted
-     * and ANY of the followings are true :
+     * A destination node is ready to send data if:
      * <ol>
-     * <li>The record set is full
-     * <li>The record set has sat in the accumulator for at least lingerMs milliseconds
-     * <li>The accumulator is out of memory and threads are blocking waiting for data (in this case all partitions are
-     * immediately considered ready).
-     * <li>The accumulator has been closed
+     * <li>There is at least one partition that is not backing off its send
+     * <li><b>and</b> those partitions are not muted (to prevent reordering if
+     *   {@value org.apache.kafka.clients.producer.ProducerConfig#MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION}
+     *   is set to one)</li>
+     * <li><b>and <i>any</i></b> of the following are true</li>
+     * <ul>
+     *     <li>The record set is full</li>
+     *     <li>The record set has sat in the accumulator for at least lingerMs milliseconds</li>
+     *     <li>The accumulator is out of memory and threads are blocking waiting for data (in this case all partitions
+     *     are immediately considered ready).</li>
+     *     <li>The accumulator has been closed</li>
+     * </ul>
      * </ol>
      */
     public ReadyCheckResult ready(Cluster cluster, long nowMs) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -59,7 +59,6 @@ public final class RecordAccumulator {
     private static final Logger log = LoggerFactory.getLogger(RecordAccumulator.class);
 
     private volatile boolean closed;
-    private int drainIndex;
     private final AtomicInteger flushesInProgress;
     private final AtomicInteger appendsInProgress;
     private final int batchSize;
@@ -70,7 +69,9 @@ public final class RecordAccumulator {
     private final Time time;
     private final ConcurrentMap<TopicPartition, Deque<RecordBatch>> batches;
     private final IncompleteRecordBatches incomplete;
+    // The following variables are only accessed by the sender thread, so we don't need to protect them.
     private final Set<TopicPartition> muted;
+    private int drainIndex;
 
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -260,8 +260,8 @@ public final class RecordAccumulator {
      * partition will be ready; Also return the flag for whether there are any unknown leaders for the accumulated
      * partition batches.
      * <p>
-     * A destination node is ready to send data if ANY one of its partition is not backing off the send and has no
-     * in flight batches and ANY of the following are true :
+     * A destination node is ready to send data if ANY one of its partition is not backing off the send and is not muted
+     * and ANY of the followings are true :
      * <ol>
      * <li>The record set is full
      * <li>The record set has sat in the accumulator for at least lingerMs milliseconds
@@ -283,7 +283,7 @@ public final class RecordAccumulator {
             Node leader = cluster.leaderFor(part);
             if (leader == null) {
                 unknownLeadersExist = true;
-            } else if (!readyNodes.contains(leader) && (!muted.contains(part))) {
+            } else if (!readyNodes.contains(leader) && !muted.contains(part)) {
                 synchronized (deque) {
                     RecordBatch batch = deque.peekFirst();
                     if (batch != null) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -67,8 +67,8 @@ public class Sender implements Runnable {
     /* the metadata for the client */
     private final Metadata metadata;
 
-    /* the flag indicating whether the producer should send messages in order or not. */
-    private final boolean sendInOrder;
+    /* the flag indicating whether the producer should guarantee the message order on the broker or not. */
+    private final boolean guaranteeMessageOrder;
 
     /* the maximum request size to attempt to send to the server */
     private final int maxRequestSize;
@@ -100,7 +100,7 @@ public class Sender implements Runnable {
     public Sender(KafkaClient client,
                   Metadata metadata,
                   RecordAccumulator accumulator,
-                  boolean sendInOrder,
+                  boolean guaranteeMessageOrder,
                   int maxRequestSize,
                   short acks,
                   int retries,
@@ -111,7 +111,7 @@ public class Sender implements Runnable {
         this.client = client;
         this.accumulator = accumulator;
         this.metadata = metadata;
-        this.sendInOrder = sendInOrder;
+        this.guaranteeMessageOrder = guaranteeMessageOrder;
         this.maxRequestSize = maxRequestSize;
         this.running = true;
         this.acks = acks;
@@ -194,7 +194,7 @@ public class Sender implements Runnable {
                                                                          result.readyNodes,
                                                                          this.maxRequestSize,
                                                                          now);
-        if (sendInOrder) {
+        if (guaranteeMessageOrder) {
             // Mute all the partitions drained
             for (List<RecordBatch> batchList : batches.values()) {
                 for (RecordBatch batch : batchList)
@@ -317,7 +317,7 @@ public class Sender implements Runnable {
         if (error.exception() instanceof InvalidMetadataException)
             metadata.requestUpdate();
         // Unmute the completed partition.
-        if (sendInOrder)
+        if (guaranteeMessageOrder)
             this.accumulator.unmutePartition(batch.topicPartition);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -67,7 +67,7 @@ public class Sender implements Runnable {
     /* the metadata for the client */
     private final Metadata metadata;
 
-    /* the map tracks the number of batch in progress for each partition. */
+    /* the flag indicating whether the producer should send messages in order or not. */
     private final boolean sendInOrder;
 
     /* the maximum request size to attempt to send to the server */
@@ -196,8 +196,8 @@ public class Sender implements Runnable {
                                                                          now);
         if (sendInOrder) {
             // Mute all the partitions drained
-            for (Map.Entry<Integer, List<RecordBatch>> entry : batches.entrySet()) {
-                for (RecordBatch batch : entry.getValue())
+            for (List<RecordBatch> batchList : batches.values()) {
+                for (RecordBatch batch : batchList)
                     this.accumulator.mutePartition(batch.topicPartition);
             }
         }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -15,7 +15,6 @@ package org.apache.kafka.clients.producer.internals;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer;
@@ -335,7 +334,7 @@ public class RecordAccumulatorTest {
         // Test ready without muted partition
         accum.unmutePartition(tp1);
         result = accum.ready(cluster, time.milliseconds());
-        assertNotEquals("The batch should be ready", 0, result.readyNodes.size());
+        assertTrue("The batch should be ready", result.readyNodes.size() > 0);
 
         // Test drain with muted partition
         accum.mutePartition(tp1);
@@ -345,6 +344,6 @@ public class RecordAccumulatorTest {
         // Test drain without muted partition.
         accum.unmutePartition(tp1);
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertNotEquals("No batch should have been drained.", 0, drained.get(node1.id()).size());
+        assertTrue("The batch should have been drained.", drained.get(node1.id()).size() > 0);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -77,12 +77,12 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, 10L, 100L, metrics, time);
         int appends = 1024 / msgSize;
         for (int i = 0; i < appends; i++) {
-            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, null, now).readyNodes.size());
+            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
         }
-        accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, null, time.milliseconds()).readyNodes);
-        List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, null, 0).get(node1.id());
+        accum.append(tp1, key, value, null, maxBlockTimeMs);
+        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, 0).get(node1.id());
         assertEquals(1, batches.size());
         RecordBatch batch = batches.get(0);
 
@@ -99,19 +99,19 @@ public class RecordAccumulatorTest {
     public void testAppendLarge() throws Exception {
         int batchSize = 512;
         RecordAccumulator accum = new RecordAccumulator(batchSize, 10 * 1024, CompressionType.NONE, 0L, 100L, metrics, time);
-        accum.append(tp1, 0L, key, new byte[2 * batchSize], null, maxBlockTimeMs);
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, null, time.milliseconds()).readyNodes);
+        accum.append(tp1, key, new byte[2 * batchSize], null, maxBlockTimeMs);
+        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
     }
 
     @Test
     public void testLinger() throws Exception {
         long lingerMs = 10L;
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, lingerMs, 100L, metrics, time);
-        accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-        assertEquals("No partitions should be ready", 0, accum.ready(cluster, null, time.milliseconds()).readyNodes.size());
+        accum.append(tp1, key, value, null, maxBlockTimeMs);
+        assertEquals("No partitions should be ready", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
         time.sleep(10);
-        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, null, time.milliseconds()).readyNodes);
-        List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, null, 0).get(node1.id());
+        assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
+        List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, 0).get(node1.id());
         assertEquals(1, batches.size());
         RecordBatch batch = batches.get(0);
 
@@ -131,9 +131,9 @@ public class RecordAccumulatorTest {
             for (int i = 0; i < appends; i++)
                 accum.append(tp, 0L, key, value, null, maxBlockTimeMs);
         }
-        assertEquals("Partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, null, time.milliseconds()).readyNodes);
+        assertEquals("Partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
 
-        List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), 1024, null, 0).get(node1.id());
+        List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), 1024, 0).get(node1.id());
         assertEquals("But due to size bound only one partition should have been retrieved", 1, batches.size());
     }
 
@@ -163,8 +163,8 @@ public class RecordAccumulatorTest {
         int read = 0;
         long now = time.milliseconds();
         while (read < numThreads * msgs) {
-            Set<Node> nodes = accum.ready(cluster, null, now).readyNodes;
-            List<RecordBatch> batches = accum.drain(cluster, nodes, 5 * 1024, null, 0).get(node1.id());
+            Set<Node> nodes = accum.ready(cluster, now).readyNodes;
+            List<RecordBatch> batches = accum.drain(cluster, nodes, 5 * 1024, 0).get(node1.id());
             if (batches != null) {
                 for (RecordBatch batch : batches) {
                     for (LogEntry entry : batch.records)
@@ -189,8 +189,8 @@ public class RecordAccumulatorTest {
 
         // Partition on node1 only
         for (int i = 0; i < appends; i++)
-            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, null, time.milliseconds());
+            accum.append(tp1, key, value, null, maxBlockTimeMs);
+        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
         assertEquals("Next check time should be the linger time", lingerMs, result.nextReadyCheckDelayMs);
 
@@ -198,15 +198,15 @@ public class RecordAccumulatorTest {
 
         // Add partition on node2 only
         for (int i = 0; i < appends; i++)
-            accum.append(tp3, 0L, key, value, null, maxBlockTimeMs);
-        result = accum.ready(cluster, null, time.milliseconds());
+            accum.append(tp3, key, value, null, maxBlockTimeMs);
+        result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
         assertEquals("Next check time should be defined by node1, half remaining linger time", lingerMs / 2, result.nextReadyCheckDelayMs);
 
         // Add data for another partition on node1, enough to make data sendable immediately
         for (int i = 0; i < appends + 1; i++)
-            accum.append(tp2, 0L, key, value, null, maxBlockTimeMs);
-        result = accum.ready(cluster, null, time.milliseconds());
+            accum.append(tp2, key, value, null, maxBlockTimeMs);
+        result = accum.ready(cluster, time.milliseconds());
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
         // Note this can actually be < linger time because it may use delays from partitions that aren't sendable
         // but have leaders with other sendable data.
@@ -220,10 +220,10 @@ public class RecordAccumulatorTest {
         final RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, lingerMs, retryBackoffMs, metrics, time);
 
         long now = time.milliseconds();
-        accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, null, now + lingerMs + 1);
+        accum.append(tp1, key, value, null, maxBlockTimeMs);
+        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, now + lingerMs + 1);
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
-        Map<Integer, List<RecordBatch>> batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, null, now + lingerMs + 1);
+        Map<Integer, List<RecordBatch>> batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + lingerMs + 1);
         assertEquals("Node1 should be the only ready node.", 1, batches.size());
         assertEquals("Partition 0 should only have one batch drained.", 1, batches.get(0).size());
 
@@ -232,20 +232,20 @@ public class RecordAccumulatorTest {
         accum.reenqueue(batches.get(0).get(0), now);
 
         // Put message for partition 1 into accumulator
-        accum.append(tp2, 0L, key, value, null, maxBlockTimeMs);
-        result = accum.ready(cluster, null, now + lingerMs + 1);
+        accum.append(tp2, key, value, null, maxBlockTimeMs);
+        result = accum.ready(cluster, now + lingerMs + 1);
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
 
         // tp1 should backoff while tp2 should not
-        batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, null, now + lingerMs + 1);
+        batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + lingerMs + 1);
         assertEquals("Node1 should be the only ready node.", 1, batches.size());
         assertEquals("Node1 should only have one batch drained.", 1, batches.get(0).size());
         assertEquals("Node1 should only have one batch for partition 1.", tp2, batches.get(0).get(0).topicPartition);
 
         // Partition 0 can be drained after retry backoff
-        result = accum.ready(cluster, null, now + retryBackoffMs + 1);
+        result = accum.ready(cluster, now + retryBackoffMs + 1);
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
-        batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, null, now + retryBackoffMs + 1);
+        batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + retryBackoffMs + 1);
         assertEquals("Node1 should be the only ready node.", 1, batches.size());
         assertEquals("Node1 should only have one batch drained.", 1, batches.get(0).size());
         assertEquals("Node1 should only have one batch for partition 0.", tp1, batches.get(0).get(0).topicPartition);
@@ -256,15 +256,15 @@ public class RecordAccumulatorTest {
         long lingerMs = Long.MAX_VALUE;
         final RecordAccumulator accum = new RecordAccumulator(4 * 1024, 64 * 1024, CompressionType.NONE, lingerMs, 100L, metrics, time);
         for (int i = 0; i < 100; i++)
-            accum.append(new TopicPartition(topic, i % 3), 0L, key, value, null, maxBlockTimeMs);
-        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, null, time.milliseconds());
+            accum.append(new TopicPartition(topic, i % 3), key, value, null, maxBlockTimeMs);
+        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
         
         accum.beginFlush();
-        result = accum.ready(cluster, null, time.milliseconds());
+        result = accum.ready(cluster, time.milliseconds());
         
         // drain and deallocate all batches
-        Map<Integer, List<RecordBatch>> results = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, null, time.milliseconds());
+        Map<Integer, List<RecordBatch>> results = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
         for (List<RecordBatch> batches: results.values())
             for (RecordBatch batch: batches)
                 accum.deallocate(batch);
@@ -287,8 +287,8 @@ public class RecordAccumulatorTest {
             }
         }
         for (int i = 0; i < 100; i++)
-            accum.append(new TopicPartition(topic, i % 3), 0L, key, value, new TestCallback(), maxBlockTimeMs);
-        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, null, time.milliseconds());
+            accum.append(new TopicPartition(topic, i % 3), key, value, new TestCallback(), maxBlockTimeMs);
+        RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
 
         accum.abortIncompleteBatches();
@@ -303,13 +303,13 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, 10, 100L, metrics, time);
         int appends = 1024 / msgSize;
         for (int i = 0; i < appends; i++) {
-            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, null, now).readyNodes.size());
+            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
         }
         time.sleep(2000);
-        accum.ready(cluster, null, now);
-        accum.append(tp1, 0L, key, value, null, 0);
-        Set<Node> readyNodes = accum.ready(cluster, null, time.milliseconds()).readyNodes;
+        accum.ready(cluster, now);
+        accum.append(tp1, key, value, null, 0);
+        Set<Node> readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
         assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
         Cluster cluster = new Cluster(new ArrayList<Node>(), new ArrayList<PartitionInfo>(), Collections.<String>emptySet());
         now = time.milliseconds();
@@ -323,8 +323,8 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, 10, 100L, metrics, time);
         int appends = 1024 / msgSize;
         for (int i = 0; i < appends; i++) {
-            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
-            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, null, now).readyNodes.size());
+            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
         }
         time.sleep(2000);
         Set<TopicPartition> partitionsSendInProgress = new HashSet<>();
@@ -335,7 +335,7 @@ public class RecordAccumulatorTest {
         assertEquals("No node should be ready", 0, result.readyNodes.size());
 
         // Test ready without partition with batch in flight
-        result = accum.ready(cluster, null, time.milliseconds());
+        result = accum.ready(cluster, time.milliseconds());
         assertNotEquals("The batch should be ready", 0, result.readyNodes.size());
 
         // Test drain for partition with batch in flight.
@@ -343,7 +343,7 @@ public class RecordAccumulatorTest {
         assertEquals("There should be no batch drained.", 0, drained.get(node1.id()).size());
 
         // Test drain for partition without batch in flight.
-        drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, null, time.milliseconds());
+        drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
         assertNotEquals("There should be no batch drained.", 0, drained.get(node1.id()).size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -76,10 +76,10 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, 10L, 100L, metrics, time);
         int appends = 1024 / msgSize;
         for (int i = 0; i < appends; i++) {
-            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
             assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
         }
-        accum.append(tp1, key, value, null, maxBlockTimeMs);
+        accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
         assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
         List<RecordBatch> batches = accum.drain(cluster, Collections.singleton(node1), Integer.MAX_VALUE, 0).get(node1.id());
         assertEquals(1, batches.size());
@@ -98,7 +98,7 @@ public class RecordAccumulatorTest {
     public void testAppendLarge() throws Exception {
         int batchSize = 512;
         RecordAccumulator accum = new RecordAccumulator(batchSize, 10 * 1024, CompressionType.NONE, 0L, 100L, metrics, time);
-        accum.append(tp1, key, new byte[2 * batchSize], null, maxBlockTimeMs);
+        accum.append(tp1, 0L, key, new byte[2 * batchSize], null, maxBlockTimeMs);
         assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
     }
 
@@ -106,7 +106,7 @@ public class RecordAccumulatorTest {
     public void testLinger() throws Exception {
         long lingerMs = 10L;
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, lingerMs, 100L, metrics, time);
-        accum.append(tp1, key, value, null, maxBlockTimeMs);
+        accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
         assertEquals("No partitions should be ready", 0, accum.ready(cluster, time.milliseconds()).readyNodes.size());
         time.sleep(10);
         assertEquals("Our partition's leader should be ready", Collections.singleton(node1), accum.ready(cluster, time.milliseconds()).readyNodes);
@@ -188,7 +188,7 @@ public class RecordAccumulatorTest {
 
         // Partition on node1 only
         for (int i = 0; i < appends; i++)
-            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
         assertEquals("Next check time should be the linger time", lingerMs, result.nextReadyCheckDelayMs);
@@ -197,14 +197,14 @@ public class RecordAccumulatorTest {
 
         // Add partition on node2 only
         for (int i = 0; i < appends; i++)
-            accum.append(tp3, key, value, null, maxBlockTimeMs);
+            accum.append(tp3, 0L, key, value, null, maxBlockTimeMs);
         result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
         assertEquals("Next check time should be defined by node1, half remaining linger time", lingerMs / 2, result.nextReadyCheckDelayMs);
 
         // Add data for another partition on node1, enough to make data sendable immediately
         for (int i = 0; i < appends + 1; i++)
-            accum.append(tp2, key, value, null, maxBlockTimeMs);
+            accum.append(tp2, 0L, key, value, null, maxBlockTimeMs);
         result = accum.ready(cluster, time.milliseconds());
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
         // Note this can actually be < linger time because it may use delays from partitions that aren't sendable
@@ -219,7 +219,7 @@ public class RecordAccumulatorTest {
         final RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, lingerMs, retryBackoffMs, metrics, time);
 
         long now = time.milliseconds();
-        accum.append(tp1, key, value, null, maxBlockTimeMs);
+        accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, now + lingerMs + 1);
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
         Map<Integer, List<RecordBatch>> batches = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, now + lingerMs + 1);
@@ -231,7 +231,7 @@ public class RecordAccumulatorTest {
         accum.reenqueue(batches.get(0).get(0), now);
 
         // Put message for partition 1 into accumulator
-        accum.append(tp2, key, value, null, maxBlockTimeMs);
+        accum.append(tp2, 0L, key, value, null, maxBlockTimeMs);
         result = accum.ready(cluster, now + lingerMs + 1);
         assertEquals("Node1 should be ready", Collections.singleton(node1), result.readyNodes);
 
@@ -255,7 +255,7 @@ public class RecordAccumulatorTest {
         long lingerMs = Long.MAX_VALUE;
         final RecordAccumulator accum = new RecordAccumulator(4 * 1024, 64 * 1024, CompressionType.NONE, lingerMs, 100L, metrics, time);
         for (int i = 0; i < 100; i++)
-            accum.append(new TopicPartition(topic, i % 3), key, value, null, maxBlockTimeMs);
+            accum.append(new TopicPartition(topic, i % 3), 0L, key, value, null, maxBlockTimeMs);
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
         
@@ -286,7 +286,7 @@ public class RecordAccumulatorTest {
             }
         }
         for (int i = 0; i < 100; i++)
-            accum.append(new TopicPartition(topic, i % 3), key, value, new TestCallback(), maxBlockTimeMs);
+            accum.append(new TopicPartition(topic, i % 3), 0L, key, value, new TestCallback(), maxBlockTimeMs);
         RecordAccumulator.ReadyCheckResult result = accum.ready(cluster, time.milliseconds());
         assertEquals("No nodes should be ready.", 0, result.readyNodes.size());
 
@@ -302,12 +302,12 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, 10, 100L, metrics, time);
         int appends = 1024 / msgSize;
         for (int i = 0; i < appends; i++) {
-            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
             assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
         }
         time.sleep(2000);
         accum.ready(cluster, now);
-        accum.append(tp1, key, value, null, 0);
+        accum.append(tp1, 0L, key, value, null, 0);
         Set<Node> readyNodes = accum.ready(cluster, time.milliseconds()).readyNodes;
         assertEquals("Our partition's leader should be ready", Collections.singleton(node1), readyNodes);
         Cluster cluster = new Cluster(new ArrayList<Node>(), new ArrayList<PartitionInfo>(), Collections.<String>emptySet());
@@ -322,7 +322,7 @@ public class RecordAccumulatorTest {
         RecordAccumulator accum = new RecordAccumulator(1024, 10 * 1024, CompressionType.NONE, 10, 100L, metrics, time);
         int appends = 1024 / msgSize;
         for (int i = 0; i < appends; i++) {
-            accum.append(tp1, key, value, null, maxBlockTimeMs);
+            accum.append(tp1, 0L, key, value, null, maxBlockTimeMs);
             assertEquals("No partitions should be ready.", 0, accum.ready(cluster, now).readyNodes.size());
         }
         time.sleep(2000);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordAccumulatorTest.java
@@ -340,11 +340,11 @@ public class RecordAccumulatorTest {
         // Test drain with muted partition
         accum.mutePartition(tp1);
         Map<Integer, List<RecordBatch>> drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertEquals("There should be no batch drained.", 0, drained.get(node1.id()).size());
+        assertEquals("No batch should have been drained", 0, drained.get(node1.id()).size());
 
         // Test drain without muted partition.
         accum.unmutePartition(tp1);
         drained = accum.drain(cluster, result.readyNodes, Integer.MAX_VALUE, time.milliseconds());
-        assertNotEquals("There should be no batch drained.", 0, drained.get(node1.id()).size());
+        assertNotEquals("No batch should have been drained.", 0, drained.get(node1.id()).size());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -219,9 +219,7 @@ public class SenderTest {
         // Update metadata before sender receives response from broker 0. Now partition 2 moves to broker 0
         Cluster cluster2 = TestUtils.singletonCluster("test", 2);
         metadata.update(cluster2, time.milliseconds());
-        // Sender should not send the second message to node 0. Try twice to make sure.
-        sender.run(time.milliseconds());
-        assertEquals(1, client.inFlightRequestCount());
+        // Sender should not send the second message to node 0.
         sender.run(time.milliseconds());
         assertEquals(1, client.inFlightRequestCount());
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -185,43 +185,47 @@ public class SenderTest {
     public void testSendInOrder() throws Exception {
         int maxRetries = 1;
         Metrics m = new Metrics();
-        Sender sender = new Sender(client,
-                                   metadata,
-                                   this.accumulator,
-                                   true,
-                                   MAX_REQUEST_SIZE,
-                                   ACKS_ALL,
-                                   maxRetries,
-                                   m,
-                                   time,
-                                   "clientId",
-                                   REQUEST_TIMEOUT);
+        try {
+            Sender sender = new Sender(client,
+                metadata,
+                this.accumulator,
+                true,
+                MAX_REQUEST_SIZE,
+                ACKS_ALL,
+                maxRetries,
+                m,
+                time,
+                "clientId",
+                REQUEST_TIMEOUT);
 
-        // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
-        Cluster cluster1 = TestUtils.clusterWith(2, "test", 2);
-        metadata.update(cluster1, time.milliseconds());
+            // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
+            Cluster cluster1 = TestUtils.clusterWith(2, "test", 2);
+            metadata.update(cluster1, time.milliseconds());
 
-        // Send the first message.
-        TopicPartition tp2 = new TopicPartition("test", 1);
-        accumulator.append(tp2, 0L, "key1".getBytes(), "value1".getBytes(), null, MAX_BLOCK_TIMEOUT);
-        sender.run(time.milliseconds()); // connect
-        sender.run(time.milliseconds()); // send produce request
-        String id = client.requests().peek().request().destination();
-        assertEquals(ApiKeys.PRODUCE.id, client.requests().peek().request().header().apiKey());
-        Node node = new Node(Integer.valueOf(id), "localhost", 0);
-        assertEquals(1, client.inFlightRequestCount());
-        assertTrue("Client ready status should be true", client.isReady(node, 0L));
+            // Send the first message.
+            TopicPartition tp2 = new TopicPartition("test", 1);
+            accumulator.append(tp2, 0L, "key1".getBytes(), "value1".getBytes(), null, MAX_BLOCK_TIMEOUT);
+            sender.run(time.milliseconds()); // connect
+            sender.run(time.milliseconds()); // send produce request
+            String id = client.requests().peek().request().destination();
+            assertEquals(ApiKeys.PRODUCE.id, client.requests().peek().request().header().apiKey());
+            Node node = new Node(Integer.valueOf(id), "localhost", 0);
+            assertEquals(1, client.inFlightRequestCount());
+            assertTrue("Client ready status should be true", client.isReady(node, 0L));
 
-        time.sleep(900);
-        // Now send another message to tp2
-        accumulator.append(tp2, 0L, "key2".getBytes(), "value2".getBytes(), null, MAX_BLOCK_TIMEOUT);
+            time.sleep(900);
+            // Now send another message to tp2
+            accumulator.append(tp2, 0L, "key2".getBytes(), "value2".getBytes(), null, MAX_BLOCK_TIMEOUT);
 
-        // Update metadata before sender receives response from broker 0. Now partition 2 moves to broker 0
-        Cluster cluster2 = TestUtils.singletonCluster("test", 2);
-        metadata.update(cluster2, time.milliseconds());
-        // Sender should not send the second message to node 0.
-        sender.run(time.milliseconds());
-        assertEquals(1, client.inFlightRequestCount());
+            // Update metadata before sender receives response from broker 0. Now partition 2 moves to broker 0
+            Cluster cluster2 = TestUtils.singletonCluster("test", 2);
+            metadata.update(cluster2, time.milliseconds());
+            // Sender should not send the second message to node 0.
+            sender.run(time.milliseconds());
+            assertEquals(1, client.inFlightRequestCount());
+        } finally {
+            m.close();
+        }
 
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -203,7 +203,7 @@ public class SenderTest {
 
         // Send the first message.
         TopicPartition tp2 = new TopicPartition("test", 1);
-        accumulator.append(tp2, "key1".getBytes(), "value1".getBytes(), null, MAX_BLOCK_TIMEOUT);
+        accumulator.append(tp2, 0L, "key1".getBytes(), "value1".getBytes(), null, MAX_BLOCK_TIMEOUT);
         sender.run(time.milliseconds()); // connect
         sender.run(time.milliseconds()); // send produce request
         String id = client.requests().peek().request().destination();
@@ -214,7 +214,7 @@ public class SenderTest {
 
         time.sleep(900);
         // Now send another message to tp2
-        accumulator.append(tp2, "key2".getBytes(), "value2".getBytes(), null, MAX_BLOCK_TIMEOUT);
+        accumulator.append(tp2, 0L, "key2".getBytes(), "value2".getBytes(), null, MAX_BLOCK_TIMEOUT);
 
         // Update metadata before sender receives response from broker 0. Now partition 2 moves to broker 0
         Cluster cluster2 = TestUtils.singletonCluster("test", 2);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.CompressionType;
@@ -75,6 +76,7 @@ public class SenderTest {
         sender = new Sender(client,
                             metadata,
                             this.accumulator,
+                            true,
                             MAX_REQUEST_SIZE,
                             ACKS_ALL,
                             MAX_RETRIES,
@@ -134,6 +136,7 @@ public class SenderTest {
             Sender sender = new Sender(client,
                                        metadata,
                                        this.accumulator,
+                                       false,
                                        MAX_REQUEST_SIZE,
                                        ACKS_ALL,
                                        maxRetries,
@@ -176,6 +179,76 @@ public class SenderTest {
         } finally {
             m.close();
         }
+    }
+
+    @Test
+    public void testSendInOrder() throws Exception {
+        int maxRetries = 1;
+        Metrics m = new Metrics();
+        Sender sender = new Sender(client,
+                                   metadata,
+                                   this.accumulator,
+                                   true,
+                                   MAX_REQUEST_SIZE,
+                                   ACKS_ALL,
+                                   maxRetries,
+                                   m,
+                                   time,
+                                   "clientId",
+                                   REQUEST_TIMEOUT);
+
+        // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
+        Cluster cluster1 = TestUtils.clusterWith(2, "test", 2);
+        metadata.update(cluster1, time.milliseconds());
+
+        // Send the first message.
+        TopicPartition tp2 = new TopicPartition("test", 1);
+        Future<RecordMetadata> future0 = accumulator.append(tp2, "key1".getBytes(), "value1".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
+        sender.run(time.milliseconds()); // connect
+        sender.run(time.milliseconds()); // send produce request
+        String id = client.requests().peek().request().destination();
+        assertEquals(ApiKeys.PRODUCE.id, client.requests().peek().request().header().apiKey());
+        Node node = new Node(Integer.valueOf(id), "localhost", 0);
+        assertEquals("The request should be sent to node 1", 1, node.id());
+        assertEquals(1, client.inFlightRequestCount());
+        assertTrue("Client ready status should be true", client.isReady(node, 0L));
+
+        time.sleep(900);
+        // Now send another message to tp2
+        Future<RecordMetadata> future1 = accumulator.append(tp2, "key2".getBytes(), "value2".getBytes(), null, MAX_BLOCK_TIMEOUT).future;
+
+        // Update metadata before sender receives response from broker 0. Now partition 2 moves to broker 0
+        Cluster cluster2 = TestUtils.singletonCluster("test", 2);
+        metadata.update(cluster2, time.milliseconds());
+        // Sender should not send the second message to node 1.
+        sender.run(time.milliseconds());
+        assertEquals(1, client.inFlightRequestCount());
+        sender.run(time.milliseconds());
+        assertEquals(1, client.inFlightRequestCount());
+        sender.run(time.milliseconds());
+        assertEquals(1, client.inFlightRequestCount());
+        // Sleep a while so we hit request timeout.
+        time.sleep(900);
+        client.respond(produceResponse(tp2, -1L, Errors.REQUEST_TIMED_OUT.code(), 0));
+        sender.run(time.milliseconds()); // Request timeout and disconnect
+
+        // Now send the first message
+        sender.run(time.milliseconds()); // Send first message
+        assertEquals(1, client.inFlightRequestCount()); // Mock client does not clean up inflight request.
+        assertEquals("Should be sending to node 0", 0, Integer.parseInt(client.requests().peek().request().destination()));
+        client.respond(produceResponse(tp2, 0L, Errors.NONE.code(), 0));
+        sender.run(time.milliseconds()); // receive first response
+        assertTrue(future0.isDone());
+        assertEquals(0L, future0.get().offset());
+        assertFalse(future1.isDone());
+
+        sender.run(time.milliseconds()); // Send second message
+        assertEquals(1, client.inFlightRequestCount());
+        assertEquals("Should be sending to node 0", 0, Integer.parseInt(client.requests().peek().request().destination()));
+        client.respond(produceResponse(tp2, 1L, Errors.NONE.code(), 0));
+        sender.run(time.milliseconds()); // Receive second response
+        assertTrue(future1.isDone());
+        assertEquals(1L, future1.get().offset());
     }
 
     private void completedWithError(Future<RecordMetadata> future, Errors error) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -52,7 +52,7 @@ public class TestUtils {
     public static Cluster clusterWith(int nodes, String topic, int partitions) {
         Node[] ns = new Node[nodes];
         for (int i = 0; i < nodes; i++)
-            ns[i] = new Node(0, "localhost", 1969);
+            ns[i] = new Node(i, "localhost", 1969);
         List<PartitionInfo> parts = new ArrayList<PartitionInfo>();
         for (int i = 0; i < partitions; i++)
             parts.add(new PartitionInfo(topic, i, ns[i % ns.length], ns, ns));


### PR DESCRIPTION
This patch reuse max.in.flight.request.per.connection. When it equals to one, we take it as user wants order protection. The current approach is make sure there is only one batch per partition on the fly.
