### PR TITLE
KAFKA-3982: Fix processing order of some of the consumer properties

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -200,20 +200,8 @@ object ConsoleConsumer extends Logging {
     if (!props.containsKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
       props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, if (config.options.has(config.resetBeginningOpt)) "earliest" else "latest")
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
-
-    if (config.keyDeserializer != null)
-      // the argument that is provided directly takes precedence
-      props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, config.keyDeserializer)
-    else if (!props.containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
-      // the default is used if the argument is not provided directly or indirectly
-      props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
-
-    if (config.valueDeserializer != null)
-      // the argument that is provided directly takes precedence
-      props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, config.valueDeserializer)
-    else if (!props.containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
-      // the default is used if the argument is not provided directly or indirectly
-      props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
 
     props
   }
@@ -329,6 +317,32 @@ object ConsoleConsumer extends Logging {
     val keyDeserializer = options.valueOf(keyDeserializerOpt)
     val valueDeserializer = options.valueOf(valueDeserializerOpt)
     val formatter: MessageFormatter = messageFormatterClass.newInstance().asInstanceOf[MessageFormatter]
+
+    if (keyDeserializer != null && !keyDeserializer.isEmpty)
+      // the argument that is provided directly takes precedence
+      formatterArgs.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer)
+    else if (extraConsumerProps.containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+      // then the argument that is provided through --consumer-property
+      formatterArgs.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, extraConsumerProps.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+    else if (consumerProps.containsKey(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+      // then the argument that is provided through --consumer.config
+      formatterArgs.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, consumerProps.getProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG))
+    else
+      // the default is used if the argument is not provided directly or indirectly
+      formatterArgs.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
+
+    if (valueDeserializer != null && !valueDeserializer.isEmpty)
+      // the argument that is provided directly takes precedence
+      formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer)
+    else if (extraConsumerProps.containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+      // then the argument that is provided through --consumer-property
+      formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, extraConsumerProps.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+    else if (consumerProps.containsKey(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+      // then the argument that is provided through --consumer.config
+      formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, consumerProps.getProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG))
+    else
+      // the default is used if the argument is not provided directly or indirectly
+      formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
 
     formatter.init(formatterArgs)
 

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -196,6 +196,7 @@ class ConsoleConsumerTest {
   def shouldOverwriteConfigFromConfigFileOrPropertiesWithConfigFromArguments() {
     val propsFile = TestUtils.tempFile()
     val propsStream = new FileOutputStream(propsFile)
+    propsStream.write("bootstrap.servers=localhost:9093\n".getBytes())
     propsStream.write("auto.offset.reset=earliest\n".getBytes())
     propsStream.write("key.deserializer=org.apache.kafka.common.serialization.LongDeserializer\n".getBytes())
     propsStream.write("value.deserializer=org.apache.kafka.common.serialization.LongDeserializer".getBytes())
@@ -214,8 +215,12 @@ class ConsoleConsumerTest {
     val config = new ConsoleConsumer.ConsumerConfig(args)
     val props = ConsoleConsumer.getNewConsumerProps(config)
 
+    assertEquals("localhost:9092", props.getProperty("bootstrap.servers"))
     assertEquals("latest", props.getProperty("auto.offset.reset"))
-    assertEquals("org.apache.kafka.common.serialization.DoubleDeserializer", props.getProperty("key.deserializer"))
-    assertEquals("org.apache.kafka.common.serialization.DoubleDeserializer", props.getProperty("value.deserializer"))
+    assertEquals("org.apache.kafka.common.serialization.DoubleDeserializer", config.formatterArgs.getProperty("key.deserializer"))
+    assertEquals("org.apache.kafka.common.serialization.DoubleDeserializer", config.formatterArgs.getProperty("value.deserializer"))
+    // serde settings applies to message formatter only, not the consumer itself
+    assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", props.getProperty("key.deserializer"))
+    assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", props.getProperty("value.deserializer"))
   }
 }


### PR DESCRIPTION
This PR updates processing of console consumer's input properties.

For both old and new consumer, the value provided for `auto.offset.reset` indirectly through `consumer.config` or `consumer.property` arguments will now take effect.
For new consumer and for `key.deserializer` and `value.deserializer` properties, the precedence order is fixed to first the value directly provided as an argument, then the value provided indirectly via `consumer.property` and then `consumer.config`, and finally a default value.
