### PR TITLE
MINOR: MetadataCache brokerId is not set on first run with generated …

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -131,7 +131,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
   val kafkaScheduler = new KafkaScheduler(config.backgroundThreads)
 
   var kafkaHealthcheck: KafkaHealthcheck = null
-  val metadataCache: MetadataCache = new MetadataCache(config.brokerId)
+  var metadataCache: MetadataCache = null
 
   var zkUtils: ZkUtils = null
   val correlationId: AtomicInteger = new AtomicInteger(0)
@@ -187,6 +187,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
         /* generate brokerId */
         config.brokerId =  getBrokerId
         this.logIdent = "[Kafka Server " + config.brokerId + "], "
+
+        metadataCache = new MetadataCache(config.brokerId)
 
         socketServer = new SocketServer(config, metrics, kafkaMetricsTime)
         socketServer.startup()

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -52,7 +52,7 @@ class MetadataRequestTest extends BaseRequestTest {
     assertNotEquals("Controller id should switch to a new broker", controllerId, controllerId2)
     TestUtils.waitUntilTrue(() => {
       val metadataResponse2 = sendMetadataRequest(MetadataRequest.allTopics(), 1)
-      controllerServer2.apis.brokerId == metadataResponse2.controller.id
+      metadataResponse2.controller() != null && controllerServer2.apis.brokerId == metadataResponse2.controller.id
     }, "Controller id should match the active controller after failover", 5000)
   }
 

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -52,7 +52,7 @@ class MetadataRequestTest extends BaseRequestTest {
     assertNotEquals("Controller id should switch to a new broker", controllerId, controllerId2)
     TestUtils.waitUntilTrue(() => {
       val metadataResponse2 = sendMetadataRequest(MetadataRequest.allTopics(), 1)
-      metadataResponse2.controller() != null && controllerServer2.apis.brokerId == metadataResponse2.controller.id
+      metadataResponse2.controller != null && controllerServer2.apis.brokerId == metadataResponse2.controller.id
     }, "Controller id should match the active controller after failover", 5000)
   }
 


### PR DESCRIPTION
…broker id

This is because the id passed into the MetadataCache is the value from the config before the real broker id is generated.
