### PR TITLE
KAFKA-3648; maxTimeToBlock in BufferPool.allocate should be enforced

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -126,7 +126,7 @@ public final class BufferPool {
                     boolean waitingTimeElapsed = !moreMemory.await(remainingTimeToBlockNs, TimeUnit.NANOSECONDS);
                     long endWaitNs = time.nanoseconds();
                     long timeNs = Math.max(0L, endWaitNs - startWaitNs);
-                    this.waitTime.record(timeNs, TimeUnit.NANOSECONDS.toMillis(endWaitNs));
+                    this.waitTime.record(timeNs, time.milliseconds());
 
                     if (waitingTimeElapsed)
                         throw new TimeoutException("Failed to allocate memory within the configured max blocking time " + maxTimeToBlockMs + " ms.");

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -125,6 +125,7 @@ public final class BufferPool {
                     if (!moreMemory.await(maxTimeToBlock, TimeUnit.MILLISECONDS))
                         throw new TimeoutException("Failed to allocate memory within the configured max blocking time");
                     long endWait = time.nanoseconds();
+                    maxTimeToBlock -= (endWait - startWait)/1000000;
                     this.waitTime.record(endWait - startWait, time.milliseconds());
 
                     // check if we can satisfy this request from the free list,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -83,13 +83,13 @@ public final class BufferPool {
      * is configured with blocking mode.
      * 
      * @param size The buffer size to allocate in bytes
-     * @param maxTimeToBlock The maximum time in milliseconds to block for buffer memory to be available
+     * @param maxTimeToBlockMs The maximum time in milliseconds to block for buffer memory to be available
      * @return The buffer
      * @throws InterruptedException If the thread is interrupted while blocked
      * @throws IllegalArgumentException if size is larger than the total memory controlled by the pool (and hence we would block
      *         forever)
      */
-    public ByteBuffer allocate(int size, long maxTimeToBlock) throws InterruptedException {
+    public ByteBuffer allocate(int size, long maxTimeToBlockMs) throws InterruptedException {
         if (size > this.totalMemory)
             throw new IllegalArgumentException("Attempt to allocate " + size
                                                + " bytes, but there is a hard limit of "
@@ -117,21 +117,21 @@ public final class BufferPool {
                 int accumulated = 0;
                 ByteBuffer buffer = null;
                 Condition moreMemory = this.lock.newCondition();
-                long remainingTimeToBlockMs = maxTimeToBlock;
+                long remainingTimeToBlockNs = TimeUnit.MILLISECONDS.toNanos(maxTimeToBlockMs);
                 this.waiters.addLast(moreMemory);
                 // loop over and over until we have a buffer or have reserved
                 // enough memory to allocate one
                 while (accumulated < size) {
                     long startWaitNs = time.nanoseconds();
-                    long endWaitNs;
-                    if (!moreMemory.await(remainingTimeToBlockMs, TimeUnit.MILLISECONDS)) {
-                        endWaitNs = time.nanoseconds();
-                        this.waitTime.record(endWaitNs - startWaitNs, endWaitNs / 1000000);
-                        throw new TimeoutException("Failed to allocate memory within the configured max blocking time");
-                    }
-                    endWaitNs = time.nanoseconds();
-                    remainingTimeToBlockMs = Math.max(remainingTimeToBlockMs - (endWaitNs - startWaitNs) / 1000000, 0L);
-                    this.waitTime.record(endWaitNs - startWaitNs, endWaitNs / 1000000);
+                    boolean waitingTimeElapsed = !moreMemory.await(remainingTimeToBlockNs, TimeUnit.NANOSECONDS);
+                    long endWaitNs = time.nanoseconds();
+                    long timeNs = Math.max(0L, endWaitNs - startWaitNs);
+                    this.waitTime.record(timeNs, TimeUnit.NANOSECONDS.toMillis(endWaitNs));
+
+                    if (waitingTimeElapsed)
+                        throw new TimeoutException("Failed to allocate memory within the configured max blocking time " + maxTimeToBlockMs + " ms.");
+
+                    remainingTimeToBlockNs -= timeNs;
 
                     // check if we can satisfy this request from the free list,
                     // otherwise allocate memory

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -158,8 +158,8 @@ public class BufferPoolTest {
         ByteBuffer buffer2 = pool.allocate(1, maxBlockTimeMs);
         ByteBuffer buffer3 = pool.allocate(1, maxBlockTimeMs);
         // First two buffers will be de-allocated within maxBlockTimeMs since the most recent de-allocation
-        delayedDeallocate(pool, buffer1, maxBlockTimeMs / 2 * 1);
-        delayedDeallocate(pool, buffer2, maxBlockTimeMs / 2 * 2);
+        delayedDeallocate(pool, buffer1, maxBlockTimeMs / 2);
+        delayedDeallocate(pool, buffer2, maxBlockTimeMs);
         // The third buffer will be de-allocated after maxBlockTimeMs since the most recent de-allocation
         delayedDeallocate(pool, buffer3, maxBlockTimeMs / 2 * 5);
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.clients.producer.internals;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Test;
@@ -27,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertTrue;
@@ -35,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 
 public class BufferPoolTest {
     private MockTime time = new MockTime();
+    private SystemTime systemTime = new SystemTime();
     private Metrics metrics = new Metrics(time);
     private final long maxBlockTimeMs =  2000;
     String metricGroup = "TestMetrics";
@@ -96,7 +100,7 @@ public class BufferPoolTest {
         CountDownLatch allocation = asyncAllocate(pool, 5 * 1024);
         assertEquals("Allocation shouldn't have happened yet, waiting on memory.", 1L, allocation.getCount());
         doDealloc.countDown(); // return the memory
-        allocation.await();
+        assertEquals("Allocation should succeed soon after de-allocation", true, allocation.await(1, TimeUnit.SECONDS));
     }
 
     private CountDownLatch asyncDeallocate(final BufferPool pool, final ByteBuffer buffer) {
@@ -113,6 +117,16 @@ public class BufferPoolTest {
         };
         thread.start();
         return latch;
+    }
+
+    private void delayedDeallocate(final BufferPool pool, final ByteBuffer buffer, final long delayMs) {
+        Thread thread = new Thread() {
+            public void run() {
+                systemTime.sleep(delayMs);
+                pool.deallocate(buffer);
+            }
+        };
+        thread.start();
     }
 
     private CountDownLatch asyncAllocate(final BufferPool pool, final int size) {
@@ -133,20 +147,30 @@ public class BufferPoolTest {
     }
 
     /**
-     * Test if Timeout exception is thrown when there is not enough memory to allocate and the elapsed time is greater than the max specified block time
+     * Test if Timeout exception is thrown when there is not enough memory to allocate and the elapsed time is greater than the max specified block time.
+     * And verify that the allocation should finish soon after the maxBlockTimeMs.
      *
      * @throws Exception
      */
     @Test
     public void testBlockTimeout() throws Exception {
-        BufferPool pool = new BufferPool(2, 1, metrics, time, metricGroup);
-        pool.allocate(1, maxBlockTimeMs);
+        BufferPool pool = new BufferPool(10, 1, metrics, systemTime, metricGroup);
+        ByteBuffer buffer1 = pool.allocate(1, maxBlockTimeMs);
+        ByteBuffer buffer2 = pool.allocate(1, maxBlockTimeMs);
+        ByteBuffer buffer3 = pool.allocate(1, maxBlockTimeMs);
+        delayedDeallocate(pool, buffer1, maxBlockTimeMs / 2 * 1);
+        delayedDeallocate(pool, buffer2, maxBlockTimeMs / 2 * 2);
+        delayedDeallocate(pool, buffer3, maxBlockTimeMs / 2 * 5);
+
+        long beginTimeMs = systemTime.milliseconds();
         try {
-            pool.allocate(2, maxBlockTimeMs);
+            pool.allocate(10, maxBlockTimeMs);
             fail("The buffer allocated more memory than its maximum value 2");
         } catch (TimeoutException e) {
             // this is good
         }
+        long endTimeMs = systemTime.milliseconds();
+        assertTrue("Allocation should finish not much later than maxBlockTimeMs", endTimeMs - beginTimeMs < maxBlockTimeMs + 1000);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.SystemTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Test;


### PR DESCRIPTION
 `maxTimeToBlock` needs to be updated in each loop iteration. Also record waitTime before throwing `TimeoutException`
