### PR TITLE
KAFKA-3651 : Remove the condition variable waiting on memory availability in Bufferpool when a TimeoutException is thrown

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -123,19 +123,20 @@ public final class BufferPool {
                 // enough memory to allocate one
                 while (accumulated < size) {
                     long startWaitNs = time.nanoseconds();
-                    boolean waitingTimeElapsed = false;
-                    long endWaitNs;
                     long timeNs;
+                    boolean waitingTimeElapsed;
                     try {
                         waitingTimeElapsed = !moreMemory.await(remainingTimeToBlockNs, TimeUnit.NANOSECONDS);
                     } catch (InterruptedException e) {
                         this.waiters.remove(moreMemory);
-                        endWaitNs = time.nanoseconds();
+                        throw e;
+                    } finally {
+                        long endWaitNs = time.nanoseconds();
                         timeNs = Math.max(0L, endWaitNs - startWaitNs);
                         this.waitTime.record(timeNs, time.milliseconds());
-                        throw e;
                     }
-                    endWaitNs = time.nanoseconds();
+
+                    long endWaitNs = time.nanoseconds();
                     timeNs = Math.max(0L, endWaitNs - startWaitNs);
                     this.waitTime.record(timeNs, time.milliseconds());
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -129,7 +129,7 @@ public final class BufferPool {
                     this.waitTime.record(timeNs, time.milliseconds());
 
                     if (waitingTimeElapsed) {
-                        this.waiters.removeLast();
+                        this.waiters.remove(moreMemory);
                         throw new TimeoutException("Failed to allocate memory within the configured max blocking time " + maxTimeToBlockMs + " ms.");
                     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -128,11 +128,12 @@ public final class BufferPool {
                     long timeNs = Math.max(0L, endWaitNs - startWaitNs);
                     this.waitTime.record(timeNs, time.milliseconds());
 
-                    if (waitingTimeElapsed)
+                    if (waitingTimeElapsed) {
+                        this.waiters.removeLast();
                         throw new TimeoutException("Failed to allocate memory within the configured max blocking time " + maxTimeToBlockMs + " ms.");
+                    }
 
                     remainingTimeToBlockNs -= timeNs;
-
                     // check if we can satisfy this request from the free list,
                     // otherwise allocate memory
                     if (accumulated == 0 && size == this.poolableSize && !this.free.isEmpty()) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/BufferPool.java
@@ -136,10 +136,6 @@ public final class BufferPool {
                         this.waitTime.record(timeNs, time.milliseconds());
                     }
 
-                    long endWaitNs = time.nanoseconds();
-                    timeNs = Math.max(0L, endWaitNs - startWaitNs);
-                    this.waitTime.record(timeNs, time.milliseconds());
-
                     if (waitingTimeElapsed) {
                         this.waiters.remove(moreMemory);
                         throw new TimeoutException("Failed to allocate memory within the configured max blocking time " + maxTimeToBlockMs + " ms.");

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -148,8 +148,6 @@ public class BufferPoolTest {
     /**
      * Test if Timeout exception is thrown when there is not enough memory to allocate and the elapsed time is greater than the max specified block time.
      * And verify that the allocation should finish soon after the maxBlockTimeMs.
-     *
-     * @throws Exception
      */
     @Test
     public void testBlockTimeout() throws Exception {
@@ -176,8 +174,6 @@ public class BufferPoolTest {
 
     /**
      * Test if the  waiter that is waiting on availability of more memory is cleaned up when a timeout occurs
-     *
-     * @throws Exception
      */
     @Test
     public void testCleanupMemoryAvailabilityWaiterOnBlockTimeout() throws Exception {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -185,7 +185,7 @@ public class BufferPoolTest {
         } catch (TimeoutException e) {
             // this is good
         }
-        assertTrue(pool.queued() == 0);
+        assertEquals(pool.queued(), 0);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -175,6 +175,24 @@ public class BufferPoolTest {
     }
 
     /**
+     * Test if the  waiter that is waiting on availability of more memory is cleaned up when a timeout occurs
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCleanupMemoryAvailabilityWaiterOnBlockTimeout() throws Exception {
+        BufferPool pool = new BufferPool(2, 1, metrics, time, metricGroup);
+        pool.allocate(1, maxBlockTimeMs);
+        try {
+            pool.allocate(2, maxBlockTimeMs);
+            fail("The buffer allocated more memory than its maximum value 2");
+        } catch (TimeoutException e) {
+            // this is good
+        }
+        assertTrue(pool.queued() == 0);
+    }
+
+    /**
      * This test creates lots of threads that hammer on the pool
      */
     @Test


### PR DESCRIPTION
Whenever the BufferPool throws a "Failed to allocate memory within the configured max blocking time" exception, it should also remove the condition object from the waiters deque
