### PR TITLE
KAFKA-4039: delay invocation of System.exit via FatalExitException

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -41,6 +41,7 @@
   <allow pkg="org.apache.kafka.common" exact-match="true" />
   <allow pkg="org.apache.kafka.common.security" />
   <allow pkg="org.apache.kafka.common.utils" />
+  <allow pkg="org.apache.kafka.common.errors" exact-match="true" />
 
   <subpackage name="common">
     <disallow pkg="org.apache.kafka.clients" />

--- a/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
@@ -27,7 +27,7 @@ public class FatalExitError extends Error {
     private final static long serialVersionUID = 1L;
 
     // TODO: remove this when we have System.exit disabled my mocking in tests
-    private static boolean testMode = true;
+    private static boolean testMode = false;
 
     protected int exitStatus;
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
@@ -20,9 +20,9 @@ import org.slf4j.LoggerFactory;
  * caught at the highest level of the thread so that no shared lock would be held by the thread
  * when it calls {@link System#exit(int)}
  */
-public class FatalExitException extends RuntimeException {
+public class FatalExitError extends Error {
 
-    private static final Logger log = LoggerFactory.getLogger(FatalExitException.class);
+    private static final Logger log = LoggerFactory.getLogger(FatalExitError.class);
 
     private final static long serialVersionUID = 1L;
 
@@ -35,22 +35,22 @@ public class FatalExitException extends RuntimeException {
         testMode = true;
     }
 
-    public FatalExitException(int exitStatus, String message, Throwable cause) {
+    public FatalExitError(int exitStatus, String message, Throwable cause) {
         super(message, cause);
         this.exitStatus = exitStatus;
     }
 
-    public FatalExitException(int exitStatus, String message) {
+    public FatalExitError(int exitStatus, String message) {
         super(message);
         this.exitStatus = exitStatus;
     }
 
-    public FatalExitException(int exitStatus, Throwable cause) {
+    public FatalExitError(int exitStatus, Throwable cause) {
         super(cause);
         this.exitStatus = exitStatus;
     }
 
-    public FatalExitException(int exitStatus) {
+    public FatalExitError(int exitStatus) {
         super();
         this.exitStatus = exitStatus;
     }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
@@ -50,6 +50,28 @@ public class FatalExitError extends Error {
 
     public void shutdownSystem() {
         log.error("System.exit is invoked", this);
+        Thread t = new Thread("shutdown-system-thread") {
+            @Override
+            public void run() {
+                doShutdownSystem();
+            }
+        };
+        this.setUncaughtExceptionHandler(t);
+        t.start();
+    }
+
+    // this method can be overridden for testing
+    protected void setUncaughtExceptionHandler(Thread t) {
+        t.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread t, Throwable e) {
+                log.error("Uncaught exception while shutting down the process", e);
+            }
+        });
+    }
+
+    // this method can be overridden for testing
+    protected void doShutdownSystem() {
         System.exit(exitStatus);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FatalExitError.java
@@ -26,14 +26,7 @@ public class FatalExitError extends Error {
 
     private final static long serialVersionUID = 1L;
 
-    // TODO: remove this when we have System.exit disabled my mocking in tests
-    private static boolean testMode = false;
-
     protected int exitStatus;
-
-    public static void testMode() {
-        testMode = true;
-    }
 
     public FatalExitError(int exitStatus, String message, Throwable cause) {
         super(message, cause);
@@ -57,8 +50,6 @@ public class FatalExitError extends Error {
 
     public void shutdownSystem() {
         log.error("System.exit is invoked", this);
-        if (!testMode) {
-            System.exit(exitStatus);
-        }
+        System.exit(exitStatus);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/FatalExitException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/FatalExitException.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The exception that indicates the need to exit the process. This exception is expected to be
+ * caught at the highest level of the thread so that no shared lock would be held by the thread
+ * when it calls {@link System#exit(int)}
+ */
+public class FatalExitException extends RuntimeException {
+
+    private static final Logger log = LoggerFactory.getLogger(FatalExitException.class);
+
+    private final static long serialVersionUID = 1L;
+
+    // TODO: remove this when we have System.exit disabled my mocking in tests
+    private static boolean testMode = true;
+
+    protected int exitStatus;
+
+    public static void testMode() {
+        testMode = true;
+    }
+
+    public FatalExitException(int exitStatus, String message, Throwable cause) {
+        super(message, cause);
+        this.exitStatus = exitStatus;
+    }
+
+    public FatalExitException(int exitStatus, String message) {
+        super(message);
+        this.exitStatus = exitStatus;
+    }
+
+    public FatalExitException(int exitStatus, Throwable cause) {
+        super(cause);
+        this.exitStatus = exitStatus;
+    }
+
+    public FatalExitException(int exitStatus) {
+        super();
+        this.exitStatus = exitStatus;
+    }
+
+    public void shutdownSystem() {
+        log.error("System.exit is invoked", this);
+        if (!testMode) {
+            System.exit(exitStatus);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -43,6 +43,7 @@ import java.util.Properties;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 
+import org.apache.kafka.common.errors.FatalExitException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.kafka.common.KafkaException;
@@ -482,7 +483,12 @@ public class Utils {
         thread.setDaemon(daemon);
         thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             public void uncaughtException(Thread t, Throwable e) {
-                log.error("Uncaught exception in thread '" + t.getName() + "':", e);
+                if (e instanceof FatalExitException) {
+                    log.error("Received FatalExitException ", e);
+                    ((FatalExitException) e).shutdownSystem();
+                } else {
+                    log.error("Uncaught exception in thread '" + t.getName() + "':", e);
+                }
             }
         });
         return thread;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -43,7 +43,7 @@ import java.util.Properties;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 
-import org.apache.kafka.common.errors.FatalExitException;
+import org.apache.kafka.common.errors.FatalExitError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.kafka.common.KafkaException;
@@ -483,9 +483,9 @@ public class Utils {
         thread.setDaemon(daemon);
         thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             public void uncaughtException(Thread t, Throwable e) {
-                if (e instanceof FatalExitException) {
-                    log.error("Received FatalExitException ", e);
-                    ((FatalExitException) e).shutdownSystem();
+                if (e instanceof FatalExitError) {
+                    log.error("Received FatalExitError ", e);
+                    ((FatalExitError) e).shutdownSystem();
                 } else {
                     log.error("Uncaught exception in thread '" + t.getName() + "':", e);
                 }

--- a/clients/src/test/java/org/apache/kafka/common/ExitException4Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/ExitException4Test.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common;
+
+public class ExitException4Test extends SecurityException {
+    public final int exitStatus;
+    public ExitException4Test(int exitStatus) {
+        super("System.exit() is invoked!");
+        this.exitStatus = exitStatus;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/ExitTest.java
@@ -14,34 +14,42 @@ package org.apache.kafka.common;
 
 import org.apache.kafka.common.errors.FatalExitError;
 import org.apache.kafka.common.utils.Utils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({FatalExitError.class})
 public class ExitTest {
+
+    //TODO: make all unit tests perform this init (perhaps by inheriting from a base test class)
     @Before
     public void init() {
-        // TODO: to be replaced with proper mocking
-        FatalExitError.testMode();
+        System.setSecurityManager(new SecurityManager4Test());
+    }
+
+    @After
+    public void tearDown() {
+        System.setSecurityManager(null);
     }
 
     @Test
-    public void testSystemExit() {
+    public void testExitIsMocked() throws Exception {
+        try {
+            System.exit(1);
+        } catch (ExitException4Test e) {
+            assertEquals("Exit exitStatus", 1, e.exitStatus);
+        }
+    }
+
+    @Test(expected = ExitException4Test.class)
+    public void testSystemExitInUtilThreads() {
         Thread t = Utils.newThread("test-exit-thread", new Runnable() {
             @Override
             public void run() {
             }
         }, false);
         t.getUncaughtExceptionHandler().uncaughtException(t, new FatalExitError(1));
-        /** if we reach this point it means that the {@link FatalExitError} is properly caught
-         and yet it successfully disabled invoking {@link System.exit} for unit tests
-         */
-        assertTrue(true);
     }
 }
+

--- a/clients/src/test/java/org/apache/kafka/common/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/ExitTest.java
@@ -12,7 +12,7 @@
  */
 package org.apache.kafka.common;
 
-import org.apache.kafka.common.errors.FatalExitException;
+import org.apache.kafka.common.errors.FatalExitError;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,12 +23,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FatalExitException.class})
+@PrepareForTest({FatalExitError.class})
 public class ExitTest {
     @Before
     public void init() {
         // TODO: to be replaced with proper mocking
-        FatalExitException.testMode();
+        FatalExitError.testMode();
     }
 
     @Test
@@ -38,8 +38,8 @@ public class ExitTest {
             public void run() {
             }
         }, false);
-        t.getUncaughtExceptionHandler().uncaughtException(t, new FatalExitException(1));
-        /** if we reach this point it means that the {@link FatalExitException} is properly caught
+        t.getUncaughtExceptionHandler().uncaughtException(t, new FatalExitError(1));
+        /** if we reach this point it means that the {@link FatalExitError} is properly caught
          and yet it successfully disabled invoking {@link System.exit} for unit tests
          */
         assertTrue(true);

--- a/clients/src/test/java/org/apache/kafka/common/ExitTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/ExitTest.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common;
+
+import org.apache.kafka.common.errors.FatalExitException;
+import org.apache.kafka.common.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FatalExitException.class})
+public class ExitTest {
+    @Before
+    public void init() {
+        // TODO: to be replaced with proper mocking
+        FatalExitException.testMode();
+    }
+
+    @Test
+    public void testSystemExit() {
+        Thread t = Utils.newThread("test-exit-thread", new Runnable() {
+            @Override
+            public void run() {
+            }
+        }, false);
+        t.getUncaughtExceptionHandler().uncaughtException(t, new FatalExitException(1));
+        /** if we reach this point it means that the {@link FatalExitException} is properly caught
+         and yet it successfully disabled invoking {@link System.exit} for unit tests
+         */
+        assertTrue(true);
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/SecurityManager4Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/SecurityManager4Test.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common;
+
+import java.security.Permission;
+
+public class SecurityManager4Test extends SecurityManager {
+
+    @Override
+    public void checkPermission(Permission perm) {
+    }
+
+    @Override
+    public void checkPermission(Permission perm, Object context) {
+    }
+
+    @Override
+    public void checkExit(int status) {
+        super.checkExit(status);
+        throw new ExitException4Test(status);
+    }
+}
+

--- a/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
@@ -20,6 +20,7 @@ package kafka.consumer
 import org.I0Itec.zkclient.ZkClient
 import kafka.server.{BrokerAndInitialOffset, AbstractFetcherThread, AbstractFetcherManager}
 import kafka.cluster.{BrokerEndPoint, Cluster}
+import org.apache.kafka.common.errors.FatalExitError
 import org.apache.kafka.common.protocol.SecurityProtocol
 import scala.collection.immutable
 import collection.mutable.HashMap
@@ -97,6 +98,7 @@ class ConsumerFetcherManager(private val consumerIdString: String,
             topicAndPartition -> BrokerAndInitialOffset(broker, partitionMap(topicAndPartition).getFetchOffset())}
         )
       } catch {
+        case fee: FatalExitError => throw fee
         case t: Throwable => {
           if (!isRunning.get())
             throw t /* If this thread is stopped, propagate this exception to kill the thread. */

--- a/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/AbstractFetcherThread.scala
@@ -26,7 +26,7 @@ import kafka.utils.{Pool, ShutdownableThread, DelayedItem}
 import kafka.common.{KafkaException, ClientIdAndBroker, TopicAndPartition}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.utils.CoreUtils.inLock
-import org.apache.kafka.common.errors.CorruptRecordException
+import org.apache.kafka.common.errors.{FatalExitError, CorruptRecordException}
 import org.apache.kafka.common.protocol.Errors
 import AbstractFetcherThread._
 import scala.collection.{mutable, Set, Map}
@@ -159,6 +159,8 @@ abstract class AbstractFetcherThread(name: String,
                     error("Current offset %d for partition [%s,%d] out of range; reset offset to %d"
                       .format(currentPartitionFetchState.offset, topic, partitionId, newOffset))
                   } catch {
+                    case fee: FatalExitError =>
+                      throw fee
                     case e: Throwable =>
                       error("Error getting offset for partition [%s,%d] to broker %d".format(topic, partitionId, sourceBroker.id), e)
                       partitionsWithError += topicAndPartition

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -35,7 +35,7 @@ import kafka.network.RequestChannel.{Response, Session}
 import kafka.security.auth
 import kafka.security.auth.{Authorizer, ClusterAction, Create, Describe, Group, Operation, Read, Resource, Write, Delete}
 import kafka.utils.{Logging, SystemTime, ZKGroupTopicDirs, ZkUtils}
-import org.apache.kafka.common.errors.{ClusterAuthorizationException, InvalidTopicException, NotLeaderForPartitionException, UnknownTopicOrPartitionException, TopicExistsException}
+import org.apache.kafka.common.errors.{ClusterAuthorizationException, InvalidTopicException, NotLeaderForPartitionException, UnknownTopicOrPartitionException, TopicExistsException, FatalExitError}
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, Protocol, SecurityProtocol}
 import org.apache.kafka.common.requests.{ApiVersionsResponse, DescribeGroupsRequest, DescribeGroupsResponse, GroupCoordinatorRequest, GroupCoordinatorResponse, HeartbeatRequest, HeartbeatResponse, JoinGroupRequest, JoinGroupResponse, LeaderAndIsrRequest, LeaderAndIsrResponse, LeaveGroupRequest, LeaveGroupResponse, ListGroupsResponse, ListOffsetRequest, ListOffsetResponse, MetadataRequest, MetadataResponse, OffsetCommitRequest, OffsetCommitResponse, OffsetFetchRequest, OffsetFetchResponse, ProduceRequest, ProduceResponse, ResponseHeader, ResponseSend, SaslHandshakeResponse, StopReplicaRequest, StopReplicaResponse, SyncGroupRequest, SyncGroupResponse, UpdateMetadataRequest, UpdateMetadataResponse, CreateTopicsRequest, CreateTopicsResponse, DeleteTopicsRequest, DeleteTopicsResponse}
@@ -97,6 +97,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case requestId => throw new KafkaException("Unknown api code " + requestId)
       }
     } catch {
+      case fee: FatalExitError => throw fee
       case e: Throwable =>
         if (request.requestObj != null) {
           request.requestObj.handleError(e, requestChannel, request)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -27,7 +27,7 @@ import kafka.api.{KAFKA_0_10_0_IV0, KAFKA_0_9_0}
 import kafka.common.{KafkaStorageException, TopicAndPartition}
 import ReplicaFetcherThread._
 import org.apache.kafka.clients.{ManualMetadataUpdater, NetworkClient, ClientRequest, ClientResponse}
-import org.apache.kafka.common.errors.FatalExitException
+import org.apache.kafka.common.errors.FatalExitError
 import org.apache.kafka.common.network.{LoginType, Selectable, ChannelBuilders, NetworkReceive, Selector, Mode}
 import org.apache.kafka.common.requests.{ListOffsetResponse, FetchResponse, RequestSend, AbstractRequest, ListOffsetRequest}
 import org.apache.kafka.common.requests.{FetchRequest => JFetchRequest}
@@ -179,7 +179,7 @@ class ReplicaFetcherThread(name: String,
         fatal("Exiting because log truncation is not allowed for partition %s,".format(topicAndPartition) +
           " Current leader %d's latest offset %d is less than replica %d's latest offset %d"
           .format(sourceBroker.id, leaderEndOffset, brokerConfig.brokerId, replica.logEndOffset.messageOffset))
-        throw new FatalExitException(1)
+        throw new FatalExitError(1)
       }
 
       warn("Replica %d for partition %s reset its fetch offset from %d to current leader %d's latest offset %d"

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -27,6 +27,7 @@ import kafka.api.{KAFKA_0_10_0_IV0, KAFKA_0_9_0}
 import kafka.common.{KafkaStorageException, TopicAndPartition}
 import ReplicaFetcherThread._
 import org.apache.kafka.clients.{ManualMetadataUpdater, NetworkClient, ClientRequest, ClientResponse}
+import org.apache.kafka.common.errors.FatalExitException
 import org.apache.kafka.common.network.{LoginType, Selectable, ChannelBuilders, NetworkReceive, Selector, Mode}
 import org.apache.kafka.common.requests.{ListOffsetResponse, FetchResponse, RequestSend, AbstractRequest, ListOffsetRequest}
 import org.apache.kafka.common.requests.{FetchRequest => JFetchRequest}
@@ -178,7 +179,7 @@ class ReplicaFetcherThread(name: String,
         fatal("Exiting because log truncation is not allowed for partition %s,".format(topicAndPartition) +
           " Current leader %d's latest offset %d is less than replica %d's latest offset %d"
           .format(sourceBroker.id, leaderEndOffset, brokerConfig.brokerId, replica.logEndOffset.messageOffset))
-        System.exit(1)
+        throw new FatalExitException(1)
       }
 
       warn("Replica %d for partition %s reset its fetch offset from %d to current leader %d's latest offset %d"

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -20,7 +20,7 @@ package kafka.utils
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.CountDownLatch
 
-import org.apache.kafka.common.errors.FatalExitException
+import org.apache.kafka.common.errors.FatalExitError
 
 abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean = true)
         extends Thread(name) with Logging {
@@ -65,8 +65,8 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
         doWork()
       }
     } catch{
-      case fatalExitException: FatalExitException =>
-        fatalExitException.shutdownSystem()
+      case fatalExitError: FatalExitError =>
+        fatalExitError.shutdownSystem()
       case e: Throwable =>
         if(isRunning.get())
           error("Error due to ", e)

--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -20,6 +20,8 @@ package kafka.utils
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.CountDownLatch
 
+import org.apache.kafka.common.errors.FatalExitException
+
 abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean = true)
         extends Thread(name) with Logging {
   this.setDaemon(false)
@@ -63,6 +65,8 @@ abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean
         doWork()
       }
     } catch{
+      case fatalExitException: FatalExitException =>
+        fatalExitException.shutdownSystem()
       case e: Throwable =>
         if(isRunning.get())
           error("Error due to ", e)

--- a/core/src/test/scala/unit/kafka/common/ExitTest.scala
+++ b/core/src/test/scala/unit/kafka/common/ExitTest.scala
@@ -17,26 +17,27 @@
 package unit.kafka.common
 
 import kafka.utils.ShutdownableThread
+import org.apache.kafka.common.{ExitException4Test, SecurityManager4Test}
 import org.apache.kafka.common.errors.FatalExitError
-import org.junit.{Test, Before}
-import org.junit.Assert.assertTrue
+import org.junit.{After, Test, Before}
 
 class ExitTest {
+
+  //TODO: make all unit tests perform this init (perhaps by inheriting from a base test class)
   @Before
   def init() {
-    // TODO: to be replaced with proper mocking
-    FatalExitError.testMode();
+    System.setSecurityManager(new SecurityManager4Test());
   }
 
-  @Test
+  @After
+  def tearDown() {
+    System.setSecurityManager(null);
+  }
+
+  @Test(expected = classOf[ExitException4Test])
   def testSystemExitInShutdownableThread() {
     new ShutdownableThread("exit-test-thread") {
       override def doWork(): Unit = throw new FatalExitError(1)
     }.run()
-    /**
-     * if we reach this point it means that the {@link FatalExitError} is properly caught
-     * and yet it successfully disabled invoking {@link System.exit} for unit tests
-     */
-    assertTrue(true);
   }
 }

--- a/core/src/test/scala/unit/kafka/common/ExitTest.scala
+++ b/core/src/test/scala/unit/kafka/common/ExitTest.scala
@@ -17,7 +17,7 @@
 package unit.kafka.common
 
 import kafka.utils.ShutdownableThread
-import org.apache.kafka.common.errors.FatalExitException
+import org.apache.kafka.common.errors.FatalExitError
 import org.junit.{Test, Before}
 import org.junit.Assert.assertTrue
 
@@ -25,16 +25,16 @@ class ExitTest {
   @Before
   def init() {
     // TODO: to be replaced with proper mocking
-    FatalExitException.testMode();
+    FatalExitError.testMode();
   }
 
   @Test
   def testSystemExitInShutdownableThread() {
     new ShutdownableThread("exit-test-thread") {
-      override def doWork(): Unit = throw new FatalExitException(1)
+      override def doWork(): Unit = throw new FatalExitError(1)
     }.run()
     /**
-     * if we reach this point it means that the {@link FatalExitException} is properly caught
+     * if we reach this point it means that the {@link FatalExitError} is properly caught
      * and yet it successfully disabled invoking {@link System.exit} for unit tests
      */
     assertTrue(true);

--- a/core/src/test/scala/unit/kafka/common/ExitTest.scala
+++ b/core/src/test/scala/unit/kafka/common/ExitTest.scala
@@ -19,7 +19,7 @@ package unit.kafka.common
 import kafka.utils.ShutdownableThread
 import org.apache.kafka.common.{ExitException4Test, SecurityManager4Test}
 import org.apache.kafka.common.errors.FatalExitError
-import org.junit.{After, Test, Before}
+import org.junit.{Assert, After, Test, Before}
 
 class ExitTest {
 
@@ -34,10 +34,52 @@ class ExitTest {
     System.setSecurityManager(null);
   }
 
-  @Test(expected = classOf[ExitException4Test])
+  @Test
   def testSystemExitInShutdownableThread() {
+    class FatalExitError4Test(exitStatus: Integer) extends FatalExitError(exitStatus) {
+      var shutdownInvokerThread: Thread = null
+      var exitIsInvoked = false
+      override def setUncaughtExceptionHandler(t: Thread): Unit = {
+        shutdownInvokerThread = t
+        t.setUncaughtExceptionHandler(
+          new Thread.UncaughtExceptionHandler() {
+            def uncaughtException(t: Thread, e: Throwable): Unit = {
+              exitIsInvoked = e.isInstanceOf[ExitException4Test]
+            }
+          }
+        )
+      }
+    }
+    val exitError = new FatalExitError4Test(1)
     new ShutdownableThread("exit-test-thread") {
-      override def doWork(): Unit = throw new FatalExitError(1)
+      override def doWork(): Unit = throw exitError
     }.run()
+    exitError.shutdownInvokerThread.join(1000)
+    Assert.assertTrue(exitError.exitIsInvoked)
   }
+
+  @Test
+  def testDeadlockInShutdownHook(): Unit = {
+    var shutdownableThread: Thread = null
+    class FatalExitError4Test(exitStatus: Integer) extends FatalExitError(exitStatus) {
+      var shutdownHookFinished = false;
+      // instead of calling System.exit simulate running a shutdown hook that could cause a deadlock by joining for the invoker thread
+      override def doShutdownSystem(): Unit = {
+        val shutdownHookThread = new Thread() {
+          shutdownableThread.join()
+        }
+        shutdownHookThread.start()
+        shutdownHookThread.join()
+        shutdownHookFinished = true
+      }
+    }
+    val exc = new FatalExitError4Test(1)
+    shutdownableThread = new ShutdownableThread("exit-test-thread") {
+      override def doWork(): Unit = throw exc
+    }
+    shutdownableThread.start()
+    shutdownableThread.join(1000)
+    Assert.assertFalse(exc.shutdownHookFinished)
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/common/ExitTest.scala
+++ b/core/src/test/scala/unit/kafka/common/ExitTest.scala
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package unit.kafka.common
+
+import kafka.utils.ShutdownableThread
+import org.apache.kafka.common.errors.FatalExitException
+import org.junit.{Test, Before}
+import org.junit.Assert.assertTrue
+
+class ExitTest {
+  @Before
+  def init() {
+    // TODO: to be replaced with proper mocking
+    FatalExitException.testMode();
+  }
+
+  @Test
+  def testSystemExitInShutdownableThread() {
+    new ShutdownableThread("exit-test-thread") {
+      override def doWork(): Unit = throw new FatalExitException(1)
+    }.run()
+    /**
+     * if we reach this point it means that the {@link FatalExitException} is properly caught
+     * and yet it successfully disabled invoking {@link System.exit} for unit tests
+     */
+    assertTrue(true);
+  }
+}


### PR DESCRIPTION
@resetius would be great if you can confirm that the deadlock no longer manifests with the path.
Thanks
