### PR TITLE
KAFKA-1614: Partition log directory name and segments information exposed via JMX

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -138,9 +138,9 @@ class Log(val dir: File,
   newGauge("LogSegments",
     new Gauge[util.List[String]] {
       def value = {
-        val list = logSegments.toSeq.map(
-          seg => s"baseOffset=${seg.baseOffset}, created=${seg.created}, logSize=${seg.size}, indexSize=${seg.index.sizeInBytes()}"
-        )
+        val list = logSegments.toSeq.map { seg =>
+          s"baseOffset=${seg.baseOffset}, created=${seg.created}, logSize=${seg.size}, indexSize=${seg.index.sizeInBytes()}"
+        }
         // Explicitly returning Java list to support JMX clients that don't have Scala runtime in the classpath
         new util.ArrayList[String](list.asJava)
       }


### PR DESCRIPTION
This is an updated version of https://issues.apache.org/jira/browse/KAFKA-1614 patch which was made for 0.8.1.1 version. 

It makes partition log directory and single segments information exposed via JMX. This is useful to:
- monitor disks usage in a cluster and on single broker;
- calculate disk space taken by different topics;
- estimate space to be freed when segments are expired.

Yahoo's Kafka Manager uses it to show information about topics and partitions sizes:

![topics](https://cloud.githubusercontent.com/assets/1021271/14336342/aa3a197a-fc17-11e5-9ae8-7a4a8bf32562.png)
![partitions](https://cloud.githubusercontent.com/assets/1021271/14336348/b38e2354-fc17-11e5-930d-9b36c7aae1e8.png)

Our internal tool uses it to show how segments sizes were changing over time:

![segments](https://cloud.githubusercontent.com/assets/1021271/14336349/b566ed8c-fc17-11e5-811f-d9bca5e2e099.png)

@junrao could you please review when you have time?
