### PR TITLE
MINOR: fix generics in Windows.segments and Windows.until

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
@@ -54,7 +54,7 @@ public abstract class Windows<W extends Window> {
      *
      * @return  itself
      */
-    public Windows until(long durationMs) {
+    public Windows<W> until(long durationMs) {
         this.maintainDurationMs = durationMs;
 
         return this;
@@ -66,7 +66,7 @@ public abstract class Windows<W extends Window> {
      *
      * @return  itself
      */
-    protected Windows segments(int segments) {
+    protected Windows<W> segments(int segments) {
         this.segments = segments;
 
         return this;


### PR DESCRIPTION
`Windows.segments(...)` and `Windows.until(...)` currently aren't returning the `Window` with its type param `W`. This causes the generic type to be lost and therefore methods using this can't infer the correct return types. 
