### PR TITLE
MINOR: Allow Serdes subclasses to access WrapperSerde

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/Serdes.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Serdes.java
@@ -23,7 +23,7 @@ import java.util.Map;
  */
 public class Serdes {
 
-    static private class WrapperSerde<T> implements Serde<T> {
+    static protected class WrapperSerde<T> implements Serde<T> {
         final private Serializer<T> serializer;
         final private Deserializer<T> deserializer;
 


### PR DESCRIPTION
This PR loosens access restrictions on `WrapperSerde` to `protected` so that users can define a `Serdes` subclass that provides additional custom serde members following the same pattern as the parent class.

This is my own work and is compatible with Kafka's license.
