### PR TITLE
KAFKA-3914: Global discovery of state stores

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -699,4 +699,7 @@ public class Utils {
             throw exception;
     }
 
+    public static int toPositive(int number) {
+        return number & 0x7fffffff;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -103,6 +103,9 @@ public class StreamsConfig extends AbstractConfig {
     public static final String VALUE_SERDE_CLASS_CONFIG = "value.serde";
     public static final String VALUE_SERDE_CLASS_DOC = "Serializer / deserializer class for value that implements the <code>Serde</code> interface.";
 
+    public static final String USER_ENDPOINT_CONFIG = "user.endpoint.config";
+    public static final String USER_ENDPOINT_DOC = "A user defined endpoint that can be used to connect to remote KafkaStreams instances";
+
     /** <code>metrics.sample.window.ms</code> */
     public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
 
@@ -213,7 +216,12 @@ public class StreamsConfig extends AbstractConfig {
                                         2,
                                         atLeast(1),
                                         Importance.LOW,
-                                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC);
+                                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC)
+                                .define(USER_ENDPOINT_CONFIG,
+                                        Type.STRING,
+                                        "",
+                                        Importance.LOW,
+                                        USER_ENDPOINT_DOC);
     }
 
     // this is the list of configs for underlying clients
@@ -271,6 +279,7 @@ public class StreamsConfig extends AbstractConfig {
         if (!getString(ZOOKEEPER_CONNECT_CONFIG).equals(""))
             props.put(StreamsConfig.ZOOKEEPER_CONNECT_CONFIG, getString(ZOOKEEPER_CONNECT_CONFIG));
 
+        props.put(USER_ENDPOINT_CONFIG, getString(USER_ENDPOINT_CONFIG));
         return props;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitioner.java
@@ -20,6 +20,8 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
+import static org.apache.kafka.common.utils.Utils.toPositive;
+
 public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Windowed<K>, V> {
 
     private final WindowedSerializer<K> serializer;
@@ -45,8 +47,5 @@ public class WindowedStreamPartitioner<K, V> implements StreamPartitioner<Window
         return toPositive(Utils.murmur2(keyBytes)) % numPartitions;
     }
 
-    private static int toPositive(int number) {
-        return number & 0x7fffffff;
-    }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/HostStateToTaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/HostStateToTaskMetadata.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TopologyBuilder;
+import org.apache.kafka.streams.state.HostState;
+import org.apache.kafka.streams.state.TaskMetadata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.toPositive;
+
+/**
+ * Provides a Mapping from {@link HostState} to {@link TaskMetadata}. This can be used
+ * to discovery the locations of {@link org.apache.kafka.streams.processor.StateStore}s
+ * in a KafkaStreams application
+ */
+public class HostStateToTaskMetadata {
+    private final Map<HostState, Set<TopicPartition>> hostToTopicPartition;
+    private final TopologyBuilder builder;
+    private final Map<String, List<TopicPartition>> partitionsByTopic;
+
+    public HostStateToTaskMetadata(final Map<HostState, Set<TopicPartition>> hostToTopicPartition,
+                                   final TopologyBuilder builder) {
+        this.hostToTopicPartition = hostToTopicPartition;
+        this.partitionsByTopic = getPartitionsByTopic();
+        this.builder = builder;
+    }
+
+    /**
+     * Find all of the {@link HostState}s and their associated {@link TaskMetadata} in a
+     * {@link KafkaStreams application}
+     * @return  all the {@link HostState}s in a {@link KafkaStreams} application and their corresponding
+     *          {@link TaskMetadata}
+     */
+    public Map<HostState, TaskMetadata> getAllTasks() {
+        final Map<HostState, TaskMetadata> results = new HashMap<>();
+        final Map<String, String> stateStoreNameToSourceTopics = builder.getStateStoreNameToSourceTopics();
+        for (final Map.Entry<String, String> entry : stateStoreNameToSourceTopics.entrySet()) {
+            createTasksForStore(entry.getKey(), results, partitionsByTopic.get(entry.getValue()));
+        }
+        return results;
+    }
+
+    /**
+     * Find all of the {@link HostState}s and their associated {@link TaskMetadata} for a given storeName
+     * @param storeName the storeName to find metadata for
+     * @return  A map containing {@link HostState} and {@link TaskMetadata} for the provided storeName
+     */
+    public Map<HostState, TaskMetadata> getAllTasksWithStore(final String storeName) {
+        if (storeName == null) {
+            throw new IllegalArgumentException("storeName cannot be null");
+        }
+        final String sourceTopic = builder.getStateStoreNameToSourceTopics().get(storeName);
+        if (sourceTopic == null) {
+            return Collections.emptyMap();
+        }
+        final Map<HostState, TaskMetadata> results = new HashMap<>();
+        createTasksForStore(storeName, results, partitionsByTopic.get(sourceTopic));
+        return results;
+
+    }
+
+    /**
+     * Find the {@link HostState} and its associated {@link TaskMetadata} for the
+     * given storeName and key. Note: the key may not exist in the {@link org.apache.kafka.streams.processor.StateStore},
+     * this method provides a way of finding which host it would exist on.
+     * @param storeName         Name of the store
+     * @param key               Key to use to for partition
+     * @param keySerializer     Serializer for the key
+     * @param <K>               key type
+     * @return  The {@link HostState} with its associated {@link TaskMetadata} for the storeName and key
+     */
+    public <K> Map<HostState, TaskMetadata> getTaskWithKey(final String storeName,
+                                                    final K key,
+                                                    final Serializer<K> keySerializer) {
+        if (keySerializer == null) {
+            throw new IllegalArgumentException("keySerializer cannot be null");
+        }
+
+        return getTaskWithKey(storeName, key, new StreamPartitioner<K, Object>() {
+            @Override
+            public Integer partition(final K key, final Object value, final int numPartitions) {
+                final String sourceTopic = builder.getStateStoreNameToSourceTopics().get(storeName);
+                final byte[] bytes = keySerializer.serialize(sourceTopic, key);
+                return toPositive(Utils.murmur2(bytes)) % numPartitions;
+            }
+        });
+    }
+
+    /**
+     * Find the {@link HostState} and its associated {@link TaskMetadata} for the
+     * given storeName and key. Note: the key may not exist in the {@link org.apache.kafka.streams.processor.StateStore},
+     * this method provides a way of finding which host it would exist on.
+     * @param storeName     Name of the store
+     * @param key           Key to use to for partition
+     * @param partitioner   partitioner to use to find correct partition for key
+     * @param <K>           key type
+     * @return The {@link HostState} with its associated {@link TaskMetadata} for the storeName and key
+     */
+    public <K> Map<HostState, TaskMetadata> getTaskWithKey(final String storeName,
+                                                    final K key,
+                                                    final StreamPartitioner<K, ?> partitioner) {
+        if (storeName == null) {
+            throw new IllegalArgumentException("storeName cannot be null");
+        }
+
+        if (key == null) {
+            throw new IllegalArgumentException("key cannot be null");
+        }
+
+        if (partitioner == null) {
+            throw new IllegalArgumentException("partitioner cannot be null");
+        }
+
+        final String sourceTopic = builder.getStateStoreNameToSourceTopics().get(storeName);
+        if (sourceTopic == null) {
+            return Collections.emptyMap();
+        }
+        final List<TopicPartition> allPartitions = partitionsByTopic.get(sourceTopic);
+        final Integer partition = partitioner.partition(key, null, allPartitions.size());
+        final Map<HostState, TaskMetadata> results = new HashMap<>();
+        createTasksForStore(storeName, results, Collections.singletonList(new TopicPartition(sourceTopic, partition)));
+        return results;
+    }
+
+
+    private void createTasksForStore(final String storeName,
+                                     final Map<HostState, TaskMetadata> results,
+                                     final List<TopicPartition> partitionsForTopic) {
+        for (final Map.Entry<HostState, Set<TopicPartition>> hostToPartitions : hostToTopicPartition.entrySet()) {
+            final Set<TopicPartition> partitionsForHost = new HashSet<>(hostToPartitions.getValue());
+            partitionsForHost.retainAll(partitionsForTopic);
+            if (partitionsForHost.isEmpty()) {
+                continue;
+            }
+
+            if (!results.containsKey(hostToPartitions.getKey())) {
+                results.put(hostToPartitions.getKey(), new TaskMetadata(Collections.<String>emptySet(), Collections.<TopicPartition>emptySet()));
+            }
+            final TaskMetadata taskMetadata = results.get(hostToPartitions.getKey());
+            partitionsForHost.addAll(taskMetadata.getTopicPartitions());
+            final HashSet<String> stateStoreNames = new HashSet<>();
+            stateStoreNames.add(storeName);
+            stateStoreNames.addAll(taskMetadata.getStateStoreNames());
+            results.put(hostToPartitions.getKey(), new TaskMetadata(stateStoreNames, partitionsForHost));
+        }
+    }
+
+    private Map<String, List<TopicPartition>> getPartitionsByTopic() {
+        final Map<String, List<TopicPartition>> topicPartitionByTopic = new HashMap<>();
+        for (final Set<TopicPartition> topicPartitions : hostToTopicPartition.values()) {
+            for (TopicPartition topicPartition : topicPartitions) {
+                if (!topicPartitionByTopic.containsKey(topicPartition.topic())) {
+                    topicPartitionByTopic.put(topicPartition.topic(), new ArrayList<TopicPartition>());
+                }
+                topicPartitionByTopic.get(topicPartition.topic()).add(topicPartition);
+            }
+        }
+        return topicPartitionByTopic;
+    }
+
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -43,6 +43,7 @@ import org.apache.kafka.streams.errors.TaskIdFormatException;
 import org.apache.kafka.streams.processor.PartitionGrouper;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
+import org.apache.kafka.streams.state.HostState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -550,6 +551,8 @@ public class StreamThread extends Thread {
         return tasks;
     }
 
+
+
     protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitions) {
         sensors.taskCreationSensor.record();
 
@@ -686,6 +689,13 @@ public class StreamThread extends Thread {
         } catch (Exception e) {
             log.error("Failed to remove standby tasks in thread [" + this.getName() + "]: ", e);
         }
+    }
+
+    public Map<HostState, Set<TopicPartition>> getPartitionsByHostState() {
+        if (partitionAssignor == null) {
+            return Collections.emptyMap();
+        }
+        return partitionAssignor.getPartitionsByHostState();
     }
 
     private class StreamsMetricsImpl implements StreamsMetrics {

--- a/streams/src/main/java/org/apache/kafka/streams/state/HostState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/HostState.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+
+/**
+ * Represents a user defined endpoint in a {@link org.apache.kafka.streams.KafkaStreams} application.
+ * Instances of this class can be obtained by calling one of:
+ *  {@link KafkaStreams#getAllTasks()}
+ *  {@link KafkaStreams#getAllTasksWithStore(String)}
+ *  {@link KafkaStreams#getTaskWithKey(String, Object, StreamPartitioner)}
+ *  {@link KafkaStreams#getTaskWithKey(String, Object, Serializer)}
+ *
+ *  The HostState is constructed during Partition Assignment
+ *  see {@link org.apache.kafka.streams.processor.internals.StreamPartitionAssignor}
+ *  It is extracted from the config {@link org.apache.kafka.streams.StreamsConfig#USER_ENDPOINT_CONFIG}
+ *
+ *  If developers wish to expose an endpoint in their KafkaStreams applications they should provide the above
+ *  config.
+ */
+public class HostState {
+    private final String host;
+    private final int port;
+
+    public HostState(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HostState hostState = (HostState) o;
+
+        if (port != hostState.port) return false;
+        return host.equals(hostState.host);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = host.hashCode();
+        result = 31 * result + port;
+        return result;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public String toString() {
+        return "HostState{" +
+                "host='" + host + '\'' +
+                ", port=" + port +
+                '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/TaskMetadata.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents all the {@link org.apache.kafka.streams.processor.StateStore} instances
+ * and {@link TopicPartition}s that can be found on particular instance/process of
+ * a {@link org.apache.kafka.streams.KafkaStreams} application
+ */
+public class TaskMetadata {
+    private final Set<String> stateStoreNames = new HashSet<>();
+    private final Set<TopicPartition> topicPartitions = new HashSet<>();
+
+    public TaskMetadata(final Set<String> stateStoreNames,
+                        final Set<TopicPartition> topicPartitions) {
+        this.stateStoreNames.addAll(stateStoreNames);
+        this.topicPartitions.addAll(topicPartitions);
+    }
+
+    public Set<String> getStateStoreNames() {
+        return Collections.unmodifiableSet(stateStoreNames);
+    }
+
+    public Set<TopicPartition> getTopicPartitions() {
+        return Collections.unmodifiableSet(topicPartitions);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TaskMetadata that = (TaskMetadata) o;
+
+        if (!stateStoreNames.equals(that.stateStoreNames)) return false;
+        return topicPartitions.equals(that.topicPartitions);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = stateStoreNames.hashCode();
+        result = 31 * result + topicPartitions.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskMetadata{" +
+                "stateStoreNames=" + stateStoreNames +
+                ", topicPartitions=" + topicPartitions +
+                '}';
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -339,4 +339,26 @@ public class TopologyBuilderTest {
         return nodeNames;
     }
 
+    @Test
+    public void shouldAssociateStateStoreNameWithInternalSourceTopic() throws Exception {
+        final TopologyBuilder builder = new TopologyBuilder();
+        builder.addSource("source", "topic");
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addStateStore(new MockStateStoreSupplier("store", false), true, "processor");
+        final Map<String, String> stateStoreNameToSourceTopic = builder.getStateStoreNameToSourceTopics();
+        assertEquals(1, stateStoreNameToSourceTopic.size());
+        assertEquals("topic", stateStoreNameToSourceTopic.get("store"));
+    }
+
+    @Test
+    public void shouldAssociateStateStoreNameWithExternalSourceTopic() throws Exception {
+        final TopologyBuilder builder = new TopologyBuilder();
+        builder.addSource("source", "topic");
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addStateStore(new MockStateStoreSupplier("store", false), false, "processor");
+        final Map<String, String> stateStoreNameToSourceTopic = builder.getStateStoreNameToSourceTopics();
+        assertEquals(1, stateStoreNameToSourceTopic.size());
+        assertEquals("topic", stateStoreNameToSourceTopic.get("store"));
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/HostStateToTaskMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/HostStateToTaskMetadataTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.state.HostState;
+import org.apache.kafka.streams.state.TaskMetadata;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class HostStateToTaskMetadataTest {
+
+    private HostStateToTaskMetadata discovery;
+    private HostState hostOne;
+    private HostState hostTwo;
+    private HostState hostThree;
+    private TopicPartition tp1;
+    private TopicPartition tp2;
+    private TopicPartition tp3;
+    private Map<HostState, Set<TopicPartition>> hostToPartitions;
+    private KStreamBuilder builder;
+
+    @Before
+    public void before() {
+        builder = new KStreamBuilder();
+        builder.stream("topic-one")
+                .groupByKey()
+                .count("table-one");
+
+        builder.stream("topic-two")
+                .groupByKey()
+                .count("table-two");
+
+        builder.stream("topic-three")
+                .groupByKey()
+                .count("table-three");
+
+        builder.setApplicationId("appId");
+
+        tp1 = new TopicPartition("topic-one", 0);
+        tp2 = new TopicPartition("topic-two", 0);
+        tp3 = new TopicPartition("topic-three", 0);
+
+        hostOne = new HostState("host-one", 8080);
+        hostTwo = new HostState("host-two", 9090);
+        hostThree = new HostState("host-three", 7070);
+        hostToPartitions = new HashMap<>();
+        hostToPartitions.put(hostOne, Collections.singleton(tp1));
+        hostToPartitions.put(hostTwo, Collections.singleton(tp2));
+        hostToPartitions.put(hostThree, Collections.singleton(tp3));
+
+        discovery = new HostStateToTaskMetadata(hostToPartitions, builder);
+
+    }
+
+    @Test
+    public void shouldGetAllTasks() throws Exception {
+        final Map<HostState, TaskMetadata> expected = new HashMap<>();
+        expected.put(hostOne, new TaskMetadata(Collections.singleton("table-one"), Collections.singleton(tp1)));
+        expected.put(hostTwo, new TaskMetadata(Collections.singleton("table-two"), Collections.singleton(tp2)));
+        expected.put(hostThree, new TaskMetadata(Collections.singleton("table-three"), Collections.singleton(tp3)));
+
+        final Map<HostState, TaskMetadata> actual = discovery.getAllTasks();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldGetTasksForStoreName() throws Exception {
+        final Map<HostState, TaskMetadata> expected = new HashMap<>();
+        expected.put(hostOne, new TaskMetadata(Collections.singleton("table-one"), Collections.singleton(tp1)));
+
+        final Map<HostState, TaskMetadata> actual = discovery.getAllTasksWithStore("table-one");
+        assertEquals(actual, expected);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfStoreNameIsNullOnGetAllTasksWithStore() throws Exception {
+        discovery.getAllTasksWithStore(null);
+    }
+
+    @Test
+    public void shouldReturnEmptyMapOnGetAllTasksWithStoreWhenStoreDoesntExist() throws Exception {
+        final Map<HostState, TaskMetadata> allTasksWithStore = discovery.getAllTasksWithStore("not-a-store");
+        assertEquals(Collections.emptyMap(), allTasksWithStore);
+    }
+
+    @Test
+    public void shouldGetTaskWithKey() throws Exception {
+        final TopicPartition tp4 = new TopicPartition("topic-three", 1);
+        hostToPartitions.put(hostTwo, Utils.mkSet(tp2, tp4));
+        final HostStateToTaskMetadata discovery = new HostStateToTaskMetadata(hostToPartitions, builder);
+        final Map<HostState, TaskMetadata> expected = new HashMap<>();
+
+        expected.put(hostThree, new TaskMetadata(Collections.singleton("table-three"), Collections.singleton(tp3)));
+
+        final Map<HostState, TaskMetadata> actual = discovery.getTaskWithKey("table-three", "the-key",
+                Serdes.String().serializer());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldGetTaskWithKeyAndCustomPartitioner() throws Exception {
+        final TopicPartition tp4 = new TopicPartition("topic-three", 1);
+        hostToPartitions.put(hostTwo, Utils.mkSet(tp2, tp4));
+        final HostStateToTaskMetadata discovery = new HostStateToTaskMetadata(hostToPartitions, builder);
+        final Map<HostState, TaskMetadata> expected = new HashMap<>();
+
+        expected.put(hostTwo, new TaskMetadata(Collections.singleton("table-three"), Collections.singleton(tp4)));
+
+        final Map<HostState, TaskMetadata> actual = discovery.getTaskWithKey("table-three", "the-key", new StreamPartitioner<String, Object>() {
+            @Override
+            public Integer partition(final String key, final Object value, final int numPartitions) {
+                return 1;
+            }
+        });
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnEmptyMapOnGetTaskWithKeyWhenStoreDoesntExist() throws Exception {
+        final Map<HostState, TaskMetadata> allTasksWithStore = discovery.getTaskWithKey("not-a-store",
+                "key",
+                Serdes.String().serializer());
+        assertEquals(Collections.emptyMap(), allTasksWithStore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenKeyIsNull() throws Exception {
+        discovery.getTaskWithKey("table-three", null, Serdes.String().serializer());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenSerializerIsNull() throws Exception {
+        discovery.getTaskWithKey("table-three", "key", (Serializer) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfStoreNameIsNull() throws Exception {
+        discovery.getTaskWithKey(null, "key", Serdes.String().serializer());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfStreamPartitionerIsNull() throws Exception {
+        discovery.getTaskWithKey(null, "key", (StreamPartitioner) null);
+    }
+
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.processor.internals.assignment.SubscriptionInfo;
+import org.apache.kafka.streams.state.HostState;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockStateStoreSupplier;
@@ -84,6 +85,7 @@ public class StreamPartitionAssignorTest {
     private final TaskId task1 = new TaskId(0, 1);
     private final TaskId task2 = new TaskId(0, 2);
     private final TaskId task3 = new TaskId(0, 3);
+    private String userEndPoint = null;
 
     private Properties configProps() {
         return new Properties() {
@@ -136,7 +138,7 @@ public class StreamPartitionAssignorTest {
         Set<TaskId> standbyTasks = new HashSet<>(cachedTasks);
         standbyTasks.removeAll(prevTasks);
 
-        SubscriptionInfo info = new SubscriptionInfo(processId, prevTasks, standbyTasks);
+        SubscriptionInfo info = new SubscriptionInfo(processId, prevTasks, standbyTasks, null);
         assertEquals(info.encode(), subscription.userData());
     }
 
@@ -169,11 +171,11 @@ public class StreamPartitionAssignorTest {
 
         Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer10",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks10, standbyTasks10).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks10, standbyTasks10, userEndPoint).encode()));
         subscriptions.put("consumer11",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks11, standbyTasks11).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks11, standbyTasks11, userEndPoint).encode()));
         subscriptions.put("consumer20",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, prevTasks20, standbyTasks20).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, prevTasks20, standbyTasks20, userEndPoint).encode()));
 
         Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, subscriptions);
 
@@ -235,11 +237,11 @@ public class StreamPartitionAssignorTest {
 
         Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer10",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks10, Collections.<TaskId>emptySet()).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks10, Collections.<TaskId>emptySet(), userEndPoint).encode()));
         subscriptions.put("consumer11",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks11, Collections.<TaskId>emptySet()).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks11, Collections.<TaskId>emptySet(), userEndPoint).encode()));
         subscriptions.put("consumer20",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, prevTasks20, Collections.<TaskId>emptySet()).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, prevTasks20, Collections.<TaskId>emptySet(), userEndPoint).encode()));
 
         Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, subscriptions);
 
@@ -303,11 +305,11 @@ public class StreamPartitionAssignorTest {
 
         Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer10",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, Collections.<TaskId>emptySet(), Collections.<TaskId>emptySet()).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, Collections.<TaskId>emptySet(), Collections.<TaskId>emptySet(), userEndPoint).encode()));
         subscriptions.put("consumer11",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, Collections.<TaskId>emptySet(), Collections.<TaskId>emptySet()).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, Collections.<TaskId>emptySet(), Collections.<TaskId>emptySet(), userEndPoint).encode()));
         subscriptions.put("consumer20",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, Collections.<TaskId>emptySet(), Collections.<TaskId>emptySet()).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, Collections.<TaskId>emptySet(), Collections.<TaskId>emptySet(), userEndPoint).encode()));
 
         Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, subscriptions);
 
@@ -358,11 +360,11 @@ public class StreamPartitionAssignorTest {
 
         Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer10",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks10, standbyTasks10).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks10, standbyTasks10, userEndPoint).encode()));
         subscriptions.put("consumer11",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks11, standbyTasks11).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, prevTasks11, standbyTasks11, userEndPoint).encode()));
         subscriptions.put("consumer20",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, prevTasks20, standbyTasks20).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid2, prevTasks20, standbyTasks20, userEndPoint).encode()));
 
         Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, subscriptions);
 
@@ -463,7 +465,7 @@ public class StreamPartitionAssignorTest {
         standbyTasks.put(task1, Utils.mkSet(new TopicPartition("t1", 0)));
         standbyTasks.put(task2, Utils.mkSet(new TopicPartition("t2", 0)));
 
-        AssignmentInfo info = new AssignmentInfo(activeTaskList, standbyTasks);
+        AssignmentInfo info = new AssignmentInfo(activeTaskList, standbyTasks, new HashMap<HostState, Set<TopicPartition>>());
         PartitionAssignor.Assignment assignment = new PartitionAssignor.Assignment(Utils.mkList(t1p0, t2p3), info.encode());
         partitionAssignor.onAssignment(assignment);
 
@@ -502,7 +504,7 @@ public class StreamPartitionAssignorTest {
         Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         Set<TaskId> emptyTasks = Collections.<TaskId>emptySet();
         subscriptions.put("consumer10",
-                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, emptyTasks, emptyTasks).encode()));
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode()));
 
         partitionAssignor.assign(metadata, subscriptions);
 
@@ -544,13 +546,92 @@ public class StreamPartitionAssignorTest {
         Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         Set<TaskId> emptyTasks = Collections.<TaskId>emptySet();
         subscriptions.put("consumer10",
-                          new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, emptyTasks, emptyTasks).encode()));
+                          new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, userEndPoint).encode()));
 
         Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, subscriptions);
 
         // check prepared internal topics
         assertEquals(2, internalTopicManager.readyTopics.size());
         assertEquals(allTasks.size(), (long) internalTopicManager.readyTopics.get("test-topicZ"));
+    }
+
+    @Test
+    public void shouldAddUserDefinedEndPointToSubscription() throws Exception {
+        final Properties properties = configProps();
+        properties.put(StreamsConfig.USER_ENDPOINT_CONFIG, "localhost:8080");
+        final StreamsConfig config = new StreamsConfig(properties);
+        final TopologyBuilder builder = new TopologyBuilder();
+        final String applicationId = "application-id";
+        builder.setApplicationId(applicationId);
+        builder.addSource("source", "input");
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addSink("sink", "output", "processor");
+
+        final UUID uuid1 = UUID.randomUUID();
+        final String client1 = "client1";
+
+        final MockClientSupplier clientSupplier = new MockClientSupplier();
+
+        final StreamThread streamThread = new StreamThread(builder, config, clientSupplier, applicationId, client1, uuid1, new Metrics(), new SystemTime());
+
+        final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
+        partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client1));
+        final PartitionAssignor.Subscription subscription = partitionAssignor.subscription(Utils.mkSet("input"));
+        final SubscriptionInfo subscriptionInfo = SubscriptionInfo.decode(subscription.userData());
+        assertEquals("localhost:8080", subscriptionInfo.userEndPoint);
+    }
+
+    @Test
+    public void shouldMapUserEndPointToTopicPartitions() throws Exception {
+        final Properties properties = configProps();
+        final String myEndPoint = "localhost:8080";
+        properties.put(StreamsConfig.USER_ENDPOINT_CONFIG, myEndPoint);
+        final StreamsConfig config = new StreamsConfig(properties);
+        final TopologyBuilder builder = new TopologyBuilder();
+        final String applicationId = "application-id";
+        builder.setApplicationId(applicationId);
+        builder.addSource("source", "topic1");
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addSink("sink", "output", "processor");
+
+        final List<String> topics = Utils.mkList("topic1");
+
+        final UUID uuid1 = UUID.randomUUID();
+        final String client1 = "client1";
+
+        final MockClientSupplier clientSupplier = new MockClientSupplier();
+
+        final StreamThread streamThread = new StreamThread(builder, config, clientSupplier, applicationId, client1, uuid1, new Metrics(), new SystemTime());
+
+        final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
+        partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client1));
+
+        final Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
+        final Set<TaskId> emptyTasks = Collections.<TaskId>emptySet();
+        subscriptions.put("consumer1",
+                new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, emptyTasks, emptyTasks, myEndPoint).encode()));
+
+        final Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(metadata, subscriptions);
+        final PartitionAssignor.Assignment consumerAssignment = assignments.get("consumer1");
+        final AssignmentInfo assignmentInfo = AssignmentInfo.decode(consumerAssignment.userData());
+        final Set<TopicPartition> topicPartitions = assignmentInfo.partitionsByHostState.get(new HostState("localhost", 8080));
+        assertEquals(Utils.mkSet(new TopicPartition("topic1", 0),
+                new TopicPartition("topic1", 1),
+                new TopicPartition("topic1", 2)), topicPartitions);
+    }
+
+    @Test
+    public void shouldExposeHostStateToTopicPartitionsOnAssignment() throws Exception {
+        final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
+        List<TopicPartition> topic = Arrays.asList(new TopicPartition("topic", 0));
+        final Map<HostState, Set<TopicPartition>> hostState =
+                Collections.singletonMap(new HostState("localhost", 80),
+                        Collections.singleton(new TopicPartition("topic", 0)));
+        AssignmentInfo assignmentInfo = new AssignmentInfo(Collections.singletonList(new TaskId(0, 0)),
+                Collections.<TaskId, Set<TopicPartition>>emptyMap(),
+                hostState);
+        partitionAssignor.onAssignment(new PartitionAssignor.Assignment(topic, assignmentInfo.encode()));
+        assertEquals(hostState, partitionAssignor.getPartitionsByHostState());
     }
 
     private class MockInternalTopicManager extends InternalTopicManager {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfoTest.java
@@ -20,6 +20,7 @@ package org.apache.kafka.streams.processor.internals.assignment;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.HostState;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -30,7 +31,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-public class AssginmentInfoTest {
+public class AssignmentInfoTest {
 
     @Test
     public void testEncodeDecode() {
@@ -41,7 +42,7 @@ public class AssginmentInfoTest {
         standbyTasks.put(new TaskId(1, 1), Utils.mkSet(new TopicPartition("t1", 1), new TopicPartition("t2", 1)));
         standbyTasks.put(new TaskId(2, 0), Utils.mkSet(new TopicPartition("t3", 0), new TopicPartition("t3", 0)));
 
-        AssignmentInfo info = new AssignmentInfo(activeTasks, standbyTasks);
+        AssignmentInfo info = new AssignmentInfo(activeTasks, standbyTasks, new HashMap<HostState, Set<TopicPartition>>());
         AssignmentInfo decoded = AssignmentInfo.decode(info.encode());
 
         assertEquals(info, decoded);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/SubscriptionInfoTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.streams.processor.TaskId;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -38,10 +39,18 @@ public class SubscriptionInfoTest {
         Set<TaskId> standbyTasks =
                 new HashSet<>(Arrays.asList(new TaskId(1, 1), new TaskId(2, 0)));
 
-        SubscriptionInfo info = new SubscriptionInfo(processId, activeTasks, standbyTasks);
+        SubscriptionInfo info = new SubscriptionInfo(processId, activeTasks, standbyTasks, null);
         SubscriptionInfo decoded = SubscriptionInfo.decode(info.encode());
 
         assertEquals(info, decoded);
+    }
+
+    @Test
+    public void shouldEncodeDecodeWithUserEndPoint() throws Exception {
+        SubscriptionInfo original = new SubscriptionInfo(UUID.randomUUID(),
+                Collections.singleton(new TaskId(0, 0)), Collections.<TaskId>emptySet(), "localhost:80");
+        SubscriptionInfo decoded = SubscriptionInfo.decode(original.encode());
+        assertEquals(original, decoded);
     }
 
 }


### PR DESCRIPTION
@guozhangwang @enothereska please take a look. A few things that need to be clarified
1. I've added `StreamsConfig.USER_ENDPOINT_CONFIG`, but should we have separate configs for host and port or is this one config ok?
2. `HostState` in the KIP has a `byte[]` field - not sure why and what it would be populated with
3. The API calls in the KIP all return `Map<HostState, Set<TaskMetadata>>`, however i don't see why the  `Set` is required so I've changed it to `Map<HostState, TaskMetadata>`
