### PR TITLE
KAFKA-3664: Commit offset of unsubscribed partitions of the new consumer on a subscription change

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -358,9 +358,15 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
 
     public void commitOffsetsAsync(final Map<TopicPartition, OffsetAndMetadata> offsets, OffsetCommitCallback callback) {
+        final OffsetCommitCallback cb = callback == null ? defaultOffsetCommitCallback : callback;
+
+        if (offsets.isEmpty()) {
+            cb.onComplete(offsets, null);
+            return;
+        }
+
         this.subscriptions.needRefreshCommits();
         RequestFuture<Void> future = sendOffsetCommitRequest(offsets);
-        final OffsetCommitCallback cb = callback == null ? defaultOffsetCommitCallback : callback;
         future.addListener(new RequestFutureListener<Void>() {
             @Override
             public void onSuccess(Void value) {


### PR DESCRIPTION
When users are using group management, if they call consumer.subscribe() or consumer.unsubscribe() to change the subscription, the removed subscriptions will be immediately removed and their offset will not be committed.

This pull request fixes this issue by performing a commitAsync() in subscribe() and unsubscribe() methods to trigger an offset commit.

Special thanks to @hachikuji and @becketqin for helping out and sharing their feedback along the way.
