### PR TITLE
KAFKA-3922: add constructor to AbstractStream class

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -30,6 +30,12 @@ public abstract class AbstractStream<K> {
     protected final String name;
     protected final Set<String> sourceNodes;
 
+    public AbstractStream(AbstractStream<K> stream) {
+        this.topology = stream.topology;
+        this.name = stream.name;
+        this.sourceNodes = stream.sourceNodes;
+    }
+
     public AbstractStream(KStreamBuilder topology, String name, Set<String> sourceNodes) {
         this.topology = topology;
         this.name = name;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-3922

KAFKA-3922 add copy-constructor to AbstractStream class 
This copy-constructor allow to access protected variables from subclasses. 

It should be used to extend KStreamImpl and KTableImpl classes by implementing a decorator pattern.
