### PR TITLE
KAFKA-4056: Kafka logs values of sensitive configs like passwords

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -185,7 +185,7 @@ public class AbstractConfig {
      */
     public void logUnused() {
         for (String key : unused())
-            log.warn("The configuration {} = {} was supplied but isn't a known config.", key, this.originals.get(key));
+            log.warn("The configuration '{}' was supplied but isn't a known config.", key);
     }
 
     /**


### PR DESCRIPTION
In case of unknown configs, only list the name without the value
