### PR TITLE
KAFKA-3590: KafkaConsumer fails with "Messages are rejected since there are fewer in-sync replicas than required." when polling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -451,6 +451,9 @@ public abstract class AbstractCoordinator implements Closeable {
                     log.debug("SyncGroup for group {} failed due to {}", groupId, error);
                     coordinatorDead();
                     future.raise(error);
+                } else if (error == Errors.NOT_ENOUGH_REPLICAS
+                        || error == Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND) {
+                    future.raise(new KafkaException("Unable to write to __consumer_offsets: " + error.message()));
                 } else {
                     future.raise(new KafkaException("Unexpected error from SyncGroup: " + error.message()));
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -453,7 +453,10 @@ public abstract class AbstractCoordinator implements Closeable {
                     future.raise(error);
                 } else if (error == Errors.NOT_ENOUGH_REPLICAS
                         || error == Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND) {
-                    future.raise(new KafkaException("Unable to write to __consumer_offsets: " + error.message()));
+                    log.warn("Failure to write to __consumer_offsets topic: " + error.message());
+                    coordinatorDead();
+                    //convert to GROUP_COORDINATOR_NOT_AVAILABLE to let the client retry
+                    future.raise(Errors.GROUP_COORDINATOR_NOT_AVAILABLE);
                 } else {
                     future.raise(new KafkaException("Unexpected error from SyncGroup: " + error.message()));
                 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
@@ -34,6 +34,7 @@ public class SyncGroupResponse extends AbstractRequestResponse {
      *
      * GROUP_COORDINATOR_NOT_AVAILABLE (15)
      * NOT_COORDINATOR_FOR_GROUP (16)
+     * NOT_ENOUGH_REPLICAS (19)
      * ILLEGAL_GENERATION (22)
      * UNKNOWN_MEMBER_ID (25)
      * REBALANCE_IN_PROGRESS (27)

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
@@ -35,6 +35,7 @@ public class SyncGroupResponse extends AbstractRequestResponse {
      * GROUP_COORDINATOR_NOT_AVAILABLE (15)
      * NOT_COORDINATOR_FOR_GROUP (16)
      * NOT_ENOUGH_REPLICAS (19)
+     * NOT_ENOUGH_REPLICAS_AFTER_APPEND (20)
      * ILLEGAL_GENERATION (22)
      * UNKNOWN_MEMBER_ID (25)
      * REBALANCE_IN_PROGRESS (27)


### PR DESCRIPTION
This just improves the error message since it's confusing that a consumer throws a message you'd normally see for a producer. 
