### PR TITLE
KAFKA-3767: Failed Kafka Connect's unit test with Unknown license.

### DIFF
--- a/connect/json/src/test/resources/connect-test.properties
+++ b/connect/json/src/test/resources/connect-test.properties
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# see kafka.server.KafkaConfig for additional details and defaults
 
 schemas.cache.size=1
 

--- a/connect/json/src/test/resources/connect-test.properties
+++ b/connect/json/src/test/resources/connect-test.properties
@@ -1,2 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# see kafka.server.KafkaConfig for additional details and defaults
+
 schemas.cache.size=1
 


### PR DESCRIPTION
This address to https://issues.apache.org/jira/browse/KAFKA-3767.
