### PR TITLE
KAFKA-3924: Replacing halt with exit upon LEO mismatch to trigger gra…

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -175,10 +175,10 @@ class ReplicaFetcherThread(name: String,
       if (!LogConfig.fromProps(brokerConfig.originals, AdminUtils.fetchEntityConfig(replicaMgr.zkUtils,
         ConfigType.Topic, topicAndPartition.topic)).uncleanLeaderElectionEnable) {
         // Log a fatal error and shutdown the broker to ensure that data loss does not unexpectedly occur.
-        fatal("Halting because log truncation is not allowed for topic %s,".format(topicAndPartition.topic) +
+        fatal("Exiting because log truncation is not allowed for topic %s,".format(topicAndPartition.topic) +
           " Current leader %d's latest offset %d is less than replica %d's latest offset %d"
           .format(sourceBroker.id, leaderEndOffset, brokerConfig.brokerId, replica.logEndOffset.messageOffset))
-        Runtime.getRuntime.halt(1)
+        System.exit(1)
       }
 
       warn("Replica %d for partition %s reset its fetch offset from %d to current leader %d's latest offset %d"


### PR DESCRIPTION
…ceful shutdown

The patch is pretty simple and the justification is explained in https://issues.apache.org/jira/browse/KAFKA-3924

I could not find Andrew Olson, who seems to be the contributor of this part of the code, in github so I am not sure whom I should ask to review the patch.

 the contribution is my original work and that i license the work to the project under the project's open source license.
