### PR TITLE
KAFKA-3722 : The PlaintextChannelBuilder should always use the DefaultPrincipalBuilder

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
@@ -15,6 +15,7 @@ package org.apache.kafka.common.network;
 import java.nio.channels.SelectionKey;
 import java.util.Map;
 
+import org.apache.kafka.common.security.auth.DefaultPrincipalBuilder;
 import org.apache.kafka.common.security.auth.PrincipalBuilder;
 import org.apache.kafka.common.KafkaException;
 
@@ -29,7 +30,7 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
     public void configure(Map<String, ?> configs) throws KafkaException {
         try {
             this.configs = configs;
-            principalBuilder = ChannelBuilders.createPrincipalBuilder(configs);
+            principalBuilder = new DefaultPrincipalBuilder();
         } catch (Exception e) {
             throw new KafkaException(e);
         }


### PR DESCRIPTION
Consider this scenario :
1) We have a Kafka Broker running on PlainText and SSL port simultaneously.

2) We try to plugin a custom principal builder using the config "principal.builder.class" for the request coming over the SSL port.

3) The ChannelBuilders.createPrincipalBuilder(configs) first checks if a config "principal.builder.class" is specified in the passed in configs and tries to use that even when it is building the instance of PrincipalBuilder for the PlainText port, when that custom principal class is only menat for SSL port.

IMO, having a DefaultPrincipalBuilder for PlainText port should be fine.
