### PR TITLE
KAFKA-2910: Close Zookeeper clients in unit tests

### DIFF
--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -585,6 +585,7 @@ object TestUtils extends Logging {
   def updateConsumerOffset(config : ConsumerConfig, path : String, offset : Long) = {
     val zkUtils = ZkUtils(config.zkConnect, config.zkSessionTimeoutMs, config.zkConnectionTimeoutMs, false)
     zkUtils.updatePersistentPath(path, offset.toString)
+    zkUtils.close()
 
   }
 

--- a/core/src/test/scala/unit/kafka/zk/ZKEphemeralTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZKEphemeralTest.scala
@@ -91,6 +91,7 @@ class ZKEphemeralTest(val secure: Boolean) extends ZooKeeperTestHarness {
     zkUtils = ZkUtils(zkConnect, zkSessionTimeoutMs, config.zkConnectionTimeoutMs, JaasUtils.isZkSecurityEnabled())
     val nodeExists = zkUtils.pathExists("/tmp/zktest")
     Assert.assertFalse(nodeExists)
+    zkUtils.close()
   }
 
   /*****
@@ -137,7 +138,7 @@ class ZKEphemeralTest(val secure: Boolean) extends ZooKeeperTestHarness {
     val zk1 = zkUtils.zkConnection.getZookeeper
 
     //Creates a second session
-    val (_, zkConnection2) = ZkUtils.createZkClientAndConnection(zkConnect, zkSessionTimeoutMs, zkConnectionTimeout)
+    val (zkClient2, zkConnection2) = ZkUtils.createZkClientAndConnection(zkConnect, zkSessionTimeoutMs, zkConnectionTimeout)
     val zk2 = zkConnection2.getZookeeper
     var zwe = new ZKCheckedEphemeral(path, "", zk2, JaasUtils.isZkSecurityEnabled())
 
@@ -153,6 +154,7 @@ class ZKEphemeralTest(val secure: Boolean) extends ZooKeeperTestHarness {
         gotException = true
     }
     Assert.assertTrue(gotException)
+    zkClient2.close()
   }
   
   /**

--- a/core/src/test/scala/unit/kafka/zk/ZKPathTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZKPathTest.scala
@@ -43,6 +43,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
       case configException: ConfigException =>
       case exception: Throwable => fail("Should have thrown ConfigException")
     }
+    zkUtils.close()
   }
 
   @Test
@@ -57,6 +58,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
     }
 
     assertTrue("Failed to create persistent path", zkUtils.pathExists(path))
+    zkUtils.close()
   }
 
   @Test
@@ -73,6 +75,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
       case configException: ConfigException =>
       case exception: Throwable => fail("Should have thrown ConfigException")
     }
+    zkUtils.close()
   }
 
   @Test
@@ -87,6 +90,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
     }
 
     assertTrue("Failed to create persistent path", zkUtils.pathExists(path))
+    zkUtils.close()
   }
 
   @Test
@@ -103,6 +107,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
       case configException: ConfigException =>
       case exception: Throwable => fail("Should have thrown ConfigException")
     }
+    zkUtils.close()
   }
 
   @Test
@@ -117,6 +122,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
     }
 
     assertTrue("Failed to create ephemeral path", zkUtils.pathExists(path))
+    zkUtils.close()
   }
 
   @Test
@@ -133,6 +139,7 @@ class ZKPathTest extends ZooKeeperTestHarness {
       case configException: ConfigException =>
       case exception: Throwable => fail("Should have thrown ConfigException")
     }
+    zkUtils.close()
   }
 
   @Test
@@ -149,5 +156,6 @@ class ZKPathTest extends ZooKeeperTestHarness {
     }
 
     assertTrue("Failed to create persistent path", zkUtils.pathExists(actualPath))
+    zkUtils.close()
   }
 }


### PR DESCRIPTION
Zookeeper clients that are not closed after the server is shutdown keep trying to reconnect, reloading JAAS configuration. This impacts subsequent tests which rely on JAAS config to be reset.
