### PR TITLE
KAFKA-3836: KStreamReduce and KTableReduce should not pass nulls to Deserializers

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -65,7 +65,7 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
             @Override
             public void restore(byte[] key, byte[] value) {
 
-                // directly call inner functions so that the operation is not logged. Check value for null, to avoid  deserialization.
+                // directly call inner functions so that the operation is not logged. Check value for null, to avoid  deserialization error.
                 if (value == null) {
                     inner.put(serdes.keyFrom(key), null);
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -65,7 +65,7 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
             @Override
             public void restore(byte[] key, byte[] value) {
 
-                // directly call inner functions so that the operation is not logged
+                // directly call inner functions so that the operation is not logged. Check value for null, to avoid  deserialization.
                 if (value == null) {
                     inner.put(serdes.keyFrom(key), null);
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -66,7 +66,11 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
             public void restore(byte[] key, byte[] value) {
 
                 // directly call inner functions so that the operation is not logged
-                inner.put(serdes.keyFrom(key), serdes.valueFrom(value));
+                if (value == null) {
+                    inner.put(serdes.keyFrom(key), null);
+                } else {
+                    inner.put(serdes.keyFrom(key), serdes.valueFrom(value));
+                }
             }
         });
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -237,17 +237,25 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     public V get(K key) {
         if (cache != null) {
             RocksDBCacheEntry entry = cache.get(key);
-
             if (entry == null) {
-                V value = serdes.valueFrom(getInternal(serdes.rawKey(key)));
-                cache.put(key, new RocksDBCacheEntry(value));
-
-                return value;
+                byte[] byteValue = getInternal(serdes.rawKey(key));
+                if (byteValue == null) {
+                    return null;
+                } else {
+                    V value = serdes.valueFrom(byteValue);
+                    cache.put(key, new RocksDBCacheEntry(value));
+                    return value;
+                }
             } else {
                 return entry.value;
             }
         } else {
-            return serdes.valueFrom(getInternal(serdes.rawKey(key)));
+            byte[] byteValue = getInternal(serdes.rawKey(key));
+            if (byteValue == null) {
+                return null;
+            } else {
+                return serdes.valueFrom(byteValue);
+            }
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -239,7 +239,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             RocksDBCacheEntry entry = cache.get(key);
             if (entry == null) {
                 byte[] byteValue = getInternal(serdes.rawKey(key));
-                //Check value for null, to avoid  deserialization
+                //Check value for null, to avoid  deserialization error
                 if (byteValue == null) {
                     return null;
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -239,6 +239,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             RocksDBCacheEntry entry = cache.get(key);
             if (entry == null) {
                 byte[] byteValue = getInternal(serdes.rawKey(key));
+                //Check value for null, to avoid  deserialization
                 if (byteValue == null) {
                     return null;
                 } else {


### PR DESCRIPTION
Minor changes to check null changes.
