### PR TITLE
KAFKA-4004: NetworkReceive.complete() should not throw NullPointerException after partially reading the size

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -64,7 +64,7 @@ public class NetworkReceive implements Receive {
 
     @Override
     public boolean complete() {
-        return !size.hasRemaining() && !buffer.hasRemaining();
+        return !size.hasRemaining() && buffer != null && !buffer.hasRemaining();
     }
 
     public long readFrom(ScatteringByteChannel channel) throws IOException {


### PR DESCRIPTION
NetworkReceive.readFrom can partially read the size and not allocate a buffer. A following NetworkReceive.complete() should not throw a NullPointerException and should instead just return false.
