### PR TITLE
Fix javadocs of Windowed

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windowed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windowed.java
@@ -17,12 +17,10 @@
 
 package org.apache.kafka.streams.kstream;
 
-import org.apache.kafka.common.serialization.Serde;
-
 /**
  * The windowed key interface used in {@link KTable}, used for representing a windowed table result
  * from windowed stream aggregations (e.g. as returned by
- * {@link KGroupedStream#aggregate(Initializer, Aggregator, Windows, Serde, String)}).
+ * {@link KGroupedStream#aggregate(Initializer, Aggregator, Windows, org.apache.kafka.common.serialization.Serde, String)}).
  *
  * @param <K> Type of the key
  */

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windowed.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windowed.java
@@ -17,10 +17,12 @@
 
 package org.apache.kafka.streams.kstream;
 
+import org.apache.kafka.common.serialization.Serde;
+
 /**
- * The windowed key interface used in {@link KTable}, used for representing a windowed table result from windowed stream aggregations,
- * i.e. {@link KStream#aggregateByKey(Initializer, Aggregator, Windows, org.apache.kafka.common.serialization.Serde,
- * org.apache.kafka.common.serialization.Serde)}
+ * The windowed key interface used in {@link KTable}, used for representing a windowed table result
+ * from windowed stream aggregations (e.g. as returned by
+ * {@link KGroupedStream#aggregate(Initializer, Aggregator, Windows, Serde, String)}).
  *
  * @param <K> Type of the key
  */


### PR DESCRIPTION
Previous Javadoc was referring to a 0.10.0.x method that was since removed from trunk.
