### PR TITLE
KAFKA-3123: Follower Broker cannot start if offsets are already out of range

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -146,8 +146,6 @@ private[log] class LogCleanerManager(val logDirs: Array[File], val logs: Pool[To
             case LogCleaningInProgress =>
               inProgress.put(topicAndPartition, LogCleaningAborted)
             case s =>
-              throw new IllegalStateException("Compaction for partition %s cannot be aborted and paused since it is in %s state."
-                                              .format(topicAndPartition, s))
           }
       }
       while (!isCleaningInState(topicAndPartition, LogCleaningPaused))


### PR DESCRIPTION
Function abortAndPauseCleaning() doesn't have to throw exception if the state is already LogCleaningAborted or LogCleaningPaused
@junrao @granthenke 
