### PR TITLE
MINOR: fix grammatical errors in DataException message

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -161,7 +161,7 @@ public class JsonConverter implements Converter {
                 Map<Object, Object> result = new HashMap<>();
                 if (schema == null || keySchema.type() == Schema.Type.STRING) {
                     if (!value.isObject())
-                        throw new DataException("Map's with string fields should be encoded as JSON objects, but found " + value.getNodeType());
+                        throw new DataException("Maps with string fields should be encoded as JSON objects, but found " + value.getNodeType());
                     Iterator<Map.Entry<String, JsonNode>> fieldIt = value.fields();
                     while (fieldIt.hasNext()) {
                         Map.Entry<String, JsonNode> entry = fieldIt.next();
@@ -169,7 +169,7 @@ public class JsonConverter implements Converter {
                     }
                 } else {
                     if (!value.isArray())
-                        throw new DataException("Map's with non-string fields should be encoded as JSON array of tuples, but found " + value.getNodeType());
+                        throw new DataException("Maps with non-string fields should be encoded as JSON array of tuples, but found " + value.getNodeType());
                     for (JsonNode entry : value) {
                         if (!entry.isArray())
                             throw new DataException("Found invalid map entry instead of array tuple: " + entry.getNodeType());


### PR DESCRIPTION
Was just reading kafka source code, my favourite Friday afternoon activity, when I found these small grammatical errors in some `DataException` messages.  

Could someone please review? @ewencp @dguy 
