### PR TITLE
KAFKA-3892 prune metadata response to subscribed topics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -166,7 +166,7 @@ public final class Metadata {
             listener.onMetadataUpdate(cluster);
 
         // Do this after notifying listeners as subscribed topics' list can be changed by listeners
-        this.cluster = this.needMetadataForAllTopics ? getClusterForCurrentTopics(cluster) : cluster;
+        this.cluster = getClusterForCurrentTopics(cluster);
 
         notifyAll();
         log.debug("Updated cluster metadata version {} to {}", this.version, this.cluster);

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -90,7 +90,7 @@ public class MetadataTest {
             partitionInfos.addAll(topic.availablePartitionsForTopic(topic.topics().iterator().next()));
         }
 
-        metadata.update(new Cluster(nodes, partitionInfos, new HashSet<>()), 0);
+        metadata.update(new Cluster(nodes, partitionInfos, new HashSet<String>()), 0);
 
         assertEquals(2, metadata.fetch().topics().size());
         assertNull(metadata.fetch().partitionsForTopic("bar"));

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -94,6 +94,7 @@ public class FetcherTest {
 
     @Before
     public void setup() throws Exception {
+        metadata.add(topicName);
         metadata.update(cluster, time.milliseconds());
         client.setNode(node);
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -75,6 +75,7 @@ public class SenderTest {
 
     @Before
     public void setup() {
+        metadata.add(tp.topic());
         metadata.update(cluster, time.milliseconds());
         metricTags.put("client-id", CLIENT_ID);
     }


### PR DESCRIPTION
I believe this will cause clients to defensively prune their cluster metadata in all cases. It doesn't address why a client without a Pattern subscription would receive a response containing all topics and partitions for the cluster (which is still undesirable, but I am guessing would require a fix for the broker.)

In my own testing, this restored the amount of heap required to 0.8 consumer levels.

I am concerned that I do not 100% understand all the uses of this class. My assumption is that only topics that have been added are expected in the response and that the two unit test modifications I needed to make were oversights.

I am also assuming that this behavior was only applied to the pattern matching case to avoid a small amount of (presumed) unnecessary work and not for correctness reasons.
