### PR TITLE
KAFKA-3859: Fix describe group command to report valid status when group is empty

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -303,23 +303,19 @@ object ConsumerGroupCommand {
 
     protected def describeGroup(group: String) {
       adminClient.describeConsumerGroup(group) match {
-        case None => println(s"Consumer group `${group}` does not exist.")
+        case None =>
         case Some(consumerSummaries) =>
-          if (consumerSummaries.isEmpty)
-            println(s"Consumer group `${group}` is rebalancing.")
-          else {
-            val consumer = getConsumer()
-            printDescribeHeader()
-            consumerSummaries.foreach { consumerSummary =>
-              val topicPartitions = consumerSummary.assignment.map(tp => TopicAndPartition(tp.topic, tp.partition))
-              val partitionOffsets = topicPartitions.flatMap { topicPartition =>
-                Option(consumer.committed(new TopicPartition(topicPartition.topic, topicPartition.partition))).map { offsetAndMetadata =>
-                  topicPartition -> offsetAndMetadata.offset
-                }
-              }.toMap
-              describeTopicPartition(group, topicPartitions, partitionOffsets.get,
-                _ => Some(s"${consumerSummary.clientId}_${consumerSummary.clientHost}"))
-            }
+          val consumer = getConsumer()
+          printDescribeHeader()
+          consumerSummaries.foreach { consumerSummary =>
+            val topicPartitions = consumerSummary.assignment.map(tp => TopicAndPartition(tp.topic, tp.partition))
+            val partitionOffsets = topicPartitions.flatMap { topicPartition =>
+              Option(consumer.committed(new TopicPartition(topicPartition.topic, topicPartition.partition))).map { offsetAndMetadata =>
+                topicPartition -> offsetAndMetadata.offset
+              }
+            }.toMap
+            describeTopicPartition(group, topicPartitions, partitionOffsets.get,
+              _ => Some(s"${consumerSummary.clientId}_${consumerSummary.clientHost}"))
           }
       }
     }


### PR DESCRIPTION
With the new consumer, when all consumers of a consumer group are stopped (i.e. the group is empty), the describe consumer group command returns `Consumer group ... is rebalancing.`
This PR fixes this issue by distinguishing between when the consumer group is actually rebalancing and when it has no active members.
