### PR TITLE
MINOR: set charset of Javadoc to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -182,6 +182,11 @@ subprojects {
 
   task docsJar(dependsOn: javadocJar)
 
+  javadoc {
+    options.charSet = 'UTF-8'
+    options.encoding = 'UTF-8'
+  }
+
   task systemTestLibs(dependsOn: jar)
 
   artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ subprojects {
 
   javadoc {
     options.charSet = 'UTF-8'
-    options.encoding = 'UTF-8'
+    options.docEncoding = 'UTF-8'
   }
 
   task systemTestLibs(dependsOn: jar)

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,7 @@ subprojects {
   javadoc {
     options.charSet = 'UTF-8'
     options.docEncoding = 'UTF-8'
+    options.encoding = 'UTF-8'
   }
 
   task systemTestLibs(dependsOn: jar)


### PR DESCRIPTION
Currently javadoc doesn't specify charset.
This pull reqeust will set this to UTF-8.
