### PR TITLE
HOTFIX: Include RocksDB dependency in release tarballs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -374,6 +374,7 @@ project(':core') {
     from(project(':connect:file').jar) { into("libs/") }
     from(project(':connect:file').configurations.runtime) { into("libs/") }
     from(project(':streams').jar) { into("libs/") }
+    from(project(':streams').configurations.runtime) { into("libs/") }
     from(project(':streams:examples').jar) { into("libs/") }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -376,6 +376,7 @@ project(':core') {
     from(project(':streams').jar) { into("libs/") }
     from(project(':streams').configurations.runtime) { into("libs/") }
     from(project(':streams:examples').jar) { into("libs/") }
+    from(project(':streams:examples').configurations.runtime) { into("libs/") }
   }
 
   jar {


### PR DESCRIPTION
Without this change `./gradlew releaseTarGz` (and its variants) will not include the RocksDB jar, which is required for Kafka Streams, in Kafka's `libs/` folder.  The impact is that any Streams job will fail when it runs against a broker that was installed via a release tarball.

@guozhangwang @junrao : please review.
