### PR TITLE
KAFKA-4092: retention.bytes should not be allowed to be less than segment.bytes

### DIFF
--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -324,10 +324,19 @@ object LogConfig {
   }
 
   /**
+    * Check that the property values are valid relative to each other
+    */
+  def validateValues(props: Properties) {
+    require(props.getProperty(SegmentBytesProp).toLong <= props.getProperty(RetentionBytesProp).toLong,
+      "segment.bytes "+props.getProperty(SegmentBytesProp)+" is not less than or equal to retention.bytes "+props.getProperty(RetentionBytesProp))
+  }
+
+  /**
    * Check that the given properties contain only valid log config names and that all values can be parsed and are valid
    */
   def validate(props: Properties) {
     validateNames(props)
+    validateValues(props)
     configDef.parse(props)
   }
 

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -328,7 +328,7 @@ object LogConfig {
     */
   def validateValues(props: Properties) {
     require(props.getProperty(SegmentBytesProp).toLong <= props.getProperty(RetentionBytesProp).toLong,
-      "segment.bytes "+props.getProperty(SegmentBytesProp)+" is not less than or equal to retention.bytes "+props.getProperty(RetentionBytesProp))
+      s"segment.bytes ${props.getProperty(SegmentBytesProp)} is not less than or equal to retention.bytes ${props.getProperty(RetentionBytesProp)}")
   }
 
   /**
@@ -336,8 +336,8 @@ object LogConfig {
    */
   def validate(props: Properties) {
     validateNames(props)
-    validateValues(props)
     configDef.parse(props)
+    validateValues(props)
   }
 
 }

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -327,8 +327,10 @@ object LogConfig {
     * Check that the property values are valid relative to each other
     */
   def validateValues(props: Properties) {
-    require(props.getProperty(SegmentBytesProp).toLong <= props.getProperty(RetentionBytesProp).toLong,
-      s"segment.bytes ${props.getProperty(SegmentBytesProp)} is not less than or equal to retention.bytes ${props.getProperty(RetentionBytesProp)}")
+    val segmentBytes = if (props.getProperty(SegmentBytesProp) == null) Defaults.SegmentSize*1L else props.getProperty(SegmentBytesProp).toLong
+    val retentionBytes = if (props.getProperty(RetentionBytesProp) == null) Defaults.RetentionSize else props.getProperty(RetentionBytesProp).toLong
+    require(segmentBytes <= retentionBytes || retentionBytes == -1,
+      s"segment.bytes ${segmentBytes} is not less than or equal to retention.bytes ${retentionBytes}")
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -111,6 +111,16 @@ class LogConfigTest {
       case _: ConfigException => false
     }
   }
+  def testValueValidator() {
+    val p = new Properties()
+    p.setProperty(LogConfig.SegmentBytesProp, "100")
+    p.setProperty(LogConfig.RetentionBytesProp, "100")
+    LogConfig.validate(p)
+    p.setProperty(LogConfig.RetentionBytesProp, "90")
+    val except = intercept[IllegalArgumentException] {
+      LogConfig.validate(p)
+    }
+  }
 
   private def assertPropertyInvalid(name: String, values: AnyRef*) {
     values.foreach((value) => {


### PR DESCRIPTION
adding a LogConfig value validator.  @gwenshap or @junrao would you mind taking a look?
