### PR TITLE
KAFKA-4018: Streams causing older slf4j-log4j library to be packaged along with newer version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -681,6 +681,9 @@ project(':streams') {
     compile libs.rocksDBJni
     // this dependency should be removed after KIP-4
     compile (libs.zkclient) {
+      // users should be able to choose the logging implementation (and slf4j bridge)
+      exclude module: 'slf4j-log4j12'
+      exclude module: 'log4j'
       exclude module: 'jline'
       exclude module: 'netty'
     }


### PR DESCRIPTION
This is a regression caused by 0bb1d3ae.

After that commit, Streams no longer has a direct dependency on slf4j-log4j12, but zkclient
has a dependency on an older version of slf4j-log4j12, so we get a transitive dependency on
the older version.

The fix is to simply exclude the undesired dependencies from the zkclient dependency.
