### PR TITLE
KAFKA-3732: Add an auto accept option to kafka-acls.sh

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -99,10 +99,10 @@ object AclCommand {
 
       for ((resource, acls) <- resourceToAcl) {
         if (acls.isEmpty) {
-          if (confirmAction(s"Are you sure you want to delete all ACLs for resource `${resource}`? (y/n)"))
+          if (confirmAction(opts, s"Are you sure you want to delete all ACLs for resource `${resource}`? (y/n)"))
             authorizer.removeAcls(resource)
         } else {
-          if (confirmAction(s"Are you sure you want to remove ACLs: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline from resource `${resource}`? (y/n)"))
+          if (confirmAction(opts, s"Are you sure you want to remove ACLs: $Newline ${acls.map("\t" + _).mkString(Newline)} $Newline from resource `${resource}`? (y/n)"))
             authorizer.removeAcls(acls, resource)
         }
       }
@@ -241,7 +241,9 @@ object AclCommand {
     resources
   }
 
-  private def confirmAction(msg: String): Boolean = {
+  private def confirmAction(opts: AclCommandOptions, msg: String): Boolean = {
+    if (opts.options.has(opts.yesOpt))
+        return true
     println(msg)
     Console.readLine().equalsIgnoreCase("y")
   }
@@ -328,6 +330,8 @@ object AclCommand {
       "This will generate ACLs that allows READ,DESCRIBE on topic and READ on group.")
 
     val helpOpt = parser.accepts("help", "Print usage information.")
+
+    val yesOpt = parser.accepts("yes", "Assume Yes to all queries and do not prompt.")
 
     val options = parser.parse(args: _*)
 

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -116,12 +116,10 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
 
   private def testRemove(resources: Set[Resource], resourceCmd: Array[String], args: Array[String], brokerProps: Properties) {
     for (resource <- resources) {
-      Console.withIn(new StringReader(s"y${AclCommand.Newline}" * resources.size)) {
-        AclCommand.main(args ++ resourceCmd :+ "--remove")
+        AclCommand.main(args ++ resourceCmd :+ "--remove" :+ "--yes")
         withAuthorizer(brokerProps) { authorizer =>
           TestUtils.waitAndVerifyAcls(Set.empty[Acl], authorizer, resource)
         }
-      }
     }
   }
 

--- a/docs/security.html
+++ b/docs/security.html
@@ -576,6 +576,12 @@ Kafka Authorization management CLI can be found under bin directory with all the
         <td></td>
         <td>Convenience</td>
     </tr>
+    <tr>
+        <td>--yes</td>
+        <td> Convenience option to assume yes to all queries and do not prompt.</td>
+        <td></td>
+        <td>Convenience</td>
+    </tr>
 </tbody></table>
 
 <h4><a id="security_authz_examples" href="#security_authz_examples">Examples</a></h4>


### PR DESCRIPTION
Added a new argument to AclCommand: --yes. When set, automatically answer yes to prompts
