### PR TITLE
MINOR: Small enhancement to Deserializer Javadoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
@@ -34,7 +34,7 @@ public interface Deserializer<T> extends Closeable {
     /**
      * Deserialize a record value from a bytearray into a value or object.
      * @param topic topic associated with the data
-     * @param data serialized bytes; may be null. If null, implementations should return null.
+     * @param data serialized bytes; may be null; implementations are recommended to handle null by returning a value or null rather than throwing an exception.
      * @return deserialized typed data; may be null
      */
     public T deserialize(String topic, byte[] data);

--- a/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Deserializer.java
@@ -32,10 +32,10 @@ public interface Deserializer<T> extends Closeable {
     public void configure(Map<String, ?> configs, boolean isKey);
     
     /**
-     *
+     * Deserialize a record value from a bytearray into a value or object.
      * @param topic topic associated with the data
-     * @param data serialized bytes
-     * @return deserialized typed data
+     * @param data serialized bytes; may be null. If null, implementations should return null.
+     * @return deserialized typed data; may be null
      */
     public T deserialize(String topic, byte[] data);
 


### PR DESCRIPTION
I’ve implemented my own custom Deserializer and been using it with `KStream.reduceByKey`; I observed that `reduceByKey` was passing null to my implementation, but it wasn’t clear to me what my implementation was expected to do in this case. So this attempts to clarify it.

This is my original work and I license this work to the Kafka project under Kafka’s open source license (the Apache License 2.0).
