### PR TITLE
MINOR: Fix BNF output for protocol arrays conataining primitives in docs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -792,13 +792,13 @@ public class Protocol {
                 b.append(field.name);
                 b.append("] ");
                 Type innerType = ((ArrayOf) field.type).type();
-                if (innerType instanceof Schema && !subTypes.containsKey(field.name))
-                    subTypes.put(field.name, (Schema) innerType);
+                if (!subTypes.containsKey(field.name))
+                    subTypes.put(field.name, innerType);
             } else if (field.type instanceof Schema) {
                 b.append(field.name);
                 b.append(" ");
                 if (!subTypes.containsKey(field.name))
-                    subTypes.put(field.name, (Schema) field.type);
+                    subTypes.put(field.name, field.type);
             } else {
                 b.append(field.name);
                 b.append(" ");


### PR DESCRIPTION
Before this patch arrays containing primitive types were not output:

```
Metadata Request (Version: 0) => [topics]
```

After this patch the type is listed:

```
Metadata Request (Version: 0) => [topics]
      topics => STRING
```
