### PR TITLE
KAFKA-3817: KTableRepartitionMap publish old Change first, for non-count aggregates

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -85,7 +85,7 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableProcessorSuppli
             if (oldPair != null && oldPair.key != null && oldPair.value != null) {
                 context().forward(oldPair.key, new Change<>(null, oldPair.value));
             }
-            
+
             if (newPair != null && newPair.key != null && newPair.value != null) {
                 context().forward(newPair.key, new Change<>(newPair.value, null));
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableRepartitionMap.java
@@ -81,12 +81,15 @@ public class KTableRepartitionMap<K, V, K1, V1> implements KTableProcessorSuppli
             KeyValue<K1, V1> oldPair = change.oldValue == null ? null : mapper.apply(key, change.oldValue);
 
             // if the selected repartition key or value is null, skip
-            if (newPair != null && newPair.key != null && newPair.value != null) {
-                context().forward(newPair.key, new Change<>(newPair.value, null));
-            }
+            // forward oldPair first, to be consistent with reduce and aggregate
             if (oldPair != null && oldPair.key != null && oldPair.value != null) {
                 context().forward(oldPair.key, new Change<>(null, oldPair.value));
             }
+            
+            if (newPair != null && newPair.key != null && newPair.value != null) {
+                context().forward(newPair.key, new Change<>(newPair.value, null));
+            }
+            
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -139,7 +139,7 @@ public class KTableAggregateTest {
         driver.process(topic1, "B", "4");
         driver.process(topic1, "NULL", "5");
         driver.process(topic1, "B", "7");
-        
+
         assertEquals(Utils.mkList(
                 "1:0+1",
                 "1:0+1-1",

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -88,10 +88,6 @@ public class KTableAggregateTest {
         driver.process(topic1, "B", "7");
         driver.process(topic1, "C", "8");
 
-        
-//        [A:0+1, B:0+2, A:0+1-1, A:0+1-1+3, B:0+2-2, B:0+2-2+4, C:0+5, D:0+6, B:0+2+4-2-4, B:0+2+4-2-4+7, C:0+5-5, C:0+5-5+8]> but was:
-//        [A:0+1, B:0+2, A:0+1-1, A:0+1-1+3, B:0+2-2, B:0+2-2+4, C:0+5, D:0+6, B:0+2-2+4-4, B:0+2-2+4-4+7, C:0+5-5, C:0+5-5+8]>
-
         assertEquals(Utils.mkList(
                 "A:0+1",
                 "B:0+2",

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -195,7 +195,7 @@ public class KTableAggregateTest {
 
                     @Override
                     public KeyValue<String, String> apply(String key, String value) {
-                        return KeyValue.pair(String.valueOf(key.charAt(0)), value);
+                        return KeyValue.pair(String.valueOf(key.charAt(0)), String.valueOf(key.charAt(1)));
                     }
                 }, stringSerde, stringSerde)
                 .aggregate(new Initializer<String>() {
@@ -228,10 +228,10 @@ public class KTableAggregateTest {
         driver.process(input, "12", "C");
 
         assertEquals(Utils.mkList(
-                 "1:A",
-                 "1:AB",
-                 "1:B",
-                 "1:", "1:C"
+                 "1:1",
+                 "1:12",
+                 "1:2",
+                 "1:", "1:2"
                  ), proc.processed);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -88,15 +88,19 @@ public class KTableAggregateTest {
         driver.process(topic1, "B", "7");
         driver.process(topic1, "C", "8");
 
+        
+//        [A:0+1, B:0+2, A:0+1-1, A:0+1-1+3, B:0+2-2, B:0+2-2+4, C:0+5, D:0+6, B:0+2+4-2-4, B:0+2+4-2-4+7, C:0+5-5, C:0+5-5+8]> but was:
+//        [A:0+1, B:0+2, A:0+1-1, A:0+1-1+3, B:0+2-2, B:0+2-2+4, C:0+5, D:0+6, B:0+2-2+4-4, B:0+2-2+4-4+7, C:0+5-5, C:0+5-5+8]>
+
         assertEquals(Utils.mkList(
                 "A:0+1",
                 "B:0+2",
-                "A:0+1+3", "A:0+1+3-1",
-                "B:0+2+4", "B:0+2+4-2",
+                "A:0+1-1", "A:0+1-1+3",
+                "B:0+2-2", "B:0+2-2+4",
                 "C:0+5",
                 "D:0+6",
-                "B:0+2+4-2+7", "B:0+2+4-2+7-4",
-                "C:0+5+8", "C:0+5+8-5"), proc.processed);
+                "B:0+2-2+4-4", "B:0+2-2+4-4+7",
+                "C:0+5-5", "C:0+5-5+8"), proc.processed);
     }
 
     @Test
@@ -139,16 +143,17 @@ public class KTableAggregateTest {
         driver.process(topic1, "B", "4");
         driver.process(topic1, "NULL", "5");
         driver.process(topic1, "B", "7");
-
+        
         assertEquals(Utils.mkList(
                 "1:0+1",
                 "1:0+1-1",
                 "1:0+1-1+1",
-                "2:0+2",
-                "4:0+4",
-                "2:0+2-2",
-                "7:0+7",
-                "4:0+4-4"), proc.processed);
+                "2:0+2", 
+                  //noop
+                "2:0+2-2", "4:0+4",
+                  //noop
+                "4:0+4-4", "7:0+7"
+                ), proc.processed);
     }
 
     @Test
@@ -171,6 +176,12 @@ public class KTableAggregateTest {
         driver.process(input, "C", "yellow");
         driver.process(input, "D", "green");
 
-        assertEquals(Utils.mkList("green:1", "green:2", "blue:1", "green:1", "yellow:1", "green:2"), proc.processed);
+        assertEquals(Utils.mkList(
+                 "green:1",
+                 "green:2",
+                 "green:1", "blue:1",
+                 "yellow:1",
+                 "green:2"
+                 ), proc.processed);
     }
 }


### PR DESCRIPTION
I affirm that the contribution is my original work and that I license the work to the project under the project's open source license. 

This cleans up misbehaviour that was introduce while fixing KAFKA-3817. It is impossible for a non-count aggregate to be build, when the addition happens before the removal. IMHO making sure that these details are correct is very important. 

This PR has local test errors. It somehow fails the ResetIntegrationTest. It doesn't quite appear to me why but it looks like this PR breaks it, especially because the error appears with the ordering of the events. Still I am unable to find where I could have broken it. Maybe not seems to fail on trunk aswell.
