### PR TITLE
MINOR: replace reference to HoppingWindows in streams.html

### DIFF
--- a/docs/streams.html
+++ b/docs/streams.html
@@ -301,7 +301,7 @@ based on them.
     KTable<Windowed<String>, Long> counts = source1.aggregateByKey(
         () -> 0L,  // initial value
         (aggKey, value, aggregate) -> aggregate + 1L,   // aggregating value
-        HoppingWindows.of("counts").with(5000L).every(1000L), // intervals in milliseconds
+        TimeWindows.of("counts",5000L).advanceBy(1000L), // intervals in milliseconds
     );
 
     KStream<String, String> joined = source1.leftJoin(source2,


### PR DESCRIPTION
HoppingWindows was removed prior to the 0.10.0 release. I've updated the doc to refer to the correct TimeWindows
