### PR TITLE
KAFKA-3689 - process only distinct connectionIds within processDisconnected()

### DIFF
--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -332,9 +332,8 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
       if (sendBufferSize != Selectable.USE_DEFAULT_BUFFER_SIZE)
         socketChannel.socket().setSendBufferSize(sendBufferSize)
 
-      debug("Accepted connection from %s on %s. Registering with Processor %d sendBufferSize [actual|requested]: [%d|%d] recvBufferSize [actual|requested]: [%d|%d]"
-            .format(socketChannel.socket.getRemoteSocketAddress, socketChannel.socket.getLocalSocketAddress,
-                  processor.id,
+      debug("Accepted connection from %s on %s and assigned it to processor %d, sendBufferSize [actual|requested]: [%d|%d] recvBufferSize [actual|requested]: [%d|%d]"
+            .format(socketChannel.socket.getRemoteSocketAddress, socketChannel.socket.getLocalSocketAddress, processor.id,
                   socketChannel.socket.getSendBufferSize, sendBufferSize,
                   socketChannel.socket.getReceiveBufferSize, recvBufferSize))
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -515,7 +515,7 @@ private[kafka] class Processor(val id: Int,
     // Duplicate connectionId entries could lead to a double decrement of the connection quota which is keyed by host address
     val distinct = selector.disconnected.asScala.distinct
     if (distinct.size != selector.disconnected.size)
-      warn("disconnected list has duplicates")
+      warn(s"disconnected list contains duplicates: $distinct")
     distinct.foreach { connectionId =>
       val remoteHost = ConnectionId.fromString(connectionId).getOrElse {
         throw new IllegalStateException(s"connectionId has unexpected format: $connectionId")

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -332,8 +332,9 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
       if (sendBufferSize != Selectable.USE_DEFAULT_BUFFER_SIZE)
         socketChannel.socket().setSendBufferSize(sendBufferSize)
 
-      debug("Accepted connection from %s on %s. sendBufferSize [actual|requested]: [%d|%d] recvBufferSize [actual|requested]: [%d|%d]"
-            .format(socketChannel.socket.getInetAddress, socketChannel.socket.getLocalSocketAddress,
+      debug("Accepted connection from %s on %s. Registering with Processor %d sendBufferSize [actual|requested]: [%d|%d] recvBufferSize [actual|requested]: [%d|%d]"
+            .format(socketChannel.socket.getRemoteSocketAddress, socketChannel.socket.getLocalSocketAddress,
+                  processor.id,
                   socketChannel.socket.getSendBufferSize, sendBufferSize,
                   socketChannel.socket.getReceiveBufferSize, recvBufferSize))
 


### PR DESCRIPTION
@ijuma discovered a possible scenario in which connectionQuotas may be [doubly-decremented](https://issues.apache.org/jira/browse/KAFKA-3689?focusedCommentId=15385962&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15385962)

This PR intends to remove that possibility by first filtering out any duplicate connectionIds. This way each 
