### PR TITLE
KAFKA-3176: Add partition/offset options to the new consumer

### DIFF
--- a/core/src/main/scala/kafka/consumer/BaseConsumer.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumer.scala
@@ -20,10 +20,22 @@ package kafka.consumer
 import java.util.Properties
 import java.util.regex.Pattern
 
+import kafka.api.FetchRequestBuilder
+import kafka.api.OffsetRequest
+import kafka.api.Request
+import kafka.client.ClientUtils
+import kafka.cluster.BrokerEndPoint
 import kafka.common.StreamEndException
 import kafka.message.Message
+import kafka.common.TopicAndPartition
+import kafka.message.MessageAndOffset
+import kafka.utils.ToolsUtils
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
 import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.TopicPartition
 
 /**
  * A base consumer used to abstract both old and new consumer
@@ -45,20 +57,33 @@ case class BaseConsumerRecord(topic: String,
                               key: Array[Byte],
                               value: Array[Byte])
 
-class NewShinyConsumer(topic: Option[String], whitelist: Option[String], consumerProps: Properties, val timeoutMs: Long = Long.MaxValue) extends BaseConsumer {
+class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: Option[Long], whitelist: Option[String], consumerProps: Properties, val timeoutMs: Long = Long.MaxValue) extends BaseConsumer {
   import org.apache.kafka.clients.consumer.KafkaConsumer
 
   import scala.collection.JavaConversions._
 
   val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](consumerProps)
-  if (topic.isDefined)
-    consumer.subscribe(List(topic.get))
-  else if (whitelist.isDefined)
-    consumer.subscribe(Pattern.compile(whitelist.get), new NoOpConsumerRebalanceListener())
-  else
-    throw new IllegalArgumentException("Exactly one of topic or whitelist has to be provided.")
-
+  consumerInit()
   var recordIter = consumer.poll(0).iterator
+
+  def consumerInit() {
+    if (topic.isDefined)
+      if (partitionId.isDefined) {
+        val topicPartition = new TopicPartition(topic.get, partitionId.get)
+        consumer.assign(List(topicPartition))
+        offset.get match {
+          case OffsetRequest.EarliestTime => consumer.seekToBeginning(List(topicPartition))
+          case OffsetRequest.LatestTime => consumer.seekToEnd(List(topicPartition))
+          case _ => consumer.seek(topicPartition, offset.get)
+        }
+      }
+      else
+        consumer.subscribe(List(topic.get))
+    else if (whitelist.isDefined)
+      consumer.subscribe(Pattern.compile(whitelist.get), new NoOpConsumerRebalanceListener())
+    else
+      throw new IllegalArgumentException("Exactly one of topic or whitelist has to be provided.")
+  }
 
   override def receive(): BaseConsumerRecord = {
     if (!recordIter.hasNext) {
@@ -124,4 +149,3 @@ class OldConsumer(topicFilter: TopicFilter, consumerProps: Properties) extends B
     this.consumerConnector.commitOffsets
   }
 }
-

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -114,6 +114,49 @@ class ConsoleConsumerTest extends JUnitSuite {
     assertEquals(true, config.fromBeginning)
   }
 
+  @Test
+  def shouldParseValidNewSimpleConsumerValidConfigWithNumericOffset() {
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--partition", "0",
+      "--offset", "3",
+      "--new-consumer") //new
+
+    //When
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+
+    //Then
+    assertTrue(config.useNewConsumer)
+    assertEquals("localhost:9092", config.bootstrapServer)
+    assertEquals("test", config.topicArg)
+    assertEquals(0, config.partitionArg.get)
+    assertEquals(3, config.offsetArg)
+    assertEquals(false, config.fromBeginning)
+  }
+
+  @Test
+  def shouldParseValidNewSimpleConsumerValidConfigWithStringOffset() {
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--partition", "0",
+      "--offset", "LatEst",
+      "--new-consumer") //new
+
+    //When
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+
+    //Then
+    assertTrue(config.useNewConsumer)
+    assertEquals("localhost:9092", config.bootstrapServer)
+    assertEquals("test", config.topicArg)
+    assertEquals(0, config.partitionArg.get)
+    assertEquals(-1, config.offsetArg)
+    assertEquals(false, config.fromBeginning)
+  }
 
   @Test
   def shouldParseConfigsFromFile() {


### PR DESCRIPTION
With this pull request the new console consumer can be provided with optional --partition and --offset arguments so only messages from a particular partition and starting from a particular offset are consumed.

The following rules are also implemented to avoid invalid combinations of arguments:
- If --partition or --offset is provided --new-consumer has to be provided too.
- If --partition is provided --topic has to be provided too.
- If --offset is provided --partition has to be provided too.
- --offset and --from-beginning cannot be used at the same time.

This patch is co-authored with @rajinisivaram.
