### PR TITLE
KAFKA-3436: Speed up controlled shutdown.

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -17,32 +17,29 @@
 package kafka.controller
 
 import java.util
-
-import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException}
-import org.apache.kafka.common.protocol.ApiKeys
-import org.apache.kafka.common.requests.{AbstractRequest, AbstractRequestResponse}
-
-import scala.collection._
-import com.yammer.metrics.core.Gauge
 import java.util.concurrent.TimeUnit
-import kafka.admin.AdminUtils
-import kafka.admin.PreferredReplicaLeaderElectionCommand
+import java.util.concurrent.locks.ReentrantLock
+
+import com.yammer.metrics.core.Gauge
+import kafka.admin.{PreferredReplicaLeaderElectionCommand}
 import kafka.api._
 import kafka.cluster.Broker
 import kafka.common._
-import kafka.log.LogConfig
-import kafka.metrics.{KafkaTimer, KafkaMetricsGroup}
+import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
+import kafka.server._
+import kafka.utils.CoreUtils._
 import kafka.utils.ZkUtils._
 import kafka.utils._
-import kafka.utils.CoreUtils._
-import org.apache.zookeeper.Watcher.Event.KeeperState
+import org.I0Itec.zkclient.exception.{ZkNoNodeException, ZkNodeExistsException}
+import org.I0Itec.zkclient.{IZkChildListener, IZkDataListener, IZkStateListener, ZkClient}
+import org.apache.kafka.common.errors.{BrokerNotAvailableException, ControllerMovedException}
 import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.protocol.ApiKeys
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractRequestResponse}
 import org.apache.kafka.common.utils.Time
-import org.I0Itec.zkclient.{IZkChildListener, IZkDataListener, IZkStateListener, ZkClient, ZkConnection}
-import org.I0Itec.zkclient.exception.{ZkNodeExistsException, ZkNoNodeException}
-import java.util.concurrent.locks.ReentrantLock
-import kafka.server._
-import kafka.common.TopicAndPartition
+import org.apache.zookeeper.Watcher.Event.KeeperState
+
+import scala.collection._
 
 class ControllerContext(val zkUtils: ZkUtils,
                         val zkSessionTimeout: Int) {
@@ -254,43 +251,50 @@ class KafkaController(val config : KafkaConfig, zkUtils: ZkUtils, val brokerStat
             .map(topicAndPartition => (topicAndPartition, controllerContext.partitionReplicaAssignment(topicAndPartition).size))
         }
 
-      allPartitionsAndReplicationFactorOnBroker.foreach {
-        case(topicAndPartition, replicationFactor) =>
-          // Move leadership serially to relinquish lock.
-          inLock(controllerContext.controllerLock) {
+      inLock(controllerContext.controllerLock) {
+        val leadersOnBroker = new mutable.HashSet[TopicAndPartition]
+        val followersOnBroker = new mutable.HashSet[PartitionAndReplica]
+
+        allPartitionsAndReplicationFactorOnBroker.foreach {
+          case (topicAndPartition, replicationFactor) =>
             controllerContext.partitionLeadershipInfo.get(topicAndPartition).foreach { currLeaderIsrAndControllerEpoch =>
               if (replicationFactor > 1) {
                 if (currLeaderIsrAndControllerEpoch.leaderAndIsr.leader == id) {
-                  // If the broker leads the topic partition, transition the leader and update isr. Updates zk and
-                  // notifies all affected brokers
-                  partitionStateMachine.handleStateChanges(Set(topicAndPartition), OnlinePartition,
-                    controlledShutdownPartitionLeaderSelector)
+                  leadersOnBroker += topicAndPartition
                 } else {
-                  // Stop the replica first. The state change below initiates ZK changes which should take some time
-                  // before which the stop replica request should be completed (in most cases)
-                  try {
-                    brokerRequestBatch.newBatch()
-                    brokerRequestBatch.addStopReplicaRequestForBrokers(Seq(id), topicAndPartition.topic,
-                      topicAndPartition.partition, deletePartition = false)
-                    brokerRequestBatch.sendRequestsToBrokers(epoch)
-                  } catch {
-                    case e : IllegalStateException => {
-                      // Resign if the controller is in an illegal state
-                      error("Forcing the controller to resign")
-                      brokerRequestBatch.clear()
-                      controllerElector.resign()
-
-                      throw e
-                    }
-                  }
-                  // If the broker is a follower, updates the isr in ZK and notifies the current leader
-                  replicaStateMachine.handleStateChanges(Set(PartitionAndReplica(topicAndPartition.topic,
-                    topicAndPartition.partition, id)), OfflineReplica)
+                  followersOnBroker += PartitionAndReplica(topicAndPartition.topic, topicAndPartition.partition, id)
                 }
               }
             }
+        }
+        // If the broker leads the topic partitions, transition all the leaders and update isr. Updates zk and
+        // notifies all affected brokers
+        partitionStateMachine.handleStateChanges(leadersOnBroker, OnlinePartition,
+          controlledShutdownPartitionLeaderSelector)
+
+        // Stop the follower replicas first. The state change below initiates ZK changes which should take some time
+        // before which the stop replica request should be completed (in most cases)
+        brokerRequestBatch.newBatch()
+        followersOnBroker.foreach {partitionAndReplica =>
+          try {
+            brokerRequestBatch.addStopReplicaRequestForBrokers(Seq(partitionAndReplica.replica), partitionAndReplica.topic,
+              partitionAndReplica.partition, deletePartition = false)
+          } catch {
+            case e: IllegalStateException => {
+              // Resign if the controller is in an illegal state
+              error("Forcing the controller to resign")
+              brokerRequestBatch.clear()
+              controllerElector.resign()
+
+              throw e
+            }
           }
+        }
+        brokerRequestBatch.sendRequestsToBrokers(epoch)
+        // If the broker is a follower of the partitions, updates the isr in ZK and notifies the current leaders
+        replicaStateMachine.handleStateChanges(followersOnBroker, OfflineReplica)
       }
+
       def replicatedPartitionsBrokerLeads() = inLock(controllerContext.controllerLock) {
         trace("All leaders = " + controllerContext.partitionLeadershipInfo.mkString(","))
         controllerContext.partitionLeadershipInfo.filter {
@@ -821,6 +825,27 @@ class KafkaController(val config : KafkaConfig, zkUtils: ZkUtils, val brokerStat
     controllerContext.controllerChannelManager.startup()
   }
 
+  def refreshLeaderAndIsrFromZk(topicAndPartitions: Set[TopicAndPartition]): Map[TopicAndPartition, ZkLeaderAndIsrReadResult] = {
+    val leaderAndIsrReadResults = ReplicationUtils.asyncGetLeaderIsrAndEpochForPartitions(zkUtils, topicAndPartitions)
+    leaderAndIsrReadResults.foreach { case (tap, leaderAndIsrReadResult) =>
+      leaderAndIsrReadResult.leaderIsrAndControllerEpochOpt match {
+        case Some(leaderIsrAndControllerEpoch) =>
+          if (leaderIsrAndControllerEpoch.controllerEpoch > epoch)
+            throw new StateChangeFailedException(s"Leader and isr path written by another controller. This probably" +
+              s"means the current controller with epoch $epoch went through a soft failure and another " +
+              s"controller was elected with epoch ${leaderIsrAndControllerEpoch.controllerEpoch}. Aborting state " +
+              s"change by this controller")
+        case None =>
+      }
+      leaderAndIsrReadResult.exceptionOpt match {
+        case Some(exception) =>
+          throw new KafkaException(s"Asychronously reading LeaderAndIsr information for $tap", exception)
+        case None =>
+      }
+    }
+    leaderAndIsrReadResults
+  }
+
   def updateLeaderAndIsrCache(topicAndPartitions: Set[TopicAndPartition] = controllerContext.partitionReplicaAssignment.keySet) {
     val leaderAndIsrInfo = zkUtils.getPartitionLeaderAndIsrForTopics(zkUtils.zkClient, topicAndPartitions)
     for((topicPartition, leaderIsrAndControllerEpoch) <- leaderAndIsrInfo)
@@ -1038,73 +1063,6 @@ class KafkaController(val config : KafkaConfig, zkUtils: ZkUtils, val brokerStat
         throw e
       }
     }
-  }
-
-  /**
-   * Removes a given partition replica from the ISR; if it is not the current
-   * leader and there are sufficient remaining replicas in ISR.
-   * @param topic topic
-   * @param partition partition
-   * @param replicaId replica Id
-   * @return the new leaderAndIsr (with the replica removed if it was present),
-   *         or None if leaderAndIsr is empty.
-   */
-  def removeReplicaFromIsr(topic: String, partition: Int, replicaId: Int): Option[LeaderIsrAndControllerEpoch] = {
-    val topicAndPartition = TopicAndPartition(topic, partition)
-    debug("Removing replica %d from ISR %s for partition %s.".format(replicaId,
-      controllerContext.partitionLeadershipInfo(topicAndPartition).leaderAndIsr.isr.mkString(","), topicAndPartition))
-    var finalLeaderIsrAndControllerEpoch: Option[LeaderIsrAndControllerEpoch] = None
-    var zkWriteCompleteOrUnnecessary = false
-    while (!zkWriteCompleteOrUnnecessary) {
-      // refresh leader and isr from zookeeper again
-      val leaderIsrAndEpochOpt = ReplicationUtils.getLeaderIsrAndEpochForPartition(zkUtils, topic, partition)
-      zkWriteCompleteOrUnnecessary = leaderIsrAndEpochOpt match {
-        case Some(leaderIsrAndEpoch) => // increment the leader epoch even if the ISR changes
-          val leaderAndIsr = leaderIsrAndEpoch.leaderAndIsr
-          val controllerEpoch = leaderIsrAndEpoch.controllerEpoch
-          if(controllerEpoch > epoch)
-            throw new StateChangeFailedException("Leader and isr path written by another controller. This probably" +
-              "means the current controller with epoch %d went through a soft failure and another ".format(epoch) +
-              "controller was elected with epoch %d. Aborting state change by this controller".format(controllerEpoch))
-          if (leaderAndIsr.isr.contains(replicaId)) {
-            // if the replica to be removed from the ISR is also the leader, set the new leader value to -1
-            val newLeader = if (replicaId == leaderAndIsr.leader) LeaderAndIsr.NoLeader else leaderAndIsr.leader
-            var newIsr = leaderAndIsr.isr.filter(b => b != replicaId)
-
-            // if the replica to be removed from the ISR is the last surviving member of the ISR and unclean leader election
-            // is disallowed for the corresponding topic, then we must preserve the ISR membership so that the replica can
-            // eventually be restored as the leader.
-            if (newIsr.isEmpty && !LogConfig.fromProps(config.originals, AdminUtils.fetchEntityConfig(zkUtils,
-              ConfigType.Topic, topicAndPartition.topic)).uncleanLeaderElectionEnable) {
-              info("Retaining last ISR %d of partition %s since unclean leader election is disabled".format(replicaId, topicAndPartition))
-              newIsr = leaderAndIsr.isr
-            }
-
-            val newLeaderAndIsr = new LeaderAndIsr(newLeader, leaderAndIsr.leaderEpoch + 1,
-              newIsr, leaderAndIsr.zkVersion + 1)
-            // update the new leadership decision in zookeeper or retry
-            val (updateSucceeded, newVersion) = ReplicationUtils.updateLeaderAndIsr(zkUtils, topic, partition,
-              newLeaderAndIsr, epoch, leaderAndIsr.zkVersion)
-
-            newLeaderAndIsr.zkVersion = newVersion
-            finalLeaderIsrAndControllerEpoch = Some(LeaderIsrAndControllerEpoch(newLeaderAndIsr, epoch))
-            controllerContext.partitionLeadershipInfo.put(topicAndPartition, finalLeaderIsrAndControllerEpoch.get)
-            if (updateSucceeded)
-              info("New leader and ISR for partition %s is %s".format(topicAndPartition, newLeaderAndIsr.toString()))
-            updateSucceeded
-          } else {
-            warn("Cannot remove replica %d from ISR of partition %s since it is not in the ISR. Leader = %d ; ISR = %s"
-                 .format(replicaId, topicAndPartition, leaderAndIsr.leader, leaderAndIsr.isr))
-            finalLeaderIsrAndControllerEpoch = Some(LeaderIsrAndControllerEpoch(leaderAndIsr, epoch))
-            controllerContext.partitionLeadershipInfo.put(topicAndPartition, finalLeaderIsrAndControllerEpoch.get)
-            true
-          }
-        case None =>
-          warn("Cannot remove replica %d from ISR of %s - leaderAndIsr is empty.".format(replicaId, topicAndPartition))
-          true
-      }
-    }
-    finalLeaderIsrAndControllerEpoch
   }
 
   /**

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -219,6 +219,8 @@ class KafkaController(val config : KafkaConfig, zkUtils: ZkUtils, val brokerStat
     "id_%d-host_%s-port_%d".format(config.brokerId, controllerListener.get.host, controllerListener.get.port)
   }
 
+  def isValidController = zkUtils.getController == config.brokerId
+
   /**
    * On clean shutdown, the controller first determines the partitions that the
    * shutting down broker leads, and moves leadership of those partitions to another broker

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -147,11 +147,22 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
             targetState, leaderSelector, callbacks)
         }
         // Make sure we update zk first because the callbacks will fill in the BrokerRequestBatch
-        leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch, Some(e => controller.isValidController))
+        try {
+          leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch, Some(() => controller.isValidController))
+        } catch {
+          // the exception thrown here is likely because of the zk disconnection or session expiration. In this case
+          // we swallow the error and retry. For the LeaderAndIsr updates that has been sent but not acked yet, they
+          // might be updated again, but that does not hurt.
+          case e: Throwable => error("Error while updating LeaderAndIsr in zookeeper.", e)
+        }
         brokerRequestBatch.sendRequestsToBrokers(controller.epoch)
         remainingParititions.retain(leaderAndIsrUpdateBatch.containsPartition(_))
-        if (!remainingParititions.isEmpty)
+        if (!remainingParititions.isEmpty) {
           debug(s"The following partitions are still waiting for state change: $remainingParititions.")
+          if (!controller.isValidController)
+            throw new StateChangeFailedException(s"Controller ${controller.config.brokerId} epoch ${controller.epoch}" +
+              s" is no longer the valid controller.")
+        }
       } while (!remainingParititions.isEmpty)
     }catch {
       case e: Throwable => error("Error while moving some partitions to %s state".format(targetState), e)

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -147,7 +147,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
             targetState, leaderSelector, callbacks)
         }
         // Make sure we update zk first because the callbacks will fill in the BrokerRequestBatch
-        leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch)
+        leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch, Some(e => controller.isValidController))
         brokerRequestBatch.sendRequestsToBrokers(controller.epoch)
         remainingParititions.retain(leaderAndIsrUpdateBatch.containsPartition(_))
         if (!remainingParititions.isEmpty)

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -21,7 +21,7 @@ import collection.JavaConversions
 import collection.mutable.Buffer
 import java.util.concurrent.atomic.AtomicBoolean
 import kafka.api.LeaderAndIsr
-import kafka.common.{LeaderElectionNotNeededException, TopicAndPartition, StateChangeFailedException, NoReplicaOnlineException}
+import kafka.common.{KafkaException, LeaderElectionNotNeededException, TopicAndPartition, StateChangeFailedException, NoReplicaOnlineException}
 import kafka.utils.{Logging, ReplicationUtils}
 import kafka.utils.ZkUtils._
 import org.I0Itec.zkclient.{IZkDataListener, IZkChildListener}
@@ -47,6 +47,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
   private val zkUtils = controllerContext.zkUtils
   private val partitionState: mutable.Map[TopicAndPartition, PartitionState] = mutable.Map.empty
   private val brokerRequestBatch = new ControllerBrokerRequestBatch(controller)
+  private val leaderAndIsrUpdateBatch = new ZkLeaderAndIsrUpdateBatch(zkUtils)
   private val hasStarted = new AtomicBoolean(false)
   private val noOpPartitionLeaderSelector = new NoOpLeaderSelector(controllerContext)
   private val topicChangeListener = new TopicChangeListener()
@@ -110,21 +111,12 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
    * state. This is called on a successful controller election and on broker changes
    */
   def triggerOnlinePartitionStateChange() {
-    try {
-      brokerRequestBatch.newBatch()
-      // try to move all partitions in NewPartition or OfflinePartition state to OnlinePartition state except partitions
-      // that belong to topics to be deleted
-      for((topicAndPartition, partitionState) <- partitionState
-          if(!controller.deleteTopicManager.isTopicQueuedUpForDeletion(topicAndPartition.topic))) {
-        if(partitionState.equals(OfflinePartition) || partitionState.equals(NewPartition))
-          handleStateChange(topicAndPartition.topic, topicAndPartition.partition, OnlinePartition, controller.offlinePartitionSelector,
-                            (new CallbackBuilder).build)
-      }
-      brokerRequestBatch.sendRequestsToBrokers(controller.epoch)
-    } catch {
-      case e: Throwable => error("Error while moving some partitions to the online state", e)
-      // TODO: It is not enough to bail out and log an error, it is important to trigger leader election for those partitions
-    }
+    val partitions = partitionState.filter { case (topicAndPartition, partitionState) =>
+      val isBeingDeleted = controller.deleteTopicManager.isTopicQueuedUpForDeletion(topicAndPartition.topic)
+      !isBeingDeleted && (partitionState.equals(OfflinePartition) || partitionState.equals(NewPartition))
+    }.keySet
+
+    handleStateChanges(partitions, OnlinePartition, controller.offlinePartitionSelector, (new CallbackBuilder).build)
   }
 
   def partitionsInState(state: PartitionState): Set[TopicAndPartition] = {
@@ -141,11 +133,26 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
                          callbacks: Callbacks = (new CallbackBuilder).build) {
     info("Invoking state change to %s for partitions %s".format(targetState, partitions.mkString(",")))
     try {
-      brokerRequestBatch.newBatch()
-      partitions.foreach { topicAndPartition =>
-        handleStateChange(topicAndPartition.topic, topicAndPartition.partition, targetState, leaderSelector, callbacks)
-      }
-      brokerRequestBatch.sendRequestsToBrokers(controller.epoch)
+      val remainingParititions = collection.mutable.Set(partitions.toArray:_*)
+      do {
+        // First refresh all the LeaderAndIsr info from zookeeper
+        // Make sure all the LeaderAndIsr information are successfully read and this is the valid controller.
+        val leaderAndIsrReadResults = controller.refreshLeaderAndIsrFromZk(remainingParititions)
+        trace(s"Refreshed LeaderAndIsr information for partitions: ${leaderAndIsrReadResults}")
+        leaderAndIsrUpdateBatch.newBatch()
+        brokerRequestBatch.newBatch()
+        partitions.foreach { topicAndPartition =>
+          val leaderIsrAndControllerEpoch = leaderAndIsrReadResults(topicAndPartition).leaderIsrAndControllerEpochOpt
+          handleStateChange(topicAndPartition.topic, topicAndPartition.partition, leaderIsrAndControllerEpoch,
+            targetState, leaderSelector, callbacks)
+        }
+        // Make sure we update zk first because the callbacks will fill in the BrokerRequestBatch
+        leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch)
+        brokerRequestBatch.sendRequestsToBrokers(controller.epoch)
+        remainingParititions.retain(leaderAndIsrUpdateBatch.containsPartition(_))
+        if (!remainingParititions.isEmpty)
+          debug(s"The following partitions are still waiting for state change: $remainingParititions.")
+      } while (!remainingParititions.isEmpty)
     }catch {
       case e: Throwable => error("Error while moving some partitions to %s state".format(targetState), e)
       // TODO: It is not enough to bail out and log an error, it is important to trigger state changes for those partitions
@@ -175,7 +182,10 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
    * @param partition   The partition for which the state transition is invoked
    * @param targetState The end state that the partition should be moved to
    */
-  private def handleStateChange(topic: String, partition: Int, targetState: PartitionState,
+  private def handleStateChange(topic: String,
+                                partition: Int,
+                                leaderIsrAndControllerEpoch: Option[LeaderIsrAndControllerEpoch],
+                                targetState: PartitionState,
                                 leaderSelector: PartitionLeaderSelector,
                                 callbacks: Callbacks) {
     val topicAndPartition = TopicAndPartition(topic, partition)
@@ -201,16 +211,17 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
             case NewPartition =>
               // initialize leader and isr path for new partition
               initializeLeaderAndIsrForPartition(topicAndPartition)
+              partitionState.put(topicAndPartition, OnlinePartition)
+              val leader = controllerContext.partitionLeadershipInfo(topicAndPartition).leaderAndIsr.leader
+              stateChangeLogger.trace("Controller %d epoch %d changed partition %s from %s to %s with leader %d"
+                .format(controllerId, controller.epoch, topicAndPartition, currState, targetState, leader))
             case OfflinePartition =>
-              electLeaderForPartition(topic, partition, leaderSelector)
+              electLeaderForPartition(topic, partition, OfflinePartition, leaderIsrAndControllerEpoch, leaderSelector)
             case OnlinePartition => // invoked when the leader needs to be re-elected
-              electLeaderForPartition(topic, partition, leaderSelector)
+              electLeaderForPartition(topic, partition, OnlinePartition, leaderIsrAndControllerEpoch, leaderSelector)
             case _ => // should never come here since illegal previous states are checked above
           }
-          partitionState.put(topicAndPartition, OnlinePartition)
-          val leader = controllerContext.partitionLeadershipInfo(topicAndPartition).leaderAndIsr.leader
-          stateChangeLogger.trace("Controller %d epoch %d changed partition %s from %s to %s with leader %d"
-                                    .format(controllerId, controller.epoch, topicAndPartition, currState, targetState, leader))
+
            // post: partition has a leader
         case OfflinePartition =>
           // pre: partition should be in New or Online state
@@ -316,49 +327,56 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
   /**
    * Invoked on the OfflinePartition,OnlinePartition->OnlinePartition state change.
    * It invokes the leader election API to elect a leader for the input offline partition
-   * @param topic               The topic of the offline partition
-   * @param partition           The offline partition
-   * @param leaderSelector      Specific leader selector (e.g., offline/reassigned/etc.)
+   * @param topic                                 The topic of the offline partition
+   * @param partition                             The offline partition
+   * @param leaderIsrAndControllerEpochOpt        The current leader and isr information in zookeeper
+   * @param leaderSelector                        Specific leader selector (e.g., offline/reassigned/etc.)
    */
-  def electLeaderForPartition(topic: String, partition: Int, leaderSelector: PartitionLeaderSelector) {
+  def electLeaderForPartition(topic: String,
+                              partition: Int,
+                              currState: PartitionState,
+                              leaderIsrAndControllerEpochOpt: Option[LeaderIsrAndControllerEpoch],
+                              leaderSelector: PartitionLeaderSelector) {
     val topicAndPartition = TopicAndPartition(topic, partition)
     // handle leader election for the partitions whose leader is no longer alive
     stateChangeLogger.trace("Controller %d epoch %d started leader election for partition %s"
                               .format(controllerId, controller.epoch, topicAndPartition))
     try {
-      var zookeeperPathUpdateSucceeded: Boolean = false
-      var newLeaderAndIsr: LeaderAndIsr = null
-      var replicasForThisPartition: Seq[Int] = Seq.empty[Int]
-      while(!zookeeperPathUpdateSucceeded) {
-        val currentLeaderIsrAndEpoch = getLeaderIsrAndEpochOrThrowException(topic, partition)
-        val currentLeaderAndIsr = currentLeaderIsrAndEpoch.leaderAndIsr
-        val controllerEpoch = currentLeaderIsrAndEpoch.controllerEpoch
-        if (controllerEpoch > controller.epoch) {
-          val failMsg = ("aborted leader election for partition [%s,%d] since the LeaderAndIsr path was " +
-                         "already written by another controller. This probably means that the current controller %d went through " +
-                         "a soft failure and another controller was elected with epoch %d.")
-                           .format(topic, partition, controllerId, controllerEpoch)
-          stateChangeLogger.error("Controller %d epoch %d ".format(controllerId, controller.epoch) + failMsg)
-          throw new StateChangeFailedException(failMsg)
-        }
-        // elect new leader or throw exception
-        val (leaderAndIsr, replicas) = leaderSelector.selectLeader(topicAndPartition, currentLeaderAndIsr)
-        val (updateSucceeded, newVersion) = ReplicationUtils.updateLeaderAndIsr(zkUtils, topic, partition,
-          leaderAndIsr, controller.epoch, currentLeaderAndIsr.zkVersion)
-        newLeaderAndIsr = leaderAndIsr
-        newLeaderAndIsr.zkVersion = newVersion
-        zookeeperPathUpdateSucceeded = updateSucceeded
-        replicasForThisPartition = replicas
+
+      val currLeaderIsrAndEpoch = leaderIsrAndControllerEpochOpt.getOrElse({
+        val failMsg = "LeaderAndIsr information doesn't exist for partition %s in %s state"
+          .format(topicAndPartition, partitionState(topicAndPartition))
+        throw new StateChangeFailedException(failMsg)
+      })
+      val currLeaderAndIsr = currLeaderIsrAndEpoch.leaderAndIsr
+      // elect new leader or throw exception
+      val (newLeaderAndIsr, replicas) = leaderSelector.selectLeader(topicAndPartition, currLeaderAndIsr)
+      leaderAndIsrUpdateBatch.addLeaderAndIsrUpdate(topicAndPartition,
+                                                    newLeaderAndIsr,
+                                                    currLeaderAndIsr.zkVersion,
+                                                    onLeaderAndIsrUpdateSuccess)
+
+      def onLeaderAndIsrUpdateSuccess(topicAndPartition: TopicAndPartition,
+                                      leaderAndIsrUpdateResult: ZkLeaderAndIsrUpdateResult) = {
+        val newLeaderAndIsr = leaderAndIsrUpdateResult.leaderAndIsr
+        val newZkVersion = leaderAndIsrUpdateResult.newZkVersion
+        updateLocalState(newLeaderAndIsr, newZkVersion)
       }
-      val newLeaderIsrAndControllerEpoch = new LeaderIsrAndControllerEpoch(newLeaderAndIsr, controller.epoch)
-      // update the leader cache
-      controllerContext.partitionLeadershipInfo.put(TopicAndPartition(topic, partition), newLeaderIsrAndControllerEpoch)
-      stateChangeLogger.trace("Controller %d epoch %d elected leader %d for Offline partition %s"
-                                .format(controllerId, controller.epoch, newLeaderAndIsr.leader, topicAndPartition))
-      val replicas = controllerContext.partitionReplicaAssignment(TopicAndPartition(topic, partition))
-      // store new leader and isr info in cache
-      brokerRequestBatch.addLeaderAndIsrRequestForBrokers(replicasForThisPartition, topic, partition,
-        newLeaderIsrAndControllerEpoch, replicas)
+
+      def updateLocalState(newLeaderAndIsr: LeaderAndIsr, newZkVersion: Int) = {
+        val newLeaderIsrAndControllerEpoch = new LeaderIsrAndControllerEpoch(newLeaderAndIsr, controller.epoch)
+        // update the leader cache
+        controllerContext.partitionLeadershipInfo.put(topicAndPartition, newLeaderIsrAndControllerEpoch)
+        val assignedReplicas = controllerContext.partitionReplicaAssignment(TopicAndPartition(topic, partition))
+        // store new leader and isr info in cache
+        brokerRequestBatch.addLeaderAndIsrRequestForBrokers(replicas, topic, partition,
+          newLeaderIsrAndControllerEpoch, assignedReplicas)
+        partitionState.put(topicAndPartition, OnlinePartition)
+        stateChangeLogger.trace(s"Controller $controllerId epoch ${controller.epoch} changed partition $topicAndPartition " +
+          s"from $currState to $OnlinePartition with leader ${newLeaderAndIsr.leader}")
+        debug(s"After leader election, leader cache is updated to " +
+          s"${controllerContext.partitionLeadershipInfo.map(l => (l._1, l._2))}")
+      }
     } catch {
       case lenne: LeaderElectionNotNeededException => // swallow
       case nroe: NoReplicaOnlineException => throw nroe
@@ -367,7 +385,6 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
         stateChangeLogger.error("Controller %d epoch %d ".format(controllerId, controller.epoch) + failMsg)
         throw new StateChangeFailedException(failMsg, sce)
     }
-    debug("After leader election, leader cache is updated to %s".format(controllerContext.partitionLeadershipInfo.map(l => (l._1, l._2))))
   }
 
   private def registerTopicChangeListener() = {

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -132,7 +132,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
               leaderAndIsrReadResults(TopicAndPartition(r.topic, r.partition)).leaderIsrAndControllerEpochOpt
             handleStateChange(r, leaderIsrAndControllerEpochOpt, targetState, callbacks)
           })
-          leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch)
+          leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controller.epoch, Some(e => controller.isValidController))
           brokerRequestBatch.sendRequestsToBrokers(controller.epoch)
           remainingTopicAndPartitions.retain(leaderAndIsrUpdateBatch.containsPartition(_))
           remainingReplicas.retain(r => leaderAndIsrUpdateBatch.containsPartition(TopicAndPartition(r.topic, r.partition)))

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -140,7 +140,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
             debug(s"The following replicas are still waiting for state change: $remainingReplicas.")
         } while (!remainingReplicas.isEmpty)
 
-      }catch {
+      } catch {
         case e: Throwable => error("Error while moving some replicas to %s state".format(targetState), e)
       }
     }

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -301,6 +301,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
    * @param topic the topic
    * @param partition the partition id
    * @param replicaId the replica id
+   * @param currState the current state fot the replica
    * @param leaderIsrAndEpochOpt The current LeaderAndIsr information. It is refreshed from zookeeper before the state
    *                             change.
    */

--- a/core/src/main/scala/kafka/controller/ZkLeaderAndIsrUpdateBatch.scala
+++ b/core/src/main/scala/kafka/controller/ZkLeaderAndIsrUpdateBatch.scala
@@ -17,8 +17,11 @@
 
 package kafka.controller
 
+import java.util.concurrent.CountDownLatch
+
 import kafka.api.LeaderAndIsr
 import kafka.common.TopicAndPartition
+import kafka.utils.ReplicationUtils.trace
 import kafka.utils.{ReplicationUtils, ZkUtils}
 
 /**
@@ -49,7 +52,7 @@ class ZkLeaderAndIsrUpdateBatch(zkUtils: ZkUtils) {
     leaderAndIsrUpdates -= topicAndPartition
   }
 
-  def size = this synchronized(leaderAndIsrUpdates.size)
+  def incompleteUpdates = this synchronized(leaderAndIsrUpdates.size)
 
   def containsPartition(topicAndPartition: TopicAndPartition): Boolean =
     leaderAndIsrUpdates.contains(topicAndPartition)
@@ -58,8 +61,8 @@ class ZkLeaderAndIsrUpdateBatch(zkUtils: ZkUtils) {
     leaderAndIsrUpdates(topicAndPartition)
   }
 
-  def writeLeaderAndIsrUpdateToZk(controllerEpoch: Int, retryOnException: Option[Exception => Boolean] = None) =
-    ReplicationUtils.asyncUpdateLeaderAndIsr(zkUtils, this, controllerEpoch, retryOnException)
+  def writeLeaderAndIsrUpdateToZk(controllerEpoch: Int, preConditionCheckerOpt: Option[() => Boolean] = None) =
+    ReplicationUtils.asyncUpdateLeaderAndIsr(zkUtils, this, controllerEpoch, preConditionCheckerOpt)
 }
 
 /**

--- a/core/src/main/scala/kafka/controller/ZkLeaderAndIsrUpdateBatch.scala
+++ b/core/src/main/scala/kafka/controller/ZkLeaderAndIsrUpdateBatch.scala
@@ -58,8 +58,8 @@ class ZkLeaderAndIsrUpdateBatch(zkUtils: ZkUtils) {
     leaderAndIsrUpdates(topicAndPartition)
   }
 
-  def writeLeaderAndIsrUpdateToZk(controllerEpoch: Int) =
-    ReplicationUtils.asyncUpdateLeaderAndIsr(zkUtils, this, controllerEpoch)
+  def writeLeaderAndIsrUpdateToZk(controllerEpoch: Int, retryOnException: Option[Exception => Boolean] = None) =
+    ReplicationUtils.asyncUpdateLeaderAndIsr(zkUtils, this, controllerEpoch, retryOnException)
 }
 
 /**

--- a/core/src/main/scala/kafka/controller/ZkLeaderAndIsrUpdateBatch.scala
+++ b/core/src/main/scala/kafka/controller/ZkLeaderAndIsrUpdateBatch.scala
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.controller
+
+import kafka.api.LeaderAndIsr
+import kafka.common.TopicAndPartition
+import kafka.utils.{ReplicationUtils, ZkUtils}
+
+/**
+ * The class that batches the LeaderAndisrUpdate together.
+ */
+class ZkLeaderAndIsrUpdateBatch(zkUtils: ZkUtils) {
+  val leaderAndIsrUpdates = new collection.mutable.HashMap[TopicAndPartition, ZkLeaderAndIsrUpdate]
+
+  def newBatch() = leaderAndIsrUpdates.clear()
+
+  def addLeaderAndIsrUpdate(topicAndPartition: TopicAndPartition,
+                            newLeaderAndIsr: LeaderAndIsr,
+                            expectZkVersion: Int,
+                            onSuccess: (TopicAndPartition, ZkLeaderAndIsrUpdateResult) => Unit) = {
+    // We need to chain up the callbacks if there are multiple callbacks to be fired for the same partition.
+    // This is used by the ReplicaStateMachine where multiple replicas of the same partition can change in the same
+    // batch.
+    val onSuccessCallbacks = {
+      if (leaderAndIsrUpdates.contains(topicAndPartition))
+        leaderAndIsrUpdates(topicAndPartition).onSuccessCallbacks :+ onSuccess
+      else
+        List(onSuccess)
+    }
+    leaderAndIsrUpdates += (topicAndPartition -> new ZkLeaderAndIsrUpdate(newLeaderAndIsr, expectZkVersion, onSuccessCallbacks))
+  }
+
+  def completeLeaderAndIsrUpdate(topicAndPartition: TopicAndPartition) = {
+    leaderAndIsrUpdates -= topicAndPartition
+  }
+
+  def size = this synchronized(leaderAndIsrUpdates.size)
+
+  def containsPartition(topicAndPartition: TopicAndPartition): Boolean =
+    leaderAndIsrUpdates.contains(topicAndPartition)
+
+  def pendingLeaderAndIsrUpdate(topicAndPartition: TopicAndPartition) = {
+    leaderAndIsrUpdates(topicAndPartition)
+  }
+
+  def writeLeaderAndIsrUpdateToZk(controllerEpoch: Int) =
+    ReplicationUtils.asyncUpdateLeaderAndIsr(zkUtils, this, controllerEpoch)
+}
+
+/**
+ * This is a container class to host the LeaderAndIsr updates in zookeeper.
+ * @param newLeaderAndIsr The new LeaderAndIsr information.
+ * @param expectZkVersion The expected zkVersion of the path
+ * @param onSuccessCallbacks The callbacks to fire when the LeaderAndIsr update succeeded. We need a list because there
+ *                           might be multiple replica state changes for the same partition in one batch.
+ */
+class ZkLeaderAndIsrUpdate(val newLeaderAndIsr: LeaderAndIsr,
+                           val expectZkVersion: Int,
+                           val onSuccessCallbacks: List[(TopicAndPartition, ZkLeaderAndIsrUpdateResult) => Unit])
+
+case class ZkLeaderAndIsrUpdateResult(val leaderAndIsr: LeaderAndIsr,
+                                      val newZkVersion: Int)
+
+case class ZkLeaderAndIsrReadResult(val leaderIsrAndControllerEpochOpt: Option[LeaderIsrAndControllerEpoch],
+                                    val exceptionOpt: Option[Exception]) {
+  override def toString: String = "[" + leaderIsrAndControllerEpochOpt + "," + exceptionOpt + "]"
+}

--- a/core/src/main/scala/kafka/utils/ReplicationUtils.scala
+++ b/core/src/main/scala/kafka/utils/ReplicationUtils.scala
@@ -49,7 +49,8 @@ object ReplicationUtils extends Logging {
    */
   def asyncUpdateLeaderAndIsr(zkUtils: ZkUtils,
                               leaderAndIsrUpdateBatch: ZkLeaderAndIsrUpdateBatch,
-                              controllerEpoch: Int) = {
+                              controllerEpoch: Int,
+                              retryOnException: Option[Exception => Boolean] = None) = {
     val unprocessedUpdates = new CountDownLatch(leaderAndIsrUpdateBatch.size)
     leaderAndIsrUpdateBatch.leaderAndIsrUpdates.foreach { case (tp, update) => {
       val path = getTopicPartitionLeaderAndIsrPath(tp.topic, tp.partition)
@@ -72,7 +73,7 @@ object ReplicationUtils extends Logging {
           } finally {
             unprocessedUpdates.countDown()
           }
-        })
+        }, retryOnException)
     }}
     unprocessedUpdates.await()
   }

--- a/core/src/main/scala/kafka/utils/ReplicationUtils.scala
+++ b/core/src/main/scala/kafka/utils/ReplicationUtils.scala
@@ -21,8 +21,9 @@ import java.util.concurrent.CountDownLatch
 
 import kafka.api.LeaderAndIsr
 import kafka.common.TopicAndPartition
-import kafka.controller.{ZkLeaderAndIsrReadResult, ZkLeaderAndIsrUpdateResult, ZkLeaderAndIsrUpdateBatch, IsrChangeNotificationListener, LeaderIsrAndControllerEpoch}
+import kafka.controller.{ZkLeaderAndIsrUpdate, ZkLeaderAndIsrReadResult, ZkLeaderAndIsrUpdateResult, ZkLeaderAndIsrUpdateBatch, IsrChangeNotificationListener, LeaderIsrAndControllerEpoch}
 import kafka.utils.ZkUtils._
+import org.apache.zookeeper.ZooKeeper
 import org.apache.zookeeper.data.Stat
 
 import scala.collection._
@@ -42,39 +43,54 @@ object ReplicationUtils extends Logging {
   }
 
   /**
+   * This method asynchronously updates the leader and ISR information in a LeaderAndIsrUpdateBatch. It will block waiting
+   * until all the updates finish.
+   *
+   * The method takes an optional precondition check method and makes sure the precondition is met before updating the
+   * leader and ISR. This is useful for the controller. When the controller updates leader and ISR in zookeeper, it is
+   * important that the controller remains the controller during the entire update process. To guarantee that, this
+   * method first take the current ZooKeeper session, and then check if the current broker is the controller. If it
+   * is valid then this method will use the current ZK session for all the updates.
+   *
+   * During the leader and ISR update, if the zookeeper connection is lost or ZooKeeper session expired, the current
+   * ZooKeeper session will throw exception. We propagate the exception to caller and let the caller to decide
+   * whether to continue or abort.
+   *
    * Unlike the synchronous leader and isr update call which takes an optional checker function, the async leader and
-   * isr update call does not verify if the leader and isr data is the same or not. The update will fail even if the
+   * ISR update call does not verify if the leader and isr data is the same or not. The update will fail even if the
    * data are the same but the zk version mismatch. We do this because we cannot read data in the zookeeper event
    * thread.
    */
   def asyncUpdateLeaderAndIsr(zkUtils: ZkUtils,
                               leaderAndIsrUpdateBatch: ZkLeaderAndIsrUpdateBatch,
                               controllerEpoch: Int,
-                              retryOnException: Option[Exception => Boolean] = None) = {
-    val unprocessedUpdates = new CountDownLatch(leaderAndIsrUpdateBatch.size)
-    leaderAndIsrUpdateBatch.leaderAndIsrUpdates.foreach { case (tp, update) => {
-      val path = getTopicPartitionLeaderAndIsrPath(tp.topic, tp.partition)
-      val newLeaderAndIsr = update.newLeaderAndIsr
-      val newLeaderData = zkUtils.leaderAndIsrZkData(newLeaderAndIsr, controllerEpoch)
-      zkUtils.asyncConditionalUpdatePersistentPath(path, newLeaderData, update.expectZkVersion,
-        (updateSucceeded, updatedZkVersion) => {
-          // Remove the successfully updated partitions
-          // We do not handle failure and retry to make Zookeeper EventThread light weighted. The caller is
-          // responsible to check if the update batch is finished or retry is needed.
-          try {
-            trace(s"Received LeaderAndIsr update callback of update $newLeaderAndIsr for $tp. " +
-              s"UpdateSucceeded = $updateSucceeded")
-            if (updateSucceeded) {
-              leaderAndIsrUpdateBatch.completeLeaderAndIsrUpdate(tp)
-              update.onSuccessCallbacks.foreach { case onSuccess =>
-                onSuccess(tp, new ZkLeaderAndIsrUpdateResult(newLeaderAndIsr, updatedZkVersion))
+                              preconditionCheckerOpt: Option[() => Boolean] = None) = {
+    val unprocessedUpdates = new CountDownLatch(leaderAndIsrUpdateBatch.incompleteUpdates)
+    zkUtils.withCurrentSession(preconditionCheckerOpt) { zk =>
+      leaderAndIsrUpdateBatch.leaderAndIsrUpdates.foreach { case (tp, update) => {
+        val path = getTopicPartitionLeaderAndIsrPath(tp.topic, tp.partition)
+        val newLeaderAndIsr = update.newLeaderAndIsr
+        val newLeaderData = zkUtils.leaderAndIsrZkData(newLeaderAndIsr, controllerEpoch)
+        zkUtils.asyncConditionalUpdatePersistentPath(path, newLeaderData, update.expectZkVersion,
+          (updateSucceeded, updatedZkVersion) => {
+            // Remove the successfully updated partitions
+            // We do not handle failure and retry to make Zookeeper EventThread light weighted. The caller is
+            // responsible to check if the update batch is finished or retry is needed.
+            try {
+              trace(s"Received LeaderAndIsr update callback of update $newLeaderAndIsr for $tp. " +
+                s"UpdateSucceeded = $updateSucceeded")
+              if (updateSucceeded) {
+                leaderAndIsrUpdateBatch.completeLeaderAndIsrUpdate(tp)
+                update.onSuccessCallbacks.foreach { case onSuccess =>
+                  onSuccess(tp, new ZkLeaderAndIsrUpdateResult(newLeaderAndIsr, updatedZkVersion))
+                }
               }
+            } finally {
+              unprocessedUpdates.countDown()
             }
-          } finally {
-            unprocessedUpdates.countDown()
-          }
-        }, retryOnException)
-    }}
+          }, Some(zk))
+      }}
+    }
     unprocessedUpdates.await()
   }
 

--- a/core/src/main/scala/kafka/utils/ReplicationUtils.scala
+++ b/core/src/main/scala/kafka/utils/ReplicationUtils.scala
@@ -17,9 +17,11 @@
 
 package kafka.utils
 
+import java.util.concurrent.CountDownLatch
+
 import kafka.api.LeaderAndIsr
 import kafka.common.TopicAndPartition
-import kafka.controller.{IsrChangeNotificationListener, LeaderIsrAndControllerEpoch}
+import kafka.controller.{ZkLeaderAndIsrReadResult, ZkLeaderAndIsrUpdateResult, ZkLeaderAndIsrUpdateBatch, IsrChangeNotificationListener, LeaderIsrAndControllerEpoch}
 import kafka.utils.ZkUtils._
 import org.apache.zookeeper.data.Stat
 
@@ -37,6 +39,42 @@ object ReplicationUtils extends Logging {
     // use the epoch of the controller that made the leadership decision, instead of the current controller epoch
     val updatePersistentPath: (Boolean, Int) = zkUtils.conditionalUpdatePersistentPath(path, newLeaderData, zkVersion, Some(checkLeaderAndIsrZkData))
     updatePersistentPath
+  }
+
+  /**
+   * Unlike the synchronous leader and isr update call which takes an optional checker function, the async leader and
+   * isr update call does not verify if the leader and isr data is the same or not. The update will fail even if the
+   * data are the same but the zk version mismatch. We do this because we cannot read data in the zookeeper event
+   * thread.
+   */
+  def asyncUpdateLeaderAndIsr(zkUtils: ZkUtils,
+                              leaderAndIsrUpdateBatch: ZkLeaderAndIsrUpdateBatch,
+                              controllerEpoch: Int) = {
+    val unprocessedUpdates = new CountDownLatch(leaderAndIsrUpdateBatch.size)
+    leaderAndIsrUpdateBatch.leaderAndIsrUpdates.foreach { case (tp, update) => {
+      val path = getTopicPartitionLeaderAndIsrPath(tp.topic, tp.partition)
+      val newLeaderAndIsr = update.newLeaderAndIsr
+      val newLeaderData = zkUtils.leaderAndIsrZkData(newLeaderAndIsr, controllerEpoch)
+      zkUtils.asyncConditionalUpdatePersistentPath(path, newLeaderData, update.expectZkVersion,
+        (updateSucceeded, updatedZkVersion) => {
+          // Remove the successfully updated partitions
+          // We do not handle failure and retry to make Zookeeper EventThread light weighted. The caller is
+          // responsible to check if the update batch is finished or retry is needed.
+          try {
+            trace(s"Received LeaderAndIsr update callback of update $newLeaderAndIsr for $tp. " +
+              s"UpdateSucceeded = $updateSucceeded")
+            if (updateSucceeded) {
+              leaderAndIsrUpdateBatch.completeLeaderAndIsrUpdate(tp)
+              update.onSuccessCallbacks.foreach { case onSuccess =>
+                onSuccess(tp, new ZkLeaderAndIsrUpdateResult(newLeaderAndIsr, updatedZkVersion))
+              }
+            }
+          } finally {
+            unprocessedUpdates.countDown()
+          }
+        })
+    }}
+    unprocessedUpdates.await()
   }
 
   def propagateIsrChanges(zkUtils: ZkUtils, isrChangeSet: Set[TopicAndPartition]): Unit = {
@@ -73,6 +111,34 @@ object ReplicationUtils extends Logging {
     val leaderAndIsrPath = getTopicPartitionLeaderAndIsrPath(topic, partition)
     val (leaderAndIsrOpt, stat) = zkUtils.readDataMaybeNull(leaderAndIsrPath)
     leaderAndIsrOpt.flatMap(leaderAndIsrStr => parseLeaderAndIsr(leaderAndIsrStr, leaderAndIsrPath, stat))
+  }
+
+  def asyncGetLeaderIsrAndEpochForPartitions(zkUtils: ZkUtils,
+                                             partitions: Set[TopicAndPartition]): Map[TopicAndPartition, ZkLeaderAndIsrReadResult] = {
+    val unprocessedReads = new CountDownLatch(partitions.size)
+    val zkLeaderAndIsrReadResults = new mutable.HashMap[TopicAndPartition, ZkLeaderAndIsrReadResult]
+    partitions.foreach { case tap =>
+      val leaderAndIsrPath = getTopicPartitionLeaderAndIsrPath(tap.topic, tap.partition)
+      zkUtils.asyncReadDataMaybeNull(leaderAndIsrPath, new ZkReadCallback {
+        override def handle(dataOpt: Option[String], stat: Stat, exceptionOpt: Option[Exception]): Unit = {
+          try {
+            zkLeaderAndIsrReadResults += tap -> {
+                if (exceptionOpt.isEmpty) {
+                  val leaderIsrControllerEpochOpt =
+                    dataOpt.flatMap(leaderAndIsrStr => parseLeaderAndIsr(leaderAndIsrStr, leaderAndIsrPath, stat))
+                  new ZkLeaderAndIsrReadResult(leaderIsrControllerEpochOpt, None)
+                }
+                else
+                  new ZkLeaderAndIsrReadResult(None, exceptionOpt)
+              }
+          } finally {
+            unprocessedReads.countDown()
+          }
+        }
+      })
+    }
+    unprocessedReads.await()
+    zkLeaderAndIsrReadResults
   }
 
   private def parseLeaderAndIsr(leaderAndIsrStr: String, path: String, stat: Stat)

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -1166,7 +1166,7 @@ private[kafka] class ZkClient(zkConnection: IZkConnection, connectionTimeout: In
   def asyncReadData(path: String, callback: DataCallback) {
     retryUntilConnected(new Callable[Object] {
       def call: Object = {
-        _connection.asInstanceOf[ZkConnection].getZookeeper.getData(path, false, callback, null)
+        currentZk.getData(path, false, callback, null)
         null
       }
     })
@@ -1197,14 +1197,14 @@ private[kafka] abstract class ZkWriteCallbackWithData(val data: String,
   override def processResult(rc: Int, path: String, ctx: Object, stat: Stat) {
     val code = Code.get(rc)
     trace(s"Received return code $code for update of zk path $path")
-    val (updateSucceeded, newZkVesion) = code match {
+    val (updateSucceeded, newZkVersion) = code match {
       case Code.OK => (true, stat.getVersion)
       case _ =>
         warn("Conditional update of path %s with data %s and expected version %d failed due to %s".format(path, data,
           expectVersion, KeeperException.create(code).getMessage))
         (false, -1)
     }
-    handle(updateSucceeded, newZkVesion)
+    handle(updateSucceeded, newZkVersion)
   }
 
   def handle(updateSucceeded: Boolean, newZkVersion: Int)

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -17,8 +17,7 @@
 
 package kafka.utils
 
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.{ConcurrentHashMap, Callable, CountDownLatch}
+import java.util.concurrent.{Callable, CountDownLatch}
 
 import kafka.admin._
 import kafka.api.{ApiVersion, KAFKA_0_10_0_IV0, LeaderAndIsr}
@@ -34,7 +33,7 @@ import org.I0Itec.zkclient.{IZkConnection, ZkConnection}
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.zookeeper.AsyncCallback.{DataCallback, StatCallback, StringCallback}
-import org.apache.zookeeper.KeeperException.{ConnectionLossException, SessionExpiredException, Code}
+import org.apache.zookeeper.KeeperException.Code
 import org.apache.zookeeper.data.{ACL, Stat}
 import org.apache.zookeeper.{CreateMode, KeeperException, ZooDefs, ZooKeeper}
 

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,15 +18,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka.server.LeaderElectionTest=TRACE
-log4j.logger.state.change.logger=TRACE
-log4j.logger.kafka.controller.ReplicaStateMachine=TRACE
-log4j.logger.kafka.server.ReplicaManager=TRACE
-log4j.logger.kafka.controller.KafkaController=TRACE
-log4j.logger.kafka.controller.PartitionStateMachine=TRACE
-log4j.logger.kafka.controller.ControllerBrokerRequestBatch=TRACE
-log4j.logger.kafka.utils.ReplicationUtils=TRACE
-log4j.logger.kafka.utils.ZkUtils=TRACE
+log4j.logger.kafka=ERROR
 log4j.logger.org.apache.kafka=ERROR
 
 # zkclient can be verbose, during debugging it is common to adjust is separately

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -18,7 +18,15 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
-log4j.logger.kafka=ERROR
+log4j.logger.kafka.server.LeaderElectionTest=TRACE
+log4j.logger.state.change.logger=TRACE
+log4j.logger.kafka.controller.ReplicaStateMachine=TRACE
+log4j.logger.kafka.server.ReplicaManager=TRACE
+log4j.logger.kafka.controller.KafkaController=TRACE
+log4j.logger.kafka.controller.PartitionStateMachine=TRACE
+log4j.logger.kafka.controller.ControllerBrokerRequestBatch=TRACE
+log4j.logger.kafka.utils.ReplicationUtils=TRACE
+log4j.logger.kafka.utils.ZkUtils=TRACE
 log4j.logger.org.apache.kafka=ERROR
 
 # zkclient can be verbose, during debugging it is common to adjust is separately

--- a/core/src/test/scala/unit/kafka/consumer/PartitionAssignorTest.scala
+++ b/core/src/test/scala/unit/kafka/consumer/PartitionAssignorTest.scala
@@ -18,9 +18,8 @@
 package kafka.consumer
 
 import org.easymock.EasyMock
-import org.I0Itec.zkclient.ZkClient
 import org.apache.zookeeper.data.Stat
-import kafka.utils.{TestUtils, Logging, ZkUtils, Json}
+import kafka.utils.{ZkClient, TestUtils, Logging, ZkUtils, Json}
 import org.junit.Assert._
 import kafka.common.TopicAndPartition
 import kafka.consumer.PartitionAssignorTest.StaticSubscriptionInfo

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -251,6 +251,7 @@ class UncleanLeaderElectionTest extends ZooKeeperTestHarness {
 
     produceMessage(servers, topic, "third")
     waitUntilMetadataIsPropagated(servers, topic, partitionId)
+    Thread.sleep(1000)
     servers.filter(server => server.config.brokerId == leaderId).map(server => shutdownServer(server))
 
     // verify clean leader transition to ISR follower

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -25,8 +25,7 @@ import kafka.api.{FetchResponsePartitionData, PartitionFetchInfo}
 import kafka.cluster.Broker
 import kafka.common.TopicAndPartition
 import kafka.message.{ByteBufferMessageSet, Message}
-import kafka.utils.{MockScheduler, MockTime, TestUtils, ZkUtils}
-import org.I0Itec.zkclient.ZkClient
+import kafka.utils.{ZkClient, MockScheduler, MockTime, TestUtils, ZkUtils}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.LeaderAndIsrRequest

--- a/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
@@ -130,7 +130,7 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
     assertEquals(1, leaderAndIsrUpdateBatch.size)
     assertTrue(leaderAndIsrUpdateBatch.containsPartition(topicAndPartition))
 
-    // Test mismatched zkversion with same data
+    // Test mismatched zkversion with different data
     var updateSucceeded6 = false
     var newZkVersion6 = -1
     val newLeaderAndIsr6 = new LeaderAndIsr(brokerId, leaderEpoch + 2, replicas, zkVersion = 3)

--- a/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
@@ -112,7 +112,7 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
     leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controllerEpoch)
     assertTrue(updateSucceeded4)
     assertEquals(2, newZkVersion4)
-    assertEquals(0, leaderAndIsrUpdateBatch.size)
+    assertEquals(0, leaderAndIsrUpdateBatch.incompleteUpdates)
 
     // Test mismatched zkversion with same data
     var updateSucceeded5 = false
@@ -127,7 +127,7 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
     leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controllerEpoch)
     assertFalse(updateSucceeded5)
     assertEquals(-1, newZkVersion5)
-    assertEquals(1, leaderAndIsrUpdateBatch.size)
+    assertEquals(1, leaderAndIsrUpdateBatch.incompleteUpdates)
     assertTrue(leaderAndIsrUpdateBatch.containsPartition(topicAndPartition))
 
     // Test mismatched zkversion with different data
@@ -143,7 +143,7 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
     leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controllerEpoch)
     assertFalse(updateSucceeded6)
     assertEquals(-1, newZkVersion6)
-    assertEquals(1, leaderAndIsrUpdateBatch.size)
+    assertEquals(1, leaderAndIsrUpdateBatch.incompleteUpdates)
     assertTrue(leaderAndIsrUpdateBatch.containsPartition(topicAndPartition))
   }
 

--- a/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ReplicationUtilsTest.scala
@@ -17,7 +17,7 @@
 
 package kafka.utils
 
-import kafka.controller.LeaderIsrAndControllerEpoch
+import kafka.controller.{ZkLeaderAndIsrUpdateBatch, LeaderIsrAndControllerEpoch}
 import kafka.server.{ReplicaFetcherManager, KafkaConfig}
 import kafka.api.LeaderAndIsr
 import kafka.zk.ZooKeeperTestHarness
@@ -94,6 +94,57 @@ class ReplicationUtilsTest extends ZooKeeperTestHarness {
       "my-topic-test", partitionId, newLeaderAndIsr3, controllerEpoch, zkVersion + 1)
     assertFalse(updateSucceeded3)
     assertEquals(newZkVersion3,-1)
+
+    //test async update leader and isr
+    val topicAndPartition = TopicAndPartition("my-topic-test", partitionId)
+    val leaderAndIsrUpdateBatch = new ZkLeaderAndIsrUpdateBatch(zkUtils)
+
+    // Test regular update
+    var updateSucceeded4 = false
+    var newZkVersion4 = -1
+    val newLeaderAndIsr4 = new LeaderAndIsr(brokerId, leaderEpoch + 1, replicas, zkVersion = 2)
+    leaderAndIsrUpdateBatch.addLeaderAndIsrUpdate(topicAndPartition, newLeaderAndIsr4, expectZkVersion = 1,
+      (_, updateResult) => {
+        updateSucceeded4 = true
+        newZkVersion4 = updateResult.newZkVersion
+      }
+    )
+    leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controllerEpoch)
+    assertTrue(updateSucceeded4)
+    assertEquals(2, newZkVersion4)
+    assertEquals(0, leaderAndIsrUpdateBatch.size)
+
+    // Test mismatched zkversion with same data
+    var updateSucceeded5 = false
+    var newZkVersion5 = -1
+    val newLeaderAndIsr5 = new LeaderAndIsr(brokerId, leaderEpoch + 1, replicas, zkVersion = 3)
+    leaderAndIsrUpdateBatch.addLeaderAndIsrUpdate(topicAndPartition, newLeaderAndIsr5, expectZkVersion = 3,
+      (_, updateResult) => {
+        updateSucceeded5 = true
+        newZkVersion5 = updateResult.newZkVersion
+      }
+    )
+    leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controllerEpoch)
+    assertFalse(updateSucceeded5)
+    assertEquals(-1, newZkVersion5)
+    assertEquals(1, leaderAndIsrUpdateBatch.size)
+    assertTrue(leaderAndIsrUpdateBatch.containsPartition(topicAndPartition))
+
+    // Test mismatched zkversion with same data
+    var updateSucceeded6 = false
+    var newZkVersion6 = -1
+    val newLeaderAndIsr6 = new LeaderAndIsr(brokerId, leaderEpoch + 2, replicas, zkVersion = 3)
+    leaderAndIsrUpdateBatch.addLeaderAndIsrUpdate(topicAndPartition, newLeaderAndIsr1, expectZkVersion = 3,
+      (_, updateResult) => {
+        updateSucceeded6 = true
+        newZkVersion6 = updateResult.newZkVersion
+      }
+    )
+    leaderAndIsrUpdateBatch.writeLeaderAndIsrUpdateToZk(controllerEpoch)
+    assertFalse(updateSucceeded6)
+    assertEquals(-1, newZkVersion6)
+    assertEquals(1, leaderAndIsrUpdateBatch.size)
+    assertTrue(leaderAndIsrUpdateBatch.containsPartition(topicAndPartition))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/zk/ZkClientAsyncOperationTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkClientAsyncOperationTest.scala
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.zk
+
+import kafka.utils.{ZkReadCallback, TestUtils}
+import org.apache.zookeeper.data.Stat
+import org.junit.Test
+import org.junit.Assert._
+
+class ZkClientAsyncOperationTest extends ZooKeeperTestHarness {
+
+  @Test
+  def testAsyncWrite() {
+    val numPaths = 1000
+    val paths = (0 until numPaths).map { i => {
+      val path = "/testPath" + i
+      zkUtils.createPersistentPath(path, i.toString)
+      val (dataOpt, stat) = zkUtils.readDataMaybeNull(path)
+      assertEquals(i.toString, dataOpt.get)
+      val zkVersion = stat.getVersion
+      assertEquals(0, zkVersion)
+      path
+    }}
+
+    var callbackFired = 0
+    def handleResult(updateSucceeded: Boolean, newZkVersion: Int) = {
+      assertTrue(updateSucceeded)
+      assertEquals(1, newZkVersion)
+      callbackFired += 1
+    }
+    paths.foreach { path =>
+      zkUtils.asyncConditionalUpdatePersistentPath(path, "-1", 0, handleResult)
+    }
+    TestUtils.waitUntilTrue(() => callbackFired == numPaths, "Callback did not fire before timeout.")
+
+    paths.foreach { path =>
+      val (newData, newStat) = zkUtils.readDataMaybeNull(path)
+      assertEquals("-1", newData.get)
+      assertEquals(1, newStat.getVersion)
+    }
+  }
+
+  @Test
+  def testAsyncRead() {
+    val numPaths = 1000
+    val paths = (0 until numPaths).map { i => {
+      val path = "/testPath" + i
+      zkUtils.createPersistentPath(path, i.toString)
+      val (dataOpt, stat) = zkUtils.readDataMaybeNull(path)
+      assertEquals(i.toString, dataOpt.get)
+      val zkVersion = stat.getVersion
+      assertEquals(0, zkVersion)
+      path
+    }}
+
+    var writeCallbackFired = 0
+    def handleWriteResult(updateSucceeded: Boolean, newZkVersion: Int) = {
+      assertTrue(updateSucceeded)
+      assertEquals(1, newZkVersion)
+      writeCallbackFired += 1
+    }
+    paths.foreach { path =>
+      zkUtils.asyncConditionalUpdatePersistentPath(path, path + "data", 0, handleWriteResult)
+    }
+    TestUtils.waitUntilTrue(() => writeCallbackFired == numPaths, "Callback did not fire before timeout.")
+
+    var readCallbackFired = 0
+    paths.foreach { path => {
+      zkUtils.asyncReadDataMaybeNull(path, new ZkReadCallback() {
+        override def handle(dataOpt: Option[String], stat: Stat, exceptionOpt: Option[Exception]) = {
+          assertTrue(exceptionOpt.isEmpty)
+          assertEquals(path + "data", dataOpt.get)
+          assertEquals(1, stat.getVersion)
+          readCallbackFired += 1
+        }
+      })
+    }}
+    TestUtils.waitUntilTrue(() => readCallbackFired == numPaths, "Callback did not fire before timeout.")
+  }
+
+}


### PR DESCRIPTION
This patch does the followings:
1. Batched LeaderAndIsrRequest and UpdateMetadataRequest during controlled shutdown.
2. Added async read and write method to an extending ZkClient. Used the async zk operation for LeaderAndIsr read and update. The async method can be used in other places as well (e.g. preferred leader election, replica reassignment, controller bootstrap, etc), but those are out of the scope of this ticket.

Conducted some rolling boucne test, a controlled shutdown involving 2500 partitions takes around 3 seconds now. Previously it can takes more than 30 seconds.
