### PR TITLE
HOTFIX: fix streams issues

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -201,7 +201,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public boolean persistent() {
-        return false;
+        return true;
     }
 
     @Override
@@ -241,6 +241,11 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             byte[] rawKey = serdes.rawKey(key);
             byte[] rawValue = serdes.rawValue(value);
             putInternal(rawKey, rawValue);
+
+            if (loggingEnabled) {
+                changeLogger.add(rawKey);
+                changeLogger.maybeLogChange(this.getter);
+            }
         }
     }
 
@@ -259,11 +264,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
                 throw new ProcessorStateException("Error while executing put key " + serdes.keyFrom(rawKey) +
                         " and value " + serdes.keyFrom(rawValue) + " from store " + this.name, e);
             }
-        }
-
-        if (loggingEnabled) {
-            changeLogger.add(rawKey);
-            changeLogger.maybeLogChange(this.getter);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreChangeLogger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StoreChangeLogger.java
@@ -86,6 +86,9 @@ public class StoreChangeLogger<K, V> {
     }
 
     public void logChange(ValueGetter<K, V> getter) {
+        if (this.removed.isEmpty() && this.dirty.isEmpty())
+            return;
+
         RecordCollector collector = ((RecordCollector.Supplier) context).recordCollector();
         if (collector != null) {
             Serializer<K> keySerializer = serialization.keySerializer();


### PR DESCRIPTION
- RocksDBStore.putInternal should bypass logging.
- StoreChangeLogger should not call context.recordCollector() when nothing to log
  - This is for standby tasks. In standby task, recordCollector() throws an exception. There should be nothing to log anyway.
- fixed ConcurrentModificationException in StreamThread

@guozhangwang 
