### PR TITLE
MINOR: Exclude jline, netty and findbugs annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -833,7 +833,10 @@ project(':connect:runtime') {
     compile libs.jettyServer
     compile libs.jettyServlet
     compile libs.jettyServlets
-    compile libs.reflections
+    compile(libs.reflections) {
+      // Exclude because of LGPL license
+      exclude group: 'com.google.code.findbugs', module: 'annotations'
+    }
 
     testCompile project(':clients').sourceSets.test.output
     testCompile libs.easymock

--- a/build.gradle
+++ b/build.gradle
@@ -663,19 +663,17 @@ project(':streams') {
     compile project(':connect:json')  // this dependency should be removed after we unify data API
     compile libs.slf4jlog4j
     compile libs.rocksDBJni
-    compile libs.zkclient // this dependency should be removed after KIP-4
+    // this dependency should be removed after KIP-4
+    compile (libs.zkclient) {
+      exclude module: 'jline'
+      exclude module: 'netty'
+    }
     compile libs.jacksonDatabind // this dependency should be removed after KIP-4
 
     testCompile project(':clients').sourceSets.test.output
     testCompile project(':core')
     testCompile project(':core').sourceSets.test.output
     testCompile libs.junit
-  }
-
-  configurations {
-    // manually exclude unnecessary zkclient transitive dependencies, remove this after KIP-4
-    compile.exclude module: 'jline'
-    compile.exclude module: 'netty'
   }
 
   javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -672,6 +672,12 @@ project(':streams') {
     testCompile libs.junit
   }
 
+  configurations {
+    // manually exclude unnecessary zkclient transitive dependencies, remove this after KIP-4
+    compile.exclude module: 'jline'
+    compile.exclude module: 'netty'
+  }
+
   javadoc {
     include "**/org/apache/kafka/streams/**"
     exclude "**/internals/**"


### PR DESCRIPTION
These dependencies are unnecessary and they are acquired
transitively via zkclient (jline, netty) and reflections (annotations).

Ewen did the hard work in figuring out why we have unexpected
additional dependencies since 0.9.x.
