### PR TITLE
KAFKA-3205 Support passive close by broker

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -59,7 +59,7 @@ public class NetworkReceive implements Receive {
         if (size.hasRemaining()) {
             int bytesRead = channel.read(size);
             if (bytesRead < 0)
-                throw new EOFException();
+                return bytesRead;
             read += bytesRead;
             if (!size.hasRemaining()) {
                 size.rewind();

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -234,7 +234,7 @@ public class Selector implements Selectable {
 
                 try {
                 	boolean passiveClose = false;
-                	
+
                     /* complete any connections that have finished their handshake */
                     if (key.isConnectable()) {
                         channel.finishConnect();
@@ -249,8 +249,8 @@ public class Selector implements Selectable {
                             transmissions.receive = new NetworkReceive(transmissions.id);
                         long bytesRead = transmissions.receive.readFrom(channel);
                         if (bytesRead < 0) {
-                        	//Reached EOF between receives, treat as passive close
-                        	passiveClose = true;
+                            //Reached EOF between receives, treat as passive close
+                            passiveClose = true;
                         } else if (transmissions.receive.complete()) {
                             transmissions.receive.payload().rewind();
                             this.completedReceives.add(transmissions.receive);


### PR DESCRIPTION
An attempt to fix KAFKA-3205.  It appears the problem is that the broker has closed the connection passively, and the client should react appropriately.

In NetworkReceive.readFrom() rather than throw an EOFException (Which means the end of stream has been reached unexpectedly during input), instead return the negative bytes read signifying an acceptable end of stream.

In Selector if the channel is being passively closed, don't try to read any more data, don't try to write, and close the key.

I believe this will fix the problem.
