### PR TITLE
KAFKA-3703: Flush outgoing writes before closing client selector

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -133,4 +133,9 @@ public interface KafkaClient extends Closeable {
      */
     public void wakeup();
 
+    /**
+     * Flush any outgoing buffers and close the client.
+     */
+    public void closeGracefully();
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -341,6 +341,14 @@ public class NetworkClient implements KafkaClient {
     }
 
     /**
+     * Flush any outgoing buffers and close the network client.
+     */
+    @Override
+    public void closeGracefully() {
+        this.selector.closeGracefully();
+    }
+
+    /**
      * Choose the node with the fewest outstanding requests which is at least eligible for connection. This method will
      * prefer a node with an existing connection, but will potentially choose a node for which we don't yet have a
      * connection if all existing connections are in use. This method will never choose a node for which there is no

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -399,7 +399,7 @@ public class ConsumerNetworkClient implements Closeable {
     @Override
     public void close() throws IOException {
         synchronized (this) {
-            client.close();
+            client.closeGracefully();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -155,7 +155,10 @@ public class Sender implements Runnable {
             this.accumulator.abortIncompleteBatches();
         }
         try {
-            this.client.close();
+            if (!forceClose)
+                this.client.closeGracefully();
+            else
+                this.client.close();
         } catch (Exception e) {
             log.error("Failed to close network client", e);
         }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
@@ -48,6 +48,11 @@ public interface Selectable {
     public void close();
 
     /**
+     * Flush outgoing writes on all connected channels and close the selector
+     */
+    public void closeGracefully();
+
+    /**
      * Close the connection identified by the given id
      */
     public void close(String id);

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -266,6 +266,11 @@ public class MockClient implements KafkaClient {
     }
 
     @Override
+    public void closeGracefully() {
+        close();
+    }
+
+    @Override
     public void close(String node) {
         ready.remove(node);
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/EchoServer.java
@@ -39,6 +39,7 @@ class EchoServer extends Thread {
     private final List<Socket> sockets;
     private final SslFactory sslFactory;
     private final AtomicBoolean renegotiate = new AtomicBoolean();
+    private DataOutputStream echoOutputStream;
 
     public EchoServer(SecurityProtocol securityProtocol, Map<String, ?> configs) throws Exception {
         switch (securityProtocol) {
@@ -64,6 +65,10 @@ class EchoServer extends Thread {
         renegotiate.set(true);
     }
 
+    public void echoOutputStream(DataOutputStream outputStream) {
+        this.echoOutputStream = outputStream;
+    }
+
     @Override
     public void run() {
         try {
@@ -76,6 +81,8 @@ class EchoServer extends Thread {
                         try {
                             DataInputStream input = new DataInputStream(socket.getInputStream());
                             DataOutputStream output = new DataOutputStream(socket.getOutputStream());
+                            if (echoOutputStream != null)
+                                output = echoOutputStream;
                             while (socket.isConnected() && !socket.isClosed()) {
                                 int size = input.readInt();
                                 if (renegotiate.get()) {

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -53,6 +53,10 @@ public class MockSelector implements Selectable {
     }
 
     @Override
+    public void closeGracefully() {
+    }
+
+    @Override
     public void close(String id) {
         this.disconnected.add(id);
         for (int i = 0; i < this.connected.size(); i++) {


### PR DESCRIPTION
Close client connections only after outgoing writes complete or timeout.
