### PR TITLE
wrong property was mentioned in doc

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -108,7 +108,7 @@ The essential old consumer configurations are the following:
     <tr>
       <td>socket.timeout.ms</td>
       <td colspan="1">30 * 1000</td>
-      <td>The socket timeout for network requests. The actual timeout set will be max.fetch.wait + socket.timeout.ms.</td>
+      <td>The socket timeout for network requests. The actual timeout set will be fetch.wait.max.ms + socket.timeout.ms.</td>
     </tr>
     <tr>
       <td>socket.receive.buffer.bytes</td>


### PR DESCRIPTION
max.fetch.wait is mentioned in document where it should have been fetch.wait.max.ms
