### PR TITLE
KAFKA-3830; getTGT() debug logging exposes confidential information

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -334,7 +334,8 @@ public class KerberosLogin extends AbstractLogin {
         for (KerberosTicket ticket : tickets) {
             KerberosPrincipal server = ticket.getServer();
             if (server.getName().equals("krbtgt/" + server.getRealm() + "@" + server.getRealm())) {
-                log.debug("Found TGT {}.", ticket);
+                log.debug("Found TGT with client principal '{}' and server principal '{}'.", ticket.getClient().getName(),
+                        ticket.getServer().getName());
                 return ticket;
             }
         }


### PR DESCRIPTION
Only log the client and server principals, which is what ZooKeeper does after ZOOKEEPER-2405.
