### PR TITLE
KAFKA-3407 - ErrorLoggingCallback trims helpful diagnostic information.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
@@ -44,7 +44,7 @@ public class ErrorLoggingCallback implements Callback {
                     logAsString ? new String(key) : key.length + " bytes";
             String valueString = (valueLength == -1) ? "null" :
                     logAsString ? new String(value) : valueLength + " bytes";
-            log.error("Error when sending message to topic {} with key: {}, value: {} with error: {}",
+            log.error("Error when sending message to topic {} with key: {}, value: {} with error:",
                     topic, keyString, valueString, e);
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ErrorLoggingCallback.java
@@ -45,7 +45,7 @@ public class ErrorLoggingCallback implements Callback {
             String valueString = (valueLength == -1) ? "null" :
                     logAsString ? new String(value) : valueLength + " bytes";
             log.error("Error when sending message to topic {} with key: {}, value: {} with error: {}",
-                    topic, keyString, valueString, e.getMessage());
+                    topic, keyString, valueString, e);
         }
     }
 }


### PR DESCRIPTION
This should help when diagnosing issues with the console producer. This allows the logger to use `exception` rather than `exception.getMessage()`.
