### PR TITLE
KAFKA-3279: Remove checks for JAAS system property

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
@@ -91,7 +91,7 @@ public class JaasUtils {
             Configuration loginConf = Configuration.getConfiguration();
             isSecurityEnabled = loginConf.getAppConfigurationEntry(zkLoginContextName) != null;
         } catch (Exception e) {
-            throw new KafkaException(e);
+            throw new KafkaException("Exception while loading Zookeeper JAAS login context '" + zkLoginContextName + "'", e);
         }
         if (isSecurityEnabled && !zkSaslEnabled) {
             LOG.error("JAAS configuration is present, but system property " +

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
@@ -21,7 +21,6 @@ import javax.security.auth.login.AppConfigurationEntry;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.io.IOException;
-import java.io.File;
 
 import org.apache.kafka.common.KafkaException;
 import org.slf4j.Logger;
@@ -88,25 +87,17 @@ public class JaasUtils {
         boolean zkSaslEnabled = Boolean.parseBoolean(System.getProperty(ZK_SASL_CLIENT, "true"));
         String zkLoginContextName = System.getProperty(ZK_LOGIN_CONTEXT_NAME_KEY, "Client");
 
-        String loginConfigFile = System.getProperty(JAVA_LOGIN_CONFIG_PARAM);
-        if (loginConfigFile != null && loginConfigFile.length() > 0) {
-            File configFile = new File(loginConfigFile);
-            if (!configFile.canRead()) {
-                throw new KafkaException("File " + loginConfigFile + "cannot be read.");
-            }
-                
-            try {
-                Configuration loginConf = Configuration.getConfiguration();
-                isSecurityEnabled = loginConf.getAppConfigurationEntry(zkLoginContextName) != null;
-            } catch (Exception e) {
-                throw new KafkaException(e);
-            }
-            if (isSecurityEnabled && !zkSaslEnabled) {
-                LOG.error("JAAS file is present, but system property " + 
-                            ZK_SASL_CLIENT + " is set to false, which disables " +
-                            "SASL in the ZooKeeper client");
-                throw new KafkaException("Exception while determining if ZooKeeper is secure");
-            }
+        try {
+            Configuration loginConf = Configuration.getConfiguration();
+            isSecurityEnabled = loginConf.getAppConfigurationEntry(zkLoginContextName) != null;
+        } catch (Exception e) {
+            throw new KafkaException(e);
+        }
+        if (isSecurityEnabled && !zkSaslEnabled) {
+            LOG.error("JAAS configuration is present, but system property " +
+                        ZK_SASL_CLIENT + " is set to false, which disables " +
+                        "SASL in the ZooKeeper client");
+            throw new KafkaException("Exception while determining if ZooKeeper is secure");
         }
 
         return isSecurityEnabled;

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/Login.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/Login.java
@@ -286,11 +286,12 @@ public class Login {
     private synchronized LoginContext login(final String loginContextName) throws LoginException {
         String jaasConfigFile = System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM);
         if (jaasConfigFile == null) {
-            log.info("System property '" + JaasUtils.JAVA_LOGIN_CONFIG_PARAM + "' is not set, using default JAAS configuration.");
+            log.debug("System property '" + JaasUtils.JAVA_LOGIN_CONFIG_PARAM + "' is not set, using default JAAS configuration.");
         }
         AppConfigurationEntry[] configEntries = Configuration.getConfiguration().getAppConfigurationEntry(loginContextName);
         if (configEntries == null) {
-            String errorMessage = "Could not find a '" + loginContextName + "' entry in the JAAS configuration.";
+            String errorMessage = "Could not find a '" + loginContextName + "' entry in the JAAS configuration. System property '" +
+                JaasUtils.JAVA_LOGIN_CONFIG_PARAM + "' is " + (jaasConfigFile == null ? "not set" : jaasConfigFile);
             throw new IllegalArgumentException(errorMessage);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/Login.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/Login.java
@@ -286,11 +286,11 @@ public class Login {
     private synchronized LoginContext login(final String loginContextName) throws LoginException {
         String jaasConfigFile = System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM);
         if (jaasConfigFile == null) {
-            throw new IllegalArgumentException("You must pass " + JaasUtils.JAVA_LOGIN_CONFIG_PARAM + " in secure mode.");
+            log.info("System property '" + JaasUtils.JAVA_LOGIN_CONFIG_PARAM + "' is not set, using default JAAS configuration.");
         }
         AppConfigurationEntry[] configEntries = Configuration.getConfiguration().getAppConfigurationEntry(loginContextName);
         if (configEntries == null) {
-            String errorMessage = "Could not find a '" + loginContextName + "' entry in `" + jaasConfigFile + "`.";
+            String errorMessage = "Could not find a '" + loginContextName + "' entry in the JAAS configuration.";
             throw new IllegalArgumentException(errorMessage);
         }
 

--- a/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
@@ -55,9 +55,11 @@ class ZkAuthorizationTest extends ZooKeeperTestHarness with Logging{
   @Test
   def testIsZkSecurityEnabled() {
     assertTrue(JaasUtils.isZkSecurityEnabled())
+    Configuration.setConfiguration(null)
     System.clearProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)
     assertFalse(JaasUtils.isZkSecurityEnabled())
-    try {     
+    try {
+      Configuration.setConfiguration(null)
       System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, "no-such-file-exists.conf")
       JaasUtils.isZkSecurityEnabled()
       fail("Should have thrown an exception")

--- a/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ZkAuthorizationTest.scala
@@ -46,6 +46,7 @@ class ZkAuthorizationTest extends ZooKeeperTestHarness with Logging{
     super.tearDown()
     System.clearProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)
     System.clearProperty(authProvider)
+    Configuration.setConfiguration(null)
   }
 
   /**


### PR DESCRIPTION
JAAS configuration may be set using other methods and hence the check for System property doesn't  always match where the actual configuration used by Kafka is loaded from.
