### PR TITLE
KAFKA-3906 - Connect logical types do not support nulls.

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Date.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Date.java
@@ -58,19 +58,41 @@ public class Date {
     public static Integer fromLogical(Schema schema, java.util.Date value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Date object but the schema does not match.");
-        Calendar calendar = Calendar.getInstance(UTC);
-        calendar.setTime(value);
-        if (calendar.get(Calendar.HOUR_OF_DAY) != 0 || calendar.get(Calendar.MINUTE) != 0 ||
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Date object but the schema is not nullable and a null was supplied.");
+
+        Integer result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            Calendar calendar = Calendar.getInstance(UTC);
+            calendar.setTime(value);
+            if (calendar.get(Calendar.HOUR_OF_DAY) != 0 || calendar.get(Calendar.MINUTE) != 0 ||
                 calendar.get(Calendar.SECOND) != 0 || calendar.get(Calendar.MILLISECOND) != 0) {
-            throw new DataException("Kafka Connect Date type should not have any time fields set to non-zero values.");
+                throw new DataException("Kafka Connect Date type should not have any time fields set to non-zero values.");
+            }
+            long unixMillis = calendar.getTimeInMillis();
+            result = (int) (unixMillis / MILLIS_PER_DAY);
         }
-        long unixMillis = calendar.getTimeInMillis();
-        return (int) (unixMillis / MILLIS_PER_DAY);
+
+        return result;
     }
 
     public static java.util.Date toLogical(Schema schema, Integer value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Date object but the schema does not match.");
-        return new java.util.Date(value * MILLIS_PER_DAY);
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Date object but the schema is not nullable and a null was supplied.");
+
+        java.util.Date result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            result = new java.util.Date(value * MILLIS_PER_DAY);
+        }
+
+        return result;
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Date.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Date.java
@@ -55,7 +55,7 @@ public class Date {
      * @param value the logical value
      * @return the encoded value
      */
-    public static int fromLogical(Schema schema, java.util.Date value) {
+    public static Integer fromLogical(Schema schema, java.util.Date value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Date object but the schema does not match.");
         Calendar calendar = Calendar.getInstance(UTC);
@@ -68,7 +68,7 @@ public class Date {
         return (int) (unixMillis / MILLIS_PER_DAY);
     }
 
-    public static java.util.Date toLogical(Schema schema, int value) {
+    public static java.util.Date toLogical(Schema schema, Integer value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Date object but the schema does not match.");
         return new java.util.Date(value * MILLIS_PER_DAY);

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Decimal.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Decimal.java
@@ -65,13 +65,35 @@ public class Decimal {
      * @return the encoded value
      */
     public static byte[] fromLogical(Schema schema, BigDecimal value) {
-        if (value.scale() != scale(schema))
-            throw new DataException("BigDecimal has mismatching scale value for given Decimal schema");
-        return value.unscaledValue().toByteArray();
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Decimal object but the schema is not nullable and a null was supplied.");
+
+        byte[] result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            if (value.scale() != scale(schema))
+                throw new DataException("BigDecimal has mismatching scale value for given Decimal schema");
+            result = value.unscaledValue().toByteArray();
+        }
+
+        return result;
     }
 
     public static BigDecimal toLogical(Schema schema, byte[] value) {
-        return new BigDecimal(new BigInteger(value), scale(schema));
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Decimal object but the schema is not nullable and a null was supplied.");
+
+        BigDecimal result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            result = new BigDecimal(new BigInteger(value), scale(schema));
+        }
+
+        return result;
     }
 
     private static int scale(Schema schema) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Time.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Time.java
@@ -58,20 +58,42 @@ public class Time {
     public static Integer fromLogical(Schema schema, java.util.Date value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Time object but the schema does not match.");
-        Calendar calendar = Calendar.getInstance(UTC);
-        calendar.setTime(value);
-        long unixMillis = calendar.getTimeInMillis();
-        if (unixMillis < 0 || unixMillis > MILLIS_PER_DAY) {
-            throw new DataException("Kafka Connect Time type should not have any date fields set to non-zero values.");
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Time object but the schema is not nullable and a null was supplied.");
+
+        Integer result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            Calendar calendar = Calendar.getInstance(UTC);
+            calendar.setTime(value);
+            long unixMillis = calendar.getTimeInMillis();
+            if (unixMillis < 0 || unixMillis > MILLIS_PER_DAY) {
+                throw new DataException("Kafka Connect Time type should not have any date fields set to non-zero values.");
+            }
+            result = (int) unixMillis;
         }
-        return (int) unixMillis;
+
+        return result;
     }
 
     public static java.util.Date toLogical(Schema schema, Integer value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Date object but the schema does not match.");
-        if (value  < 0 || value > MILLIS_PER_DAY)
-            throw new DataException("Time values must use number of milliseconds greater than 0 and less than 86400000");
-        return new java.util.Date(value);
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Date object but the schema is not nullable and a null was supplied.");
+
+        java.util.Date result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            if (value  < 0 || value > MILLIS_PER_DAY)
+                throw new DataException("Time values must use number of milliseconds greater than 0 and less than 86400000");
+            result = new java.util.Date(value);
+        }
+
+        return result;
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Time.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Time.java
@@ -55,7 +55,7 @@ public class Time {
      * @param value the logical value
      * @return the encoded value
      */
-    public static int fromLogical(Schema schema, java.util.Date value) {
+    public static Integer fromLogical(Schema schema, java.util.Date value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Time object but the schema does not match.");
         Calendar calendar = Calendar.getInstance(UTC);
@@ -67,7 +67,7 @@ public class Time {
         return (int) unixMillis;
     }
 
-    public static java.util.Date toLogical(Schema schema, int value) {
+    public static java.util.Date toLogical(Schema schema, Integer value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Date object but the schema does not match.");
         if (value  < 0 || value > MILLIS_PER_DAY)

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Timestamp.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Timestamp.java
@@ -50,13 +50,13 @@ public class Timestamp {
      * @param value the logical value
      * @return the encoded value
      */
-    public static long fromLogical(Schema schema, java.util.Date value) {
+    public static Long fromLogical(Schema schema, java.util.Date value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Timestamp object but the schema does not match.");
         return value.getTime();
     }
 
-    public static java.util.Date toLogical(Schema schema, long value) {
+    public static java.util.Date toLogical(Schema schema, Long value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Timestamp object but the schema does not match.");
         return new java.util.Date(value);

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Timestamp.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Timestamp.java
@@ -53,12 +53,34 @@ public class Timestamp {
     public static Long fromLogical(Schema schema, java.util.Date value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Timestamp object but the schema does not match.");
-        return value.getTime();
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Timestamp object but the schema is not nullable and a null was supplied.");
+
+        Long result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            result = value.getTime();
+        }
+
+        return result;
     }
 
     public static java.util.Date toLogical(Schema schema, Long value) {
         if (schema.name() == null || !(schema.name().equals(LOGICAL_NAME)))
             throw new DataException("Requested conversion of Timestamp object but the schema does not match.");
-        return new java.util.Date(value);
+        if (!schema.isOptional() && null == value)
+            throw new DataException("Requested conversion of Timestamp object but the schema is not nullable and a null was supplied.");
+
+        java.util.Date result;
+
+        if (schema.isOptional() && null == value) {
+            result = null;
+        } else {
+            result = new java.util.Date(value);
+        }
+
+        return result;
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DateTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DateTest.java
@@ -25,6 +25,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DateTest {
     private static final GregorianCalendar EPOCH;
@@ -51,8 +52,8 @@ public class DateTest {
 
     @Test
     public void testFromLogical() {
-        assertEquals(0, Date.fromLogical(Date.SCHEMA, EPOCH.getTime()));
-        assertEquals(10000, Date.fromLogical(Date.SCHEMA, EPOCH_PLUS_TEN_THOUSAND_DAYS.getTime()));
+        assertEquals((Integer) 0, Date.fromLogical(Date.SCHEMA, EPOCH.getTime()));
+        assertEquals((Integer) 10000, Date.fromLogical(Date.SCHEMA, EPOCH_PLUS_TEN_THOUSAND_DAYS.getTime()));
     }
 
     @Test(expected = DataException.class)
@@ -74,5 +75,19 @@ public class DateTest {
     @Test(expected = DataException.class)
     public void testToLogicalInvalidSchema() {
         Date.toLogical(Date.builder().name("invalid").build(), 0);
+    }
+
+    @Test
+    public void testToLogicalNull() {
+        Schema nullableSchema = Date.builder().optional().build();
+        java.util.Date actual = Date.toLogical(nullableSchema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test
+    public void testFromLogicalNull() {
+        Schema nullableSchema = Date.builder().optional().build();
+        Integer actual = Date.fromLogical(nullableSchema, null);
+        assertNull("actual should be null.", actual);
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DateTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DateTest.java
@@ -78,15 +78,29 @@ public class DateTest {
     }
 
     @Test
-    public void testToLogicalNull() {
+    public void testToLogicalNullValue() {
         Schema nullableSchema = Date.builder().optional().build();
         java.util.Date actual = Date.toLogical(nullableSchema, null);
         assertNull("actual should be null.", actual);
     }
 
+    @Test(expected = DataException.class)
+    public void testToLogicalNullValueNonOptionalSchema() {
+        Schema nullableSchema = Date.builder().build();
+        java.util.Date actual = Date.toLogical(nullableSchema, null);
+        assertNull("actual should be null.", actual);
+    }
+
     @Test
-    public void testFromLogicalNull() {
+    public void testFromLogicalNullValue() {
         Schema nullableSchema = Date.builder().optional().build();
+        Integer actual = Date.fromLogical(nullableSchema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test(expected = DataException.class)
+    public void testFromLogicalNullValueNonOptionalSchema() {
+        Schema nullableSchema = Date.builder().build();
         Integer actual = Date.fromLogical(nullableSchema, null);
         assertNull("actual should be null.", actual);
     }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.connect.data;
 
+
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -25,6 +26,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class DecimalTest {
     private static final int TEST_SCALE = 2;
@@ -60,4 +62,20 @@ public class DecimalTest {
         converted = Decimal.toLogical(schema, TEST_BYTES_NEGATIVE);
         assertEquals(TEST_DECIMAL_NEGATIVE, converted);
     }
+
+    @Test
+    public void testFromLogicalNull() {
+        Schema schema = Decimal.builder(2).optional().build();
+        byte[] actual = Decimal.fromLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test
+    public void testToLogicalNull() {
+        Schema schema = Decimal.builder(2).optional().build();
+        BigDecimal actual = Decimal.toLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/DecimalTest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.connect.data;
 
 
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
 import java.math.BigDecimal;
@@ -64,18 +65,30 @@ public class DecimalTest {
     }
 
     @Test
-    public void testFromLogicalNull() {
+    public void testFromLogicalNullValue() {
         Schema schema = Decimal.builder(2).optional().build();
         byte[] actual = Decimal.fromLogical(schema, null);
         assertNull("actual should be null.", actual);
     }
 
+    @Test(expected = DataException.class)
+    public void testFromLogicalNullValueNonOptionalSchema() {
+        Schema schema = Decimal.builder(2).build();
+        byte[] actual = Decimal.fromLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
     @Test
-    public void testToLogicalNull() {
+    public void testToLogicalNullValue() {
         Schema schema = Decimal.builder(2).optional().build();
         BigDecimal actual = Decimal.toLogical(schema, null);
         assertNull("actual should be null.", actual);
     }
 
-
+    @Test(expected = DataException.class)
+    public void testToLogicalNullValueNonOptionalSchema() {
+        Schema schema = Decimal.builder(2).build();
+        BigDecimal actual = Decimal.toLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimeTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimeTest.java
@@ -25,6 +25,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TimeTest {
     private static final GregorianCalendar EPOCH;
@@ -53,8 +54,8 @@ public class TimeTest {
 
     @Test
     public void testFromLogical() {
-        assertEquals(0, Time.fromLogical(Time.SCHEMA, EPOCH.getTime()));
-        assertEquals(10000, Time.fromLogical(Time.SCHEMA, EPOCH_PLUS_TEN_THOUSAND_MILLIS.getTime()));
+        assertEquals((Integer) 0, Time.fromLogical(Time.SCHEMA, EPOCH.getTime()));
+        assertEquals((Integer) 10000, Time.fromLogical(Time.SCHEMA, EPOCH_PLUS_TEN_THOUSAND_MILLIS.getTime()));
     }
 
     @Test(expected = DataException.class)
@@ -76,5 +77,19 @@ public class TimeTest {
     @Test(expected = DataException.class)
     public void testToLogicalInvalidSchema() {
         Time.toLogical(Time.builder().name("invalid").build(), 0);
+    }
+
+    @Test
+    public void testFromLogicalNull() {
+        Schema schema = Timestamp.builder().optional().build();
+        Integer actual = Time.fromLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test
+    public void testToLogicalNull() {
+        Schema schema = Timestamp.builder().optional().build();
+        java.util.Date actual = Time.toLogical(schema, null);
+        assertNull("actual should be null.", actual);
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimeTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimeTest.java
@@ -80,15 +80,29 @@ public class TimeTest {
     }
 
     @Test
-    public void testFromLogicalNull() {
-        Schema schema = Timestamp.builder().optional().build();
+    public void testFromLogicalNullValue() {
+        Schema schema = Time.builder().optional().build();
+        Integer actual = Time.fromLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test(expected = DataException.class)
+    public void testFromLogicalNullValueNonOptionalSchema() {
+        Schema schema = Time.builder().build();
         Integer actual = Time.fromLogical(schema, null);
         assertNull("actual should be null.", actual);
     }
 
     @Test
-    public void testToLogicalNull() {
-        Schema schema = Timestamp.builder().optional().build();
+    public void testToLogicalNullValue() {
+        Schema schema = Time.builder().optional().build();
+        java.util.Date actual = Time.toLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test(expected = DataException.class)
+    public void testToLogicalNullValueNonOptionalSchema() {
+        Schema schema = Time.builder().build();
         java.util.Date actual = Time.toLogical(schema, null);
         assertNull("actual should be null.", actual);
     }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampTest.java
@@ -81,6 +81,13 @@ public class TimestampTest {
         assertNull("actual should be null.", actual);
     }
 
+    @Test(expected = DataException.class)
+    public void testFromLogicalNullNonOptionalSchema() {
+        Schema schema = Timestamp.builder().build();
+        Long actual = Timestamp.fromLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
     @Test
     public void testToLogicalNull() {
         Schema schema = Timestamp.builder().optional().build();
@@ -88,4 +95,10 @@ public class TimestampTest {
         assertNull("actual should be null.", actual);
     }
 
+    @Test(expected = DataException.class)
+    public void testToLogicalNullNonOptionalSchema() {
+        Schema schema = Timestamp.builder().build();
+        java.util.Date actual = Timestamp.toLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/TimestampTest.java
@@ -25,6 +25,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TimestampTest {
     private static final GregorianCalendar EPOCH;
@@ -53,8 +54,8 @@ public class TimestampTest {
 
     @Test
     public void testFromLogical() {
-        assertEquals(0L, Timestamp.fromLogical(Timestamp.SCHEMA, EPOCH.getTime()));
-        assertEquals(TOTAL_MILLIS, Timestamp.fromLogical(Timestamp.SCHEMA, EPOCH_PLUS_MILLIS.getTime()));
+        assertEquals((Long) 0L, Timestamp.fromLogical(Timestamp.SCHEMA, EPOCH.getTime()));
+        assertEquals((Long) TOTAL_MILLIS, Timestamp.fromLogical(Timestamp.SCHEMA, EPOCH_PLUS_MILLIS.getTime()));
     }
 
     @Test(expected = DataException.class)
@@ -72,4 +73,19 @@ public class TimestampTest {
     public void testToLogicalInvalidSchema() {
         Date.toLogical(Date.builder().name("invalid").build(), 0);
     }
+
+    @Test
+    public void testFromLogicalNull() {
+        Schema schema = Timestamp.builder().optional().build();
+        Long actual = Timestamp.fromLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
+    @Test
+    public void testToLogicalNull() {
+        Schema schema = Timestamp.builder().optional().build();
+        java.util.Date actual = Timestamp.toLogical(schema, null);
+        assertNull("actual should be null.", actual);
+    }
+
 }


### PR DESCRIPTION
Initial commit with failing unit tests for proposed functionality.
