### PR TITLE
MINOR: Add more verbose logging for offset map building

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -536,7 +536,7 @@ private[log] class Cleaner(val id: Int,
     if(readBuffer.capacity >= maxIoBufferSize || writeBuffer.capacity >= maxIoBufferSize)
       throw new IllegalStateException("This log contains a message larger than maximum allowable size of %s.".format(maxIoBufferSize))
     val newSize = math.min(this.readBuffer.capacity * 2, maxIoBufferSize)
-    info("Growing cleaner I/O buffers from " + readBuffer.capacity + "bytes to " + newSize + " bytes.")
+    info("Growing cleaner I/O buffers from " + readBuffer.capacity + " bytes to " + newSize + " bytes.")
     this.readBuffer = ByteBuffer.allocate(newSize)
     this.writeBuffer = ByteBuffer.allocate(newSize)
   }
@@ -632,6 +632,7 @@ private[log] class Cleaner(val id: Int,
     var position = 0
     var offset = segment.baseOffset
     val maxDesiredMapSize = (map.slots * this.dupBufferLoadFactor).toInt
+    info("Updating offset map for segment %s of partition %s...".format(segment.baseOffset, topicAndPartition))
     while (position < segment.log.sizeInBytes) {
       checkDone(topicAndPartition)
       readBuffer.clear()


### PR DESCRIPTION
I propose to make the offset map building a bit more verbose to make log cleaning messages a bit easier to follow, for people not much familiar with the code like myself.

Specifically, it's confusing when we get messages like these in the log:

```
[2016-08-15 16:22:42,861] INFO Cleaner 0: Growing cleaner I/O buffers from 65536bytes to 131072 bytes. (kafka.log.LogCleaner)
[2016-08-15 16:22:46,002] INFO Cleaner 0: Growing cleaner I/O buffers from 65536bytes to 131072 bytes. (kafka.log.LogCleaner)
[2016-08-15 16:22:48,844] INFO Cleaner 0: Growing cleaner I/O buffers from 65536bytes to 131072 bytes. (kafka.log.LogCleaner)
```

When stumbling upon this the first time, these looked like a bug (why are buffers trying to grow into the same sizes, for the same thread?).
Then, after checking the code, I realized these are for different segments.

This PR aims to make that a bit more clear.

Does this look good?
