### PR TITLE
KAFKA-4042: Contain connector & task start/stop failures within the Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ results
 tests/results
 .ducktape
 tests/.ducktape
+tests/venv
 .cache
 
 docs/generated/

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.Connect;
+import org.apache.kafka.connect.runtime.ConnectorFactory;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedHerder;
@@ -62,6 +63,7 @@ public class ConnectDistributed {
                 Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.<String, String>emptyMap();
 
         Time time = new SystemTime();
+        ConnectorFactory connectorFactory = new ConnectorFactory();
         DistributedConfig config = new DistributedConfig(workerProps);
 
         RestServer rest = new RestServer(config);
@@ -71,7 +73,7 @@ public class ConnectDistributed {
         KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore();
         offsetBackingStore.configure(config);
 
-        Worker worker = new Worker(workerId, time, config, offsetBackingStore);
+        Worker worker = new Worker(workerId, time, connectorFactory, config, offsetBackingStore);
 
         StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, worker.getInternalValueConverter());
         statusBackingStore.configure(config);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.runtime.Connect;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
+import org.apache.kafka.connect.runtime.ConnectorFactory;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.rest.RestServer;
@@ -67,13 +68,14 @@ public class ConnectStandalone {
                 Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.<String, String>emptyMap();
 
         Time time = new SystemTime();
+        ConnectorFactory connectorFactory = new ConnectorFactory();
         StandaloneConfig config = new StandaloneConfig(workerProps);
 
         RestServer rest = new RestServer(config);
         URI advertisedUrl = rest.advertisedUrl();
         String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
 
-        Worker worker = new Worker(workerId, time, config, new FileOffsetBackingStore());
+        Worker worker = new Worker(workerId, time, connectorFactory, config, new FileOffsetBackingStore());
 
         Herder herder = new StandaloneHerder(worker);
         final Connect connect = new Connect(herder, rest);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -361,7 +361,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         if (tempConnectors.containsKey(connType)) {
             return tempConnectors.get(connType);
         } else {
-            Connector connector = worker.getConnector(connType);
+            Connector connector = Worker.createConnector(connType);
             tempConnectors.put(connType, connector);
             return connector;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -40,7 +40,6 @@ import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.ReflectionsUtil;
-import org.apache.kafka.connect.util.WorkerUtil;
 import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
@@ -362,7 +361,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         if (tempConnectors.containsKey(connType)) {
             return tempConnectors.get(connType);
         } else {
-            Connector connector = WorkerUtil.createConnector(connType);
+            Connector connector = worker.getConnectorFactory().newConnector(connType);
             tempConnectors.put(connType, connector);
             return connector;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -40,6 +40,7 @@ import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.ReflectionsUtil;
+import org.apache.kafka.connect.util.WorkerUtil;
 import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
@@ -361,7 +362,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         if (tempConnectors.containsKey(connType)) {
             return tempConnectors.get(connType);
         } else {
-            Connector connector = Worker.createConnector(connType);
+            Connector connector = WorkerUtil.createConnector(connType);
             tempConnectors.put(connType, connector);
             return connector;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorFactory.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,10 +17,11 @@
  * under the License.
  */
 
-package org.apache.kafka.connect.util;
+package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
@@ -31,19 +32,31 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-public class WorkerUtil {
+public class ConnectorFactory {
 
-    public static Connector createConnector(String connType) {
-        return instantiate(getConnectorClass(connType));
+    public Connector newConnector(String connectorClassOrAlias) {
+        return instantiate(getConnectorClass(connectorClassOrAlias));
+    }
+
+    public Task newTask(Class<? extends Task> taskClass) {
+        return instantiate(taskClass);
+    }
+
+    private static <T> T instantiate(Class<? extends T> cls) {
+        try {
+            return Utils.newInstance(cls);
+        } catch (Throwable t) {
+            throw new ConnectException("Instantiation error", t);
+        }
     }
 
     @SuppressWarnings("unchecked")
-    private static Class<? extends Connector> getConnectorClass(String connectorAlias) {
+    private static Class<? extends Connector> getConnectorClass(String connectorClassOrAlias) {
         // Avoid the classpath scan if the full class name was provided
         try {
-            Class<?> clazz = Class.forName(connectorAlias);
+            Class<?> clazz = Class.forName(connectorClassOrAlias);
             if (!Connector.class.isAssignableFrom(clazz))
-                throw new ConnectException("Class " + connectorAlias + " does not implement Connector");
+                throw new ConnectException("Class " + connectorClassOrAlias + " does not implement Connector");
             return (Class<? extends Connector>) clazz;
         } catch (ClassNotFoundException e) {
             // Fall through to scan for the alias
@@ -59,19 +72,19 @@ public class WorkerUtil {
 
         for (Class<? extends Connector> connector: connectors) {
             // Configuration included the class name but not package
-            if (connector.getSimpleName().equals(connectorAlias))
+            if (connector.getSimpleName().equals(connectorClassOrAlias))
                 results.add(connector);
 
             // Configuration included a short version of the name (i.e. FileStreamSink instead of FileStreamSinkConnector)
-            if (connector.getSimpleName().equals(connectorAlias + "Connector"))
+            if (connector.getSimpleName().equals(connectorClassOrAlias + "Connector"))
                 results.add(connector);
         }
 
         if (results.isEmpty())
-            throw new ConnectException("Failed to find any class that implements Connector and which name matches " + connectorAlias +
+            throw new ConnectException("Failed to find any class that implements Connector and which name matches " + connectorClassOrAlias +
                     ", available connectors are: " + connectorNames(connectors));
         if (results.size() > 1) {
-            throw new ConnectException("More than one connector matches alias " +  connectorAlias +
+            throw new ConnectException("More than one connector matches alias " +  connectorClassOrAlias +
                     ". Please use full package and class name instead. Classes found: " + connectorNames(results));
         }
 
@@ -83,16 +96,7 @@ public class WorkerUtil {
         StringBuilder names = new StringBuilder();
         for (Class<?> c : connectors)
             names.append(c.getName()).append(", ");
-
         return names.substring(0, names.toString().length() - 2);
-    }
-
-    public static <T> T instantiate(Class<? extends T> cls) {
-        try {
-            return Utils.newInstance(cls);
-        } catch (Throwable t) {
-            throw new ConnectException("Instantiation error", t);
-        }
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedHerder.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.connect.runtime.distributed;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -31,7 +30,6 @@ import org.apache.kafka.connect.runtime.HerderConnectorContext;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.SourceConnectorConfig;
 import org.apache.kafka.connect.runtime.TargetState;
-import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.rest.RestServer;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -322,7 +320,7 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
 
             // additionally, if the worker is running the connector itself, then we need to
             // request reconfiguration to ensure that config changes while paused take effect
-            if (worker.ownsConnector(connector) && targetState == TargetState.STARTED)
+            if (targetState == TargetState.STARTED)
                 reconfigureConnectorTasksWithRetry(connector);
         }
     }
@@ -331,18 +329,9 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
     public void halt() {
         synchronized (this) {
             // Clean up any connectors and tasks that are still running.
-            log.info("Stopping connectors and tasks that are still assigned to this worker.");
-            for (String connName : new HashSet<>(worker.connectorNames())) {
-                try {
-                    worker.stopConnector(connName);
-                } catch (Throwable t) {
-                    log.error("Failed to shut down connector " + connName, t);
-                }
-            }
-
-            Set<ConnectorTaskId> tasks = new HashSet<>(worker.taskIds());
-            worker.stopTasks(tasks);
-            worker.awaitStopTasks(tasks);
+            log.info("Stopping connectors and tasks that are still assigned to the worker");
+            worker.stopConnectors();
+            worker.stopAndAwaitTasks();
 
             member.stop();
 
@@ -573,11 +562,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     return null;
                 }
 
-                if (worker.ownsConnector(connName)) {
+                if (assignment.connectors().contains(connName)) {
                     try {
                         worker.stopConnector(connName);
-                        startConnector(connName);
-                        callback.onCompletion(null, null);
+                        if (startConnector(connName))
+                            callback.onCompletion(null, null);
+                        else
+                            callback.onCompletion(new ConnectException("Failed to start connector: " + connName), null);
                     } catch (Throwable t) {
                         callback.onCompletion(t, null);
                     }
@@ -609,11 +600,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                     return null;
                 }
 
-                if (worker.ownsTask(id)) {
+                if (assignment.tasks().contains(id)) {
                     try {
                         worker.stopAndAwaitTask(id);
-                        startTask(id);
-                        callback.onCompletion(null, null);
+                        if (startTask(id))
+                            callback.onCompletion(null, null);
+                        else
+                            callback.onCompletion(new ConnectException("Failed to start task: " + id), null);
                     } catch (Throwable t) {
                         callback.onCompletion(t, null);
                     }
@@ -751,48 +744,41 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
         // Start assigned connectors and tasks
         log.info("Starting connectors and tasks using config offset {}", assignment.offset());
         for (String connectorName : assignment.connectors()) {
-            try {
-                startConnector(connectorName);
-            } catch (ConfigException e) {
-                log.error("Couldn't instantiate connector " + connectorName + " because it has an invalid connector " +
-                        "configuration. This connector will not execute until reconfigured.", e);
-            }
+            startConnector(connectorName);
         }
         for (ConnectorTaskId taskId : assignment.tasks()) {
-            try {
-                startTask(taskId);
-            } catch (ConfigException e) {
-                log.error("Couldn't instantiate task " + taskId + " because it has an invalid task " +
-                        "configuration. This task will not execute until reconfigured.", e);
-            }
+            startTask(taskId);
         }
         log.info("Finished starting connectors and tasks");
     }
 
-    private void startTask(ConnectorTaskId taskId) {
+    private boolean startTask(ConnectorTaskId taskId) {
         log.info("Starting task {}", taskId);
-        TargetState initialState = configState.targetState(taskId.connector());
-        TaskConfig taskConfig = new TaskConfig(configState.taskConfig(taskId));
-        ConnectorConfig connConfig = new ConnectorConfig(configState.connectorConfig(taskId.connector()));
-        worker.startTask(taskId, taskConfig, connConfig, this, initialState);
+        return worker.startTask(
+                taskId,
+                configState.connectorConfig(taskId.connector()),
+                configState.taskConfig(taskId),
+                this,
+                configState.targetState(taskId.connector())
+        );
     }
 
     // Helper for starting a connector with the given name, which will extract & parse the config, generate connector
     // context and add to the worker. This needs to be called from within the main worker thread for this herder.
-    private void startConnector(String connectorName) {
+    private boolean startConnector(String connectorName) {
         log.info("Starting connector {}", connectorName);
-        Map<String, String> configs = configState.connectorConfig(connectorName);
-        ConnectorConfig connConfig = new ConnectorConfig(configs);
-        String connName = connConfig.getString(ConnectorConfig.NAME_CONFIG);
-        ConnectorContext ctx = new HerderConnectorContext(DistributedHerder.this, connName);
-        TargetState initialState = configState.targetState(connectorName);
-        worker.startConnector(connConfig, ctx, this, initialState);
+        final Map<String, String> configProps = configState.connectorConfig(connectorName);
+        final ConnectorContext ctx = new HerderConnectorContext(DistributedHerder.this, connectorName);
+        final TargetState initialState = configState.targetState(connectorName);
+        boolean started = worker.startConnector(connectorName, configProps, ctx, this, initialState);
 
         // Immediately request configuration since this could be a brand new connector. However, also only update those
         // task configs if they are actually different from the existing ones to avoid unnecessary updates when this is
         // just restoring an existing connector.
-        if (initialState == TargetState.STARTED)
-            reconfigureConnectorTasksWithRetry(connName);
+        if (started && initialState == TargetState.STARTED)
+            reconfigureConnectorTasksWithRetry(connectorName);
+
+        return started;
     }
 
     private void reconfigureConnectorTasksWithRetry(final String connName) {
@@ -1053,17 +1039,13 @@ public class DistributedHerder extends AbstractHerder implements Runnable {
                 // this worker. Instead, we can let them continue to run but buffer any update requests (which should be
                 // rare anyway). This would avoid a steady stream of start/stop, which probably also includes lots of
                 // unnecessary repeated connections to the source/sink system.
-                for (String connectorName : connectors)
-                    worker.stopConnector(connectorName);
+                worker.stopConnectors(connectors);
 
                 // TODO: We need to at least commit task offsets, but if we could commit offsets & pause them instead of
                 // stopping them then state could continue to be reused when the task remains on this worker. For example,
                 // this would avoid having to close a connection and then reopen it when the task is assigned back to this
                 // worker again.
-                if (!tasks.isEmpty()) {
-                    worker.stopTasks(tasks); // trigger stop() for all tasks
-                    worker.awaitStopTasks(tasks); // await stopping tasks
-                }
+                worker.stopAndAwaitTasks(tasks);
 
                 // Ensure that all status updates have been pushed to the storage system before rebalancing.
                 // Otherwise, we may inadvertently overwrite the state with a stale value after the rebalance

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerder.java
@@ -26,7 +26,6 @@ import org.apache.kafka.connect.runtime.HerderConnectorContext;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.SourceConnectorConfig;
 import org.apache.kafka.connect.runtime.TargetState;
-import org.apache.kafka.connect.runtime.TaskConfig;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.distributed.ClusterConfigState;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -81,11 +80,7 @@ public class StandaloneHerder extends AbstractHerder {
         // the tasks.
         for (String connName : configState.connectors()) {
             removeConnectorTasks(connName);
-            try {
-                worker.stopConnector(connName);
-            } catch (ConnectException e) {
-                log.error("Error shutting down connector {}: ", connName, e);
-            }
+            worker.stopConnector(connName);
         }
         stopServices();
         log.info("Herder stopped");
@@ -161,7 +156,10 @@ public class StandaloneHerder extends AbstractHerder {
                 created = true;
             }
             if (config != null) {
-                startConnector(config);
+                if (!startConnector(config)) {
+                    callback.onCompletion(new ConnectException("Failed to start connector: " + connName), null);
+                    return;
+                }
                 updateConnectorTasks(connName);
             }
             if (config != null)
@@ -209,18 +207,14 @@ public class StandaloneHerder extends AbstractHerder {
         Map<String, String> taskConfigProps = configState.taskConfig(taskId);
         if (taskConfigProps == null)
             cb.onCompletion(new NotFoundException("Task " + taskId + " not found", null), null);
-        TaskConfig taskConfig = new TaskConfig(taskConfigProps);
-        ConnectorConfig connConfig = new ConnectorConfig(configState.connectorConfig(taskId.connector()));
+        Map<String, String> connConfigProps = configState.connectorConfig(taskId.connector());
 
         TargetState targetState = configState.targetState(taskId.connector());
-        try {
-            worker.stopAndAwaitTask(taskId);
-            worker.startTask(taskId, taskConfig, connConfig, this, targetState);
+        worker.stopAndAwaitTask(taskId);
+        if (worker.startTask(taskId, connConfigProps, taskConfigProps, this, targetState))
             cb.onCompletion(null, null);
-        } catch (Exception e) {
-            log.error("Failed to restart task {}", taskId, e);
-            cb.onCompletion(e, null);
-        }
+        else
+            cb.onCompletion(new ConnectException("Failed to start task: " + taskId), null);
     }
 
     @Override
@@ -229,28 +223,18 @@ public class StandaloneHerder extends AbstractHerder {
             cb.onCompletion(new NotFoundException("Connector " + connName + " not found", null), null);
 
         Map<String, String> config = configState.connectorConfig(connName);
-        try {
-            worker.stopConnector(connName);
-            startConnector(config);
+        worker.stopConnector(connName);
+        if (startConnector(config))
             cb.onCompletion(null, null);
-        } catch (Exception e) {
-            log.error("Failed to restart connector {}", connName, e);
-            cb.onCompletion(e, null);
-        }
+        else
+            cb.onCompletion(new ConnectException("Failed to start connector: " + connName), null);
     }
 
-    /**
-     * Start a connector in the worker and record its state.
-     * @param connectorProps new connector configuration
-     * @return the connector name
-     */
-    private String startConnector(Map<String, String> connectorProps) {
-        ConnectorConfig connConfig = new ConnectorConfig(connectorProps);
-        String connName = connConfig.getString(ConnectorConfig.NAME_CONFIG);
+    private boolean startConnector(Map<String, String> connectorProps) {
+        String connName = connectorProps.get(ConnectorConfig.NAME_CONFIG);
         configBackingStore.putConnectorConfig(connName, connectorProps);
         TargetState targetState = configState.targetState(connName);
-        worker.startConnector(connConfig, new HerderConnectorContext(this, connName), this, targetState);
-        return connName;
+        return worker.startConnector(connName, connectorProps, new HerderConnectorContext(this, connName), this, targetState);
     }
 
     private List<Map<String, String>> recomputeTaskConfigs(String connName) {
@@ -273,27 +257,17 @@ public class StandaloneHerder extends AbstractHerder {
 
     private void createConnectorTasks(String connName, TargetState initialState) {
         Map<String, String> connConfigs = configState.connectorConfig(connName);
-        ConnectorConfig connConfig = new ConnectorConfig(connConfigs);
 
         for (ConnectorTaskId taskId : configState.tasks(connName)) {
             Map<String, String> taskConfigMap = configState.taskConfig(taskId);
-            TaskConfig taskConfig = new TaskConfig(taskConfigMap);
-            try {
-                worker.startTask(taskId, taskConfig, connConfig, this, initialState);
-            } catch (Throwable e) {
-                log.error("Failed to add task {}: ", taskId, e);
-                // Swallow this so we can continue updating the rest of the tasks
-                // FIXME what's the proper response? Kill all the tasks? Consider this the same as a task
-                // that died after starting successfully.
-            }
+            worker.startTask(taskId, connConfigs, taskConfigMap, this, initialState);
         }
     }
 
     private void removeConnectorTasks(String connName) {
         Collection<ConnectorTaskId> tasks = configState.tasks(connName);
         if (!tasks.isEmpty()) {
-            worker.stopTasks(tasks);
-            worker.awaitStopTasks(tasks);
+            worker.stopAndAwaitTasks(tasks);
             configBackingStore.removeTaskConfigs(connName);
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/WorkerUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/WorkerUtil.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.kafka.connect.util;
+
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.reflections.Reflections;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class WorkerUtil {
+
+    public static Connector createConnector(String connType) {
+        return instantiate(getConnectorClass(connType));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Connector> getConnectorClass(String connectorAlias) {
+        // Avoid the classpath scan if the full class name was provided
+        try {
+            Class<?> clazz = Class.forName(connectorAlias);
+            if (!Connector.class.isAssignableFrom(clazz))
+                throw new ConnectException("Class " + connectorAlias + " does not implement Connector");
+            return (Class<? extends Connector>) clazz;
+        } catch (ClassNotFoundException e) {
+            // Fall through to scan for the alias
+        }
+
+        // Iterate over our entire classpath to find all the connectors and hopefully one of them matches the alias from the connector configration
+        Reflections reflections = new Reflections(new ConfigurationBuilder()
+                .setUrls(ClasspathHelper.forJavaClassPath()));
+
+        Set<Class<? extends Connector>> connectors = reflections.getSubTypesOf(Connector.class);
+
+        List<Class<? extends Connector>> results = new ArrayList<>();
+
+        for (Class<? extends Connector> connector: connectors) {
+            // Configuration included the class name but not package
+            if (connector.getSimpleName().equals(connectorAlias))
+                results.add(connector);
+
+            // Configuration included a short version of the name (i.e. FileStreamSink instead of FileStreamSinkConnector)
+            if (connector.getSimpleName().equals(connectorAlias + "Connector"))
+                results.add(connector);
+        }
+
+        if (results.isEmpty())
+            throw new ConnectException("Failed to find any class that implements Connector and which name matches " + connectorAlias +
+                    ", available connectors are: " + connectorNames(connectors));
+        if (results.size() > 1) {
+            throw new ConnectException("More than one connector matches alias " +  connectorAlias +
+                    ". Please use full package and class name instead. Classes found: " + connectorNames(results));
+        }
+
+        // We just validated that we have exactly one result, so this is safe
+        return results.get(0);
+    }
+
+    private static String connectorNames(Collection<Class<? extends Connector>> connectors) {
+        StringBuilder names = new StringBuilder();
+        for (Class<?> c : connectors)
+            names.append(c.getName()).append(", ");
+
+        return names.substring(0, names.toString().length() - 2);
+    }
+
+    public static <T> T instantiate(Class<? extends T> cls) {
+        try {
+            return Utils.newInstance(cls);
+        } catch (Throwable t) {
+            throw new ConnectException("Instantiation error", t);
+        }
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -38,6 +38,7 @@ import org.apache.kafka.connect.storage.OffsetStorageWriter;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.MockTime;
 import org.apache.kafka.connect.util.ThreadedTest;
+import org.apache.kafka.connect.util.WorkerUtil;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -59,7 +60,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Worker.class)
+@PrepareForTest({Worker.class, WorkerUtil.class})
 @PowerMockIgnore("javax.management.*")
 public class WorkerTest extends ThreadedTest {
 
@@ -96,8 +97,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -153,8 +154,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -205,8 +206,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -269,8 +270,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -342,8 +343,8 @@ public class WorkerTest extends ThreadedTest {
         WorkerSourceTask workerTask = PowerMock.createMock(WorkerSourceTask.class);
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
         EasyMock.expect(task.version()).andReturn("1.0");
 
         PowerMock.expectNew(
@@ -410,8 +411,8 @@ public class WorkerTest extends ThreadedTest {
         WorkerSourceTask workerTask = PowerMock.createMock(WorkerSourceTask.class);
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
         EasyMock.expect(task.version()).andReturn("1.0");
         
         PowerMock.expectNew(
@@ -462,8 +463,8 @@ public class WorkerTest extends ThreadedTest {
         WorkerSourceTask workerTask = PowerMock.createMock(WorkerSourceTask.class);
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiate");
-        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
+        PowerMock.mockStaticPartial(WorkerUtil.class, "instantiate");
+        PowerMock.expectPrivate(WorkerUtil.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
         EasyMock.expect(task.version()).andReturn("1.0");
 
         Capture<TestConverter> keyConverter = EasyMock.newCapture();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -96,8 +96,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateConnector");
-        PowerMock.expectPrivate(Worker.class, "instantiateConnector", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -128,12 +128,11 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), config, offsetBackingStore);
         worker.start();
 
-        ConnectorConfig config = new ConnectorConfig(props);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(config, ctx, connectorStatusListener, TargetState.STARTED);
+        worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         try {
-            worker.startConnector(config, ctx, connectorStatusListener, TargetState.STARTED);
+            worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
             fail("Should have thrown exception when trying to add connector with same name.");
         } catch (ConnectException e) {
             // expected
@@ -154,8 +153,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateConnector");
-        PowerMock.expectPrivate(Worker.class, "instantiateConnector", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -186,9 +185,8 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), config, offsetBackingStore);
         worker.start();
 
-        ConnectorConfig config = new ConnectorConfig(props);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(config, ctx, connectorStatusListener, TargetState.STARTED);
+        worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
 
         worker.stopConnector(CONNECTOR_ID);
@@ -207,8 +205,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateConnector");
-        PowerMock.expectPrivate(Worker.class, "instantiateConnector", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -239,9 +237,8 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), config, offsetBackingStore);
         worker.start();
 
-        ConnectorConfig config = new ConnectorConfig(props);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(config, ctx, connectorStatusListener, TargetState.STARTED);
+        worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
 
         worker.stopConnector(CONNECTOR_ID);
@@ -252,8 +249,7 @@ public class WorkerTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-
-    @Test(expected = ConnectException.class)
+    @Test
     public void testStopInvalidConnector() {
         expectStartStorage();
 
@@ -273,8 +269,8 @@ public class WorkerTest extends ThreadedTest {
         Connector connector = PowerMock.createMock(Connector.class);
         ConnectorContext ctx = PowerMock.createMock(ConnectorContext.class);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateConnector");
-        PowerMock.expectPrivate(Worker.class, "instantiateConnector", new Object[]{WorkerTestConnector.class}).andReturn(connector);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{WorkerTestConnector.class}).andReturn(connector);
         EasyMock.expect(connector.version()).andReturn("1.0");
 
         Map<String, String> props = new HashMap<>();
@@ -311,12 +307,11 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), config, offsetBackingStore);
         worker.start();
 
-        ConnectorConfig config = new ConnectorConfig(props);
         assertEquals(Collections.emptySet(), worker.connectorNames());
-        worker.startConnector(config, ctx, connectorStatusListener, TargetState.STARTED);
+        worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         try {
-            worker.startConnector(config, ctx, connectorStatusListener, TargetState.STARTED);
+            worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
             fail("Should have thrown exception when trying to add connector with same name.");
         } catch (ConnectException e) {
             // expected
@@ -347,8 +342,8 @@ public class WorkerTest extends ThreadedTest {
         WorkerSourceTask workerTask = PowerMock.createMock(WorkerSourceTask.class);
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateTask");
-        PowerMock.expectPrivate(Worker.class, "instantiateTask", new Object[]{TestSourceTask.class}).andReturn(task);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
         EasyMock.expect(task.version()).andReturn("1.0");
 
         PowerMock.expectNew(
@@ -384,7 +379,7 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), config, offsetBackingStore);
         worker.start();
         assertEquals(Collections.emptySet(), worker.taskIds());
-        worker.startTask(TASK_ID, new TaskConfig(origProps), anyConnectorConfig(), taskStatusListener, TargetState.STARTED);
+        worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(TASK_ID)), worker.taskIds());
         worker.stopAndAwaitTask(TASK_ID);
         assertEquals(Collections.emptySet(), worker.taskIds());
@@ -394,7 +389,7 @@ public class WorkerTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testStopInvalidTask() {
         expectStartStorage();
 
@@ -415,8 +410,8 @@ public class WorkerTest extends ThreadedTest {
         WorkerSourceTask workerTask = PowerMock.createMock(WorkerSourceTask.class);
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateTask");
-        PowerMock.expectPrivate(Worker.class, "instantiateTask", new Object[]{TestSourceTask.class}).andReturn(task);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
         EasyMock.expect(task.version()).andReturn("1.0");
         
         PowerMock.expectNew(
@@ -453,7 +448,7 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), config, offsetBackingStore);
         worker.start();
-        worker.startTask(TASK_ID, new TaskConfig(origProps), anyConnectorConfig(), taskStatusListener, TargetState.STARTED);
+        worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED);
         worker.stop();
 
         PowerMock.verifyAll();
@@ -467,8 +462,8 @@ public class WorkerTest extends ThreadedTest {
         WorkerSourceTask workerTask = PowerMock.createMock(WorkerSourceTask.class);
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
-        PowerMock.mockStaticPartial(Worker.class, "instantiateTask");
-        PowerMock.expectPrivate(Worker.class, "instantiateTask", new Object[]{TestSourceTask.class}).andReturn(task);
+        PowerMock.mockStaticPartial(Worker.class, "instantiate");
+        PowerMock.expectPrivate(Worker.class, "instantiate", new Object[]{TestSourceTask.class}).andReturn(task);
         EasyMock.expect(task.version()).andReturn("1.0");
 
         Capture<TestConverter> keyConverter = EasyMock.newCapture();
@@ -512,7 +507,7 @@ public class WorkerTest extends ThreadedTest {
         connProps.put("key.converter.extra.config", "foo");
         connProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
         connProps.put("value.converter.extra.config", "bar");
-        worker.startTask(TASK_ID, new TaskConfig(origProps), new ConnectorConfig(connProps), taskStatusListener, TargetState.STARTED);
+        worker.startTask(TASK_ID, connProps, origProps, taskStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(TASK_ID)), worker.taskIds());
         worker.stopAndAwaitTask(TASK_ID);
         assertEquals(Collections.emptySet(), worker.taskIds());
@@ -544,10 +539,6 @@ public class WorkerTest extends ThreadedTest {
         props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
         props.put(ConnectorConfig.TASKS_MAX_CONFIG, "1");
         return props;
-    }
-
-    private ConnectorConfig anyConnectorConfig() {
-        return new ConnectorConfig(anyConnectorConfigMap());
     }
 
     /* Name here needs to be unique as we are testing the aliasing mechanism */

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -39,7 +39,6 @@ import org.apache.kafka.connect.storage.StatusBackingStore;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
-import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.Before;
@@ -169,14 +168,15 @@ public class DistributedHerderTest {
         EasyMock.expect(member.memberId()).andStubReturn("member");
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
 
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
-        worker.startTask(EasyMock.eq(TASK1), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -193,13 +193,14 @@ public class DistributedHerderTest {
         EasyMock.expect(member.memberId()).andStubReturn("member");
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
-        worker.startTask(EasyMock.eq(TASK1), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -207,9 +208,9 @@ public class DistributedHerderTest {
                 1, Arrays.asList(CONN1), Arrays.<ConnectorTaskId>asList());
 
         // and the new assignment started
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
@@ -229,13 +230,14 @@ public class DistributedHerderTest {
         EasyMock.expect(member.memberId()).andStubReturn("member");
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
-        worker.startTask(EasyMock.eq(TASK1), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -243,9 +245,9 @@ public class DistributedHerderTest {
                 1, Arrays.asList(CONN1), Arrays.<ConnectorTaskId>asList());
 
         // and the new assignment started
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(false);
 
         // worker is not running, so we should see no call to connectorTaskConfigs()
@@ -263,13 +265,9 @@ public class DistributedHerderTest {
 
     @Test
     public void testHaltCleansUpWorker() {
-        EasyMock.expect(worker.connectorNames()).andReturn(Collections.singleton(CONN1));
-        worker.stopConnector(CONN1);
+        worker.stopConnectors();
         PowerMock.expectLastCall();
-        EasyMock.expect(worker.taskIds()).andReturn(Collections.singleton(TASK1));
-        worker.stopTasks(Collections.singleton(TASK1));
-        PowerMock.expectLastCall();
-        worker.awaitStopTasks(Collections.singleton(TASK1));
+        worker.stopAndAwaitTasks();
         PowerMock.expectLastCall();
         member.stop();
         PowerMock.expectLastCall();
@@ -342,9 +340,9 @@ public class DistributedHerderTest {
         // Start with one connector
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
 
@@ -377,9 +375,9 @@ public class DistributedHerderTest {
         expectPostRebalanceCatchup(SNAPSHOT);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
 
         // now handle the connector restart
@@ -390,13 +388,11 @@ public class DistributedHerderTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(true);
-
         worker.stopConnector(CONN1);
-        PowerMock.expectLastCall();
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        PowerMock.expectLastCall().andReturn(true);
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
 
         PowerMock.replayAll();
@@ -461,8 +457,6 @@ public class DistributedHerderTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(false);
-
         PowerMock.replayAll();
 
         herder.tick();
@@ -498,7 +492,6 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
 
         String ownerUrl = "ownerUrl";
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(false);
         EasyMock.expect(member.ownerUrl(CONN1)).andReturn(ownerUrl);
 
         PowerMock.replayAll();
@@ -530,8 +523,9 @@ public class DistributedHerderTest {
         expectPostRebalanceCatchup(SNAPSHOT);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
-        worker.startTask(EasyMock.eq(TASK0), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK0), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
 
         // now handle the task restart
         member.wakeup();
@@ -541,12 +535,11 @@ public class DistributedHerderTest {
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
-        EasyMock.expect(worker.ownsTask(TASK0)).andReturn(true);
-
         worker.stopAndAwaitTask(TASK0);
-        PowerMock.expectLastCall();
-        worker.startTask(EasyMock.eq(TASK0), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
+        worker.startTask(EasyMock.eq(TASK0), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
 
         PowerMock.replayAll();
 
@@ -602,7 +595,6 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
 
         // now handle the task restart
-        EasyMock.expect(worker.ownsTask(TASK0)).andReturn(false);
         member.wakeup();
         PowerMock.expectLastCall();
         member.ensureActive();
@@ -638,7 +630,6 @@ public class DistributedHerderTest {
 
         // now handle the task restart
         String ownerUrl = "ownerUrl";
-        EasyMock.expect(worker.ownsTask(TASK0)).andReturn(false);
         EasyMock.expect(member.ownerUrl(TASK0)).andReturn(ownerUrl);
         member.wakeup();
         PowerMock.expectLastCall();
@@ -687,10 +678,10 @@ public class DistributedHerderTest {
         // Performs rebalance and gets new assignment
         expectRebalance(Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList(),
                 ConnectProtocol.Assignment.NO_ERROR, 1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
-        PowerMock.expectLastCall();
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -715,9 +706,9 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
@@ -729,10 +720,10 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
         EasyMock.expect(configStorage.snapshot()).andReturn(SNAPSHOT); // for this test, it doesn't matter if we use the same config snapshot
         worker.stopConnector(CONN1);
-        PowerMock.expectLastCall();
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        PowerMock.expectLastCall().andReturn(true);
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
@@ -757,9 +748,9 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
         member.poll(EasyMock.anyInt());
@@ -772,8 +763,6 @@ public class DistributedHerderTest {
 
         EasyMock.expect(configStorage.snapshot()).andReturn(SNAPSHOT_PAUSED_CONN1);
         PowerMock.expectLastCall();
-
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(true);
 
         worker.setTargetState(CONN1, TargetState.PAUSED);
         PowerMock.expectLastCall();
@@ -798,9 +787,9 @@ public class DistributedHerderTest {
         // start with the connector paused
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT_PAUSED_CONN1);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.PAUSED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -814,7 +803,6 @@ public class DistributedHerderTest {
         PowerMock.expectLastCall();
 
         // we expect reconfiguration after resuming
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
 
@@ -841,8 +829,9 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Collections.<String>emptyList(), Collections.singletonList(TASK0));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startTask(EasyMock.eq(TASK0), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK0), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -877,8 +866,9 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Collections.<String>emptyList(), Collections.singletonList(TASK0));
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startTask(EasyMock.eq(TASK0), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK0), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -889,8 +879,6 @@ public class DistributedHerderTest {
 
         EasyMock.expect(configStorage.snapshot()).andReturn(SNAPSHOT_PAUSED_CONN1);
         PowerMock.expectLastCall();
-
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(false);
 
         worker.setTargetState(CONN1, TargetState.PAUSED);
         PowerMock.expectLastCall();
@@ -918,8 +906,9 @@ public class DistributedHerderTest {
         // join
         expectRebalance(1, Collections.<String>emptyList(), Collections.singletonList(TASK0));
         expectPostRebalanceCatchup(SNAPSHOT_PAUSED_CONN1);
-        worker.startTask(EasyMock.eq(TASK0), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.PAUSED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK0), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.PAUSED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -931,10 +920,10 @@ public class DistributedHerderTest {
         EasyMock.expect(configStorage.snapshot()).andReturn(SNAPSHOT);
         PowerMock.expectLastCall();
 
-        EasyMock.expect(worker.ownsConnector(CONN1)).andReturn(false);
-
         worker.setTargetState(CONN1, TargetState.STARTED);
         PowerMock.expectLastCall();
+
+        EasyMock.expect(worker.isRunning(CONN1)).andReturn(false);
 
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -970,8 +959,9 @@ public class DistributedHerderTest {
         expectRebalance(Collections.<String>emptyList(), Collections.<ConnectorTaskId>emptyList(),
                 ConnectProtocol.Assignment.NO_ERROR, 1, Collections.<String>emptyList(),
                 Arrays.asList(TASK0));
-        worker.startTask(EasyMock.eq(TASK0), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK0), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
 
@@ -1004,12 +994,13 @@ public class DistributedHerderTest {
         expectRebalance(1, Arrays.asList(CONN1), Arrays.asList(TASK1));
         expectPostRebalanceCatchup(SNAPSHOT);
 
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
-        worker.startTask(EasyMock.eq(TASK1), EasyMock.<TaskConfig>anyObject(), EasyMock.<ConnectorConfig>anyObject(), EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        worker.startTask(EasyMock.eq(TASK1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<Map<String, String>>anyObject(),
+                EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         member.poll(EasyMock.anyInt());
         PowerMock.expectLastCall();
@@ -1070,9 +1061,9 @@ public class DistributedHerderTest {
         EasyMock.expect(member.memberId()).andStubReturn("leader");
         expectRebalance(1, Arrays.asList(CONN1), Collections.<ConnectorTaskId>emptyList());
         expectPostRebalanceCatchup(SNAPSHOT);
-        worker.startConnector(EasyMock.<ConnectorConfig>anyObject(), EasyMock.<ConnectorContext>anyObject(),
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
 
@@ -1098,11 +1089,10 @@ public class DistributedHerderTest {
         // connector without rebalance
         EasyMock.expect(configStorage.snapshot()).andReturn(SNAPSHOT_UPDATED_CONN1_CONFIG);
         worker.stopConnector(CONN1);
-        PowerMock.expectLastCall();
-        Capture<ConnectorConfig> capturedUpdatedConfig = EasyMock.newCapture();
-        worker.startConnector(EasyMock.capture(capturedUpdatedConfig), EasyMock.<ConnectorContext>anyObject(),
+        PowerMock.expectLastCall().andReturn(true);
+        worker.startConnector(EasyMock.eq(CONN1), EasyMock.<Map<String, String>>anyObject(), EasyMock.<ConnectorContext>anyObject(),
                 EasyMock.eq(herder), EasyMock.eq(TargetState.STARTED));
-        PowerMock.expectLastCall();
+        PowerMock.expectLastCall().andReturn(true);
         EasyMock.expect(worker.isRunning(CONN1)).andReturn(true);
         EasyMock.expect(worker.connectorTaskConfigs(CONN1, MAX_TASKS, null)).andReturn(TASK_CONFIGS);
 
@@ -1147,7 +1137,6 @@ public class DistributedHerderTest {
         // This requires inter-worker communication, so needs the REST API
     }
 
-
     private void expectRebalance(final long offset,
                                  final List<String> assignedConnectors,
                                  final List<ConnectorTaskId> assignedTasks) {
@@ -1175,17 +1164,13 @@ public class DistributedHerderTest {
         });
 
         if (revokedConnectors != null) {
-            for (String connector : revokedConnectors) {
-                worker.stopConnector(connector);
-                PowerMock.expectLastCall();
-            }
+            worker.stopConnectors(revokedConnectors);
+            PowerMock.expectLastCall().andReturn(revokedConnectors);
         }
 
-        if (revokedTasks != null && !revokedTasks.isEmpty()) {
-            worker.stopTasks(revokedTasks);
-            PowerMock.expectLastCall();
-            worker.awaitStopTasks(revokedTasks);
-            PowerMock.expectLastCall();
+        if (revokedTasks != null) {
+            worker.stopAndAwaitTasks(revokedTasks);
+            PowerMock.expectLastCall().andReturn(revokedTasks);
         }
 
         if (revokedConnectors != null) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaStatusBackingStoreTest.java
@@ -25,11 +25,13 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.ConnectorStatus;
 import org.apache.kafka.connect.runtime.TaskStatus;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.easymock.Capture;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.easymock.IAnswer;
 import org.junit.Test;
@@ -183,6 +185,33 @@ public class KafkaStatusBackingStoreTest extends EasyMockSupport {
         assertEquals(status, store.get(CONNECTOR));
 
         verifyAll();
+    }
+
+    @Test
+    public void putSafeWithNoPreviousValueIsPropagated() {
+        final Converter converter = mock(Converter.class);
+        final KafkaBasedLog<String, byte[]> kafkaBasedLog = mock(KafkaBasedLog.class);
+        final KafkaStatusBackingStore store = new KafkaStatusBackingStore(new MockTime(), converter, STATUS_TOPIC, kafkaBasedLog);
+
+        final byte[] value = new byte[0];
+
+        final Capture<Struct> statusValueStruct = newCapture();
+        converter.fromConnectData(eq(STATUS_TOPIC), anyObject(Schema.class), capture(statusValueStruct));
+        EasyMock.expectLastCall().andReturn(value);
+
+        kafkaBasedLog.send(eq("status-connector-" + CONNECTOR), eq(value), anyObject(Callback.class));
+        expectLastCall();
+
+        replayAll();
+
+        final ConnectorStatus status = new ConnectorStatus(CONNECTOR, ConnectorStatus.State.FAILED, WORKER_ID, 0);
+        store.putSafe(status);
+
+        verifyAll();
+
+        assertEquals(status.state().toString(), statusValueStruct.getValue().get(KafkaStatusBackingStore.STATE_KEY_NAME));
+        assertEquals(status.workerId(), statusValueStruct.getValue().get(KafkaStatusBackingStore.WORKER_ID_KEY_NAME));
+        assertEquals(status.generation(), statusValueStruct.getValue().get(KafkaStatusBackingStore.GENERATION_KEY_NAME));
     }
 
     @Test

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -379,13 +379,12 @@ class MockSink(object):
 
 class MockSource(object):
 
-    def __init__(self, cc, topics, mode=None, delay_sec=10, name="mock-source"):
+    def __init__(self, cc, mode=None, delay_sec=10, name="mock-source"):
         self.cc = cc
         self.logger = self.cc.logger
         self.name = name
         self.mode = mode
         self.delay_sec = delay_sec
-        self.topics = topics
 
     def start(self):
         self.logger.info("Creating connector MockSourceConnector %s", self.name)
@@ -393,8 +392,6 @@ class MockSource(object):
             'name': self.name,
             'connector.class': 'org.apache.kafka.connect.tools.MockSourceConnector',
             'tasks.max': 1,
-            'topics': ",".join(self.topics),
             'mock_mode': self.mode,
             'delay_ms': self.delay_sec * 1000
         })
-        


### PR DESCRIPTION
Invoke the statusListener.onFailure() callback on start failures so that the statusBackingStore is updated. This involved a fix to the putSafe() functionality which prevented any update that was not preceded by a (non-safe) put() from completing, so here when a connector or task is transitioning directly to FAILED.

Worker start methods can still throw if the same connector name or task ID is already registered with the worker, as this condition should not happen.
