### PR TITLE
MINOR: Remove # from .bat start script

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -81,7 +81,7 @@ rem Log4j settings
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
 ) ELSE (
-  # create logs directory
+  rem create logs directory
   IF not exist %LOG_DIR% (
       mkdir %LOG_DIR%
   )


### PR DESCRIPTION
On Windows, the following output is seen when starting Zookeeper and Kafka servers:

```
'#' is not recognized as an internal or external command,
operable program or batch file.
```

This pull request makes a minor correction to the Windows `kafka-run-class.bat` script to replace the use of `#` with `rem`.
