### PR TITLE
MINOR: use Vector instead of List

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -655,12 +655,12 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
   }
 
   private def checkpointBrokerId(brokerId: Int) {
-    var logDirsWithoutMetaProps: List[String] = List()
+    var logDirsWithoutMetaProps: Vector[String] = Vector()
 
     for (logDir <- config.logDirs) {
       val brokerMetadataOpt = brokerMetadataCheckpoints(logDir).read()
       if(brokerMetadataOpt.isEmpty)
-          logDirsWithoutMetaProps ++= List(logDir)
+          logDirsWithoutMetaProps :+= logDir
     }
 
     for(logDir <- logDirsWithoutMetaProps) {


### PR DESCRIPTION
`Vector#:+` is more efficient rather than `List#++` in this case.
