### PR TITLE
Guards against null-pointer during schema validation

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
@@ -48,8 +48,8 @@ public class OffsetUtils {
             if (value == null)
                 continue;
             Schema.Type schemaType = ConnectSchema.schemaType(value.getClass());
-            if (!schemaType.isPrimitive())
-                throw new DataException("Offsets may only contain primitive types as values, but field " + entry.getKey() + " contains " + schemaType);
+            if (schemaType == null || !schemaType.isPrimitive())
+                throw new DataException("Offsets may only contain primitive types as values, but field " + entry.getKey() + " contains " + value.getClass());
         }
     }
 }


### PR DESCRIPTION
This edit fixes a null-pointer exception which we encountered during testing. Truncated stack trace:

```
[2016-04-04 18:27:03,667] ERROR CRITICAL: Failed to serialize offset data, making it impossible to commit offsets under namespace test-fileconnector-source. This likely won't recover unless the unserializable partition or offset information is overwritten. (org.apache.kafka.connect.storage.OffsetStorageWriter:152)
[2016-04-04 18:27:03,667] ERROR Cause of serialization failure: (org.apache.kafka.connect.storage.OffsetStorageWriter:155)
java.lang.NullPointerException
    at org.apache.kafka.connect.storage.OffsetUtils.validateFormat(OffsetUtils.java:50)
    at org.apache.kafka.connect.storage.OffsetStorageWriter.doFlush(OffsetStorageWriter.java:141)
    at org.apache.kafka.connect.runtime.WorkerSourceTask.commitOffsets(WorkerSourceTask.java:267)
...
```
