### PR TITLE
MINOR: Improve handling of channel close exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Authenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Authenticator.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.network;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 import java.security.Principal;
@@ -27,7 +28,7 @@ import org.apache.kafka.common.KafkaException;
 /**
  * Authentication for Channel
  */
-public interface Authenticator {
+public interface Authenticator extends Closeable {
 
     /**
      * Configures Authenticator using the provided parameters.
@@ -53,12 +54,5 @@ public interface Authenticator {
      * returns true if authentication is complete otherwise returns false;
      */
     boolean complete();
-
-    /**
-     * Closes this Authenticator
-     *
-     * @throws IOException if any I/O error occurs
-     */
-    void close() throws IOException;
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -42,8 +42,11 @@ public class KafkaChannel {
     }
 
     public void close() throws IOException {
-        transportLayer.close();
-        authenticator.close();
+        try {
+            transportLayer.close();
+        } finally {
+            authenticator.close();
+        }
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -42,11 +42,22 @@ public class KafkaChannel {
     }
 
     public void close() throws IOException {
+        IOException exception = null;
         try {
             transportLayer.close();
-        } finally {
-            authenticator.close();
+        } catch (IOException e) {
+            exception = e;
         }
+        try {
+            authenticator.close();
+        } catch (IOException e) {
+            if (exception != null)
+                exception.addSuppressed(e);
+            else
+                exception = e;
+        }
+        if (exception != null)
+            throw exception;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -26,6 +26,8 @@ import java.nio.channels.SelectionKey;
 
 import java.security.Principal;
 
+import org.apache.kafka.common.utils.Utils;
+
 public class KafkaChannel {
     private final String id;
     private final TransportLayer transportLayer;
@@ -42,22 +44,7 @@ public class KafkaChannel {
     }
 
     public void close() throws IOException {
-        IOException exception = null;
-        try {
-            transportLayer.close();
-        } catch (IOException e) {
-            exception = e;
-        }
-        try {
-            authenticator.close();
-        } catch (IOException e) {
-            if (exception != null)
-                exception.addSuppressed(e);
-            else
-                exception = e;
-        }
-        if (exception != null)
-            throw exception;
+        Utils.closeAll(transportLayer, authenticator);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -141,7 +141,7 @@ public class SslTransportLayer implements TransportLayer {
     * Sends a SSL close message and closes socketChannel.
     */
     @Override
-    public void close() {
+    public void close() throws IOException {
         if (closing) return;
         closing = true;
         sslEngine.closeOutbound();
@@ -168,12 +168,11 @@ public class SslTransportLayer implements TransportLayer {
             try {
                 socketChannel.socket().close();
                 socketChannel.close();
-            } catch (IOException e) {
-                log.warn("Failed to close SSL socket channel: " + e);
+            } finally {
+                key.attach(null);
+                key.cancel();
             }
         }
-        key.attach(null);
-        key.cancel();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -14,6 +14,7 @@ package org.apache.kafka.common.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.OutputStream;
@@ -674,6 +675,28 @@ public class Utils {
                 throw inner;
             }
         }
+    }
+
+    /**
+     * Closes all the provided closeables.
+     * @throws IOException if any of the close methods throws an IOException.
+     *         The first IOException is thrown with subsequent exceptions
+     *         added as suppressed exceptions.
+     */
+    public static void closeAll(Closeable... closeables) throws IOException {
+        IOException exception = null;
+        for (Closeable closeable : closeables) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                if (exception != null)
+                    exception.addSuppressed(e);
+                else
+                    exception = e;
+            }
+        }
+        if (exception != null)
+            throw exception;
     }
 
 }


### PR DESCRIPTION
Propagate IOException in SslTransportLayer channel.close to be consistent with PlaintextTransportLayer,  close authenticator on channel close even if transport layer close fails.
