### PR TITLE
KAFKA-3557; Update rocksdb to 4.4.1 and patch updates to snappy and slf4j

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -41,8 +41,8 @@ versions += [
   scalaTest: "2.2.6",
   scalaParserCombinators: "1.0.4",
   scoverage: "1.1.1",
-  slf4j: "1.7.18",
-  snappy: "1.1.2.1",
+  slf4j: "1.7.21",
+  snappy: "1.1.2.4",
   zkclient: "0.8",
   zookeeper: "3.4.6",
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -37,7 +37,7 @@ versions += [
   metrics: "2.2.0",
   powermock: "1.6.4",
   reflections: "0.9.10",
-  rocksDB: "4.1.0",
+  rocksDB: "4.4.1",
   scalaTest: "2.2.6",
   scalaParserCombinators: "1.0.4",
   scoverage: "1.1.1",


### PR DESCRIPTION
- The hope is that RocksDb 4.4.1 is more stable than 4.1.0 (occasional segfaults) and 4.2.0 (very frequent segfaults), release notes for 4.4.1: https://www.facebook.com/groups/rocksdb.dev/permalink/925995520832296/
- slf4j 1.7.21 includes thread-safety fixes: http://www.slf4j.org/news.html
- snappy 1.1.2.4 includes performance improvements requested by Spark, which apply to our usage: https://github.com/xerial/snappy-java/blob/master/Milestone.md

I ran the stream tests several times and they passed every time while 4.2.0 segfaulted every time.
