### PR TITLE
MINOR: Change type of StreamsConfig.BOOTSTRAP_SERVERS_CONFIG to List

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -120,7 +120,7 @@ public class StreamsConfig extends AbstractConfig {
                                         Importance.HIGH,
                                         StreamsConfig.APPLICATION_ID_DOC)
                                 .define(BOOTSTRAP_SERVERS_CONFIG,       // required with no default value
-                                        Type.STRING,
+                                        Type.LIST,
                                         Importance.HIGH,
                                         CommonClientConfigs.BOOSTRAP_SERVERS_DOC)
                                 .define(CLIENT_ID_CONFIG,

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -20,14 +20,20 @@ package org.apache.kafka.streams;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 public class StreamsConfigTest {
 
@@ -84,4 +90,18 @@ public class StreamsConfigTest {
         assertEquals("Should get the original string after serialization and deserialization with the configured encoding",
                 str, streamsConfig.valueSerde().deserializer().deserialize(topic, serializer.serialize(topic, str)));
     }
+
+    @Test
+    public void shouldSupportMultipleBootstrapServers() {
+        List<String> expectedBootstrapServers = Arrays.asList("broker1:9092", "broker2:9092");
+        String bootstrapServersString = Utils.mkString(expectedBootstrapServers, ",").toString();
+        Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "irrelevant");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServersString);
+        StreamsConfig config = new StreamsConfig(props);
+
+        List<String> actualBootstrapServers = config.getList(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
+        assertThat(actualBootstrapServers, equalTo(expectedBootstrapServers));
+    }
+
 }


### PR DESCRIPTION
This is an improved version of https://github.com/apache/kafka/pull/1374, where we include a unit test.
