### PR TITLE
KAFKA-3717; Support building aggregate javadoc for all project modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Follow instructions in http://kafka.apache.org/documentation.html#quickstart
 ### Building source jar ###
     ./gradlew srcJar
 
-### Building aggregated javadocs ###
+### Building aggregated javadoc ###
     ./gradlew aggregatedJavadoc
 
-### Building javadocs and scaladocs ###
+### Building javadoc and scaladoc ###
     ./gradlew javadoc
-    ./gradlew javadocJar # builds a jar from the javadocs
+    ./gradlew javadocJar # builds a javadoc jar for each module
     ./gradlew scaladoc
-    ./gradlew scaladocJar # builds a jar from the scaladocs
-    ./gradlew docsJar # builds both javadoc and scaladoc jar
+    ./gradlew scaladocJar # builds a scaladoc jar for each module
+    ./gradlew docsJar # builds both (if applicable) javadoc and scaladoc jars for each module
 
 ### Running unit tests ###
     ./gradlew test

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Follow instructions in http://kafka.apache.org/documentation.html#quickstart
 ### Building source jar ###
     ./gradlew srcJar
 
+### Building aggregated javadocs ###
+    ./gradlew aggregatedJavadoc
+
 ### Building javadocs and scaladocs ###
     ./gradlew javadoc
     ./gradlew javadocJar # builds a jar from the javadocs

--- a/build.gradle
+++ b/build.gradle
@@ -548,6 +548,10 @@ project(':examples') {
     compile project(':core')
   }
 
+  javadoc {
+    enabled = false
+  }
+
   checkstyle {
     configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
   }
@@ -636,7 +640,7 @@ project(':tools') {
   }
 
   javadoc {
-    include "**/org/apache/kafka/tools/*"
+    enabled = false
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
@@ -741,8 +745,9 @@ project(':log4j-appender') {
   }
 
   javadoc {
-    include "**/org/apache/kafka/log4jappender/*"
+    enabled = false
   }
+
 }
 
 project(':connect:api') {
@@ -758,6 +763,7 @@ project(':connect:api') {
   }
 
   javadoc {
+    include "**/org/apache/kafka/connect/**" // needed for the `javadocAll` task
     options.links "http://docs.oracle.com/javase/7/docs/api/"
   }
 
@@ -903,4 +909,13 @@ project(':connect:file') {
   jar {
     dependsOn copyDependantLibs
   }
+}
+
+task javadocAll(type: Javadoc) {
+  def projectsWithJavadoc = subprojects.findAll { it.javadoc.enabled }
+  source = projectsWithJavadoc.collect { it.sourceSets.main.allJava }
+  classpath = files(projectsWithJavadoc.collect { it.sourceSets.main.compileClasspath })
+  includes = projectsWithJavadoc.collectMany { it.javadoc.getIncludes() }
+  excludes = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
+  options.links "http://docs.oracle.com/javase/7/docs/api/"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,15 @@ allprojects {
       }
     }
   }
+
+  if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+      // disable the crazy super-strict doclint tool in Java 8
+      // noinspection SpellCheckingInspection
+      options.addStringOption('Xdoclint:none', '-quiet')
+    }
+  }
+
 }
 
 ext {
@@ -110,14 +119,6 @@ subprojects {
     options.encoding = 'UTF-8'
     // Add unchecked once we drop support for Java 7 as @SuppressWarnings("unchecked") is too buggy in Java 7
     options.compilerArgs << "-Xlint:deprecation"
-  }
-
-  if (JavaVersion.current().isJava8Compatible()) {
-    tasks.withType(Javadoc) {
-        // disable the crazy super-strict doclint tool in Java 8
-        //noinspection SpellCheckingInspection
-        options.addStringOption('Xdoclint:none', '-quiet')
-      }
   }
 
   uploadArchives {

--- a/build.gradle
+++ b/build.gradle
@@ -911,7 +911,7 @@ project(':connect:file') {
   }
 }
 
-task javadocAll(type: Javadoc) {
+task aggregatedJavadoc(type: Javadoc) {
   def projectsWithJavadoc = subprojects.findAll { it.javadoc.enabled }
   source = projectsWithJavadoc.collect { it.sourceSets.main.allJava }
   classpath = files(projectsWithJavadoc.collect { it.sourceSets.main.compileClasspath })


### PR DESCRIPTION
The task is called `aggregatedJavadoc` and the generated html will be under `<project.dir>/build/docs/javadoc/`.

I also disabled javadoc for `tools` and `log4j-appender` as they are not public API.
