### PR TITLE
KAFKA-3564: Count metric always increments by 1.0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Count.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Count.java
@@ -27,7 +27,7 @@ public class Count extends SampledStat {
 
     @Override
     protected void update(Sample sample, MetricConfig config, double value, long now) {
-        sample.value += 1.0;
+        sample.value += value;
     }
 
     @Override


### PR DESCRIPTION
Increment the counter by the value passed into the function
