### PR TITLE
KAFKA-3561: Auto create through topic for KStream aggregation and join [WIP]

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -148,7 +148,7 @@
       <allow pkg="scala" />
       <allow pkg="scala.collection" />
       <allow pkg="org.I0Itec.zkclient" />
-      <allow pkg="org.hamcrest.CoreMatchers" />
+      <allow pkg="org.hamcrest" />
     </subpackage>
 
     <subpackage name="state">

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -80,6 +80,11 @@ public interface KStream<K, V> {
      */
     <K1, V1> KStream<K1, V1> map(KeyValueMapper<K, V, KeyValue<K1, V1>> mapper);
 
+    <K1, V1> KStream<K1, V1> map(KeyValueMapper<K, V, KeyValue<K1, V1>> mapper,
+                                 Serde<K1> keySerde,
+                                 Serde<V1> valueSerde,
+                                 String topic);
+
     /**
      * Create a new instance of {@link KStream} by transforming the value of each element in this stream into a new value in the new stream.
      *

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -45,8 +45,6 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K> implements KGroup
 
     private static final String REDUCE_NAME = "KTABLE-REDUCE-";
 
-    private static final String REPARTITION_TOPIC_SUFFIX = "-repartition";
-
     protected final Serde<K> keySerde;
     protected final Serde<V> valSerde;
 
@@ -88,7 +86,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K> implements KGroup
         String sourceName = topology.newName(KStreamImpl.SOURCE_NAME);
         String funcName = topology.newName(functionName);
 
-        String topic = name + REPARTITION_TOPIC_SUFFIX;
+        String topic = name + KStreamImpl.REPARTITION_TOPIC_SUFFIX;
 
         Serializer<K> keySerializer = keySerde == null ? null : keySerde.serializer();
         Deserializer<K> keyDeserializer = keySerde == null ? null : keySerde.deserializer();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -190,7 +190,8 @@ public class TopologyBuilder {
     /**
      * Create a new builder.
      */
-    public TopologyBuilder() {}
+    public TopologyBuilder() {
+    }
 
     /**
      * Add a new source that consumes the named topics and forwards the records to child processor and/or sink nodes.
@@ -620,20 +621,33 @@ public class TopologyBuilder {
      * Returns the copartition groups.
      * A copartition group is a group of source topics that are required to be copartitioned.
      *
+     * @param applicationId
      * @return groups of topic names
      */
-    public Collection<Set<String>> copartitionGroups() {
+    public Collection<Set<String>> copartitionGroups(final String applicationId) {
         List<Set<String>> list = new ArrayList<>(copartitionSourceGroups.size());
         for (Set<String> nodeNames : copartitionSourceGroups) {
             Set<String> copartitionGroup = new HashSet<>();
             for (String node : nodeNames) {
                 String[] topics = nodeToSourceTopics.get(node);
                 if (topics != null)
-                    copartitionGroup.addAll(Arrays.asList(topics));
+                    copartitionGroup.addAll(convertInternalTopicNames(topics, applicationId));
             }
             list.add(Collections.unmodifiableSet(copartitionGroup));
         }
         return Collections.unmodifiableList(list);
+    }
+
+    private List<String> convertInternalTopicNames(String[] topics, String applicationId) {
+        final List<String> topicNames = new ArrayList<>();
+        for (String topic : topics) {
+            if (internalTopicNames.contains(topic)) {
+                topicNames.add(applicationId + "-" + topic);
+            } else {
+                topicNames.add(topic);
+            }
+        }
+        return topicNames;
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -264,7 +264,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             sourceTopicGroups.put(entry.getKey(), entry.getValue().sourceTopics);
             internalSourceTopicGroups.put(entry.getKey(), entry.getValue().interSourceTopics);
         }
-        Collection<Set<String>> copartitionTopicGroups = streamThread.builder.copartitionGroups();
+        Collection<Set<String>> copartitionTopicGroups = streamThread.builder.copartitionGroups(streamThread.applicationId);
 
         ensureCopartitioning(copartitionTopicGroups, internalSourceTopicGroups, metadata);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionMappedKeyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionMappedKeyTest.java
@@ -1,0 +1,195 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements.  See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.  You may obtain a
+ * copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedSingleNodeKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class KStreamRepartitionMappedKeyTest {
+
+    @Rule
+    public final EmbeddedSingleNodeKafkaCluster cluster = new EmbeddedSingleNodeKafkaCluster();
+    private final String streamOneInput = "streamOneInput";
+    private final String streamTwoInput = "streamTwo";
+
+    private final String outputTopic = "outputTopic";
+    private KStreamBuilder builder;
+    private Properties streamsConfiguration;
+
+
+    @Before
+    public void whenStarting() throws ExecutionException, InterruptedException {
+        cluster.createTopic(streamOneInput, 5, 1);
+        cluster.createTopic(streamTwoInput, 5, 1);
+        cluster.createTopic(outputTopic);
+
+        builder = new KStreamBuilder();
+
+        streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, "my-test");
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        streamsConfiguration.put(StreamsConfig.ZOOKEEPER_CONNECT_CONFIG, cluster.zKConnectString());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+
+    }
+
+    @Test
+    public void shouldMapToDifferentKeyAndJoin() throws ExecutionException, InterruptedException {
+        produceMessages();
+
+        final KStream<Long, Integer> streamOne = builder.stream(Serdes.Long(), Serdes.Integer(), streamOneInput);
+        final KStream<Integer, String> streamTwo = builder.stream(Serdes.Integer(), Serdes.String(), streamTwoInput);
+
+        streamOne.map(new KeyValueMapper<Long, Integer, KeyValue<Integer, Integer>>() {
+            @Override
+            public KeyValue<Integer, Integer> apply(final Long key, final Integer value) {
+                return new KeyValue<>(value, value);
+            }
+        }, Serdes.Integer(), Serdes.Integer(), "the-key-mapped-topic")
+                .join(streamTwo, new ValueJoiner<Integer, String, String>() {
+                    @Override
+                    public String apply(final Integer value1, final String value2) {
+                        return value1 + ":" + value2;
+                    }
+                }, JoinWindows.of("the-join").within(60 * 1000), Serdes.Integer(), Serdes.Integer(), Serdes.String())
+                .to(Serdes.Integer(), Serdes.String(), outputTopic);
+
+
+        final KafkaStreams kafkaStreams = new KafkaStreams(builder, streamsConfiguration);
+        kafkaStreams.start();
+
+        final List<String> expected = Arrays.asList("1:A", "2:B", "3:C", "4:D", "5:E");
+        final List<String> received = receiveMessages(new StringDeserializer(), 5);
+        Collections.sort(received);
+        assertThat(received, is(expected));
+    }
+
+
+//    @Test
+//    public void shouldSelectKeyAndJoin() throws ExecutionException, InterruptedException {
+//        produceMessages();
+//        final KStream<Long, Integer> streamOne = builder.stream(Serdes.Long(), Serdes.Integer(), streamOneInput);
+//        final KStream<Integer, String> streamTwo = builder.stream(Serdes.Integer(), Serdes.String(), streamTwoInput);
+//
+//        streamOne.selectKey(new KeyValueMapper<Long, Integer, Integer>() {
+//            @Override
+//            public Integer apply(final Long key, final Integer value) {
+//                return value;
+//            }
+//        }).join(streamTwo, new ValueJoiner<Integer, String, String>() {
+//            @Override
+//            public String apply(final Integer value1, final String value2) {
+//                return value1 + ":" + value2;
+//            }
+//        }, JoinWindows.of("the-join").within(60 * 1000), Serdes.Integer(), Serdes.Integer(), Serdes.String())
+//                .to(Serdes.Integer(), Serdes.String(), outputTopic);
+//
+//        final KafkaStreams kafkaStreams = new KafkaStreams(builder, streamsConfiguration);
+//        kafkaStreams.start();
+//
+//        final List<String> expected = Arrays.asList("1:A", "2:B", "3:C", "4:D", "5:E");
+//        final List<String> received = receiveMessages(new StringDeserializer(), 5);
+//        assertThat(received, is(expected));
+//    }
+
+
+    private void produceMessages() throws ExecutionException, InterruptedException {
+        IntegrationTestUtils.produceKeyValuesSynchronously(streamOneInput,
+                Arrays.asList(
+                        new KeyValue<>(10L, 1),
+                        new KeyValue<>(5L, 2),
+                        new KeyValue<>(12L, 3),
+                        new KeyValue<>(15L, 4),
+                        new KeyValue<>(20L, 5)),
+                IntegrationTestUtils.producerConfig(cluster.bootstrapServers(),
+                        LongSerializer.class,
+                        IntegerSerializer.class,
+                        new Properties()));
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(streamTwoInput,
+                Arrays.asList(
+                        new KeyValue<>(1, "A"),
+                        new KeyValue<>(2, "B"),
+                        new KeyValue<>(3, "C"),
+                        new KeyValue<>(4, "D"),
+                        new KeyValue<>(5, "E")),
+                IntegrationTestUtils.producerConfig(cluster.bootstrapServers(),
+                        IntegerSerializer.class,
+                        StringSerializer.class,
+                        new Properties()));
+    }
+
+
+    private List<String> receiveMessages(final Deserializer<?> valueDeserializer,
+                                         final int numMessages) {
+        final Properties consumerProperties = new Properties();
+        consumerProperties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+        consumerProperties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "kstream-test");
+        consumerProperties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        final KafkaConsumer<Integer, ?>
+                consumer =
+                new KafkaConsumer<>(consumerProperties, new IntegerDeserializer(), valueDeserializer);
+        consumer.subscribe(Collections.singleton(outputTopic));
+
+        final List<String> received = new ArrayList<>();
+        final long now = System.currentTimeMillis();
+        while (received.size() != numMessages
+                && System.currentTimeMillis() - now < TimeUnit.MILLISECONDS
+                .convert(1, TimeUnit.MINUTES)) {
+            final ConsumerRecords<Integer, ?> records = consumer.poll(10);
+            for (final ConsumerRecord<Integer, ?> record : records) {
+                received.add(record.value().toString());
+            }
+        }
+        consumer.close();
+        return received;
+    }
+
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedSingleNodeKafkaCluster.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedSingleNodeKafkaCluster.java
@@ -19,12 +19,12 @@ package org.apache.kafka.streams.integration.utils;
 
 import kafka.server.KafkaConfig$;
 import kafka.zk.EmbeddedZookeeper;
+import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Properties;
-import org.junit.rules.ExternalResource;
 
 /**
  * Runs an in-memory, "embedded" Kafka cluster with 1 ZooKeeper instance and 1 Kafka broker.

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.utils.Utils;
@@ -225,5 +226,19 @@ public class IntegrationTestUtils {
                     " records before timeout " + waitTime + " ms");
             Thread.sleep(Math.min(waitTime, 100L));
         }
+    }
+
+    public static Properties producerConfig(final String bootstrapServers,
+                                            final Class keySerializer,
+                                            final Class valueSerializer,
+                                            final Properties additional) {
+        final Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        properties.put(ProducerConfig.ACKS_CONFIG, "all");
+        properties.put(ProducerConfig.RETRIES_CONFIG, 0);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer);
+        properties.putAll(additional);
+        return properties;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
@@ -76,6 +76,7 @@ public class KafkaEmbedded {
         KafkaConfig kafkaConfig = new KafkaConfig(effectiveConfig, loggingEnabled);
         log.debug("Starting embedded Kafka broker (with log.dirs={} and ZK ensemble at {}) ...",
             logDir, zookeeperConnect());
+        System.out.println(logDir);
         kafka = TestUtils.createServer(kafkaConfig, SystemTime$.MODULE$);
         log.debug("Startup of embedded Kafka broker at {} completed (with ZK ensemble at {}) ...",
             brokerList(), zookeeperConnect());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -80,7 +80,7 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(stream2, MockValueJoiner.STRING_JOINER, JoinWindows.of("test").within(100), intSerde, stringSerde, stringSerde);
         joined.process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
@@ -178,7 +178,7 @@ public class KStreamKStreamJoinTest {
         joined = stream1.outerJoin(stream2, MockValueJoiner.STRING_JOINER, JoinWindows.of("test").within(100), intSerde, stringSerde, stringSerde);
         joined.process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
@@ -278,7 +278,7 @@ public class KStreamKStreamJoinTest {
         joined = stream1.join(stream2, MockValueJoiner.STRING_JOINER, JoinWindows.of("test").within(100), intSerde, stringSerde, stringSerde);
         joined.process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -81,7 +81,7 @@ public class KStreamKStreamLeftJoinTest {
         joined = stream1.leftJoin(stream2, MockValueJoiner.STRING_JOINER, JoinWindows.of("test").within(100), intSerde, stringSerde);
         joined.process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
@@ -159,7 +159,7 @@ public class KStreamKStreamLeftJoinTest {
         joined = stream1.leftJoin(stream2, MockValueJoiner.STRING_JOINER, JoinWindows.of("test").within(100), intSerde, stringSerde);
         joined.process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
@@ -80,7 +80,7 @@ public class KStreamKTableLeftJoinTest {
         table = builder.table(intSerde, stringSerde, topic2);
         stream.leftJoin(table, MockValueJoiner.STRING_JOINER).process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
@@ -83,7 +83,7 @@ public class KTableKTableJoinTest {
         joined = table1.join(table2, MockValueJoiner.STRING_JOINER);
         joined.toStream().process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -79,7 +79,7 @@ public class KTableKTableLeftJoinTest {
         processor = new MockProcessorSupplier<>();
         joined.toStream().process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoinTest.java
@@ -83,7 +83,7 @@ public class KTableKTableOuterJoinTest {
         joined = table1.outerJoin(table2, MockValueJoiner.STRING_JOINER);
         joined.toStream().process(processor);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(1, copartitionGroups.size());
         assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -228,7 +228,7 @@ public class TopologyBuilderTest {
         assertEquals(3, topicGroups.size());
         assertEquals(expectedTopicGroups, topicGroups);
 
-        Collection<Set<String>> copartitionGroups = builder.copartitionGroups();
+        Collection<Set<String>> copartitionGroups = builder.copartitionGroups("applicationId");
 
         assertEquals(mkSet(mkSet("topic-1", "topic-1x", "topic-2")), new HashSet<>(copartitionGroups));
     }


### PR DESCRIPTION
@guozhangwang can you please take a look at this? It is not close to being done but i'd like some feedback to ensure i'm heading down the right path and understand what this JIRA is asking. The main things to look at are the `KStreamImpl.map(...)` method I added and the change made to `TopologyBuilder.copartitionGroups`

There is also a test, `KStreamRepartitionMappedKeyTest`, that passes with these changes.
