### PR TITLE
KAFKA-3496 - add policies for client reconnect attempts

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/clients/CommonClientConfigs.java
@@ -49,6 +49,15 @@ public class CommonClientConfigs {
     public static final String RECONNECT_BACKOFF_MS_CONFIG = "reconnect.backoff.ms";
     public static final String RECONNECT_BACKOFF_MS_DOC = "The amount of time to wait before attempting to reconnect to a given host. This avoids repeatedly connecting to a host in a tight loop. This backoff applies to all requests sent by the consumer to the broker.";
 
+    public static final String RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG = "reconnect.attempts.policy.class";
+    public static final String RECONNECT_ATTEMPTS_POLICY_CLASS_DOC = "The policy used to determine the amount of time to wait before attempting to reconnect to a given host. ";
+
+    public static final String RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG = "reconnect.exponential.baseDelayMs";
+    public static final String RECONNECT_EXPONENTIAL_BASE_DELAY_MS_DOC = "The amount of time to wait before attempting a first reconnection to a given host.";
+
+    public static final String RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG = "reconnect.exponential.maxDelayMs";
+    public static final String RECONNECT_EXPONENTIAL_MAX_DELAY_MS_DOC = "The maximum amount of time to wait before attempting to reconnect to a given host.";
+
     public static final String RETRY_BACKOFF_MS_CONFIG = "retry.backoff.ms";
     public static final String RETRY_BACKOFF_MS_DOC = "The amount of time to wait before attempting to retry a failed fetch request to a given topic partition. This avoids repeated fetching-and-failing in a tight loop.";
 

--- a/clients/src/main/java/org/apache/kafka/clients/ConstantReconnectAttemptPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ConstantReconnectAttemptPolicy.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.config.AbstractConfig;
+
+/**
+ * A policy which used a constant delay between each reconnection attempt.
+ */
+public class ConstantReconnectAttemptPolicy implements ReconnectAttemptPolicy {
+
+    private long reconnectBackoffMs;
+
+    /**
+     * Creates a new {@link ConstantReconnectAttemptPolicy} instance.
+     */
+    public ConstantReconnectAttemptPolicy() {
+
+    }
+
+    /**
+     * Creates a new {@link ConstantReconnectAttemptPolicy} instance.
+     */
+    public ConstantReconnectAttemptPolicy(long reconnectBackoffMs) {
+        setReconnectBackoffMs(reconnectBackoffMs);
+    }
+
+    @Override
+    public void configure(AbstractConfig configs) {
+        Long reconnectBackoffMs = configs.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG);
+        setReconnectBackoffMs(reconnectBackoffMs);
+    }
+
+    private void setReconnectBackoffMs(long reconnectBackoffMs) {
+        if (reconnectBackoffMs < 0)
+            throw new IllegalArgumentException(String.format("Delay must be positive - reconnect.backoff.ms %d", reconnectBackoffMs));
+        this.reconnectBackoffMs = reconnectBackoffMs;
+    }
+
+    @Override
+    public ReconnectAttemptScheduler newScheduler() {
+        return new ConstantScheduler();
+    }
+
+    private class ConstantScheduler implements ReconnectAttemptScheduler {
+
+        @Override
+        public long nextReconnectBackoffMs() {
+            return reconnectBackoffMs;
+        }
+    }
+}
+
+

--- a/clients/src/main/java/org/apache/kafka/clients/ExponentialReconnectAttemptPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ExponentialReconnectAttemptPolicy.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.config.AbstractConfig;
+
+/**
+ * A policy which exponentially grows the delay between each reconnection attempt.
+ * A reconnection attempt (@code i] is tried after {@code Math.min(2^(i-1) * getBaseDelayMs(), getMaxDelayMs())} milliseconds.
+ */
+public class ExponentialReconnectAttemptPolicy implements ReconnectAttemptPolicy {
+
+    /**
+     * The amount of time to wait before attempting a first reconnection to a given host.
+     */
+    private long baseDelayMs;
+    /**
+     * The maximum amount of time to wait before attempting to reconnect to a given host.
+     */
+    private long maxDelayMs;
+
+    /**
+     * Creates a new {@link ExponentialReconnectAttemptPolicy} instance.
+     */
+    public ExponentialReconnectAttemptPolicy() {
+
+    }
+
+    /**
+     * Creates a new {@link ExponentialReconnectAttemptPolicy} instance.
+     *
+     * @param baseDelayMs {@link #baseDelayMs}.
+     * @param maxDelayMs {@link #maxDelayMs}.
+     */
+    public ExponentialReconnectAttemptPolicy(long baseDelayMs, long maxDelayMs) {
+        setDelays(baseDelayMs, maxDelayMs);
+    }
+
+    public long getBaseDelayMs() {
+        return baseDelayMs;
+    }
+
+    public long getMaxDelayMs() {
+        return maxDelayMs;
+    }
+
+    @Override
+    public void configure(AbstractConfig configs) {
+        setDelays(configs.getLong(CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG),
+                configs.getLong(CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG));
+    }
+
+    private void setDelays(long baseDelayMs, long maxDelayMs) {
+        if (baseDelayMs < 0 || maxDelayMs < 0)
+            throw new IllegalArgumentException(String.format("Delay must be positive - baseDelayMs %d, maxDelayMs %d ", baseDelayMs, maxDelayMs));
+        if (maxDelayMs < baseDelayMs)
+            throw new IllegalArgumentException(String.format("maxDelayMs (%d) must be superior to baseDelayMs (%d)", maxDelayMs, baseDelayMs));
+        this.baseDelayMs = baseDelayMs;
+        this.maxDelayMs  = maxDelayMs;
+    }
+
+    @Override
+    public ReconnectAttemptScheduler newScheduler() {
+        return new ExponentialScheduler();
+    }
+
+    public class ExponentialScheduler implements ReconnectAttemptScheduler {
+
+        private long attempts = 0L;
+
+        @Override
+        public long nextReconnectBackoffMs() {
+            try {
+                if (attempts + 1 > 64) return maxDelayMs;
+                return Math.min(multiplyExact(baseDelayMs, 1L << attempts++), maxDelayMs);
+            } catch (ArithmeticException e) {  // this should never happen
+                return maxDelayMs;
+            }
+        }
+    }
+
+    /**
+     * This method is part of Math class since java 8.
+     */
+    private static long multiplyExact(long x, long y) {
+        long r = x * y;
+        long ax = Math.abs(x);
+        long ay = Math.abs(y);
+        if ((ax | ay) >>> 31 != 0) {
+            // Some bits greater than 2^31 that might cause overflow
+            // Check the result using the divide operator
+            // and check for the special case of Long.MIN_VALUE * -1
+            if (((y != 0) && (r / y != x)) ||
+                    (x == Long.MIN_VALUE && y == -1)) {
+                throw new ArithmeticException("long overflow");
+            }
+        }
+        return r;
+    }
+}
+
+

--- a/clients/src/main/java/org/apache/kafka/clients/ReconnectAttemptPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ReconnectAttemptPolicy.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.apache.kafka.common.config.AbstractConfig;
+
+public interface ReconnectAttemptPolicy {
+
+    void configure(AbstractConfig configs);
+
+    ReconnectAttemptScheduler newScheduler();
+
+    interface ReconnectAttemptScheduler {
+
+        long nextReconnectBackoffMs();
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -133,6 +133,21 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String RECONNECT_BACKOFF_MS_CONFIG = CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG;
 
     /**
+     * <code>reconnect.attempts.policy</code>
+     */
+    public static final String RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG = CommonClientConfigs.RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG;
+
+    /**
+     * <code>reconnect.exponential.baseDelayMs/code>
+     */
+    public static final String RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG = CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG;
+
+    /**
+     * <code>reconnect.exponential.maxDelayMs</code>
+     */
+    public static final String RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG = CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG;
+
+    /**
      * <code>retry.backoff.ms</code>
      */
     public static final String RETRY_BACKOFF_MS_CONFIG = CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG;
@@ -265,6 +280,23 @@ public class ConsumerConfig extends AbstractConfig {
                                         atLeast(0L),
                                         Importance.LOW,
                                         CommonClientConfigs.RECONNECT_BACKOFF_MS_DOC)
+                                .define(RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG,
+                                        Type.CLASS,
+                                        "org.apache.kafka.clients.ConstantReconnectAttemptPolicy",
+                                        Importance.HIGH,
+                                        CommonClientConfigs.RECONNECT_ATTEMPTS_POLICY_CLASS_DOC)
+                                .define(RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG,
+                                        Type.LONG,
+                                        50L,
+                                        atLeast(0L),
+                                        Importance.LOW,
+                                        CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_DOC)
+                                .define(RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG,
+                                        Type.LONG,
+                                        5000L,
+                                        atLeast(0L),
+                                        Importance.LOW,
+                                        CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_DOC)
                                 .define(RETRY_BACKOFF_MS_CONFIG,
                                         Type.LONG,
                                         100L,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -137,6 +137,21 @@ public class ProducerConfig extends AbstractConfig {
                                                     + "These methods can be blocked either because the buffer is full or metadata unavailable."
                                                     + "Blocking in the user-supplied serializers or partitioner will not be counted against this timeout.";
 
+    /**
+     * <code>reconnect.attempts.policy</code>
+     */
+    public static final String RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG = CommonClientConfigs.RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG;
+
+    /**
+     * <code>reconnect.exponential.baseDelayMs/code>
+     */
+    public static final String RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG = CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG;
+
+    /**
+     * <code>reconnect.exponential.maxDelayMs</code>
+     */
+    public static final String RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG = CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG;
+
     /** <code>block.on.buffer.full</code> */
     /**
      * @deprecated This config will be removed in a future release. Also, the {@link #METADATA_FETCH_TIMEOUT_CONFIG} is no longer honored when this property is set to true.
@@ -245,6 +260,23 @@ public class ProducerConfig extends AbstractConfig {
                                 .define(RECONNECT_BACKOFF_MS_CONFIG, Type.LONG, 50L, atLeast(0L), Importance.LOW, CommonClientConfigs.RECONNECT_BACKOFF_MS_DOC)
                                 .define(METRIC_REPORTER_CLASSES_CONFIG, Type.LIST, "", Importance.LOW, CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC)
                                 .define(RETRY_BACKOFF_MS_CONFIG, Type.LONG, 100L, atLeast(0L), Importance.LOW, CommonClientConfigs.RETRY_BACKOFF_MS_DOC)
+                                .define(RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG,
+                                        Type.CLASS,
+                                        "org.apache.kafka.clients.ConstantReconnectAttemptPolicy",
+                                        Importance.HIGH,
+                                        CommonClientConfigs.RECONNECT_ATTEMPTS_POLICY_CLASS_DOC)
+                                .define(RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG,
+                                        Type.LONG,
+                                        50L,
+                                        atLeast(0L),
+                                        Importance.LOW,
+                                        CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_DOC)
+                                .define(RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG,
+                                        Type.LONG,
+                                        5000L,
+                                        atLeast(0L),
+                                        Importance.LOW,
+                                        CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_DOC)
                                 .define(METADATA_FETCH_TIMEOUT_CONFIG,
                                         Type.LONG,
                                         60 * 1000,

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -342,7 +342,7 @@ public class Selector implements Selectable {
             } catch (Exception e) {
                 String desc = channel.socketDescription();
                 if (e instanceof IOException)
-                    log.debug("Connection with {} disconnected", desc, e);
+                    log.warn("Connection with {} disconnected", desc, e);
                 else
                     log.warn("Unexpected error from {}; closing connection", desc, e);
                 close(channel);

--- a/clients/src/test/java/org/apache/kafka/clients/ExponentialReconnectAttemptPolicyTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ExponentialReconnectAttemptPolicyTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class ExponentialReconnectAttemptPolicyTest {
+
+
+    public static final long BASE_DELAY_MS = 2000L;
+
+    @Test
+    public void testSimpleExponentialReconnectionPolicy() {
+
+        ExponentialReconnectAttemptPolicy policy = new ExponentialReconnectAttemptPolicy(BASE_DELAY_MS, BASE_DELAY_MS * 60 * 5);
+        ReconnectAttemptPolicy.ReconnectAttemptScheduler scheduler = policy.newScheduler();
+        assertEquals(2000, scheduler.nextReconnectBackoffMs());
+        assertEquals(4000, scheduler.nextReconnectBackoffMs());
+        assertEquals(8000, scheduler.nextReconnectBackoffMs());
+        assertEquals(16000, scheduler.nextReconnectBackoffMs());
+        assertEquals(32000, scheduler.nextReconnectBackoffMs());
+        for (int i = 0; i < 64; i++) { // force overflow
+            scheduler.nextReconnectBackoffMs();
+        }
+        assertEquals(policy.getMaxDelayMs(), scheduler.nextReconnectBackoffMs());
+    }
+
+    @Test
+    public void testIllegalArgumentsExponentialReconnectionPolicy() {
+        try {
+            new ExponentialReconnectAttemptPolicy(-1, -1);
+            fail();
+        } catch (Throwable t) {
+            assertTrue(t instanceof IllegalArgumentException);
+        }
+
+        try {
+            new ExponentialReconnectAttemptPolicy(100, 10);
+            fail();
+        } catch (Throwable t) {
+            assertTrue(t instanceof IllegalArgumentException);
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -53,11 +53,12 @@ public class NetworkClientTest {
     private Cluster cluster = TestUtils.singletonCluster("test", nodeId);
     private Node node = cluster.nodes().get(0);
     private long reconnectBackoffMsTest = 10 * 1000;
-    private NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE, reconnectBackoffMsTest, 
+
+    private NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE, new ConstantReconnectAttemptPolicy(reconnectBackoffMsTest),
             64 * 1024, 64 * 1024, requestTimeoutMs, time);
     
     private NetworkClient clientWithStaticNodes = new NetworkClient(selector, new ManualMetadataUpdater(Arrays.asList(node)),
-            "mock-static", Integer.MAX_VALUE, 0, 64 * 1024, 64 * 1024, requestTimeoutMs, time);
+            "mock-static", Integer.MAX_VALUE, new ConstantReconnectAttemptPolicy(0), 64 * 1024, 64 * 1024, requestTimeoutMs, time);
 
     @Before
     public void setup() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -127,6 +127,23 @@ public class DistributedConfig extends WorkerConfig {
                         atLeast(0L),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.RECONNECT_BACKOFF_MS_DOC)
+                .define(CommonClientConfigs.RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG,
+                        ConfigDef.Type.CLASS,
+                        "org.apache.kafka.clients.ConstantReconnectAttemptPolicy",
+                        ConfigDef.Importance.HIGH,
+                        CommonClientConfigs.RECONNECT_ATTEMPTS_POLICY_CLASS_DOC)
+                .define(CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        50L,
+                        atLeast(0L),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_DOC)
+                .define(CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG,
+                        ConfigDef.Type.LONG,
+                        5000L,
+                        atLeast(0L),
+                        ConfigDef.Importance.LOW,
+                        CommonClientConfigs.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_DOC)
                 .define(CommonClientConfigs.RETRY_BACKOFF_MS_CONFIG,
                         ConfigDef.Type.LONG,
                         100L,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -21,6 +21,8 @@ import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.ReconnectAttemptPolicy;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
@@ -90,12 +92,16 @@ public class WorkerGroupMember {
             this.metadata.update(Cluster.bootstrap(addresses), 0);
             String metricGrpPrefix = "connect";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config.values());
+
+            ReconnectAttemptPolicy reconnectAttemptPolicy = config.getConfiguredInstance(ConsumerConfig.RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG, ReconnectAttemptPolicy.class);
+            reconnectAttemptPolicy.configure(config);
+
             NetworkClient netClient = new NetworkClient(
                     new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder),
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice
-                    config.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG),
+                    reconnectAttemptPolicy,
                     config.getInt(CommonClientConfigs.SEND_BUFFER_CONFIG),
                     config.getInt(CommonClientConfigs.RECEIVE_BUFFER_CONFIG),
                     config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG), time);

--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -234,7 +234,7 @@ object AdminClient {
       metadata,
       "admin-" + AdminClientIdSequence.getAndIncrement(),
       DefaultMaxInFlightRequestsPerConnection,
-      DefaultReconnectBackoffMs,
+      new ConstantReconnectAttemptPolicy(DefaultReconnectBackoffMs),
       DefaultSendBufferBytes,
       DefaultReceiveBufferBytes,
       DefaultRequestTimeoutMs,

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -24,7 +24,7 @@ import kafka.cluster.Broker
 import kafka.common.{KafkaException, TopicAndPartition}
 import kafka.server.KafkaConfig
 import kafka.utils._
-import org.apache.kafka.clients.{ClientRequest, ClientResponse, ManualMetadataUpdater, NetworkClient}
+import org.apache.kafka.clients._
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.{ChannelBuilders, LoginType, Mode, NetworkReceive, Selectable, Selector}
 import org.apache.kafka.common.protocol.{ApiKeys, SecurityProtocol}
@@ -104,7 +104,7 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
         new ManualMetadataUpdater(Seq(brokerNode).asJava),
         config.brokerId.toString,
         1,
-        0,
+        new ConstantReconnectAttemptPolicy(0),
         Selectable.USE_DEFAULT_BUFFER_SIZE,
         Selectable.USE_DEFAULT_BUFFER_SIZE,
         config.requestTimeoutMs,

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -31,7 +31,7 @@ import java.io.{IOException, File}
 
 import kafka.security.auth.Authorizer
 import kafka.utils._
-import org.apache.kafka.clients.{ManualMetadataUpdater, ClientRequest, NetworkClient}
+import org.apache.kafka.clients.{ManualMetadataUpdater, ClientRequest, NetworkClient, ConstantReconnectAttemptPolicy}
 import org.apache.kafka.common.Node
 import org.apache.kafka.common.metrics._
 import org.apache.kafka.common.network.{LoginType, Selectable, ChannelBuilders, NetworkReceive, Selector, Mode}
@@ -341,7 +341,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
           metadataUpdater,
           config.brokerId.toString,
           1,
-          0,
+          new ConstantReconnectAttemptPolicy(0),
           Selectable.USE_DEFAULT_BUFFER_SIZE,
           Selectable.USE_DEFAULT_BUFFER_SIZE,
           config.requestTimeoutMs,

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -26,7 +26,7 @@ import kafka.message.ByteBufferMessageSet
 import kafka.api.{KAFKA_0_10_0_IV0, KAFKA_0_9_0}
 import kafka.common.{KafkaStorageException, TopicAndPartition}
 import ReplicaFetcherThread._
-import org.apache.kafka.clients.{ManualMetadataUpdater, NetworkClient, ClientRequest, ClientResponse}
+import org.apache.kafka.clients.{ManualMetadataUpdater, NetworkClient, ClientRequest, ClientResponse, ConstantReconnectAttemptPolicy}
 import org.apache.kafka.common.network.{LoginType, Selectable, ChannelBuilders, NetworkReceive, Selector, Mode}
 import org.apache.kafka.common.requests.{ListOffsetResponse, FetchResponse, RequestSend, AbstractRequest, ListOffsetRequest}
 import org.apache.kafka.common.requests.{FetchRequest => JFetchRequest}
@@ -88,7 +88,7 @@ class ReplicaFetcherThread(name: String,
       new ManualMetadataUpdater(),
       clientId,
       1,
-      0,
+      new ConstantReconnectAttemptPolicy(0),
       Selectable.USE_DEFAULT_BUFFER_SIZE,
       brokerConfig.replicaSocketReceiveBufferBytes,
       brokerConfig.requestTimeoutMs,


### PR DESCRIPTION
This PR enables to configure a policy for the client reconnection attempts.
It provides this following policies : 
- ConstantReconnectAttemptPolicy (default policy which uses the reconnect.backoff.ms property)
- ExponentialReconnectAttemptPolicy

Example : 

``` java
Properties config = new Properties();
config.put(ConsumerConfig.RECONNECT_ATTEMPTS_POLICY_CLASS_CONFIG, "org.apache.kafka.clients.ExponentialReconnectAttemptPolicy");
config.put(ConsumerConfig.RECONNECT_EXPONENTIAL_MAX_DELAY_MS_CONFIG, 5000);
config.put(ConsumerConfig.RECONNECT_EXPONENTIAL_BASE_DELAY_MS_CONFIG, 50);
```

This implementation is inspired from the cassandra client driver.

In addition, this PR fixes some log level as describe in this issue : https://issues.apache.org/jira/browse/KAFKA-2998
