### PR TITLE
KAFKA-3357; Update to Scala 2.11.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ The release file can be found inside `./core/build/distributions/`.
 ### Cleaning the build ###
     ./gradlew clean
 
-### Running a task on a particular version of Scala (either 2.10.6 or 2.11.7) ###
+### Running a task on a particular version of Scala (either 2.10.6 or 2.11.8) ###
 *Note that if building the jars with a version other than 2.10, you need to set the `SCALA_BINARY_VERSION` variable or change it in `bin/kafka-run-class.sh` to run the quick start.*
 
-You can pass either the major version (eg 2.11) or the full version (eg 2.11.7):
+You can pass either the major version (eg 2.11) or the full version (eg 2.11.8):
 
     ./gradlew -PscalaVersion=2.11 jar
     ./gradlew -PscalaVersion=2.11 test

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,7 +47,7 @@ versions += [
 
 // Add Scala version
 def defaultScala210Version = '2.10.6'
-def defaultScala211Version = '2.11.7'
+def defaultScala211Version = '2.11.8'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.10') {
     versions["scala"] = defaultScala210Version


### PR DESCRIPTION
Scala 2.11.8 has been released with a number of bug fixes:
- http://www.scala-lang.org/news/2.11.8/

There are a few important collection fixes:
- https://issues.scala-lang.org/browse/SI-9497
- https://github.com/scala/scala/pull/4714
- https://github.com/scala/scala/pull/4693

And also some pattern matcher fixes.
