### PR TITLE
KAFKA-3710: MemoryOffsetBackingStore shutdown

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryOffsetBackingStore.java
@@ -40,7 +40,7 @@ public class MemoryOffsetBackingStore implements OffsetBackingStore {
     private static final Logger log = LoggerFactory.getLogger(MemoryOffsetBackingStore.class);
 
     protected Map<ByteBuffer, ByteBuffer> data = new HashMap<>();
-    protected ExecutorService executor = Executors.newSingleThreadExecutor();
+    protected ExecutorService executor;
 
     public MemoryOffsetBackingStore() {
 
@@ -52,11 +52,15 @@ public class MemoryOffsetBackingStore implements OffsetBackingStore {
 
     @Override
     public synchronized void start() {
+        executor = Executors.newSingleThreadExecutor();
     }
 
     @Override
     public synchronized void stop() {
-        // Nothing to do since this doesn't maintain any outstanding connections/data
+        if (executor != null) {
+            executor.shutdown();
+            executor = null;
+        }
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/MemoryOffsetBackingStore.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.slf4j.Logger;
@@ -30,6 +31,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Implementation of OffsetBackingStore that doesn't actually persist any data. To ensure this
@@ -51,12 +53,12 @@ public class MemoryOffsetBackingStore implements OffsetBackingStore {
     }
 
     @Override
-    public synchronized void start() {
+    public void start() {
         executor = Executors.newSingleThreadExecutor();
     }
 
     @Override
-    public synchronized void stop() {
+    public void stop() {
         if (executor != null) {
             executor.shutdown();
             // Best effort wait for any get() and set() tasks (and caller's callbacks) to complete.


### PR DESCRIPTION
ExecutorService needs to be shutdown on close, lest a zombie thread
prevent clean shutdown.

@ewencp 
