### PR TITLE
MINOR: Move `ConsoleProducerTest` to the unit test directory

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -17,12 +17,10 @@
 
 package kafka.tools
 
-import kafka.producer
-import kafka.tools.ConsoleProducer.LineMessageReader
+import kafka.producer.ProducerConfig
+import ConsoleProducer.LineMessageReader
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.junit.Assert
-import org.junit.Test
-
+import org.junit.{Assert, Test}
 
 class ConsoleProducerTest {
 
@@ -47,20 +45,21 @@ class ConsoleProducerTest {
     val config = new ConsoleProducer.ProducerConfig(validArgs)
     // New ProducerConfig constructor is package private, so we can't call it directly
     // Creating new Producer to validate instead
-    new KafkaProducer[Array[Byte],Array[Byte]](ConsoleProducer.getNewProducerProps(config))
+    val producer = new KafkaProducer(ConsoleProducer.getNewProducerProps(config))
+    producer.close()
   }
 
   @Test
   @deprecated("This test has been deprecated and it will be removed in a future release.", "0.10.0.0")
   def testValidConfigsOldProducer() {
     val config = new ConsoleProducer.ProducerConfig(validArgs)
-    new producer.ProducerConfig(ConsoleProducer.getOldProducerProps(config))
+    new ProducerConfig(ConsoleProducer.getOldProducerProps(config))
   }
 
   @Test
   def testInvalidConfigs() {
     try {
-      val config = new ConsoleProducer.ProducerConfig(invalidArgs)
+      new ConsoleProducer.ProducerConfig(invalidArgs)
       Assert.fail("Should have thrown an UnrecognizedOptionException")
     } catch {
       case e: joptsimple.OptionException => // expected exception


### PR DESCRIPTION
Included a couple of clean-ups: removed unused variable and the instantiated `KafkaProducer` is now closed.
