### PR TITLE
KAFKA-3701: Expose KafkaStreams Metrics in public API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.streams;
 
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -30,7 +32,9 @@ import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -215,6 +219,13 @@ public class KafkaStreams {
     public void setUncaughtExceptionHandler(Thread.UncaughtExceptionHandler eh) {
         for (StreamThread thread : threads)
             thread.setUncaughtExceptionHandler(eh);
+    }
+
+    /**
+     * Get the full set of internal metrics maintained by this KafkaStreams instance.
+     */
+    public Map<MetricName, ? extends Metric> metrics() {
+        return Collections.unmodifiableMap(this.metrics.metrics());
     }
 
 }


### PR DESCRIPTION
The Kafka clients expose their metrics registries through a `metrics` method presenting an unmodifiable collection (see [KafkaProducer's metrics() method](https://github.com/apache/kafka/blob/2790d0cb1fc6ade216f2c1bf2667a0ebb53d85e3/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L609-L615)), but `KafkaStreams` does not expose its registry.

This PR exposes an unmodifiable collection of metrics on `KafkaStreams` in direct analogy to `KafkaProducer`.

This contribution is my original work and I license the work to the project under the project's open source license.

cc @guozhangwang @miguno @mjsax 
