### PR TITLE
HOTFIX: open window segments on init

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -60,6 +60,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     private static final String DB_FILE_DIR = "rocksdb";
 
     private final String name;
+    private final String parentDir;
 
     private final Options options;
     private final WriteOptions wOptions;
@@ -91,7 +92,12 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     }
 
     public RocksDBStore(String name, Serdes<K, V> serdes) {
+        this(name, DB_FILE_DIR, serdes);
+    }
+
+    public RocksDBStore(String name, String parentDir, Serdes<K, V> serdes) {
         this.name = name;
+        this.parentDir = parentDir;
         this.serdes = serdes;
 
         // initialize the rocksdb options
@@ -131,7 +137,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     public void openDB(ProcessorContext context) {
         this.context = context;
-        this.dbDir = new File(new File(this.context.stateDir(), DB_FILE_DIR), this.name);
+        this.dbDir = new File(new File(this.context.stateDir(), parentDir), this.name);
         this.db = openDB(this.dbDir, this.options, TTL_SECONDS);
     }
 


### PR DESCRIPTION
@guozhangwang 

A window store should open all existing segments. This is important for segment cleanup, and it also ensures that the first fetch() call returns the hits, the values in the search range. (previously, it missed the hits in fetch() immediately after initialization).
