### PR TITLE
KAFKA-3303: Pass partial record metadata to ProducerInterceptor.onAcknowledgement on error

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerInterceptor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerInterceptor.java
@@ -76,7 +76,12 @@ public interface ProducerInterceptor<K, V> extends Configurable {
      * This method will generally execute in the background I/O thread, so the implementation should be reasonably fast.
      * Otherwise, sending of messages from other threads could be delayed.
      *
-     * @param metadata The metadata for the record that was sent (i.e. the partition and offset). Null if an error occurred.
+     * @param metadata The metadata for the record that was sent (i.e. the partition and offset).
+     *                 If an error occurred, metadata will contain only valid topic and maybe
+     *                 partition. If partition is not given in ProducerRecord and an error occurs
+     *                 before partition gets assigned, then partition will be set to -1. The
+     *                 metadata may be null if the client passed null record to
+     *                 {@link org.apache.kafka.clients.producer.KafkaProducer#send(ProducerRecord)}.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      */
     public void onAcknowledgement(RecordMetadata metadata, Exception exception);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerInterceptor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerInterceptor.java
@@ -79,7 +79,7 @@ public interface ProducerInterceptor<K, V> extends Configurable {
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset).
      *                 If an error occurred, metadata will contain only valid topic and maybe
      *                 partition. If partition is not given in ProducerRecord and an error occurs
-     *                 before partition gets assigned, then partition will be set to TopicPartition.NO_PARTITION.
+     *                 before partition gets assigned, then partition will be set to RecordMetadata.NO_PARTITION.
      *                 The metadata may be null if the client passed null record to
      *                 {@link org.apache.kafka.clients.producer.KafkaProducer#send(ProducerRecord)}.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerInterceptor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerInterceptor.java
@@ -79,8 +79,8 @@ public interface ProducerInterceptor<K, V> extends Configurable {
      * @param metadata The metadata for the record that was sent (i.e. the partition and offset).
      *                 If an error occurred, metadata will contain only valid topic and maybe
      *                 partition. If partition is not given in ProducerRecord and an error occurs
-     *                 before partition gets assigned, then partition will be set to -1. The
-     *                 metadata may be null if the client passed null record to
+     *                 before partition gets assigned, then partition will be set to TopicPartition.NO_PARTITION.
+     *                 The metadata may be null if the client passed null record to
      *                 {@link org.apache.kafka.clients.producer.KafkaProducer#send(ProducerRecord)}.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
@@ -26,7 +26,7 @@ public final class RecordMetadata {
     /**
      * Partition value for record without partition assigned
      */
-    public static final int NO_PARTITION = -1;
+    public static final int UNKNOWN_PARTITION = -1;
 
     private final long offset;
     // The timestamp of the message.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/RecordMetadata.java
@@ -23,6 +23,11 @@ import org.apache.kafka.common.TopicPartition;
  */
 public final class RecordMetadata {
 
+    /**
+     * Partition value for record without partition assigned
+     */
+    public static final int NO_PARTITION = -1;
+
     private final long offset;
     // The timestamp of the message.
     // If LogAppendTime is used for the topic, the timestamp will be the timestamp returned by the broker.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -112,7 +112,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                     TopicPartition interceptTopicPartition = tp;
                     if (interceptTopicPartition == null) {
                         interceptTopicPartition = new TopicPartition(record.topic(),
-                                                                     record.partition() == null ? TopicPartition.NO_PARTITION : record.partition());
+                                                                     record.partition() == null ? RecordMetadata.NO_PARTITION : record.partition());
                     }
                     interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1, Record.NO_TIMESTAMP, -1, -1, -1),
                                                   exception);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -99,20 +99,19 @@ public class ProducerInterceptors<K, V> implements Closeable {
      * method for each interceptor
      *
      * @param record The record from client
-     * @param tp The topic/partition for the record if an error occurred after partition gets assigned;
-     *           the topic part of tp is the same as in record.
+     * @param interceptTopicPartition  The topic/partition for the record if an error occurred
+     *        after partition gets assigned; the topic part of interceptTopicPartition is the same as in record.
      * @param exception The exception thrown during processing of this record.
      */
-    public void onSendError(ProducerRecord<K, V> record, TopicPartition tp, Exception exception) {
+    public void onSendError(ProducerRecord<K, V> record, TopicPartition interceptTopicPartition, Exception exception) {
         for (ProducerInterceptor<K, V> interceptor : this.interceptors) {
             try {
-                if (record == null && tp == null) {
+                if (record == null && interceptTopicPartition == null) {
                     interceptor.onAcknowledgement(null, exception);
                 } else {
-                    TopicPartition interceptTopicPartition = tp;
                     if (interceptTopicPartition == null) {
                         interceptTopicPartition = new TopicPartition(record.topic(),
-                                                                     record.partition() == null ? RecordMetadata.NO_PARTITION : record.partition());
+                                                                     record.partition() == null ? RecordMetadata.UNKNOWN_PARTITION : record.partition());
                     }
                     interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1, Record.NO_TIMESTAMP, -1, -1, -1),
                                                   exception);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -112,7 +112,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                     TopicPartition interceptTopicPartition = tp;
                     if (interceptTopicPartition == null) {
                         interceptTopicPartition = new TopicPartition(record.topic(),
-                                                                     record.partition() == null ? -1 : record.partition());
+                                                                     record.partition() == null ? TopicPartition.NO_PARTITION : record.partition());
                     }
                     interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1, Record.NO_TIMESTAMP, -1, -1, -1),
                                                   exception);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -20,6 +20,8 @@ package org.apache.kafka.clients.producer.internals;
 import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.Record;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,13 +78,45 @@ public class ProducerInterceptors<K, V> implements Closeable {
      *
      * This method does not throw exceptions. Exceptions thrown by any of interceptor methods are caught and ignored.
      *
-     * @param metadata The metadata for the record that was sent (i.e. the partition and offset). Null if an error occurred.
+     * @param metadata The metadata for the record that was sent (i.e. the partition and offset).
+     *                 If an error occurred, metadata will only contain valid topic and maybe partition.
      * @param exception The exception thrown during processing of this record. Null if no error occurred.
      */
     public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
         for (ProducerInterceptor<K, V> interceptor : this.interceptors) {
             try {
                 interceptor.onAcknowledgement(metadata, exception);
+            } catch (Exception e) {
+                // do not propagate interceptor exceptions, just log
+                log.warn("Error executing interceptor onAcknowledgement callback", e);
+            }
+        }
+    }
+
+    /**
+     * This method is called when sending the record fails in {@link ProducerInterceptor#onSend
+     * (ProducerRecord)} method. This method calls {@link ProducerInterceptor#onAcknowledgement(RecordMetadata, Exception)}
+     * method for each interceptor
+     *
+     * @param record The record from client
+     * @param tp The topic/partition for the record if an error occurred after partition gets assigned;
+     *           the topic part of tp is the same as in record.
+     * @param exception The exception thrown during processing of this record.
+     */
+    public void onSendError(ProducerRecord<K, V> record, TopicPartition tp, Exception exception) {
+        for (ProducerInterceptor<K, V> interceptor : this.interceptors) {
+            try {
+                if (record == null && tp == null) {
+                    interceptor.onAcknowledgement(null, exception);
+                } else {
+                    TopicPartition interceptTopicPartition = tp;
+                    if (interceptTopicPartition == null) {
+                        interceptTopicPartition = new TopicPartition(record.topic(),
+                                                                     record.partition() == null ? -1 : record.partition());
+                    }
+                    interceptor.onAcknowledgement(new RecordMetadata(interceptTopicPartition, -1, -1, Record.NO_TIMESTAMP, -1, -1, -1),
+                                                  exception);
+                }
             } catch (Exception e) {
                 // do not propagate interceptor exceptions, just log
                 log.warn("Error executing interceptor onAcknowledgement callback", e);

--- a/clients/src/main/java/org/apache/kafka/common/TopicPartition.java
+++ b/clients/src/main/java/org/apache/kafka/common/TopicPartition.java
@@ -23,6 +23,11 @@ import java.io.Serializable;
  */
 public final class TopicPartition implements Serializable {
 
+    /**
+     * Partition value for topic-partition without partition assigned
+     */
+    public static final int NO_PARTITION = -1;
+
     private int hash = 0;
     private final int partition;
     private final String topic;

--- a/clients/src/main/java/org/apache/kafka/common/TopicPartition.java
+++ b/clients/src/main/java/org/apache/kafka/common/TopicPartition.java
@@ -23,11 +23,6 @@ import java.io.Serializable;
  */
 public final class TopicPartition implements Serializable {
 
-    /**
-     * Partition value for topic-partition without partition assigned
-     */
-    public static final int NO_PARTITION = -1;
-
     private int hash = 0;
     private final int partition;
     private final String topic;

--- a/clients/src/test/java/org/apache/kafka/test/MockProducerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockProducerInterceptor.java
@@ -32,6 +32,7 @@ public class MockProducerInterceptor implements ProducerInterceptor<String, Stri
     public static final AtomicInteger ONSEND_COUNT = new AtomicInteger(0);
     public static final AtomicInteger ON_SUCCESS_COUNT = new AtomicInteger(0);
     public static final AtomicInteger ON_ERROR_COUNT = new AtomicInteger(0);
+    public static final AtomicInteger ON_ERROR_WITH_METADATA_COUNT = new AtomicInteger(0);
     public static final String APPEND_STRING_PROP = "mock.interceptor.append";
     private String appendStr;
 
@@ -64,9 +65,12 @@ public class MockProducerInterceptor implements ProducerInterceptor<String, Stri
 
     @Override
     public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
-        if (exception != null)
+        if (exception != null) {
             ON_ERROR_COUNT.incrementAndGet();
-        else if (metadata != null)
+            if (metadata != null) {
+                ON_ERROR_WITH_METADATA_COUNT.incrementAndGet();
+            }
+        } else if (metadata != null)
             ON_SUCCESS_COUNT.incrementAndGet();
     }
 
@@ -81,5 +85,6 @@ public class MockProducerInterceptor implements ProducerInterceptor<String, Stri
         ONSEND_COUNT.set(0);
         ON_SUCCESS_COUNT.set(0);
         ON_ERROR_COUNT.set(0);
+        ON_ERROR_WITH_METADATA_COUNT.set(0);
     }
 }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -568,7 +568,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       testProducer.send(null, null)
       fail("Should not allow sending a null record")
     } catch {
-      case e: Throwable => assertEquals("Interceptor should be notified about exception", 1, MockProducerInterceptor.ON_ERROR_COUNT.intValue()) // this is ok
+      case e: Throwable => {
+        assertEquals("Interceptor should be notified about exception", 1, MockProducerInterceptor.ON_ERROR_COUNT.intValue())
+        assertEquals("Interceptor should not receive metadata with an exception when record is null", 0, MockProducerInterceptor.ON_ERROR_WITH_METADATA_COUNT.intValue())
+      }
     }
 
     // create consumer with interceptor


### PR DESCRIPTION
This is a KIP-42 followup. 

Currently, If sending the record fails before it gets to the server, ProducerInterceptor.onAcknowledgement() is called with metadata == null, and non-null exception. However, it is useful to pass topic and partition, if known, to ProducerInterceptor.onAcknowledgement() as well. This patch ensures that  ProducerInterceptor.onAcknowledgement()  gets record metadata with topic and maybe partition. If partition is not set in 'record' and KafkaProducer.send() fails before partition gets assigned, then ProducerInterceptor.onAcknowledgement() gets RecordMetadata with partition == -1. Only time when  ProducerInterceptor.onAcknowledgement() gets null record metadata is when the client passes null record to KafkaProducer.send().
