### PR TITLE
KAFKA-3769 - KStream job spending 60% of time writing metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -768,13 +768,14 @@ public class Fetcher<K, V> {
         }
 
         public void recordTopicFetchMetrics(String topic, int bytes, int records) {
-            Map<String, String> metricTags = new HashMap<>();
-            metricTags.put("topic", topic.replace(".", "_"));
-
             // record bytes fetched
-            String name = "topic." + topic + ".bytes-fetched";
+            String name = String.format("topic.%s.bytes-fetched", topic);
             Sensor bytesFetched = this.metrics.getSensor(name);
+
             if (bytesFetched == null) {
+                Map<String, String> metricTags = new HashMap<>();
+                metricTags.put("topic", topic.replace(".", "_"));
+
                 bytesFetched = this.metrics.sensor(name);
                 bytesFetched.add(this.metrics.metricName("fetch-size-avg",
                         this.metricGrpName,
@@ -792,9 +793,12 @@ public class Fetcher<K, V> {
             bytesFetched.record(bytes);
 
             // record records fetched
-            name = "topic." + topic + ".records-fetched";
+            name = String.format("topic.%s.records-fetched", topic);
             Sensor recordsFetched = this.metrics.getSensor(name);
             if (recordsFetched == null) {
+                Map<String, String> metricTags = new HashMap<>();
+                metricTags.put("topic", topic.replace(".", "_"));
+
                 recordsFetched = this.metrics.sensor(name);
                 recordsFetched.add(this.metrics.metricName("records-per-request-avg",
                         this.metricGrpName,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -346,19 +346,23 @@ public class StreamThread extends Thread {
             // try to process one fetch record from each task via the topology, and also trigger punctuate
             // functions if necessary, which may result in more records going through the topology in this loop
             if (!activeTasks.isEmpty()) {
+                long totalProcessTime = 0L;
+
                 for (StreamTask task : activeTasks.values()) {
                     long startProcess = time.milliseconds();
 
                     totalNumBuffered += task.process();
                     requiresPoll = requiresPoll || task.requiresPoll();
 
-                    sensors.processTimeSensor.record(time.milliseconds() - startProcess);
+                    totalProcessTime += (time.milliseconds() - startProcess);
 
                     maybePunctuate(task);
 
                     if (task.commitNeeded())
                         commitOne(task, time.milliseconds());
                 }
+
+                sensors.processTimeSensor.record(totalProcessTime);
 
                 // if pollTimeMs has passed since the last poll, we poll to respond to a possible rebalance
                 // even when we paused all partitions.


### PR DESCRIPTION
In profiling a complex Kafka Streaming job:
- 50% of CPU time was found to be spent writing the metrics for process time to the process time Sensor.
- 7-8% of CPU time was spent doing various unnecessary work in Fetcher.

This PR addresses the first by rolling up the process time per iteration into a single metric, and addresses the second point directly (see patch.) I think this PR is incomplete because the metric itself has changed in meaning. Additionally, the latency metrics recorded during writes to rocksdb also incur significant cost. If there is a better fix in mind, please advise.
