### PR TITLE
KAFKA-3667:Improve Section 7.2 Encryption and Authentication using SSL to include proper hostname verification configuration

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -45,17 +45,17 @@ Apache Kafka allows clients to connect over SSL. By default SSL is disabled but 
             <li>validity: the valid time of the certificate in days.</li>
         </ol>
         <br>
-	Note: By default the property ssl.endpoint.identification.algorithim has been set to null. Unless configured otherwise hostname verification will not performed. In order to enable hostname verification the following property will need to be set:
+	Note: By default the property <code>ssl.endpoint.identification.algorithm</code> is not defined, so hostname verification is not performed. In order to enable hostname verification, set the following property:
 
-	<pre>	ssl.endpoint.identification.algorithim = HTTPS </pre>
+	<pre>	ssl.endpoint.identification.algorithm=HTTPS </pre>
 
-	Once enabled clients will verify the server's fully qualified domain name (FQDN) against of the following two fields:
+	Once enabled, clients will verify the server's fully qualified domain name (FQDN) against one of the following two fields:
 	<ol>
 		<li>Common Name (CN)*
 		<li>Subject Alternative Name (SAN)
 	</ol>
 	<br>
-	*The Common Name, although technically valid, is only used to keep backward compatibility. In order to more strictly adhere to RFC-2818 the servers FQDN should be placed in a SAN field. To accomplish this append the following argument -ext SAN=DNS:{FQDN} to the keytool command:
+	Both fileds are valid, RFC-2818 recommends the use of SAN however. SAN is also more flexible, allowing for mutliple DNS entries to be decalred. This leaves the CN available for more meaningful authorization purposes. To add a SAN field  append the following argument -ext SAN=DNS:{FQDN} to the keytool command:
 	<pre>
 	keytool -keystore server.keystore.jks -alias localhost -validity {validity} -genkey -ext SAN=DNS:{FQDN}
 	</pre>

--- a/docs/security.html
+++ b/docs/security.html
@@ -44,8 +44,26 @@ Apache Kafka allows clients to connect over SSL. By default SSL is disabled but 
             <li>keystore: the keystore file that stores the certificate. The keystore file contains the private key of the certificate; therefore, it needs to be kept safely.</li>
             <li>validity: the valid time of the certificate in days.</li>
         </ol>
-        Ensure that common name (CN) matches exactly with the fully qualified domain name (FQDN) of the server. The client compares the CN with the DNS domain name to ensure that it is indeed connecting to the desired server, not the malicious one.</li>
+        <br>
+	Note: By default the property ssl.endpoint.identification.algorithim has been set to null. Unless configured otherwise hostname verification will not performed. In order to enable hostname verification the following property will need to be set:
 
+	<pre>	ssl.endpoint.identification.algorithim = HTTPS </pre>
+
+	Once enabled clients will verify the server's fully qualified domain name (FQDN) against of the following two fields:
+	<ol>
+		<li>Common Name (CN)*
+		<li>Subject Alternative Name (SAN)
+	</ol>
+	<br>
+	*The Common Name, although technically valid, is only used to keep backward compatibility. In order to more strictly adhere to RFC-2818 the servers FQDN should be placed in a SAN field. To accomplish this append the following argument -ext SAN=DNS:{FQDN} to the keytool command:
+	<pre>
+	keytool -keystore server.keystore.jks -alias localhost -validity {validity} -genkey -ext SAN=DNS:{FQDN}
+	</pre>
+	The following command can be run afterwards to verify the contents of the generated certificate:
+	<pre>
+	keytool -list -v -keystore server.keystore.jks
+	</pre>
+    </li>
     <li><h4><a id="security_ssl_ca" href="#security_ssl_ca">Creating your own CA</a></h4>
         After the first step, each machine in the cluster has a public-private key pair, and a certificate to identify the machine. The certificate, however, is unsigned, which means that an attacker can create such a certificate to pretend to be any machine.<p>
         Therefore, it is important to prevent forged certificates by signing them for each machine in the cluster. A certificate authority (CA) is responsible for signing certificates. CA works likes a government that issues passports—the government stamps (signs) each passport so that the passport becomes difficult to forge. Other governments verify the stamps to ensure the passport is authentic. Similarly, the CA signs the certificates, and the cryptography guarantees that a signed certificate is computationally difficult to forge. Thus, as long as the CA is a genuine and trusted authority, the clients have high assurance that they are connecting to the authentic machines.

--- a/docs/security.html
+++ b/docs/security.html
@@ -55,7 +55,7 @@ Apache Kafka allows clients to connect over SSL. By default SSL is disabled but 
 		<li>Subject Alternative Name (SAN)
 	</ol>
 	<br>
-	Both fileds are valid, RFC-2818 recommends the use of SAN however. SAN is also more flexible, allowing for mutliple DNS entries to be decalred. This leaves the CN available for more meaningful authorization purposes. To add a SAN field  append the following argument -ext SAN=DNS:{FQDN} to the keytool command:
+	Both fields are valid, RFC-2818 recommends the use of SAN however. SAN is also more flexible, allowing for multiple DNS entries to be decalred. This leaves the CN available for more meaningful authorization purposes. To add a SAN field  append the following argument <pre> -ext SAN=DNS:{FQDN} </pre> to the keytool command:
 	<pre>
 	keytool -keystore server.keystore.jks -alias localhost -validity {validity} -genkey -ext SAN=DNS:{FQDN}
 	</pre>


### PR DESCRIPTION
By default Kafka is configured to allow ssl communication without hostname verification. This docs has been amended to include instructions on how to set that up in the event clients would like to take a more conservative approach. 
