### PR TITLE
MINOR: lower logging severity for offset reset

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -90,7 +90,7 @@ private[log] class LogCleanerManager(val logDirs: Array[File], val logs: Pool[To
           val firstDirtyOffset = {
             val offset = lastClean.getOrElse(topicAndPartition, logStartOffset)
             if (offset < logStartOffset) {
-              error("Resetting first dirty offset to log start offset %d since the checkpointed offset %d is invalid."
+              warn("Resetting first dirty offset to log start offset %d since the checkpointed offset %d is invalid."
                     .format(logStartOffset, offset))
               logStartOffset
             } else {


### PR DESCRIPTION
When resetting the first dirty offset to the log start offset, we currently log an ERROR which makes users think the log cleaner has a problem and maybe has exited.  We should log a WARN instead to avoid alarming the users.
