### PR TITLE
KAFKA-3802 log mtimes reset on broker restart / shutdown

### DIFF
--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -333,6 +333,7 @@ class FileMessageSet private[kafka](@volatile var file: File,
   /**
    * Truncate this file message set to the given size in bytes. Note that this API does no checking that the
    * given size falls on a valid message boundary.
+   * It is expected that no other threads will do writes to the log when this function is called.
    * @param targetSize The size to truncate to.
    * @return The number of bytes truncated off
    */

--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -341,7 +341,7 @@ class FileMessageSet private[kafka](@volatile var file: File,
     if(targetSize > originalSize || targetSize < 0)
       throw new KafkaException("Attempt to truncate log segment to " + targetSize + " bytes failed, " +
                                " size of this log segment is " + originalSize + " bytes.")
-    if (targetSize != channel.size()) {
+    if (targetSize != channel.size().toInt) {
       channel.truncate(targetSize)
       channel.position(targetSize)
       _size.set(targetSize)

--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -54,12 +54,12 @@ class FileMessageSet private[kafka](@volatile var file: File,
     if(isSlice)
       new AtomicInteger(end - start) // don't check the file size if this is just a slice view
     else
-      new AtomicInteger(math.min(channel.size().toInt, end) - start)
+      new AtomicInteger(math.min(channel.size.toInt, end) - start)
 
   /* if this is not a slice, update the file pointer to the end of the file */
   if (!isSlice)
     /* set the file position to the last byte in the file */
-    channel.position(math.min(channel.size().toInt, end))
+    channel.position(math.min(channel.size.toInt, end))
 
   /**
    * Create a file message set with no slicing.
@@ -157,7 +157,7 @@ class FileMessageSet private[kafka](@volatile var file: File,
    */
   def writeTo(destChannel: GatheringByteChannel, writePosition: Long, size: Int): Int = {
     // Ensure that the underlying size has not changed.
-    val newSize = math.min(channel.size().toInt, end) - start
+    val newSize = math.min(channel.size.toInt, end) - start
     if (newSize < _size.get()) {
       throw new KafkaException("Size of FileMessageSet %s has been truncated during write: old size %d, new size %d"
         .format(file.getAbsolutePath, _size.get(), newSize))
@@ -342,7 +342,7 @@ class FileMessageSet private[kafka](@volatile var file: File,
     if(targetSize > originalSize || targetSize < 0)
       throw new KafkaException("Attempt to truncate log segment to " + targetSize + " bytes failed, " +
                                " size of this log segment is " + originalSize + " bytes.")
-    if (targetSize != channel.size().toInt) {
+    if (targetSize != channel.size.toInt) {
       channel.truncate(targetSize)
       channel.position(targetSize)
       _size.set(targetSize)

--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -341,9 +341,11 @@ class FileMessageSet private[kafka](@volatile var file: File,
     if(targetSize > originalSize || targetSize < 0)
       throw new KafkaException("Attempt to truncate log segment to " + targetSize + " bytes failed, " +
                                " size of this log segment is " + originalSize + " bytes.")
-    channel.truncate(targetSize)
-    channel.position(targetSize)
-    _size.set(targetSize)
+    if (targetSize != channel.size()) {
+      channel.truncate(targetSize)
+      channel.position(targetSize)
+      _size.set(targetSize)
+    }
     originalSize - targetSize
   }
 

--- a/core/src/test/scala/unit/kafka/log/FileMessageSetTest.scala
+++ b/core/src/test/scala/unit/kafka/log/FileMessageSetTest.scala
@@ -162,8 +162,8 @@ class FileMessageSetTest extends BaseMessageSetTestCases {
   def testTruncateNotCalledIfSizeIsSameAsTargetSize() {
     val channelMock = EasyMock.createMock(classOf[FileChannel])
 
-    EasyMock.expect(channelMock.size).andReturn(42L).times(3) // in constructor and method
-    EasyMock.expect(channelMock.position(42L)).andReturn(null) // constructor
+    EasyMock.expect(channelMock.size).andReturn(42L).atLeastOnce()
+    EasyMock.expect(channelMock.position(42L)).andReturn(null)
     EasyMock.replay(channelMock)
 
     val msgSet = new FileMessageSet(tempFile(), channelMock)
@@ -179,7 +179,7 @@ class FileMessageSetTest extends BaseMessageSetTestCases {
   def testTruncateIfSizeIsDifferentToTargetSize() {
     val channelMock = EasyMock.createMock(classOf[FileChannel])
 
-    EasyMock.expect(channelMock.size).andReturn(42L).times(3)
+    EasyMock.expect(channelMock.size).andReturn(42L).atLeastOnce()
     EasyMock.expect(channelMock.position(42L)).andReturn(null).once()
     EasyMock.expect(channelMock.truncate(23L)).andReturn(null).once()
     EasyMock.expect(channelMock.position(23L)).andReturn(null).once()

--- a/core/src/test/scala/unit/kafka/log/FileMessageSetTest.scala
+++ b/core/src/test/scala/unit/kafka/log/FileMessageSetTest.scala
@@ -162,7 +162,7 @@ class FileMessageSetTest extends BaseMessageSetTestCases {
   def testTruncateNotCalledIfSizeIsSameAsTargetSize() {
     val channelMock = EasyMock.createMock(classOf[FileChannel])
 
-    EasyMock.expect(channelMock.size()).andReturn(42L).times(3) // in constructor and method
+    EasyMock.expect(channelMock.size).andReturn(42L).times(3) // in constructor and method
     EasyMock.expect(channelMock.position(42L)).andReturn(null) // constructor
     EasyMock.replay(channelMock)
 
@@ -179,7 +179,7 @@ class FileMessageSetTest extends BaseMessageSetTestCases {
   def testTruncateIfSizeIsDifferentToTargetSize() {
     val channelMock = EasyMock.createMock(classOf[FileChannel])
 
-    EasyMock.expect(channelMock.size()).andReturn(42L).times(3)
+    EasyMock.expect(channelMock.size).andReturn(42L).times(3)
     EasyMock.expect(channelMock.position(42L)).andReturn(null).once()
     EasyMock.expect(channelMock.truncate(23L)).andReturn(null).once()
     EasyMock.expect(channelMock.position(23L)).andReturn(null).once()


### PR DESCRIPTION
There seems to be a bug in the JDK that on some versions the mtime of
the file is modified on FileChannel.truncate() even if the javadoc states
`If the given size is greater than or equal to the file's current size then
 the file is not modified.`.

This causes problems with log retention, as all the files then look like
they contain recent data to Kafka. Therefore this is only done if the channel size is different to the target size.
