### PR TITLE
KAFKA-3597: Query ConsoleConsumer and VerifiableProducer if they shutdown cleanly

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -257,7 +257,8 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("deserializer for values")
       .ofType(classOf[String])
-    val enableLifecycleLoggingOpt = parser.accepts("enable-lifecycle-logging", "Log lifecycle events of the consumer.")
+    val enableLifecycleLoggingOpt = parser.accepts("enable-lifecycle-logging", "Log lifecycle events of the consumer in addition to logging consumed " +
+                                                                               "messages. (This is specific for system tests.)")
 
     if (args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, "The console consumer is a tool that reads data from Kafka and outputs it to standard output.")

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -104,7 +104,9 @@ object ConsoleConsumer extends Logging {
 
         shutdownLatch.await()
 
-        System.out.println("shutdown_complete")
+        if (conf.enableLifecycleLogging) {
+          System.out.println("shutdown_complete")
+        }
       }
     })
   }
@@ -255,6 +257,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("deserializer for values")
       .ofType(classOf[String])
+    val enableLifecycleLoggingOpt = parser.accepts("enable-lifecycle-logging", "Log lifecycle events of the consumer.")
 
     if (args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, "The console consumer is a tool that reads data from Kafka and outputs it to standard output.")
@@ -262,6 +265,7 @@ object ConsoleConsumer extends Logging {
     var groupIdPassed = true
     val options: OptionSet = tryParse(parser, args)
     val useNewConsumer = options.has(useNewConsumerOpt)
+    val enableLifecycleLogging = options.has(enableLifecycleLoggingOpt)
 
     // If using old consumer, exactly one of whitelist/blacklist/topic is required.
     // If using new consumer, topic must be specified.

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -103,6 +103,8 @@ object ConsoleConsumer extends Logging {
         consumer.stop()
 
         shutdownLatch.await()
+
+        System.out.println("shutdown_complete")
       }
     })
   }

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -104,7 +104,7 @@ object ConsoleConsumer extends Logging {
 
         shutdownLatch.await()
 
-        if (conf.enableLifecycleLogging) {
+        if (conf.enableSystestEventsLogging) {
           System.out.println("shutdown_complete")
         }
       }
@@ -257,8 +257,9 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("deserializer for values")
       .ofType(classOf[String])
-    val enableLifecycleLoggingOpt = parser.accepts("enable-lifecycle-logging", "Log lifecycle events of the consumer in addition to logging consumed " +
-                                                                               "messages. (This is specific for system tests.)")
+    val enableSystestEventsLoggingOpt = parser.accepts("enable-systest-events",
+                                                       "Log lifecycle events of the consumer in addition to logging consumed " +
+                                                       "messages. (This is specific for system tests.)")
 
     if (args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, "The console consumer is a tool that reads data from Kafka and outputs it to standard output.")
@@ -266,7 +267,7 @@ object ConsoleConsumer extends Logging {
     var groupIdPassed = true
     val options: OptionSet = tryParse(parser, args)
     val useNewConsumer = options.has(useNewConsumerOpt)
-    val enableLifecycleLogging = options.has(enableLifecycleLoggingOpt)
+    val enableSystestEventsLogging = options.has(enableSystestEventsLoggingOpt)
 
     // If using old consumer, exactly one of whitelist/blacklist/topic is required.
     // If using new consumer, topic must be specified.

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -123,7 +123,7 @@ class ConsoleConsumer(JmxMixin, BackgroundThreadService):
         self.from_beginning = from_beginning
         self.message_validator = message_validator
         self.messages_consumed = {idx: [] for idx in range(1, num_nodes + 1)}
-        self.node_indexes_clean_shutdown = set()
+        self.clean_shutdown_nodes = set()
         self.client_id = client_id
         self.print_key = print_key
         self.log_level = "TRACE"
@@ -186,7 +186,7 @@ class ConsoleConsumer(JmxMixin, BackgroundThreadService):
         if node.version > LATEST_0_9:
             cmd+=" --formatter kafka.tools.LoggingMessageFormatter"
 
-        cmd += " --enable-lifecycle-logging"
+        cmd += " --enable-systest-events"
         cmd += " 2>> %(stderr)s | tee -a %(stdout)s &" % args
         return cmd
 
@@ -229,9 +229,9 @@ class ConsoleConsumer(JmxMixin, BackgroundThreadService):
             for line in itertools.chain([first_line], consumer_output):
                 msg = line.strip()
                 if msg == "shutdown_complete":
-                    if idx in self.node_indexes_clean_shutdown:
+                    if node in self.clean_shutdown_nodes:
                         raise Exception("Unexpected shutdown event from consumer, already shutdown. Consumer index: %d" % idx)
-                    self.node_indexes_clean_shutdown.add(idx)
+                    self.clean_shutdown_nodes.add(node)
                 else:
                     if self.message_validator is not None:
                         msg = self.message_validator(msg)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -71,7 +71,7 @@ class VerifiableProducer(BackgroundThreadService):
         self.acked_values = []
         self.not_acked_values = []
         self.produced_count = {}
-        self.nodes_clean_shutdown = []
+        self.node_indexes_clean_shutdown = set()
 
 
     @property
@@ -137,7 +137,8 @@ class VerifiableProducer(BackgroundThreadService):
                         prev_msg = data
 
                     elif data["name"] == "tool_data":
-                        self.nodes_clean_shutdown.append(idx)
+                        # the stats summary is printed after producer's close(), which means shutdown was clean
+                        self.node_indexes_clean_shutdown.add(idx)
 
     def start_cmd(self, node, idx):
 
@@ -183,9 +184,6 @@ class VerifiableProducer(BackgroundThreadService):
 
     def alive(self, node):
         return len(self.pids(node)) > 0
-
-    def clean_shutdown(self, node):
-        return self.idx(node) in self.nodes_clean_shutdown
 
     @property
     def acked(self):

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -71,7 +71,7 @@ class VerifiableProducer(BackgroundThreadService):
         self.acked_values = []
         self.not_acked_values = []
         self.produced_count = {}
-        self.node_indexes_clean_shutdown = set()
+        self.clean_shutdown_nodes = set()
         self.acks = acks
 
 
@@ -140,9 +140,10 @@ class VerifiableProducer(BackgroundThreadService):
                         last_produced_time = t
                         prev_msg = data
 
-                    elif data["name"] == "tool_data":
-                        # the stats summary is printed after producer's close(), which means shutdown was clean
-                        self.node_indexes_clean_shutdown.add(idx)
+                    elif data["name"] == "shutdown_complete":
+                        if node in self.clean_shutdown_nodes:
+                            raise Exception("Unexpected shutdown event from producer, already shutdown. Producer index: %d" % idx)
+                        self.clean_shutdown_nodes.add(node)
 
     def start_cmd(self, node, idx):
 

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -71,6 +71,7 @@ class VerifiableProducer(BackgroundThreadService):
         self.acked_values = []
         self.not_acked_values = []
         self.produced_count = {}
+        self.nodes_clean_shutdown = []
 
 
     @property
@@ -135,6 +136,9 @@ class VerifiableProducer(BackgroundThreadService):
                         last_produced_time = t
                         prev_msg = data
 
+                    elif data["name"] == "tool_data":
+                        self.nodes_clean_shutdown.append(idx)
+
     def start_cmd(self, node, idx):
 
         cmd = ""
@@ -179,6 +183,9 @@ class VerifiableProducer(BackgroundThreadService):
 
     def alive(self, node):
         return len(self.pids(node)) > 0
+
+    def clean_shutdown(self, node):
+        return self.idx(node) in self.nodes_clean_shutdown
 
     @property
     def acked(self):

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -247,6 +247,14 @@ public class VerifiableProducer {
     /** Close the producer to flush any remaining messages. */
     public void close() {
         producer.close();
+        System.out.println(shutdownString());
+    }
+
+    String shutdownString() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("class", this.getClass().toString());
+        data.put("name", "shutdown_complete");
+        return toJsonString(data);
     }
 
     /**


### PR DESCRIPTION
Even if a test calls stop() on console_consumer or verifiable_producer, it is still possible that producer/consumer will not shutdown cleanly, and will be killed forcefully after a timeout. It will be useful for some tests to know whether a clean shutdown happened or not. This PR adds methods to console_consumer and verifiable_producer to query whether clean shutdown happened or not.

@hachikuji and/or @granders Please review.
