### PR TITLE
KAFKA-3905:check collection elements in KafkaConsumer#subscribe.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -795,6 +795,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     public void subscribe(Collection<String> topics, ConsumerRebalanceListener listener) {
         acquire();
         try {
+            for (String topic : topics)
+                if (topic == null || topic.equals(""))
+                    throw new IllegalArgumentException("Topic collection shouldn't contain null or empty string");
             if (topics.isEmpty()) {
                 // treat subscribing to empty topic list as the same as unsubscribing
                 this.unsubscribe();


### PR DESCRIPTION
If topic collection has null or "" as its element, throw an IllegalArgumentException.
