### PR TITLE
KAFKA-4057: Allow to specify the request version and replica ID in ka…

### DIFF
--- a/core/src/main/scala/kafka/javaapi/FetchRequest.scala
+++ b/core/src/main/scala/kafka/javaapi/FetchRequest.scala
@@ -26,7 +26,9 @@ class FetchRequest(correlationId: Int,
                    clientId: String,
                    maxWait: Int,
                    minBytes: Int,
-                   requestInfo: java.util.Map[TopicAndPartition, PartitionFetchInfo]) {
+                   requestInfo: java.util.Map[TopicAndPartition, PartitionFetchInfo],
+                   versionId: Short = kafka.api.FetchRequest.CurrentVersion,
+                   replicaId: Int = Request.OrdinaryConsumerId) {
 
   val underlying = {
     val scalaMap: Map[TopicAndPartition, PartitionFetchInfo] = {
@@ -34,9 +36,10 @@ class FetchRequest(correlationId: Int,
       (requestInfo: mutable.Map[TopicAndPartition, PartitionFetchInfo]).toMap
     }
     kafka.api.FetchRequest(
+      versionId = versionId,
       correlationId = correlationId,
       clientId = clientId,
-      replicaId = Request.OrdinaryConsumerId,
+      replicaId = replicaId,
       maxWait = maxWait,
       minBytes = minBytes,
       requestInfo = scalaMap


### PR DESCRIPTION
…fka.javaapi.FetchRequest
- Added new arguments for versionId and replicaId in the constructor instead of using hardcoded values
