### PR TITLE
KAFKA-3762 Log.loadSegments() should log the message in exception

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -194,10 +194,9 @@ class Log(val dir: File,
               segment.index.sanityCheck()
           } catch {
             case e: java.lang.IllegalArgumentException =>
-              warn("Found a corrupted index file, %s, deleting and rebuilding index...".format(indexFile.getAbsolutePath))
+              error("Found a corrupted index file, %s, deleting and rebuilding index.".format(indexFile.getAbsolutePath), e)
               indexFile.delete()
               segment.recover(config.maxMessageSize)
-              error("Corrupted Index File", e)
           }
         }
         else {

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -194,7 +194,7 @@ class Log(val dir: File,
               segment.index.sanityCheck()
           } catch {
             case e: java.lang.IllegalArgumentException =>
-              error("Found a corrupted index file, %s, deleting and rebuilding index.".format(indexFile.getAbsolutePath), e)
+              warn("Found a corrupted index file, %s, deleting and rebuilding index.".format(indexFile.getAbsolutePath), e)
               indexFile.delete()
               segment.recover(config.maxMessageSize)
           }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -197,6 +197,7 @@ class Log(val dir: File,
               warn("Found a corrupted index file, %s, deleting and rebuilding index...".format(indexFile.getAbsolutePath))
               indexFile.delete()
               segment.recover(config.maxMessageSize)
+              error("Corrupted Index File", e)
           }
         }
         else {

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -194,7 +194,7 @@ class Log(val dir: File,
               segment.index.sanityCheck()
           } catch {
             case e: java.lang.IllegalArgumentException =>
-              warn("Found a corrupted index file, %s, deleting and rebuilding index.".format(indexFile.getAbsolutePath), e)
+              warn("Found a corrupted index file, %s, deleting and rebuilding index. Error Message: %s".format(indexFile.getAbsolutePath, e.getMessage))
               indexFile.delete()
               segment.recover(config.maxMessageSize)
           }


### PR DESCRIPTION
Adding an error logging message in Log.loadSegments() in the case when an index file corresponding to a log file exists but an exception is thrown.

Signed-off-by: Ishita Mandhan imandha@us.ibm.com
