### PR TITLE
KAFKA-3943 - ConfigDef with Builder pattern

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -873,6 +873,162 @@ public class ConfigDef {
         }
     }
 
+    public Builder define() {
+        return new Builder(this);
+    }
+
+
+    public class Builder {
+        final ConfigDef configDef;
+
+        public Builder(ConfigDef configDef) {
+            this.configDef = configDef;
+        }
+
+        String name;
+        ConfigDef.Type type;
+        Object defaultValue = NO_DEFAULT_VALUE;
+        ConfigDef.Validator validator;
+        ConfigDef.Importance importance;
+        String documentation;
+        String group;
+        int orderInGroup = -1;
+        ConfigDef.Width width = Width.NONE;
+        String displayName;
+        List<String> dependents = new ArrayList<>();
+        ConfigDef.Recommender recommender;
+
+        public String name() {
+            return this.name;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public ConfigDef.Type type() {
+            return this.type;
+        }
+
+        public Builder type(ConfigDef.Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Object defaultValue() {
+            return this.defaultValue;
+        }
+
+        public Builder defaultValue(Object defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public ConfigDef.Validator validator() {
+            return this.validator;
+        }
+
+        public Builder validator(ConfigDef.Validator validator) {
+            this.validator = validator;
+            return this;
+        }
+
+        public ConfigDef.Importance importance() {
+            return this.importance;
+        }
+
+        public Builder importance(ConfigDef.Importance importance) {
+            this.importance = importance;
+            return this;
+        }
+
+        public String documentation() {
+            return this.documentation;
+        }
+
+        public Builder documentation(String documentation) {
+            this.documentation = documentation;
+            return this;
+        }
+
+        public String group() {
+            return this.group;
+        }
+
+        public Builder group(String group) {
+            this.group = group;
+            return this;
+        }
+
+        public int orderInGroup() {
+            return this.orderInGroup;
+        }
+
+        public Builder orderInGroup(int orderInGroup) {
+            this.orderInGroup = orderInGroup;
+            return this;
+        }
+
+        public ConfigDef.Width width() {
+            return this.width;
+        }
+
+        public Builder width(ConfigDef.Width width) {
+            this.width = width;
+            return this;
+        }
+
+        public String displayName() {
+            return this.displayName;
+        }
+
+        public Builder displayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        public List<String> dependents() {
+            return this.dependents;
+        }
+
+        public Builder dependents(List<String> dependents) {
+            this.dependents = dependents;
+            return this;
+        }
+
+        public Builder dependents(String... dependents) {
+            return dependents(Arrays.asList(dependents));
+        }
+
+        public ConfigDef.Recommender recommender() {
+            return this.recommender;
+        }
+
+        public Builder recommender(ConfigDef.Recommender recommender) {
+            this.recommender = recommender;
+            return this;
+        }
+
+
+        public ConfigDef build() {
+            return this.configDef.define(
+                name,
+                type,
+                defaultValue,
+                validator,
+                importance,
+                documentation,
+                group,
+                orderInGroup,
+                width,
+                displayName,
+                dependents,
+                recommender
+            );
+        }
+    }
+
     public String toHtmlTable() {
         List<ConfigKey> configs = sortedConfigs();
         StringBuilder b = new StringBuilder();

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -363,4 +363,48 @@ public class ConfigDefTest {
             }
         }
     }
+
+    @Test
+    public void builder() {
+        ConfigDef expected = new ConfigDef().define("a", Type.INT, 5, Range.between(0, 14), Importance.HIGH, "docs")
+            .define("b", Type.LONG, Importance.HIGH, "docs")
+            .define("c", Type.STRING, "hello", Importance.HIGH, "docs")
+            .define("d", Type.LIST, Importance.HIGH, "docs")
+            .define("e", Type.DOUBLE, Importance.HIGH, "docs")
+            .define("f", Type.CLASS, Importance.HIGH, "docs")
+            .define("g", Type.BOOLEAN, Importance.HIGH, "docs")
+            .define("h", Type.BOOLEAN, Importance.HIGH, "docs")
+            .define("i", Type.BOOLEAN, Importance.HIGH, "docs")
+            .define("j", Type.PASSWORD, Importance.HIGH, "docs");
+        ConfigDef actual = new ConfigDef()
+            .define().name("a").type(Type.INT).defaultValue(5).validator(Range.between(0, 14)).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("b").type(Type.LONG).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("c").type(Type.STRING).defaultValue("hello").importance(Importance.HIGH).documentation("docs").build()
+            .define().name("d").type(Type.LIST).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("e").type(Type.DOUBLE).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("f").type(Type.CLASS).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("g").type(Type.BOOLEAN).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("h").type(Type.BOOLEAN).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("i").type(Type.BOOLEAN).importance(Importance.HIGH).documentation("docs").build()
+            .define().name("j").type(Type.PASSWORD).importance(Importance.HIGH).documentation("docs").build();
+
+        assertEquals(expected.configKeys().keySet(), actual.configKeys().keySet());
+
+        for (String key:expected.configKeys().keySet()) {
+            ConfigDef.ConfigKey expectedConfigKey = expected.configKeys().get(key);
+            ConfigDef.ConfigKey actualConfigKey = actual.configKeys().get(key);
+
+            assertEquals(expectedConfigKey.defaultValue, actualConfigKey.defaultValue);
+            assertEquals(expectedConfigKey.dependents, actualConfigKey.dependents);
+            assertEquals(expectedConfigKey.documentation, actualConfigKey.documentation);
+            assertEquals(expectedConfigKey.group, actualConfigKey.group);
+            assertEquals(expectedConfigKey.name, actualConfigKey.name);
+            assertEquals(expectedConfigKey.importance, actualConfigKey.importance);
+            assertEquals(expectedConfigKey.orderInGroup, actualConfigKey.orderInGroup);
+            assertEquals(expectedConfigKey.type, actualConfigKey.type);
+            assertEquals(expectedConfigKey.width, actualConfigKey.width);
+        }
+
+
+    }
 }


### PR DESCRIPTION
Added Builder class and define() method with no arguments. Added testcase validating the ConfigDef using the current implementation against the new builder implementation.
