### PR TITLE
KAFKA-3383: remove in flight request only after response parsing succeeds

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -55,17 +55,10 @@ final class InFlightRequests {
     }
 
     /**
-     * Get the oldest request (the one that that will be completed next) for the given node and remove it from the queue
+     * Get the oldest request (the one that that will be completed next) for the given node
      */
     public ClientRequest completeNext(String node) {
         return requestQueue(node).pollLast();
-    }
-
-    /**
-     * Get the oldest request (the one that that will be completed next) for the given node
-     */
-    public ClientRequest earliestSent(String node) {
-        return requestQueue(node).peekLast();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -55,10 +55,17 @@ final class InFlightRequests {
     }
 
     /**
-     * Get the oldest request (the one that that will be completed next) for the given node
+     * Get the oldest request (the one that that will be completed next) for the given node and remove it from the queue
      */
     public ClientRequest completeNext(String node) {
         return requestQueue(node).pollLast();
+    }
+
+    /**
+     * Get the oldest request (the one that that will be completed next) for the given node
+     */
+    public ClientRequest earliestSent(String node) {
+        return requestQueue(node).peekLast();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -431,7 +431,7 @@ public class NetworkClient implements KafkaClient {
     private void handleCompletedReceives(List<ClientResponse> responses, long now) {
         for (NetworkReceive receive : this.selector.completedReceives()) {
             String source = receive.source();
-            ClientRequest req = inFlightRequests.completeNext(source);
+            ClientRequest req = inFlightRequests.earliestSent(source);
             ResponseHeader header = ResponseHeader.parse(receive.payload());
             // Always expect the response version id to be the same as the request version id
             short apiKey = req.request().header().apiKey();
@@ -440,6 +440,7 @@ public class NetworkClient implements KafkaClient {
             correlate(req.request().header(), header);
             if (!metadataUpdater.maybeHandleCompletedReceive(req, now, body))
                 responses.add(new ClientResponse(req, now, false, body));
+            inFlightRequests.completeNext(source);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
@@ -16,6 +16,7 @@ package org.apache.kafka.common.network;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.Set;
 
 /**
  * An interface for asynchronous, multi-channel network I/O
@@ -74,6 +75,16 @@ public interface Selectable {
      * The list of receives that completed on the last {@link #poll(long) poll()} call.
      */
     public List<NetworkReceive> completedReceives();
+
+    /**
+     * The list of connections that received response that can not be parsed on the last {@link #poll(long) poll()} call.
+     */
+    public Set<String> failedReceives();
+
+    /**
+     * Add node to the list of connections that received response that can not be parsed on the last {@link #poll(long) poll()} call.
+     */
+    public void failReceive(String id);
 
     /**
      * The list of connections that finished disconnecting on the last {@link #poll(long) poll()}

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -24,6 +24,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -87,6 +88,7 @@ public class Selector implements Selectable {
     private final List<String> disconnected;
     private final List<String> connected;
     private final List<String> failedSends;
+    private final Set<String> failedReceives;
     private final Time time;
     private final SelectorMetrics sensors;
     private final String metricGrpPrefix;
@@ -121,6 +123,7 @@ public class Selector implements Selectable {
         this.connected = new ArrayList<String>();
         this.disconnected = new ArrayList<String>();
         this.failedSends = new ArrayList<String>();
+        this.failedReceives = new HashSet<String>();
         this.sensors = new SelectorMetrics(metrics);
         this.channelBuilder = channelBuilder;
         // initial capacity and load factor are default, we set them explicitly because we want to set accessOrder = true
@@ -332,8 +335,6 @@ public class Selector implements Selectable {
         maybeCloseOldestConnection();
     }
 
-
-
     @Override
     public List<Send> completedSends() {
         return this.completedSends;
@@ -342,6 +343,16 @@ public class Selector implements Selectable {
     @Override
     public List<NetworkReceive> completedReceives() {
         return this.completedReceives;
+    }
+
+    @Override
+    public Set<String> failedReceives() {
+        return this.failedReceives;
+    }
+
+    @Override
+    public void failReceive(String id) {
+        this.failedReceives.add(id);
     }
 
     @Override
@@ -417,6 +428,7 @@ public class Selector implements Selectable {
         this.disconnected.clear();
         this.disconnected.addAll(this.failedSends);
         this.failedSends.clear();
+        this.failedReceives.clear();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -15,7 +15,9 @@ package org.apache.kafka.test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.NetworkSend;
@@ -32,6 +34,7 @@ public class MockSelector implements Selectable {
     private final List<Send> initiatedSends = new ArrayList<Send>();
     private final List<Send> completedSends = new ArrayList<Send>();
     private final List<NetworkReceive> completedReceives = new ArrayList<NetworkReceive>();
+    private final Set<String> failedReceives = new HashSet<String>();
     private final List<String> disconnected = new ArrayList<String>();
     private final List<String> connected = new ArrayList<String>();
 
@@ -66,6 +69,7 @@ public class MockSelector implements Selectable {
     public void clear() {
         this.completedSends.clear();
         this.completedReceives.clear();
+        this.failedReceives.clear();
         this.disconnected.clear();
         this.connected.clear();
     }
@@ -94,6 +98,14 @@ public class MockSelector implements Selectable {
     @Override
     public List<NetworkReceive> completedReceives() {
         return completedReceives;
+    }
+
+    public Set<String> failedReceives() {
+        return failedReceives;
+    }
+
+    public void failReceive(String id) {
+        failedReceives.add(id);
     }
 
     public void completeReceive(NetworkReceive receive) {


### PR DESCRIPTION
@becketqin, could you take a look at the patch?
