### PR TITLE
KAFKA-3727 - ClientListener for UnknownTopicOrPartitionException

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientListener.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientListener.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.clients;
+
+import java.util.Map;
+
+import org.apache.kafka.common.protocol.Errors;
+
+public interface ClientListener {
+
+    void onMetadataErrors(Map<String, Errors> topicErrors);
+
+    void onClientException(Exception e);
+
+}

--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -133,4 +133,6 @@ public interface KafkaClient extends Closeable {
      */
     public void wakeup();
 
+    public void addListener(ClientListener clientListener);
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -12,6 +12,7 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.clients.ClientListener;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
@@ -1437,5 +1438,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     private void release() {
         if (refcount.decrementAndGet() == 0)
             currentThread.set(NO_CURRENT_THREAD);
+    }
+
+    public void addListener(ClientListener clientListener) {
+        fetcher.addListener(clientListener);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -12,6 +12,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.clients.ClientListener;
 import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.KafkaClient;
@@ -426,5 +427,9 @@ public class ConsumerNetworkClient implements Closeable {
                 complete(response);
             }
         }
+    }
+
+    public void addListener(ClientListener clientListener) {
+        client.addListener(clientListener);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.utils.Time;
@@ -66,6 +67,7 @@ public class MockClient implements KafkaClient {
     private final Queue<ClientRequest> requests = new ArrayDeque<>();
     private final Queue<ClientResponse> responses = new ArrayDeque<>();
     private final Queue<FutureResponse> futureResponses = new ArrayDeque<>();
+    private final List<ClientListener> listeners = new ArrayList<>();
 
     public MockClient(Time time) {
         this.time = time;
@@ -285,4 +287,12 @@ public class MockClient implements KafkaClient {
         boolean matches(ClientRequest request);
     }
 
+    private <T> void fireListeners(Map<String, Errors> errors) {
+        for (ClientListener listener : listeners)
+            listener.onMetadataErrors(errors);
+    }
+
+    public void addListener(ClientListener listener) {
+        this.listeners.add(listener);
+    }
 }


### PR DESCRIPTION
Added a ClientListener to KafkaConsumer, Fetcher and Client

Modified Fetcher and NetworkClient to notify listeners for Unknown Topic
or Partition

Added unit test
