### PR TITLE
MINOR: server stop scripts don't work correctlly in shell

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -19,6 +19,6 @@ if [ -z "$PIDS" ]; then
   echo "No kafka server to stop"
   exit 1
 else 
-  kill -SIGTERM $PIDS
+  kill $PIDS
 fi
 

--- a/bin/zookeeper-server-stop.sh
+++ b/bin/zookeeper-server-stop.sh
@@ -19,6 +19,6 @@ if [ -z "$PIDS" ]; then
   echo "No zookeeper server to stop"
   exit 1
 else
-  kill -SIGTERM $PIDS
+  kill $PIDS
 fi
 


### PR DESCRIPTION
kafka-server-stop.sh and zookeeper-server-stop.sh don't work in shell.
(however these work correctlly in bash)
