### PR TITLE
KAFKA-4038: Transient failure in DeleteTopicsRequestTest.testErrorDel…

### DIFF
--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
@@ -73,6 +73,7 @@ class DeleteTopicsRequestTest extends BaseRequestTest {
 
     // Timeout
     TestUtils.createTopic(zkUtils, timeoutTopic, 5, 2, servers)
+    // Must be a 0ms timeout to avoid transient test failures. Even a timeout of 1ms has succeeded in the past.
     validateErrorDeleteTopicRequests(new DeleteTopicsRequest(Set(timeoutTopic).asJava, 0),
       Map(timeoutTopic -> Errors.REQUEST_TIMED_OUT))
     // The topic should still get deleted eventually

--- a/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DeleteTopicsRequestTest.scala
@@ -73,7 +73,7 @@ class DeleteTopicsRequestTest extends BaseRequestTest {
 
     // Timeout
     TestUtils.createTopic(zkUtils, timeoutTopic, 5, 2, servers)
-    validateErrorDeleteTopicRequests(new DeleteTopicsRequest(Set(timeoutTopic).asJava, 1),
+    validateErrorDeleteTopicRequests(new DeleteTopicsRequest(Set(timeoutTopic).asJava, 0),
       Map(timeoutTopic -> Errors.REQUEST_TIMED_OUT))
     // The topic should still get deleted eventually
     TestUtils.waitUntilTrue(() => !servers.head.metadataCache.contains(timeoutTopic), s"Topic $timeoutTopic is never deleted")


### PR DESCRIPTION
…eteTopicRequests
