### PR TITLE
KAFKA-3933: close deepIterator during log recovery

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/CloseableIterator.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CloseableIterator.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import java.util.Iterator;
+
+/**
+ * A interface that lets you iterate over a collection of entries, and
+ * also close underlying resources.
+ * @param <T> The type of thing we are iterating over
+ */
+public interface CloseableIterator<T> extends Iterator<T>, java.lang.AutoCloseable {
+}

--- a/core/src/main/scala/kafka/common/CloseableIterator.scala
+++ b/core/src/main/scala/kafka/common/CloseableIterator.scala
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.common
+
+/**
+ * A scala.Iterator that can be closed as per
+ * org.apache.kafka.commons.utils.CloseableIterator
+ */
+trait CloseableIterator[T] extends Iterator[T] with org.apache.kafka.common.utils.CloseableIterator[T] {
+
+}

--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -217,9 +217,13 @@ class FileMessageSet private[kafka](@volatile var file: File,
       } else {
         // File message set only has shallow iterator. We need to do deep iteration here if needed.
         val deepIter = ByteBufferMessageSet.deepIterator(messageAndOffset)
-        for (innerMessageAndOffset <- deepIter) {
-          newMessages += innerMessageAndOffset.message.toFormatVersion(toMagicValue)
-          offsets += innerMessageAndOffset.offset
+        try {
+          for (innerMessageAndOffset <- deepIter) {
+            newMessages += innerMessageAndOffset.message.toFormatVersion(toMagicValue)
+            offsets += innerMessageAndOffset.offset
+          }
+        } finally {
+          deepIter.close()
         }
       }
     }

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -186,7 +186,9 @@ class LogSegment(val log: FileMessageSet,
               case NoCompressionCodec =>
                 entry.offset
               case _ =>
-                ByteBufferMessageSet.deepIterator(entry).next().offset
+                val iterator = ByteBufferMessageSet.deepIterator(entry)
+                try iterator.next().offset
+                finally iterator.close()
           }
           index.append(startOffset, validBytes)
           lastIndexEntry = validBytes

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -316,6 +316,8 @@ private class ReplicaBuffer(expectedReplicasPerTopicAndPartition: Map[TopicAndPa
             case t: Throwable =>
               throw new RuntimeException("Error in processing replica %d in partition %s at offset %d."
               .format(replicaId, topicAndPartition, fetchOffsetMap.get(topicAndPartition)), t)
+          } finally {
+            messageIterator.close()
           }
         }
         if (isMessageInAllReplicas) {

--- a/core/src/main/scala/kafka/utils/CloseableIteratorTemplate.scala
+++ b/core/src/main/scala/kafka/utils/CloseableIteratorTemplate.scala
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils
+
+import kafka.common.CloseableIterator
+
+trait CloseableIteratorTemplate[T] extends IteratorTemplate[T] with CloseableIterator[T] {
+}

--- a/core/src/main/scala/kafka/utils/IteratorTemplate.scala
+++ b/core/src/main/scala/kafka/utils/IteratorTemplate.scala
@@ -56,7 +56,7 @@ abstract class IteratorTemplate[T] extends Iterator[T] with java.util.Iterator[T
       case _ => maybeComputeNext()
     }
   }
-  
+
   protected def makeNext(): T
   
   def maybeComputeNext(): Boolean = {


### PR DESCRIPTION
Avoids leaking native memory and hence crashing brokers on bootup due to
running out of memory.

Introduces `kafka.common.ClosableIterator`, which is an iterator that
can be closed, and changes the signature of
`ByteBufferMessageSet.deepIterator` to return it, then changes the
callers to always close the iterator.

This is a followup from https://github.com/apache/kafka/pull/1598 with more native memory leaks in the broker code found and fixed.
