### PR TITLE
KAFKA-3942: Change IntegrationTestUtils.purgeLocalStreamsState to use java.io.tmpdir

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/JoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/JoinIntegrationTest.java
@@ -143,11 +143,6 @@ public class JoinIntegrationTest {
         streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        // Explicitly place the state directory under /tmp so that we can remove it via
-        // `purgeLocalStreamsState` below.  Once Streams is updated to expose the effective
-        // StreamsConfig configuration (so we can retrieve whatever state directory Streams came up
-        // with automatically) we don't need to set this anymore and can update `purgeLocalStreamsState`
-        // accordingly.
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG,
                                  TestUtils.tempDirectory().getPath());
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/WordCountIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/WordCountIntegrationTest.java
@@ -87,11 +87,6 @@ public class WordCountIntegrationTest {
         streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        // Explicitly place the state directory under /tmp so that we can remove it via
-        // `purgeLocalStreamsState` below.  Once Streams is updated to expose the effective
-        // StreamsConfig configuration (so we can retrieve whatever state directory Streams came up
-        // with automatically) we don't need to set this anymore and can update `purgeLocalStreamsState`
-        // accordingly.
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
 
         KStreamBuilder builder = new KStreamBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/WordCountIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/WordCountIntegrationTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.test.TestUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -91,7 +92,7 @@ public class WordCountIntegrationTest {
         // StreamsConfig configuration (so we can retrieve whatever state directory Streams came up
         // with automatically) we don't need to set this anymore and can update `purgeLocalStreamsState`
         // accordingly.
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kstreams-word-count");
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
 
         KStreamBuilder builder = new KStreamBuilder();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -115,7 +115,7 @@ public class IntegrationTestUtils {
      * @param streamsConfiguration Streams configuration settings
      */
     public static void purgeLocalStreamsState(Properties streamsConfiguration) throws IOException {
-        final String tmpDir = System.getProperty("java.io.tmpdir");
+        final String tmpDir = TestUtils.IO_TMP_DIR.getPath();
         String path = streamsConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
         if (path != null) {
             File node = Paths.get(path).normalize().toFile();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -119,7 +119,7 @@ public class IntegrationTestUtils {
         String path = streamsConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
         if (path != null) {
             File node = Paths.get(path).normalize().toFile();
-            // Only purge state when it's under /tmp.  This is a safety net to prevent accidentally
+            // Only purge state when it's under java.io.tmpdir.  This is a safety net to prevent accidentally
             // deleting important local directory trees.
             if (node.getAbsolutePath().startsWith(tmpDir)) {
                 Utils.delete(new File(node.getAbsolutePath()));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -115,12 +115,13 @@ public class IntegrationTestUtils {
      * @param streamsConfiguration Streams configuration settings
      */
     public static void purgeLocalStreamsState(Properties streamsConfiguration) throws IOException {
+        final String tmpDir = System.getProperty("java.io.tmpdir");
         String path = streamsConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
         if (path != null) {
             File node = Paths.get(path).normalize().toFile();
             // Only purge state when it's under /tmp.  This is a safety net to prevent accidentally
             // deleting important local directory trees.
-            if (node.getAbsolutePath().startsWith("/tmp")) {
+            if (node.getAbsolutePath().startsWith(tmpDir)) {
                 Utils.delete(new File(node.getAbsolutePath()));
             }
         }

--- a/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/test/StreamsTestUtils.java
@@ -36,7 +36,7 @@ public class StreamsTestUtils {
         streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, keySerdeClassName);
         streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, valueSerdeClassName);
         streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/" + applicationId);
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         streamsConfiguration.putAll(additional);
         return streamsConfiguration;
 


### PR DESCRIPTION
It was previously only deleting files/folders where the path started with /tmp. Changed it to delete from the value of the System Property `java.io.tmpdir`. Also changed the tests that were creating State dirs under /tmp to just use `TestUtils.tempDirectory(..)`
