### PR TITLE
MINOR: Increased default EC2 instance size

### DIFF
--- a/vagrant/aws/aws-example-Vagrantfile.local
+++ b/vagrant/aws/aws-example-Vagrantfile.local
@@ -17,7 +17,7 @@
 # Use this template Vagrantfile.local for running system tests on aws 
 # To use it, move it to the base kafka directory and rename
 # it to Vagrantfile.local, and adjust variables as needed.
-ec2_instance_type = "m3.medium"
+ec2_instance_type = "m3.xlarge"
 num_zookeepers = 0
 num_brokers = 0
 num_workers = 9


### PR DESCRIPTION
AWS instance size increased to m3.xlarge to allow all system tests to pass. @ijuma @ewencp have a look please.
