### PR TITLE
Fix main classpath libs glob for release (fixup KAFKA-3615 regression)

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -118,7 +118,7 @@ do
 done
 
 # classpath addition for release
-for file in $base_dir/libs;
+for file in $base_dir/libs/*;
 do
   if should_include_file "$file"; then
     CLASSPATH=$CLASSPATH:$file


### PR DESCRIPTION
bin/kafka-run-class.sh does not correctly setup the CLASSPATH in release rc2.
