### PR TITLE
HOTFIX: Missing streams jar in release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -373,6 +373,7 @@ project(':core') {
     from(project(':connect:json').configurations.runtime) { into("libs/") }
     from(project(':connect:file').jar) { into("libs/") }
     from(project(':connect:file').configurations.runtime) { into("libs/") }
+    from(project(':streams').jar) { into("libs/") }
   }
 
   jar {


### PR DESCRIPTION
Observation: when doing "gradlew releaseTarGz" the streams jar was not included in the tarball. Adding a line to include it. @ijuma @guozhangwang could you please review. Thanks.
