### PR TITLE
KAFKA-1543: Change replication factor during partition map generation

### DIFF
--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -148,8 +148,8 @@ object ZkUtils {
   def parsePartitionReassignmentData(jsonData: String): Map[TopicAndPartition, Seq[Int]] =
     parsePartitionReassignmentDataWithoutDedup(jsonData).toMap
 
-  def parseTopicsData(jsonData: String): Seq[String] = {
-    var topics = List.empty[String]
+  def parseTopicsData(jsonData: String): Seq[(String, Int)] = {
+    var topics = List.empty[(String, Int)]
     Json.parseFull(jsonData) match {
       case Some(m) =>
         m.asInstanceOf[Map[String, Any]].get("topics") match {
@@ -157,7 +157,8 @@ object ZkUtils {
             val mapPartitionSeq = partitionsSeq.asInstanceOf[Seq[Map[String, Any]]]
             mapPartitionSeq.foreach(p => {
               val topic = p.get("topic").get.asInstanceOf[String]
-              topics ++= List(topic)
+              val replicationFactor = p.getOrElse("replication-factor", -1).asInstanceOf[Int]
+              topics ++= List((topic, replicationFactor))
             })
           case None =>
         }


### PR DESCRIPTION
If the topic-to-move-json-file contains a new replication-factor for
a topic, it is used when assigning partitions to brokers.  If missing,
the existing replication-factor of the topic is maintained.
