### PR TITLE
KAFKA-3233: expose per topic consumer metrics to metrics reporter

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -700,18 +700,20 @@ public class Fetcher<K, V> {
         }
 
         public void recordTopicFetchMetrics(String topic, int bytes, int records) {
+            String topicMetricPrefix = "topic." + topic;
+
             // record bytes fetched
-            String name = "topic." + topic + ".bytes-fetched";
+            String name = topicMetricPrefix + ".bytes-fetched";
             Sensor bytesFetched = this.metrics.getSensor(name);
             if (bytesFetched == null) {
                 bytesFetched = this.metrics.sensor(name);
-                bytesFetched.add(this.metrics.metricName("topic." + topic + ".fetch-size-avg",
+                bytesFetched.add(this.metrics.metricName(topicMetricPrefix + ".fetch-size-avg",
                         this.metricGrpName,
                         "The average number of bytes fetched per request for topic " + topic), new Avg());
-                bytesFetched.add(this.metrics.metricName("topic." + topic + ".fetch-size-max",
+                bytesFetched.add(this.metrics.metricName(topicMetricPrefix + ".fetch-size-max",
                         this.metricGrpName,
                         "The maximum number of bytes fetched per request for topic " + topic), new Max());
-                bytesFetched.add(this.metrics.metricName("topic." + topic + ".bytes-consumed-rate",
+                bytesFetched.add(this.metrics.metricName(topicMetricPrefix + ".bytes-consumed-rate",
                         this.metricGrpName,
                         "The average number of bytes consumed per second for topic " + topic), new Rate());
             }
@@ -722,10 +724,10 @@ public class Fetcher<K, V> {
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
                 recordsFetched = this.metrics.sensor(name);
-                recordsFetched.add(this.metrics.metricName("topic." + topic + ".records-per-request-avg",
+                recordsFetched.add(this.metrics.metricName(topicMetricPrefix + ".records-per-request-avg",
                         this.metricGrpName,
                         "The average number of records in each request for topic " + topic), new Avg());
-                recordsFetched.add(this.metrics.metricName("topic." + topic + ".records-consumed-rate",
+                recordsFetched.add(this.metrics.metricName(topicMetricPrefix + ".records-consumed-rate",
                         this.metricGrpName,
                         "The average number of records consumed per second for topic " + topic), new Rate());
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -720,7 +720,7 @@ public class Fetcher<K, V> {
             bytesFetched.record(bytes);
 
             // record records fetched
-            name = "topic." + topic + ".records-fetched";
+            name = topicMetricPrefix + ".records-fetched";
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
                 recordsFetched = this.metrics.sensor(name);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -705,9 +705,15 @@ public class Fetcher<K, V> {
             Sensor bytesFetched = this.metrics.getSensor(name);
             if (bytesFetched == null) {
                 bytesFetched = this.metrics.sensor(name);
-                bytesFetched.add(this.metrics.metricName(name,
+                bytesFetched.add(this.metrics.metricName(topic + ".fetch-size-avg",
                         this.metricGrpName,
-                        "The number of bytes fetched for topic " + topic), new Rate(new Count()));
+                        "The average number of bytes fetched per request for topic " + topic), new Avg());
+                bytesFetched.add(this.metrics.metricName(topic + ".fetch-size-max",
+                        this.metricGrpName,
+                        "The maximum number of bytes fetched per request for topic " + topic), new Max());
+                bytesFetched.add(this.metrics.metricName(topic + ".bytes-consumed-rate",
+                        this.metricGrpName,
+                        "The average number of bytes consumed per second for topic " + topic), new Rate());
             }
             bytesFetched.record(bytes);
 
@@ -716,9 +722,12 @@ public class Fetcher<K, V> {
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
                 recordsFetched = this.metrics.sensor(name);
-                recordsFetched.add(this.metrics.metricName(name,
+                recordsFetched.add(this.metrics.metricName(topic + ".records-per-request-avg",
                         this.metricGrpName,
-                        "The number of records fetched for topic " + topic), new Rate(new Count()));
+                        "The average number of records in each request for topic " + topic), new Avg());
+                recordsFetched.add(this.metrics.metricName(topic + ".records-consumed-rate",
+                        this.metricGrpName,
+                        "The average number of records consumed per second for topic " + topic), new Rate());
             }
             recordsFetched.record(records);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -703,15 +703,23 @@ public class Fetcher<K, V> {
             // record bytes fetched
             String name = "topic." + topic + ".bytes-fetched";
             Sensor bytesFetched = this.metrics.getSensor(name);
-            if (bytesFetched == null)
+            if (bytesFetched == null) {
                 bytesFetched = this.metrics.sensor(name);
+                bytesFetched.add(this.metrics.metricName(name,
+                        this.metricGrpName,
+                        "The number of bytes fetched for topic " + topic), new Rate(new Count()));
+            }
             bytesFetched.record(bytes);
 
             // record records fetched
             name = "topic." + topic + ".records-fetched";
             Sensor recordsFetched = this.metrics.getSensor(name);
-            if (recordsFetched == null)
+            if (recordsFetched == null) {
                 recordsFetched = this.metrics.sensor(name);
+                recordsFetched.add(this.metrics.metricName(name,
+                        this.metricGrpName,
+                        "The number of records fetched for topic " + topic), new Rate(new Count()));
+            }
             recordsFetched.record(records);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -700,36 +700,42 @@ public class Fetcher<K, V> {
         }
 
         public void recordTopicFetchMetrics(String topic, int bytes, int records) {
-            String topicMetricPrefix = "topic." + topic;
+            Map<String, String> metricTags = new HashMap<>();
+            metricTags.put("topic", topic);
 
             // record bytes fetched
-            String name = topicMetricPrefix + ".bytes-fetched";
+            String name = "topic." + topic + ".bytes-fetched";
             Sensor bytesFetched = this.metrics.getSensor(name);
             if (bytesFetched == null) {
                 bytesFetched = this.metrics.sensor(name);
-                bytesFetched.add(this.metrics.metricName(topicMetricPrefix + ".fetch-size-avg",
+                bytesFetched.add(this.metrics.metricName("fetch-size-avg",
                         this.metricGrpName,
-                        "The average number of bytes fetched per request for topic " + topic), new Avg());
-                bytesFetched.add(this.metrics.metricName(topicMetricPrefix + ".fetch-size-max",
+                        "The average number of bytes fetched per request for topic " + topic,
+                        metricTags), new Avg());
+                bytesFetched.add(this.metrics.metricName("fetch-size-max",
                         this.metricGrpName,
-                        "The maximum number of bytes fetched per request for topic " + topic), new Max());
-                bytesFetched.add(this.metrics.metricName(topicMetricPrefix + ".bytes-consumed-rate",
+                        "The maximum number of bytes fetched per request for topic " + topic,
+                        metricTags), new Max());
+                bytesFetched.add(this.metrics.metricName("bytes-consumed-rate",
                         this.metricGrpName,
-                        "The average number of bytes consumed per second for topic " + topic), new Rate());
+                        "The average number of bytes consumed per second for topic " + topic,
+                        metricTags), new Rate());
             }
             bytesFetched.record(bytes);
 
             // record records fetched
-            name = topicMetricPrefix + ".records-fetched";
+            name = "topic." + topic + ".records-fetched";
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
                 recordsFetched = this.metrics.sensor(name);
-                recordsFetched.add(this.metrics.metricName(topicMetricPrefix + ".records-per-request-avg",
+                recordsFetched.add(this.metrics.metricName("records-per-request-avg",
                         this.metricGrpName,
-                        "The average number of records in each request for topic " + topic), new Avg());
-                recordsFetched.add(this.metrics.metricName(topicMetricPrefix + ".records-consumed-rate",
+                        "The average number of records in each request for topic " + topic,
+                        metricTags), new Avg());
+                recordsFetched.add(this.metrics.metricName("records-consumed-rate",
                         this.metricGrpName,
-                        "The average number of records consumed per second for topic " + topic), new Rate());
+                        "The average number of records consumed per second for topic " + topic,
+                        metricTags), new Rate());
             }
             recordsFetched.record(records);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -705,13 +705,13 @@ public class Fetcher<K, V> {
             Sensor bytesFetched = this.metrics.getSensor(name);
             if (bytesFetched == null) {
                 bytesFetched = this.metrics.sensor(name);
-                bytesFetched.add(this.metrics.metricName(topic + ".fetch-size-avg",
+                bytesFetched.add(this.metrics.metricName("topic." + topic + ".fetch-size-avg",
                         this.metricGrpName,
                         "The average number of bytes fetched per request for topic " + topic), new Avg());
-                bytesFetched.add(this.metrics.metricName(topic + ".fetch-size-max",
+                bytesFetched.add(this.metrics.metricName("topic." + topic + ".fetch-size-max",
                         this.metricGrpName,
                         "The maximum number of bytes fetched per request for topic " + topic), new Max());
-                bytesFetched.add(this.metrics.metricName(topic + ".bytes-consumed-rate",
+                bytesFetched.add(this.metrics.metricName("topic." + topic + ".bytes-consumed-rate",
                         this.metricGrpName,
                         "The average number of bytes consumed per second for topic " + topic), new Rate());
             }
@@ -722,10 +722,10 @@ public class Fetcher<K, V> {
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
                 recordsFetched = this.metrics.sensor(name);
-                recordsFetched.add(this.metrics.metricName(topic + ".records-per-request-avg",
+                recordsFetched.add(this.metrics.metricName("topic." + topic + ".records-per-request-avg",
                         this.metricGrpName,
                         "The average number of records in each request for topic " + topic), new Avg());
-                recordsFetched.add(this.metrics.metricName(topic + ".records-consumed-rate",
+                recordsFetched.add(this.metrics.metricName("topic." + topic + ".records-consumed-rate",
                         this.metricGrpName,
                         "The average number of records consumed per second for topic " + topic), new Rate());
             }


### PR DESCRIPTION
In version of 0.8.2.1, the old consumer will provide the metrics reporter per-topic consumer metrics under group 'ConsumerTopicMetrics'. For example:

*.ConsumerTopicMetrics.clientId.[topic name].BytesPerSec.count
*.ConsumerTopicMetrics.clientId.[topic name].MessagesPerSec.count

These consumer metrics are useful since it helps us monitor consumer rate for each topic. But the new consumer(0.9.0.0) doesn't expose per topic metrics anymore, even though I did find sensor objects in consumer metrics object collecting per-topic metrics.

After investigation, I found that these sensors are not registering any KafkaMetrics.
