### PR TITLE
KAFKA-3586: Revert to default quota when client quota override is deleted

### DIFF
--- a/core/src/main/scala/kafka/server/ClientQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientQuotaManager.scala
@@ -276,6 +276,10 @@ class ClientQuotaManager(private val config: ClientQuotaManagerConfig,
     }
   }
 
+  def removeQuotaOverride(clientId: String) = {
+    updateQuota(clientId, defaultQuota)
+  }
+
   private def clientRateMetricName(clientId: String): MetricName = {
     metrics.metricName("byte-rate", apiKey,
                    "Tracking byte-rate per client",

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -82,11 +82,13 @@ class ClientIdConfigHandler(private val quotaManagers: Map[Short, ClientQuotaMan
     if (clientConfig.containsKey(ClientConfigOverride.ProducerOverride)) {
       quotaManagers(ApiKeys.PRODUCE.id).updateQuota(clientId,
         new Quota(clientConfig.getProperty(ClientConfigOverride.ProducerOverride).toLong, true))
-    }
+    } else
+      quotaManagers(ApiKeys.PRODUCE.id).removeQuotaOverride(clientId)
 
     if (clientConfig.containsKey(ClientConfigOverride.ConsumerOverride)) {
       quotaManagers(ApiKeys.FETCH.id).updateQuota(clientId,
         new Quota(clientConfig.getProperty(ClientConfigOverride.ConsumerOverride).toLong, true))
-    }
+    } else
+      quotaManagers(ApiKeys.FETCH.id).removeQuotaOverride(clientId)
   }
 }


### PR DESCRIPTION
Update client quota when override is deleted from config
