### PR TITLE
KAFKA-3397: use -1(latest) as time default value for tools.GetOffsetShell

### DIFF
--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -43,10 +43,11 @@ object GetOffsetShell {
                            .describedAs("partition ids")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val timeOpt = parser.accepts("time", "REQUIRED: Timestamp of the offsets before that")
+    val timeOpt = parser.accepts("time", "Timestamp of the offsets before that")
                            .withRequiredArg
                            .describedAs("timestamp/-1(latest)/-2(earliest)")
                            .ofType(classOf[java.lang.Long])
+                           .defaultsTo(-1)
     val nOffsetsOpt = parser.accepts("offsets", "number of offsets returned")
                            .withRequiredArg
                            .describedAs("count")

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -43,7 +43,7 @@ object GetOffsetShell {
                            .describedAs("partition ids")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val timeOpt = parser.accepts("time", "timestamp of the offsets before that")
+    val timeOpt = parser.accepts("time", "REQUIRED: Timestamp of the offsets before that")
                            .withRequiredArg
                            .describedAs("timestamp/-1(latest)/-2(earliest)")
                            .ofType(classOf[java.lang.Long])

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -43,7 +43,7 @@ object GetOffsetShell {
                            .describedAs("partition ids")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val timeOpt = parser.accepts("time", "Timestamp of the offsets before that")
+    val timeOpt = parser.accepts("time", "timestamp of the offsets before that")
                            .withRequiredArg
                            .describedAs("timestamp/-1(latest)/-2(earliest)")
                            .ofType(classOf[java.lang.Long])


### PR DESCRIPTION
minor fix for prompt the user, or we will get a error message:

> Missing required argument "[time]"
