### PR TITLE
MINOR: Fix checkstyle failure in `StreamsConfigTest`

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsConfigTest.java
@@ -30,10 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 public class StreamsConfigTest {
 
@@ -101,7 +99,7 @@ public class StreamsConfigTest {
         StreamsConfig config = new StreamsConfig(props);
 
         List<String> actualBootstrapServers = config.getList(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG);
-        assertThat(actualBootstrapServers, equalTo(expectedBootstrapServers));
+        assertEquals(expectedBootstrapServers, actualBootstrapServers);
     }
 
 }


### PR DESCRIPTION
I removed the hamcrest matcher to unbreak the build, but we probably want to tweak the `import-control.xml` as it currently only allows it for `<subpackage name="integration">`, which is weird.
