### PR TITLE
HOTFIX: open window segments in order, add segment id check in getSegment

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -638,6 +638,111 @@ public class RocksDBWindowStoreTest {
         }
     }
 
+    @Test
+    public void testSegmentMaintenace() throws IOException {
+        File baseDir = Files.createTempDirectory("test").toFile();
+        try {
+            final List<KeyValue<byte[], byte[]>> changeLog = new ArrayList<>();
+            Producer<byte[], byte[]> producer = new MockProducer<>(true, byteArraySerializer, byteArraySerializer);
+            RecordCollector recordCollector = new RecordCollector(producer) {
+                @Override
+                public <K1, V1> void send(ProducerRecord<K1, V1> record, Serializer<K1> keySerializer, Serializer<V1> valueSerializer) {
+                    // do nothing
+                }
+            };
+
+            MockProcessorContext context = new MockProcessorContext(
+                    null, baseDir,
+                    byteArraySerializer, byteArrayDeserializer, byteArraySerializer, byteArrayDeserializer,
+                    recordCollector);
+
+            WindowStore<Integer, String> store = createWindowStore(context, serdes);
+            RocksDBWindowStore<Integer, String> inner =
+                    (RocksDBWindowStore<Integer, String>) ((MeteredWindowStore<Integer, String>) store).inner();
+
+            try {
+
+                context.setTime(0L);
+                store.put(0, "v");
+                assertEquals(
+                        Utils.mkSet(inner.segmentName(0L)),
+                        segmentDirs(baseDir)
+                );
+
+                context.setTime(59999L);
+                store.put(0, "v");
+                context.setTime(59999L);
+                store.put(0, "v");
+                assertEquals(
+                        Utils.mkSet(inner.segmentName(0L)),
+                        segmentDirs(baseDir)
+                );
+
+                context.setTime(60000L);
+                store.put(0, "v");
+                assertEquals(
+                        Utils.mkSet(inner.segmentName(0L), inner.segmentName(1L)),
+                        segmentDirs(baseDir)
+                );
+
+                WindowStoreIterator iter;
+                int fetchedCount;
+
+                iter = store.fetch(0, 0L, 240000L);
+                fetchedCount = 0;
+                while (iter.hasNext()) {
+                    iter.next();
+                    fetchedCount++;
+                }
+                assertEquals(4, fetchedCount);
+
+                assertEquals(
+                        Utils.mkSet(inner.segmentName(0L), inner.segmentName(1L)),
+                        segmentDirs(baseDir)
+                );
+
+                context.setTime(180000L);
+                store.put(0, "v");
+
+                iter = store.fetch(0, 0L, 240000L);
+                fetchedCount = 0;
+                while (iter.hasNext()) {
+                    iter.next();
+                    fetchedCount++;
+                }
+                assertEquals(2, fetchedCount);
+
+                assertEquals(
+                        Utils.mkSet(inner.segmentName(1L), inner.segmentName(2L), inner.segmentName(3L)),
+                        segmentDirs(baseDir)
+                );
+
+                context.setTime(300000L);
+                store.put(0, "v");
+
+                iter = store.fetch(0, 240000L, 1000000L);
+                fetchedCount = 0;
+                while (iter.hasNext()) {
+                    iter.next();
+                    fetchedCount++;
+                }
+                assertEquals(1, fetchedCount);
+
+                assertEquals(
+                        Utils.mkSet(inner.segmentName(3L), inner.segmentName(4L), inner.segmentName(5L)),
+                        segmentDirs(baseDir)
+                );
+
+            } finally {
+                store.close();
+            }
+
+        } finally {
+            Utils.delete(baseDir);
+        }
+    }
+
+
     private <E> List<E> toList(WindowStoreIterator<E> iterator) {
         ArrayList<E> list = new ArrayList<>();
         while (iterator.hasNext()) {


### PR DESCRIPTION
- During window store initialization, we have to open segments in the segment id order and update `currentSegmentId`, otherwise cleanup won't work.
- `getSegment()` should not create a segment and clean up old segments if the segment id is greater than `currentSegmentId`. Segment maintenance should be driven not by query but only by data insertion.
