### PR TITLE
MINOR: Update streams RocksDb to 4.1.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,7 +36,7 @@ versions += [
   metrics: "2.2.0",
   powermock: "1.6.4",
   reflections: "0.9.10",
-  rocksDB: "3.10.1",
+  rocksDB: "4.1.0",
   scalaTest: "2.2.6",
   scalaParserCombinators: "1.0.4",
   slf4j: "1.7.15",


### PR DESCRIPTION
This is the latest version in Maven even though HISTORY.md includes releases all the way to 4.5.0.
