### PR TITLE
KAFKA-4042: prevent DistributedHerder thread from dying from connector/task lifecycle exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ results
 tests/results
 .ducktape
 tests/.ducktape
+tests/venv
 .cache
 
 docs/generated/

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -379,13 +379,12 @@ class MockSink(object):
 
 class MockSource(object):
 
-    def __init__(self, cc, topics, mode=None, delay_sec=10, name="mock-source"):
+    def __init__(self, cc, mode=None, delay_sec=10, name="mock-source"):
         self.cc = cc
         self.logger = self.cc.logger
         self.name = name
         self.mode = mode
         self.delay_sec = delay_sec
-        self.topics = topics
 
     def start(self):
         self.logger.info("Creating connector MockSourceConnector %s", self.name)
@@ -393,8 +392,6 @@ class MockSource(object):
             'name': self.name,
             'connector.class': 'org.apache.kafka.connect.tools.MockSourceConnector',
             'tasks.max': 1,
-            'topics': ",".join(self.topics),
             'mock_mode': self.mode,
             'delay_ms': self.delay_sec * 1000
         })
-        

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -23,7 +23,7 @@ from kafkatest.services.security.security_config import SecurityConfig
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix
 import subprocess, itertools, time
-from collections import Counter
+from collections import Counter, namedtuple
 import operator
 
 class ConnectDistributedTest(Test):
@@ -155,7 +155,43 @@ class ConnectDistributedTest(Test):
         wait_until(lambda: self.connector_is_running(self.sink), timeout_sec=10,
                    err_msg="Failed to see connector transition to the RUNNING state")
 
-    
+    @matrix(delete_before_reconfig=[False, True])
+    def test_bad_connector_class(self, delete_before_reconfig):
+        """
+        For the same connector name, first configure it with a bad connector class name such that it fails to start, verify that it enters a FAILED state.
+        Restart should also fail.
+        Then try to rectify by reconfiguring it as a MockConnector and verifying it successfully transitions to RUNNING.
+        """
+        self.setup_services()
+        self.cc.set_configs(lambda node: self.render("connect-distributed.properties", node=node))
+        self.cc.start()
+
+        connector_name = 'bad-to-good-test'
+
+        connector = namedtuple('BadConnector', ['name', 'tasks'])(connector_name, 1)
+        config = {
+            'name': connector.name,
+            'tasks.max': connector.tasks,
+            'connector.class': 'java.util.HashMap'
+        }
+        self.cc.create_connector(config)
+
+        wait_until(lambda: self.connector_is_failed(connector), timeout_sec=15, err_msg="Failed to see connector transition to FAILED state")
+
+        try:
+            self.cc.restart_connector(connector_name)
+        except ConnectRestError:
+            pass
+        else:
+            raise AssertionError("Expected restart of %s to fail" % connector_name)
+
+        if delete_before_reconfig:
+            self.cc.delete_connector(connector_name)
+
+        config['connector.class'] = 'org.apache.kafka.connect.tools.MockSourceConnector'
+        self.cc.set_connector_config(connector_name, config)
+        wait_until(lambda: self.connector_is_running(connector), timeout_sec=15, err_msg="Failed to see connector transition to the RUNNING state")
+
     @matrix(connector_type=["source", "sink"])
     def test_restart_failed_task(self, connector_type):
         self.setup_services()
@@ -166,7 +202,7 @@ class ConnectDistributedTest(Test):
         if connector_type == "sink":
             connector = MockSink(self.cc, self.topics.keys(), mode='task-failure', delay_sec=5)
         else:
-            connector = MockSource(self.cc, self.topics.keys(), mode='task-failure', delay_sec=5)
+            connector = MockSource(self.cc, mode='task-failure', delay_sec=5)
             
         connector.start()
 


### PR DESCRIPTION
- `worker.startConnector()` and `worker.startTask()` can throw (e.g. `ClassNotFoundException`, `ConnectException`, or any other exception arising from the constructor of the connector or task class when we `newInstance()`), so add catch blocks around those calls from the `DistributedHerder` and handle by invoking `onFailure()` which updates the `StatusBackingStore`.
- `worker.stopConnector()` throws `ConnectException` if start failed causing the connector to not be registered with the worker, so guard with `worker.ownsConnector()`
- `worker.stopTasks()` and `worker.awaitStopTasks()` throw `ConnectException` if any of them failed to start and are hence not registered with the worker, so guard those calls by filtering the task IDs with `worker.ownsTask()`
