### PR TITLE
KAFKA-3554 Improve ProducerPerformance test

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -131,10 +131,10 @@ public class ProducerPerformance {
             for (ProducerPerformanceThread t : producerPerformanceThreads)
                 t.join();
             producer.flush();
+            /* print final results */
             stats.printTotal();
             if (shouldPrintMetrics)
                 ToolsUtils.printMetrics(producer.metrics());
-            /* print final results */
             producer.close();
         } catch (ArgumentParserException e) {
             if (args.length == 0) {

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -118,7 +118,7 @@ public class ProducerPerformance {
             Stats stats = new Stats(numRecords, 5000, numThreads);
             ProducerPerformanceThread[] producerPerformanceThreads = new ProducerPerformanceThread[numThreads];
             long numRecordsPerThread = numRecords / numThreads;
-            int throughputPerThread = Math.max(throughput / numThreads, 1);
+            int throughputPerThread = throughput <= 0 ? throughput : Math.max(throughput / numThreads, 1);
             for (int i = 0; i < numThreads; i++) {
                 // If number of records cannot be exactly divided by num threads, some threads need to send one more record.
                 int numRecordsAdjustment = i < numRecords % numThreads ? 1 : 0;


### PR DESCRIPTION
1. Added multiple thread support.
2. Added value-bound to make compressed data more realistic.
3. Print out the producer metrics.
