### PR TITLE
MINOR: Remove slf4j-log4j from kafka-streams compile dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -677,7 +677,7 @@ project(':streams') {
   dependencies {
     compile project(':clients')
     compile project(':connect:json')  // this dependency should be removed after we unify data API
-    compile libs.slf4jlog4j
+    compile libs.slf4jApi
     compile libs.rocksDBJni
     // this dependency should be removed after KIP-4
     compile (libs.zkclient) {
@@ -690,6 +690,8 @@ project(':streams') {
     testCompile project(':core')
     testCompile project(':core').sourceSets.test.output
     testCompile libs.junit
+
+    testRuntime libs.slf4jlog4j
   }
 
   javadoc {


### PR DESCRIPTION
As kafka-streams is intended to be used by applications that may or may not wish to use log4j, kafka-streams itself should not have a dependency on a concrete log framework.  This change adapts the dependencies to be API-only for compile, and framework-specific for the test runtime only.

I read through the [Contributing Code Guidelines](https://cwiki.apache.org/confluence/display/KAFKA/Contributing+Code+Changes) and interpreted this as a trivial change that doesn't require a Jira ticket.  Please let me know if I've interpreted that wrongly.

This contribution is my original work and I license the work to the project under the project's open source license.
