### PR TITLE
KAFKA-3864: make field.get return field's default value when needed

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -85,8 +85,8 @@ public class Struct {
      */
     public Object get(Field field) {
         Object val = values[field.index()];
-        if (val == null && schema.defaultValue() != null) {
-            val = schema.defaultValue();
+        if (val == null && field.schema().defaultValue() != null) {
+            val = field.schema().defaultValue();
         }
         return val;
     }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 public class StructTest {
 
@@ -158,6 +159,20 @@ public class StructTest {
         Schema schema = SchemaBuilder.struct().field("field", DEFAULT_FIELD_SCHEMA).build();
         Struct struct = new Struct(schema);
         struct.validate();
+    }
+
+    @Test
+    public void testMissingFieldWithDefaultValue() {
+        Schema schema = SchemaBuilder.struct().field("field", DEFAULT_FIELD_SCHEMA).build();
+        Struct struct = new Struct(schema);
+        assertEquals((byte) 0, struct.get("field"));
+    }
+
+    @Test
+    public void testMissingFieldWithoutDefaultValue() {
+        Schema schema = SchemaBuilder.struct().field("field", REQUIRED_FIELD_SCHEMA).build();
+        Struct struct = new Struct(schema);
+        assertNull(struct.get("field"));
     }
 
 


### PR DESCRIPTION
And not the containing struct's default value.

The contribution is my original work and that I license the work to the project under the project's open source license.

@ewencp 
