### PR TITLE
KAFKA-4051: Use nanosecond clock for timers in broker

### DIFF
--- a/core/src/main/scala/kafka/utils/Time.scala
+++ b/core/src/main/scala/kafka/utils/Time.scala
@@ -17,6 +17,8 @@
 
 package kafka.utils
 
+import java.util.concurrent.TimeUnit
+
 /**
  * Some common constants
  */
@@ -43,6 +45,8 @@ trait Time {
   def milliseconds: Long
 
   def nanoseconds: Long
+
+  def hiResClockMs: Long = TimeUnit.NANOSECONDS.toMillis(nanoseconds)
 
   def sleep(ms: Long)
 }

--- a/core/src/main/scala/kafka/utils/timer/Timer.scala
+++ b/core/src/main/scala/kafka/utils/timer/Timer.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import kafka.utils.threadsafe
 import org.apache.kafka.common.utils.Utils
+import kafka.utils.SystemTime
 
 trait Timer {
   /**
@@ -55,7 +56,7 @@ trait Timer {
 class SystemTimer(executorName: String,
                   tickMs: Long = 1,
                   wheelSize: Int = 20,
-                  startMs: Long = System.currentTimeMillis) extends Timer {
+                  startMs: Long = SystemTime.hiResClockMs) extends Timer {
 
   // timeout timer
   private[this] val taskExecutor = Executors.newFixedThreadPool(1, new ThreadFactory() {
@@ -81,7 +82,7 @@ class SystemTimer(executorName: String,
   def add(timerTask: TimerTask): Unit = {
     readLock.lock()
     try {
-      addTimerTaskEntry(new TimerTaskEntry(timerTask, timerTask.delayMs + System.currentTimeMillis()))
+      addTimerTaskEntry(new TimerTaskEntry(timerTask, timerTask.delayMs + SystemTime.hiResClockMs))
     } finally {
       readLock.unlock()
     }

--- a/core/src/main/scala/kafka/utils/timer/TimerTaskList.scala
+++ b/core/src/main/scala/kafka/utils/timer/TimerTaskList.scala
@@ -117,7 +117,7 @@ private[timer] class TimerTaskList(taskCounter: AtomicInteger) extends Delayed {
   }
 
   def getDelay(unit: TimeUnit): Long = {
-    unit.convert(max(getExpiration - SystemTime.milliseconds, 0), TimeUnit.MILLISECONDS)
+    unit.convert(max(getExpiration - SystemTime.hiResClockMs, 0), TimeUnit.MILLISECONDS)
   }
 
   def compareTo(d: Delayed): Int = {


### PR DESCRIPTION
Use System.nanoseconds instead of System.currentTimeMillis in broker timer tasks to cope with changes to wall-clock time.
