### PR TITLE
KAFKA-3857 Additional log cleaner metrics

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -236,7 +236,7 @@ class LogCleaner(val config: CleanerConfig,
           try {
             endOffset = cleaner.clean(cleanable)
             recordStats(cleaner.id, cleanable.log.name, cleanable.firstDirtyOffset, endOffset, cleaner.stats)
-            cleanerManager.successfulClean()
+            cleanerManager.decrementNumFilthyLogs()
           } catch {
             case pe: LogCleaningAbortedException => // task can be aborted, let it go.
           } finally {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -236,6 +236,7 @@ class LogCleaner(val config: CleanerConfig,
           try {
             endOffset = cleaner.clean(cleanable)
             recordStats(cleaner.id, cleanable.log.name, cleanable.firstDirtyOffset, endOffset, cleaner.stats)
+            cleanerManager.successfulClean()
           } catch {
             case pe: LogCleaningAbortedException => // task can be aborted, let it go.
           } finally {

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -236,7 +236,6 @@ class LogCleaner(val config: CleanerConfig,
           try {
             endOffset = cleaner.clean(cleanable)
             recordStats(cleaner.id, cleanable.log.name, cleanable.firstDirtyOffset, endOffset, cleaner.stats)
-            cleanerManager.decrementNumFilthyLogs()
           } catch {
             case pe: LogCleaningAbortedException => // task can be aborted, let it go.
           } finally {

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -87,7 +87,6 @@ private[log] class LogCleanerManager(val logDirs: Array[File], val logs: Pool[To
     inLock(lock) {
       this.numLogCleanRuns = this.numLogCleanRuns + 1
       this.logCleanLastRun = System.currentTimeMillis
-      info("Number of log cleaner runs: %s. Log cleaner time %s".format(this.numLogCleanRuns, this.logCleanLastRun))
       val lastClean = allCleanerCheckpoints()
       val dirtyLogs = logs.filter {
         case (topicAndPartition, log) => log.config.compact  // skip any logs marked for delete rather than dedupe

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -66,7 +66,7 @@ private[log] class LogCleanerManager(val logDirs: Array[File], val logs: Pool[To
 
   /* a gauge for tracking the number of logCleaner runs */
   @volatile private var numLogCleanRuns = 0
-  newGauge("number-of-runs", new Gauge[Int] { def value = numLogCleanRuns })
+  newGauge("num-runs", new Gauge[Int] { def value = numLogCleanRuns })
 
   /* a gauge for tracking the last time of logCleaner run */
   @volatile private var logCleanLastRun : Long = System.currentTimeMillis
@@ -161,7 +161,6 @@ private[log] class LogCleanerManager(val logDirs: Array[File], val logs: Pool[To
           state match {
             case LogCleaningInProgress =>
               inProgress.put(topicAndPartition, LogCleaningAborted)
-
             case s =>
               throw new IllegalStateException("Compaction for partition %s cannot be aborted and paused since it is in %s state."
                                               .format(topicAndPartition, s))


### PR DESCRIPTION
Fixes KAFKA-3857

Changes proposed in this pull request:

The following additional log cleaner metrics have been added.
1. num-runs: Cumulative number of successful log cleaner runs since last broker restart.
2. last-run-time: Time of last log cleaner run.
3. num-filthy-logs: Number of filthy logs. A non zero value for an extended period of time indicates that the cleaner has not been successful in cleaning the logs.

A note on num-filthy-logs: It is incremented whenever a filthy topic partition is added to inProgress HashMap. And it is decremented once the cleaning is successful, or if the cleaning is aborted. Note that the existing LogCleaner code does not provide a metric to check if the clean operation is successful or not. There is an inProgress HashMap with topicPartition  => LogCleaningInProgress entries in it, but the entries are removed from the HashMap even when clean operation throws an exception. So, added an additional metric num-filthy-logs, to differentiate between a successful log clean case and an exception case.

The code is ready. I have tested and verified JMX metrics. There is one case I couldn't test though. It's the case where numFilthyLogs is decremented in 'resumeCleaning(...)' in LogCleanerManager.scala Line 188. It seems to be a part of the workflow that aborts the cleaning of a particular partition. Any ideas on how to test this scenario?
