### PR TITLE
HOTFIX: Fix punctuation timestamp in PunctuationQueue.java

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PunctuationQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PunctuationQueue.java
@@ -42,7 +42,7 @@ public class PunctuationQueue {
             while (top != null && top.timestamp <= timestamp) {
                 PunctuationSchedule sched = top;
                 pq.poll();
-                punctuator.punctuate(sched.node(), timestamp);
+                punctuator.punctuate(sched.node(), top.timestamp);
                 pq.add(sched.next(timestamp));
                 punctuated = true;
 


### PR DESCRIPTION
Actually, there are two problems:

1) Processor's "punctuate" method is not calling if there are NO new messages in "source" topic
2) When message comes after let's say 20 seconds delay (punctuation timeout was set to 2 seconds) - method punctuate is calling 10 times in a loop for every "missed" call within delayed period with the SAME timestamp

Actually suggested change only fixes second item (every missed call will be using it's timestamp). Can anyone, please, comment if first item's statement is intended behavior or a bug?
