### PR TITLE
MINOR: Stabilize transient replication test failures in 0.9.0

### DIFF
--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -51,7 +51,7 @@ class ProduceConsumeValidateTest(Test):
 
         # Check that producer is still successfully producing
         currently_acked = self.producer.num_acked
-        wait_until(lambda: self.producer.num_acked > currently_acked + 5, timeout_sec=10,
+        wait_until(lambda: self.producer.num_acked > currently_acked + 5, timeout_sec=30,
              err_msg="Expected producer to still be producing.")
 
         self.producer.stop()

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -38,7 +38,7 @@ class ProduceConsumeValidateTest(Test):
         wait_until(lambda: self.producer.num_acked > 5, timeout_sec=10,
              err_msg="Producer failed to start in a reasonable amount of time.")
         self.consumer.start()
-        wait_until(lambda: len(self.consumer.messages_consumed[1]) > 0, timeout_sec=10,
+        wait_until(lambda: len(self.consumer.messages_consumed[1]) > 0, timeout_sec=60,
              err_msg="Consumer failed to start in a reasonable amount of time.")
 
     def stop_producer_and_consumer(self):

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -93,9 +93,9 @@ class ReplicationTest(ProduceConsumeValidateTest):
         self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,
-                                                                    "min.insync.replicas": 2}
-                                                                })
-        self.producer_throughput = 10000
+                                                                    'configs': {"min.insync.replicas": 2}}
+                                                                    })
+        self.producer_throughput = 1000
         self.num_producers = 1
         self.num_consumers = 1
 

--- a/tests/kafkatest/tests/upgrade_test.py
+++ b/tests/kafkatest/tests/upgrade_test.py
@@ -34,7 +34,7 @@ class TestUpgrade(ProduceConsumeValidateTest):
         self.kafka = KafkaService(self.test_context, num_nodes=3, zk=self.zk, version=LATEST_0_8_2, topics={self.topic: {
                                                                     "partitions": 3,
                                                                     "replication-factor": 3,
-                                                                    "min.insync.replicas": 2}})
+                                                                    'configs': {"min.insync.replicas": 2}}})
         self.zk.start()
         self.kafka.start()
 


### PR DESCRIPTION
- ported timeout values in `produce_consume_validate.py` from trunk to 0.9.0
- ported `producer_throughput_value` in `replication_test.py` from trunk to 0.9.0
- fixed `min.insync.replicas` config, which due to an error, was not getting applied to its intended topics
