### PR TITLE
Hotfix: auto-repartitioning for merge() and code simplifications

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -33,6 +33,7 @@ public abstract class AbstractStream<K> {
     public AbstractStream(KStreamBuilder topology, String name, Set<String> sourceNodes) {
         this.topology = topology;
         this.name = name;
+        assert (sourceNodes != null);
         this.sourceNodes = sourceNodes;
     }
 
@@ -42,9 +43,6 @@ public abstract class AbstractStream<K> {
     protected Set<String> ensureJoinableWith(AbstractStream<K> other) {
         Set<String> thisSourceNodes = sourceNodes;
         Set<String> otherSourceNodes = other.sourceNodes;
-
-        if (thisSourceNodes == null || otherSourceNodes == null)
-            throw new TopologyBuilderException(this.name + " and " + other.name + " are not joinable");
 
         Set<String> allSourceNodes = new HashSet<>();
         allSourceNodes.addAll(thisSourceNodes);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -31,9 +31,10 @@ public abstract class AbstractStream<K> {
     protected final Set<String> sourceNodes;
 
     public AbstractStream(KStreamBuilder topology, String name, Set<String> sourceNodes) {
+        assert sourceNodes != null && !sourceNodes.isEmpty() : "parameter <sourceNodes> must not be null or empty";
+
         this.topology = topology;
         this.name = name;
-        assert (sourceNodes != null);
         this.sourceNodes = sourceNodes;
     }
 
@@ -41,12 +42,9 @@ public abstract class AbstractStream<K> {
      * @throws TopologyBuilderException if the streams are not joinable
      */
     protected Set<String> ensureJoinableWith(AbstractStream<K> other) {
-        Set<String> thisSourceNodes = sourceNodes;
-        Set<String> otherSourceNodes = other.sourceNodes;
-
         Set<String> allSourceNodes = new HashSet<>();
-        allSourceNodes.addAll(thisSourceNodes);
-        allSourceNodes.addAll(otherSourceNodes);
+        allSourceNodes.addAll(sourceNodes);
+        allSourceNodes.addAll(other.sourceNodes);
 
         topology.copartitionSources(allSourceNodes);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -31,7 +31,7 @@ public abstract class AbstractStream<K> {
     protected final Set<String> sourceNodes;
 
     public AbstractStream(KStreamBuilder topology, String name, Set<String> sourceNodes) {
-        if(sourceNodes == null || sourceNodes.isEmpty()) {
+        if (sourceNodes == null || sourceNodes.isEmpty()) {
             throw new IllegalArgumentException("parameter <sourceNodes> must not be null or empty");
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -31,7 +31,9 @@ public abstract class AbstractStream<K> {
     protected final Set<String> sourceNodes;
 
     public AbstractStream(KStreamBuilder topology, String name, Set<String> sourceNodes) {
-        assert sourceNodes != null && !sourceNodes.isEmpty() : "parameter <sourceNodes> must not be null or empty";
+        if(sourceNodes == null || sourceNodes.isEmpty()) {
+            throw new IllegalArgumentException("parameter <sourceNodes> must not be null or empty");
+        }
 
         this.topology = topology;
         this.name = name;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -231,24 +231,19 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         String name = topology.newName(MERGE_NAME);
         String[] parentNames = new String[streams.length];
         Set<String> allSourceNodes = new HashSet<>();
+        boolean requireRepartitioning = false;
 
         for (int i = 0; i < streams.length; i++) {
             KStreamImpl stream = (KStreamImpl) streams[i];
 
             parentNames[i] = stream.name;
-
-            if (allSourceNodes != null) {
-                if (stream.sourceNodes != null)
-                    allSourceNodes.addAll(stream.sourceNodes);
-                else
-                    allSourceNodes = null;
-            }
-
+            requireRepartitioning |= stream.repartitionRequired;
+            allSourceNodes.addAll(stream.sourceNodes);
         }
 
         topology.addProcessor(name, new KStreamPassThrough<>(), parentNames);
 
-        return new KStreamImpl<>(topology, name, allSourceNodes, false);
+        return new KStreamImpl<>(topology, name, allSourceNodes, requireRepartitioning);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -228,7 +228,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
     }
 
     public static <K, V> KStream<K, V> merge(KStreamBuilder topology, KStream<K, V>[] streams) {
-        if(streams == null || streams.length == 0) {
+        if (streams == null || streams.length == 0) {
             throw new IllegalArgumentException("Parameter <streams> must not be null or has length zero");
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -228,6 +228,10 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
     }
 
     public static <K, V> KStream<K, V> merge(KStreamBuilder topology, KStream<K, V>[] streams) {
+        if(streams == null || streams.length == 0) {
+            throw new IllegalArgumentException("Parameter <streams> must not be null or has length zero");
+        }
+
         String name = topology.newName(MERGE_NAME);
         String[] parentNames = new String[streams.length];
         Set<String> allSourceNodes = new HashSet<>();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -318,7 +318,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         topology.addProcessor(name, new KStreamTransform<>(transformerSupplier), this.name);
         topology.connectProcessorAndStateStores(name, stateStoreNames);
 
-        return new KStreamImpl<>(topology, name, null, true);
+        return new KStreamImpl<>(topology, name, sourceNodes, true);
     }
 
     @Override


### PR DESCRIPTION
follow-up to auto-through feature:
- add sourceNode to transform()
- enable auto-repartitioning in merge()
- null check not required anymore (always join-able due to auto-through)
