### PR TITLE
MINOR: Updated kafkatest version to match version specified in gradle.properties

### DIFF
--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -23,4 +23,4 @@
 # Instead, in trunk, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 0.9.0.0-SNAPSHOT, this should be something like "0.9.0.0.dev0"
-__version__ = '0.9.0.0.dev0'
+__version__ = '0.9.0.1.dev0'


### PR DESCRIPTION
This discrepancy was causing a few system tests which to some version validation to fail consistently on 0.9.0 branch. Namely:

```
Module: kafkatest.sanity_checks.test_verifiable_producer
Class:  TestVerifiableProducer
Method: test_simple_run
Arguments:
{
  "producer_version": "0.8.2.2"
}

Module: kafkatest.sanity_checks.test_verifiable_producer
Class:  TestVerifiableProducer
Method: test_simple_run
Arguments:
{
  "producer_version": "trunk"
}

Module: kafkatest.sanity_checks.test_kafka_version
Class:  KafkaVersionTest
Method: test_multi_version
```
