### PR TITLE
Kafka Connect metrics NPE prevention

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -257,13 +257,23 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
 
             Measurable numConnectors = new Measurable() {
                 public double measure(MetricConfig config, long now) {
-                    return assignmentSnapshot.connectors().size();
+		    if (assignmentSnapshot != null) {
+			return assignmentSnapshot.connectors().size();
+		    }
+		    else {
+			return 0.0;
+		    }
                 }
             };
 
             Measurable numTasks = new Measurable() {
                 public double measure(MetricConfig config, long now) {
-                    return assignmentSnapshot.tasks().size();
+		    if (assignmentSnapshot != null) {
+			return assignmentSnapshot.tasks().size();
+		    }
+		    else {
+			return 0.0;
+		    }
                 }
             };
 


### PR DESCRIPTION
Summary:
When a worker is started up but hasn't setup the assignmentSnapshot it
is possible to throw a NPE. This happens in our environment as we have a
custom reporter running every 10 seconds. This change prevents that null
pointer from happening
