### PR TITLE
MINOR: Expose window store sequence number

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreUtils.java
@@ -62,4 +62,8 @@ public class WindowStoreUtils {
     public static long timestampFromBinaryKey(byte[] binaryKey) {
         return ByteBuffer.wrap(binaryKey).getLong(binaryKey.length - TIMESTAMP_SIZE - SEQNUM_SIZE);
     }
+
+    public static int sequenceNumberFromBinaryKey(byte[] binaryKey) {
+        return ByteBuffer.wrap(binaryKey).getInt(binaryKey.length - SEQNUM_SIZE);
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreUtilsTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WindowStoreUtilsTest {
+    protected StateSerdes<String, String> serdes = new StateSerdes<>("dummy", new Serdes.StringSerde(), new Serdes.StringSerde());
+
+    @Test
+    public void testSerialization() throws Exception {
+        final String key = "key1";
+        final long timestamp = 99L;
+        final int seqNum = 3;
+        byte[] bytes = WindowStoreUtils.toBinaryKey(key, timestamp, seqNum, serdes);
+        final String parsedKey = WindowStoreUtils.keyFromBinaryKey(bytes, serdes);
+        final long parsedTs = WindowStoreUtils.timestampFromBinaryKey(bytes);
+        final int parsedSeqNum = WindowStoreUtils.sequenceNumberFromBinaryKey(bytes);
+        assertEquals(key, parsedKey);
+        assertEquals(timestamp, parsedTs);
+        assertEquals(seqNum, parsedSeqNum);
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreUtilsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WindowStoreUtilsTest.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class WindowStoreUtilsTest {
     protected StateSerdes<String, String> serdes = new StateSerdes<>("dummy", new Serdes.StringSerde(), new Serdes.StringSerde());


### PR DESCRIPTION
@guozhangwang @mjsax @enothereska 

Currently, Kafka Streams does not have a util to get access to the sequence number added to the key of windows state store changelogs.  I'm interested in exposing it so the the contents of a changelog topic can be 1) inspected for debugging purposes and 2) saved to text file and loaded from text file
