### PR TITLE
MINOR: Inline `Record.write` into `Compressor.putRecord`

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/Compressor.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/Compressor.java
@@ -218,7 +218,29 @@ public class Compressor {
 
     private void putRecord(final long crc, final byte attributes, final long timestamp, final byte[] key, final byte[] value, final int valueOffset, final int valueSize) {
         maxTimestamp = Math.max(maxTimestamp, timestamp);
-        Record.write(this, crc, attributes, timestamp, key, value, valueOffset, valueSize);
+        // write crc
+        putInt((int) (crc & 0xffffffffL));
+        // write magic value
+        putByte(Record.CURRENT_MAGIC_VALUE);
+        // write attributes
+        putByte(attributes);
+        // write timestamp
+        putLong(timestamp);
+        // write the key
+        if (key == null) {
+            putInt(-1);
+        } else {
+            putInt(key.length);
+            put(key, 0, key.length);
+        }
+        // write the value
+        if (value == null) {
+            putInt(-1);
+        } else {
+            int size = valueSize >= 0 ? valueSize : (value.length - valueOffset);
+            putInt(size);
+            put(value, valueOffset, size);
+        }
     }
 
     public void recordWritten(int size) {

--- a/clients/src/main/java/org/apache/kafka/common/record/Record.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/Record.java
@@ -154,32 +154,6 @@ public final class Record {
         }
     }
 
-    public static void write(Compressor compressor, long crc, byte attributes, long timestamp, byte[] key, byte[] value, int valueOffset, int valueSize) {
-        // write crc
-        compressor.putInt((int) (crc & 0xffffffffL));
-        // write magic value
-        compressor.putByte(CURRENT_MAGIC_VALUE);
-        // write attributes
-        compressor.putByte(attributes);
-        // write timestamp
-        compressor.putLong(timestamp);
-        // write the key
-        if (key == null) {
-            compressor.putInt(-1);
-        } else {
-            compressor.putInt(key.length);
-            compressor.put(key, 0, key.length);
-        }
-        // write the value
-        if (value == null) {
-            compressor.putInt(-1);
-        } else {
-            int size = valueSize >= 0 ? valueSize : (value.length - valueOffset);
-            compressor.putInt(size);
-            compressor.put(value, valueOffset, size);
-        }
-    }
-
     public static int recordSize(byte[] key, byte[] value) {
         return recordSize(key == null ? 0 : key.length, value == null ? 0 : value.length);
     }


### PR DESCRIPTION
This simplifies the call path making the code easier to understand. Previously, `Record.write(ByteBuffer...)` called `Compressor.putRecord` which after a few overloaded calls, would end up in`Record.write(Compressor...)`.
