### PR TITLE
KAFKA-3662: Fix timing issue in SocketServerTest.tooBigRequestIsRejected

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -156,7 +156,7 @@ class SocketServerTest extends JUnitSuite {
       // Server closes client connection when it processes the request length because
       // it is too big. The write of request body may fail if the connection has been closed.
       outgoing.write(tooManyBytes)
-      outgoing.flush
+      outgoing.flush()
       receiveResponse(socket)
     } catch {
       case e: IOException => // thats fine

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -150,8 +150,13 @@ class SocketServerTest extends JUnitSuite {
     val tooManyBytes = new Array[Byte](server.config.socketRequestMaxBytes + 1)
     new Random().nextBytes(tooManyBytes)
     val socket = connect()
-    sendRequest(socket, tooManyBytes, Some(0))
+    val outgoing = new DataOutputStream(socket.getOutputStream)
+    outgoing.writeInt(tooManyBytes.length)
     try {
+      // Server closes client connection when it processes the request length because
+      // it is too big. The write of request body may fail if the connection has been closed.
+      outgoing.write(tooManyBytes)
+      outgoing.flush
       receiveResponse(socket)
     } catch {
       case e: IOException => // thats fine


### PR DESCRIPTION
Test sends large request using multiple writes of length followed by request body. The first write should succeed, but since the server closes the connection on processing the length that is too big, subsequent writes may fail. Modified test to handle this exception.
