### PR TITLE
KAFKA-4031: Check if buffer cleaner is null before using it

### DIFF
--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -309,12 +309,10 @@ class OffsetIndex(@volatile private[this] var _file: File, val baseOffset: Long,
   private def forceUnmap(m: MappedByteBuffer) {
     try {
       m match {
-        case buffer: DirectBuffer => {
+        case buffer: DirectBuffer =>
           val bufferCleaner = buffer.cleaner()
-          if (bufferCleaner != null) {
+          if (bufferCleaner != null)
             bufferCleaner.clean()
-          }
-        }
         case _ =>
       }
     } catch {

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -309,7 +309,12 @@ class OffsetIndex(@volatile private[this] var _file: File, val baseOffset: Long,
   private def forceUnmap(m: MappedByteBuffer) {
     try {
       m match {
-        case buffer: DirectBuffer => buffer.cleaner().clean()
+        case buffer: DirectBuffer => {
+          val bufferCleaner = buffer.cleaner()
+          if (bufferCleaner != null) {
+            bufferCleaner.clean()
+          }
+        }
         case _ =>
       }
     } catch {

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -311,6 +311,7 @@ class OffsetIndex(@volatile private[this] var _file: File, val baseOffset: Long,
       m match {
         case buffer: DirectBuffer =>
           val bufferCleaner = buffer.cleaner()
+          /* cleaner can be null if the mapped region has size 0 */
           if (bufferCleaner != null)
             bufferCleaner.clean()
         case _ =>


### PR DESCRIPTION
A small fix to check null before using the reference
