### PR TITLE
KAFKA-3783: Catch proper exception on path delete

### DIFF
--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -515,7 +515,7 @@ class ZkUtils(val zkClient: ZkClient,
 
   /**
     * Conditional delete the persistent path data, return true if it succeeds,
-    * otherwise (the current version is not the expected version)
+    * false otherwise (the current version is not the expected version)
     */
    def conditionalDeletePath(path: String, expectedVersion: Int): Boolean = {
     try {

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -522,7 +522,7 @@ class ZkUtils(val zkClient: ZkClient,
       zkClient.delete(path, expectedVersion)
       true
     } catch {
-      case e: KeeperException.BadVersionException => false
+      case e: ZkBadVersionException => false
     }
   }
 

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
@@ -336,7 +336,7 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
       aclId % 10 != 0
     }.toSet
 
-    TestUtils.assertConcurrent("Should support many concurrent calls", concurrentFuctions, 15000)
+    TestUtils.assertConcurrent("Should support many concurrent calls", concurrentFuctions, 30 * 1000)
 
     TestUtils.waitAndVerifyAcls(expectedAcls, simpleAclAuthorizer, commonResource)
     TestUtils.waitAndVerifyAcls(expectedAcls, simpleAclAuthorizer2, commonResource)
@@ -354,7 +354,7 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
       }
     }
 
-    TestUtils.assertConcurrent("Should support many concurrent calls", concurrentFuctions, 15000)
+    TestUtils.assertConcurrent("Should support many concurrent calls", concurrentFuctions, 30 * 1000)
 
     TestUtils.waitAndVerifyAcls(Set.empty[Acl], simpleAclAuthorizer, resource)
     TestUtils.waitAndVerifyAcls(Set.empty[Acl], simpleAclAuthorizer2, resource)

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
@@ -342,6 +342,24 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
     TestUtils.waitAndVerifyAcls(expectedAcls, simpleAclAuthorizer2, commonResource)
   }
 
+  @Test
+  def testHighConcurrencyDeletionOfResourceAcls() {
+    val acl = new Acl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, username), Allow, WildCardHost, All)
+
+    // Alternate authorizer to keep adding and removing zookeeper path
+    val concurrentFuctions = (0 to 50).map { i =>
+      () => {
+        simpleAclAuthorizer.addAcls(Set(acl), resource)
+        simpleAclAuthorizer2.removeAcls(Set(acl), resource)
+      }
+    }
+
+    TestUtils.assertConcurrent("Should support many concurrent calls", concurrentFuctions, 15000)
+
+    TestUtils.waitAndVerifyAcls(Set.empty[Acl], simpleAclAuthorizer, resource)
+    TestUtils.waitAndVerifyAcls(Set.empty[Acl], simpleAclAuthorizer2, resource)
+  }
+
   private def changeAclAndVerify(originalAcls: Set[Acl], addedAcls: Set[Acl], removedAcls: Set[Acl], resource: Resource = resource): Set[Acl] = {
     var acls = originalAcls
 

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.utils
+
+import java.util.UUID
+
+import kafka.zk.ZooKeeperTestHarness
+import org.junit.Assert._
+import org.junit.Test
+
+class ZkUtilsTest extends ZooKeeperTestHarness {
+
+  @Test
+  def testSuccessfulConditionalDeletePath() {
+    // Given an existing path
+    val randomPath = "/" + UUID.randomUUID()
+    zkUtils.createPersistentPath(randomPath)
+    val (_, statAfterCreation) = zkUtils.readData(randomPath)
+
+    // Deletion is successful when the version number matches
+    assertTrue("Deletion should be successful", zkUtils.conditionalDeletePath(randomPath, statAfterCreation.getVersion()))
+    val (optionalData, _) = zkUtils.readDataMaybeNull(randomPath)
+    assertTrue("Node should be deleted", optionalData.isEmpty)
+
+    // Deletion is successful when the node does not exist too
+    assertTrue("Deletion should be successful", zkUtils.conditionalDeletePath(randomPath, 0))
+  }
+
+  @Test
+  def testAbortedConditionalDeletePath() {
+    // Given an existing path that gets updated
+    val randomPath = "/" + UUID.randomUUID()
+    zkUtils.createPersistentPath(randomPath)
+    val (_, statAfterCreation) = zkUtils.readData(randomPath)
+    zkUtils.updatePersistentPath(randomPath, "data")
+
+    // Deletion is aborted when the version number does not match
+    assertFalse("Deletion should be aborted", zkUtils.conditionalDeletePath(randomPath, statAfterCreation.getVersion))
+    val (optionalData, _) = zkUtils.readDataMaybeNull(randomPath)
+    assertTrue("Node should still be there", optionalData.isDefined)
+  }
+}

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -15,9 +15,7 @@
  * limitations under the License.
  */
 
-package unit.kafka.utils
-
-import java.util.UUID
+package kafka.utils
 
 import kafka.zk.ZooKeeperTestHarness
 import org.junit.Assert._
@@ -25,33 +23,33 @@ import org.junit.Test
 
 class ZkUtilsTest extends ZooKeeperTestHarness {
 
+  val path = "/path"
+
   @Test
   def testSuccessfulConditionalDeletePath() {
     // Given an existing path
-    val randomPath = "/" + UUID.randomUUID()
-    zkUtils.createPersistentPath(randomPath)
-    val (_, statAfterCreation) = zkUtils.readData(randomPath)
+    zkUtils.createPersistentPath(path)
+    val (_, statAfterCreation) = zkUtils.readData(path)
 
     // Deletion is successful when the version number matches
-    assertTrue("Deletion should be successful", zkUtils.conditionalDeletePath(randomPath, statAfterCreation.getVersion()))
-    val (optionalData, _) = zkUtils.readDataMaybeNull(randomPath)
+    assertTrue("Deletion should be successful", zkUtils.conditionalDeletePath(path, statAfterCreation.getVersion))
+    val (optionalData, _) = zkUtils.readDataMaybeNull(path)
     assertTrue("Node should be deleted", optionalData.isEmpty)
 
     // Deletion is successful when the node does not exist too
-    assertTrue("Deletion should be successful", zkUtils.conditionalDeletePath(randomPath, 0))
+    assertTrue("Deletion should be successful", zkUtils.conditionalDeletePath(path, 0))
   }
 
   @Test
   def testAbortedConditionalDeletePath() {
     // Given an existing path that gets updated
-    val randomPath = "/" + UUID.randomUUID()
-    zkUtils.createPersistentPath(randomPath)
-    val (_, statAfterCreation) = zkUtils.readData(randomPath)
-    zkUtils.updatePersistentPath(randomPath, "data")
+    zkUtils.createPersistentPath(path)
+    val (_, statAfterCreation) = zkUtils.readData(path)
+    zkUtils.updatePersistentPath(path, "data")
 
     // Deletion is aborted when the version number does not match
-    assertFalse("Deletion should be aborted", zkUtils.conditionalDeletePath(randomPath, statAfterCreation.getVersion))
-    val (optionalData, _) = zkUtils.readDataMaybeNull(randomPath)
+    assertFalse("Deletion should be aborted", zkUtils.conditionalDeletePath(path, statAfterCreation.getVersion))
+    val (optionalData, _) = zkUtils.readDataMaybeNull(path)
     assertTrue("Node should still be there", optionalData.isDefined)
   }
 }


### PR DESCRIPTION
- ZkClient is used for conditional path deletion and wraps `KeeperException.BadVersionException` into `ZkBadVersionException`
- add unit test to `SimpleAclAuthorizerTest` to reproduce the issue and catch potential future regression
