### PR TITLE
KAFKA-3199: LoginManager should allow using an existing Subject

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/Login.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/Login.java
@@ -103,7 +103,7 @@ public class Login {
         this.lastLogin = currentElapsedTime();
         login = login(loginContextName);
         subject = login.getSubject();
-        isKrbTicket = !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
+        isKrbTicket = getTGT() != null;
 
         AppConfigurationEntry[] entries = Configuration.getConfiguration().getAppConfigurationEntry(loginContextName);
         if (entries.length == 0) {


### PR DESCRIPTION
One possible solution which doesn't require a new configuration parameter:
But it assumes that if there is already a Subject you want to use its existing credentials, and not login from another keytab specified by kafka_client_jaas.conf.

Because this makes the jaas.conf no longer required, a missing KafkaClient context is no longer an error, but merely a warning.
