### PR TITLE
KAFKA-3740: Add configs for RocksDBStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsMetrics;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Processor context interface.
@@ -160,4 +161,27 @@ public interface ProcessorContext {
      * @return the timestamp
      */
     long timestamp();
+
+    /**
+     * Returns all the application config properties as key/value pairs.
+     *
+     * The config properties are defined in the {@link org.apache.kafka.streams.StreamsConfig}
+     * object and associated to the ProcessorContext.
+     *
+     * @return all the key/values from the StreamsConfig properties
+     */
+    Map<String, Object> appConfigs();
+
+    /**
+     * Returns all the application config properties with the given key prefix, as key/value pairs
+     * stripping the prefix.
+     *
+     * The config properties are defined in the {@link org.apache.kafka.streams.StreamsConfig}
+     * object and associated to the ProcessorContext.
+     *
+     * @param prefix the properties prefix
+     * @return the key/values matching the given prefix from the StreamsConfig properties.
+     *
+     */
+    Map<String, Object> appConfigsWithPrefix(String prefix);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.TaskId;
 
 import java.io.File;
+import java.util.Map;
 
 public class ProcessorContextImpl implements ProcessorContext, RecordCollector.Supplier {
 
@@ -38,6 +39,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
     private final RecordCollector collector;
     private final ProcessorStateManager stateMgr;
 
+    private final StreamsConfig config;
     private final Serde<?> keySerde;
     private final Serde<?> valSerde;
 
@@ -56,6 +58,7 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
         this.collector = collector;
         this.stateMgr = stateMgr;
 
+        this.config = config;
         this.keySerde = config.keySerde();
         this.valSerde = config.valueSerde();
 
@@ -205,5 +208,15 @@ public class ProcessorContextImpl implements ProcessorContext, RecordCollector.S
     @Override
     public void schedule(long interval) {
         task.schedule(interval);
+    }
+
+    @Override
+    public Map<String, Object> appConfigs() {
+        return config.originals();
+    }
+
+    @Override
+    public Map<String, Object> appConfigsWithPrefix(String prefix) {
+        return config.originalsWithPrefix(prefix);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 
 import java.io.File;
+import java.util.Map;
 
 public class StandbyContextImpl implements ProcessorContext, RecordCollector.Supplier {
 
@@ -34,6 +35,7 @@ public class StandbyContextImpl implements ProcessorContext, RecordCollector.Sup
     private final StreamsMetrics metrics;
     private final ProcessorStateManager stateMgr;
 
+    private final StreamsConfig config;
     private final Serde<?> keySerde;
     private final Serde<?> valSerde;
 
@@ -49,6 +51,7 @@ public class StandbyContextImpl implements ProcessorContext, RecordCollector.Sup
         this.metrics = metrics;
         this.stateMgr = stateMgr;
 
+        this.config = config;
         this.keySerde = config.keySerde();
         this.valSerde = config.valueSerde();
 
@@ -187,5 +190,15 @@ public class StandbyContextImpl implements ProcessorContext, RecordCollector.Sup
     @Override
     public void schedule(long interval) {
         throw new UnsupportedOperationException("this should not happen: schedule() not supported in standby tasks.");
+    }
+
+    @Override
+    public Map<String, Object> appConfigs() {
+        return config.originals();
+    }
+
+    @Override
+    public Map<String, Object> appConfigsWithPrefix(String prefix) {
+        return config.originalsWithPrefix(prefix);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -251,6 +251,16 @@ public class KeyValueStoreTestDriver<K, V> {
             public File stateDir() {
                 return stateDir;
             }
+
+            @Override
+            public Map<String, Object> appConfigs() {
+                return null;
+            }
+
+            @Override
+            public Map<String, Object> appConfigsWithPrefix(String prefix) {
+                return null;
+            }
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -189,6 +189,16 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
         return this.timestamp;
     }
 
+    @Override
+    public Map<String, Object> appConfigs() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> appConfigsWithPrefix(String prefix) {
+        return null;
+    }
+
     public Map<String, StateStore> allStateStores() {
         return Collections.unmodifiableMap(storeMap);
     }


### PR DESCRIPTION
This is the part I of the work to add the StreamsConfig to ProcessorContext.

We need to access StreamsConfig in the ProcessorContext so other components (e.g. RocksDBWindowStore or LRUCache can retrieve config parameter from application)
