### PR TITLE
MINOR: Advance system test ducktape dependency from 0.3.10 to 0.4.0

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -30,5 +30,5 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.3.10", "requests>=2.5.0"]
+      install_requires=["ducktape==0.4.0", "requests>=2.5.0"]
       )


### PR DESCRIPTION
Previous version of ducktape was found to have a memory leak which caused occasional failures in nightly runs.
