### PR TITLE
KAFKA-1194: New config to specify memory mapped file update capability for underlying OS

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -181,7 +181,8 @@ class Log(val dir: File,
         // if its a log file, load the corresponding log segment
         val start = filename.substring(0, filename.length - LogFileSuffix.length).toLong
         val indexFile = Log.indexFilename(dir, start)
-        val segment = new LogSegment(dir = dir,
+        val segment = new LogSegment(config,
+                                     dir = dir,
                                      startOffset = start,
                                      indexIntervalBytes = config.indexInterval,
                                      maxIndexSize = config.maxIndexSize,
@@ -215,8 +216,9 @@ class Log(val dir: File,
       val fileName = logFile.getName
       val startOffset = fileName.substring(0, fileName.length - LogFileSuffix.length).toLong
       val indexFile = new File(CoreUtils.replaceSuffix(logFile.getPath, LogFileSuffix, IndexFileSuffix) + SwapFileSuffix)
-      val index =  new OffsetIndex(indexFile, baseOffset = startOffset, maxIndexSize = config.maxIndexSize)
-      val swapSegment = new LogSegment(new FileMessageSet(file = swapFile),
+      val index =  new OffsetIndex(config, indexFile, baseOffset = startOffset, maxIndexSize = config.maxIndexSize)
+      val swapSegment = new LogSegment(config,
+                                       new FileMessageSet(file = swapFile),
                                        index = index,
                                        baseOffset = startOffset,
                                        indexIntervalBytes = config.indexInterval,
@@ -230,7 +232,8 @@ class Log(val dir: File,
 
     if(logSegments.isEmpty) {
       // no existing segments, create a new mutable segment beginning at offset 0
-      segments.put(0L, new LogSegment(dir = dir,
+      segments.put(0L, new LogSegment(logConfig = config,
+                                     dir = dir,
                                      startOffset = 0,
                                      indexIntervalBytes = config.indexInterval,
                                      maxIndexSize = config.maxIndexSize,
@@ -656,7 +659,8 @@ class Log(val dir: File,
           entry.getValue.log.trim()
         }
       }
-      val segment = new LogSegment(dir,
+      val segment = new LogSegment(logConfig = config,
+                                   dir,
                                    startOffset = newOffset,
                                    indexIntervalBytes = config.indexInterval,
                                    maxIndexSize = config.maxIndexSize,
@@ -755,7 +759,8 @@ class Log(val dir: File,
     lock synchronized {
       val segmentsToDelete = logSegments.toList
       segmentsToDelete.foreach(deleteSegment(_))
-      addSegment(new LogSegment(dir,
+      addSegment(new LogSegment(logConfig = config,
+                                dir,
                                 newOffset,
                                 indexIntervalBytes = config.indexInterval,
                                 maxIndexSize = config.maxIndexSize,

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -368,8 +368,8 @@ private[log] class Cleaner(val id: Int,
     val indexFile = new File(segments.head.index.file.getPath + Log.CleanedFileSuffix)
     indexFile.delete()
     val messages = new FileMessageSet(logFile, fileAlreadyExists = false, initFileSize = log.initFileSize(), preallocate = log.config.preallocate)
-    val index = new OffsetIndex(indexFile, segments.head.baseOffset, segments.head.index.maxIndexSize)
-    val cleaned = new LogSegment(messages, index, segments.head.baseOffset, segments.head.indexIntervalBytes, log.config.randomSegmentJitter, time)
+    val index = new OffsetIndex(log.config, indexFile, segments.head.baseOffset, segments.head.index.maxIndexSize)
+    val cleaned = new LogSegment(log.config, messages, index, segments.head.baseOffset, segments.head.indexIntervalBytes, log.config.randomSegmentJitter, time)
 
     try {
       // clean segments into the new destination segment

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -52,6 +52,7 @@ object Defaults {
   val MessageFormatVersion = kafka.server.Defaults.LogMessageFormatVersion
   val MessageTimestampType = kafka.server.Defaults.LogMessageTimestampType
   val MessageTimestampDifferenceMaxMs = kafka.server.Defaults.LogMessageTimestampDifferenceMaxMs
+  val MemoryMappedFileUpdatesEnabled = kafka.server.Defaults.MemoryMappedFileUpdatesEnabled
 }
 
 case class LogConfig(props: java.util.Map[_, _]) extends AbstractConfig(LogConfig.configDef, props, false) {
@@ -80,9 +81,11 @@ case class LogConfig(props: java.util.Map[_, _]) extends AbstractConfig(LogConfi
   val messageFormatVersion = ApiVersion(getString(LogConfig.MessageFormatVersionProp))
   val messageTimestampType = TimestampType.forName(getString(LogConfig.MessageTimestampTypeProp))
   val messageTimestampDifferenceMaxMs = getLong(LogConfig.MessageTimestampDifferenceMaxMsProp).longValue
-
+  val MemoryMappedFileUpdatesEnabled = getBoolean(LogConfig.MemoryMappedFileUpdatesEnabledProp)
+  
   def randomSegmentJitter: Long =
     if (segmentJitterMs == 0) 0 else Utils.abs(scala.util.Random.nextInt()) % math.min(segmentJitterMs, segmentMs)
+    
 }
 
 object LogConfig {
@@ -115,6 +118,7 @@ object LogConfig {
   val MessageFormatVersionProp = "message.format.version"
   val MessageTimestampTypeProp = "message.timestamp.type"
   val MessageTimestampDifferenceMaxMsProp = "message.timestamp.difference.max.ms"
+  val MemoryMappedFileUpdatesEnabledProp = "memorymapped.file.updates.enabled"
 
   val SegmentSizeDoc = "The hard maximum for the size of a segment file in the log"
   val SegmentMsDoc = "The soft maximum on the amount of time before a new log segment is rolled"
@@ -142,6 +146,8 @@ object LogConfig {
   val MessageFormatVersionDoc = KafkaConfig.LogMessageFormatVersionDoc
   val MessageTimestampTypeDoc = KafkaConfig.LogMessageTimestampTypeDoc
   val MessageTimestampDifferenceMaxMsDoc = KafkaConfig.LogMessageTimestampDifferenceMaxMsDoc
+  val MemoryMappedFileUpdatesEnabledDoc = "Indicates if the underlying OS supports metadata(resize, update length)" + 
+    " updates on memory mapped failes"
 
   private val configDef = {
     import org.apache.kafka.common.config.ConfigDef.Importance._
@@ -177,6 +183,7 @@ object LogConfig {
       .define(MessageFormatVersionProp, STRING, Defaults.MessageFormatVersion, MEDIUM, MessageFormatVersionDoc)
       .define(MessageTimestampTypeProp, STRING, Defaults.MessageTimestampType, MEDIUM, MessageTimestampTypeDoc)
       .define(MessageTimestampDifferenceMaxMsProp, LONG, Defaults.MessageTimestampDifferenceMaxMs, atLeast(0), MEDIUM, MessageTimestampDifferenceMaxMsDoc)
+      .define(MemoryMappedFileUpdatesEnabledProp, BOOLEAN, Defaults.MemoryMappedFileUpdatesEnabled, HIGH, MemoryMappedFileUpdatesEnabledDoc)
   }
 
   def apply(): LogConfig = LogConfig(new Properties())

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -78,6 +78,7 @@ object KafkaServer {
     logProps.put(LogConfig.MessageFormatVersionProp, kafkaConfig.logMessageFormatVersion.version)
     logProps.put(LogConfig.MessageTimestampTypeProp, kafkaConfig.logMessageTimestampType.name)
     logProps.put(LogConfig.MessageTimestampDifferenceMaxMsProp, kafkaConfig.logMessageTimestampDifferenceMaxMs)
+    logProps.put(LogConfig.MemoryMappedFileUpdatesEnabledProp, kafkaConfig.memoryMappedFileUpdatesEnabled)
     logProps
   }
 }

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -19,6 +19,7 @@ package kafka.tools
 
 import java.io._
 import java.nio.ByteBuffer
+import java.util.Properties
 
 import joptsimple.OptionParser
 import kafka.coordinator.{GroupMetadataKey, GroupMetadataManager, OffsetKey}
@@ -124,7 +125,8 @@ object DumpLogSegments {
     val startOffset = file.getName().split("\\.")(0).toLong
     val logFile = new File(file.getAbsoluteFile.getParent, file.getName.split("\\.")(0) + Log.LogFileSuffix)
     val messageSet = new FileMessageSet(logFile, false)
-    val index = new OffsetIndex(file, baseOffset = startOffset)
+    val logConfig = LogConfig(new Properties())
+    val index = new OffsetIndex(logConfig, file, baseOffset = startOffset)
 
     //Check that index passes sanityCheck, this is the check that determines if indexes will be rebuilt on startup or not.
     if (indexSanityOnly) {

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -22,6 +22,7 @@ import java.util.Properties
 import kafka.server.KafkaConfig
 import kafka.server.KafkaServer
 import kafka.utils.TestUtils
+import kafka.utils.Os
 import org.apache.kafka.common.config.ConfigException
 import org.junit.{Assert, Test}
 import org.junit.Assert._
@@ -37,11 +38,22 @@ class LogConfigTest {
     kafkaProps.put(KafkaConfig.LogRollTimeJitterHoursProp, "2")
     kafkaProps.put(KafkaConfig.LogRetentionTimeHoursProp, "2")
 
-    val kafkaConfig = KafkaConfig.fromProps(kafkaProps)
-    val logProps = KafkaServer.copyKafkaConfigToLog(kafkaConfig)
+    var kafkaConfig = KafkaConfig.fromProps(kafkaProps)
+    var logProps = KafkaServer.copyKafkaConfigToLog(kafkaConfig)
     assertEquals(2 * millisInHour, logProps.get(LogConfig.SegmentMsProp))
     assertEquals(2 * millisInHour, logProps.get(LogConfig.SegmentJitterMsProp))
     assertEquals(2 * millisInHour, logProps.get(LogConfig.RetentionMsProp))
+    assertEquals(!Os.isWindows, logProps.get(LogConfig.MemoryMappedFileUpdatesEnabledProp).asInstanceOf[Boolean])
+    
+    kafkaProps.put(KafkaConfig.MemoryMappedFileUpdatesEnabledProp, "true")
+    kafkaConfig = KafkaConfig.fromProps(kafkaProps)
+    logProps = KafkaServer.copyKafkaConfigToLog(kafkaConfig)
+    assertTrue(logProps.get(LogConfig.MemoryMappedFileUpdatesEnabledProp).asInstanceOf[Boolean])
+    
+    kafkaProps.put(KafkaConfig.MemoryMappedFileUpdatesEnabledProp, "false")
+    kafkaConfig = KafkaConfig.fromProps(kafkaProps)
+    logProps = KafkaServer.copyKafkaConfigToLog(kafkaConfig)
+    assertFalse(logProps.get(LogConfig.MemoryMappedFileUpdatesEnabledProp).asInstanceOf[Boolean])
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -19,7 +19,7 @@ package kafka.log
 
 import java.io._
 import org.junit.Assert._
-import java.util.{Collections, Arrays}
+import java.util.{Collections, Arrays, Properties}
 import org.junit._
 import org.scalatest.junit.JUnitSuite
 import scala.collection._
@@ -31,10 +31,10 @@ class OffsetIndexTest extends JUnitSuite {
   
   var idx: OffsetIndex = null
   val maxEntries = 30
-  
+  val config = LogConfig (new Properties())
   @Before
   def setup() {
-    this.idx = new OffsetIndex(nonExistantTempFile(), baseOffset = 45L, maxIndexSize = 30 * 8)
+    this.idx = new OffsetIndex(config, nonExistantTempFile(), baseOffset = 45L, maxIndexSize = 30 * 8)
   }
   
   @After
@@ -103,7 +103,7 @@ class OffsetIndexTest extends JUnitSuite {
     idx.append(first.offset, first.position)
     idx.append(sec.offset, sec.position)
     idx.close()
-    val idxRo = new OffsetIndex(idx.file, baseOffset = idx.baseOffset)
+    val idxRo = new OffsetIndex(config, idx.file, baseOffset = idx.baseOffset)
     assertEquals(first, idxRo.lookup(first.offset))
     assertEquals(sec, idxRo.lookup(sec.offset))
     assertEquals(sec.offset, idxRo.lastOffset)
@@ -113,7 +113,7 @@ class OffsetIndexTest extends JUnitSuite {
   
   @Test
   def truncate() {
-	val idx = new OffsetIndex(nonExistantTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
+	val idx = new OffsetIndex(config, nonExistantTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
 	idx.truncate()
     for(i <- 1 until 10)
       idx.append(i, i)


### PR DESCRIPTION
A new configuration value that can be used to indicate if the underlying OS (and environment) supports updates to memory mapped files. 

On windows systems, metadata updates, and rename operations fail if the file is still memory mapped. 
This fix will close the file if updates are not supported, and then proceeds to execute the update operations.
