### PR TITLE
HOTFIX: fix NPE after standby task reassignment

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -682,6 +682,7 @@ public class StreamThread extends Thread {
 
         standbyTasks.clear();
         standbyTasksByPartition.clear();
+        standbyRecords.clear();
     }
 
     private void ensureCopartitioning(Collection<Set<String>> copartitionGroups) {


### PR DESCRIPTION
Buffered records of change logs must be cleared upon reassignment of standby tasks. 
