### PR TITLE
KAFKA-3890 Kafka Streams: task assignment is not maintained on cluster restart or rolling restart

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -69,4 +69,14 @@ public class ClientState<T> {
         this.cost += cost;
     }
 
+    @Override
+    public String toString() {
+        return "[activeTasks: (" + activeTasks +
+            ") assignedTasks: (" + assignedTasks +
+            ") prevActiveTasks: (" + prevActiveTasks +
+            ") prevAssignedTasks: (" + prevAssignedTasks +
+            ") capacity: " + capacity +
+            " cost: " + cost +
+            "]";
+    }
 }


### PR DESCRIPTION
Current task assignment in TaskAssignor is not deterministic.

During cluster restart or rolling restart, we have the same set of participating worker nodes.  But the current TaskAssignor is not able to maintain a deterministic mapping, so about 20% partitions will be reassigned which would cause state repopulation.
When the topology of work nodes (# of worker nodes, the TaskIds they are carrying with) is not changed, we really just want to keep the old task assignment.

Add the code to check whether the node topology is changing or not:
- when the prevAssignedTasks from the old clientStates is the same as the new task list
- when there is no new node joining (its prevAssignTasks would be either empty or conflict with some other nodes)
- when there is no node dropping out (the total of prevAssignedTasks from other nodes would not be equal to the new task list)

When the topology is not changing, we would just use the old mapping.

I also added the code to check whether the previous assignment is balanced (whether each node's task list is within [1/2 average -- 2 \* average]), if it's not balanced, we will still start the a new task assignment.
