### PR TITLE
MINOR: Set additivity false for kafkaAppender (log4j.properties)

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -62,6 +62,7 @@ log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 #log4j.logger.kafka.perf.ProducerPerformance$ProducerThread=DEBUG, kafkaAppender
 #log4j.logger.org.I0Itec.zkclient.ZkClient=DEBUG
 log4j.logger.kafka=INFO, kafkaAppender
+log4j.additivity.kafka=false
 
 log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
 log4j.additivity.kafka.network.RequestChannel$=false


### PR DESCRIPTION
Since current additivity setting of `kafkaAppender` is `true` (default value), This causes duplicated logs in the `kafkaAppender` and the `root` appender.  
It would be better default log4j configuration for **production env** if the additivity value of `kafkaAppender` is `false`
