### PR TITLE
MINOR: fix extra broker setup

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -106,11 +106,13 @@ config/server-1.properties:
     broker.id=1
     listeners=PLAINTEXT://:9093
     log.dir=/tmp/kafka-logs-1
+    zookeeper.connect=localhost:2181
 
 config/server-2.properties:
     broker.id=2
     listeners=PLAINTEXT://:9094
     log.dir=/tmp/kafka-logs-2
+    zookeeper.connect=localhost:2181
 </pre>
 The <code>broker.id</code> property is the unique and permanent name of each node in the cluster. We have to override the port and log directory only because we are running these all on the same machine and we want to keep the brokers from all trying to register on the same port or overwrite each others data.
 <p>


### PR DESCRIPTION
Quickstart setup for brokers 1 and 2 need "zookeeper.connect" setting.

Otherwise you are greeted with:
org.apache.kafka.common.config.ConfigException: Missing required configuration "zookeeper.connect" which has no default value.
