### PR TITLE
MINOR: increase usability of shell-scripts

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -143,6 +143,7 @@ object ConfigCommand {
             .withRequiredArg
             .describedAs("urls")
             .ofType(classOf[String])
+            .defaultsTo("localhost:2181")
     val alterOpt = parser.accepts("alter", "Alter the configuration for the entity.")
     val describeOpt = parser.accepts("describe", "List configs for the given entity.")
     val entityType = parser.accepts("entity-type", "Type of entity (topics/clients)")

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -398,6 +398,7 @@ object ConsumerGroupCommand {
                              .withRequiredArg
                              .describedAs("urls")
                              .ofType(classOf[String])
+                             .defaultsTo("localhost:2181")
     val bootstrapServerOpt = parser.accepts("bootstrap-server", BootstrapServerDoc)
                                    .withRequiredArg
                                    .describedAs("server to connect to")

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -41,6 +41,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
       .withRequiredArg
       .describedAs("urls")
       .ofType(classOf[String])
+      .defaultsTo("localhost:2181")
       
     if(args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, "This tool causes leadership for each partition to be transferred back to the 'preferred replica'," + 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -189,6 +189,7 @@ object ReassignPartitionsCommand extends Logging {
                       .withRequiredArg
                       .describedAs("urls")
                       .ofType(classOf[String])
+                      .defaultsTo("localhost:2181")
     val generateOpt = parser.accepts("generate", "Generate a candidate partition reassignment configuration." +
       " Note that this only generates a candidate assignment, it does not execute it.")
     val executeOpt = parser.accepts("execute", "Kick off the reassignment as specified by the --reassignment-json-file option.")

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -279,6 +279,7 @@ object TopicCommand extends Logging {
                            .withRequiredArg
                            .describedAs("urls")
                            .ofType(classOf[String])
+                           .defaultsTo("localhost:2181")
     val listOpt = parser.accepts("list", "List all available topics.")
     val createOpt = parser.accepts("create", "Create a new topic.")
     val deleteOpt = parser.accepts("delete", "Delete a topic")

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -229,6 +229,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("urls")
       .ofType(classOf[String])
+      .defaultsTo("localhost:2181")
     val consumerPropertyOpt = parser.accepts("consumer-property", "A mechanism to pass user-defined properties in the form key=value to the consumer.")
       .withRequiredArg
       .describedAs("consumer_prop")

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -168,6 +168,7 @@ object ConsumerPerformance {
       .withRequiredArg
       .describedAs("urls")
       .ofType(classOf[String])
+      .defaultsTo("localhost:2181")
     val bootstrapServersOpt = parser.accepts("broker-list", "A broker list to use for connecting if using the new consumer.")
       .withRequiredArg()
       .describedAs("host")

--- a/core/src/main/scala/kafka/tools/ReplayLogProducer.scala
+++ b/core/src/main/scala/kafka/tools/ReplayLogProducer.scala
@@ -69,7 +69,7 @@ object ReplayLogProducer extends Logging {
       .withRequiredArg
       .describedAs("zookeeper url")
       .ofType(classOf[String])
-      .defaultsTo("127.0.0.1:2181")
+      .defaultsTo("localhost:2181")
     val brokerListOpt = parser.accepts("broker-list", "REQUIRED: the broker list must be specified.")
       .withRequiredArg
       .describedAs("hostname:port")


### PR DESCRIPTION
we do this by ensuring that the --zookeeper parameter consistently
defaults to localhost:2181 — as it already does in some places.
