### PR TITLE
MINOR: Include TopicPartition in warning when log cleaner resets dirty offset

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -92,8 +92,8 @@ private[log] class LogCleanerManager(val logDirs: Array[File], val logs: Pool[To
             if (offset < logStartOffset) {
               // don't bother with the warning if compact and delete are enabled.
               if (!isCompactAndDelete(log))
-                warn("Resetting first dirty offset to log start offset %d since the checkpointed offset %d is invalid."
-                    .format(logStartOffset, offset))
+                warn("Resetting first dirty offset for %s to log start offset %d since the checkpointed offset %d is invalid."
+                    .format(topicAndPartition, logStartOffset, offset))
               logStartOffset
             } else {
               offset


### PR DESCRIPTION
Typically this error condition is caused by topic-level configuration issues, so it is useful to include which topic partition was reset for operator use when debugging the root cause.
