### PR TITLE
KAFKA-3910 [WIP]: Cyclic schema support in ConnectSchema and SchemaBuilder

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -290,25 +290,23 @@ public class ConnectSchema implements Schema {
     }
 
     @Override
-    public synchronized boolean equals(Object o) {
+    public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || !(o instanceof Schema)) return false;
         Schema schema = (Schema) o;
-
         return Objects.equals(optional, schema.isOptional()) &&
-                    Objects.equals(type, schema.type()) &&
-                    Objects.equals(defaultValue, schema.defaultValue()) &&
-                    (type != Type.STRUCT ||
-                            Objects.equals(fields, schema.fields())) &&
-                    (type != Type.MAP ||
-                            Objects.equals(keySchema, schema.keySchema())) &&
-                    ((type != Type.MAP && type != Type.ARRAY) ||
-                            Objects.equals(valueSchema, schema.valueSchema())) &&
-                    Objects.equals(name, schema.name()) &&
-                    Objects.equals(version, schema.version()) &&
-                    Objects.equals(doc, schema.doc()) &&
-                    Objects.equals(parameters, schema.parameters());
-
+                Objects.equals(type, schema.type()) &&
+                Objects.equals(defaultValue, schema.defaultValue()) &&
+                (type != Type.STRUCT ||
+                        Objects.equals(fields, schema.fields())) &&
+                (type != Type.MAP ||
+                        Objects.equals(keySchema, schema.keySchema())) &&
+                ((type != Type.MAP && type != Type.ARRAY) ||
+                        Objects.equals(valueSchema, schema.valueSchema())) &&
+                Objects.equals(name, schema.name()) &&
+                Objects.equals(version, schema.version()) &&
+                Objects.equals(doc, schema.doc()) &&
+                Objects.equals(parameters, schema.parameters());
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/FutureSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/FutureSchema.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package org.apache.kafka.connect.data;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class FutureSchema implements Schema {
+    private Schema child;
+    private final String name;
+    private final boolean optional;
+
+    public FutureSchema(String name, boolean optional) {
+        this.child = null;
+        this.name = name;
+        this.optional = optional;
+    }
+
+    private void checkChild() {
+        if (child == null)
+            throw new DataException("Accessing unresolved FutureSchema(name:" + name + " optional:" + optional + ")");
+    }
+
+    /**
+     * Resolve this future schema by searching through the parents for a concrete schema that matches.
+     * @param parents a list of schemas that are parents of this schema
+     * @return the resolved schema
+     */
+    @Override
+    public Schema resolve(List<Schema> parents) {
+        if (child == null) {
+            if (parents != null) {
+                for (Schema parent : parents) {
+                    /*
+                     * Optionality (nullability) is used as an identifying characteristic because
+                     * it is embedded in the schema, as opposed to other systems where
+                     * optionality is assigned to the field where the schema is used.
+                     */
+                    if (parent.name() == name && parent.isOptional() == optional) {
+                        child = parent;
+                        return child;
+                    }
+                }
+            }
+            return this;
+        }
+        return child;
+    }
+
+    /**
+     * Return the hashcode of the child if set, so that the wrapper is transparent for comparisons.
+     * @return the hashcode
+     */
+    @Override
+    public int hashCode() {
+        if (child != null) {
+            return child.hashCode();
+        } else {
+            return Objects.hash(name, optional);
+        }
+    }
+
+    /**
+     * Test equality with the child if set, so that the wrapper is transparent for comparisons.
+     * @param o the other object to compare to
+     * @return if the objects are equal
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (child != null) {
+            return child.equals(o);
+        } else {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FutureSchema schema = (FutureSchema) o;
+
+            return Objects.equals(name, schema.name) &&
+                    Objects.equals(optional, schema.optional);
+        }
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return optional;
+    }
+
+    @Override
+    public Type type() {
+        checkChild();
+        return child.type();
+    }
+
+    @Override
+    public Object defaultValue() {
+        checkChild();
+        return child.defaultValue();
+    }
+
+    @Override
+    public Integer version() {
+        checkChild();
+        return child.version();
+    }
+
+    @Override
+    public String doc() {
+        checkChild();
+        return child.doc();
+    }
+
+    @Override
+    public Map<String, String> parameters() {
+        checkChild();
+        return child.parameters();
+    }
+
+    @Override
+    public Schema keySchema() {
+        checkChild();
+        return child.keySchema();
+    }
+
+    @Override
+    public Schema valueSchema() {
+        checkChild();
+        return child.valueSchema();
+    }
+
+    @Override
+    public List<Field> fields() {
+        checkChild();
+        return child.fields();
+    }
+
+    @Override
+    public Field field(String fieldName) {
+        checkChild();
+        return child.field(fieldName);
+    }
+
+    @Override
+    public Schema schema() {
+        checkChild();
+        return child.schema();
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/FutureSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/FutureSchema.java
@@ -19,7 +19,6 @@ package org.apache.kafka.connect.data;
 
 import org.apache.kafka.connect.errors.DataException;
 
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -29,14 +28,10 @@ public class FutureSchema implements Schema {
     private final String name;
     private final boolean optional;
 
-    // Tokens to stop recursive comparing
-    private IdentityHashMap<Schema, Schema> others;
-
     public FutureSchema(String name, boolean optional) {
         this.child = null;
         this.name = name;
         this.optional = optional;
-        this.others = new IdentityHashMap<>();
     }
 
     private void checkChild() {
@@ -70,10 +65,6 @@ public class FutureSchema implements Schema {
         return child;
     }
 
-    /**
-     * Return the hashcode of the child if set, so that the wrapper is transparent for comparisons.
-     * @return the hashcode
-     */
     @Override
     public int hashCode() {
         return Objects.hash(name, optional);
@@ -84,7 +75,6 @@ public class FutureSchema implements Schema {
         if (this == o) return true;
         if ((o == null) || ((child == null) && getClass() != o.getClass()) || !(o instanceof Schema)) return false;
         Schema schema = (Schema) o;
-
         return Objects.equals(name, schema.name()) &&
                 Objects.equals(optional, schema.isOptional());
     }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/FutureSchemaBuilder.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/FutureSchemaBuilder.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package org.apache.kafka.connect.data;
+
+import org.apache.kafka.connect.errors.SchemaBuilderException;
+
+/**
+ * The FutureSchemaBuilder supports creating a schema that references an existing type.
+ *
+ * It allows setting fields that are related to the instance of the schema, but blocks
+ * access to defining characteristics.
+ */
+class FutureSchemaBuilder extends SchemaBuilder {
+
+    public FutureSchemaBuilder(String name) {
+        super(null);
+        this.name = name;
+    }
+
+    @Override
+    public SchemaBuilder name(String name) {
+        return unsupportedField(NAME_FIELD);
+    }
+
+    @Override
+    public SchemaBuilder version(Integer version) {
+        return unsupportedField(VERSION_FIELD);
+    }
+
+    @Override
+    public SchemaBuilder doc(String doc) {
+        return unsupportedField(DOC_FIELD);
+    }
+
+    @Override
+    public Schema build() {
+        Schema result = new FutureSchema(name, isOptional(), defaultValue);
+        return result;
+    }
+
+    private SchemaBuilder unsupportedField(String fieldName) {
+        throw new SchemaBuilderException("Invalid SchemaBuilder call: " + fieldName + " not supported by " +
+                "reference type");
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Schema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Schema.java
@@ -161,4 +161,11 @@ public interface Schema {
      * @return the {@link Schema}
      */
     Schema schema();
+
+    /**
+     * Resolve this and any child schemas that may symbolic or have cyclic references
+     * @param parents a list of schemas that are parents of this schema
+     * @return the resolved schema
+     */
+    Schema resolve(List<Schema> parents);
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Schema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Schema.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.connect.data;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -168,4 +169,13 @@ public interface Schema {
      * @return the resolved schema
      */
     Schema resolve(List<Schema> parents);
+
+    /**
+     * Get a comparison context for this schema. This is a thread safe way to manage the context of a nested
+     * comparison that may have cyclic references. The comparison logic reviews the context to detect loops and
+     * break cyclic hashing or equals.
+     * @param context
+     * @return A new ComparisonContext
+     */
+    Object compareContext(LinkedList<Object> context);
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Schema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Schema.java
@@ -163,7 +163,7 @@ public interface Schema {
     Schema schema();
 
     /**
-     * Resolve this and any child schemas that may symbolic or have cyclic references
+     * Resolve this and any child schemas that may be symbolic or have cyclic references
      * @param parents a list of schemas that are parents of this schema
      * @return the resolved schema
      */

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaBuilder.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaBuilder.java
@@ -325,6 +325,29 @@ public class SchemaBuilder implements Schema {
     }
 
     /**
+     * Add a field to the struct schema by name, that will be resolved later. Throws a SchemaBuilderException if this
+     * is not a struct schema.
+     * @param fieldName the name of the field to add
+     * @param schemaName the name of the schema for the field
+     * @param optional a flag if the schema is optional or not
+     * @return the SchemaBuilder
+     */
+    public SchemaBuilder field(String fieldName, String schemaName, boolean optional) {
+        return field(fieldName, new FutureSchema(schemaName, optional));
+    }
+
+    /**
+     * Add a optional field to the struct by name, that will be resolved later. Throws a SchemaBuilderException if this
+     * is not a struct schema.
+     * @param fieldName the name of the field to add
+     * @param schemaName the name of the schema for the field
+     * @return the SchemaBuilder
+     */
+    public SchemaBuilder field(String fieldName, String schemaName) {
+        return field(fieldName, schemaName, true);
+    }
+
+    /**
      * Get the list of fields for this Schema. Throws a DataException if this schema is not a struct.
      * @return the list of fields for this Schema
      */
@@ -399,6 +422,10 @@ public class SchemaBuilder implements Schema {
         return build();
     }
 
+    @Override
+    public Schema resolve(List<Schema> parents) {
+        return build();
+    }
 
     private static void checkNull(String fieldName, Object val) {
         if (val != null)

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaBuilder.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/SchemaBuilder.java
@@ -337,7 +337,7 @@ public class SchemaBuilder implements Schema {
     }
 
     /**
-     * Add a optional field to the struct by name, that will be resolved later. Throws a SchemaBuilderException if this
+     * Add an optional field to the struct by name, that will be resolved later. Throws a SchemaBuilderException if this
      * is not a struct schema.
      * @param fieldName the name of the field to add
      * @param schemaName the name of the schema for the field

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -286,18 +286,17 @@ public class ConnectSchemaTest {
     public void testStructEquality() {
         // Same as testArrayEquality, but checks differences in fields. Only does a simple check, relying on tests of
         // Field's equals() method to validate all variations in the list of fields will be checked
-        ConnectSchema s1 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
+        Schema s1 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
                 Arrays.asList(new Field("field", 0, SchemaBuilder.int8().build()),
                         new Field("field2", 1, SchemaBuilder.int16().build())), null, null);
-        ConnectSchema s2 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
+        Schema s2 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
                 Arrays.asList(new Field("field", 0, SchemaBuilder.int8().build()),
                         new Field("field2", 1, SchemaBuilder.int16().build())), null, null);
-        ConnectSchema differentField = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
+        Schema differentField = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
                 Arrays.asList(new Field("field", 0, SchemaBuilder.int8().build()),
                         new Field("different field name", 1, SchemaBuilder.int16().build())), null, null);
 
         assertEquals(s1, s2);
         assertNotEquals(s1, differentField);
     }
-
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -286,13 +286,13 @@ public class ConnectSchemaTest {
     public void testStructEquality() {
         // Same as testArrayEquality, but checks differences in fields. Only does a simple check, relying on tests of
         // Field's equals() method to validate all variations in the list of fields will be checked
-        Schema s1 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
+        ConnectSchema s1 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
                 Arrays.asList(new Field("field", 0, SchemaBuilder.int8().build()),
                         new Field("field2", 1, SchemaBuilder.int16().build())), null, null);
-        Schema s2 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
+        ConnectSchema s2 = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
                 Arrays.asList(new Field("field", 0, SchemaBuilder.int8().build()),
                         new Field("field2", 1, SchemaBuilder.int16().build())), null, null);
-        Schema differentField = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
+        ConnectSchema differentField = new ConnectSchema(Schema.Type.STRUCT, false, null, null, null, null, null,
                 Arrays.asList(new Field("field", 0, SchemaBuilder.int8().build()),
                         new Field("different field name", 1, SchemaBuilder.int16().build())), null, null);
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/FutureSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/FutureSchemaTest.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package org.apache.kafka.connect.data;
+
+
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class FutureSchemaTest {
+
+    @Test
+    public void testEquality() {
+        Schema s1 = new FutureSchema("name", true);
+        Schema s2 = new FutureSchema("name", true);
+        Schema otherName = new FutureSchema("otherName", true);
+        Schema otherOptional = new FutureSchema("name", false);
+
+        assertEquals(s1, s2);
+        assertNotEquals(s1, otherName);
+        assertNotEquals(s1, otherOptional);
+    }
+
+    @Test
+    public void testResolution() {
+        Schema futureS1 = new FutureSchema("s1", false);
+        Schema futureS1Opt = new FutureSchema("s1", true);
+        Schema futureS2Opt = new FutureSchema("s2", true);
+
+        Schema s1 = new ConnectSchema(Schema.Type.STRUCT, false, null, "s1", null, null);
+        Schema s1Opt = new ConnectSchema(Schema.Type.STRUCT, true, null, "s1", null, null);
+        Schema s2Opt = new ConnectSchema(Schema.Type.STRUCT, true, null, "s2", null, null);
+
+        futureS1.resolve(Arrays.asList(s1));
+        futureS1Opt.resolve(Arrays.asList(s1Opt));
+        futureS2Opt.resolve(Arrays.asList(s2Opt));
+
+        assertEquals(futureS1, s1);
+        assertEquals(futureS1Opt, s1Opt);
+        assertEquals(futureS2Opt, s2Opt);
+    }
+
+    @Test(expected = DataException.class)
+    public void testResolutionFailed() {
+        Schema futureS1 = new FutureSchema("s1", false);
+        Schema futureS1Opt = new FutureSchema("s1", true);
+        Schema futureS2Opt = new FutureSchema("s2", true);
+
+        Schema s1 = new ConnectSchema(Schema.Type.STRUCT, false, null, "s1", null, null);
+        Schema s1Opt = new ConnectSchema(Schema.Type.STRUCT, true, null, "s1", null, null);
+        Schema s2Opt = new ConnectSchema(Schema.Type.STRUCT, true, null, "s2", null, null);
+
+        futureS1.resolve(Arrays.asList(s1Opt, s2Opt));
+        futureS1Opt.resolve(Arrays.asList(s1, s2Opt));
+        futureS2Opt.resolve(Arrays.asList(s1, s1Opt));
+
+        assertNotEquals(futureS1, s1);
+        assertNotEquals(futureS1Opt, s1Opt);
+        assertNotEquals(futureS2Opt, s2Opt);
+
+        futureS1.name();
+    }
+
+    @Test
+    public void testCyclicEquality() {
+        ConnectSchema s1 = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+                Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, new FutureSchema("node", true))), null, null);
+
+        ConnectSchema s2 = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+                Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, new FutureSchema("node", true))), null, null);
+
+        ConnectSchema different = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+                Arrays.asList(new Field("different", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, new FutureSchema("node", true))), null, null);
+
+        assertEquals(s1, s2);
+        assertEquals(s2, s1);
+        assertNotEquals(s1, different);
+    }
+
+    @Test
+    public void testNameAccessUnresolvedSchema() {
+        assertEquals(new FutureSchema("test", true).name(), "test");
+    }
+
+    @Test
+    public void testIsOptionalAccessUnresolvedSchema() {
+        assert new FutureSchema("test", true).isOptional();
+        assert !(new FutureSchema("test", false).isOptional());
+    }
+
+    @Test(expected = DataException.class)
+    public void testTypeAccessUnresolvedSchema() {
+        new FutureSchema("test", true).type();
+    }
+
+    @Test(expected = DataException.class)
+    public void testDefaultValueAccessUnresolvedSchema() {
+        new FutureSchema("test", true).defaultValue();
+    }
+    @Test(expected = DataException.class)
+    public void testVersionAccessUnresolvedSchema() {
+        new FutureSchema("test", true).version();
+    }
+
+    @Test(expected = DataException.class)
+    public void testDocAccessUnresolvedSchema() {
+        new FutureSchema("test", true).doc();
+    }
+
+    @Test(expected = DataException.class)
+    public void testParametersAccessUnresolvedSchema() {
+        new FutureSchema("test", true).parameters();
+    }
+
+    @Test(expected = DataException.class)
+    public void testKeySchemaAccessUnresolvedSchema() {
+        new FutureSchema("test", true).keySchema();
+    }
+
+    @Test(expected = DataException.class)
+    public void testValueSchemaAccessUnresolvedSchema() {
+        new FutureSchema("test", true).valueSchema();
+    }
+
+    @Test(expected = DataException.class)
+    public void testFieldsAccessUnresolvedSchema() {
+        new FutureSchema("test", true).fields();
+    }
+
+    @Test(expected = DataException.class)
+    public void testFieldAccessUnresolvedSchema() {
+        new FutureSchema("test", true).field("field");
+    }
+
+    @Test(expected = DataException.class)
+    public void testSchemaAccessUnresolvedSchema() {
+        new FutureSchema("test", true).schema();
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/FutureSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/FutureSchemaTest.java
@@ -90,13 +90,36 @@ public class FutureSchemaTest {
                 Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
                         new Field("next", 1, new FutureSchema("node", true))), null, null);
 
-        ConnectSchema different = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+        // Double nesting is equivalent, just inefficient.
+        ConnectSchema s3 = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+                Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, s2)), null, null);
+
+        assertEquals(s1, s2);
+        assertEquals(s1, s3);
+    }
+
+    @Test
+    public void testCyclicInequality() {
+        ConnectSchema s1 = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+                Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, new FutureSchema("node", true))), null, null);
+
+        ConnectSchema differentField = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
                 Arrays.asList(new Field("different", 0, SchemaBuilder.int8().build()),
                         new Field("next", 1, new FutureSchema("node", true))), null, null);
 
-        assertEquals(s1, s2);
-        assertEquals(s2, s1);
-        assertNotEquals(s1, different);
+        ConnectSchema differentNode = new ConnectSchema(Schema.Type.STRUCT, true, null, "node", null, null, null,
+                Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, new FutureSchema("different", true))), null, null);
+
+        ConnectSchema differentStructure = new ConnectSchema(Schema.Type.STRUCT, true, null, "different", null, null, null,
+                Arrays.asList(new Field("value", 0, SchemaBuilder.int8().build()),
+                        new Field("next", 1, differentNode)), null, null);
+
+
+        assertNotEquals(s1, differentField);
+        assertNotEquals(s1, differentStructure);
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/FutureSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/FutureSchemaTest.java
@@ -77,7 +77,7 @@ public class FutureSchemaTest {
         assertNotEquals(futureS1Opt, s1Opt);
         assertNotEquals(futureS2Opt, s2Opt);
 
-        futureS1.name();
+        futureS1.type();
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaBuilderTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaBuilderTest.java
@@ -283,7 +283,38 @@ public class SchemaBuilderTest {
                 .defaultValue(defMap).build();
     }
 
+    @Test
+    public void testSimpleCyclicSchema() {
+        Schema schemaA = SchemaBuilder.struct()
+                .name("A")
+                .field("value", Schema.INT8_SCHEMA)
+                .optional().field("next", "A")
+                .build();
 
+        assertEquals(schemaA.field("next").schema(), schemaA);
+    }
+
+    @Test
+    public void testNestedCyclicSchema() {
+        Schema schemaA = SchemaBuilder.struct()
+                .name("A").optional()
+                .field("valueA", Schema.INT8_SCHEMA)
+                .field("b", "B")
+                .build();
+
+        Schema schemaB = SchemaBuilder.struct()
+                .name("B").optional()
+                .field("valueB", Schema.STRING_SCHEMA)
+                .field("a", schemaA)
+                .build();
+
+
+        assertEquals(schemaB.field("a").schema().field("b").schema(),
+                     schemaB);
+        schemaA = schemaB.field("a").schema();
+        assertEquals(schemaA.field("b").schema().field("a").schema(),
+                     schemaA);
+    }
 
     private void assertTypeAndDefault(Schema schema, Schema.Type type, boolean optional, Object defaultValue) {
         assertEquals(type, schema.type());

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaBuilderTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaBuilderTest.java
@@ -288,7 +288,7 @@ public class SchemaBuilderTest {
         Schema schemaA = SchemaBuilder.struct()
                 .name("A")
                 .field("value", Schema.INT8_SCHEMA)
-                .optional().field("next", "A")
+                .optional().field("next", SchemaBuilder.type("A").optional())
                 .build();
 
         assertEquals(schemaA.field("next").schema(), schemaA);
@@ -299,11 +299,11 @@ public class SchemaBuilderTest {
         Schema schemaA = SchemaBuilder.struct()
                 .name("A").optional()
                 .field("valueA", Schema.INT8_SCHEMA)
-                .field("b", "B")
+                .field("b", SchemaBuilder.type("B"))
                 .build();
 
         Schema schemaB = SchemaBuilder.struct()
-                .name("B").optional()
+                .name("B")
                 .field("valueB", Schema.STRING_SCHEMA)
                 .field("a", schemaA)
                 .build();

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -60,7 +60,7 @@ public class StructTest {
     private static final Schema CYCLIC_SCHEMA = SchemaBuilder.struct()
             .name("node")
             .field("value", Schema.INT32_SCHEMA)
-            .optional().field("next", "node")
+            .optional().field("next", SchemaBuilder.type("node").optional())
             .build();
 
     private static final Schema REQUIRED_FIELD_SCHEMA = Schema.INT8_SCHEMA;


### PR DESCRIPTION
This feature uses a FutureSchema as a placeholder to be resolved later. Resolution is attempted whenever a ConnectSchema is constructed, it attempts to resolve all its children (fields, keySchema, or valueSchema) and recurses until the end of the tree. 

A FutureSchema is resolved when it finds a parent schema that matches its name, and optional flag. If a FutureSchema is accessed before being resolved, it will throw a DataException.

The SchemaBuilder constructs a FutureSchema if a field is added with only a type name.
