### PR TITLE
MINOR: Pass absolute directory path to RocksDB.open

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -212,7 +212,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         try {
             if (ttl == TTL_NOT_USED) {
                 dir.getParentFile().mkdirs();
-                return RocksDB.open(options, dir.toString());
+                return RocksDB.open(options, dir.getAbsolutePath());
             } else {
                 throw new UnsupportedOperationException("Change log is not supported for store " + this.name + " since it is TTL based.");
                 // TODO: support TTL with change log?


### PR DESCRIPTION
The method `RocksDB.open` assumes an absolute file path. If a relative path is configured, it leads to an exception like the following:

```
org.apache.kafka.streams.errors.ProcessorStateException: Error opening store CustomerIdToUserIdLookup at location ./tmp/rocksdb/CustomerIdToUserIdLookup
    at org.rocksdb.RocksDB.open(Native Method)
    at org.rocksdb.RocksDB.open(RocksDB.java:183)
    at org.apache.kafka.streams.state.internals.RocksDBStore.openDB(RocksDBStore.java:214)
    at org.apache.kafka.streams.state.internals.RocksDBStore.openDB(RocksDBStore.java:165)
    at org.apache.kafka.streams.state.internals.RocksDBStore.init(RocksDBStore.java:170)
    at org.apache.kafka.streams.state.internals.MeteredKeyValueStore.init(MeteredKeyValueStore.java:85)
    at org.apache.kafka.test.KStreamTestDriver.<init>(KStreamTestDriver.java:64)
    at org.apache.kafka.test.KStreamTestDriver.<init>(KStreamTestDriver.java:50)
    at com.simple.estuary.transform.streaming.CartesianTransactionEnrichmentJobTest.testBuilder(CartesianTransactionEnrichmentJobTest.java:41)
```

Is there any risk to always fetching the absolute path as proposed here?

Let me know if you think this requires a JIRA issue or a unit test. I started working on a unit test, but don't know of a great solution for writing out a file to a relative directory.

This contribution is my original work and I license the work to the project under the project's open source license.
