### PR TITLE
KAFKA-3591: JmxTool should exit out if a provided query matches no values.

### DIFF
--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -99,6 +99,10 @@ object JmxTool extends Logging {
           (name, mbsc.getAttributes(name, mbean.getAttributes.map(_.getName)).size)}.toMap
       }
 
+    if(numExpectedAttributes.isEmpty) {
+      CommandLineUtils.printUsageAndDie(parser, "No matched object names or attributes to show.")
+    }
+
     // print csv header
     val keys = List("time") ++ queryAttributes(mbsc, names, attributesWhitelist).keys.toArray.sorted
     if(keys.size == numExpectedAttributes.map(_._2).sum + 1)


### PR DESCRIPTION
Testing: I did manual tests by building locally and running the class against a remote 0.9.0.0 broker JMX URL. Running with a bad object-name produces the exit condition, and running with a good one continues to behave as before (prints the values). Running with no object name dumps all the metrics (KAFKA-2278).

Docs: This should need no doc changes.

This contribution is my original work and I license the work to the project under the project's open source license.
