### PR TITLE
KAFKA-3325: Out of date instructions in quickstart guide

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -104,12 +104,12 @@ Now edit these new files and set the following properties:
 
 config/server-1.properties:
     broker.id=1
-    port=9093
+    listeners=PLAINTEXT://:9093
     log.dir=/tmp/kafka-logs-1
 
 config/server-2.properties:
     broker.id=2
-    port=9094
+    listeners=PLAINTEXT://:9094
     log.dir=/tmp/kafka-logs-2
 </pre>
 The <code>broker.id</code> property is the unique and permanent name of each node in the cluster. We have to override the port and log directory only because we are running these all on the same machine and we want to keep the brokers from all trying to register on the same port or overwrite each others data.


### PR DESCRIPTION
Adjust the listeners property rather than the port.  Following the original instructions would result in all of the brokers being started with the same listeners setting, and so fail to work.
