### PR TITLE
Kafka 3940: Log should check the return value of dir.mkdirs()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -621,9 +621,9 @@ public class Utils {
                 for (File f : files)
                     delete(f);
             }
-            file.delete();
+            Files.delete(file.toPath());
         } else {
-            file.delete();
+            Files.delete(file.toPath());
         }
     }
 

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -30,6 +30,7 @@ import org.powermock.api.easymock.PowerMock;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -63,8 +64,7 @@ public class FileStreamSourceTaskTest {
 
     @After
     public void teardown() {
-        tempFile.delete();
-
+        Files.delete(tempFile.toPath());
         if (verifyMocks)
             PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/FileOffsetBackingStoreTest.java
@@ -28,6 +28,7 @@ import org.powermock.api.easymock.PowerMock;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class FileOffsetBackingStoreTest {
 
     @After
     public void teardown() {
-        tempFile.delete();
+    	Files.delete(tempFile.toPath());
     }
 
     @Test

--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -20,6 +20,7 @@ package kafka.log
 import java.io._
 import java.nio._
 import java.nio.channels._
+import java.nio.file.Files
 import java.util.concurrent.atomic._
 
 import kafka.utils._
@@ -325,9 +326,9 @@ class FileMessageSet private[kafka](@volatile var file: File,
    * Delete this message set from the filesystem
    * @return True iff this message set was deleted.
    */
-  def delete(): Boolean = {
+  def delete() {
     CoreUtils.swallow(channel.close())
-    file.delete()
+    Files.delete(file.toPath())
   }
 
   /**

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -152,18 +152,18 @@ class Log(val dir: File,
       val filename = file.getName
       if(filename.endsWith(DeletedFileSuffix) || filename.endsWith(CleanedFileSuffix)) {
         // if the file ends in .deleted or .cleaned, delete it
-        file.delete()
+        Files.delete(file.toPath())
       } else if(filename.endsWith(SwapFileSuffix)) {
         // we crashed in the middle of a swap operation, to recover:
         // if a log, delete the .index file, complete the swap operation later
         // if an index just delete it, it will be rebuilt
         val baseName = new File(CoreUtils.replaceSuffix(file.getPath, SwapFileSuffix, ""))
         if(baseName.getPath.endsWith(IndexFileSuffix)) {
-          file.delete()
+          Files.delete(file.toPath())
         } else if(baseName.getPath.endsWith(LogFileSuffix)){
           // delete the index
           val index = new File(CoreUtils.replaceSuffix(baseName.getPath, LogFileSuffix, IndexFileSuffix))
-          index.delete()
+          Files.delete(index.toPath())
           swapFiles += file
         }
       }
@@ -177,7 +177,7 @@ class Log(val dir: File,
         val logFile = new File(file.getAbsolutePath.replace(IndexFileSuffix, LogFileSuffix))
         if(!logFile.exists) {
           warn("Found an orphaned index file, %s, with no corresponding log file.".format(file.getAbsolutePath))
-          file.delete()
+          Files.delete(file.toPath())
         }
       } else if(filename.endsWith(LogFileSuffix)) {
         // if its a log file, load the corresponding log segment
@@ -197,7 +197,7 @@ class Log(val dir: File,
           } catch {
             case e: java.lang.IllegalArgumentException =>
               warn("Found a corrupted index file, %s, deleting and rebuilding index. Error Message: %s".format(indexFile.getAbsolutePath, e.getMessage))
-              indexFile.delete()
+              Files.delete(indexFile.toPath())
               segment.recover(config.maxMessageSize)
           }
         }
@@ -648,7 +648,7 @@ class Log(val dir: File,
       val indexFile = indexFilename(dir, newOffset)
       for(file <- List(logFile, indexFile); if file.exists) {
         warn("Newly rolled segment file " + file.getName + " already exists; deleting it first")
-        file.delete()
+        Files.delete(file.toPath())
       }
 
       segments.lastEntry() match {

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -23,6 +23,7 @@ import kafka.common._
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.{BrokerTopicStats, FetchDataInfo, LogOffsetMetadata}
 import java.io.{File, IOException}
+import java.nio.file.Files
 import java.util.concurrent.{ConcurrentNavigableMap, ConcurrentSkipListMap}
 import java.util.concurrent.atomic._
 import java.text.NumberFormat
@@ -139,7 +140,8 @@ class Log(val dir: File,
   /* Load the log segments from the log files on disk */
   private def loadSegments() {
     // create the log directory if it doesn't exist
-    dir.mkdirs()
+    Files.createDirectory(dir.toPath())
+
     var swapFiles = Set[File]()
 
     // first do a pass through the files in the log directory and remove any temporary files

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -19,6 +19,7 @@ package kafka.log
 
 import java.io.{DataOutputStream, File}
 import java.nio._
+import java.nio.file.Files
 import java.util.Date
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
@@ -364,9 +365,9 @@ private[log] class Cleaner(val id: Int,
                                  deleteHorizonMs: Long) {
     // create a new segment with the suffix .cleaned appended to both the log and index name
     val logFile = new File(segments.head.log.file.getPath + Log.CleanedFileSuffix)
-    logFile.delete()
+    Files.delete(logFile.toPath())
     val indexFile = new File(segments.head.index.file.getPath + Log.CleanedFileSuffix)
-    indexFile.delete()
+    Files.delete(indexFile.toPath())
     val messages = new FileMessageSet(logFile, fileAlreadyExists = false, initFileSize = log.initFileSize(), preallocate = log.config.preallocate)
     val index = new OffsetIndex(indexFile, segments.head.baseOffset, segments.head.index.maxIndexSize)
     val cleaned = new LogSegment(messages, index, segments.head.baseOffset, segments.head.indexIntervalBytes, log.config.randomSegmentJitter, time)

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io._
+import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 
 import kafka.utils._
@@ -81,9 +82,7 @@ class LogManager(val logDirs: Array[File],
     for(dir <- dirs) {
       if(!dir.exists) {
         info("Log directory '" + dir.getAbsolutePath + "' not found, creating it.")
-        val created = dir.mkdirs()
-        if(!created)
-          throw new KafkaException("Failed to create data directory " + dir.getAbsolutePath)
+        Files.createDirectory(dir.toPath())
       }
       if(!dir.isDirectory || !dir.canRead)
         throw new KafkaException(dir.getAbsolutePath + " is not a readable log directory.")
@@ -358,7 +357,7 @@ class LogManager(val logDirs: Array[File],
       // if not, create it
       val dataDir = nextLogDir()
       val dir = new File(dataDir, topicAndPartition.topic + "-" + topicAndPartition.partition)
-      dir.mkdirs()
+      Files.createDirectory(dir.toPath())
       log = new Log(dir, 
                     config,
                     recoveryPoint = 0L,

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -165,7 +165,7 @@ class LogManager(val logDirs: Array[File],
     try {
       for ((cleanShutdownFile, dirJobs) <- jobs) {
         dirJobs.foreach(_.get)
-        cleanShutdownFile.delete()
+        Files.delete(cleanShutdownFile.toPath())
       }
     } catch {
       case e: ExecutionException => {

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -23,6 +23,7 @@ import scala.math._
 import java.io._
 import java.nio._
 import java.nio.channels._
+import java.nio.file.Files
 import java.util.concurrent.locks._
 
 import kafka.utils._
@@ -329,11 +330,11 @@ class OffsetIndex(@volatile private[this] var _file: File, val baseOffset: Long,
   /**
    * Delete this index file
    */
-  def delete(): Boolean = {
+  def delete() {
     info("Deleting index " + _file.getAbsolutePath)
     if (Os.isWindows)
       CoreUtils.swallow(forceUnmap(mmap))
-    _file.delete()
+    Files.delete(_file.toPath())
   }
   
   /** The number of entries in this index */

--- a/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
+++ b/core/src/main/scala/kafka/metrics/KafkaCSVMetricsReporter.scala
@@ -22,6 +22,7 @@ package kafka.metrics
 
 import com.yammer.metrics.Metrics
 import java.io.File
+import java.nio.file.Files
 
 import com.yammer.metrics.reporting.CsvReporter
 import java.util.concurrent.TimeUnit
@@ -50,7 +51,7 @@ private class KafkaCSVMetricsReporter extends KafkaMetricsReporter
         val metricsConfig = new KafkaMetricsConfig(props)
         csvDir = new File(props.getString("kafka.csv.metrics.dir", "kafka_metrics"))
         Utils.delete(csvDir)
-        csvDir.mkdirs()
+        Files.createDirectory(csvDir.toPath())
         underlying = new CsvReporter(Metrics.defaultRegistry(), csvDir)
         if (props.getBoolean("kafka.csv.metrics.reporter.enabled", default = false)) {
           initialized = true

--- a/core/src/test/scala/kafka/tools/TestLogCleaning.scala
+++ b/core/src/test/scala/kafka/tools/TestLogCleaning.scala
@@ -21,6 +21,7 @@ import joptsimple.OptionParser
 import java.util.Properties
 import java.util.Random
 import java.io._
+import java.nio.file.Files
 import kafka.consumer._
 import kafka.serializer._
 import kafka.utils._
@@ -129,8 +130,8 @@ object TestLogCleaning {
     
     println("De-duplicating and validating output files...")
     validateOutput(producedDataFile, consumedDataFile)
-    producedDataFile.delete()
-    consumedDataFile.delete()
+    Files.delete(producedDataFile.toPath())
+    Files.delete(consumedDataFile.toPath())
   }
   
   def dumpLog(dir: File) {
@@ -180,8 +181,8 @@ object TestLogCleaning {
     require(!consumed.hasNext, "Additional values consumed not found in producer log.")
     require(mismatched == 0, "Non-zero number of row mismatches.")
     // if all the checks worked out we can delete the deduped files
-    producedDedupedFile.delete()
-    consumedDedupedFile.delete()
+    Files.delete(producedDedupedFile.toPath())
+    Files.delete(consumedDedupedFile.toPath())
   }
   
   def valuesIterator(reader: BufferedReader) = {

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io.File
+import java.nio.file.Files
 import java.util.Properties
 
 import kafka.common.TopicAndPartition
@@ -134,7 +135,7 @@ class LogCleanerIntegrationTest(compressionCodec: String) {
     val logs = new Pool[TopicAndPartition, Log]()
     for(i <- 0 until parts) {
       val dir = new File(logDir, "log-" + i)
-      dir.mkdirs()
+      Files.createDirectory(dir.toPath())
       val logProps = new Properties()
       logProps.put(LogConfig.SegmentBytesProp, segmentSize: java.lang.Integer)
       logProps.put(LogConfig.SegmentIndexBytesProp, 100*1024: java.lang.Integer)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io.File
+import java.nio.file.Files
 import java.util.Properties
 
 import kafka.api.{KAFKA_0_10_0_IV1, KAFKA_0_9_0}
@@ -220,7 +221,7 @@ class LogCleanerIntegrationTest(compressionCodec: String) {
     val logs = new Pool[TopicAndPartition, Log]()
     for(i <- 0 until parts) {
       val dir = new File(logDir, "log-" + i)
-      dir.mkdirs()
+      Files.createDirectory(dir.toPath())
 
       val log = new Log(dir = dir,
                         LogConfig(logConfigProperties(maxMessageSize, minCleanableDirtyRatio)),

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io._
+import java.nio.file.Files
 import java.util.Properties
 
 import kafka.common._
@@ -242,7 +243,7 @@ class LogManagerTest {
   def testRecoveryDirectoryMappingWithRelativeDirectory() {
     logManager.shutdown()
     logDir = new File("data" + File.separator + logDir.getName)
-    logDir.mkdirs()
+    Files.createDirectory(logDir.toPath())
     logDir.deleteOnExit()
     logManager = createLogManager()
     logManager.startup

--- a/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogSegmentTest.scala
@@ -18,6 +18,7 @@
 
 import org.junit.Assert._
 import java.util.concurrent.atomic._
+import java.nio.file.Files
 
 import kafka.common.LongRef
 import org.junit.{After, Test}
@@ -36,7 +37,7 @@ class LogSegmentTest {
     val msFile = TestUtils.tempFile()
     val ms = new FileMessageSet(msFile)
     val idxFile = TestUtils.tempFile()
-    idxFile.delete()
+    Files.delete(idxFile.toPath())
     val idx = new OffsetIndex(idxFile, offset, 1000)
     val seg = new LogSegment(ms, idx, offset, 10, 0, SystemTime)
     segments += seg

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -854,7 +854,7 @@ class LogTest extends JUnitSuite {
     recoveryPoint = log.logEndOffset
     log = new Log(logDir, config, 0L, time.scheduler, time)
     assertEquals(recoveryPoint, log.logEndOffset)
-    cleanShutdownFile.delete()
+    Files.delete(cleanShutdownFile.toPath())
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io._
+import java.nio.file.Files
 import java.util.Properties
 
 import org.apache.kafka.common.errors.{CorruptRecordException, OffsetOutOfRangeException, RecordBatchTooLargeException, RecordTooLargeException}
@@ -322,7 +323,7 @@ class LogTest extends JUnitSuite {
   @Test
   def testThatGarbageCollectingSegmentsDoesntChangeOffset() {
     for(messagesToAppend <- List(0, 1, 25)) {
-      logDir.mkdirs()
+      Files.createDirectory(logDir.toPath())
       // first test a log segment starting at 0
       val logProps = new Properties()
       logProps.put(LogConfig.SegmentBytesProp, 100: java.lang.Integer)
@@ -799,7 +800,7 @@ class LogTest extends JUnitSuite {
     val recoveryPoint = 50L
     for(iteration <- 0 until 50) {
       // create a log and write some messages to it
-      logDir.mkdirs()
+      Files.createDirectory(logDir.toPath())
       var log = new Log(logDir,
                         config,
                         recoveryPoint = 0L,

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -18,6 +18,8 @@
 package kafka.log
 
 import java.io._
+import java.io.File
+import java.nio.file.Files
 import org.junit.Assert._
 import java.util.{Collections, Arrays}
 import org.junit._
@@ -40,7 +42,7 @@ class OffsetIndexTest extends JUnitSuite {
   @After
   def teardown() {
     if(this.idx != null)
-      this.idx.file.delete()
+      Files.delete(this.idx.file.toPath())
   }
   
   @Test
@@ -166,7 +168,7 @@ class OffsetIndexTest extends JUnitSuite {
   
   def nonExistantTempFile(): File = {
     val file = TestUtils.tempFile()
-    file.delete()
+    Files.delete(file.toPath())
     file
   }
 }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -80,7 +80,7 @@ object TestUtils extends Logging {
    */
   def tempRelativeDir(parent: String): File = {
     val parentFile = new File(parent)
-    parentFile.mkdirs()
+    Files.createDirectory(parentFile.toPath())
 
     JTestUtils.tempDirectory(parentFile.toPath, null)
   }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -92,7 +92,7 @@ object TestUtils extends Logging {
    */
   def tempRelativeDir(parent: String): File = {
     val parentFile = new File(parent)
-    parentFile.mkdirs()
+    Files.createDirectory(parentFile.toPath())
 
     org.apache.kafka.test.TestUtils.tempDirectory(parentFile.toPath, "kafka-")
   }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -43,6 +43,7 @@ import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -224,7 +225,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     private RocksDB openDB(File dir, Options options, int ttl) {
         try {
             if (ttl == TTL_NOT_USED) {
-                dir.getParentFile().mkdirs();
+                Files.createDirectory(dir.getParentFile().toPath());
                 return RocksDB.open(options, dir.getAbsolutePath());
             } else {
                 throw new UnsupportedOperationException("Change log is not supported for store " + this.name + " since it is TTL based.");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -40,6 +40,7 @@ import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -211,7 +212,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     private RocksDB openDB(File dir, Options options, int ttl) {
         try {
             if (ttl == TTL_NOT_USED) {
-                dir.getParentFile().mkdirs();
+                Files.createDirectory(dir.getParentFile().toPath());
                 return RocksDB.open(options, dir.getAbsolutePath());
             } else {
                 throw new UnsupportedOperationException("Change log is not supported for store " + this.name + " since it is TTL based.");

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -38,6 +38,7 @@ import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -214,7 +215,7 @@ public class KeyValueStoreTestDriver<K, V> {
             }
         };
         this.stateDir = TestUtils.tempDirectory();
-        this.stateDir.mkdirs();
+        Files.createDirectory(this.stateDir.toPath();
 
         props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "applicationId");

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -38,6 +38,7 @@ import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -212,7 +213,7 @@ public class KeyValueStoreTestDriver<K, V> {
             }
         };
         this.stateDir = TestUtils.tempDirectory();
-        this.stateDir.mkdirs();
+        Files.createDirectory(this.stateDir.toPath();
 
         Properties props = new Properties();
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");


### PR DESCRIPTION
Changed occurrences of dir.mkdirs() to Files.createDirectory and similarly for File.delete to Files.delete
