### PR TITLE
KAFKA-3993 Console Producer Drops Data 

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -57,6 +57,7 @@ object ConsoleProducer {
           if (message != null)
             producer.send(message.topic, message.key, message.value)
         } while (message != null)
+        producer.close()
     } catch {
       case e: joptsimple.OptionException =>
         System.err.println(e.getMessage)


### PR DESCRIPTION
@ijuma Would you mind taking a look?

This fixes the problem for me using this test script.

```
export BOOTSTRAP_SERVERS=localhost:9092
export TOPIC=bar
export MESSAGES=10000
./bin/kafka-topics.sh --zookeeper localhost:2181 --create --partitions 1 --replication-factor 1 --topic "$TOPIC" \
&& echo "acks=all" > /tmp/producer.config \
&& echo "linger.ms=0" >> /tmp/producer.config \
&& seq "$MESSAGES" | ./bin/kafka-console-producer.sh --broker-list "$BOOTSTRAP_SERVERS" --topic "$TOPIC" \
&& ./bin/kafka-console-consumer.sh --bootstrap-server "$BOOTSTRAP_SERVERS" --new-consumer --from-beginning --max-messages "${MESSAGES}" --topic "$TOPIC"
```
