### PR TITLE
KAFKA-3190 Producer should not fire callback in Send() method

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -442,14 +442,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             }
             return result.future;
             // handling exceptions and record the errors;
-            // for API exceptions return them in the future,
-            // for other exceptions throw directly
         } catch (ApiException e) {
             log.debug("Exception occurred during message send:", e);
-            if (callback != null)
-                callback.onCompletion(null, e);
             this.errors.record();
-            return new FutureFailure(e);
+            throw e;
         } catch (InterruptedException e) {
             this.errors.record();
             throw new InterruptException(e);

--- a/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
@@ -17,8 +17,8 @@
 
 package kafka.api
 
-import java.util.concurrent.{ExecutionException, TimeUnit, TimeoutException}
-import java.util.{Properties, Random}
+import java.util.Properties
+import java.util.concurrent.ExecutionException
 
 import kafka.common.Topic
 import kafka.consumer.SimpleConsumer
@@ -27,8 +27,7 @@ import kafka.server.KafkaConfig
 import kafka.utils.{ShutdownableThread, TestUtils}
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
-import org.apache.kafka.common.KafkaException
-import org.apache.kafka.common.errors.{InvalidTopicException, NotEnoughReplicasAfterAppendException, NotEnoughReplicasException}
+import org.apache.kafka.common.errors.{TimeoutException, InvalidTopicException, NotEnoughReplicasAfterAppendException, NotEnoughReplicasException}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 
@@ -113,7 +112,7 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
   def testNonExistentTopic() {
     // send a record with non-exist topic
     val record = new ProducerRecord[Array[Byte],Array[Byte]](topic2, null, "key".getBytes, "value".getBytes)
-    intercept[ExecutionException] {
+    intercept[TimeoutException] {
       producer1.send(record).get
     }
   }
@@ -138,7 +137,7 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
 
     // send a record with incorrect broker list
     val record = new ProducerRecord[Array[Byte],Array[Byte]](topic1, null, "key".getBytes, "value".getBytes)
-    intercept[ExecutionException] {
+    intercept[TimeoutException] {
       producer4.send(record).get
     }
   }


### PR DESCRIPTION
@guozhangwang Would you mind take a look? This was originally introduced in KAFKA-1260. I did not find specific reason in the original rb that we have to handle ApiException separately in callback.
