### PR TITLE
KAFKA-3248: AdminClient Blocks Forever in send Method

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -99,6 +99,7 @@
     <allow pkg="org.apache.kafka.common" />
     <allow pkg="org.apache.kafka.clients" exact-match="true"/>
     <allow pkg="org.apache.kafka.test" />
+    <allow pkg="org.apache.kafka.clients.consumer.internals"/>
 
     <subpackage name="consumer">
       <allow pkg="org.apache.kafka.clients.consumer" />


### PR DESCRIPTION
 Block while in bounds of timeout

 Author: Warren Green s.green.warren@gmail.com
