### PR TITLE
KAFKA-4064 Add support for infinite endpoints for range queries in Kafka Streams KV stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -51,6 +51,26 @@ public interface ReadOnlyKeyValueStore<K, V> {
     KeyValueIterator<K, V> range(K from, K to);
 
     /**
+     * Get an iterator over all keys less than or equal to the key passed in. This iterator MUST be closed after use.
+     * The returned iterator must be safe from {@link java.util.ConcurrentModificationException}s
+     * and must not return null values. No ordering guarantees are provided.
+     * @param to The last key that could be in the range
+     * @return The iterator for this range.
+     * @throws NullPointerException If null is used for to.
+     */
+    KeyValueIterator<K, V> rangeUntil(K to);
+
+    /**
+     * Get an iterator over all keys greater than or equal to the key passed in. This iterator MUST be closed after use.
+     * The returned iterator must be safe from {@link java.util.ConcurrentModificationException}s
+     * and must not return null values. No ordering guarantees are provided.
+     * @param from The first key that could be in the range
+     * @return The iterator for this range.
+     * @throws NullPointerException If null is used for to.
+     */
+    KeyValueIterator<K, V> rangeFrom(K from);
+
+    /**
      * Return an iterator over all keys in this store. This iterator MUST be closed after use.
      * The returned iterator must be safe from {@link java.util.ConcurrentModificationException}s
      * and must not return null values. No ordering guarantees are provided.

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -166,6 +166,22 @@ class CachingKeyValueStore<K, V> implements KeyValueStore<K, V>, CachedStateStor
     }
 
     @Override
+    public KeyValueIterator<K, V> rangeUntil(K to) {
+        final byte[] origTo = serdes.rawKey(to);
+        final PeekingKeyValueIterator<Bytes, byte[]> storeIterator = new DelegatingPeekingKeyValueIterator<>(underlying.rangeUntil(Bytes.wrap(origTo)));
+        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.rangeUntil(name, origTo);
+        return new MergedSortedCacheKeyValueStoreIterator<>(cacheIterator, storeIterator, serdes);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(K from) {
+        final byte[] origFrom = serdes.rawKey(from);
+        final PeekingKeyValueIterator<Bytes, byte[]> storeIterator = new DelegatingPeekingKeyValueIterator<>(underlying.rangeFrom(Bytes.wrap(origFrom)));
+        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.rangeFrom(name, origFrom);
+        return new MergedSortedCacheKeyValueStoreIterator<>(cacheIterator, storeIterator, serdes);
+    }
+
+    @Override
     public KeyValueIterator<K, V> all() {
         final PeekingKeyValueIterator<Bytes, byte[]> storeIterator = new DelegatingPeekingKeyValueIterator<>(underlying.all());
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.all(name);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
@@ -79,6 +79,30 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
     }
 
     @Override
+    public KeyValueIterator<K, V> rangeUntil(final K to) {
+        final NextIteratorFunction<K, V> nextIteratorFunction = new NextIteratorFunction<K, V>() {
+            @Override
+            public KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store) {
+                return store.rangeUntil(to);
+            }
+        };
+        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
+        return new CompositeKeyValueIterator(stores.iterator(), nextIteratorFunction);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(final K from) {
+        final NextIteratorFunction<K, V> nextIteratorFunction = new NextIteratorFunction<K, V>() {
+            @Override
+            public KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store) {
+                return store.rangeFrom(from);
+            }
+        };
+        final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
+        return new CompositeKeyValueIterator(stores.iterator(), nextIteratorFunction);
+    }
+
+    @Override
     public KeyValueIterator<K, V> all() {
         final NextIteratorFunction<K, V> nextIteratorFunction = new NextIteratorFunction<K, V>() {
             @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -149,6 +149,16 @@ public class InMemoryKeyValueLoggedStore<K, V> implements KeyValueStore<K, V> {
     }
 
     @Override
+    public KeyValueIterator<K, V> rangeUntil(K to) {
+        return this.inner.rangeUntil(to);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(K from) {
+        return this.inner.rangeFrom(from);
+    }
+
+    @Override
     public KeyValueIterator<K, V> all() {
         return this.inner.all();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreSupplier.java
@@ -63,6 +63,8 @@ public class InMemoryKeyValueStoreSupplier<K, V> extends AbstractStoreSupplier<K
     }
 
     private static class MemoryStore<K, V> implements KeyValueStore<K, V> {
+        private static final boolean RANGE_FROM_INCLUSIVE = true;
+        private static final boolean RANGE_TO_INCLUSIVE = false;
         private final String name;
         private final Serde<K> keySerde;
         private final Serde<V> valueSerde;
@@ -155,7 +157,18 @@ public class InMemoryKeyValueStoreSupplier<K, V> extends AbstractStoreSupplier<K
 
         @Override
         public synchronized KeyValueIterator<K, V> range(K from, K to) {
-            return new MemoryStoreIterator<>(this.map.subMap(from, true, to, false).entrySet().iterator());
+            //TODO - toInclusive should be true?
+            return new MemoryStoreIterator<>(this.map.subMap(from, RANGE_FROM_INCLUSIVE, to, RANGE_TO_INCLUSIVE).entrySet().iterator());
+        }
+
+        @Override
+        public synchronized KeyValueIterator<K, V> rangeUntil(K to) {
+            return new MemoryStoreIterator<>(this.map.headMap(to, RANGE_TO_INCLUSIVE).entrySet().iterator());
+        }
+
+        @Override
+        public synchronized KeyValueIterator<K, V> rangeFrom(K from) {
+            return new MemoryStoreIterator<>(this.map.tailMap(from, RANGE_FROM_INCLUSIVE).entrySet().iterator());
         }
 
         @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreSupplier.java
@@ -157,7 +157,6 @@ public class InMemoryKeyValueStoreSupplier<K, V> extends AbstractStoreSupplier<K
 
         @Override
         public synchronized KeyValueIterator<K, V> range(K from, K to) {
-            //TODO - toInclusive should be true?
             return new MemoryStoreIterator<>(this.map.subMap(from, RANGE_FROM_INCLUSIVE, to, RANGE_TO_INCLUSIVE).entrySet().iterator());
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreSupplier.java
@@ -64,7 +64,7 @@ public class InMemoryKeyValueStoreSupplier<K, V> extends AbstractStoreSupplier<K
 
     private static class MemoryStore<K, V> implements KeyValueStore<K, V> {
         private static final boolean RANGE_FROM_INCLUSIVE = true;
-        private static final boolean RANGE_TO_INCLUSIVE = false;
+        private static final boolean RANGE_TO_INCLUSIVE = true;
         private final String name;
         private final Serde<K> keySerde;
         private final Serde<V> valueSerde;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryLRUCache.java
@@ -174,6 +174,22 @@ public class MemoryLRUCache<K, V> implements KeyValueStore<K, V> {
      * @throws UnsupportedOperationException
      */
     @Override
+    public KeyValueIterator<K, V> rangeUntil(K to) {
+        throw new UnsupportedOperationException("MemoryLRUCache does not support rangeUtil() function.");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(K from) {
+        throw new UnsupportedOperationException("MemoryLRUCache does not support rangeFrom() function.");
+    }
+
+    /**
+     * @throws UnsupportedOperationException
+     */
+    @Override
     public KeyValueIterator<K, V> all() {
         throw new UnsupportedOperationException("MemoryLRUCache does not support all() function.");
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class MemoryNavigableLRUCache<K, V> extends MemoryLRUCache<K, V> {
+    private static final boolean RANGE_FROM_INCLUSIVE = true;
+    private static final boolean RANGE_TO_INCLUSIVE = true;
 
 
     public MemoryNavigableLRUCache(String name, final int maxCacheSize, Serde<K> keySerde, Serde<V> valueSerde) {
@@ -42,6 +44,18 @@ public class MemoryNavigableLRUCache<K, V> extends MemoryLRUCache<K, V> {
     public KeyValueIterator<K, V> range(K from, K to) {
         final TreeMap<K, V> treeMap = toTreeMap();
         return new MemoryNavigableLRUCache.CacheIterator<>(treeMap.navigableKeySet().subSet(from, true, to, true).iterator(), treeMap);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeUntil(K to) {
+        final TreeMap<K, V> treeMap = toTreeMap();
+        return new MemoryNavigableLRUCache.CacheIterator<>(treeMap.navigableKeySet().headSet(to, RANGE_TO_INCLUSIVE).iterator(), treeMap);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(K from) {
+        final TreeMap<K, V> treeMap = toTreeMap();
+        return new MemoryNavigableLRUCache.CacheIterator<>(treeMap.navigableKeySet().tailSet(from, RANGE_FROM_INCLUSIVE).iterator(), treeMap);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MemoryNavigableLRUCache.java
@@ -43,7 +43,7 @@ public class MemoryNavigableLRUCache<K, V> extends MemoryLRUCache<K, V> {
     @Override
     public KeyValueIterator<K, V> range(K from, K to) {
         final TreeMap<K, V> treeMap = toTreeMap();
-        return new MemoryNavigableLRUCache.CacheIterator<>(treeMap.navigableKeySet().subSet(from, true, to, true).iterator(), treeMap);
+        return new MemoryNavigableLRUCache.CacheIterator<>(treeMap.navigableKeySet().subSet(from, RANGE_FROM_INCLUSIVE, to, RANGE_TO_INCLUSIVE).iterator(), treeMap);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -154,6 +154,16 @@ public class MeteredKeyValueStore<K, V> implements KeyValueStore<K, V> {
     }
 
     @Override
+    public KeyValueIterator<K, V> rangeUntil(K to) {
+        return this.inner.rangeUntil(to);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(K from) {
+        return this.inner.rangeFrom(from);
+    }
+
+    @Override
     public KeyValueIterator<K, V> all() {
         return new MeteredKeyValueIterator<>(this.inner.all(), this.allTime);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -155,12 +155,12 @@ public class MeteredKeyValueStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public KeyValueIterator<K, V> rangeUntil(K to) {
-        return this.inner.rangeUntil(to);
+        return new MeteredKeyValueIterator<>(this.inner.rangeUntil(to), this.rangeTime);
     }
 
     @Override
     public KeyValueIterator<K, V> rangeFrom(K from) {
-        return this.inner.rangeFrom(from);
+        return new MeteredKeyValueIterator<>(this.inner.rangeFrom(from), this.rangeTime);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -237,7 +237,7 @@ class NamedCache {
     }
 
     synchronized Iterator<Bytes> keyRange(final Bytes from, final Bytes to) {
-        return keySetIterator(cache.navigableKeySet().subSet(from, true, to, true));
+        return keySetIterator(cache.navigableKeySet().subSet(from, RANGE_FROM_INCLUSIVE, to, RANGE_TO_INCLUSIVE));
     }
 
     synchronized Iterator<Bytes> keyRangeUntil(final Bytes to) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -32,6 +32,8 @@ import java.util.TreeSet;
 
 class NamedCache {
     private static final Logger log = LoggerFactory.getLogger(NamedCache.class);
+    private static final boolean RANGE_FROM_INCLUSIVE = true;
+    private static final boolean RANGE_TO_INCLUSIVE = true;
     private final String name;
     private final TreeMap<Bytes, LRUNode> cache = new TreeMap<>();
     private final Set<Bytes> dirtyKeys = new LinkedHashSet<>();
@@ -236,6 +238,14 @@ class NamedCache {
 
     synchronized Iterator<Bytes> keyRange(final Bytes from, final Bytes to) {
         return keySetIterator(cache.navigableKeySet().subSet(from, true, to, true));
+    }
+
+    synchronized Iterator<Bytes> keyRangeUntil(final Bytes to) {
+        return keySetIterator(cache.navigableKeySet().headSet(to, RANGE_TO_INCLUSIVE));
+    }
+
+    synchronized Iterator<Bytes> keyRangeFrom(final Bytes from) {
+        return keySetIterator(cache.navigableKeySet().tailSet(from, RANGE_FROM_INCLUSIVE));
     }
 
     private Iterator<Bytes> keySetIterator(final Set<Bytes> keySet) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -507,8 +507,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             super(iter, serdes);
             if (from == null) {
                 iter.seekToFirst();
-            }
-            else {
+            } else {
                 iter.seek(serdes.rawKey(from));
             }
             if (to != null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -316,7 +316,33 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     }
 
     @Override
-    public synchronized KeyValueIterator<K, V> range(K from, K to) {
+    public KeyValueIterator<K, V> range(K from, K to) {
+        if (from == null) {
+            throw new NullPointerException("Start key is null");
+        }
+        if (to == null) {
+            throw new NullPointerException("End key is null");
+        }
+        return rangeImpl(from, to);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeUntil(K to) {
+        if (to == null) {
+            throw new NullPointerException("End key is null");
+        }
+        return rangeImpl(null, to);
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(K from) {
+        if (from == null) {
+            throw new NullPointerException("Start key is null");
+        }
+        return rangeImpl(from, null);
+    }
+
+    private synchronized KeyValueIterator<K, V> rangeImpl(K from, K to) {
         validateStoreOpen();
         // query rocksdb
         final RocksDBRangeIterator rocksDBRangeIterator = new RocksDBRangeIterator(db.newIterator(), serdes, from, to);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -156,6 +156,22 @@ public class ThreadCache {
         return new MemoryLRUCacheBytesIterator(cache.keyRange(cacheKey(from), cacheKey(to)), cache);
     }
 
+    public MemoryLRUCacheBytesIterator rangeUntil(final String namespace, final byte[] to) {
+        final NamedCache cache = getCache(namespace);
+        if (cache == null) {
+            return new MemoryLRUCacheBytesIterator(Collections.<Bytes>emptyIterator(), new NamedCache(namespace));
+        }
+        return new MemoryLRUCacheBytesIterator(cache.keyRangeUntil(cacheKey(to)), cache);
+    }
+
+    public MemoryLRUCacheBytesIterator rangeFrom(final String namespace, final byte[] from) {
+        final NamedCache cache = getCache(namespace);
+        if (cache == null) {
+            return new MemoryLRUCacheBytesIterator(Collections.<Bytes>emptyIterator(), new NamedCache(namespace));
+        }
+        return new MemoryLRUCacheBytesIterator(cache.keyRangeFrom(cacheKey(from)), cache);
+    }
+
     public MemoryLRUCacheBytesIterator all(final String namespace) {
         final NamedCache cache = getCache(namespace);
         if (cache == null) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -83,40 +83,47 @@ public abstract class AbstractKeyValueStoreTest {
         assertEquals(false, driver.flushedEntryRemoved(4));
         assertEquals(true, driver.flushedEntryRemoved(5));
 
-        // Check range iteration ...
-        try (KeyValueIterator<Integer, String> iter = store.range(2, 4)) {
-            while (iter.hasNext()) {
-                KeyValue<Integer, String> entry = iter.next();
-                if (entry.key.equals(2))
-                    assertEquals("two", entry.value);
-                else if (entry.key.equals(4))
-                    assertEquals("four", entry.value);
-                else
-                    fail("Unexpected entry: " + entry);
-            }
-        }
 
-        // Check range iteration ...
-        try (KeyValueIterator<Integer, String> iter = store.range(2, 6)) {
-            while (iter.hasNext()) {
-                KeyValue<Integer, String> entry = iter.next();
-                if (entry.key.equals(2))
-                    assertEquals("two", entry.value);
-                else if (entry.key.equals(4))
-                    assertEquals("four", entry.value);
-                else
-                    fail("Unexpected entry: " + entry);
+        try {
+            // Check range iteration ...
+            try (KeyValueIterator<Integer, String> iter = store.range(2, 4)) {
+                assertTrue("First row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(2, "two"), iter.next());
+                assertTrue("Second row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(4, "four"), iter.next());
+                assertFalse("No more rows", iter.hasNext());
             }
-        }
 
-        // Check rangeUntil() ...
-        try (KeyValueIterator<Integer, String> iter = store.rangeUntil(2)) {
-            assertTrue(iter.hasNext());
-            assertEquals(new KeyValue<>(0, "zero"), iter.next());
-            assertTrue(iter.hasNext());
-            assertEquals(new KeyValue<>(1, "one"), iter.next());
-            assertTrue(iter.hasNext());
-            assertEquals(new KeyValue<>(2, "two"), iter.next());
+            // Check range iteration ...
+            try (KeyValueIterator<Integer, String> iter = store.range(2, 6)) {
+                assertTrue("First row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(2, "two"), iter.next());
+                assertTrue("Second row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(4, "four"), iter.next());
+                assertFalse("No more rows", iter.hasNext());
+            }
+
+            // Check rangeUntil() ...
+            try (KeyValueIterator<Integer, String> iter = store.rangeUntil(2)) {
+                assertTrue("First row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(0, "zero"), iter.next());
+                assertTrue("Second row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(1, "one"), iter.next());
+                assertTrue("Third row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(2, "two"), iter.next());
+                assertFalse("No more rows", iter.hasNext());
+            }
+
+            // Check rangeFrom()
+            try (KeyValueIterator<Integer, String> iter = store.rangeFrom(2)) {
+                assertTrue("First row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(2, "two"), iter.next());
+                assertTrue("Second row exists", iter.hasNext());
+                assertEquals(new KeyValue<>(4, "four"), iter.next());
+                assertFalse("No more rows", iter.hasNext());
+            }
+        } finally {
+            store.close();
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -27,7 +27,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public abstract class AbstractKeyValueStoreTest {
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -17,10 +17,6 @@
 
 package org.apache.kafka.streams.state.internals;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -30,6 +26,8 @@ import org.apache.kafka.test.MockProcessorContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public abstract class AbstractKeyValueStoreTest {
 
@@ -109,6 +107,16 @@ public abstract class AbstractKeyValueStoreTest {
                 else
                     fail("Unexpected entry: " + entry);
             }
+        }
+
+        // Check rangeUntil() ...
+        try (KeyValueIterator<Integer, String> iter = store.rangeUntil(2)) {
+            assertTrue(iter.hasNext());
+            assertEquals(new KeyValue<>(0, "zero"), iter.next());
+            assertTrue(iter.hasNext());
+            assertEquals(new KeyValue<>(1, "one"), iter.next());
+            assertTrue(iter.hasNext());
+            assertEquals(new KeyValue<>(2, "two"), iter.next());
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -22,11 +22,9 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
 import org.apache.kafka.streams.kstream.internals.Change;
-import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.MockProcessorContext;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +36,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class CachingKeyValueStoreTest {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -105,7 +105,7 @@ class InMemoryKeyValueStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public KeyValueIterator<K, V> range(final K from, final K to) {
-        return new TheIterator(this.map.subMap(from, true, to, false).entrySet().iterator());
+        return new TheIterator(this.map.subMap(from, RANGE_FROM_INCLUSIVE, to, RANGE_TO_INCLUSIVE).entrySet().iterator());
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -28,7 +28,7 @@ import java.util.TreeMap;
 
 class InMemoryKeyValueStore<K, V> implements KeyValueStore<K, V> {
     private static final boolean RANGE_FROM_INCLUSIVE = true;
-    private static final boolean RANGE_TO_INCLUSIVE = false;
+    private static final boolean RANGE_TO_INCLUSIVE = true;
     private final TreeMap<K, V> map = new TreeMap<>();
     private final String name;
     private boolean open = true;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStore.java
@@ -27,6 +27,8 @@ import java.util.NoSuchElementException;
 import java.util.TreeMap;
 
 class InMemoryKeyValueStore<K, V> implements KeyValueStore<K, V> {
+    private static final boolean RANGE_FROM_INCLUSIVE = true;
+    private static final boolean RANGE_TO_INCLUSIVE = false;
     private final TreeMap<K, V> map = new TreeMap<>();
     private final String name;
     private boolean open = true;
@@ -104,6 +106,16 @@ class InMemoryKeyValueStore<K, V> implements KeyValueStore<K, V> {
     @Override
     public KeyValueIterator<K, V> range(final K from, final K to) {
         return new TheIterator(this.map.subMap(from, true, to, false).entrySet().iterator());
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeUntil(final K to) {
+        return new TheIterator(this.map.headMap(to, RANGE_TO_INCLUSIVE).entrySet().iterator());
+    }
+
+    @Override
+    public KeyValueIterator<K, V> rangeFrom(final K from) {
+        return new TheIterator(this.map.tailMap(from, RANGE_FROM_INCLUSIVE).entrySet().iterator());
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreTestUtils.java
@@ -60,6 +60,16 @@ public class StateStoreTestUtils {
         }
 
         @Override
+        public KeyValueIterator<K, V> rangeUntil(final K to) {
+            return null;
+        }
+
+        @Override
+        public KeyValueIterator<K, V> rangeFrom(final K from) {
+            return null;
+        }
+
+        @Override
         public KeyValueIterator<K, V> all() {
             return null;
         }


### PR DESCRIPTION
@guozhangwang 

I had to fix the bug with in-memory ranges being exclusive and RocksDB being inclusive to get meaningful tests to work.
