### PR TITLE
KAFKA-3600: Enhance java clients to use ApiVersion Req/Resp to check if the broker they are talking to supports required api versions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -93,8 +93,9 @@ public class ClientUtils {
         List<ApiVersionsResponse.ApiVersion> expectedApiVersions = new ArrayList<>();
         for (ApiKeys apiKey : apiKeys)
             expectedApiVersions.add(
+                    // once backwards client compatibility is added, expected min API version for an API should be set to it's min version
                     new ApiVersionsResponse.ApiVersion(
-                            apiKey.id, Protocol.MIN_VERSIONS[apiKey.id], Protocol.CURR_VERSION[apiKey.id]));
+                            apiKey.id, Protocol.CURR_VERSION[apiKey.id], Protocol.CURR_VERSION[apiKey.id]));
         return expectedApiVersions;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java
@@ -15,6 +15,7 @@ package org.apache.kafka.clients;
 import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -22,10 +23,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.common.network.ChannelBuilders;
 import org.apache.kafka.common.network.LoginType;
 import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Protocol;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,4 +89,12 @@ public class ClientUtils {
         return ChannelBuilders.create(securityProtocol, Mode.CLIENT, LoginType.CLIENT, configs, clientSaslMechanism, true);
     }
 
+    public static Collection<ApiVersionsResponse.ApiVersion> buildExpectedApiVersions(Collection<ApiKeys> apiKeys) {
+        List<ApiVersionsResponse.ApiVersion> expectedApiVersions = new ArrayList<>();
+        for (ApiKeys apiKey : apiKeys)
+            expectedApiVersions.add(
+                    new ApiVersionsResponse.ApiVersion(
+                            apiKey.id, Protocol.MIN_VERSIONS[apiKey.id], Protocol.CURR_VERSION[apiKey.id]));
+        return expectedApiVersions;
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -115,15 +115,6 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Return true if the connection is checking_api_versions.
-     * @param id the connection identifier
-     */
-    public boolean isCheckingApiVersions(String id) {
-        NodeConnectionState state = nodeState.get(id);
-        return state != null && state.state == ConnectionState.CHECKING_API_VERSIONS;
-    }
-
-    /**
      * Enter the ready state for the given node.
      * @param id the connection identifier
      */

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -31,8 +31,8 @@ final class ClusterConnectionStates {
     /**
      * Return true iff we can currently initiate a new connection. This will be the case if we are not
      * connected and haven't been connected for at least the minimum reconnection backoff period.
-     * @param id The connection id to check
-     * @param now The current time in MS
+     * @param id the connection id to check
+     * @param now the current time in MS
      * @return true if we can initiate a new connection
      */
     public boolean canConnect(String id, long now) {
@@ -44,9 +44,9 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Return true if we are disconnected from the given node and can't re-establish a connection yet
-     * @param id The connection to check
-     * @param now The current time in ms
+     * Return true if we are disconnected from the given node and can't re-establish a connection yet.
+     * @param id the connection to check
+     * @param now the current time in ms
      */
     public boolean isBlackedOut(String id, long now) {
         NodeConnectionState state = nodeState.get(id);
@@ -60,8 +60,8 @@ final class ClusterConnectionStates {
      * Returns the number of milliseconds to wait, based on the connection state, before attempting to send data. When
      * disconnected, this respects the reconnect backoff time. When connecting or connected, this handles slow/stalled
      * connections.
-     * @param id The connection to check
-     * @param now The current time in ms
+     * @param id the connection to check
+     * @param now the current time in ms
      */
     public long connectionDelay(String id, long now) {
         NodeConnectionState state = nodeState.get(id);
@@ -87,16 +87,16 @@ final class ClusterConnectionStates {
 
     /**
      * Enter the connecting state for the given connection.
-     * @param id The id of the connection
-     * @param now The current time.
+     * @param id the id of the connection
+     * @param now the current time
      */
     public void connecting(String id, long now) {
         nodeState.put(id, new NodeConnectionState(ConnectionState.CONNECTING, now));
     }
 
     /**
-     * Return true iff a specific connection is connected
-     * @param id The id of the connection to check
+     * Return true iff a specific connection is connected.
+     * @param id the id of the connection to check
      */
     public boolean isConnected(String id) {
         NodeConnectionState state = nodeState.get(id);
@@ -104,8 +104,8 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Enter the connected state for the given connection
-     * @param id The connection identifier
+     * Enter the connected state for the given connection.
+     * @param id the connection identifier
      */
     public void connected(String id) {
         NodeConnectionState nodeState = nodeState(id);
@@ -113,9 +113,9 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Enter the disconnected state for the given node
-     * @param id The connection we have disconnected
-     * @param now The current time
+     * Enter the disconnected state for the given node.
+     * @param id the connection we have disconnected
+     * @param now the current time
      */
     public void disconnected(String id, long now) {
         NodeConnectionState nodeState = nodeState(id);
@@ -124,28 +124,55 @@ final class ClusterConnectionStates {
     }
 
     /**
+     * Enter the checking_api_versions state for the given node.
+     * @param id the connection identifier
+     */
+    public void checkingApiVersions(String id) {
+        NodeConnectionState nodeState = nodeState(id);
+        nodeState.state = ConnectionState.CHECKING_API_VERSIONS;
+    }
+
+    /**
+     * Enter the ready state for the given node.
+     * @param id the connection identifier
+     */
+    public void ready(String id) {
+        NodeConnectionState nodeState = nodeState(id);
+        nodeState.state = ConnectionState.READY;
+    }
+
+    /**
+     * Return true if the connection is ready.
+     * @param id the connection identifier
+     */
+    public boolean isReady(String id) {
+        NodeConnectionState state = nodeState.get(id);
+        return state != null && state.state == ConnectionState.READY;
+    }
+
+    /**
      * Remove the given node from the tracked connection states. The main difference between this and `disconnected`
      * is the impact on `connectionDelay`: it will be 0 after this call whereas `reconnectBackoffMs` will be taken
      * into account after `disconnected` is called.
      *
-     * @param id The connection to remove
+     * @param id the connection to remove
      */
     public void remove(String id) {
         nodeState.remove(id);
     }
     
     /**
-     * Get the state of a given connection
-     * @param id The id of the connection
-     * @return The state of our connection
+     * Get the state of a given connection.
+     * @param id the id of the connection
+     * @return the state of our connection
      */
     public ConnectionState connectionState(String id) {
         return nodeState(id).state;
     }
     
     /**
-     * Get the state of a given node
-     * @param id The connection to fetch the state for
+     * Get the state of a given node.
+     * @param id the connection to fetch the state for
      */
     private NodeConnectionState nodeState(String id) {
         NodeConnectionState state = this.nodeState.get(id);
@@ -155,7 +182,7 @@ final class ClusterConnectionStates {
     }
     
     /**
-     * The state of our connection to a node
+     * The state of our connection to a node.
      */
     private static class NodeConnectionState {
 

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -95,24 +95,6 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Return true iff a specific connection is connected.
-     * @param id the id of the connection to check
-     */
-    public boolean isConnected(String id) {
-        NodeConnectionState state = nodeState.get(id);
-        return state != null && state.state == ConnectionState.CONNECTED;
-    }
-
-    /**
-     * Enter the connected state for the given connection.
-     * @param id the connection identifier
-     */
-    public void connected(String id) {
-        NodeConnectionState nodeState = nodeState(id);
-        nodeState.state = ConnectionState.CONNECTED;
-    }
-
-    /**
      * Enter the disconnected state for the given node.
      * @param id the connection we have disconnected
      * @param now the current time
@@ -130,6 +112,15 @@ final class ClusterConnectionStates {
     public void checkingApiVersions(String id) {
         NodeConnectionState nodeState = nodeState(id);
         nodeState.state = ConnectionState.CHECKING_API_VERSIONS;
+    }
+
+    /**
+     * Return true if the connection is checking_api_versions.
+     * @param id the connection identifier
+     */
+    public boolean isCheckingApiVersions(String id) {
+        NodeConnectionState state = nodeState.get(id);
+        return state != null && state.state == ConnectionState.CHECKING_API_VERSIONS;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/ConnectionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ConnectionState.java
@@ -16,5 +16,5 @@ package org.apache.kafka.clients;
  * The states of a node connection
  */
 public enum ConnectionState {
-    DISCONNECTED, CONNECTING, CONNECTED
+    DISCONNECTED, CONNECTING, CONNECTED, CHECKING_API_VERSIONS, READY
 }

--- a/clients/src/main/java/org/apache/kafka/clients/ConnectionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ConnectionState.java
@@ -14,7 +14,12 @@ package org.apache.kafka.clients;
 
 /**
  * The states of a node connection
+ *
+ * DISCONNECTED: connection has not been successfully established yet
+ * CONNECTING: connection is under progress
+ * CHECKING_API_VERSIONS: connection has been established and api versions check is in progress. Failure of this check will cause connection to close
+ * READY: connection is ready to send requests
  */
 public enum ConnectionState {
-    DISCONNECTED, CONNECTING, CONNECTED, CHECKING_API_VERSIONS, READY
+    DISCONNECTED, CONNECTING, CHECKING_API_VERSIONS, READY
 }

--- a/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ManualMetadataUpdater.java
@@ -14,7 +14,7 @@
 package org.apache.kafka.clients;
 
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
 
 import java.util.ArrayList;
@@ -66,7 +66,7 @@ public class ManualMetadataUpdater implements MetadataUpdater {
     }
 
     @Override
-    public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, AbstractResponse body) {
+    public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse response) {
         // Do nothing
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -14,7 +14,7 @@
 package org.apache.kafka.clients;
 
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.RequestHeader;
 
 import java.util.List;
@@ -64,7 +64,7 @@ interface MetadataUpdater {
      * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
      * requests with special handling for completed receives of such requests.
      */
-    void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, AbstractResponse body);
+    void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse);
 
     /**
      * Schedules an update of the current cluster metadata info. A subsequent call to `maybeUpdate` would trigger the

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -268,6 +268,10 @@ public class NetworkClient implements KafkaClient {
         return !metadataUpdater.isUpdateDue(now) && canSendRequest(node.idString());
     }
 
+    private boolean canSendRequest(String node, short apiKey) {
+        return this.requiredApiVersions != null && apiKey == ApiKeys.API_VERSIONS.id && apiVersionsRequestQueue.contains(node) || canSendRequest(node);
+    }
+
     /**
      * Are we connected and ready and able to send more requests to the given connection?
      *
@@ -295,7 +299,7 @@ public class NetworkClient implements KafkaClient {
 
     private void doSend(ClientRequest request, boolean isInternalMetadataRequest, long now) {
         String nodeId = request.destination();
-        if (!canSendRequest(nodeId))
+        if (!canSendRequest(nodeId, request.header().apiKey()))
             throw new IllegalStateException("Attempt to send a request to node " + nodeId + " which is not ready.");
 
         Send send = request.body().toSend(nodeId, request.header());

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -534,7 +534,7 @@ public class NetworkClient implements KafkaClient {
             if (req.isInternalMetadataRequest)
                 metadataUpdater.handleCompletedMetadataResponse(req.header, now, body);
             else if (body instanceof ApiVersionsResponse)
-                    handleApiVersionsResponse(req, (ApiVersionsResponse) body);
+                handleApiVersionsResponse(req, (ApiVersionsResponse) body);
             else
                 responses.add(req.completed(body, now));
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -38,6 +38,9 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Protocol;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
@@ -46,6 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
@@ -505,6 +510,20 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private static final long NO_CURRENT_THREAD = -1L;
     private static final AtomicInteger CONSUMER_CLIENT_ID_SEQUENCE = new AtomicInteger(1);
     private static final String JMX_PREFIX = "kafka.consumer";
+    /**
+     * APIs used by KafkaConsumer
+     */
+    private static final List<Short> USED_API_KEYS = Arrays.asList(
+            ApiKeys.METADATA.id,
+            ApiKeys.FETCH.id,
+            ApiKeys.GROUP_COORDINATOR.id,
+            ApiKeys.HEARTBEAT.id,
+            ApiKeys.JOIN_GROUP.id,
+            ApiKeys.LEAVE_GROUP.id,
+            ApiKeys.LIST_OFFSETS.id,
+            ApiKeys.OFFSET_COMMIT.id,
+            ApiKeys.OFFSET_FETCH.id,
+            ApiKeys.SYNC_GROUP.id);
 
     private final String clientId;
     private final ConsumerCoordinator coordinator;
@@ -648,15 +667,16 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.metadata.update(Cluster.bootstrap(addresses), 0);
             String metricGrpPrefix = "consumer";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config.values());
-            NetworkClient netClient = new NetworkClient(
-                    new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder),
+            NetworkClient netClient = new NetworkClient(new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder),
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice
                     config.getLong(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG),
                     config.getInt(ConsumerConfig.SEND_BUFFER_CONFIG),
                     config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
-                    config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), time);
+                    config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
+                    time,
+                    expectedApiVersions());
             this.client = new ConsumerNetworkClient(netClient, metadata, time, retryBackoffMs,
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG));
             OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
@@ -737,6 +757,15 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         this.metadata = metadata;
         this.retryBackoffMs = retryBackoffMs;
         this.requestTimeoutMs = requestTimeoutMs;
+    }
+
+    private Collection<ApiVersionsResponse.ApiVersion> expectedApiVersions() {
+        List<ApiVersionsResponse.ApiVersion> expectedApiVersions = new ArrayList<>();
+        for (Short apiKey: this.USED_API_KEYS)
+            expectedApiVersions.add(
+                    new ApiVersionsResponse.ApiVersion(
+                            apiKey, Protocol.MIN_VERSIONS[apiKey], Protocol.CURR_VERSION[apiKey]));
+        return expectedApiVersions;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -39,7 +39,6 @@ import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.Protocol;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.AppInfoParser;
@@ -49,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -510,20 +508,18 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private static final long NO_CURRENT_THREAD = -1L;
     private static final AtomicInteger CONSUMER_CLIENT_ID_SEQUENCE = new AtomicInteger(1);
     private static final String JMX_PREFIX = "kafka.consumer";
-    /**
-     * APIs used by KafkaConsumer
-     */
-    private static final List<Short> USED_API_KEYS = Arrays.asList(
-            ApiKeys.METADATA.id,
-            ApiKeys.FETCH.id,
-            ApiKeys.GROUP_COORDINATOR.id,
-            ApiKeys.HEARTBEAT.id,
-            ApiKeys.JOIN_GROUP.id,
-            ApiKeys.LEAVE_GROUP.id,
-            ApiKeys.LIST_OFFSETS.id,
-            ApiKeys.OFFSET_COMMIT.id,
-            ApiKeys.OFFSET_FETCH.id,
-            ApiKeys.SYNC_GROUP.id);
+    private static final List<ApiKeys> CONSUMER_APIS = Arrays.asList(
+            ApiKeys.METADATA,
+            ApiKeys.FETCH,
+            ApiKeys.GROUP_COORDINATOR,
+            ApiKeys.HEARTBEAT,
+            ApiKeys.JOIN_GROUP,
+            ApiKeys.LEAVE_GROUP,
+            ApiKeys.LIST_OFFSETS,
+            ApiKeys.OFFSET_COMMIT,
+            ApiKeys.OFFSET_FETCH,
+            ApiKeys.SYNC_GROUP);
+    private static final Collection<ApiVersionsResponse.ApiVersion> EXPECTED_API_VERSIONS = ClientUtils.buildExpectedApiVersions(CONSUMER_APIS);
 
     private final String clientId;
     private final ConsumerCoordinator coordinator;
@@ -667,7 +663,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             this.metadata.update(Cluster.bootstrap(addresses), 0);
             String metricGrpPrefix = "consumer";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config.values());
-            NetworkClient netClient = new NetworkClient(new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder),
+            NetworkClient netClient = new NetworkClient(
+                    new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder),
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice
@@ -676,7 +673,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getInt(ConsumerConfig.RECEIVE_BUFFER_CONFIG),
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                     time,
-                    expectedApiVersions());
+                    EXPECTED_API_VERSIONS);
             this.client = new ConsumerNetworkClient(netClient, metadata, time, retryBackoffMs,
                     config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG));
             OffsetResetStrategy offsetResetStrategy = OffsetResetStrategy.valueOf(config.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG).toUpperCase(Locale.ROOT));
@@ -757,15 +754,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         this.metadata = metadata;
         this.retryBackoffMs = retryBackoffMs;
         this.requestTimeoutMs = requestTimeoutMs;
-    }
-
-    private Collection<ApiVersionsResponse.ApiVersion> expectedApiVersions() {
-        List<ApiVersionsResponse.ApiVersion> expectedApiVersions = new ArrayList<>();
-        for (Short apiKey: this.USED_API_KEYS)
-            expectedApiVersions.add(
-                    new ApiVersionsResponse.ApiVersion(
-                            apiKey, Protocol.MIN_VERSIONS[apiKey], Protocol.CURR_VERSION[apiKey]));
-        return expectedApiVersions;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ProtoUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ProtoUtils.java
@@ -40,6 +40,12 @@ public class ProtoUtils {
         return Protocol.CURR_VERSION[apiKey];
     }
 
+    public static short oldestVersion(int apiKey) {
+        if (apiKey < 0 || apiKey >= Protocol.CURR_VERSION.length)
+            throw new IllegalArgumentException("Invalid api key: " + apiKey);
+        return Protocol.MIN_VERSIONS[apiKey];
+    }
+
     public static Schema requestSchema(int apiKey, int version) {
         return schemaFor(Protocol.REQUESTS, apiKey, version);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -22,8 +22,12 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 
 public class ApiVersionsRequest extends AbstractRequest {
-
     private static final Schema CURRENT_SCHEMA = ProtoUtils.currentRequestSchema(ApiKeys.API_VERSIONS.id);
+    public static final ApiVersionsRequest API_VERSIONS_REQUEST = createApiVersionsRequest();
+
+    private static ApiVersionsRequest createApiVersionsRequest() {
+        return new ApiVersionsRequest();
+    }
 
     public ApiVersionsRequest() {
         super(new Struct(CURRENT_SCHEMA));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java
@@ -23,11 +23,7 @@ import java.util.Collections;
 
 public class ApiVersionsRequest extends AbstractRequest {
     private static final Schema CURRENT_SCHEMA = ProtoUtils.currentRequestSchema(ApiKeys.API_VERSIONS.id);
-    public static final ApiVersionsRequest API_VERSIONS_REQUEST = createApiVersionsRequest();
-
-    private static ApiVersionsRequest createApiVersionsRequest() {
-        return new ApiVersionsRequest();
-    }
+    public static final ApiVersionsRequest API_VERSIONS_REQUEST = new ApiVersionsRequest();
 
     public ApiVersionsRequest() {
         super(new Struct(CURRENT_SCHEMA));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -30,8 +30,8 @@ import java.util.Map;
 public class ApiVersionsResponse extends AbstractResponse {
 
     private static final Schema CURRENT_SCHEMA = ProtoUtils.currentResponseSchema(ApiKeys.API_VERSIONS.id);
-    private static final ApiVersionsResponse API_VERSIONS_RESPONSE = createApiVersionsResponse();
 
+    public static final ApiVersionsResponse API_VERSIONS_RESPONSE = createApiVersionsResponse();
     public static final String ERROR_CODE_KEY_NAME = "error_code";
     public static final String API_VERSIONS_KEY_NAME = "api_versions";
     public static final String API_KEY_NAME = "api_key";
@@ -106,10 +106,6 @@ public class ApiVersionsResponse extends AbstractResponse {
 
     public static ApiVersionsResponse fromError(Errors error) {
         return new ApiVersionsResponse(error.code(), Collections.<ApiVersion>emptyList());
-    }
-
-    public static ApiVersionsResponse apiVersionsResponse() {
-        return API_VERSIONS_RESPONSE;
     }
 
     private static ApiVersionsResponse createApiVersionsResponse() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -56,6 +56,15 @@ public class ApiVersionsResponse extends AbstractResponse {
             this.minVersion = minVersion;
             this.maxVersion = maxVersion;
         }
+
+        @Override
+        public String toString() {
+            return "ApiVersion {" +
+                    " apiKey: " + apiKey +
+                    " minVersion: " + minVersion +
+                    " maxVersion: " + maxVersion +
+                    "}";
+        }
     }
 
     public ApiVersionsResponse(short errorCode, List<ApiVersion> apiVersions) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java
@@ -59,11 +59,11 @@ public class ApiVersionsResponse extends AbstractResponse {
 
         @Override
         public String toString() {
-            return "ApiVersion {" +
-                    " apiKey: " + apiKey +
-                    " minVersion: " + minVersion +
-                    " maxVersion: " + maxVersion +
-                    "}";
+            return "ApiVersion(" +
+                    "apiKey=" + apiKey +
+                    ", minVersion=" + minVersion +
+                    ", maxVersion= " + maxVersion +
+                    ")";
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -152,6 +152,9 @@ public class SaslClientAuthenticator implements Authenticator {
 
         switch (saslState) {
             case SEND_HANDSHAKE_REQUEST:
+                // When multiple versions of SASL_HANDSHAKE_REQUEST are to be supported,
+                // API_VERSIONS_REQUEST must be sent prior to sending SASL_HANDSHAKE_REQUEST to
+                // fetch supported versions.
                 String clientId = (String) configs.get(CommonClientConfigs.CLIENT_ID_CONFIG);
                 currentRequestHeader = new RequestHeader(ApiKeys.SASL_HANDSHAKE.id, clientId, correlationId++);
                 SaslHandshakeRequest handshakeRequest = new SaslHandshakeRequest(mechanism);

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -359,7 +359,7 @@ public class SaslServerAuthenticator implements Authenticator {
     }
 
     private void handleApiVersionsRequest(RequestHeader requestHeader) throws IOException, UnsupportedSaslMechanismException {
-        sendKafkaResponse(requestHeader, ApiVersionsResponse.apiVersionsResponse());
+        sendKafkaResponse(requestHeader, ApiVersionsResponse.API_VERSIONS_RESPONSE);
     }
 
     private void sendKafkaResponse(RequestHeader requestHeader, AbstractResponse response) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
@@ -20,83 +20,71 @@ package org.apache.kafka.clients;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.ProtoUtils;
 import org.apache.kafka.common.protocol.Protocol;
-import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.requests.AbstractRequestResponse;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.requests.ResponseHeader;
 import org.apache.kafka.test.DelayedReceive;
+import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
-import static org.apache.kafka.common.requests.ApiVersionsResponse.API_KEY_NAME;
-import static org.apache.kafka.common.requests.ApiVersionsResponse.API_VERSIONS_KEY_NAME;
-import static org.apache.kafka.common.requests.ApiVersionsResponse.ERROR_CODE_KEY_NAME;
-import static org.apache.kafka.common.requests.ApiVersionsResponse.MAX_VERSION_KEY_NAME;
-import static org.apache.kafka.common.requests.ApiVersionsResponse.MIN_VERSION_KEY_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class NetworkClientApiVersionsCheckTest extends NetworkClientTest {
-
-    private static final ApiKeys USED_API_KEY = ApiKeys.METADATA;
-    private static final Collection<ApiVersionsResponse.ApiVersion> EXPECTED_API_VERSIONS = createExpectedApiVersions();
-
-    private static Collection<ApiVersionsResponse.ApiVersion> createExpectedApiVersions() {
-        List<ApiVersionsResponse.ApiVersion> expectedApiVersions = new ArrayList<>();
-        expectedApiVersions.add(new ApiVersionsResponse.ApiVersion(USED_API_KEY.id, Protocol.MIN_VERSIONS[USED_API_KEY.id], Protocol.CURR_VERSION[USED_API_KEY.id]));
-        return expectedApiVersions;
-    }
+    
+    private static final List<ApiVersionsResponse.ApiVersion> EXPECTED_API_VERSIONS = Collections.singletonList(
+            new ApiVersionsResponse.ApiVersion(ApiKeys.METADATA.id, Protocol.MIN_VERSIONS[ApiKeys.METADATA.id],
+                    Protocol.CURR_VERSION[ApiKeys.METADATA.id]));
 
     @Override
-    protected Collection<ApiVersionsResponse.ApiVersion> getExpectedApiVersions() {
+    protected List<ApiVersionsResponse.ApiVersion> expectedApiVersions() {
         return EXPECTED_API_VERSIONS;
     }
 
     @Test
     public void testUnsupportedLesserApiVersions() {
-        unsupportedApiVersionsCheck(getExpectedApiVersions(), (short) (ProtoUtils.latestVersion(USED_API_KEY.id) + 1), Short.MAX_VALUE, "Node 0 does not support required versions for Api " + USED_API_KEY.id);
+        unsupportedApiVersionsCheck(expectedApiVersions(), (short) (ProtoUtils.latestVersion(ApiKeys.METADATA.id) + 1), Short.MAX_VALUE, "Node 0 does not support required versions for Api " + ApiKeys.METADATA.id);
     }
 
     @Test
     public void testUnsupportedGreaterApiVersions() {
-        unsupportedApiVersionsCheck(getExpectedApiVersions(), Short.MIN_VALUE, (short) (ProtoUtils.oldestVersion(USED_API_KEY.id) - 1), "Node 0 does not support required versions for Api " + USED_API_KEY.id);
+        unsupportedApiVersionsCheck(expectedApiVersions(), Short.MIN_VALUE, (short) (ProtoUtils.oldestVersion(ApiKeys.METADATA.id) - 1), "Node 0 does not support required versions for Api " + ApiKeys.METADATA.id);
     }
 
     @Test
     public void testUnsupportedMissingApiVersions() {
-        unsupportedApiVersionsCheck(new ArrayList<ApiVersionsResponse.ApiVersion>(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2), "Node 0 does not support Api " + USED_API_KEY.id);
+        unsupportedApiVersionsCheck(Collections.emptyList(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2), "Node 0 does not support Api " + ApiKeys.METADATA.id);
     }
 
-    private void unsupportedApiVersionsCheck(final Collection<ApiVersionsResponse.ApiVersion> expectedApiVersions, short minVersion, short maxVersion, String errorMessage) {
-        ResponseHeader respHeader = new ResponseHeader(0);
-        Struct resp = new Struct(ProtoUtils.currentResponseSchema(ApiKeys.API_VERSIONS.id));
-        resp.set(ERROR_CODE_KEY_NAME, (short) 0);
-        List<Struct> apiVersionList = new ArrayList<>();
-        for (ApiVersionsResponse.ApiVersion apiVersion : expectedApiVersions) {
-            Struct apiVersionStruct = resp.instance(API_VERSIONS_KEY_NAME);
-            apiVersionStruct.set(API_KEY_NAME, apiVersion.apiKey);
-            apiVersionStruct.set(MIN_VERSION_KEY_NAME, minVersion);
-            apiVersionStruct.set(MAX_VERSION_KEY_NAME, maxVersion);
-            apiVersionList.add(apiVersionStruct);
-        }
-        resp.set(API_VERSIONS_KEY_NAME, apiVersionList.toArray());
-        int size = respHeader.sizeOf() + resp.sizeOf();
-        ByteBuffer buffer = ByteBuffer.allocate(size);
-        respHeader.writeTo(buffer);
-        resp.writeTo(buffer);
-        buffer.flip();
+    private void unsupportedApiVersionsCheck(final Collection<ApiVersionsResponse.ApiVersion> expectedApiVersions,
+                                             short minVersion, short maxVersion, String errorMessage) {
+        ResponseHeader responseHeader = new ResponseHeader(0);
+        List<ApiVersionsResponse.ApiVersion> apiVersions = new ArrayList<>();
+        for (ApiVersionsResponse.ApiVersion apiVersion : expectedApiVersions)
+            apiVersions.add(new ApiVersionsResponse.ApiVersion(apiVersion.apiKey, minVersion, maxVersion));
+        ApiVersionsResponse response = new ApiVersionsResponse(Errors.NONE.code(), apiVersions);
+        ByteBuffer buffer = AbstractRequestResponse.serialize(responseHeader, response);
+
         selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));
         try {
-            while (!client.ready(node, time.milliseconds()))
+            long deadline = time.milliseconds() + TestUtils.DEFAULT_MAX_WAIT_MS;
+            while (time.milliseconds() < deadline && !client.ready(node, time.milliseconds()))
                 client.poll(1, time.milliseconds());
-            fail("Api versions check failed. Should have thrown KafkaException as required api versions are not supported.");
+
+            fail("KafkaException should have been thrown for " + expectedApiVersions + ", minVersion: " + minVersion +
+                    ", maxVersion: " + maxVersion);
         } catch (KafkaException kex) {
-            assertTrue("Api versions check should have failed.", kex.getMessage().contains(errorMessage));
+            assertTrue("Exception containing `" + errorMessage + "` should have been thrown due to ApiVersions " +
+                    "check, but exception message was: " + kex.getMessage(), kex.getMessage().contains(errorMessage));
         }
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
@@ -61,7 +61,7 @@ public class NetworkClientApiVersionsCheckTest extends NetworkClientTest {
 
     @Test
     public void testUnsupportedMissingApiVersions() {
-        unsupportedApiVersionsCheck(Collections.<ApiVersionsResponse.ApiVersion>emptyList(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2), "Node 0 does not support Api " + ApiKeys.METADATA.id);
+        unsupportedApiVersionsCheck(Collections.<ApiVersionsResponse.ApiVersion>emptyList(), Short.MIN_VALUE, Short.MAX_VALUE, "Node 0 does not support Api " + ApiKeys.METADATA.id);
     }
 
     private void unsupportedApiVersionsCheck(final List<ApiVersionsResponse.ApiVersion> expectedApiVersions,

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -62,10 +61,10 @@ public class NetworkClientApiVersionsCheckTest extends NetworkClientTest {
 
     @Test
     public void testUnsupportedMissingApiVersions() {
-        unsupportedApiVersionsCheck(Collections.emptyList(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2), "Node 0 does not support Api " + ApiKeys.METADATA.id);
+        unsupportedApiVersionsCheck(Collections.<ApiVersionsResponse.ApiVersion>emptyList(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2), "Node 0 does not support Api " + ApiKeys.METADATA.id);
     }
 
-    private void unsupportedApiVersionsCheck(final Collection<ApiVersionsResponse.ApiVersion> expectedApiVersions,
+    private void unsupportedApiVersionsCheck(final List<ApiVersionsResponse.ApiVersion> expectedApiVersions,
                                              short minVersion, short maxVersion, String errorMessage) {
         ResponseHeader responseHeader = new ResponseHeader(0);
         List<ApiVersionsResponse.ApiVersion> apiVersions = new ArrayList<>();

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientApiVersionsCheckTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.network.NetworkReceive;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ProtoUtils;
+import org.apache.kafka.common.protocol.Protocol;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
+import org.apache.kafka.common.requests.ResponseHeader;
+import org.apache.kafka.test.DelayedReceive;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.kafka.common.requests.ApiVersionsResponse.API_KEY_NAME;
+import static org.apache.kafka.common.requests.ApiVersionsResponse.API_VERSIONS_KEY_NAME;
+import static org.apache.kafka.common.requests.ApiVersionsResponse.ERROR_CODE_KEY_NAME;
+import static org.apache.kafka.common.requests.ApiVersionsResponse.MAX_VERSION_KEY_NAME;
+import static org.apache.kafka.common.requests.ApiVersionsResponse.MIN_VERSION_KEY_NAME;
+import static org.junit.Assert.fail;
+
+public class NetworkClientApiVersionsCheckTest extends NetworkClientTest {
+
+    private static final List<Short> USED_API_KEYS = Arrays.asList(
+            ApiKeys.METADATA.id,
+            ApiKeys.FETCH.id,
+            ApiKeys.GROUP_COORDINATOR.id,
+            ApiKeys.HEARTBEAT.id,
+            ApiKeys.JOIN_GROUP.id,
+            ApiKeys.LEAVE_GROUP.id,
+            ApiKeys.LIST_OFFSETS.id,
+            ApiKeys.OFFSET_COMMIT.id,
+            ApiKeys.OFFSET_FETCH.id,
+            ApiKeys.SYNC_GROUP.id);
+
+    @Override
+    protected Collection<ApiVersionsResponse.ApiVersion> getExpectedApiVersions() {
+        List<ApiVersionsResponse.ApiVersion> expectedApiVersions = new ArrayList<>();
+        for (Short apiKey: this.USED_API_KEYS)
+            expectedApiVersions.add(new ApiVersionsResponse.ApiVersion(apiKey, Protocol.MIN_VERSIONS[apiKey], Protocol.CURR_VERSION[apiKey]));
+        return expectedApiVersions;
+    }
+
+    @Test
+    public void testUnsupportedLesserApiVersions() {
+        unsupportedApiVersionsCheck(getExpectedApiVersions(), (short) (Short.MAX_VALUE - 2), Short.MAX_VALUE);
+    }
+
+    @Test
+    public void testUnsupportedGreaterApiVersions() {
+        unsupportedApiVersionsCheck(getExpectedApiVersions(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2));
+    }
+
+    @Test
+    public void testUnsupportedMissingApiVersions() {
+        unsupportedApiVersionsCheck(new ArrayList<ApiVersionsResponse.ApiVersion>(), Short.MIN_VALUE, (short) (Short.MAX_VALUE + 2));
+    }
+
+    private void unsupportedApiVersionsCheck(final Collection<ApiVersionsResponse.ApiVersion> expectedApiVersions, short minVersion, short maxVersion) {
+        ResponseHeader respHeader = new ResponseHeader(0);
+        Struct resp = new Struct(ProtoUtils.currentResponseSchema(ApiKeys.API_VERSIONS.id));
+        resp.set(ERROR_CODE_KEY_NAME, (short) 0);
+        List<Struct> apiVersionList = new ArrayList<>();
+        for (ApiVersionsResponse.ApiVersion apiVersion : expectedApiVersions) {
+            Struct apiVersionStruct = resp.instance(API_VERSIONS_KEY_NAME);
+            apiVersionStruct.set(API_KEY_NAME, apiVersion.apiKey);
+            apiVersionStruct.set(MIN_VERSION_KEY_NAME, minVersion);
+            apiVersionStruct.set(MAX_VERSION_KEY_NAME, maxVersion);
+            apiVersionList.add(apiVersionStruct);
+        }
+        resp.set(API_VERSIONS_KEY_NAME, apiVersionList.toArray());
+        int size = respHeader.sizeOf() + resp.sizeOf();
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        respHeader.writeTo(buffer);
+        resp.writeTo(buffer);
+        buffer.flip();
+        selector.delayedReceive(new DelayedReceive(node.idString(), new NetworkReceive(node.idString(), buffer)));
+        try {
+            while (!client.ready(node, time.milliseconds()))
+                client.poll(1, time.milliseconds());
+            fail("Api versions check failed.");
+        } catch (KafkaException kex) {
+            // Expected
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -134,11 +134,11 @@ public class NetworkClientTest {
     }
 
     private void checkSimpleRequestResponse(NetworkClient networkClient) {
+        awaitReady(networkClient, node); // has to be before creating any request, as it may send ApiVersionsRequest and its response is mocked with correlation id 0
         ProduceRequest produceRequest = new ProduceRequest((short) 1, 1000, Collections.<TopicPartition, MemoryRecords>emptyMap());
         RequestHeader reqHeader = networkClient.nextRequestHeader(ApiKeys.PRODUCE);
         TestCallbackHandler handler = new TestCallbackHandler();
         ClientRequest request = new ClientRequest(node.idString(), time.milliseconds(), true, reqHeader, produceRequest, handler);
-        awaitReady(networkClient, node);
         networkClient.send(request, time.milliseconds());
         networkClient.poll(1, time.milliseconds());
         assertEquals(1, networkClient.inFlightRequestCount());
@@ -191,11 +191,11 @@ public class NetworkClientTest {
 
     @Test
     public void testRequestTimeout() {
+        awaitReady(client, node); // has to be before creating any request, as it may send ApiVersionsRequest and its response is mocked with correlation id 0
         ProduceRequest produceRequest = new ProduceRequest((short) 1, 1000, Collections.<TopicPartition, MemoryRecords>emptyMap());
         RequestHeader reqHeader = client.nextRequestHeader(ApiKeys.PRODUCE);
         TestCallbackHandler handler = new TestCallbackHandler();
         ClientRequest request = new ClientRequest(node.idString(), time.milliseconds(), true, reqHeader, produceRequest, handler);
-        awaitReady(client, node);
         long now = time.milliseconds();
         client.send(request, now);
         // sleeping to make sure that the time since last send is greater than requestTimeOut

--- a/clients/src/test/java/org/apache/kafka/test/DelayedReceive.java
+++ b/clients/src/test/java/org/apache/kafka/test/DelayedReceive.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.common.network.NetworkReceive;
+
+/**
+ * Used by MockSelector to allow clients to add responses whose associated requests are added later.
+ */
+public class DelayedReceive {
+    private String source;
+    private NetworkReceive receive;
+
+    public DelayedReceive(String source, NetworkReceive receive) {
+        this.source = source;
+        this.receive = receive;
+    }
+
+    public String source() {
+        return source;
+    }
+
+    public NetworkReceive receive() {
+        return receive;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/test/DelayedReceive.java
+++ b/clients/src/test/java/org/apache/kafka/test/DelayedReceive.java
@@ -22,8 +22,8 @@ import org.apache.kafka.common.network.NetworkReceive;
  * Used by MockSelector to allow clients to add responses whose associated requests are added later.
  */
 public class DelayedReceive {
-    private String source;
-    private NetworkReceive receive;
+    private final String source;
+    private final NetworkReceive receive;
 
     public DelayedReceive(String source, NetworkReceive receive) {
         this.source = source;

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -81,7 +81,7 @@ public class MockSelector implements Selectable {
     public void poll(long timeout) throws IOException {
         this.completedSends.addAll(this.initiatedSends);
         this.initiatedSends.clear();
-        for (Send completedSend: completedSends) {
+        for (Send completedSend : completedSends) {
             Iterator<DelayedReceive> delayedReceiveIterator = delayedReceives.iterator();
             while (delayedReceiveIterator.hasNext()) {
                 DelayedReceive delayedReceive = delayedReceiveIterator.next();

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -15,6 +15,7 @@ package org.apache.kafka.test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.apache.kafka.common.network.NetworkReceive;
@@ -34,6 +35,7 @@ public class MockSelector implements Selectable {
     private final List<NetworkReceive> completedReceives = new ArrayList<NetworkReceive>();
     private final List<String> disconnected = new ArrayList<String>();
     private final List<String> connected = new ArrayList<String>();
+    private final List<DelayedReceive> delayedReceives = new ArrayList<>();
 
     public MockSelector(Time time) {
         this.time = time;
@@ -79,6 +81,16 @@ public class MockSelector implements Selectable {
     public void poll(long timeout) throws IOException {
         this.completedSends.addAll(this.initiatedSends);
         this.initiatedSends.clear();
+        for (Send completedSend: completedSends) {
+            Iterator<DelayedReceive> delayedReceiveIterator = delayedReceives.iterator();
+            while (delayedReceiveIterator.hasNext()) {
+                DelayedReceive delayedReceive = delayedReceiveIterator.next();
+                if (delayedReceive.source().equals(completedSend.destination())) {
+                    completedReceives.add(delayedReceive.receive());
+                    delayedReceiveIterator.remove();
+                }
+            }
+        }
         time.sleep(timeout);
     }
 
@@ -100,6 +112,10 @@ public class MockSelector implements Selectable {
         this.completedReceives.add(receive);
     }
 
+    public void delayedReceive(DelayedReceive receive) {
+        this.delayedReceives.add(receive);
+    }
+
     @Override
     public List<String> disconnected() {
         return disconnected;
@@ -107,7 +123,9 @@ public class MockSelector implements Selectable {
 
     @Override
     public List<String> connected() {
-        return connected;
+        List<String> currentConnected = new ArrayList<>(connected);
+        connected.clear();
+        return currentConnected;
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -66,7 +66,6 @@ public class WorkerGroupMember {
             ApiKeys.HEARTBEAT,
             ApiKeys.JOIN_GROUP,
             ApiKeys.LEAVE_GROUP,
-            ApiKeys.LIST_OFFSETS,
             ApiKeys.SYNC_GROUP);
     private static final Collection<ApiVersionsResponse.ApiVersion> EXPECTED_API_VERSIONS = ClientUtils.buildExpectedApiVersions(WORKER_GROUP_MEMBER_APIS);
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -30,6 +30,8 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.util.ConnectorTaskId;
@@ -38,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +60,15 @@ public class WorkerGroupMember {
 
     private static final AtomicInteger CONNECT_CLIENT_ID_SEQUENCE = new AtomicInteger(1);
     private static final String JMX_PREFIX = "kafka.connect";
+    private static final List<ApiKeys> WORKER_GROUP_MEMBER_APIS = Arrays.asList(
+            ApiKeys.METADATA,
+            ApiKeys.GROUP_COORDINATOR,
+            ApiKeys.HEARTBEAT,
+            ApiKeys.JOIN_GROUP,
+            ApiKeys.LEAVE_GROUP,
+            ApiKeys.LIST_OFFSETS,
+            ApiKeys.SYNC_GROUP);
+    private static final Collection<ApiVersionsResponse.ApiVersion> EXPECTED_API_VERSIONS = ClientUtils.buildExpectedApiVersions(WORKER_GROUP_MEMBER_APIS);
 
     private final Time time;
     private final String clientId;
@@ -99,7 +112,9 @@ public class WorkerGroupMember {
                     config.getLong(CommonClientConfigs.RECONNECT_BACKOFF_MS_CONFIG),
                     config.getInt(CommonClientConfigs.SEND_BUFFER_CONFIG),
                     config.getInt(CommonClientConfigs.RECEIVE_BUFFER_CONFIG),
-                    config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG), time);
+                    config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG),
+                    time,
+                    EXPECTED_API_VERSIONS);
             this.client = new ConsumerNetworkClient(netClient, metadata, time, retryBackoffMs,
                     config.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG));
             this.coordinator = new WorkerCoordinator(this.client,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1133,7 +1133,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     // with client authentication which is performed at an earlier stage of the connection where the
     // ApiVersionRequest is not available.
     val responseBody = if (Protocol.apiVersionSupported(ApiKeys.API_VERSIONS.id, request.header.apiVersion))
-      ApiVersionsResponse.apiVersionsResponse
+      ApiVersionsResponse.API_VERSIONS_RESPONSE
     else
       ApiVersionsResponse.fromError(Errors.UNSUPPORTED_VERSION)
     requestChannel.sendResponse(new RequestChannel.Response(request, responseBody))

--- a/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionsRequestTest.scala
@@ -28,7 +28,7 @@ import scala.collection.JavaConverters._
 object ApiVersionsRequestTest {
   def validateApiVersionsResponse(apiVersionsResponse: ApiVersionsResponse) {
     assertEquals("API keys in ApiVersionsResponse must match API keys supported by broker.", ApiKeys.values.length, apiVersionsResponse.apiVersions.size)
-    for (expectedApiVersion: ApiVersion <- ApiVersionsResponse.apiVersionsResponse.apiVersions.asScala) {
+    for (expectedApiVersion: ApiVersion <- ApiVersionsResponse.API_VERSIONS_RESPONSE.apiVersions.asScala) {
       val actualApiVersion = apiVersionsResponse.apiVersion(expectedApiVersion.apiKey)
       assertNotNull(s"API key ${actualApiVersion.apiKey} is supported by broker, but not received in ApiVersionsResponse.", actualApiVersion)
       assertEquals("API key must be supported by the broker.", expectedApiVersion.apiKey, actualApiVersion.apiKey)

--- a/core/src/test/scala/unit/kafka/server/ApiVersionsTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ApiVersionsTest.scala
@@ -26,11 +26,11 @@ class ApiVersionsTest {
 
   @Test
   def testApiVersions {
-    val apiVersions = ApiVersionsResponse.apiVersionsResponse.apiVersions
+    val apiVersions = ApiVersionsResponse.API_VERSIONS_RESPONSE.apiVersions
     assertEquals("API versions for all API keys must be maintained.", apiVersions.size, ApiKeys.values().length)
 
     for (key <- ApiKeys.values) {
-      val version = ApiVersionsResponse.apiVersionsResponse.apiVersion(key.id)
+      val version = ApiVersionsResponse.API_VERSIONS_RESPONSE.apiVersion(key.id)
       assertNotNull(s"Could not find ApiVersion for API ${key.name}", version)
       assertEquals(s"Incorrect min version for Api ${key.name}.", version.minVersion, Protocol.MIN_VERSIONS(key.id))
       assertEquals(s"Incorrect max version for Api ${key.name}.", version.maxVersion, Protocol.CURR_VERSION(key.id))

--- a/tests/kafkatest/tests/core/api_versions_check_test.py
+++ b/tests/kafkatest/tests/core/api_versions_check_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import LATEST_0_9, LATEST_0_8_2, TRUNK, KafkaVersion
+from kafkatest.version import LATEST_0_9, LATEST_0_8_2, TRUNK, LATEST_0_10, KafkaVersion
 
 
 # Tests to check api versions check is performed correctly.
@@ -45,9 +45,10 @@ class ApiVersionsCheckTest(ProduceConsumeValidateTest):
         self.messages_per_producer = 1000
 
     @parametrize(broker_version=str(TRUNK), should_fail=False)
+    @parametrize(broker_version=str(LATEST_0_10), should_fail=True)
     @parametrize(broker_version=str(LATEST_0_9), should_fail=True)
     @parametrize(broker_version=str(LATEST_0_8_2), should_fail=True)
-    def test_api_versions_check(self, broker_version, should_fail=False):
+    def test_api_versions_check(self, broker_version, should_fail):
 
         self.kafka = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=KafkaVersion(broker_version), topics={self.topic: {
                                                                     "partitions": 1,

--- a/tests/kafkatest/tests/core/api_versions_check_test.py
+++ b/tests/kafkatest/tests/core/api_versions_check_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.verifiable_producer import VerifiableProducer
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
-from kafkatest.version import LATEST_0_9, LATEST_0_8_2, TRUNK, LATEST_0_10, KafkaVersion
+from kafkatest.version import LATEST_0_9, LATEST_0_8_2, TRUNK, LATEST_0_10_0, KafkaVersion
 
 # Tests to check api versions check is performed correctly.
 class ApiVersionsCheckTest(ProduceConsumeValidateTest):

--- a/tests/kafkatest/tests/core/api_versions_check_test.py
+++ b/tests/kafkatest/tests/core/api_versions_check_test.py
@@ -1,0 +1,77 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ducktape.errors import TimeoutError
+from ducktape.mark import parametrize
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.utils import is_int
+from kafkatest.version import LATEST_0_9, LATEST_0_8_2, TRUNK, KafkaVersion
+
+
+# Tests to check api versions check is performed correctly.
+class ApiVersionsCheckTest(ProduceConsumeValidateTest):
+
+    def __init__(self, test_context):
+        super(ApiVersionsCheckTest, self).__init__(test_context=test_context)
+
+    def setUp(self):
+        self.topic = "test_topic"
+        self.zk = ZookeeperService(self.test_context, num_nodes=1)
+            
+        self.zk.start()
+
+        # Producer and consumer
+        self.producer_throughput = 10000
+        self.num_producers = 1
+        self.num_consumers = 1
+        self.messages_per_producer = 1000
+
+    @parametrize(broker_version=str(TRUNK), should_fail=False)
+    @parametrize(broker_version=str(LATEST_0_9), should_fail=True)
+    @parametrize(broker_version=str(LATEST_0_8_2), should_fail=True)
+    def test_api_versions_check(self, broker_version, should_fail=False):
+
+        self.kafka = KafkaService(self.test_context, num_nodes=1, zk=self.zk, version=KafkaVersion(broker_version), topics={self.topic: {
+                                                                    "partitions": 1,
+                                                                    "replication-factor": 1,
+                                                                    'configs': {"min.insync.replicas": 1}}})
+        self.kafka.start()
+         
+        self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka,
+                                           self.topic, throughput=self.producer_throughput,
+                                           message_validator=is_int,
+                                           compression_types=["none"],
+                                           version=KafkaVersion(str(TRUNK)))
+
+        self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka,
+                                        self.topic, consumer_timeout_ms=30000, new_consumer=True,
+                                        message_validator=is_int, version=KafkaVersion(str(TRUNK)))
+
+        try:
+            self.run_produce_consume_validate(lambda: wait_until(
+                lambda: self.producer.each_produced_at_least(self.messages_per_producer) == True,
+                timeout_sec=120, backoff_sec=1,
+                err_msg="Producer did not produce all messages in reasonable amount of time"))
+            if should_fail:
+                raise Exception("Producer from version {} should fail to produce to broker version {}".format(KafkaVersion(str(TRUNK)), KafkaVersion(str(broker_version))))
+        except TimeoutError as timeout_error:
+            if not should_fail:
+                raise timeout_error

--- a/tests/kafkatest/tests/core/api_versions_check_test.py
+++ b/tests/kafkatest/tests/core/api_versions_check_test.py
@@ -25,7 +25,6 @@ from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
 from kafkatest.utils import is_int
 from kafkatest.version import LATEST_0_9, LATEST_0_8_2, TRUNK, LATEST_0_10, KafkaVersion
 
-
 # Tests to check api versions check is performed correctly.
 class ApiVersionsCheckTest(ProduceConsumeValidateTest):
 
@@ -45,7 +44,7 @@ class ApiVersionsCheckTest(ProduceConsumeValidateTest):
         self.messages_per_producer = 1000
 
     @parametrize(broker_version=str(TRUNK), should_fail=False)
-    @parametrize(broker_version=str(LATEST_0_10), should_fail=True)
+    @parametrize(broker_version=str(LATEST_0_10_0), should_fail=True)
     @parametrize(broker_version=str(LATEST_0_9), should_fail=True)
     @parametrize(broker_version=str(LATEST_0_8_2), should_fail=True)
     def test_api_versions_check(self, broker_version, should_fail):

--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -78,7 +78,10 @@ LATEST_0_9 = V_0_9_0_1
 # 0.10.0.X versions
 V_0_10_0_0 = KafkaVersion("0.10.0.0")
 V_0_10_0_1 = KafkaVersion("0.10.0.1")
-# Adding 0.10.0 as the next version will be 0.10.1.x
 LATEST_0_10_0 = V_0_10_0_1
 
-LATEST_0_10 = LATEST_0_10_0
+# 0.10.1.x versions
+V_0_10_1_0 = KafkaVersion("0.10.1.0")
+LATEST_0_10_1 = V_0_10_1_0
+
+LATEST_0_10 = LATEST_0_10_1


### PR DESCRIPTION
This includes changes from https://github.com/apache/kafka/pull/986. To ease reviewing and as requested by release manager, @gwenshap , these are separate PRs.
