### PR TITLE
KAFKA-3740: Enable configuration of RocksDBStores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -118,6 +118,10 @@ public class StreamsConfig extends AbstractConfig {
     /** <code>client.id</code> */
     public static final String CLIENT_ID_CONFIG = CommonClientConfigs.CLIENT_ID_CONFIG;
 
+    public static final String ROCKSDB_CONFIG_SETTER_CLASS_CONFIG = "rocksdb.config.setter";
+    public static final String ROCKSDB_CONFIG_SETTER_CLASS_DOC = "A Rocks DB config setter class that implements the <code>RocksDBConfigSetter</code> interface";
+
+
     static {
         CONFIG = new ConfigDef().define(APPLICATION_ID_CONFIG,      // required with no default value
                                         Type.STRING,
@@ -213,7 +217,12 @@ public class StreamsConfig extends AbstractConfig {
                                         2,
                                         atLeast(1),
                                         Importance.LOW,
-                                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC);
+                                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC)
+                                .define(ROCKSDB_CONFIG_SETTER_CLASS_CONFIG,
+                                        Type.CLASS,
+                                        null,
+                                        Importance.LOW,
+                                        ROCKSDB_CONFIG_SETTER_CLASS_DOC);
     }
 
     // this is the list of configs for underlying clients

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.state;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Options;
 
+import java.util.Map;
+
 /**
  * An interface to that allows developers to customize the RocksDB settings
  * for a given Store. Please read the <a href="https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide">RocksDB Tuning Guide</a>.
@@ -33,6 +35,7 @@ public interface RocksDBConfigSetter {
      * </p>
      * @param storeName     the name of the store being configured
      * @param options       the Rocks DB optionse
+     * @param configs       the configuration supplied to {@link org.apache.kafka.streams.StreamsConfig}
      */
-    void setConfig(final String storeName, final Options options);
+    void setConfig(final String storeName, final Options options, final Map<String, Object> configs);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state;
+
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.Options;
+
+/**
+ * An interface to that allows developers to customize the RocksDB settings
+ * for a given Store. Please read the <a href="https://github.com/facebook/rocksdb/wiki/RocksDB-Tuning-Guide">RocksDB Tuning Guide</a>.
+ */
+public interface RocksDBConfigSetter {
+
+    /**
+     * Set the rocks db options for the provided storeName.
+     * <p>
+     *  Note: Some options may be taken as a hint, i.e, {@link BlockBasedTableConfig#setBlockCacheSize(long)} might be
+     *  reduced due to memory constraints.
+     * </p>
+     * @param storeName     the name of the store being configured
+     * @param options       the Rocks DB optionse
+     */
+    void setConfig(final String storeName, final Options options);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/RocksDBConfigSetter.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.state;
 
-import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Options;
 
 import java.util.Map;
@@ -29,12 +28,9 @@ public interface RocksDBConfigSetter {
 
     /**
      * Set the rocks db options for the provided storeName.
-     * <p>
-     *  Note: Some options may be taken as a hint, i.e, {@link BlockBasedTableConfig#setBlockCacheSize(long)} might be
-     *  reduced due to memory constraints.
-     * </p>
+     * 
      * @param storeName     the name of the store being configured
-     * @param options       the Rocks DB optionse
+     * @param options       the Rocks DB options
      * @param configs       the configuration supplied to {@link org.apache.kafka.streams.StreamsConfig}
      */
     void setConfig(final String storeName, final Options options, final Map<String, Object> configs);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -166,7 +166,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         final Class<RocksDBConfigSetter> configSetterClass = (Class<RocksDBConfigSetter>) configs.get(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG);
         if (configSetterClass != null) {
             final RocksDBConfigSetter configSetter = Utils.newInstance(configSetterClass);
-            configSetter.setConfig(name, options);
+            configSetter.setConfig(name, options, configs);
         }
         // we need to construct the serde while opening DB since
         // it is also triggered by windowed DB segments without initialization

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -19,13 +19,16 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.StateSerdes;
 
 import org.rocksdb.BlockBasedTableConfig;
@@ -44,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -121,7 +125,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
 
-        // initialize the rocksdb options
+        // initialize the default rocksdb options
         BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
         tableConfig.setBlockCacheSize(BLOCK_CACHE_SIZE);
         tableConfig.setBlockSize(BLOCK_SIZE);
@@ -158,6 +162,12 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     @SuppressWarnings("unchecked")
     public void openDB(ProcessorContext context) {
+        final Map<String, Object> configs = context.appConfigs();
+        final Class<RocksDBConfigSetter> configSetterClass = (Class<RocksDBConfigSetter>) configs.get(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG);
+        if (configSetterClass != null) {
+            final RocksDBConfigSetter configSetter = Utils.newInstance(configSetterClass);
+            configSetter.setConfig(name, options);
+        }
         // we need to construct the serde while opening DB since
         // it is also triggered by windowed DB segments without initialization
         this.serdes = new StateSerdes<>(name,

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -131,6 +131,8 @@ import java.util.Set;
  */
 public class KeyValueStoreTestDriver<K, V> {
 
+    private final Properties props;
+
     /**
      * Create a driver object that will have a {@link #context()} that records messages
      * {@link ProcessorContext#forward(Object, Object) forwarded} by the store and that provides default serializers and
@@ -214,11 +216,14 @@ public class KeyValueStoreTestDriver<K, V> {
         this.stateDir = TestUtils.tempDirectory();
         this.stateDir.mkdirs();
 
-        Properties props = new Properties();
+        props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "applicationId");
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         props.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class);
         props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, serdes.keySerde().getClass());
         props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, serdes.valueSerde().getClass());
+
+
 
         this.context = new MockProcessorContext(null, this.stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector) {
             @Override
@@ -254,12 +259,12 @@ public class KeyValueStoreTestDriver<K, V> {
 
             @Override
             public Map<String, Object> appConfigs() {
-                return null;
+                return new StreamsConfig(props).originals();
             }
 
             @Override
             public Map<String, Object> appConfigsWithPrefix(String prefix) {
-                return null;
+                return new StreamsConfig(props).originalsWithPrefix(prefix);
             }
         };
     }
@@ -418,5 +423,9 @@ public class KeyValueStoreTestDriver<K, V> {
         restorableEntries.clear();
         flushedEntries.clear();
         flushedRemovals.clear();
+    }
+
+    public void setConfig(final String configName, final Object configValue) {
+        props.put(configName, configValue);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.streams.state.Stores;
 import org.junit.Test;
 import org.rocksdb.Options;
 
+import java.util.Map;
+
 import static org.junit.Assert.assertTrue;
 
 public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
@@ -56,7 +58,7 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
         static boolean called = false;
 
         @Override
-        public void setConfig(final String storeName, final Options options) {
+        public void setConfig(final String storeName, final Options options, final Map<String, Object> configs) {
             called = true;
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -16,10 +16,17 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.KeyValueStoreTestDriver;
+import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.Stores;
+import org.junit.Test;
+import org.rocksdb.Options;
+
+import static org.junit.Assert.assertTrue;
 
 public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
@@ -43,4 +50,23 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
         return store;
 
     }
+
+    public static class TheRocksDbConfigSetter implements RocksDBConfigSetter {
+
+        static boolean called = false;
+
+        @Override
+        public void setConfig(final String storeName, final Options options) {
+            called = true;
+        }
+    }
+
+    @Test
+    public void shouldUseCustomRocksDbConfigSetter() throws Exception {
+        final KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create(Integer.class, String.class);
+        driver.setConfig(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, TheRocksDbConfigSetter.class);
+        createKeyValueStore(driver.context(), Integer.class, String.class, false);
+        assertTrue(TheRocksDbConfigSetter.called);
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.TaskId;
@@ -35,9 +36,11 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.TestUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -57,6 +60,7 @@ public class StreamThreadStateStoreProviderTest {
     private StreamTask taskTwo;
     private StreamThreadStateStoreProvider provider;
     private StateDirectory stateDirectory;
+    private File stateDir;
 
     @Before
     public void before() throws IOException {
@@ -77,7 +81,8 @@ public class StreamThreadStateStoreProviderTest {
         final String applicationId = "applicationId";
         properties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
         properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        final String stateConfigDir = TestUtils.tempDirectory().getPath();
+        stateDir = TestUtils.tempDirectory();
+        final String stateConfigDir = stateDir.getPath();
         properties.put(StreamsConfig.STATE_DIR_CONFIG,
                 stateConfigDir);
 
@@ -111,6 +116,11 @@ public class StreamThreadStateStoreProviderTest {
 
     }
 
+    @After
+    public void cleanUp() {
+        Utils.delete(stateDir);
+    }
+    
     @Test
     public void shouldFindKeyValueStores() throws Exception {
         List<ReadOnlyKeyValueStore<String, String>> kvStores =

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -191,12 +191,12 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
 
     @Override
     public Map<String, Object> appConfigs() {
-        return null;
+        return Collections.emptyMap();
     }
 
     @Override
     public Map<String, Object> appConfigsWithPrefix(String prefix) {
-        return null;
+        return Collections.emptyMap();
     }
 
     public Map<String, StateStore> allStateStores() {


### PR DESCRIPTION
Add new config StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG to enable advanced
RocksDB users to override default RocksDB configuration
