### PR TITLE
KAFKA-3742: (FIX) Can't run bin/connect-*.sh with -daemon flag

### DIFF
--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -14,10 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ $# -lt 1 ];
+then
+        echo "USAGE: $0 [-daemon] connect-distributed.properties"
+        exit 1
+fi
+
 base_dir=$(dirname $0)
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.connect.cli.ConnectDistributed "$@"
+EXTRA_ARGS=${EXTRA_ARGS-'-name connectDistributed'}
+
+COMMAND=$1
+case $COMMAND in
+  -daemon)
+    EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    shift
+    ;;
+  *)
+    ;;
+esac
+
+exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectDistributed "$@"

--- a/bin/connect-standalone.sh
+++ b/bin/connect-standalone.sh
@@ -14,10 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [ $# -lt 1 ];
+then
+        echo "USAGE: $0 [-daemon] connect-standalone.properties"
+        exit 1
+fi
+
 base_dir=$(dirname $0)
 
 if [ "x$KAFKA_LOG4J_OPTS" = "x" ]; then
     export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:$base_dir/../config/connect-log4j.properties"
 fi
 
-exec $(dirname $0)/kafka-run-class.sh org.apache.kafka.connect.cli.ConnectStandalone "$@"
+EXTRA_ARGS=${EXTRA_ARGS-'-name connectStandalone'}
+
+COMMAND=$1
+case $COMMAND in
+  -daemon)
+    EXTRA_ARGS="-daemon "$EXTRA_ARGS
+    shift
+    ;;
+  *)
+    ;;
+esac
+
+exec $(dirname $0)/kafka-run-class.sh $EXTRA_ARGS org.apache.kafka.connect.cli.ConnectStandalone "$@"


### PR DESCRIPTION
## Problem

Current connect scripts (`connect-distributed.sh`, `connect-standalone.sh`) do not support `-daemon` flag even if users specify the flag
since `kafka-run-class.sh` requires that the`-daemon` flag should precede other arguments (e.g. class name)
## Solution

Do the same thing like in `kafka-server-start.sh`
- Parse a command
- Add `-daemon` to `$EXTRA_ARGS` if exists
