### PR TITLE
KAFKA-4025 - make sure file.encoding system property is set to UTF-8 when invoking the rat task

### DIFF
--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -84,9 +84,15 @@ class RatTask extends DefaultTask {
     if (!reportDir.exists()) {
       reportDir.mkdirs()
     }
-    generateXmlReport(reportDir)
-    printUnknownFiles()
-    generateHtmlReport()
+    def origEncoding = System.getProperty("file.encoding")
+    try {
+      System.setProperty("file.encoding", "UTF-8") //affects the output of the ant rat task
+      generateXmlReport(reportDir)
+      printUnknownFiles()
+      generateHtmlReport()
+    } finally {
+      System.setProperty("file.encoding", origEncoding)
+    }
   }
 }
 


### PR DESCRIPTION
reset back to previous value after.
