### PR TITLE
MINOR: Use `--force` instead of `--yes` in `AclCommand`

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -242,7 +242,7 @@ object AclCommand {
   }
 
   private def confirmAction(opts: AclCommandOptions, msg: String): Boolean = {
-    if (opts.options.has(opts.yesOpt))
+    if (opts.options.has(opts.forceOpt))
         return true
     println(msg)
     Console.readLine().equalsIgnoreCase("y")
@@ -331,7 +331,7 @@ object AclCommand {
 
     val helpOpt = parser.accepts("help", "Print usage information.")
 
-    val yesOpt = parser.accepts("force", "Assume Yes to all queries and do not prompt.")
+    val forceOpt = parser.accepts("force", "Assume Yes to all queries and do not prompt.")
 
     val options = parser.parse(args: _*)
 

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -331,7 +331,7 @@ object AclCommand {
 
     val helpOpt = parser.accepts("help", "Print usage information.")
 
-    val yesOpt = parser.accepts("yes", "Assume Yes to all queries and do not prompt.")
+    val yesOpt = parser.accepts("force", "Assume Yes to all queries and do not prompt.")
 
     val options = parser.parse(args: _*)
 

--- a/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AclCommandTest.scala
@@ -116,7 +116,7 @@ class AclCommandTest extends ZooKeeperTestHarness with Logging {
 
   private def testRemove(resources: Set[Resource], resourceCmd: Array[String], args: Array[String], brokerProps: Properties) {
     for (resource <- resources) {
-        AclCommand.main(args ++ resourceCmd :+ "--remove" :+ "--yes")
+        AclCommand.main(args ++ resourceCmd :+ "--remove" :+ "--force")
         withAuthorizer(brokerProps) { authorizer =>
           TestUtils.waitAndVerifyAcls(Set.empty[Acl], authorizer, resource)
         }

--- a/docs/security.html
+++ b/docs/security.html
@@ -577,7 +577,7 @@ Kafka Authorization management CLI can be found under bin directory with all the
         <td>Convenience</td>
     </tr>
     <tr>
-        <td>--yes</td>
+        <td>--force</td>
         <td> Convenience option to assume yes to all queries and do not prompt.</td>
         <td></td>
         <td>Convenience</td>


### PR DESCRIPTION
To be consistent with `ConfigCommand` and `TopicCommand`.

No release includes this option yet, so we can simply change it.
