### PR TITLE
KAFKA-3297: Fair consumer partition assignment strategy (new consumer)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/FairAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/FairAssignor.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.clients.consumer;
+
+import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Utils;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The fair assignor attempts to balance partitions across consumers such that each consumer is assigned approximately
+ * the same number of partitions, even if the consumer topic subscriptions are substantially different (if they are
+ * identical, then the result will be equivalent to that of the roundrobin assignor). The running total of assignments
+ * per consumer is tracked as the algorithm executes in order to accomplish this.
+ *
+ * The algorithm starts with the topic with the fewest consumer subscriptions, and assigns its partitions in roundrobin
+ * fashion. In the event of a tie for least subscriptions, the topic with the highest partition count is assigned
+ * first, as this generally creates a more balanced distribution. The final tiebreaker is the topic name.
+ *
+ * The partitions for subsequent topics are assigned to the subscribing consumer with the fewest number of assignments.
+ * In the event of a tie for least assignments, the tiebreaker is the consumer id, so that the assignment pattern is
+ * deterministic and fairly similar to how the roundrobin assignor functions.
+ *
+ * For example, suppose there are two consumers C0 and C1, two topics t0 and t1, and each topic has 3 partitions,
+ * resulting in partitions t0p0, t0p1, t0p2, t1p0, t1p1, and t1p2. If both C0 and C1 are consuming t0, but only C1 is
+ * consuming t1 then the assignment will be:
+ * C0 -> [t0p0, t0p1, t0p2]
+ * C1 -> [t1p0, t1p1, t1p2]
+ */
+public class FairAssignor extends AbstractPartitionAssignor {
+
+    @Override
+    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+                                                    Map<String, List<String>> subscriptions) {
+        List<String> consumers = Utils.sorted(subscriptions.keySet());
+
+        // Invert topics-per-consumer map to consumers-per-topic.
+        Map<String, List<String>> consumersPerTopic = consumersPerTopic(subscriptions);
+
+        // Map for tracking the total number of partitions assigned to each consumer
+        Map<String, Integer> consumerAssignmentCounts = new HashMap<>();
+        for (String consumer : consumers) {
+            consumerAssignmentCounts.put(consumer, 0);
+        }
+
+        Map<String, List<TopicPartition>> assignment = new HashMap<>();
+        for (String memberId : subscriptions.keySet()) {
+            assignment.put(memberId, new ArrayList<TopicPartition>());
+        }
+
+        Comparator<String> consumerComparator = new ConsumerFairness(consumerAssignmentCounts);
+        for (TopicPartition partition : allPartitionsSorted(partitionsPerTopic, subscriptions, consumersPerTopic)) {
+            // Find the most appropriate consumer for the partition.
+            String assignedConsumer = null;
+            for (String consumer : consumersPerTopic.get(partition.topic())) {
+                if (assignedConsumer == null || consumerComparator.compare(consumer, assignedConsumer) < 0) {
+                    assignedConsumer = consumer;
+                }
+            }
+
+            consumerAssignmentCounts.put(assignedConsumer, consumerAssignmentCounts.get(assignedConsumer) + 1);
+            assignment.get(assignedConsumer).add(partition);
+        }
+
+        return assignment;
+    }
+
+    private static List<TopicPartition> allPartitionsSorted(Map<String, Integer> partitionsPerTopic,
+                                                            Map<String, List<String>> topicsPerConsumer,
+                                                            Map<String, List<String>> consumersPerTopic) {
+        // Collect all topics
+        Set<String> topics = new HashSet<>();
+        for (List<String> consumerTopics : topicsPerConsumer.values()) {
+            topics.addAll(consumerTopics);
+        }
+
+        // Sort topics for optimal fairness, the general idea is to keep the most flexible assignment choices available
+        // as long as possible by starting with the most constrained assignments.
+        List<String> sortedTopics = new ArrayList<>(topics);
+        Collections.sort(sortedTopics, new TopicOrder(partitionsPerTopic, consumersPerTopic));
+
+        List<TopicPartition> allPartitions = new ArrayList<>();
+        for (String topic : sortedTopics) {
+            Integer numPartitionsForTopic = partitionsPerTopic.get(topic);
+            if (numPartitionsForTopic != null)
+                allPartitions.addAll(AbstractPartitionAssignor.partitions(topic, numPartitionsForTopic));
+        }
+        return allPartitions;
+    }
+
+    @Override
+    public String name() {
+        return "fair";
+    }
+
+    private static class TopicOrder implements Comparator<String> {
+
+        private final Map<String, Integer> topicConsumerCounts;
+        private final Map<String, Integer> partitionsPerTopic;
+
+        TopicOrder(Map<String, Integer> partitionsPerTopic, Map<String, List<String>> consumersPerTopic) {
+            this.partitionsPerTopic = partitionsPerTopic;
+            this.topicConsumerCounts = new HashMap<>();
+            for (Map.Entry<String, List<String>> consumersPerTopicEntry : consumersPerTopic.entrySet()) {
+                topicConsumerCounts.put(consumersPerTopicEntry.getKey(), consumersPerTopicEntry.getValue().size());
+            }
+        }
+
+        @Override
+        public int compare(String t1, String t2) {
+            // Assign topics with fewer consumers first, tiebreakers are who has more partitions then topic name
+            int comparison = Integer.compare(topicConsumerCounts.get(t1), topicConsumerCounts.get(t2));
+            if (comparison == 0) {
+                comparison = -Integer.compare(partitionsPerTopic.get(t1), partitionsPerTopic.get(t2));
+                if (comparison == 0) {
+                    comparison = t1.compareTo(t2);
+                }
+            }
+
+            return comparison;
+        }
+    }
+
+    private static class ConsumerFairness implements Comparator<String> {
+
+        private final Map<String, Integer> consumerAssignmentCounts;
+
+        ConsumerFairness(Map<String, Integer> consumerAssignmentCounts) {
+            this.consumerAssignmentCounts = consumerAssignmentCounts;
+        }
+
+        @Override
+        public int compare(String c1, String c2) {
+            // Prefer consumer with fewer assignments, tiebreaker is consumer id
+            int comparison = Integer.compare(consumerAssignmentCounts.get(c1), consumerAssignmentCounts.get(c2));
+            if (comparison == 0) {
+                comparison = c1.compareTo(c2);
+            }
+            return comparison;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
@@ -45,16 +45,6 @@ public class RangeAssignor extends AbstractPartitionAssignor {
         return "range";
     }
 
-    private Map<String, List<String>> consumersPerTopic(Map<String, List<String>> consumerMetadata) {
-        Map<String, List<String>> res = new HashMap<>();
-        for (Map.Entry<String, List<String>> subscriptionEntry : consumerMetadata.entrySet()) {
-            String consumerId = subscriptionEntry.getKey();
-            for (String topic : subscriptionEntry.getValue())
-                put(res, topic, consumerId);
-        }
-        return res;
-    }
-
     @Override
     public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
                                                     Map<String, List<String>> subscriptions) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
@@ -69,8 +69,8 @@ public class RoundRobinAssignor extends AbstractPartitionAssignor {
     }
 
 
-    public List<TopicPartition> allPartitionsSorted(Map<String, Integer> partitionsPerTopic,
-                                                    Map<String, List<String>> subscriptions) {
+    private static List<TopicPartition> allPartitionsSorted(Map<String, Integer> partitionsPerTopic,
+                                                            Map<String, List<String>> subscriptions) {
         SortedSet<String> topics = new TreeSet<>();
         for (List<String> subscription : subscriptions.values())
             topics.addAll(subscription);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
@@ -94,4 +94,13 @@ public abstract class AbstractPartitionAssignor implements PartitionAssignor {
             partitions.add(new TopicPartition(topic, i));
         return partitions;
     }
+
+    protected static Map<String, List<String>> consumersPerTopic(Map<String, List<String>> topicsPerConsumer) {
+        Map<String, List<String>> res = new HashMap<>();
+        for (Map.Entry<String, List<String>> subscriptionEntry : topicsPerConsumer.entrySet()) {
+            for (String topic : subscriptionEntry.getValue())
+                put(res, topic, subscriptionEntry.getKey());
+        }
+        return res;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/PartitionAssignor.java
@@ -63,7 +63,7 @@ public interface PartitionAssignor {
 
 
     /**
-     * Unique name for this assignor (e.g. "range" or "roundrobin")
+     * Unique name for this assignor (e.g. "range", "roundrobin", or "fair")
      * @return non-null unique name
      */
     String name();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/FairAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/FairAssignorTest.java
@@ -24,10 +24,9 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class RoundRobinAssignorTest {
+public class FairAssignorTest {
 
-    private RoundRobinAssignor assignor = new RoundRobinAssignor();
-
+    private FairAssignor assignor = new FairAssignor();
 
     @Test
     public void testOneConsumerNoTopic() {
@@ -47,6 +46,8 @@ public class RoundRobinAssignorTest {
         String consumerId = "consumer";
 
         Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, 0);
+
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, Arrays.asList(topic)));
 
@@ -101,9 +102,9 @@ public class RoundRobinAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, Arrays.asList(topic1, topic2)));
         assertEquals(Arrays.asList(
-                new TopicPartition(topic1, 0),
                 new TopicPartition(topic2, 0),
-                new TopicPartition(topic2, 1)), assignment.get(consumerId));
+                new TopicPartition(topic2, 1),
+                new TopicPartition(topic1, 0)), assignment.get(consumerId));
     }
 
     @Test
@@ -161,13 +162,13 @@ public class RoundRobinAssignorTest {
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertEquals(Arrays.asList(
-                new TopicPartition(topic1, 0)), assignment.get(consumer1));
+                new TopicPartition(topic1, 0),
+                new TopicPartition(topic1, 2)), assignment.get(consumer1));
         assertEquals(Arrays.asList(
-                new TopicPartition(topic1, 1),
                 new TopicPartition(topic2, 0),
                 new TopicPartition(topic2, 1)), assignment.get(consumer2));
         assertEquals(Arrays.asList(
-                new TopicPartition(topic1, 2)), assignment.get(consumer3));
+                new TopicPartition(topic1, 1)), assignment.get(consumer3));
     }
 
     @Test
@@ -228,25 +229,16 @@ public class RoundRobinAssignorTest {
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertEquals(Arrays.asList(
+                new TopicPartition(topic2, 0),
+                new TopicPartition(topic3, 0)), assignment.get(consumer1));
+        assertEquals(Arrays.asList(
                 new TopicPartition(topic1, 0),
-                new TopicPartition(topic3, 0),
-                new TopicPartition(topic5, 0)), assignment.get(consumer1));
+                new TopicPartition(topic3, 1)), assignment.get(consumer2));
         assertEquals(Arrays.asList(
                 new TopicPartition(topic1, 1),
-                new TopicPartition(topic3, 1),
-                new TopicPartition(topic5, 1)), assignment.get(consumer2));
-        assertTrue(assignment.get(consumer3).isEmpty());
+                new TopicPartition(topic5, 0)), assignment.get(consumer3));
         assertEquals(Arrays.asList(
-                new TopicPartition(topic2, 0),
-                new TopicPartition(topic4, 0)), assignment.get(consumer4));
+                new TopicPartition(topic4, 0),
+                new TopicPartition(topic5, 1)), assignment.get(consumer4));
     }
-
-    public static List<String> topics(String... topics) {
-        return Arrays.asList(topics);
-    }
-
-    public static TopicPartition tp(String topic, int partition) {
-        return new TopicPartition(topic, partition);
-    }
-
 }


### PR DESCRIPTION
Pull request for https://issues.apache.org/jira/browse/KAFKA-3297
