### PR TITLE
KAFKA-4033: KIP-70: Revise Partition Assignment Semantics on New Consumer's Subscription Change

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -552,7 +552,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * A consumer is instantiated by providing a {@link java.util.Properties} object as configuration.
      * <p>
      * Valid configuration strings are documented at {@link ConsumerConfig}
-     * 
+     *
      * @param properties The consumer configuration properties
      */
     public KafkaConsumer(Properties properties) {
@@ -802,7 +802,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 }
                 log.debug("Subscribed to topic(s): {}", Utils.join(topics, ", "));
                 this.subscriptions.subscribe(new HashSet<>(topics), listener);
-                metadata.setTopics(subscriptions.groupSubscription());
             }
         } finally {
             release();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -115,14 +115,6 @@ public class SubscriptionState {
         changeSubscription(topics);
     }
 
-    public void subscribeFromAutoTopics(Set<String> topics) {
-        if (subscriptionType != SubscriptionType.AUTO_TOPICS)
-            throw new IllegalArgumentException("Attempt to subscribe from topics while subscription type set to " +
-                    subscriptionType);
-
-        changeSubscription(topics);
-    }
-
     public void subscribeFromPattern(Set<String> topics) {
         if (subscriptionType != SubscriptionType.AUTO_PATTERN)
             throw new IllegalArgumentException("Attempt to subscribe from pattern while subscription type set to " +
@@ -204,10 +196,6 @@ public class SubscriptionState {
         this.subscribedPattern = pattern;
     }
 
-    public boolean hasAutoTopicSubscription() {
-        return this.subscriptionType == SubscriptionType.AUTO_TOPICS;
-    }
-
     public boolean hasPatternSubscription() {
         return this.subscriptionType == SubscriptionType.AUTO_PATTERN;
     }
@@ -219,7 +207,6 @@ public class SubscriptionState {
         this.subscribedPattern = null;
         this.subscriptionType = SubscriptionType.NONE;
     }
-
 
     public Pattern getSubscribedPattern() {
         return this.subscribedPattern;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -116,6 +115,14 @@ public class SubscriptionState {
         changeSubscription(topics);
     }
 
+    public void subscribeFromAutoTopics(Set<String> topics) {
+        if (subscriptionType != SubscriptionType.AUTO_TOPICS)
+            throw new IllegalArgumentException("Attempt to subscribe from topics while subscription type set to " +
+                    subscriptionType);
+
+        changeSubscription(topics);
+    }
+
     public void subscribeFromPattern(Set<String> topics) {
         if (subscriptionType != SubscriptionType.AUTO_PATTERN)
             throw new IllegalArgumentException("Attempt to subscribe from pattern while subscription type set to " +
@@ -128,13 +135,6 @@ public class SubscriptionState {
         if (!this.subscription.equals(topicsToSubscribe)) {
             this.subscription = topicsToSubscribe;
             this.groupSubscription.addAll(topicsToSubscribe);
-
-            // Remove any assigned partitions which are no longer subscribed to
-            for (Iterator<TopicPartition> it = assignment.keySet().iterator(); it.hasNext(); ) {
-                TopicPartition tp = it.next();
-                if (!subscription.contains(tp.topic()))
-                    it.remove();
-            }
         }
     }
 
@@ -202,6 +202,10 @@ public class SubscriptionState {
 
         this.listener = listener;
         this.subscribedPattern = pattern;
+    }
+
+    public boolean hasAutoTopicSubscription() {
+        return this.subscriptionType == SubscriptionType.AUTO_TOPICS;
     }
 
     public boolean hasPatternSubscription() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
@@ -3,9 +3,9 @@
  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
@@ -3,9 +3,9 @@
  * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
  * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
  * License. You may obtain a copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.Selectable;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.CompressionType;
@@ -79,6 +80,13 @@ import static org.junit.Assert.fail;
 public class KafkaConsumerTest {
     private final String topic = "test";
     private final TopicPartition tp0 = new TopicPartition(topic, 0);
+    private final TopicPartition tp1 = new TopicPartition(topic, 1);
+
+    private final String topic2 = "test2";
+    private final TopicPartition t2p0 = new TopicPartition(topic2, 0);
+
+    private final String topic3 = "test3";
+    private final TopicPartition t3p0 = new TopicPartition(topic3, 0);
 
     @Test
     public void testConstructorClose() throws Exception {
@@ -333,13 +341,13 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RoundRobinAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
 
         consumer.subscribe(Arrays.asList(topic), getConsumerRebalanceListener(consumer));
         Node coordinator = prepareRebalance(client, node, assignor, Arrays.asList(tp0), null);
 
         // initial fetch
-        client.prepareResponseFrom(fetchResponse(Arrays.asList(tp0), 0, 0), node);
+        client.prepareResponseFrom(fetchResponse(tp0, 0, 0), node);
 
         consumer.poll(0);
         assertEquals(Collections.singleton(tp0), consumer.assignment());
@@ -372,7 +380,7 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RoundRobinAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
 
         consumer.subscribe(Arrays.asList(topic), getConsumerRebalanceListener(consumer));
         Node coordinator = prepareRebalance(client, node, assignor, Arrays.asList(tp0), null);
@@ -380,10 +388,10 @@ public class KafkaConsumerTest {
         consumer.poll(0);
 
         // respond to the outstanding fetch so that we have data available on the next poll
-        client.respondFrom(fetchResponse(Arrays.asList(tp0), 0, 5), node);
+        client.respondFrom(fetchResponse(tp0, 0, 5), node);
         client.poll(0, time.milliseconds());
 
-        client.prepareResponseFrom(fetchResponse(Arrays.asList(tp0), 5, 0), node);
+        client.prepareResponseFrom(fetchResponse(tp0, 5, 0), node);
         AtomicBoolean heartbeatReceived = prepareHeartbeatResponse(client, coordinator);
 
         time.sleep(heartbeatIntervalMs);
@@ -411,14 +419,14 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RoundRobinAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
         consumer.assign(Arrays.asList(tp0));
         consumer.seekToBeginning(Arrays.asList(tp0));
 
         // there shouldn't be any need to lookup the coordinator or fetch committed offsets.
         // we just lookup the starting position and send the record fetch.
         client.prepareResponse(listOffsetsResponse(Collections.singletonMap(tp0, 50L), Errors.NONE.code()));
-        client.prepareResponse(fetchResponse(Arrays.asList(tp0), 50L, 5));
+        client.prepareResponse(fetchResponse(tp0, 50L, 5));
 
         ConsumerRecords<String, String> records = consumer.poll(0);
         assertEquals(5, records.count());
@@ -427,8 +435,6 @@ public class KafkaConsumerTest {
 
     @Test
     public void testCommitsFetchedDuringAssign() {
-        final TopicPartition tp1 = new TopicPartition(topic, 1);
-
         long offset1 = 10000;
         long offset2 = 20000;
 
@@ -447,7 +453,7 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RoundRobinAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
         consumer.assign(Arrays.asList(tp0));
 
         // lookup coordinator
@@ -493,7 +499,7 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RoundRobinAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
 
         consumer.subscribe(Arrays.asList(topic), getConsumerRebalanceListener(consumer));
         Node coordinator = prepareRebalance(client, node, assignor, Arrays.asList(tp0), null);
@@ -501,15 +507,15 @@ public class KafkaConsumerTest {
         consumer.poll(0);
 
         // respond to the outstanding fetch so that we have data available on the next poll
-        client.respondFrom(fetchResponse(Arrays.asList(tp0), 0, 5), node);
+        client.respondFrom(fetchResponse(tp0, 0, 5), node);
         client.poll(0, time.milliseconds());
 
         time.sleep(autoCommitIntervalMs);
 
-        client.prepareResponseFrom(fetchResponse(Arrays.asList(tp0), 5, 0), node);
+        client.prepareResponseFrom(fetchResponse(tp0, 5, 0), node);
 
         // no data has been returned to the user yet, so the committed offset should be 0
-        AtomicBoolean commitReceived = prepareOffsetCommitResponse(client, coordinator, Arrays.asList(tp0), 0);
+        AtomicBoolean commitReceived = prepareOffsetCommitResponse(client, coordinator, tp0, 0);
 
         consumer.poll(0);
 
@@ -536,7 +542,7 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RoundRobinAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
 
         consumer.subscribe(Arrays.asList(topic), getConsumerRebalanceListener(consumer));
         prepareRebalance(client, node, assignor, Arrays.asList(tp0), null);
@@ -544,7 +550,7 @@ public class KafkaConsumerTest {
         consumer.poll(0);
 
         // respond to the outstanding fetch so that we have data available on the next poll
-        client.respondFrom(fetchResponse(Arrays.asList(tp0), 0, 5), node);
+        client.respondFrom(fetchResponse(tp0, 0, 5), node);
         client.poll(0, time.milliseconds());
 
         consumer.wakeup();
@@ -563,13 +569,16 @@ public class KafkaConsumerTest {
         assertEquals(5, records.count());
     }
 
+    /**
+     * Verify that when a consumer changes its topic subscription its assigned partitions
+     * do not immediately change, and the latest consumed offsets of its to-be-revoked
+     * partitions are properly committed (when auto-commit is enabled).
+     * Upon unsubscribing from subscribed topics the consumer subscription and assignment
+     * are both updated right away and its consumed offsets are committed (if auto-commit
+     * is enabled).
+     */
     @Test
-    public void testSubscriptionChange() {
-        final String topic2 = "test2";
-        final TopicPartition t2p0 = new TopicPartition(topic2, 0);
-        final String topic3 = "test3";
-        final TopicPartition t3p0 = new TopicPartition(topic3, 0);
-
+    public void testSubscriptionChangesWithAutoCommitEnabled() {
         int rebalanceTimeoutMs = 60000;
         int sessionTimeoutMs = 30000;
         int heartbeatIntervalMs = 3000;
@@ -592,51 +601,297 @@ public class KafkaConsumerTest {
         PartitionAssignor assignor = new RangeAssignor();
 
         final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
-                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, autoCommitIntervalMs);
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
 
+        // initial subscription
         consumer.subscribe(Arrays.asList(topic, topic2), getConsumerRebalanceListener(consumer));
 
+        // verify that subscription has changed but assignment is still unchanged
         assertTrue(consumer.subscription().size() == 2);
         assertTrue(consumer.subscription().contains(topic) && consumer.subscription().contains(topic2));
         assertTrue(consumer.assignment().isEmpty());
 
+        // mock rebalance responses
         Node coordinator = prepareRebalance(client, node, assignor, Arrays.asList(tp0, t2p0), null);
 
         consumer.poll(0);
 
+        // verify that subscription is still the same, and now assignment has caught up
         assertTrue(consumer.subscription().size() == 2);
         assertTrue(consumer.subscription().contains(topic) && consumer.subscription().contains(topic2));
         assertTrue(consumer.assignment().size() == 2);
         assertTrue(consumer.assignment().contains(tp0) && consumer.assignment().contains(t2p0));
 
-        // respond to the outstanding fetch so that we have data available on the next poll
-        client.respondFrom(fetchResponse(Arrays.asList(tp0, t2p0), 0, 0), node);
+        // mock a response to the outstanding fetch so that we have data available on the next poll
+        Map<TopicPartition, FetchInfo> fetches1 = new HashMap<>();
+        fetches1.put(tp0, new FetchInfo(0, 1));
+        fetches1.put(t2p0, new FetchInfo(0, 10));
+        client.respondFrom(fetchResponse(fetches1), node);
         client.poll(0, time.milliseconds());
 
-        consumer.poll(0);
+        ConsumerRecords<String, String> records = consumer.poll(0);
+
+        // verify that the fetch occurred as expected
+        assertEquals(11, records.count());
+        assertEquals(1L, consumer.position(tp0));
+        assertEquals(10L, consumer.position(t2p0));
+
 
         // subscription change
         consumer.subscribe(Arrays.asList(topic, topic3), getConsumerRebalanceListener(consumer));
 
+        // verify that subscription has changed but assignment is still unchanged
         assertTrue(consumer.subscription().size() == 2);
         assertTrue(consumer.subscription().contains(topic) && consumer.subscription().contains(topic3));
         assertTrue(consumer.assignment().size() == 2);
         assertTrue(consumer.assignment().contains(tp0) && consumer.assignment().contains(t2p0));
 
-        AtomicBoolean commitReceived = prepareOffsetCommitResponse(client, coordinator, Arrays.asList(tp0, t2p0), 0);
+        // mock the offset commit response for to be revoked partitions
+        Map<TopicPartition, Long> partitionOffsets1 = new HashMap<>();
+        partitionOffsets1.put(tp0, 1L);
+        partitionOffsets1.put(t2p0, 10L);
+        AtomicBoolean commitReceived = prepareOffsetCommitResponse(client, coordinator, partitionOffsets1);
+
+        // mock rebalance responses
         prepareRebalance(client, node, assignor, Arrays.asList(tp0, t3p0), coordinator);
 
-        // respond to the outstanding fetch so that we have data available on the next poll
-        client.respondFrom(fetchResponse(Arrays.asList(tp0, t3p0), 0, 0), node);
+        // mock a response to the outstanding fetch so that we have data available on the next poll
+        Map<TopicPartition, FetchInfo> fetches2 = new HashMap<>();
+        fetches2.put(tp0, new FetchInfo(1, 1));
+        fetches2.put(t3p0, new FetchInfo(0, 100));
+        client.respondFrom(fetchResponse(fetches2), node);
         client.poll(0, time.milliseconds());
+        client.prepareResponse(fetchResponse(fetches2));
 
-        consumer.poll(0);
+        records = consumer.poll(0);
 
+        // verify that the fetch occurred as expected
+        assertEquals(101, records.count());
+        assertEquals(2L, consumer.position(tp0));
+        assertEquals(100L, consumer.position(t3p0));
+
+        // verify that the offset commits occurred as expected
         assertTrue(commitReceived.get());
+
+        // verify that subscription is still the same, and now assignment has caught up
         assertTrue(consumer.subscription().size() == 2);
         assertTrue(consumer.subscription().contains(topic) && consumer.subscription().contains(topic3));
         assertTrue(consumer.assignment().size() == 2);
         assertTrue(consumer.assignment().contains(tp0) && consumer.assignment().contains(t3p0));
+
+
+        // mock the offset commit response for to be revoked partitions
+        Map<TopicPartition, Long> partitionOffsets2 = new HashMap<>();
+        partitionOffsets2.put(tp0, 2L);
+        partitionOffsets2.put(t3p0, 100L);
+        commitReceived = prepareOffsetCommitResponse(client, coordinator, partitionOffsets2);
+
+        // unsubscribe
+        consumer.unsubscribe();
+
+        // verify that subscription and assignment are both cleared
+        assertTrue(consumer.subscription().isEmpty());
+        assertTrue(consumer.assignment().isEmpty());
+
+        // verify that the offset commits occurred as expected
+        assertTrue(commitReceived.get());
+
+        consumer.close();
+    }
+
+    /**
+     * Verify that when a consumer changes its topic subscription its assigned partitions
+     * do not immediately change, and the consumed offsets of its to-be-revoked partitions
+     * are not committed (when auto-commit is disabled).
+     * Upon unsubscribing from subscribed topics, the assigned partitions immediately
+     * change but if auto-commit is disabled the consumer offsets are not committed.
+     */
+    @Test
+    public void testSubscriptionChangesWithAutoCommitDisabled() {
+        int rebalanceTimeoutMs = 60000;
+        int sessionTimeoutMs = 30000;
+        int heartbeatIntervalMs = 3000;
+        int autoCommitIntervalMs = 1000;
+
+        Time time = new MockTime();
+        MockClient client = new MockClient(time);
+        Map<String, Integer> tpCounts = new HashMap<>();
+        tpCounts.put(topic, 1);
+        tpCounts.put(topic2, 1);
+        Cluster cluster = TestUtils.singletonCluster(tpCounts);
+        Node node = cluster.nodes().get(0);
+        client.setNode(node);
+        Metadata metadata = new Metadata(0, Long.MAX_VALUE);
+        metadata.update(cluster, time.milliseconds());
+        PartitionAssignor assignor = new RangeAssignor();
+
+        final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, false, autoCommitIntervalMs);
+
+        // initial subscription
+        consumer.subscribe(Arrays.asList(topic), getConsumerRebalanceListener(consumer));
+
+        // verify that subscription has changed but assignment is still unchanged
+        assertTrue(consumer.subscription().equals(Collections.singleton(topic)));
+        assertTrue(consumer.assignment().isEmpty());
+
+        // mock rebalance responses
+        prepareRebalance(client, node, assignor, Arrays.asList(tp0), null);
+
+        consumer.poll(0);
+
+        // verify that subscription is still the same, and now assignment has caught up
+        assertTrue(consumer.subscription().equals(Collections.singleton(topic)));
+        assertTrue(consumer.assignment().equals(Collections.singleton(tp0)));
+
+        consumer.poll(0);
+
+        // subscription change
+        consumer.subscribe(Arrays.asList(topic2), getConsumerRebalanceListener(consumer));
+
+        // verify that subscription has changed but assignment is still unchanged
+        assertTrue(consumer.subscription().equals(Collections.singleton(topic2)));
+        assertTrue(consumer.assignment().equals(Collections.singleton(tp0)));
+
+        // the auto commit is disabled, so no offset commit request should be sent
+        for (ClientRequest req: client.requests())
+            assertTrue(req.request().header().apiKey() != ApiKeys.OFFSET_COMMIT.id);
+
+        // subscription change
+        consumer.unsubscribe();
+
+        // verify that subscription and assignment are both updated
+        assertTrue(consumer.subscription().isEmpty());
+        assertTrue(consumer.assignment().isEmpty());
+
+        // the auto commit is disabled, so no offset commit request should be sent
+        for (ClientRequest req: client.requests())
+            assertTrue(req.request().header().apiKey() != ApiKeys.OFFSET_COMMIT.id);
+
+        consumer.close();
+    }
+
+    @Test
+    public void testManualAssignmentChangeWithAutoCommitEnabled() {
+        int rebalanceTimeoutMs = 60000;
+        int sessionTimeoutMs = 30000;
+        int heartbeatIntervalMs = 3000;
+        int autoCommitIntervalMs = 1000;
+
+        Time time = new MockTime();
+        MockClient client = new MockClient(time);
+        Map<String, Integer> tpCounts = new HashMap<>();
+        tpCounts.put(topic, 1);
+        tpCounts.put(topic2, 1);
+        Cluster cluster = TestUtils.singletonCluster(tpCounts);
+        Node node = cluster.nodes().get(0);
+        client.setNode(node);
+        Metadata metadata = new Metadata(0, Long.MAX_VALUE);
+        metadata.update(cluster, time.milliseconds());
+        PartitionAssignor assignor = new RangeAssignor();
+
+        final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, true, autoCommitIntervalMs);
+
+        // lookup coordinator
+        client.prepareResponseFrom(new GroupCoordinatorResponse(Errors.NONE.code(), node).toStruct(), node);
+        Node coordinator = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
+
+        // manual assignment
+        consumer.assign(Arrays.asList(tp0));
+        consumer.seekToBeginning(Arrays.asList(tp0));
+
+        // fetch offset for one topic
+        client.prepareResponseFrom(
+                offsetResponse(Collections.singletonMap(tp0, 0L), Errors.NONE.code()),
+                coordinator);
+        assertEquals(0, consumer.committed(tp0).offset());
+
+        // verify that assignment immediately changes
+        assertTrue(consumer.assignment().equals(Collections.singleton(tp0)));
+
+        // there shouldn't be any need to lookup the coordinator or fetch committed offsets.
+        // we just lookup the starting position and send the record fetch.
+        client.prepareResponse(listOffsetsResponse(Collections.singletonMap(tp0, 10L), Errors.NONE.code()));
+        client.prepareResponse(fetchResponse(tp0, 10L, 1));
+
+        ConsumerRecords<String, String> records = consumer.poll(0);
+        assertEquals(1, records.count());
+        assertEquals(11L, consumer.position(tp0));
+
+        // mock the offset commit response for to be revoked partitions
+        AtomicBoolean commitReceived = prepareOffsetCommitResponse(client, coordinator, tp0, 11);
+
+        // new manual assignment
+        consumer.assign(Arrays.asList(t2p0));
+
+        // verify that assignment immediately changes
+        assertTrue(consumer.assignment().equals(Collections.singleton(t2p0)));
+        // verify that the offset commits occurred as expected
+        assertTrue(commitReceived.get());
+
+        consumer.close();
+    }
+
+    @Test
+    public void testManualAssignmentChangeWithAutoCommitDisabled() {
+        int rebalanceTimeoutMs = 60000;
+        int sessionTimeoutMs = 30000;
+        int heartbeatIntervalMs = 3000;
+        int autoCommitIntervalMs = 1000;
+
+        Time time = new MockTime();
+        MockClient client = new MockClient(time);
+        Map<String, Integer> tpCounts = new HashMap<>();
+        tpCounts.put(topic, 1);
+        tpCounts.put(topic2, 1);
+        Cluster cluster = TestUtils.singletonCluster(tpCounts);
+        Node node = cluster.nodes().get(0);
+        client.setNode(node);
+        Metadata metadata = new Metadata(0, Long.MAX_VALUE);
+        metadata.update(cluster, time.milliseconds());
+        PartitionAssignor assignor = new RangeAssignor();
+
+        final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor,
+                rebalanceTimeoutMs, sessionTimeoutMs, heartbeatIntervalMs, false, autoCommitIntervalMs);
+
+        // lookup coordinator
+        client.prepareResponseFrom(new GroupCoordinatorResponse(Errors.NONE.code(), node).toStruct(), node);
+        Node coordinator = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
+
+        // manual assignment
+        consumer.assign(Arrays.asList(tp0));
+        consumer.seekToBeginning(Arrays.asList(tp0));
+
+        // fetch offset for one topic
+        client.prepareResponseFrom(
+                offsetResponse(Collections.singletonMap(tp0, 0L), Errors.NONE.code()),
+                coordinator);
+        assertEquals(0, consumer.committed(tp0).offset());
+
+        // verify that assignment immediately changes
+        assertTrue(consumer.assignment().equals(Collections.singleton(tp0)));
+
+        // there shouldn't be any need to lookup the coordinator or fetch committed offsets.
+        // we just lookup the starting position and send the record fetch.
+        client.prepareResponse(listOffsetsResponse(Collections.singletonMap(tp0, 10L), Errors.NONE.code()));
+        client.prepareResponse(fetchResponse(tp0, 10L, 1));
+
+        ConsumerRecords<String, String> records = consumer.poll(0);
+        assertEquals(1, records.count());
+        assertEquals(11L, consumer.position(tp0));
+
+        // new manual assignment
+        consumer.assign(Arrays.asList(t2p0));
+
+        // verify that assignment immediately changes
+        assertTrue(consumer.assignment().equals(Collections.singleton(t2p0)));
+
+        // the auto commit is disabled, so no offset commit request should be sent
+        for (ClientRequest req: client.requests())
+            assertTrue(req.request().header().apiKey() != ApiKeys.OFFSET_COMMIT.id);
+
+        consumer.close();
     }
 
     private ConsumerRebalanceListener getConsumerRebalanceListener(final KafkaConsumer<String, String> consumer) {
@@ -683,24 +938,32 @@ public class KafkaConsumerTest {
         return heartbeatReceived;
     }
 
-    private AtomicBoolean prepareOffsetCommitResponse(MockClient client, Node coordinator, final List<TopicPartition> partitions, final long offset) {
+    private AtomicBoolean prepareOffsetCommitResponse(MockClient client, Node coordinator, final Map<TopicPartition, Long> partitionOffsets) {
         final AtomicBoolean commitReceived = new AtomicBoolean(true);
+        Map<TopicPartition, Short> response = new HashMap<>();
+        for (TopicPartition partition : partitionOffsets.keySet())
+            response.put(partition, Errors.NONE.code());
+
         client.prepareResponseFrom(new MockClient.RequestMatcher() {
             @Override
             public boolean matches(ClientRequest request) {
                 OffsetCommitRequest commitRequest = new OffsetCommitRequest(request.request().body());
-                for (TopicPartition partition: partitions) {
-                    OffsetCommitRequest.PartitionData partitionData = commitRequest.offsetData().get(partition);
+                for (Map.Entry<TopicPartition, Long> partitionOffset : partitionOffsets.entrySet()) {
+                    OffsetCommitRequest.PartitionData partitionData = commitRequest.offsetData().get(partitionOffset.getKey());
                     // verify that the expected offset has been committed
-                    if (partitionData.offset != offset) {
+                    if (partitionData.offset != partitionOffset.getValue()) {
                         commitReceived.set(false);
                         return false;
                     }
                 }
                 return true;
             }
-        }, offsetCommitResponse(Collections.singletonMap(tp0, Errors.NONE.code())), coordinator);
+        }, offsetCommitResponse(response), coordinator);
         return commitReceived;
+    }
+
+    private AtomicBoolean prepareOffsetCommitResponse(MockClient client, Node coordinator, final TopicPartition partition, final long offset) {
+        return prepareOffsetCommitResponse(client, coordinator, Collections.singletonMap(partition, offset));
     }
 
     private Struct offsetCommitResponse(Map<TopicPartition, Short> responseData) {
@@ -735,16 +998,25 @@ public class KafkaConsumerTest {
         return new ListOffsetResponse(partitionData).toStruct();
     }
 
-    private Struct fetchResponse(List<TopicPartition> partitions, long fetchOffset, int count) {
-        MemoryRecords records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
-        for (int i = 0; i < count; i++)
-            records.append(fetchOffset + i, 0L, ("key-" + i).getBytes(), ("value-" + i).getBytes());
-        records.close();
+    private Struct fetchResponse(Map<TopicPartition, FetchInfo> fetches) {
         Map<TopicPartition, PartitionData> tpResponses = new HashMap<>();
-        for (TopicPartition partition: partitions)
+        for (Map.Entry<TopicPartition, FetchInfo> fetchEntry : fetches.entrySet()) {
+            TopicPartition partition = fetchEntry.getKey();
+            long fetchOffset = fetchEntry.getValue().offset;
+            int fetchCount = fetchEntry.getValue().count;
+            MemoryRecords records = MemoryRecords.emptyRecords(ByteBuffer.allocate(1024), CompressionType.NONE);
+            for (int i = 0; i < fetchCount; i++)
+                records.append(fetchOffset + i, 0L, ("key-" + i).getBytes(), ("value-" + i).getBytes());
+            records.close();
             tpResponses.put(partition, new FetchResponse.PartitionData(Errors.NONE.code(), 0, records.buffer()));
+        }
         FetchResponse response = new FetchResponse(tpResponses, 0);
         return response.toStruct();
+    }
+
+    private Struct fetchResponse(TopicPartition partition, long fetchOffset, int count) {
+        FetchInfo fetchInfo = new FetchInfo(fetchOffset, count);
+        return fetchResponse(Collections.singletonMap(partition, fetchInfo));
     }
 
     private KafkaConsumer<String, String> newConsumer(Time time,
@@ -754,6 +1026,7 @@ public class KafkaConsumerTest {
                                                       int rebalanceTimeoutMs,
                                                       int sessionTimeoutMs,
                                                       int heartbeatIntervalMs,
+                                                      boolean autoCommitEnabled,
                                                       int autoCommitIntervalMs) {
         // create a consumer with mocked time and mocked network
 
@@ -762,7 +1035,6 @@ public class KafkaConsumerTest {
         String metricGroupPrefix = "consumer";
         long retryBackoffMs = 100;
         long requestTimeoutMs = 30000;
-        boolean autoCommitEnabled = true;
         boolean excludeInternalTopics = true;
         int minBytes = 1;
         int maxWaitMs = 500;
@@ -828,10 +1100,17 @@ public class KafkaConsumerTest {
                 metrics,
                 subscriptions,
                 metadata,
-                autoCommitEnabled,
-                autoCommitIntervalMs,
-                heartbeatIntervalMs,
                 retryBackoffMs,
                 requestTimeoutMs);
+    }
+
+    private static class FetchInfo {
+        long offset;
+        int count;
+
+        FetchInfo(long offset, int count) {
+            this.offset = offset;
+            this.count = count;
+        }
     }
 }


### PR DESCRIPTION
This PR changes topic subscription semantics so a change in subscription does not immediately cause a rebalance.
Instead, the next poll or the next scheduled metadata refresh will update the assigned partitions.
