### PR TITLE
MINOR: Removed unnecessary Vagrantfile hack

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,24 +53,6 @@ if File.exists?(local_config_file) then
   eval(File.read(local_config_file), binding, "Vagrantfile.local")
 end
 
-# This is a horrible hack to work around bad interactions between
-# vagrant-hostmanager and vagrant-aws/vagrant's implementation. Hostmanager
-# wants to update the /etc/hosts entries, but tries to do so even on nodes that
-# aren't up (e.g. even when all nodes are stopped and you run vagrant
-# destroy). Because of the way the underlying code in vagrant works, it still
-# tries to communicate with the node and has to wait for a very long
-# timeout. This modifies the update to check for hosts that are not created or
-# stopped, skipping the update in that case since it's impossible to update
-# nodes in that state.
-Object.const_get("VagrantPlugins").const_get("HostManager").const_get("HostsFile").class_eval do
-  def update_guest(machine)
-    state_id = machine.state.id
-    return if state_id == :not_created || state_id == :stopped
-    old_update_guest(machine)
-  end
-  alias_method :old_update_guest, :update_guest
-end
-
 # TODO(ksweeney): RAM requirements are not empirical and can probably be significantly lowered.
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.hostmanager.enabled = true

--- a/tests/bootstrap-test-env.sh
+++ b/tests/bootstrap-test-env.sh
@@ -46,17 +46,9 @@ if [ "x$bad_vagrant" == "xtrue" -o "x$bad_vb" == "xtrue" ]; then
 fi
 
 echo "Checking for necessary Vagrant plugins..."
-install_hostmanager=false
 hostmanager_version=`vagrant plugin list | grep vagrant-hostmanager | egrep -o "[0-9]+\.[0-9]+\.[0-9]+"`
 if [ -z "$hostmanager_version"  ]; then
-    install_hostmanager=true
-elif [ "$hostmanager_version" != "1.5.0" ]; then
-    echo "You have the wrong version of vagrant plugin vagrant-hostmanager. Uninstalling..."
-    vagrant plugin uninstall vagrant-hostmanager
-    install_hostmanager=true
-fi
-if [ "x$install_hostmanager" == "xtrue" ]; then
-    vagrant plugin install vagrant-hostmanager --plugin-version 1.5.0
+    vagrant plugin install vagrant-hostmanager
 fi
 
 echo "Creating and packaging a reusable base box for Vagrant..."

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -6,8 +6,7 @@ Using Vagrant to get up and running.
 2) Install Vagrant >= 1.6.4 [http://www.vagrantup.com/](http://www.vagrantup.com/)
 3) Install Vagrant Plugins:
 
-    # Required (1.5.0 or 1.4 currently required due to implementation changes in the plugin)
-    $ vagrant plugin install vagrant-hostmanager --plugin-version 1.5.0
+    $ vagrant plugin install vagrant-hostmanager
     # Optional
     $ vagrant plugin install vagrant-cachier # Caches & shares package downloads across VMs
 


### PR DESCRIPTION
The hack here is no longer necessary with up-to-date versions of Vagrant, vagrant-hostmanager, and vagrant-aws. What's more, the change in c8b60b63 caused a chain of infinite recursion on OSX, preventing bringup of VMs on a typical laptop.
