### PR TITLE
KAFKA-3904: File descriptor leaking (Too many open files) for long ru…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -30,10 +30,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,10 +53,13 @@ public class ProcessorStateManager {
     public static final String CHECKPOINT_FILE_NAME = ".checkpoint";
     public static final String LOCK_FILE_NAME = ".lock";
 
+    private static final Map<File, FileChannel> CHANNELS = new HashMap<>();
+
     private final String applicationId;
     private final int defaultPartition;
     private final Map<String, TopicPartition> partitionForTopic;
     private final File baseDir;
+    private final File directoryLockFile;
     private final FileLock directoryLock;
     private final Map<String, StateStore> stores;
     private final Set<String> loggingEnabled;
@@ -90,6 +93,7 @@ public class ProcessorStateManager {
         createStateDirectory(baseDir);
 
         // try to acquire the exclusive lock on the state directory
+        directoryLockFile = new File(baseDir, ProcessorStateManager.LOCK_FILE_NAME);
         directoryLock = lockStateDirectory(baseDir, 5);
         if (directoryLock == null) {
             throw new IOException("Failed to lock the state directory: " + baseDir.getCanonicalPath());
@@ -122,7 +126,16 @@ public class ProcessorStateManager {
 
     private static FileLock lockStateDirectory(File stateDir, int retry) throws IOException {
         File lockFile = new File(stateDir, ProcessorStateManager.LOCK_FILE_NAME);
-        FileChannel channel = new RandomAccessFile(lockFile, "rw").getChannel();
+        FileChannel channel = null;
+        synchronized (CHANNELS) {
+            channel = CHANNELS.get(lockFile);
+            if (channel == null) {
+                channel = FileChannel.open(lockFile.toPath(),
+                    StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+                CHANNELS.put(lockFile, channel);
+                log.debug("Creating new channel: {} for file: {}", channel, lockFile);
+            }
+        }
 
         FileLock lock = lockStateDirectory(channel);
         while (lock == null && retry > 0) {
@@ -133,11 +146,6 @@ public class ProcessorStateManager {
             }
             retry--;
             lock = lockStateDirectory(channel);
-        }
-        // TODO: closing the channel here risks releasing all locks on the file
-        // see {@link https://issues.apache.org/jira/browse/KAFKA-3812}
-        if (lock == null) {
-            channel.close();
         }
         return lock;
     }
@@ -378,8 +386,11 @@ public class ProcessorStateManager {
             }
         } finally {
             // release the state directory directoryLock
-            directoryLock.release();
-            directoryLock.channel().close();
+            synchronized (CHANNELS) {
+                directoryLock.release();
+                directoryLock.channel().close();
+                CHANNELS.remove(directoryLockFile);
+            }
         }
     }
 


### PR DESCRIPTION
…nning stream process

I noticed when my application was running for more than one day, I will get 'Too many open files' error.

I used 'lsof' to list all the file descriptors used by the process, it's over 32K, but most of them belongs to the .lock file, e.g. a single lock file shows 2700 times.

I looked at the code, I think the problem is in:
    FileChannel channel = new RandomAccessFile(lockFile, "rw").getChannel();
Each time new RandomAccessFile is called, a new fd will be created.

Fix this by caching the FileChannels we created so far.
