### PR TITLE
MINOR: Fix a variable name semantically correct.

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/ThroughputThrottler.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ThroughputThrottler.java
@@ -72,8 +72,8 @@ public class ThroughputThrottler {
             return false;
         }
 
-        float elapsedMs = (sendStartMs - startMs) / 1000.f;
-        return elapsedMs > 0 && (amountSoFar / elapsedMs) > this.targetThroughput;
+        float elapsedSec = (sendStartMs - startMs) / 1000.f;
+        return elapsedSec > 0 && (amountSoFar / elapsedSec) > this.targetThroughput;
     }
 
     /**


### PR DESCRIPTION
Hi all,
This is my first commit to Kafka.

"msec / 1000" turns into sec, isn't it?
I just have fixed a variable name.
@granders 
