### PR TITLE
MINOR: Double timeout passed to `producer.close` in `sendAndVerifyTimestamp`

### DIFF
--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -220,7 +220,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
         val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, partition, baseTimestamp + i, "key".getBytes, "value".getBytes)
         producer.send(record, callback)
       }
-      producer.close(5000L, TimeUnit.MILLISECONDS)
+      producer.close(10000L, TimeUnit.MILLISECONDS)
       assertEquals(s"Should have offset $numRecords but only successfully sent ${callback.offset}", numRecords, callback.offset)
     } finally {
       producer.close()


### PR DESCRIPTION
We have had transient failures in this method when Jenkins is
overloaded.
