### PR TITLE
KAFKA-3378; Client blocks forever if SocketChannel connects instantly

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -68,8 +68,8 @@ public class KafkaChannel {
     }
 
 
-    public void finishConnect() throws IOException {
-        transportLayer.finishConnect();
+    public boolean finishConnect() throws IOException {
+        return transportLayer.finishConnect();
     }
 
     public boolean isConnected() {

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -50,9 +50,11 @@ public class PlaintextTransportLayer implements TransportLayer {
     }
 
     @Override
-    public void finishConnect() throws IOException {
-        socketChannel.finishConnect();
-        key.interestOps(key.interestOps() & ~SelectionKey.OP_CONNECT | SelectionKey.OP_READ);
+    public boolean finishConnect() throws IOException {
+        boolean connected = socketChannel.finishConnect();
+        if (connected)
+            key.interestOps(key.interestOps() & ~SelectionKey.OP_CONNECT | SelectionKey.OP_READ);
+        return connected;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -22,7 +22,6 @@ import java.nio.channels.SocketChannel;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -281,9 +280,8 @@ public class Selector implements Selectable {
         this.sensors.selectTime.record(endSelect - startSelect, time.milliseconds());
 
         if (readyKeys > 0 || !immediatelyConnectedKeys.isEmpty()) {
-            Set<SelectionKey> selectedKeys = this.nioSelector.selectedKeys();
-            for (Iterator<SelectionKey> iter : Arrays.asList(selectedKeys.iterator(), immediatelyConnectedKeys.iterator()))
-                pollSelectionKeys(iter);
+            pollSelectionKeys(this.nioSelector.selectedKeys());
+            pollSelectionKeys(immediatelyConnectedKeys);
         }
 
         addToCompletedReceives();
@@ -293,7 +291,8 @@ public class Selector implements Selectable {
         maybeCloseOldestConnection();
     }
 
-    private void pollSelectionKeys(Iterator<SelectionKey> iterator) {
+    private void pollSelectionKeys(Iterable<SelectionKey> selectionKeys) {
+        Iterator<SelectionKey> iterator = selectionKeys.iterator();
         while (iterator.hasNext()) {
             SelectionKey key = iterator.next();
             iterator.remove();

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -114,18 +114,17 @@ public class Selector implements Selectable {
         this.time = time;
         this.metricGrpPrefix = metricGrpPrefix;
         this.metricTags = metricTags;
-        this.channels = new HashMap<String, KafkaChannel>();
-        this.completedSends = new ArrayList<Send>();
-        this.completedReceives = new ArrayList<NetworkReceive>();
-        this.stagedReceives = new HashMap<KafkaChannel, Deque<NetworkReceive>>();
-        this.connected = new ArrayList<String>();
-        this.disconnected = new ArrayList<String>();
-        this.failedSends = new ArrayList<String>();
+        this.channels = new HashMap<>();
+        this.completedSends = new ArrayList<>();
+        this.completedReceives = new ArrayList<>();
+        this.stagedReceives = new HashMap<>();
+        this.connected = new ArrayList<>();
+        this.disconnected = new ArrayList<>();
+        this.failedSends = new ArrayList<>();
         this.sensors = new SelectorMetrics(metrics);
         this.channelBuilder = channelBuilder;
         // initial capacity and load factor are default, we set them explicitly because we want to set accessOrder = true
-        this.lruConnections = new LinkedHashMap<String, Long>(16, .75F, true);
-        currentTimeNanos = new SystemTime().nanoseconds();
+        this.lruConnections = new LinkedHashMap<>(16, .75F, true);
         nextIdleCloseCheckTime = currentTimeNanos + connectionsMaxIdleNanos;
         this.metricsPerConnection = metricsPerConnection;
     }
@@ -645,7 +644,7 @@ public class Selector implements Selectable {
                 if (nodeRequest == null) {
                     String metricGrpName = metricGrpPrefix + "-node-metrics";
 
-                    Map<String, String> tags = new LinkedHashMap<String, String>(metricTags);
+                    Map<String, String> tags = new LinkedHashMap<>(metricTags);
                     tags.put("node-id", "node-" + connectionId);
 
                     nodeRequest = sensor(nodeRequestName);

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -106,9 +106,11 @@ public class SslTransportLayer implements TransportLayer {
      * does socketChannel.finishConnect()
      */
     @Override
-    public void finishConnect() throws IOException {
-        socketChannel.finishConnect();
-        key.interestOps(key.interestOps() & ~SelectionKey.OP_CONNECT | SelectionKey.OP_READ);
+    public boolean finishConnect() throws IOException {
+        boolean connected = socketChannel.finishConnect();
+        if (connected)
+            key.interestOps(key.interestOps() & ~SelectionKey.OP_CONNECT | SelectionKey.OP_READ);
+        return connected;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
@@ -43,7 +43,7 @@ public interface TransportLayer extends ScatteringByteChannel, GatheringByteChan
     /**
      * Finishes the process of connecting a socket channel.
      */
-    void finishConnect() throws IOException;
+    boolean finishConnect() throws IOException;
 
     /**
      * disconnect socketChannel


### PR DESCRIPTION
This is a different implementation to the one in #1085 by Larkin Lowrey (@llowrey). The hard part here was actually finding the problem and all credit goes to @llowrey.

This PR also fixes our handling of `finishConnect` (we now check the return value).
