### PR TITLE
KAFKA-3214: Added system tests for compressed topics

### DIFF
--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -37,13 +37,12 @@ class TestVerifiableProducer(Test):
 
         self.num_messages = 100
         # This will produce to source kafka cluster
-        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka, topic=self.topic,
+        self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.kafka, topic=self.topic,
                                            max_messages=self.num_messages, throughput=1000)
 
     def setUp(self):
         self.zk.start()
         self.kafka.start()
-
 
     @parametrize(producer_version=str(LATEST_0_8_2))
     @parametrize(producer_version=str(TRUNK))
@@ -52,7 +51,6 @@ class TestVerifiableProducer(Test):
         Test that we can start VerifiableProducer on trunk or against the 0.8.2 jar, and
         verify that we can produce a small number of messages.
         """
-
         node = self.producer.nodes[0]
         node.version = KafkaVersion(producer_version)
         self.producer.start()

--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -36,24 +36,22 @@ class TestVerifiableProducer(Test):
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
 
         self.num_messages = 100
+        # This will produce to source kafka cluster
+        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka, topic=self.topic,
+                                           max_messages=self.num_messages, throughput=1000)
 
     def setUp(self):
         self.zk.start()
+        self.kafka.start()
 
 
-    @parametrize(producer_version=str(LATEST_0_8_2), compression_type=None)
-    @parametrize(producer_version=str(TRUNK), compression_type=None)
-    @parametrize(producer_version=str(TRUNK), compression_type=["snappy"])
-    def test_simple_run(self, producer_version=TRUNK, compression_type=None):
+    @parametrize(producer_version=str(LATEST_0_8_2))
+    @parametrize(producer_version=str(TRUNK))
+    def test_simple_run(self, producer_version=TRUNK):
         """
         Test that we can start VerifiableProducer on trunk or against the 0.8.2 jar, and
         verify that we can produce a small number of messages.
         """
-        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka,
-                                           topic=self.topic,
-                                           max_messages=self.num_messages, throughput=1000,
-                                           compression_types=compression_type)
-        self.kafka.start()
 
         node = self.producer.nodes[0]
         node.version = KafkaVersion(producer_version)

--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -36,21 +36,25 @@ class TestVerifiableProducer(Test):
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
 
         self.num_messages = 100
-        # This will produce to source kafka cluster
-        self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.kafka, topic=self.topic,
-                                           max_messages=self.num_messages, throughput=1000)
 
     def setUp(self):
         self.zk.start()
-        self.kafka.start()
 
-    @parametrize(producer_version=str(LATEST_0_8_2))
-    @parametrize(producer_version=str(TRUNK))
-    def test_simple_run(self, producer_version=TRUNK):
+
+    @parametrize(producer_version=str(LATEST_0_8_2), compression_type=None)
+    @parametrize(producer_version=str(TRUNK), compression_type=None)
+    @parametrize(producer_version=str(TRUNK), compression_type=["snappy"])
+    def test_simple_run(self, producer_version=TRUNK, compression_type=None):
         """
         Test that we can start VerifiableProducer on trunk or against the 0.8.2 jar, and
         verify that we can produce a small number of messages.
         """
+        self.producer = VerifiableProducer(self.test_context, num_nodes=1, kafka=self.kafka,
+                                           topic=self.topic,
+                                           max_messages=self.num_messages, throughput=1000,
+                                           compression_types=compression_type)
+        self.kafka.start()
+
         node = self.producer.nodes[0]
         node.version = KafkaVersion(producer_version)
         self.producer.start()

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -26,16 +26,6 @@ import os
 import subprocess
 
 
-def is_int(msg):
-    """Default method used to check whether text pulled from console consumer is a message.
-
-    return int or None
-    """
-    try:
-        return int(msg)
-    except ValueError:
-        return None
-
 """
 0.8.2.1 ConsoleConsumer options
 

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -196,10 +196,11 @@ class VerifiableProducer(BackgroundThreadService):
             return len(self.not_acked_values)
 
     def each_produced_at_least(self, count):
-        for idx in range(1, self.num_nodes):
-            if self.produced_count.get(idx) is None or self.produced_count[idx] < count:
-                return False
-        return True
+        with self.lock:
+            for idx in range(1, self.num_nodes):
+                if self.produced_count.get(idx) is None or self.produced_count[idx] < count:
+                    return False
+            return True
 
     def stop_node(self, node):
         self.kill_node(node, clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/tests/compatibility_test.py
+++ b/tests/kafkatest/tests/compatibility_test.py
@@ -18,7 +18,8 @@ from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.kafka.version import LATEST_0_8_2, TRUNK
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.utils import is_int
 
 
 class ClientCompatibilityTest(Test):

--- a/tests/kafkatest/tests/compression_test.py
+++ b/tests/kafkatest/tests/compression_test.py
@@ -32,7 +32,7 @@ class CompressionTest(ProduceConsumeValidateTest):
 
         self.topic = "test_topic"
         self.zk = ZookeeperService(test_context, num_nodes=1)
-        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
+        self.kafka = KafkaService(test_context, num_nodes=1, zk=self.zk, topics={self.topic: {
                                                                     "partitions": 10,
                                                                     "replication-factor": 1}})
         self.num_partitions = 10

--- a/tests/kafkatest/tests/compression_test.py
+++ b/tests/kafkatest/tests/compression_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from ducktape.mark import parametrize
+from ducktape.utils.util import wait_until
 
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
@@ -40,6 +41,7 @@ class CompressionTest(ProduceConsumeValidateTest):
         self.timeout_sec = 60
         self.producer_throughput = 1000
         self.num_producers = 4
+        self.messages_per_producer = 1000
         self.num_consumers = 1
 
     def setUp(self):
@@ -49,8 +51,9 @@ class CompressionTest(ProduceConsumeValidateTest):
         # Override this since we're adding services outside of the constructor
         return super(CompressionTest, self).min_cluster_size() + self.num_producers + self.num_consumers
 
-    @parametrize(compression_types=["snappy","gzip","lz4","none"])
-    def test_compressed_topic(self, compression_types):
+    @parametrize(compression_types=["snappy","gzip","lz4","none"], new_consumer=True)
+    @parametrize(compression_types=["snappy","gzip","lz4","none"], new_consumer=False)
+    def test_compressed_topic(self, compression_types, new_consumer):
         """Test produce => consume => validate for compressed topics
         Setup: 1 zk, 1 kafka node, 1 topic with partitions=10, replication-factor=1
 
@@ -66,13 +69,17 @@ class CompressionTest(ProduceConsumeValidateTest):
 
         self.kafka.security_protocol = "PLAINTEXT"
         self.kafka.interbroker_security_protocol = self.kafka.security_protocol
-        new_consumer = False if  self.kafka.security_protocol == "PLAINTEXT" else True
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka,
                                            self.topic, throughput=self.producer_throughput,
                                            message_validator=is_int_with_prefix,
                                            compression_types=compression_types)
         self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic,
-                                        new_consumer=new_consumer, consumer_timeout_ms=60000, message_validator=is_int_with_prefix)
+                                        new_consumer=new_consumer, consumer_timeout_ms=60000,
+                                        message_validator=is_int_with_prefix)
         self.kafka.start()
-        
-        self.run_produce_consume_validate()
+
+        self.run_produce_consume_validate(lambda: wait_until(
+            lambda: self.producer.each_produced_at_least(self.messages_per_producer) == True,
+            timeout_sec=120, backoff_sec=1,
+            err_msg="Producer did not produce all messages in reasonable amount of time"))
+

--- a/tests/kafkatest/tests/compression_test.py
+++ b/tests/kafkatest/tests/compression_test.py
@@ -18,8 +18,9 @@ from ducktape.mark import parametrize
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int_with_prefix
 
 class CompressionTest(ProduceConsumeValidateTest):
     """
@@ -68,9 +69,10 @@ class CompressionTest(ProduceConsumeValidateTest):
         new_consumer = False if  self.kafka.security_protocol == "PLAINTEXT" else True
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka,
                                            self.topic, throughput=self.producer_throughput,
+                                           message_validator=is_int_with_prefix,
                                            compression_types=compression_types)
         self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic,
-                                        new_consumer=new_consumer, consumer_timeout_ms=60000, message_validator=is_int)
+                                        new_consumer=new_consumer, consumer_timeout_ms=60000, message_validator=is_int_with_prefix)
         self.kafka.start()
         
         self.run_produce_consume_validate()

--- a/tests/kafkatest/tests/compression_test.py
+++ b/tests/kafkatest/tests/compression_test.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ducktape.mark import parametrize
+
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+
+class CompressionTest(ProduceConsumeValidateTest):
+    """
+    These tests validate partition reassignment.
+    Create a topic with few partitions, load some data, trigger partition re-assignment with and without broker failure,
+    check that partition re-assignment can complete and there is no data loss.
+    """
+
+    def __init__(self, test_context):
+        """:type test_context: ducktape.tests.test.TestContext"""
+        super(CompressionTest, self).__init__(test_context=test_context)
+
+        self.topic = "test_topic"
+        self.zk = ZookeeperService(test_context, num_nodes=1)
+        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
+                                                                    "partitions": 20,
+                                                                    "replication-factor": 3,
+                                                                    'configs': {"min.insync.replicas": 2}}
+                                                                })
+        self.num_partitions = 20
+        self.timeout_sec = 60
+        self.producer_throughput = 1000
+        self.num_producers = 3
+        self.num_consumers = 1
+
+    def setUp(self):
+        self.zk.start()
+
+    def min_cluster_size(self):
+        # Override this since we're adding services outside of the constructor
+        return super(CompressionTest, self).min_cluster_size() + self.num_producers + self.num_consumers
+
+    @parametrize(compression_types=["snappy","gzip","lz4"])
+    @parametrize(compression_types=["snappy","none"])
+    def test_compressed_topic(self, compression_types):
+        """Test produce => consume => validate for compressed topics
+        Setup: 1 zk, 3 kafka nodes, 1 topic with partitions=3, replication-factor=3, and min.insync.replicas=2
+
+            - Setup producers with different compression types or a mix of producers with and
+            without compression.
+            - Produce messages in the background
+            - Consume messages in the background
+            - Stop producing, and finish consuming
+            - Validate that every acked message was consumed
+        """
+
+        self.kafka.security_protocol = "PLAINTEXT"
+        self.kafka.interbroker_security_protocol = self.kafka.security_protocol
+        new_consumer = False if  self.kafka.security_protocol == "PLAINTEXT" else True
+        self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka,
+                                           self.topic, throughput=self.producer_throughput,
+                                           compression_types=compression_types)
+        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic,
+                                        new_consumer=new_consumer, consumer_timeout_ms=60000, message_validator=is_int)
+        self.kafka.start()
+        
+        self.run_produce_consume_validate()

--- a/tests/kafkatest/tests/mirror_maker_test.py
+++ b/tests/kafkatest/tests/mirror_maker_test.py
@@ -18,11 +18,12 @@ from ducktape.mark import parametrize, matrix, ignore
 
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.mirror_maker import MirrorMaker
 from kafkatest.services.security.minikdc import MiniKdc
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
 
 import time
 

--- a/tests/kafkatest/tests/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/reassign_partitions_test.py
@@ -19,8 +19,9 @@ from ducktape.utils.util import wait_until
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
 import random
 
 class ReassignPartitionsTest(ProduceConsumeValidateTest):

--- a/tests/kafkatest/tests/replication_test.py
+++ b/tests/kafkatest/tests/replication_test.py
@@ -20,8 +20,9 @@ from ducktape.mark import matrix
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
 
 import signal
 

--- a/tests/kafkatest/tests/security_rolling_upgrade_test.py
+++ b/tests/kafkatest/tests/security_rolling_upgrade_test.py
@@ -18,7 +18,8 @@ from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.utils import is_int
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from ducktape.mark import matrix
 from kafkatest.services.security.kafka_acls import ACLs

--- a/tests/kafkatest/tests/upgrade_test.py
+++ b/tests/kafkatest/tests/upgrade_test.py
@@ -17,9 +17,10 @@ from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.kafka.version import LATEST_0_8_2, TRUNK
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.kafka import config_property
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
 
 
 class TestUpgrade(ProduceConsumeValidateTest):

--- a/tests/kafkatest/tests/zookeeper_security_upgrade_test.py
+++ b/tests/kafkatest/tests/zookeeper_security_upgrade_test.py
@@ -18,10 +18,11 @@ from ducktape.mark import matrix
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.verifiable_producer import VerifiableProducer
-from kafkatest.services.console_consumer import ConsoleConsumer, is_int
+from kafkatest.services.console_consumer import ConsoleConsumer
 from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.services.security.kafka_acls import ACLs
+from kafkatest.utils import is_int
 import time
 
 class ZooKeeperSecurityUpgradeTest(ProduceConsumeValidateTest):

--- a/tests/kafkatest/utils/__init__.py
+++ b/tests/kafkatest/utils/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 # see kafka.server.KafkaConfig for additional details and defaults
 
-from util import kafkatest_version, is_version
+from util import kafkatest_version, is_version, is_int, is_int_with_prefix

--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -44,12 +44,12 @@ def is_version(node, version_list, proc_grep_string="kafka"):
 def is_int(msg):
     """Method used to check whether the given message is an integer
 
-    return int or None
+    return int or raises an exception if message is not an integer
     """
     try:
         return int(msg)
     except ValueError:
-        return None
+        raise Exception("Unexpected message format (expected an integer). Message: %s" % (msg))
 
 
 def is_int_with_prefix(msg):
@@ -57,14 +57,17 @@ def is_int_with_prefix(msg):
     Method used check whether the given message is of format 'integer_prefix'.'integer_value'
 
     :param msg: message to validate
-    :return: msg or None if message is of wrong format
+    :return: msg or raises an exception is a message is of wrong format
     """
     try:
         parts = msg.split(".")
         if len(parts) != 2:
-            return None
+            raise Exception("Unexpected message format. Message should be of format: integer "
+                            "prefix dot integer value. Message: %s" % (msg))
         int(parts[0])
         int(parts[1])
         return msg
     except ValueError:
-        return None
+        raise Exception("Unexpected message format. Message should be of format: integer "
+                        "prefix dot integer value, but one of the two parts (before or after dot) "
+                        "are not integers. Message: %s" % (msg))

--- a/tests/kafkatest/utils/util.py
+++ b/tests/kafkatest/utils/util.py
@@ -40,3 +40,31 @@ def is_version(node, version_list, proc_grep_string="kafka"):
     versions = _kafka_jar_versions(lines[0])
     return versions == {str(v) for v in version_list}
 
+
+def is_int(msg):
+    """Method used to check whether the given message is an integer
+
+    return int or None
+    """
+    try:
+        return int(msg)
+    except ValueError:
+        return None
+
+
+def is_int_with_prefix(msg):
+    """
+    Method used check whether the given message is of format 'integer_prefix'.'integer_value'
+
+    :param msg: message to validate
+    :return: msg or None if message is of wrong format
+    """
+    try:
+        parts = msg.split(".")
+        if len(parts) != 2:
+            return None
+        int(parts[0])
+        int(parts[1])
+        return msg
+    except ValueError:
+        return None


### PR DESCRIPTION
Added CompressionTest that tests 4 producers, each using a different compression type and one not using compression.

Enabled VerifiableProducer to run producers with different compression types (passed in the constructor). This includes enabling each producer to output unique values, so that the verification process in ProduceConsumeValidateTest is correct (counts acks from all producers). 

Also a fix for console consumer to raise an exception if it sees the incorrect consumer output (before we swallowed an exception, so was hard to debug the issue).
