### PR TITLE
MINOR: Reconcile differences in .bat & .sh start scripts

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -25,7 +25,6 @@ rem Using pushd popd to set BASE_DIR to the absolute path
 pushd %~dp0..\..
 set BASE_DIR=%CD%
 popd
-set CLASSPATH=
 
 IF ["%SCALA_VERSION%"] EQU [""] (
   set SCALA_VERSION=2.10.6
@@ -56,9 +55,7 @@ for %%i in (%BASE_DIR%\examples\build\libs\kafka-examples-*.jar) do (
 )
 
 rem Classpath addition for release
-for %%i in (%BASE_DIR%\libs\*.jar) do (
-	call :concat %%i
-)
+call :concat %BASE_DIR%\libs\*
 
 rem Classpath addition for core
 for %%i in (%BASE_DIR%\core\build\libs\kafka_%SCALA_BINARY_VERSION%*.jar) do (
@@ -75,10 +72,22 @@ IF ["%JMX_PORT%"] NEQ [""] (
 	set KAFKA_JMX_OPTS=%KAFKA_JMX_OPTS% -Dcom.sun.management.jmxremote.port=%JMX_PORT%
 )
 
+rem Log directory to use
+IF ["%LOG_DIR%"] EQU [""] (
+    set LOG_DIR=%BASE_DIR%/logs
+)
+
 rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
+) ELSE (
+  # create logs directory
+  IF not exist %LOG_DIR% (
+      mkdir %LOG_DIR%
+  )
 )
+
+set KAFKA_LOG4J_OPTS=-Dkafka.logs.dir=%LOG_DIR% %KAFKA_LOG4J_OPTS%
 
 rem Generic jvm settings you want to add
 IF ["%KAFKA_OPTS%"] EQU [""] (

--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -20,7 +20,11 @@ IF [%1] EQU [] (
 )
 
 SetLocal
-set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%~dp0../../config/log4j.properties
-set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G
+IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
+    set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%~dp0../../config/log4j.properties
+)
+IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
+    set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G
+)
 %~dp0kafka-run-class.bat kafka.Kafka %*
 EndLocal

--- a/bin/windows/zookeeper-server-start.bat
+++ b/bin/windows/zookeeper-server-start.bat
@@ -20,7 +20,11 @@ IF [%1] EQU [] (
 )
 
 SetLocal
-set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%~dp0../../config/log4j.properties
-set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
+IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
+    set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%~dp0../../config/log4j.properties
+)
+IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
+    set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
+)
 %~dp0kafka-run-class.bat org.apache.zookeeper.server.quorum.QuorumPeerMain %*
 EndLocal


### PR DESCRIPTION
A few minor fixes to reconcile differences between the windows and unix versions of the kafka/zookeeper start scripts that were causing cross-platform inconsistencies during deployment.
- Resolve differences in CLASSPATH setup between .bat and .sh start scripts
- .bat start scripts honor externally provided KAFKA_HEAP_OPTS and KAFKA_LOG4J_OPTS consistent with .sh
- .bat start scripts configure log4j similar to .sh
