### PR TITLE
KAFKA-3282: Change tools to use --new-consumer by default and introduce --old-consumer

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -55,8 +55,6 @@ object ConsumerGroupCommand {
 
     val consumerGroupService = {
       if (opts.useOldConsumer) {
-        Console.err.println("Using the ConsumerGroupCommand with old consumer is deprecated and will be removed in a future release. " +
-          "Consider using the new consumer.")
         new ZkConsumerGroupService(opts)
       } else {
         new KafkaConsumerGroupService(opts)
@@ -434,6 +432,8 @@ object ConsumerGroupCommand {
       if (useOldConsumer) {
         if (options.has(bootstrapServerOpt))
           CommandLineUtils.printUsageAndDie(parser, s"Option $bootstrapServerOpt is not valid with $zkConnectOpt.")
+        else if (options.has(newConsumerOpt))
+          CommandLineUtils.printUsageAndDie(parser, s"Option $newConsumerOpt is not valid with $zkConnectOpt.")
       } else {
         CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -55,7 +55,8 @@ object ConsumerGroupCommand {
 
     val consumerGroupService = {
       if (opts.useOldConsumer) {
-        Console.err.println("Old consumer is deprecated and will be removed in a future release. Consider using the new consumer.")
+        Console.err.println("Using the ConsumerGroupCommand with old consumer is deprecated and will be removed in a future release. " +
+          "Consider using the new consumer.")
         new ZkConsumerGroupService(opts)
       } else {
         new KafkaConsumerGroupService(opts)
@@ -431,19 +432,13 @@ object ConsumerGroupCommand {
     def checkArgs() {
       // check required args
       if (useOldConsumer) {
-        CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt)
-
         if (options.has(bootstrapServerOpt))
-          CommandLineUtils.printUsageAndDie(parser, s"Option $bootstrapServerOpt is not valid with old consumer.")
-
+          CommandLineUtils.printUsageAndDie(parser, s"Option $bootstrapServerOpt is not valid with $zkConnectOpt.")
       } else {
         CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 
-        if (options.has(zkConnectOpt))
-          CommandLineUtils.printUsageAndDie(parser, s"Option $zkConnectOpt is only valid with old consumer.")
-
         if (options.has(deleteOpt))
-          CommandLineUtils.printUsageAndDie(parser, s"Option $deleteOpt is only valid with old consumer. Note that " +
+          CommandLineUtils.printUsageAndDie(parser, s"Option $deleteOpt is only valid with $zkConnectOpt. Note that " +
             "there's no need to delete group metadata for the new consumer as it is automatically deleted when the last " +
             "member leaves")
       }

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -265,7 +265,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("metrics directory")
       .ofType(classOf[java.lang.String])
-    val useNewConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
+    val newConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
     val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED (unless old consumer is used): The server to connect to.")
       .withRequiredArg
       .describedAs("server to connect to")
@@ -315,6 +315,10 @@ object ConsoleConsumer extends Logging {
     formatter.init(formatterArgs)
 
     if (useOldConsumer) {
+      if (options.has(bootstrapServerOpt))
+        CommandLineUtils.printUsageAndDie(parser, s"Option $bootstrapServerOpt is not valid with $zkConnectOpt.")
+      else if (options.has(newConsumerOpt))
+        CommandLineUtils.printUsageAndDie(parser, s"Option $newConsumerOpt is not valid with $zkConnectOpt.")
       val topicOrFilterOpt = List(topicIdOpt, whitelistOpt, blacklistOpt).filter(options.has)
       if (topicOrFilterOpt.size != 1)
         CommandLineUtils.printUsageAndDie(parser, "Exactly one of whitelist/blacklist/topic is required.")

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -320,7 +320,8 @@ object ConsoleConsumer extends Logging {
         CommandLineUtils.printUsageAndDie(parser, "Exactly one of whitelist/blacklist/topic is required.")
       topicArg = options.valueOf(topicOrFilterOpt.head)
       filterSpec = if (options.has(blacklistOpt)) new Blacklist(topicArg) else new Whitelist(topicArg)
-      Console.err.println("Old consumer is deprecated and will be removed in a future release. Consider using the new consumer.")
+      Console.err.println("Using the ConsoleConsumer with old consumer is deprecated and will be removed " +
+        "in a future release. Consider using the new consumer.")
     } else {
       val topicOrFilterOpt = List(topicIdOpt, whitelistOpt).filter(options.has)
       if (topicOrFilterOpt.size != 1)
@@ -362,7 +363,8 @@ object ConsoleConsumer extends Logging {
       else if (fromBeginning) OffsetRequest.EarliestTime
       else OffsetRequest.LatestTime
 
-    CommandLineUtils.checkRequiredArgs(parser, options, if (useOldConsumer) zkConnectOpt else bootstrapServerOpt)
+    if (!useOldConsumer)
+      CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 
     if (options.has(csvMetricsReporterEnabledOpt)) {
       val csvReporterProps = new Properties()

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -224,7 +224,7 @@ object ConsoleConsumer extends Logging {
       .describedAs("consume offset")
       .ofType(classOf[String])
       .defaultsTo("latest")
-    val zkConnectOpt = parser.accepts("zookeeper", "REQUIRED: The connection string for the zookeeper connection in the form host:port. " +
+    val zkConnectOpt = parser.accepts("zookeeper", "REQUIRED (only when using old consumer): The connection string for the zookeeper connection in the form host:port. " +
       "Multiple URLS can be given to allow fail-over.")
       .withRequiredArg
       .describedAs("urls")
@@ -266,8 +266,7 @@ object ConsoleConsumer extends Logging {
       .describedAs("metrics directory")
       .ofType(classOf[java.lang.String])
     val useNewConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
-    val useOldConsumerOpt = parser.accepts("old-consumer", "Use the old consumer implementation.")
-    val bootstrapServerOpt = parser.accepts("bootstrap-server")
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED (unless old consumer is used): The server to connect to.")
       .withRequiredArg
       .describedAs("server to connect to")
       .ofType(classOf[String])
@@ -288,7 +287,7 @@ object ConsoleConsumer extends Logging {
 
     var groupIdPassed = true
     val options: OptionSet = tryParse(parser, args)
-    val useOldConsumer = options.has(useOldConsumerOpt)
+    val useOldConsumer = options.has(zkConnectOpt)
     val enableSystestEventsLogging = options.has(enableSystestEventsLoggingOpt)
 
     // If using old consumer, exactly one of whitelist/blacklist/topic is required.
@@ -321,6 +320,7 @@ object ConsoleConsumer extends Logging {
         CommandLineUtils.printUsageAndDie(parser, "Exactly one of whitelist/blacklist/topic is required.")
       topicArg = options.valueOf(topicOrFilterOpt.head)
       filterSpec = if (options.has(blacklistOpt)) new Blacklist(topicArg) else new Whitelist(topicArg)
+      Console.err.println("Old consumer is deprecated and will be removed in a future release. Consider using the new consumer.")
     } else {
       val topicOrFilterOpt = List(topicIdOpt, whitelistOpt).filter(options.has)
       if (topicOrFilterOpt.size != 1)

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -50,6 +50,9 @@ object ConsumerPerformance {
     val totalBytesRead = new AtomicLong(0)
     val consumerTimeout = new AtomicBoolean(false)
 
+    if (config.useOldConsumer)
+      Console.err.println("Old consumer is deprecated and will be removed in a future release. Consider using the new consumer.")
+
     if (!config.hideHeader) {
       if (!config.showDetailedStats)
         println("start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec")
@@ -163,12 +166,12 @@ object ConsumerPerformance {
   }
 
   class ConsumerPerfConfig(args: Array[String]) extends PerfConfig(args) {
-    val zkConnectOpt = parser.accepts("zookeeper", "The connection string for the zookeeper connection in the form host:port. " +
+    val zkConnectOpt = parser.accepts("zookeeper", "REQUIRED (only when using old consumer): The connection string for the zookeeper connection in the form host:port. " +
       "Multiple URLS can be given to allow fail-over. This option is only used with the old consumer.")
       .withRequiredArg
       .describedAs("urls")
       .ofType(classOf[String])
-    val bootstrapServersOpt = parser.accepts("broker-list", "A broker list to use for connecting if using the new consumer.")
+    val bootstrapServersOpt = parser.accepts("broker-list", "REQUIRED (unless old consumer is used): A broker list to use for connecting if using the new consumer.")
       .withRequiredArg()
       .describedAs("host")
       .ofType(classOf[String])
@@ -204,7 +207,6 @@ object ConsumerPerformance {
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1)
     val useNewConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
-    val useOldConsumerOpt = parser.accepts("old-consumer", "Use the old consumer implementation.")
     val consumerConfigOpt = parser.accepts("consumer.config", "Consumer config properties file.")
       .withRequiredArg
       .describedAs("config file")
@@ -214,8 +216,8 @@ object ConsumerPerformance {
 
     CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt)
 
-    val useOldConsumer = options.has(useOldConsumerOpt)
-    
+    val useOldConsumer = options.has(zkConnectOpt)
+
     val props = if (options.has(consumerConfigOpt))
       Utils.loadProps(options.valueOf(consumerConfigOpt))
     else

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -50,9 +50,6 @@ object ConsumerPerformance {
     val totalBytesRead = new AtomicLong(0)
     val consumerTimeout = new AtomicBoolean(false)
 
-    if (config.useOldConsumer)
-      Console.err.println("Old consumer is deprecated and will be removed in a future release. Consider using the new consumer.")
-
     if (!config.hideHeader) {
       if (!config.showDetailedStats)
         println("start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec")

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -58,7 +58,7 @@ object ConsumerPerformance {
     }
 
     var startMs, endMs = 0L
-    if(!config.useOldConsumer) {
+    if (!config.useOldConsumer) {
       val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](config.props)
       consumer.subscribe(List(config.topic))
       startMs = System.currentTimeMillis
@@ -203,7 +203,7 @@ object ConsumerPerformance {
       .describedAs("count")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1)
-    val useNewConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
+    val newConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
     val consumerConfigOpt = parser.accepts("consumer.config", "Consumer config properties file.")
       .withRequiredArg
       .describedAs("config file")
@@ -219,7 +219,7 @@ object ConsumerPerformance {
       Utils.loadProps(options.valueOf(consumerConfigOpt))
     else
       new Properties
-    if(!useOldConsumer) {
+    if (!useOldConsumer) {
       CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServersOpt)
       import org.apache.kafka.clients.consumer.ConsumerConfig
       props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServersOpt))
@@ -231,6 +231,10 @@ object ConsumerPerformance {
       props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[ByteArrayDeserializer])
       props.put(ConsumerConfig.CHECK_CRCS_CONFIG, "false")
     } else {
+      if (options.has(bootstrapServersOpt))
+        CommandLineUtils.printUsageAndDie(parser, s"Option $bootstrapServersOpt is not valid with $zkConnectOpt.")
+      else if (options.has(newConsumerOpt))
+        CommandLineUtils.printUsageAndDie(parser, s"Option $newConsumerOpt is not valid with $zkConnectOpt.")
       CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt, numMessagesOpt)
       props.put("group.id", options.valueOf(groupIdOpt))
       props.put("socket.receive.buffer.bytes", options.valueOf(socketBufferSizeOpt).toString)

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -58,7 +58,7 @@ object ConsumerPerformance {
     }
 
     var startMs, endMs = 0L
-    if (config.useNewConsumer) {
+    if(!config.useOldConsumer) {
       val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](config.props)
       consumer.subscribe(List(config.topic))
       startMs = System.currentTimeMillis
@@ -203,7 +203,8 @@ object ConsumerPerformance {
       .describedAs("count")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1)
-    val useNewConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation.")
+    val useNewConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
+    val useOldConsumerOpt = parser.accepts("old-consumer", "Use the old consumer implementation.")
     val consumerConfigOpt = parser.accepts("consumer.config", "Consumer config properties file.")
       .withRequiredArg
       .describedAs("config file")
@@ -213,13 +214,14 @@ object ConsumerPerformance {
 
     CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, numMessagesOpt)
 
-    val useNewConsumer = options.has(useNewConsumerOpt)
-
+    val useOldConsumer = options.has(useOldConsumerOpt)
+    
     val props = if (options.has(consumerConfigOpt))
       Utils.loadProps(options.valueOf(consumerConfigOpt))
     else
       new Properties
-    if (useNewConsumer) {
+    if(!useOldConsumer) {
+      CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServersOpt)
       import org.apache.kafka.clients.consumer.ConsumerConfig
       props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServersOpt))
       props.put(ConsumerConfig.GROUP_ID_CONFIG, options.valueOf(groupIdOpt))

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -83,13 +83,14 @@ class ConsoleConsumerTest extends JUnitSuite {
     val args: Array[String] = Array(
       "--zookeeper", "localhost:2181",
       "--topic", "test",
-      "--from-beginning")
+      "--from-beginning",
+      "--old-consumer") // old consumer
 
     //When
     val config = new ConsoleConsumer.ConsumerConfig(args)
 
     //Then
-    assertFalse(config.useNewConsumer)
+    assertTrue(config.useOldConsumer)
     assertEquals("localhost:2181", config.zkConnectionStr)
     assertEquals("test", config.topicArg)
     assertEquals(true, config.fromBeginning)
@@ -108,14 +109,14 @@ class ConsoleConsumerTest extends JUnitSuite {
     val config = new ConsoleConsumer.ConsumerConfig(args)
 
     //Then
-    assertTrue(config.useNewConsumer)
+    assertFalse(config.useOldConsumer)
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
     assertEquals(true, config.fromBeginning)
   }
 
   @Test
-  def shouldParseValidNewSimpleConsumerValidConfigWithNumericOffset() {
+  def shouldParseValidNewSimpleConsumerValidConfigWithNumericOffset(): Unit = {
     //Given
     val args: Array[String] = Array(
       "--bootstrap-server", "localhost:9092",
@@ -128,12 +129,28 @@ class ConsoleConsumerTest extends JUnitSuite {
     val config = new ConsoleConsumer.ConsumerConfig(args)
 
     //Then
-    assertTrue(config.useNewConsumer)
+    assertFalse(config.useOldConsumer)
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
     assertEquals(0, config.partitionArg.get)
     assertEquals(3, config.offsetArg)
     assertEquals(false, config.fromBeginning)
+
+  }
+
+  @Test
+  def testDefaultConsumer() {
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--from-beginning")
+
+    //When
+    val config = new ConsoleConsumer.ConsumerConfig(args)
+
+    //Then
+    assertFalse(config.useOldConsumer)
   }
 
   @Test
@@ -150,7 +167,7 @@ class ConsoleConsumerTest extends JUnitSuite {
     val config = new ConsoleConsumer.ConsumerConfig(args)
 
     //Then
-    assertTrue(config.useNewConsumer)
+    assertFalse(config.useOldConsumer)
     assertEquals("localhost:9092", config.bootstrapServer)
     assertEquals("test", config.topicArg)
     assertEquals(0, config.partitionArg.get)
@@ -165,7 +182,7 @@ class ConsoleConsumerTest extends JUnitSuite {
     propsStream.write("consumer.timeout.ms=1000".getBytes())
     propsStream.close()
     val args: Array[String] = Array(
-      "--zookeeper", "localhost:2181",
+      "--bootstrap-server", "localhost:9092",
       "--topic", "test",
       "--consumer.config", propsFile.getAbsolutePath
     )

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -178,7 +178,7 @@ class ConsoleConsumerTest extends JUnitSuite {
   def shouldParseConfigsFromFile() {
     val propsFile = TestUtils.tempFile()
     val propsStream = new FileOutputStream(propsFile)
-    propsStream.write("consumer.timeout.ms=1000".getBytes())
+    propsStream.write("request.timeout.ms=1000".getBytes())
     propsStream.close()
     val args: Array[String] = Array(
       "--bootstrap-server", "localhost:9092",
@@ -188,6 +188,6 @@ class ConsoleConsumerTest extends JUnitSuite {
 
     val config = new ConsoleConsumer.ConsumerConfig(args)
 
-    assertEquals("1000", config.consumerProps.getProperty("consumer.timeout.ms"))
+    assertEquals("1000", config.consumerProps.getProperty("request.timeout.ms"))
   }
 }

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -83,8 +83,7 @@ class ConsoleConsumerTest extends JUnitSuite {
     val args: Array[String] = Array(
       "--zookeeper", "localhost:2181",
       "--topic", "test",
-      "--from-beginning",
-      "--old-consumer") // old consumer
+      "--from-beginning")
 
     //When
     val config = new ConsoleConsumer.ConsumerConfig(args)


### PR DESCRIPTION
1. Made new consumer the default in console consumer
2. Added --old-consumer option to choose old consumer
