### PR TITLE
KAFKA-1489: Global threshold on data retention size

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -95,6 +95,11 @@ log.retention.hours=168
 # segments don't drop below log.retention.bytes.
 #log.retention.bytes=1073741824
 
+# An aggregate size-based retention policy for logs, applied per physical disk. Oldest segments
+# are pruned until usage falls below this percentage of each disk's capacity, in order to prevent
+# disk space exhaustion.
+#log.retention.disk.usage.percent=100
+
 # The maximum size of a log segment file. When this size is reached a new log segment will be created.
 log.segment.bytes=1073741824
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -26,6 +26,7 @@ import scala.collection._
 import kafka.common.{KafkaException, TopicAndPartition}
 import kafka.server.{BrokerState, OffsetCheckpoint, RecoveringFromUncleanShutdown}
 import java.util.concurrent.{ExecutionException, ExecutorService, Executors, Future}
+import java.nio.file.{Files, FileStore, Paths}
 
 /**
  * The entry point to the kafka log management subsystem. The log manager is responsible for log creation, retrieval, and cleaning.
@@ -46,6 +47,7 @@ class LogManager(val logDirs: Array[File],
                  val flushCheckMs: Long,
                  val flushCheckpointMs: Long,
                  val retentionCheckMs: Long,
+                 val retentionDiskUsagePercent: Long,
                  scheduler: Scheduler,
                  val brokerState: BrokerState,
                  private val time: Time) extends Logging {
@@ -447,6 +449,64 @@ class LogManager(val logDirs: Array[File],
   }
 
   /**
+   *  Removes oldest segments (across all logs) from each physical disk until
+   *  the percentage of capacity in use is less than logRetentionDiskUsagePercent.
+   *  Returns the number of segments scheduled for deletion. The underlying method
+   *  Log.deleteOldSegments() guarantees that at least one segment per topic
+   *  partition remains.
+   */
+  private def cleanupSegmentsToMaintainFreeSpace(): Int = {
+    if(retentionDiskUsagePercent == 100)
+      return 0
+    var totalSegmentsDeleted = 0
+
+    // Determine the number of bytes to delete from each disk.
+    var bytesToDeleteByDisk = mutable.Map.empty[String, Long]
+    for(dir <- this.logDirs) {
+      val fileStore = Files.getFileStore(Paths.get(dir.getAbsolutePath()));
+      if(!bytesToDeleteByDisk.contains(fileStore.name)) {
+        val totalBytes = fileStore.getTotalSpace()
+        val usedBytes = totalBytes - fileStore.getUsableSpace()
+        val goalBytes = totalBytes * retentionDiskUsagePercent / 100
+        val bytesToDelete = math.max(0, usedBytes - goalBytes)
+        bytesToDeleteByDisk += ((fileStore.name, bytesToDelete))
+        if(bytesToDelete > 0) {
+          val currentUsagePercent = 100 * usedBytes / totalBytes
+          info("Usage matches or exceeds log.retention.disk.usage.percent" +
+              " (%d%% >= %d%%) on disk %s. Oldest segments will be deleted.".format(
+                  currentUsagePercent, retentionDiskUsagePercent, fileStore.name))
+        }
+      }
+    }
+    // Gather all the segments for each disk that requires deletions.
+    type LogAndSegmentArray = mutable.ArrayBuffer[Tuple2[Log, LogSegment]]
+    var logsAndSegmentsByDisk = mutable.Map.empty[String, LogAndSegmentArray]
+    for(log <- allLogs; if !log.config.compact) {
+      val fileStore = Files.getFileStore(Paths.get(log.dir.getAbsolutePath()));
+      var bytesToDelete = bytesToDeleteByDisk(fileStore.name)
+      if(bytesToDelete > 0) {
+        var logAndSegmentArray = logsAndSegmentsByDisk.getOrElseUpdate(
+            fileStore.name, new LogAndSegmentArray)
+        logAndSegmentArray ++= (for (segment <- log.logSegments) yield (log, segment))
+      }
+    }
+    // Delete oldest segments from each disk that requires deletions.
+    for((fileStoreName, logAndSegmentArray) <- logsAndSegmentsByDisk) {
+      var bytesToDelete = bytesToDeleteByDisk(fileStoreName)
+      val sortedArray = logAndSegmentArray.sortWith((s1, s2) => s1._2.lastModified < s2._2.lastModified)
+      for((log, segment) <- sortedArray; if bytesToDelete > 0) {
+        val size = segment.size
+        val segmentsDeleted = log.deleteOldSegments(_.baseOffset == segment.baseOffset)
+        if(segmentsDeleted > 0) {
+          bytesToDelete -= size
+          totalSegmentsDeleted += segmentsDeleted
+        }
+      }
+    }
+    totalSegmentsDeleted
+  }
+
+  /**
    * Delete any eligible logs. Return the number of segments deleted.
    */
   def cleanupLogs() {
@@ -457,6 +517,7 @@ class LogManager(val logDirs: Array[File],
       debug("Garbage collecting '" + log.name + "'")
       total += cleanupExpiredSegments(log) + cleanupSegmentsToMaintainSize(log)
     }
+    total += cleanupSegmentsToMaintainFreeSpace()
     debug("Log cleanup completed. " + total + " files deleted in " +
                   (time.milliseconds - startMs) / 1000 + " seconds")
   }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -75,6 +75,7 @@ object Defaults {
   val LogRetentionHours = 24 * 7
 
   val LogRetentionBytes = -1L
+  val LogRetentionDiskUsagePercent = 100L
   val LogCleanupIntervalMs = 5 * 60 * 1000L
   val Delete = "delete"
   val Compact = "compact"
@@ -243,6 +244,7 @@ object KafkaConfig {
   val LogRetentionTimeHoursProp = "log.retention.hours"
 
   val LogRetentionBytesProp = "log.retention.bytes"
+  val LogRetentionDiskUsagePercentProp = "log.retention.disk.usage.percent"
   val LogCleanupIntervalMsProp = "log.retention.check.interval.ms"
   val LogCleanupPolicyProp = "log.cleanup.policy"
   val LogCleanerThreadsProp = "log.cleaner.threads"
@@ -420,6 +422,7 @@ object KafkaConfig {
   val LogRetentionTimeHoursDoc = "The number of hours to keep a log file before deleting it (in hours), tertiary to " + LogRetentionTimeMillisProp + " property"
 
   val LogRetentionBytesDoc = "The maximum size of the log before deleting it"
+  val LogRetentionDiskUsagePercentDoc = "The percentage of disk capacity to keep free (per-disk) by deleting logs"
   val LogCleanupIntervalMsDoc = "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion"
   val LogCleanupPolicyDoc = "The default cleanup policy for segments beyond the retention window, must be either \"delete\" or \"compact\""
   val LogCleanerThreadsDoc = "The number of background threads to use for log cleaning"
@@ -609,6 +612,7 @@ object KafkaConfig {
       .define(LogRetentionTimeHoursProp, INT, Defaults.LogRetentionHours, HIGH, LogRetentionTimeHoursDoc)
 
       .define(LogRetentionBytesProp, LONG, Defaults.LogRetentionBytes, HIGH, LogRetentionBytesDoc)
+      .define(LogRetentionDiskUsagePercentProp, LONG, Defaults.LogRetentionDiskUsagePercent, MEDIUM, LogRetentionDiskUsagePercentDoc)
       .define(LogCleanupIntervalMsProp, LONG, Defaults.LogCleanupIntervalMs, atLeast(1), MEDIUM, LogCleanupIntervalMsDoc)
       .define(LogCleanupPolicyProp, STRING, Defaults.LogCleanupPolicy, in(Defaults.Compact, Defaults.Delete), MEDIUM, LogCleanupPolicyDoc)
       .define(LogCleanerThreadsProp, INT, Defaults.LogCleanerThreads, atLeast(0), MEDIUM, LogCleanerThreadsDoc)
@@ -814,6 +818,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends Abstra
   val offsetsRetentionMinutes = getInt(KafkaConfig.OffsetsRetentionMinutesProp)
   val offsetsRetentionCheckIntervalMs = getLong(KafkaConfig.OffsetsRetentionCheckIntervalMsProp)
   val logRetentionBytes = getLong(KafkaConfig.LogRetentionBytesProp)
+  val logRetentionDiskUsagePercent = getLong(KafkaConfig.LogRetentionDiskUsagePercentProp)
   val logCleanerDedupeBufferSize = getLong(KafkaConfig.LogCleanerDedupeBufferSizeProp)
   val logCleanerDedupeBufferLoadFactor = getDouble(KafkaConfig.LogCleanerDedupeBufferLoadFactorProp)
   val logCleanerIoBufferSize = getInt(KafkaConfig.LogCleanerIoBufferSizeProp)
@@ -1002,6 +1007,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends Abstra
     require(logRollTimeMillis >= 1, "log.roll.ms must be equal or greater than 1")
     require(logRollTimeJitterMillis >= 0, "log.roll.jitter.ms must be equal or greater than 0")
     require(logRetentionTimeMillis >= 1 || logRetentionTimeMillis == -1, "log.retention.ms must be unlimited (-1) or, equal or greater than 1")
+    require(logRetentionDiskUsagePercent >= 0 && logRetentionDiskUsagePercent <= 100, "log.retention.disk.usage.percent must be between 0 and 100, inclusive")
     require(logDirs.size > 0)
     require(logCleanerDedupeBufferSize / logCleanerThreads > 1024 * 1024, "log.cleaner.dedupe.buffer.size must be at least 1MB per cleaner thread.")
     require(replicaFetchWaitMaxMs <= replicaSocketTimeoutMs, "replica.socket.timeout.ms should always be at least replica.fetch.wait.max.ms" +

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -422,7 +422,7 @@ object KafkaConfig {
   val LogRetentionTimeHoursDoc = "The number of hours to keep a log file before deleting it (in hours), tertiary to " + LogRetentionTimeMillisProp + " property"
 
   val LogRetentionBytesDoc = "The maximum size of the log before deleting it"
-  val LogRetentionDiskUsagePercentDoc = "The percentage of disk capacity to keep free (per-disk) by deleting logs"
+  val LogRetentionDiskUsagePercentDoc = "The maximum percentage of disk space to use (per-disk). Deletes oldest segments (across all topics) to maintain this usage ceiling."
   val LogCleanupIntervalMsDoc = "The frequency in milliseconds that the log cleaner checks whether any log is eligible for deletion"
   val LogCleanupPolicyDoc = "The default cleanup policy for segments beyond the retention window, must be either \"delete\" or \"compact\""
   val LogCleanerThreadsDoc = "The number of background threads to use for log cleaning"

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -614,6 +614,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
                    flushCheckMs = config.logFlushSchedulerIntervalMs,
                    flushCheckpointMs = config.logFlushOffsetCheckpointIntervalMs,
                    retentionCheckMs = config.logCleanupIntervalMs,
+                   retentionDiskUsagePercent = config.logRetentionDiskUsagePercent,
                    scheduler = kafkaScheduler,
                    brokerState = brokerState,
                    time = time)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -895,6 +895,7 @@ object TestUtils extends Logging {
   def createLogManager(logDirs: Array[File] = Array.empty[File],
                        defaultConfig: LogConfig = LogConfig(),
                        cleanerConfig: CleanerConfig = CleanerConfig(enableCleaner = false),
+                       retentionDiskUsagePercent: Long = 100L,
                        time: MockTime = new MockTime()): LogManager = {
     new LogManager(logDirs = logDirs,
                    topicConfigs = Map(),
@@ -904,6 +905,7 @@ object TestUtils extends Logging {
                    flushCheckMs = 1000L,
                    flushCheckpointMs = 10000L,
                    retentionCheckMs = 1000L,
+                   retentionDiskUsagePercent = retentionDiskUsagePercent,
                    scheduler = time.scheduler,
                    time = time,
                    brokerState = new BrokerState())


### PR DESCRIPTION
Implemented a "log retention policy" based on keeping a certain
percentage of disk space free. In dynamic situations where topics
are added in unpredictable ways, the other log retention
parameters are not entirely sufficient to prevent out-of-disk
conditions from occurring. The new log.retention.disk.usage.percent
parameter provides this guarantee. It is applied after all the
other retention parameters are applied, at the end of each log
cleanup cycle. Oldest segments (across all topics) are pruned
until usage falls below this percentage of each disk's capacity.
The default value is 100, which effectively disables the feature.

This is my original work and I license the work to the project under
the project's open source license.

@junrao, @jkreps, @gwenshap
