### PR TITLE
MINOR: Fixed error in test by moving commit validation

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -199,9 +199,6 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         // We'll wait for some data, then trigger a flush
         final CountDownLatch pollLatch = expectPolls(1);
         expectOffsetFlush(true);
-
-        sourceTask.commit();
-        EasyMock.expectLastCall();
         sourceTask.stop();
         EasyMock.expectLastCall();
         expectOffsetFlush(true);
@@ -332,6 +329,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         });
         sourceTask.stop();
         EasyMock.expectLastCall();
+        expectOffsetFlush(true);
 
         PowerMock.replayAll();
 
@@ -450,6 +448,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
                 flushFuture.get(EasyMock.anyLong(), EasyMock.anyObject(TimeUnit.class)));
         if (succeed) {
             futureGetExpect.andReturn(null);
+            sourceTask.commit();
+            EasyMock.expectLastCall();
         } else {
             futureGetExpect.andThrow(new TimeoutException());
             offsetWriter.cancelFlush();


### PR DESCRIPTION
While looking at the failure here:
https://builds.apache.org/job/kafka-trunk-jdk7/ws/connect/runtime/build/reports/tests/classes/org.apache.kafka.connect.runtime.WorkerSourceTaskTest.html

I noticed some stray errors of "Unexpected method call SourceTask.commit()", so I moved the location where we expect commits to inside the expectedFlush method since this is where the commit happens (on successful flush).
