### PR TITLE
KAFKA-3581: add timeouts to joins in background thread services

### DIFF
--- a/tests/kafkatest/sanity_checks/test_verifiable_producer.py
+++ b/tests/kafkatest/sanity_checks/test_verifiable_producer.py
@@ -35,7 +35,7 @@ class TestVerifiableProducer(Test):
         self.kafka = KafkaService(test_context, num_nodes=1, zk=self.zk,
                                   topics={self.topic: {"partitions": 1, "replication-factor": 1}})
 
-        self.num_messages = 100
+        self.num_messages = 1000
         # This will produce to source kafka cluster
         self.producer = VerifiableProducer(test_context, num_nodes=1, kafka=self.kafka, topic=self.topic,
                                            max_messages=self.num_messages, throughput=1000)

--- a/tests/kafkatest/services/kafka_log4j_appender.py
+++ b/tests/kafkatest/services/kafka_log4j_appender.py
@@ -69,7 +69,8 @@ class KafkaLog4jAppender(BackgroundThreadService):
         node.account.kill_process("VerifiableLog4jAppender", allow_fail=False)
 
         stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
-        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
 
     def clean_node(self, node):
         node.account.kill_process("VerifiableLog4jAppender", clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/services/kafka_log4j_appender.py
+++ b/tests/kafkatest/services/kafka_log4j_appender.py
@@ -67,13 +67,9 @@ class KafkaLog4jAppender(BackgroundThreadService):
 
     def stop_node(self, node):
         node.account.kill_process("VerifiableLog4jAppender", allow_fail=False)
-        if self.worker_threads is None:
-            return
 
-        # block until the corresponding thread exits
-        if len(self.worker_threads) >= self.idx(node):
-            # Need to guard this because stop is preemptively called before the worker threads are added and started
-            self.worker_threads[self.idx(node) - 1].join()
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
 
     def clean_node(self, node):
         node.account.kill_process("VerifiableLog4jAppender", clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/services/performance/end_to_end_latency.py
+++ b/tests/kafkatest/services/performance/end_to_end_latency.py
@@ -17,9 +17,10 @@ from kafkatest.services.performance import PerformanceService
 from kafkatest.services.security.security_config import SecurityConfig
 
 from kafkatest.services.kafka.directory import kafka_dir
-from kafkatest.services.kafka.version import TRUNK, V_0_9_0_0, V_0_10_0_0
+from kafkatest.services.kafka.version import TRUNK, V_0_9_0_0
 
 import os
+
 
 class EndToEndLatencyService(PerformanceService):
     MESSAGE_BYTES = 21  # 0.8.X messages are fixed at 21 bytes, so we'll match that for other versions
@@ -44,7 +45,6 @@ class EndToEndLatencyService(PerformanceService):
             "path": LOG_FILE,
             "collect_default": True}
     }
-
 
     def __init__(self, context, num_nodes, kafka, topic, num_records, compression_type="none", version=TRUNK, acks=1):
         super(EndToEndLatencyService, self).__init__(context, num_nodes)

--- a/tests/kafkatest/services/performance/performance.py
+++ b/tests/kafkatest/services/performance/performance.py
@@ -28,7 +28,8 @@ class PerformanceService(BackgroundThreadService):
         node.account.kill_process("java", clean_shutdown=True, allow_fail=True)
 
         stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
-        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
 
     def clean_node(self, node):
         node.account.kill_process("java", clean_shutdown=False, allow_fail=True)

--- a/tests/kafkatest/services/performance/performance.py
+++ b/tests/kafkatest/services/performance/performance.py
@@ -18,14 +18,22 @@ from ducktape.services.background_thread import BackgroundThreadService
 
 class PerformanceService(BackgroundThreadService):
 
-    def __init__(self, context, num_nodes):
+    def __init__(self, context, num_nodes, stop_timeout_sec=30):
         super(PerformanceService, self).__init__(context, num_nodes)
         self.results = [None] * self.num_nodes
         self.stats = [[] for x in range(self.num_nodes)]
+        self.stop_timeout_sec = stop_timeout_sec
+
+    def stop_node(self, node):
+        node.account.kill_process("java", clean_shutdown=True, allow_fail=True)
+
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
 
     def clean_node(self, node):
         node.account.kill_process("java", clean_shutdown=False, allow_fail=True)
         node.account.ssh("rm -rf /mnt/*", allow_fail=False)
+
 
 def throughput(records_per_sec, mb_per_sec):
     """Helper method to ensure uniform representation of throughput data"""

--- a/tests/kafkatest/services/performance/producer_performance.py
+++ b/tests/kafkatest/services/performance/producer_performance.py
@@ -36,6 +36,7 @@ class ProducerPerformanceService(JmxMixin, PerformanceService):
 
     def __init__(self, context, num_nodes, kafka, topic, num_records, record_size, throughput, version=TRUNK, settings={},
                  intermediate_stats=False, client_id="producer-performance", jmx_object_names=None, jmx_attributes=[]):
+
         JmxMixin.__init__(self, num_nodes, jmx_object_names, jmx_attributes)
         PerformanceService.__init__(self, context, num_nodes)
 

--- a/tests/kafkatest/services/replica_verification_tool.py
+++ b/tests/kafkatest/services/replica_verification_tool.py
@@ -20,6 +20,7 @@ from kafkatest.services.security.security_config import SecurityConfig
 
 import re
 
+
 class ReplicaVerificationTool(BackgroundThreadService):
 
     logs = {
@@ -28,7 +29,7 @@ class ReplicaVerificationTool(BackgroundThreadService):
             "collect_default": False}
     }
 
-    def __init__(self, context, num_nodes, kafka, topic, report_interval_ms, security_protocol="PLAINTEXT"):
+    def __init__(self, context, num_nodes, kafka, topic, report_interval_ms, security_protocol="PLAINTEXT", stop_timeout_sec=30):
         super(ReplicaVerificationTool, self).__init__(context, num_nodes)
 
         self.kafka = kafka
@@ -37,6 +38,7 @@ class ReplicaVerificationTool(BackgroundThreadService):
         self.security_protocol = security_protocol
         self.security_config = SecurityConfig(security_protocol)
         self.partition_lag = {}
+        self.stop_timeout_sec = stop_timeout_sec
 
     def _worker(self, idx, node):
         cmd = self.start_cmd(node)
@@ -75,6 +77,9 @@ class ReplicaVerificationTool(BackgroundThreadService):
 
     def stop_node(self, node):
         node.account.kill_process("java", clean_shutdown=True, allow_fail=True)
+
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
 
     def clean_node(self, node):
         node.account.kill_process("java", clean_shutdown=False, allow_fail=True)

--- a/tests/kafkatest/services/replica_verification_tool.py
+++ b/tests/kafkatest/services/replica_verification_tool.py
@@ -79,7 +79,8 @@ class ReplicaVerificationTool(BackgroundThreadService):
         node.account.kill_process("java", clean_shutdown=True, allow_fail=True)
 
         stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
-        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
 
     def clean_node(self, node):
         node.account.kill_process("java", clean_shutdown=False, allow_fail=True)

--- a/tests/kafkatest/services/simple_consumer_shell.py
+++ b/tests/kafkatest/services/simple_consumer_shell.py
@@ -59,7 +59,8 @@ class SimpleConsumerShell(BackgroundThreadService):
         node.account.kill_process("SimpleConsumerShell", allow_fail=False)
 
         stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
-        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
 
     def clean_node(self, node):
         node.account.kill_process("SimpleConsumerShell", clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/services/simple_consumer_shell.py
+++ b/tests/kafkatest/services/simple_consumer_shell.py
@@ -26,13 +26,14 @@ class SimpleConsumerShell(BackgroundThreadService):
             "collect_default": False}
     }
 
-    def __init__(self, context, num_nodes, kafka, topic, partition=0):
+    def __init__(self, context, num_nodes, kafka, topic, partition=0, stop_timeout_sec=30):
         super(SimpleConsumerShell, self).__init__(context, num_nodes)
 
         self.kafka = kafka
         self.topic = topic
         self.partition = partition
         self.output = ""
+        self.stop_timeout_sec = stop_timeout_sec
 
     def _worker(self, idx, node):
         cmd = self.start_cmd(node)
@@ -56,13 +57,9 @@ class SimpleConsumerShell(BackgroundThreadService):
 
     def stop_node(self, node):
         node.account.kill_process("SimpleConsumerShell", allow_fail=False)
-        if self.worker_threads is None:
-            return
 
-        # block until the corresponding thread exits
-        if len(self.worker_threads) >= self.idx(node):
-            # Need to guard this because stop is preemptively called before the worker threads are added and started
-            self.worker_threads[self.idx(node) - 1].join()
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
 
     def clean_node(self, node):
         node.account.kill_process("SimpleConsumerShell", clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -272,7 +272,8 @@ class VerifiableConsumer(BackgroundThreadService):
         self.kill_node(node, clean_shutdown=clean_shutdown)
 
         stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
-        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
 
     def clean_node(self, node):
         self.kill_node(node, clean_shutdown=False)

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -15,21 +15,21 @@
 
 from ducktape.services.background_thread import BackgroundThreadService
 
-from kafkatest.services.kafka.directory import kafka_dir, KAFKA_TRUNK
+from kafkatest.services.kafka.directory import kafka_dir
 from kafkatest.services.kafka.version import TRUNK
-from kafkatest.services.security.security_config import SecurityConfig
 from kafkatest.services.kafka import TopicPartition
 
 import json
 import os
 import signal
 import subprocess
-import time
+
 
 class ConsumerState:
     Dead = 1
     Rebalancing = 3
     Joined = 2
+
 
 class ConsumerEventHandler(object):
 
@@ -111,6 +111,7 @@ class ConsumerEventHandler(object):
         else:
             return None
 
+
 class VerifiableConsumer(BackgroundThreadService):
     PERSISTENT_ROOT = "/mnt/verifiable_consumer"
     STDOUT_CAPTURE = os.path.join(PERSISTENT_ROOT, "verifiable_consumer.stdout")
@@ -135,7 +136,7 @@ class VerifiableConsumer(BackgroundThreadService):
     def __init__(self, context, num_nodes, kafka, topic, group_id,
                  max_messages=-1, session_timeout_sec=30, enable_autocommit=False,
                  assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor",
-                 version=TRUNK):
+                 version=TRUNK, stop_timeout_sec=30):
         super(VerifiableConsumer, self).__init__(context, num_nodes)
         self.log_level = "TRACE"
         
@@ -149,6 +150,7 @@ class VerifiableConsumer(BackgroundThreadService):
         self.prop_file = ""
         self.security_config = kafka.security_config.client_config(self.prop_file)
         self.prop_file += str(self.security_config)
+        self.stop_timeout_sec = stop_timeout_sec
 
         self.event_handlers = {}
         self.global_position = {}
@@ -268,14 +270,9 @@ class VerifiableConsumer(BackgroundThreadService):
 
     def stop_node(self, node, clean_shutdown=True):
         self.kill_node(node, clean_shutdown=clean_shutdown)
-        
-        if self.worker_threads is None:
-            return
 
-        # block until the corresponding thread exits
-        if len(self.worker_threads) >= self.idx(node):
-            # Need to guard this because stop is preemptively called before the worker threads are added and started
-            self.worker_threads[self.idx(node) - 1].join()
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
 
     def clean_node(self, node):
         self.kill_node(node, clean_shutdown=False)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -43,7 +43,8 @@ class VerifiableProducer(BackgroundThreadService):
         }
 
     def __init__(self, context, num_nodes, kafka, topic, max_messages=-1, throughput=100000,
-                 message_validator=is_int, compression_types=None, version=TRUNK, acks=None):
+                 message_validator=is_int, compression_types=None, version=TRUNK, acks=None,
+                 stop_timeout_sec=300):
         """
         :param max_messages is a number of messages to be produced per producer
         :param message_validator checks for an expected format of messages produced. There are
@@ -73,7 +74,7 @@ class VerifiableProducer(BackgroundThreadService):
         self.produced_count = {}
         self.clean_shutdown_nodes = set()
         self.acks = acks
-
+        self.stop_timeout_sec=stop_timeout_sec
 
     @property
     def security_config(self):
@@ -220,14 +221,10 @@ class VerifiableProducer(BackgroundThreadService):
             return True
 
     def stop_node(self, node):
-        self.kill_node(node, clean_shutdown=False, allow_fail=False)
-        if self.worker_threads is None:
-            return
+        self.kill_node(node, clean_shutdown=True, allow_fail=False)
 
-        # block until the corresponding thread exits
-        if len(self.worker_threads) >= self.idx(node):
-            # Need to guard this because stop is preemptively called before the worker threads are added and started
-            self.worker_threads[self.idx(node) - 1].join()
+        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
+        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
 
     def clean_node(self, node):
         self.kill_node(node, clean_shutdown=False, allow_fail=False)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -74,7 +74,7 @@ class VerifiableProducer(BackgroundThreadService):
         self.produced_count = {}
         self.clean_shutdown_nodes = set()
         self.acks = acks
-        self.stop_timeout_sec=stop_timeout_sec
+        self.stop_timeout_sec = stop_timeout_sec
 
     @property
     def security_config(self):

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -44,7 +44,7 @@ class VerifiableProducer(BackgroundThreadService):
 
     def __init__(self, context, num_nodes, kafka, topic, max_messages=-1, throughput=100000,
                  message_validator=is_int, compression_types=None, version=TRUNK, acks=None,
-                 stop_timeout_sec=300):
+                 stop_timeout_sec=150):
         """
         :param max_messages is a number of messages to be produced per producer
         :param message_validator checks for an expected format of messages produced. There are

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -224,7 +224,8 @@ class VerifiableProducer(BackgroundThreadService):
         self.kill_node(node, clean_shutdown=True, allow_fail=False)
 
         stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
-        assert stopped, "Node did not stop within the specified timeout of %s seconds" % str(self.stop_timeout_sec)
+        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
+                        (str(node.account), str(self.stop_timeout_sec))
 
     def clean_node(self, node):
         self.kill_node(node, clean_shutdown=False, allow_fail=False)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -30,5 +30,5 @@ setup(name="kafkatest",
       license="apache2.0",
       packages=find_packages(),
       include_package_data=True,
-      install_requires=["ducktape==0.4.0", "requests>=2.5.0"]
+      install_requires=["ducktape==0.5.0", "requests>=2.5.0"]
       )

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -265,11 +265,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         public long timestamp() {
             return timestamp;
         }
-
-        @JsonProperty("class")
-        public String clazz() {
-            return VerifiableConsumer.class.getName();
-        }
     }
 
     private static class ShutdownComplete extends ConsumerEvent {

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -84,7 +84,7 @@ public class VerifiableProducer {
         this.topic = topic;
         this.throughput = throughput;
         this.maxMessages = maxMessages;
-        this.producer = new KafkaProducer<String, String>(producerProps);
+        this.producer = new KafkaProducer<>(producerProps);
         this.valuePrefix = valuePrefix;
     }
 
@@ -252,7 +252,6 @@ public class VerifiableProducer {
 
     String shutdownString() {
         Map<String, Object> data = new HashMap<>();
-        data.put("class", this.getClass().toString());
         data.put("name", "shutdown_complete");
         return toJsonString(data);
     }
@@ -265,7 +264,6 @@ public class VerifiableProducer {
         assert e != null : "Expected non-null exception.";
 
         Map<String, Object> errorData = new HashMap<>();
-        errorData.put("class", this.getClass().toString());
         errorData.put("name", "producer_send_error");
 
         errorData.put("time_ms", nowMs);
@@ -282,7 +280,6 @@ public class VerifiableProducer {
         assert recordMetadata != null : "Expected non-null recordMetadata object.";
 
         Map<String, Object> successData = new HashMap<>();
-        successData.put("class", this.getClass().toString());
         successData.put("name", "producer_send_success");
 
         successData.put("time_ms", nowMs);
@@ -349,7 +346,6 @@ public class VerifiableProducer {
                 double avgThroughput = 1000 * ((producer.numAcked) / (double) (stopMs - startMs));
 
                 Map<String, Object> data = new HashMap<>();
-                data.put("class", producer.getClass().toString());
                 data.put("name", "tool_data");
                 data.put("sent", producer.numSent);
                 data.put("acked", producer.numAcked);


### PR DESCRIPTION
This actually removes joins altogether, as well as references to self.worker_threads, which is best left as an implementation detail in BackgroundThreadService.

This makes use of @hachikuji 's recent ducktape patch, and updates ducktape dependency to 0.5.0.
