### PR TITLE
KAFKA-3775: Throttle maximum number of tasks assigned to a single KafkaStreams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -67,6 +67,10 @@ public class StreamsConfig extends AbstractConfig {
     public static final String NUM_STANDBY_REPLICAS_CONFIG = "num.standby.replicas";
     private static final String NUM_STANDBY_REPLICAS_DOC = "The number of standby replicas for each task.";
 
+    /** <code>max.tasks.assigned</code> */
+    public static final String MAX_TASKS_ASSIGNED = "max.tasks.assigned";
+    private static final String MAX_TASKS_ASSIGNED_DOC = "The maximum number of tasks that might be assigned to a KafkaStreams instance.";
+
     /** <code>buffered.records.per.partition</code> */
     public static final String BUFFERED_RECORDS_PER_PARTITION_CONFIG = "buffered.records.per.partition";
     private static final String BUFFERED_RECORDS_PER_PARTITION_DOC = "The maximum number of records to buffer per partition.";
@@ -183,6 +187,11 @@ public class StreamsConfig extends AbstractConfig {
                                         0,
                                         Importance.LOW,
                                         NUM_STANDBY_REPLICAS_DOC)
+                                .define(MAX_TASKS_ASSIGNED,
+                                        Type.INT,
+                                        Integer.MAX_VALUE,
+                                        Importance.MEDIUM,
+                                        MAX_TASKS_ASSIGNED_DOC)
                                 .define(BUFFERED_RECORDS_PER_PARTITION_CONFIG,
                                         Type.INT,
                                         1000,
@@ -231,6 +240,7 @@ public class StreamsConfig extends AbstractConfig {
         props.put(StreamsConfig.InternalConfig.STREAM_THREAD_INSTANCE, streamThread);
         props.put(StreamsConfig.REPLICATION_FACTOR_CONFIG, getInt(REPLICATION_FACTOR_CONFIG));
         props.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, getInt(NUM_STANDBY_REPLICAS_CONFIG));
+        props.put(StreamsConfig.MAX_TASKS_ASSIGNED, getInt(MAX_TASKS_ASSIGNED));
         props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamPartitionAssignor.class.getName());
 
         if (!getString(ZOOKEEPER_CONNECT_CONFIG).equals(""))

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -84,6 +84,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
     private StreamThread streamThread;
 
     private int numStandbyReplicas;
+    private int maxNumTasksPerProcessId;
     private Map<Integer, TopologyBuilder.TopicsInfo> topicGroups;
     private Map<TopicPartition, Set<TaskId>> partitionToTaskIds;
     private Map<String, Set<TaskId>> stateChangelogTopicToTaskIds;
@@ -101,6 +102,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
     @Override
     public void configure(Map<String, ?> configs) {
         numStandbyReplicas = (Integer) configs.get(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
+        maxNumTasksPerProcessId = (Integer) configs.get(StreamsConfig.MAX_TASKS_ASSIGNED);
 
         Object o = configs.get(StreamsConfig.InternalConfig.STREAM_THREAD_INSTANCE);
         if (o == null) {
@@ -331,7 +333,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         }
 
         // assign tasks to clients
-        states = TaskAssignor.assign(states, partitionsForTask.keySet(), numStandbyReplicas);
+        states = TaskAssignor.assign(states, partitionsForTask.keySet(), maxNumTasksPerProcessId, numStandbyReplicas);
         Map<String, Assignment> assignment = new HashMap<>();
 
         for (Map.Entry<UUID, Set<String>> entry : consumersByClient.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -69,4 +69,15 @@ public class ClientState<T> {
         this.cost += cost;
     }
 
+    @Override
+    public String toString() {
+        return "ClientState{" +
+               "activeTasks=" + activeTasks +
+               ", assignedTasks=" + assignedTasks +
+               ", prevActiveTasks=" + prevActiveTasks +
+               ", prevAssignedTasks=" + prevAssignedTasks +
+               ", capacity=" + capacity +
+               ", cost=" + cost +
+               '}';
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -201,9 +201,6 @@ public class StreamPartitionAssignorTest {
         allActiveTasks.addAll(info20.activeTasks);
 
         assertEquals(3, allActiveTasks.size());
-        assertEquals(allTasks, new HashSet<>(allActiveTasks));
-
-        assertEquals(3, allActiveTasks.size());
         assertEquals(allTasks, allActiveTasks);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/TaskAssignorTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 
 import static org.apache.kafka.common.utils.Utils.mkList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -286,4 +287,22 @@ public class TaskAssignorTest {
         }
     }
 
+    @Test
+    public void testAssignWithLimitedMaxPartitions() {
+        final int numProcessors = 2;
+        final int maxNumTasksPerState = 2;
+
+        HashMap<Integer, ClientState<Integer>> states = new HashMap<>();
+        for (int i = 0; i < numProcessors; i++) {
+            states.put(i, new ClientState<Integer>(1));
+        }
+
+        Set<Integer> tasks = mkSet(0, 1, 2, 3, 4);
+        Map<Integer, ClientState<Integer>> assignments = TaskAssignor.assign(states, tasks, maxNumTasksPerState, 0);
+
+        assertEquals(numProcessors, assignments.size());
+        for (ClientState<Integer> state : assignments.values()) {
+            assertEquals(maxNumTasksPerState, state.assignedTasks.size());
+        }
+    }
 }


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/KAFKA-3775

POC. Discussion in progress.
