### PR TITLE
KAFKA-3258: Delete broker topic metrics of deleted topics

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -102,30 +102,37 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
     case Some(topic) => Map("topic" -> topic)
   }
 
-  val messagesInRate = newMeter("MessagesInPerSec", "messages", TimeUnit.SECONDS, tags)
-  val bytesInRate = newMeter("BytesInPerSec", "bytes", TimeUnit.SECONDS, tags)
-  val bytesOutRate = newMeter("BytesOutPerSec", "bytes", TimeUnit.SECONDS, tags)
-  val bytesRejectedRate = newMeter("BytesRejectedPerSec", "bytes", TimeUnit.SECONDS, tags)
-  val failedProduceRequestRate = newMeter("FailedProduceRequestsPerSec", "requests", TimeUnit.SECONDS, tags)
-  val failedFetchRequestRate = newMeter("FailedFetchRequestsPerSec", "requests", TimeUnit.SECONDS, tags)
-  val totalProduceRequestRate = newMeter("TotalProduceRequestsPerSec", "requests", TimeUnit.SECONDS, tags)
-  val totalFetchRequestRate = newMeter("TotalFetchRequestsPerSec", "requests", TimeUnit.SECONDS, tags)
+  val messagesInRate = newMeter(BrokerTopicStats.MessagesInPerSec, "messages", TimeUnit.SECONDS, tags)
+  val bytesInRate = newMeter(BrokerTopicStats.BytesInPerSec, "bytes", TimeUnit.SECONDS, tags)
+  val bytesOutRate = newMeter(BrokerTopicStats.BytesOutPerSec, "bytes", TimeUnit.SECONDS, tags)
+  val bytesRejectedRate = newMeter(BrokerTopicStats.BytesRejectedPerSec, "bytes", TimeUnit.SECONDS, tags)
+  val failedProduceRequestRate = newMeter(BrokerTopicStats.FailedProduceRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
+  val failedFetchRequestRate = newMeter(BrokerTopicStats.FailedFetchRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
+  val totalProduceRequestRate = newMeter(BrokerTopicStats.TotalProduceRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
+  val totalFetchRequestRate = newMeter(BrokerTopicStats.TotalFetchRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
 
-  val partitions = new ConcurrentHashMap[Int, Partition]
-
-  def delete() {
-    removeMetric("MessagesInPerSec", tags)
-    removeMetric("BytesInPerSec", tags)
-    removeMetric("BytesOutPerSec", tags)
-    removeMetric("BytesRejectedPerSec", tags)
-    removeMetric("FailedProduceRequestsPerSec", tags)
-    removeMetric("FailedFetchRequestsPerSec", tags)
-    removeMetric("TotalProduceRequestsPerSec", tags)
-    removeMetric("TotalFetchRequestsPerSec", tags)
+  def close() {
+    removeMetric(BrokerTopicStats.MessagesInPerSec, tags)
+    removeMetric(BrokerTopicStats.BytesInPerSec, tags)
+    removeMetric(BrokerTopicStats.BytesOutPerSec, tags)
+    removeMetric(BrokerTopicStats.BytesRejectedPerSec, tags)
+    removeMetric(BrokerTopicStats.FailedProduceRequestsPerSec, tags)
+    removeMetric(BrokerTopicStats.FailedFetchRequestsPerSec, tags)
+    removeMetric(BrokerTopicStats.TotalProduceRequestsPerSec, tags)
+    removeMetric(BrokerTopicStats.TotalFetchRequestsPerSec, tags)
   }
 }
 
 object BrokerTopicStats extends Logging {
+  val MessagesInPerSec = "MessagesInPerSec"
+  val BytesInPerSec = "BytesInPerSec"
+  val BytesOutPerSec = "BytesOutPerSec"
+  val BytesRejectedPerSec = "BytesRejectedPerSec"
+  val FailedProduceRequestsPerSec = "FailedProduceRequestsPerSec"
+  val FailedFetchRequestsPerSec = "FailedFetchRequestsPerSec"
+  val TotalProduceRequestsPerSec = "TotalProduceRequestsPerSec"
+  val TotalFetchRequestsPerSec = "TotalFetchRequestsPerSec"
+
   private val valueFactory = (k: String) => new BrokerTopicMetrics(Some(k))
   private val stats = new Pool[String, BrokerTopicMetrics](Some(valueFactory))
   private val allTopicsStats = new BrokerTopicMetrics(None)
@@ -136,18 +143,11 @@ object BrokerTopicStats extends Logging {
     stats.getAndMaybePut(topic)
   }
 
-  def onPartitionAdd(topic: String, partition: Partition) {
-    getBrokerTopicStats(topic).partitions.put(partition.partitionId, partition)
-  }
-
-  def onPartitionDelete(topic: String, partition: Partition) {
+  def removeMetrics(topic: String) {
     val metrics = stats.get(topic)
     if (metrics != null) {
-      metrics.partitions.remove(partition.partitionId, partition)
-      if (metrics.partitions.isEmpty) {
-        stats.remove(topic, metrics)
-        metrics.delete()
-      }
+      stats.remove(topic, metrics)
+      metrics.close()
     }
   }
 }

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -23,8 +23,6 @@ import kafka.metrics.KafkaMetricsGroup
 import java.util.concurrent.TimeUnit
 import com.yammer.metrics.core.Meter
 import org.apache.kafka.common.utils.Utils
-import kafka.cluster.Partition
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A thread that answers kafka requests.
@@ -144,10 +142,8 @@ object BrokerTopicStats extends Logging {
   }
 
   def removeMetrics(topic: String) {
-    val metrics = stats.get(topic)
-    if (metrics != null) {
-      stats.remove(topic, metrics)
+    val metrics = stats.remove(topic)
+    if (metrics != null)
       metrics.close()
-    }
   }
 }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -110,8 +110,9 @@ class ReplicaManager(val config: KafkaConfig,
   /* epoch of the controller that last changed the leader */
   @volatile var controllerEpoch: Int = KafkaController.InitialControllerEpoch - 1
   private val localBrokerId = config.brokerId
-  private val partitionFactory = (k: (String, Int)) => new Partition(k._1, k._2, time, this)
-  private val allPartitions = new Pool[(String, Int), Partition](Some(partitionFactory))
+  private val allPartitions = new Pool[(String, Int), Partition](valueFactory = Some { case (t, p) =>
+    new Partition(t, p, time, this)
+  })
   private val replicaStateChangeLock = new Object
   val replicaFetcherManager = new ReplicaFetcherManager(config, this, metrics, jTime, threadNamePrefix)
   private val highWatermarkCheckPointThreadStarted = new AtomicBoolean(false)

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -80,7 +80,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
   }
 
   @Test
-  def testBrokerTopicMetricsAfterDeletingTopic() {
+  def testBrokerTopicMetricsUnregisteredAfterDeletingTopic() {
     val topic = "test-broker-topic-metric"
     AdminUtils.createTopic(zkUtils, topic, 2, 1)
     createAndShutdownStep("group0", "consumer0", "producer0")

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-package kafka.consumer
+package kafka.metrics
 
 import java.util.Properties
-
 import com.yammer.metrics.Metrics
 import com.yammer.metrics.core.MetricPredicate
 import org.junit.{After, Test}
@@ -32,6 +31,7 @@ import kafka.utils.TestUtils._
 import scala.collection._
 import scala.collection.JavaConversions._
 import scala.util.matching.Regex
+import kafka.consumer.{ConsumerConfig, ZookeeperConsumerConnector}
 
 class MetricsTest extends KafkaServerTestHarness with Logging {
   val numNodes = 2
@@ -74,6 +74,17 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
   def testMetricsReporterAfterDeletingTopic() {
     val topic = "test-topic-metric"
     AdminUtils.createTopic(zkUtils, topic, 1, 1)
+    AdminUtils.deleteTopic(zkUtils, topic)
+    TestUtils.verifyTopicDeletion(zkUtils, topic, 1, servers)
+    assertFalse("Topic metrics exists after deleteTopic", checkTopicMetricsExists(topic))
+  }
+
+  @Test
+  def testBrokerTopicMetricsAfterDeletingTopic() {
+    val topic = "test-broker-topic-metric"
+    AdminUtils.createTopic(zkUtils, topic, 2, 1)
+    createAndShutdownStep("group0", "consumer0", "producer0")
+    assertNotNull(BrokerTopicStats.getBrokerTopicStats(topic))
     AdminUtils.deleteTopic(zkUtils, topic)
     TestUtils.verifyTopicDeletion(zkUtils, topic, 1, servers)
     assertFalse("Topic metrics exists after deleteTopic", checkTopicMetricsExists(topic))


### PR DESCRIPTION
Delete per-topic metrics when there are no replicas of any partitions of the topic on a broker.
