### PR TITLE
MINOR: Use `close()` instead of `dispose()` in various RocksDB classes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -88,7 +88,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     private RocksDB db;
 
-    // the following option objects will be created at constructor and disposed at close()
+    // the following option objects will be created in the constructor and closed in the close() method
     private Options options;
     private WriteOptions wOptions;
     private FlushOptions fOptions;
@@ -349,9 +349,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     // this function is only called in flushCache()
     private void putAllInternal(List<KeyValue<byte[], byte[]>> entries) {
-        WriteBatch batch = new WriteBatch();
-
-        try {
+        try (WriteBatch batch = new WriteBatch()) {
             for (KeyValue<byte[], byte[]> entry : entries) {
                 batch.put(entry.key, entry.value);
             }
@@ -359,8 +357,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             db.write(wOptions, batch);
         } catch (RocksDBException e) {
             throw new ProcessorStateException("Error while batch writing to store " + this.name, e);
-        } finally {
-            batch.dispose();
         }
     }
 
@@ -513,9 +509,9 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         }
         open = false;
         flush();
-        options.dispose();
-        wOptions.dispose();
-        fOptions.dispose();
+        options.close();
+        wOptions.close();
+        fOptions.close();
         db.close();
 
         options = null;
@@ -569,7 +565,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
         @Override
         public void close() {
-            iter.dispose();
+            iter.close();
         }
 
     }


### PR DESCRIPTION
The latter has been deprecated.
