### PR TITLE
KAFKA-3341: Improve error handling on invalid requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -38,18 +38,18 @@ public enum ApiKeys {
     DESCRIBE_GROUPS(15, "DescribeGroups"),
     LIST_GROUPS(16, "ListGroups");
 
-    private static ApiKeys[] codeToType;
+    private static final ApiKeys[] ID_TO_TYPE;
+    private static final int MIN_API_KEY = 0;
     public static final int MAX_API_KEY;
 
     static {
         int maxKey = -1;
-        for (ApiKeys key : ApiKeys.values()) {
+        for (ApiKeys key : ApiKeys.values())
             maxKey = Math.max(maxKey, key.id);
-        }
-        codeToType = new ApiKeys[maxKey + 1];
-        for (ApiKeys key : ApiKeys.values()) {
-            codeToType[key.id] = key;
-        }
+        ApiKeys[] idToType = new ApiKeys[maxKey + 1];
+        for (ApiKeys key : ApiKeys.values())
+            idToType[key.id] = key;
+        ID_TO_TYPE = idToType;
         MAX_API_KEY = maxKey;
     }
 
@@ -65,6 +65,9 @@ public enum ApiKeys {
     }
 
     public static ApiKeys forId(int id) {
-        return codeToType[id];
+        if (id < MIN_API_KEY || id > MAX_API_KEY)
+            throw new IllegalArgumentException(String.format("Unexpected ApiKeys id `%s`, it should be between `%s` " +
+                    "and `%s` (inclusive)", id, MIN_API_KEY, MAX_API_KEY));
+        return ID_TO_TYPE[id];
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -36,7 +36,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
      * Factory method for getting a request object based on ApiKey ID and a buffer
      */
     public static AbstractRequest getRequest(int requestId, int versionId, ByteBuffer buffer) {
-        switch (ApiKeys.forId(requestId)) {
+        ApiKeys apiKey = ApiKeys.forId(requestId);
+        switch (apiKey) {
             case PRODUCE:
                 return ProduceRequest.parse(buffer, versionId);
             case FETCH:
@@ -72,7 +73,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
             case LIST_GROUPS:
                 return ListGroupsRequest.parse(buffer, versionId);
             default:
-                return null;
+                throw new AssertionError(String.format("ApiKey %s is not currently handled in `getRequest`, the " +
+                        "code should be updated to do so.", apiKey));
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ApiKeysTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.protocol;
+
+import org.junit.Test;
+
+public class ApiKeysTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testForIdWithInvalidIdLow() {
+        ApiKeys.forId(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testForIdWithInvalidIdHigh() {
+        ApiKeys.forId(10000);
+    }
+
+}

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -81,7 +81,7 @@ object RequestChannel extends Logging {
         try RequestHeader.parse(buffer)
         catch {
           case ex: Throwable =>
-            throw new InvalidRequestException(s"Error parsing request header for apiKey: $requestId", ex)
+            throw new InvalidRequestException(s"Error parsing request header. Our best guess of the apiKey is: $requestId", ex)
         }
       } else
         null

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -78,14 +78,17 @@ object RequestChannel extends Logging {
     val header: RequestHeader =
       if (requestObj == null) {
         buffer.rewind
-        RequestHeader.parse(buffer)
+        try RequestHeader.parse(buffer)
+        catch {
+          case ex: Throwable =>
+            throw new InvalidRequestException(s"Error parsing request header for apiKey: $requestId", ex)
+        }
       } else
         null
     val body: AbstractRequest =
       if (requestObj == null)
-        try {
-          AbstractRequest.getRequest(header.apiKey, header.apiVersion, buffer)
-        } catch {
+        try AbstractRequest.getRequest(header.apiKey, header.apiVersion, buffer)
+        catch {
           case ex: Throwable =>
             throw new InvalidRequestException(s"Error getting request for apiKey: ${header.apiKey} and apiVersion: ${header.apiVersion}", ex)
         }

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -425,13 +425,13 @@ private[kafka] class Processor(val id: Int,
               channel.socketAddress)
             val req = RequestChannel.Request(processor = id, connectionId = receive.source, session = session, buffer = receive.payload, startTimeMs = time.milliseconds, securityProtocol = protocol)
             requestChannel.sendRequest(req)
+            selector.mute(receive.source)
           } catch {
             case e @ (_: InvalidRequestException | _: SchemaException) =>
               // note that even though we got an exception, we can assume that receive.source is valid. Issues with constructing a valid receive object were handled earlier
               error("Closing socket for " + receive.source + " because of error", e)
               close(selector, receive.source)
           }
-          selector.mute(receive.source)
         }
 
         selector.completedSends.asScala.foreach { send =>


### PR DESCRIPTION
- Include request id when parsing of request header fails
- Don't mute selector on a connection that was closed due to an error (otherwise a second exception is thrown)
- Throw appropriate exception from `ApiKeys.fromId` if invalid id is passed
- Fail fast in `AbstractRequest.getRequest` if we fail to handle an instance of `ApiKeys` (if this happens, it's a programmer error and the code in `getRequest` needs to be updated)

I ran into the top two issues while trying to figure out why a connection from a producer to a broker was failing (and it made things harder than necessary). While fixing them, I noticed the third and fourth issues.
