### PR TITLE
MINOR: rename StateStoreProvider.getStores() -> StateStoreProvider.stores()

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
@@ -46,7 +46,7 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
 
     @Override
     public V get(final K key) {
-        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.getStores(storeName, storeType);
+        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
         for (ReadOnlyKeyValueStore<K, V> store : stores) {
             V result = store.get(key);
             if (result != null) {
@@ -64,7 +64,7 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
                 return store.range(from, to);
             }
         };
-        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.getStores(storeName, storeType);
+        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
         return new CompositeKeyValueIterator(stores.iterator(), nextIteratorFunction);
     }
 
@@ -76,13 +76,13 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
                 return store.all();
             }
         };
-        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.getStores(storeName, storeType);
+        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
         return new CompositeKeyValueIterator(stores.iterator(), nextIteratorFunction);
     }
 
     @Override
     public long approximateNumEntries() {
-        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.getStores(storeName, storeType);
+        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
         long total = 0;
         for (ReadOnlyKeyValueStore<K, V> store : stores) {
             total += store.approximateNumEntries();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
@@ -42,7 +42,7 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
 
     @Override
     public WindowStoreIterator<V> fetch(final K key, final long timeFrom, final long timeTo) {
-        final List<ReadOnlyWindowStore<K, V>> stores = provider.getStores(storeName, windowStoreType);
+        final List<ReadOnlyWindowStore<K, V>> stores = provider.stores(storeName, windowStoreType);
         for (ReadOnlyWindowStore<K, V> windowStore : stores) {
             final WindowStoreIterator<V> result = windowStore.fetch(key, timeFrom, timeTo);
             if (!result.hasNext()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -42,7 +42,7 @@ public class QueryableStoreProvider {
     public <T> T getStore(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         final List<T> allStores = new ArrayList<>();
         for (StateStoreProvider storeProvider : storeProviders) {
-            allStores.addAll(storeProvider.getStores(storeName, queryableStoreType));
+            allStores.addAll(storeProvider.stores(storeName, queryableStoreType));
         }
         if (allStores.isEmpty()) {
             return null;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StateStoreProvider.java
@@ -37,5 +37,5 @@ public interface StateStoreProvider {
      * @param <T>                   The type of the Store
      * @return  List of the instances of the store in this topology. Empty List if not found
      */
-    <T> List<T> getStores(String storeName, QueryableStoreType<T> queryableStoreType);
+    <T> List<T> stores(String storeName, QueryableStoreType<T> queryableStoreType);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -36,7 +36,7 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> List<T> getStores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
+    public <T> List<T> stores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         final List<T> stores = new ArrayList<>();
         for (StreamTask streamTask : streamThread.tasks().values()) {
             final StateStore store = streamTask.getStore(storeName);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -39,11 +39,11 @@ public class WrappingStoreProvider implements StateStoreProvider {
      * @param <T>       The type of the Store, for example, {@link org.apache.kafka.streams.state.ReadOnlyKeyValueStore}
      * @return  a List of all the stores with the storeName and are accepted by {@link QueryableStoreType#accepts(StateStore)}
      */
-    public <T> List<T> getStores(final String storeName, QueryableStoreType<T> type) {
+    public <T> List<T> stores(final String storeName, QueryableStoreType<T> type) {
         final List<T> allStores = new ArrayList<>();
         for (StateStoreProvider provider : storeProviders) {
             final List<T> stores =
-                provider.getStores(storeName, type);
+                provider.stores(storeName, type);
             allStores.addAll(stores);
         }
         if (allStores.isEmpty()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreProviderStub.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreProviderStub.java
@@ -28,7 +28,7 @@ public class StateStoreProviderStub implements StateStoreProvider {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T> List<T> getStores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
+    public <T> List<T> stores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         if (stores.containsKey(storeName) && queryableStoreType.accepts(stores.get(storeName))) {
             return (List<T>) Collections.singletonList(stores.get(storeName));
         }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -124,7 +124,7 @@ public class StreamThreadStateStoreProviderTest {
     @Test
     public void shouldFindKeyValueStores() throws Exception {
         List<ReadOnlyKeyValueStore<String, String>> kvStores =
-            provider.getStores("kv-store", QueryableStoreTypes.<String, String>keyValueStore());
+            provider.stores("kv-store", QueryableStoreTypes.<String, String>keyValueStore());
         assertEquals(2, kvStores.size());
     }
 
@@ -132,33 +132,33 @@ public class StreamThreadStateStoreProviderTest {
     public void shouldFindWindowStores() throws Exception {
         final List<ReadOnlyWindowStore<Object, Object>>
             windowStores =
-            provider.getStores("window-store", windowStore());
+            provider.stores("window-store", windowStore());
         assertEquals(2, windowStores.size());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfWindowStoreClosed() throws Exception {
         taskOne.getStore("window-store").close();
-        provider.getStores("window-store", QueryableStoreTypes.windowStore());
+        provider.stores("window-store", QueryableStoreTypes.windowStore());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfKVStoreClosed() throws Exception {
         taskOne.getStore("kv-store").close();
-        provider.getStores("kv-store", QueryableStoreTypes.keyValueStore());
+        provider.stores("kv-store", QueryableStoreTypes.keyValueStore());
     }
 
     @Test
     public void shouldReturnEmptyListIfNoStoresFoundWithName() throws Exception {
-        assertEquals(Collections.emptyList(), provider.getStores("not-a-store", QueryableStoreTypes
+        assertEquals(Collections.emptyList(), provider.stores("not-a-store", QueryableStoreTypes
             .keyValueStore()));
     }
 
 
     @Test
     public void shouldReturnEmptyListIfStoreExistsButIsNotOfTypeValueStore() throws Exception {
-        assertEquals(Collections.emptyList(), provider.getStores("window-store",
-                                                                 QueryableStoreTypes.keyValueStore()));
+        assertEquals(Collections.emptyList(), provider.stores("window-store",
+                                                              QueryableStoreTypes.keyValueStore()));
     }
 
     private StreamTask createStreamsTask(final String applicationId,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -52,7 +52,7 @@ public class WrappingStoreProviderTest {
     @Test
     public void shouldFindKeyValueStores() throws Exception {
         List<ReadOnlyKeyValueStore<String, String>> results =
-                wrappingStoreProvider.getStores("kv", QueryableStoreTypes.<String, String>keyValueStore());
+                wrappingStoreProvider.stores("kv", QueryableStoreTypes.<String, String>keyValueStore());
         assertEquals(2, results.size());
     }
 
@@ -60,12 +60,12 @@ public class WrappingStoreProviderTest {
     public void shouldFindWindowStores() throws Exception {
         final List<ReadOnlyWindowStore<Object, Object>>
                 windowStores =
-                wrappingStoreProvider.getStores("window", windowStore());
+                wrappingStoreProvider.stores("window", windowStore());
         assertEquals(2, windowStores.size());
     }
 
     @Test(expected = InvalidStateStoreException.class)
     public void shouldThrowInvalidStoreExceptionIfNoStoreOfTypeFound() throws Exception {
-        wrappingStoreProvider.getStores("doesn't exist", QueryableStoreTypes.keyValueStore());
+        wrappingStoreProvider.stores("doesn't exist", QueryableStoreTypes.keyValueStore());
     }
 }


### PR DESCRIPTION
Rename StateStoreProvider.getStores(...) to StateStoreProvider.stores(...) as this is consistent with the naming of other 'getters' in the public API.
