### PR TITLE
KAFKA-3559: lazy initialisation of state stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -72,11 +72,17 @@ public interface ProcessorContext {
     StreamsMetrics metrics();
 
     /**
-     * Registers and possibly restores the specified storage engine.
+     * Registers but does not restores the specified storage engine.
      *
      * @param store the storage engine
      */
-    void register(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback);
+    void registerStore(StateStore store);
+
+    /**
+     * Restores and initializes the storage engine. Note this call assumes that the
+     * storage engine is already registered through {@link #registerStore(StateStore)}
+     */
+    void initStore(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback);
 
     /**
      * Get the state store given the store name.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -72,7 +72,7 @@ public interface ProcessorContext {
     StreamsMetrics metrics();
 
     /**
-     * Registers but does not restores the specified storage engine.
+     * Registers but does not restore the specified storage engine.
      *
      * @param store the storage engine
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -81,6 +81,21 @@ public abstract class AbstractTask {
 
         for (StateStoreSupplier stateStoreSupplier : this.topology.stateStoreSuppliers()) {
             StateStore store = stateStoreSupplier.get();
+            this.processorContext.registerStore(store);
+        }
+    }
+
+    /**
+     * Registers all state stores for this task and initializes them.
+     * Note: used by standby tasks only
+     */
+    protected void registerAndinitializeStateStores() {
+        // set initial offset limits
+        initializeOffsetLimits();
+
+        for (StateStoreSupplier stateStoreSupplier : this.topology.stateStoreSuppliers()) {
+            StateStore store = stateStoreSupplier.get();
+            this.processorContext.registerStore(store);
             store.init(this.processorContext, store);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -72,7 +72,10 @@ public abstract class AbstractTask {
         }
     }
 
-    protected void initializeStateStores() {
+    /**
+     * Registers all state stores for this task
+     */
+    protected void registerStateStores() {
         // set initial offset limits
         initializeOffsetLimits();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -113,7 +113,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
         if (initialized)
             throw new IllegalStateException("Can only create state stores during initialization.");
 
-        stateMgr.registerStore(store, this);
+        stateMgr.registerStore(store);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -109,11 +109,22 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
      * @throws IllegalStateException if this method is called before {@link #initialized()}
      */
     @Override
-    public void register(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback) {
+    public void registerStore(StateStore store) {
         if (initialized)
             throw new IllegalStateException("Can only create state stores during initialization.");
 
-        stateMgr.register(store, loggingEnabled, stateRestoreCallback);
+        stateMgr.registerStore(store, this);
+    }
+
+    /**
+     * @throws IllegalStateException if this method is called before {@link #initialized()}
+     */
+    @Override
+    public void initStore(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback) {
+        if (initialized)
+            throw new IllegalStateException("Can only create state stores during initialization.");
+
+        stateMgr.initStore(store, loggingEnabled, stateRestoreCallback);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -150,14 +150,16 @@ public class ProcessorStateManager {
     }
 
     /**
+     * Checks that the underlying change log topic exists
      * @throws StreamsException if the store's change log does not contain the partition
      */
-    protected void maybeGetPartitions(StateStore store, boolean loggingEnabled) {
+    protected void checkTopicExits(StateStore store, boolean loggingEnabled) {
         String topic;
         if (loggingEnabled)
             topic = storeChangelogTopic(this.applicationId, store.name());
         else topic = store.name();
 
+        // check that the underlying change log topic exists or not
         // block until the partition is ready for this state changelog topic or time has elapsed
         int partition = getPartition(topic);
         boolean partitionNotFound = true;
@@ -188,6 +190,7 @@ public class ProcessorStateManager {
     }
 
     /**
+     * Registers the state stores with the system
      * @throws IllegalArgumentException if the store name has already been registered or if it is not a valid name
      * (e.g., when it conflicts with the names of internal topics, like the checkpoint file name)
      */
@@ -201,7 +204,6 @@ public class ProcessorStateManager {
         if (loggingEnabled)
             this.loggingEnabled.add(store.name());
 
-        // check that the underlying change log topic exists or not
         String topic;
         if (loggingEnabled)
             topic = storeChangelogTopic(this.applicationId, store.name());
@@ -328,7 +330,7 @@ public class ProcessorStateManager {
     public StateStore getStore(String name) {
         StateStore store = stores.get(name);
         if (store != null) {
-            maybeGetPartitions(store, loggingEnabled.contains(name));
+            checkTopicExits(store, loggingEnabled.contains(name));
         }
         return store;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -353,6 +353,7 @@ public class ProcessorStateManager {
     public StateStore getStore(String name) {
         StateStore store = stores.get(name);
         if (store != null && !this.storeInitialized.contains(store.name())) {
+            log.debug("Lazily initializing store " + name);
             store.init(processorContext, store);
         }
         return store;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -102,11 +102,22 @@ public class StandbyContextImpl implements ProcessorContext, RecordCollector.Sup
      * @throws IllegalStateException
      */
     @Override
-    public void register(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback) {
+    public void initStore(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback) {
         if (initialized)
             throw new IllegalStateException("Can only create state stores during initialization.");
 
-        stateMgr.register(store, loggingEnabled, stateRestoreCallback);
+        stateMgr.initStore(store, loggingEnabled, stateRestoreCallback);
+    }
+
+    /**
+     * @throws IllegalStateException if this method is called before {@link #initialized()}
+     */
+    @Override
+    public void registerStore(StateStore store) {
+        if (initialized)
+            throw new IllegalStateException("Can only create state stores during initialization.");
+
+        stateMgr.registerStore(store, this);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -117,7 +117,7 @@ public class StandbyContextImpl implements ProcessorContext, RecordCollector.Sup
         if (initialized)
             throw new IllegalStateException("Can only create state stores during initialization.");
 
-        stateMgr.registerStore(store, this);
+        stateMgr.registerStore(store);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -61,7 +61,7 @@ public class StandbyTask extends AbstractTask {
         // initialize the topology with its own context
         this.processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
 
-        initializeStateStores();
+        registerStateStores();
 
         ((StandbyContextImpl) this.processorContext).initialized();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -61,7 +61,7 @@ public class StandbyTask extends AbstractTask {
         // initialize the topology with its own context
         this.processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
 
-        registerStateStores();
+        registerAndinitializeStateStores();
 
         ((StandbyContextImpl) this.processorContext).initialized();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -60,7 +60,7 @@ public class StandbyTask extends AbstractTask {
 
         // initialize the topology with its own context
         this.processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
-
+        stateMgr.setContext(this.processorContext);
         registerAndinitializeStateStores();
 
         ((StandbyContextImpl) this.processorContext).initialized();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -111,8 +111,8 @@ public class StreamTask extends AbstractTask implements Punctuator {
         // initialize the topology with its own context
         this.processorContext = new ProcessorContextImpl(id, this, config, recordCollector, stateMgr, metrics);
 
-        // initialize the state stores
-        initializeStateStores();
+        // register the state stores
+        registerStateStores();
 
         // initialize the task by initializing all its processor nodes in the topology
         for (ProcessorNode node : this.topology.processors()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -110,6 +110,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
         // initialize the topology with its own context
         this.processorContext = new ProcessorContextImpl(id, this, config, recordCollector, stateMgr, metrics);
+        stateMgr.setContext(this.processorContext);
 
         // register the state stores
         registerStateStores();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -60,12 +60,16 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
 
     private void maybeInitialize() {
         if (!isInitialized) {
-            init();
+            initBackend();
             isInitialized = true;
         }
     }
 
-    private void init() {
+    /**
+     * Initializes the backend (log, DB, etc) of the state store.
+     * This is usually an expensive call.
+     */
+    private void initBackend() {
         ProcessorContext context = initContext;
         StateStore root = initRoot;
         if (initContext == null || root == null) {
@@ -85,6 +89,12 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
         };
     }
 
+    /**
+     * Registers the state store. However it does not initialize their backends yet (e.g.,
+     * open database etc.), since that is done lazily in the {@link #initBackend()} method
+     * @param context Processor context
+     * @param root State store
+     */
     @Override
     @SuppressWarnings("unchecked")
     public void init(ProcessorContext context, StateStore root) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -68,8 +68,9 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
     private void init() {
         ProcessorContext context = initContext;
         StateStore root = initRoot;
-
-
+        if (initContext == null || root == null) {
+            return;
+        }
 
         this.changeLogger = new StoreChangeLogger<>(storeName, context, serdes);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -104,8 +104,6 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
                 inner.put(serdes.keyFrom(key), serdes.valueFrom(value));
             }
         });
-
-        return;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -219,7 +219,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
                 putInternal(key, value);
             }
         });
-        return;
     }
 
     private RocksDB openDB(File dir, Options options, int ttl) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -136,7 +136,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     private void maybeInitialize() {
         if (!isInitialized) {
-            init();
+            initBackend();
             isInitialized = true;
         }
     }
@@ -167,7 +167,11 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         this.db = openDB(this.dbDir, this.options, TTL_SECONDS);
     }
 
-    private void init() {
+    /**
+     * Initializes the backend (log, DB, etc) of the state store.
+     * This is usually an expensive call.
+     */
+    private void initBackend() {
         ProcessorContext context = initContext;
         StateStore root = initRoot;
         if (initContext == null || root == null) {
@@ -208,6 +212,12 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         };
     }
 
+    /**
+     * Registers the state store. However it does not initialize their backends yet (e.g.,
+     * open database etc.), since that is done lazily in the {@link #initBackend()} method
+     * @param context Processor context
+     * @param root State store
+     */
     public void init(ProcessorContext context, StateStore root) {
         initContext = context;
         initRoot = root;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -181,7 +181,7 @@ public class RocksDBWindowStore<K, V> implements WindowStore<K, V> {
         this.changeLogger = this.loggingEnabled ? new RawStoreChangeLogger(name, context) : null;
 
         // register and possibly restore the state from the logs
-        context.register(root, loggingEnabled, new StateRestoreCallback() {
+        context.initStore(root, loggingEnabled, new StateRestoreCallback() {
             @Override
             public void restore(byte[] key, byte[] value) {
                 putInternal(key, value);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -229,6 +229,7 @@ public class ProcessorStateManagerTest {
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 1, noPartitions, baseDir, new MockRestoreConsumer(), false);
             try {
                 stateMgr.register(mockStateStore, true, mockStateStore.stateRestoreCallback);
+                stateMgr.maybeGetPartitions(mockStateStore, true);
             } finally {
                 stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
             }
@@ -274,7 +275,7 @@ public class ProcessorStateManagerTest {
                 }
 
                 stateMgr.register(persistentStore, true, persistentStore.stateRestoreCallback);
-
+                stateMgr.maybeGetPartitions(persistentStore, true);
                 assertEquals(new TopicPartition(persistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(lastCheckpointedOffset, restoreConsumer.seekOffset);
                 assertFalse(restoreConsumer.seekToBeginingCalled);
@@ -327,7 +328,7 @@ public class ProcessorStateManagerTest {
                 }
 
                 stateMgr.register(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
-
+                stateMgr.maybeGetPartitions(nonPersistentStore, true);
                 assertEquals(new TopicPartition(nonPersistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(0L, restoreConsumer.seekOffset);
                 assertTrue(restoreConsumer.seekToBeginingCalled);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -229,7 +229,7 @@ public class ProcessorStateManagerTest {
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 1, noPartitions, baseDir, new MockRestoreConsumer(), false);
             try {
                 stateMgr.register(mockStateStore, true, mockStateStore.stateRestoreCallback);
-                stateMgr.maybeGetPartitions(mockStateStore, true);
+                stateMgr.checkTopicExits(mockStateStore, true);
             } finally {
                 stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
             }
@@ -275,7 +275,7 @@ public class ProcessorStateManagerTest {
                 }
 
                 stateMgr.register(persistentStore, true, persistentStore.stateRestoreCallback);
-                stateMgr.maybeGetPartitions(persistentStore, true);
+                stateMgr.checkTopicExits(persistentStore, true);
                 assertEquals(new TopicPartition(persistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(lastCheckpointedOffset, restoreConsumer.seekOffset);
                 assertFalse(restoreConsumer.seekToBeginingCalled);
@@ -328,7 +328,7 @@ public class ProcessorStateManagerTest {
                 }
 
                 stateMgr.register(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
-                stateMgr.maybeGetPartitions(nonPersistentStore, true);
+                stateMgr.checkTopicExits(nonPersistentStore, true);
                 assertEquals(new TopicPartition(nonPersistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(0L, restoreConsumer.seekOffset);
                 assertTrue(restoreConsumer.seekToBeginingCalled);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -228,8 +228,8 @@ public class ProcessorStateManagerTest {
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 1, noPartitions, baseDir, new MockRestoreConsumer(), false);
             try {
-                stateMgr.register(mockStateStore, true, mockStateStore.stateRestoreCallback);
-                stateMgr.checkTopicExits(mockStateStore, true);
+                stateMgr.registerStore(mockStateStore, null);
+                stateMgr.initStore(mockStateStore, true, mockStateStore.stateRestoreCallback);
             } finally {
                 stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
             }
@@ -273,9 +273,8 @@ public class ProcessorStateManagerTest {
                             new ConsumerRecord<>(persistentStoreTopicName, 2, 0L, offset, TimestampType.CREATE_TIME, 0L, 0, 0, key, 0)
                     );
                 }
-
-                stateMgr.register(persistentStore, true, persistentStore.stateRestoreCallback);
-                stateMgr.checkTopicExits(persistentStore, true);
+                stateMgr.registerStore(persistentStore, null);
+                stateMgr.initStore(persistentStore, true, persistentStore.stateRestoreCallback);
                 assertEquals(new TopicPartition(persistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(lastCheckpointedOffset, restoreConsumer.seekOffset);
                 assertFalse(restoreConsumer.seekToBeginingCalled);
@@ -326,9 +325,8 @@ public class ProcessorStateManagerTest {
                             new ConsumerRecord<>(nonPersistentStoreTopicName, 2, 0L, offset, TimestampType.CREATE_TIME, 0L, 0, 0, key, 0)
                     );
                 }
-
-                stateMgr.register(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
-                stateMgr.checkTopicExits(nonPersistentStore, true);
+                stateMgr.registerStore(nonPersistentStore, null);
+                stateMgr.initStore(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
                 assertEquals(new TopicPartition(nonPersistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(0L, restoreConsumer.seekOffset);
                 assertTrue(restoreConsumer.seekToBeginingCalled);
@@ -390,10 +388,12 @@ public class ProcessorStateManagerTest {
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 0, sourcePartitions, baseDir, restoreConsumer, true); // standby
             try {
                 restoreConsumer.reset();
-
-                stateMgr.register(store1, true, store1.stateRestoreCallback);
-                stateMgr.register(store2, true, store2.stateRestoreCallback);
-                stateMgr.register(store3, true, store3.stateRestoreCallback);
+                stateMgr.registerStore(store1, null);
+                stateMgr.registerStore(store2, null);
+                stateMgr.registerStore(store3, null);
+                stateMgr.initStore(store1, true, store1.stateRestoreCallback);
+                stateMgr.initStore(store2, true, store2.stateRestoreCallback);
+                stateMgr.initStore(store3, true, store3.stateRestoreCallback);
 
                 Map<TopicPartition, Long> changeLogOffsets = stateMgr.checkpointedOffsets();
 
@@ -428,7 +428,8 @@ public class ProcessorStateManagerTest {
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 1, noPartitions, baseDir, restoreConsumer, false);
             try {
-                stateMgr.register(mockStateStore, true, mockStateStore.stateRestoreCallback);
+                stateMgr.registerStore(mockStateStore, null);
+                stateMgr.initStore(mockStateStore, true, mockStateStore.stateRestoreCallback);
 
                 assertNull(stateMgr.getStore("noSuchStore"));
                 assertEquals(mockStateStore, stateMgr.getStore(nonPersistentStoreName));
@@ -474,10 +475,12 @@ public class ProcessorStateManagerTest {
                 assertFalse(checkpointFile.exists());
 
                 restoreConsumer.reset();
-                stateMgr.register(persistentStore, true, persistentStore.stateRestoreCallback);
+                stateMgr.registerStore(persistentStore, null);
+                stateMgr.initStore(persistentStore, true, persistentStore.stateRestoreCallback);
 
                 restoreConsumer.reset();
-                stateMgr.register(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
+                stateMgr.registerStore(nonPersistentStore, null);
+                stateMgr.initStore(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
             } finally {
                 // close the state manager with the ack'ed offsets
                 stateMgr.close(ackedOffsets);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -228,7 +228,7 @@ public class ProcessorStateManagerTest {
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 1, noPartitions, baseDir, new MockRestoreConsumer(), false);
             try {
-                stateMgr.registerStore(mockStateStore, null);
+                stateMgr.registerStore(mockStateStore);
                 stateMgr.initStore(mockStateStore, true, mockStateStore.stateRestoreCallback);
             } finally {
                 stateMgr.close(Collections.<TopicPartition, Long>emptyMap());
@@ -273,7 +273,7 @@ public class ProcessorStateManagerTest {
                             new ConsumerRecord<>(persistentStoreTopicName, 2, 0L, offset, TimestampType.CREATE_TIME, 0L, 0, 0, key, 0)
                     );
                 }
-                stateMgr.registerStore(persistentStore, null);
+                stateMgr.registerStore(persistentStore);
                 stateMgr.initStore(persistentStore, true, persistentStore.stateRestoreCallback);
                 assertEquals(new TopicPartition(persistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(lastCheckpointedOffset, restoreConsumer.seekOffset);
@@ -325,7 +325,7 @@ public class ProcessorStateManagerTest {
                             new ConsumerRecord<>(nonPersistentStoreTopicName, 2, 0L, offset, TimestampType.CREATE_TIME, 0L, 0, 0, key, 0)
                     );
                 }
-                stateMgr.registerStore(nonPersistentStore, null);
+                stateMgr.registerStore(nonPersistentStore);
                 stateMgr.initStore(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
                 assertEquals(new TopicPartition(nonPersistentStoreTopicName, 2), restoreConsumer.assignedPartition);
                 assertEquals(0L, restoreConsumer.seekOffset);
@@ -388,9 +388,9 @@ public class ProcessorStateManagerTest {
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 0, sourcePartitions, baseDir, restoreConsumer, true); // standby
             try {
                 restoreConsumer.reset();
-                stateMgr.registerStore(store1, null);
-                stateMgr.registerStore(store2, null);
-                stateMgr.registerStore(store3, null);
+                stateMgr.registerStore(store1);
+                stateMgr.registerStore(store2);
+                stateMgr.registerStore(store3);
                 stateMgr.initStore(store1, true, store1.stateRestoreCallback);
                 stateMgr.initStore(store2, true, store2.stateRestoreCallback);
                 stateMgr.initStore(store3, true, store3.stateRestoreCallback);
@@ -428,7 +428,7 @@ public class ProcessorStateManagerTest {
 
             ProcessorStateManager stateMgr = new ProcessorStateManager(applicationId, 1, noPartitions, baseDir, restoreConsumer, false);
             try {
-                stateMgr.registerStore(mockStateStore, null);
+                stateMgr.registerStore(mockStateStore);
                 stateMgr.initStore(mockStateStore, true, mockStateStore.stateRestoreCallback);
 
                 assertNull(stateMgr.getStore("noSuchStore"));
@@ -475,11 +475,11 @@ public class ProcessorStateManagerTest {
                 assertFalse(checkpointFile.exists());
 
                 restoreConsumer.reset();
-                stateMgr.registerStore(persistentStore, null);
+                stateMgr.registerStore(persistentStore);
                 stateMgr.initStore(persistentStore, true, persistentStore.stateRestoreCallback);
 
                 restoreConsumer.reset();
-                stateMgr.registerStore(nonPersistentStore, null);
+                stateMgr.registerStore(nonPersistentStore);
                 stateMgr.initStore(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
             } finally {
                 // close the state manager with the ack'ed offsets

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -242,9 +242,13 @@ public class KeyValueStoreTestDriver<K, V> {
             }
 
             @Override
-            public void register(StateStore store, boolean loggingEnabled, StateRestoreCallback func) {
-                storeMap.put(store.name(), store);
+            public void initStore(StateStore store, boolean loggingEnabled, StateRestoreCallback func) {
                 restoreEntries(func, serdes);
+            }
+
+            @Override
+            public void registerStore(StateStore store) {
+                storeMap.put(store.name(), store);
             }
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/test/KStreamTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/KStreamTestDriver.java
@@ -61,6 +61,7 @@ public class KStreamTestDriver {
 
         for (StateStoreSupplier stateStoreSupplier : topology.stateStoreSuppliers()) {
             StateStore store = stateStoreSupplier.get();
+            context.registerStore(store);
             store.init(context, store);
         }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -131,9 +131,13 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
     }
 
     @Override
-    public void register(StateStore store, boolean loggingEnabled, StateRestoreCallback func) {
-        storeMap.put(store.name(), store);
+    public void initStore(StateStore store, boolean loggingEnabled, StateRestoreCallback func) {
         restoreFuncs.put(store.name(), func);
+    }
+
+    @Override
+    public void registerStore(StateStore store) {
+        storeMap.put(store.name(), store);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockStateStoreSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockStateStoreSupplier.java
@@ -82,7 +82,7 @@ public class MockStateStoreSupplier implements StateStoreSupplier {
 
         @Override
         public void init(ProcessorContext context, StateStore root) {
-            context.register(root, loggingEnabled, stateRestoreCallback);
+            context.initStore(root, loggingEnabled, stateRestoreCallback);
             initialized = true;
         }
 


### PR DESCRIPTION
Instead of initialising state stores on init(), they are initialised on first access. 
