### PR TITLE
KAFKA-3817 Follow-up: Avoid forwarding old value if it is null in KTableRepartition

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -76,8 +76,8 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableProcessorSuppli
             if (key == null)
                 throw new StreamsException("Record key for the grouping KTable should not be null.");
 
-            KeyValue<K1, V1> newPair = mapper.apply(key, change.newValue);
-            // if the old value is null, we do not need to forward its selected key-value further
+            // if the value is null, we do not need to forward its selected key-value further
+            KeyValue<K1, V1> newPair = change.newValue == null ? null : mapper.apply(key, change.newValue);
             KeyValue<K1, V1> oldPair = change.oldValue == null ? null : mapper.apply(key, change.oldValue);
 
             // if the selected repartition key or value is null, skip

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -77,7 +77,8 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableProcessorSuppli
                 throw new StreamsException("Record key for the grouping KTable should not be null.");
 
             KeyValue<K1, V1> newPair = mapper.apply(key, change.newValue);
-            KeyValue<K1, V1> oldPair = mapper.apply(key, change.oldValue);
+            // if the old value is null, we do not need to forward its selected key-value further
+            KeyValue<K1, V1> oldPair = change.oldValue == null ? null : mapper.apply(key, change.oldValue);
 
             // if the selected repartition key or value is null, skip
             if (newPair != null && newPair.key != null && newPair.value != null) {

--- a/streams/src/test/java/org/apache/kafka/streams/smoketest/SmokeTestUtil.java
+++ b/streams/src/test/java/org/apache/kafka/streams/smoketest/SmokeTestUtil.java
@@ -87,7 +87,7 @@ public class SmokeTestUtil {
             return new KeyValueMapper<String, Long, KeyValue<String, Long>>() {
                 @Override
                 public KeyValue<String, Long> apply(String key, Long value) {
-                    return new KeyValue<>(Long.toString(value), 1L);
+                    return new KeyValue<>(value == null ? null : Long.toString(value), 1L);
                 }
             };
         }


### PR DESCRIPTION
Also handle Null value in SmokeTestUtil.
