### PR TITLE
KAFKA-3805: Check if DB is null.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/StateStore.java
@@ -46,7 +46,9 @@ public interface StateStore {
     void flush();
 
     /**
-     * Close the storage engine
+     * Close the storage engine.
+     * Note that this function needs to be idempotent since it may be called
+     * several times on the same state store.
      */
     void close();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -134,9 +134,7 @@ public class ProcessorStateManager {
             retry--;
             lock = lockStateDirectory(channel);
         }
-        if (lock == null) {
-            channel.close();
-        }
+
         return lock;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -134,7 +134,11 @@ public class ProcessorStateManager {
             retry--;
             lock = lockStateDirectory(channel);
         }
-
+        // TODO: closing the channel here risks releasing all locks on the file
+        // see {@link https://issues.apache.org/jira/browse/KAFKA-3812}
+        if (lock == null) {
+            channel.close();
+        }
         return lock;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -338,6 +338,8 @@ public class ProcessorStateManager {
      */
     public void close(Map<TopicPartition, Long> ackedOffsets) throws IOException {
         try {
+            // attempting to flush and close the stores, just in case they
+            // are not closed by a ProcessorNode yet
             if (!stores.isEmpty()) {
                 log.debug("Closing stores.");
                 for (Map.Entry<String, StateStore> entry : stores.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -407,6 +407,10 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public void flush() {
+        if (db == null) {
+            return;
+        }
+
         // flush of the cache entries if necessary
         flushCache();
 
@@ -427,6 +431,11 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public void close() {
+
+        if (db == null) {
+            return;
+        }
+
         flush();
         options.dispose();
         wOptions.dispose();


### PR DESCRIPTION
- Check if DB is null before flushing or closing. In some cases, a state store is closed twice. This happens in `StreamTask.close()` where both `node.close()` and `super.close` (in `ProcessorManager`) are called in a sequence. If the user's processor defines a `close` that closes the underlying state store, then the second close will be redundant.
