### PR TITLE
MINOR: MetadataCache brokerId is not set on first run with generated …

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -130,7 +130,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
   val kafkaScheduler = new KafkaScheduler(config.backgroundThreads)
 
   var kafkaHealthcheck: KafkaHealthcheck = null
-  val metadataCache: MetadataCache = new MetadataCache(config.brokerId)
+  var metadataCache: MetadataCache = null
 
   var zkUtils: ZkUtils = null
   val correlationId: AtomicInteger = new AtomicInteger(0)
@@ -186,6 +186,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
         /* generate brokerId */
         config.brokerId =  getBrokerId
         this.logIdent = "[Kafka Server " + config.brokerId + "], "
+
+        metadataCache = new MetadataCache(config.brokerId)
 
         socketServer = new SocketServer(config, metrics, kafkaMetricsTime)
         socketServer.startup()


### PR DESCRIPTION
…broker id

This is because the id passed into the MetadataCache is the value from the config before the real broker id is generated.
