### PR TITLE
KAFKA-4123: Queryable State returning null for key before all stores in instance have been initialized

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStoreException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStoreException.java
@@ -12,14 +12,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.kafka.streams.state.internals;
+package org.apache.kafka.streams.errors;
 
 /**
  * Indicates that there was a problem when trying to access
  * a {@link org.apache.kafka.streams.processor.StateStore}, i.e, the Store is no longer valid because it is closed
  * or doesn't exist any more due to a rebalance.
+ *
+ * These exceptions may be transient, i.e., during a rebalance it won't be possible to query the stores as they are
+ * being (re)-initialized. Once the rebalance has completed the stores will be available again. Hence, it is valid
+ * to backoff and retry when handling this exception.
  */
-public class InvalidStateStoreException extends RuntimeException {
+public class InvalidStateStoreException extends StreamsException {
 
     public InvalidStateStoreException(final String message) {
         super(message);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -166,14 +166,14 @@ public class ProcessorStateManager {
         if (partitionNotFound)
             throw new StreamsException("Store " + store.name() + "'s change log (" + topic + ") does not contain partition " + partition);
 
-        this.stores.put(store.name(), store);
-
         if (isStandby) {
             if (store.persistent())
                 restoreCallbacks.put(topic, stateRestoreCallback);
         } else {
             restoreActiveState(topic, stateRestoreCallback);
         }
+
+        this.stores.put(store.name(), store);
     }
 
     private void restoreActiveState(String topicName, StateRestoreCallback stateRestoreCallback) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -105,7 +105,7 @@ public class StreamThread extends Thread {
 
     private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> standbyRecords;
     private boolean processStandbyRecords = false;
-    private AtomicBoolean stateStoresAvailable = new AtomicBoolean(false);
+    private AtomicBoolean initialized = new AtomicBoolean(false);
 
     final ConsumerRebalanceListener rebalanceListener = new ConsumerRebalanceListener() {
         @Override
@@ -115,7 +115,7 @@ public class StreamThread extends Thread {
                 addStandbyTasks();
                 lastCleanMs = time.milliseconds(); // start the cleaning cycle
                 streamsMetadataState.onChange(partitionAssignor.getPartitionsByHostState(), partitionAssignor.clusterMetadata());
-                stateStoresAvailable.set(true);
+                initialized.set(true);
             } catch (Throwable t) {
                 rebalanceException = t;
                 throw t;
@@ -125,7 +125,7 @@ public class StreamThread extends Thread {
         @Override
         public void onPartitionsRevoked(Collection<TopicPartition> assignment) {
             try {
-                stateStoresAvailable.set(false);
+                initialized.set(false);
                 commitAll();
                 lastCleanMs = Long.MAX_VALUE; // stop the cleaning cycle until partitions are assigned
             } catch (Throwable t) {
@@ -141,8 +141,8 @@ public class StreamThread extends Thread {
         }
     };
 
-    public boolean allStateStoresAvailable() {
-        return stateStoresAvailable.get();
+    public boolean isInitialized() {
+        return initialized.get();
     }
 
     public StreamThread(TopologyBuilder builder,

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -15,11 +15,13 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 
 /**
  * A key value store that only supports read operations.
  * Implementations should be thread-safe as concurrent reads and writes
- * are expected
+ * are expected.
+ *
  * @param <K> the key type
  * @param <V> the value type
  */
@@ -27,11 +29,12 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 public interface ReadOnlyKeyValueStore<K, V> {
 
     /**
-     * Get the value corresponding to this key
+     * Get the value corresponding to this key.
      *
      * @param key The key to fetch
      * @return The value or null if no value is found.
      * @throws NullPointerException If null is used for key.
+     * @throws InvalidStateStoreException if the store is not initialized
      */
     V get(K key);
 
@@ -43,6 +46,7 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * @param to The last key that could be in the range
      * @return The iterator for this range.
      * @throws NullPointerException If null is used for from or to.
+     * @throws InvalidStateStoreException if the store is not initialized
      */
     KeyValueIterator<K, V> range(K from, K to);
 
@@ -51,6 +55,7 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * The returned iterator must be safe from {@link java.util.ConcurrentModificationException}s
      * and must not return null values. No ordering guarantees are provided.
      * @return An iterator of all key/value pairs in the store.
+     * @throws InvalidStateStoreException if the store is not initialized
      */
     KeyValueIterator<K, V> all();
 
@@ -61,6 +66,7 @@ public interface ReadOnlyKeyValueStore<K, V> {
      * where an exact count is expensive to calculate.
      *
      * @return an approximate count of key-value mappings in the store.
+     * @throws InvalidStateStoreException if the store is not initialized
      */
     long approximateNumEntries();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyWindowStore.java
@@ -15,6 +15,7 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 
 /**
  * A window store that only supports read operations
@@ -31,6 +32,7 @@ public interface ReadOnlyWindowStore<K, V> {
      * the existing windows.
      *
      * @return an iterator over key-value pairs {@code <timestamp, value>}
+     * @throws InvalidStateStoreException if the store is not initialized
      */
     WindowStoreIterator<V> fetch(K key, long timeFrom, long timeTo);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -14,6 +14,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -45,7 +45,7 @@ public class QueryableStoreProvider {
             allStores.addAll(storeProvider.stores(storeName, queryableStoreType));
         }
         if (allStores.isEmpty()) {
-            return null;
+            throw new InvalidStateStoreException("Store: " + storeName + " is currently not available");
         }
         return queryableStoreType.create(
                 new WrappingStoreProvider(storeProviders),

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -101,7 +101,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
     private StoreChangeLogger<Bytes, byte[]> changeLogger;
     private StoreChangeLogger.ValueGetter<Bytes, byte[]> getter;
 
-    private volatile boolean open = false;
+    protected volatile boolean open = false;
 
     public KeyValueStore<K, V> enableLogging() {
         loggingEnabled = true;
@@ -176,7 +176,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
         this.dbDir = new File(new File(context.stateDir(), parentDir), this.name);
         this.db = openDB(this.dbDir, this.options, TTL_SECONDS);
-        open = true;
     }
 
     public void init(ProcessorContext context, StateStore root) {
@@ -219,6 +218,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
                 putInternal(key, value);
             }
         });
+        open = true;
     }
 
     private RocksDB openDB(File dir, Options options, int ttl) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -66,6 +66,12 @@ public class RocksDBWindowStore<K, V> implements WindowStore<K, V> {
         public void destroy() {
             Utils.delete(dbDir);
         }
+
+        @Override
+        public void openDB(final ProcessorContext context) {
+            super.openDB(context);
+            open = true;
+        }
     }
 
     private static class RocksDBWindowStoreIterator<V> implements WindowStoreIterator<V> {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -14,6 +14,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
@@ -37,8 +38,8 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
     @SuppressWarnings("unchecked")
     @Override
     public <T> List<T> stores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
-        if (!streamThread.allStateStoresAvailable()) {
-            throw new InvalidStateStoreException("Store: " + storeName + " is currently not available");
+        if (!streamThread.isInitialized()) {
+            throw new InvalidStateStoreException("Store: " + storeName + " is currently not available as the stream thread has not (re-)initialized yet");
         }
         final List<T> stores = new ArrayList<>();
         for (StreamTask streamTask : streamThread.tasks().values()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -37,6 +37,9 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
     @SuppressWarnings("unchecked")
     @Override
     public <T> List<T> stores(final String storeName, final QueryableStoreType<T> queryableStoreType) {
+        if (!streamThread.allStateStoresAvailable()) {
+            throw new InvalidStateStoreException("Store: " + storeName + " is currently not available");
+        }
         final List<T> stores = new ArrayList<>();
         for (StreamTask streamTask : streamThread.tasks().values()) {
             final StateStore store = streamTask.getStore(storeName);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappingStoreProvider.java
@@ -14,6 +14,7 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.QueryableStoreType;
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -39,7 +39,7 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.StreamsMetadata;
 import org.apache.kafka.streams.state.WindowStoreIterator;
-import org.apache.kafka.streams.state.internals.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.test.MockKeyValueMapper;
 import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.test.TestCondition;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -15,6 +15,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.junit.Before;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -15,6 +15,7 @@
 package org.apache.kafka.streams.state.internals;
 
 
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.junit.Before;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/QueryableStoreProviderTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public class QueryableStoreProviderTest {
 
@@ -41,14 +40,14 @@ public class QueryableStoreProviderTest {
                 Collections.<StateStoreProvider>singletonList(theStoreProvider));
     }
 
-    @Test
-    public void shouldReturnNullIfKVStoreDoesntExist() throws Exception {
-        assertNull(storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore()));
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowExceptionIfKVStoreDoesntExist() throws Exception {
+        storeProvider.getStore("not-a-store", QueryableStoreTypes.keyValueStore());
     }
 
-    @Test
-    public void shouldReturnNullIfWindowStoreDoesntExist() throws Exception {
-        assertNull(storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore()));
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowExceptionIfWindowStoreDoesntExist() throws Exception {
+        storeProvider.getStore("not-a-store", QueryableStoreTypes.windowStore());
     }
 
     @Test
@@ -61,14 +60,14 @@ public class QueryableStoreProviderTest {
         assertNotNull(storeProvider.getStore(windowStore, QueryableStoreTypes.windowStore()));
     }
 
-    @Test
-    public void shouldNotReturnKVStoreWhenIsWindowStore() throws Exception {
-        assertNull(storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore()));
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowExceptionWhenLookingForWindowStoreWithDifferentType() throws Exception {
+        storeProvider.getStore(windowStore, QueryableStoreTypes.keyValueStore());
     }
 
-    @Test
-    public void shouldNotReturnWindowStoreWhenIsKVStore() throws Exception {
-        assertNull(storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore()));
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowExceptionWhenLookingForKVStoreWithDifferentType() throws Exception {
+        storeProvider.getStore(keyValueStore, QueryableStoreTypes.windowStore());
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
@@ -117,7 +118,7 @@ public class StreamThreadStateStoreProviderTest {
             }
 
             @Override
-            public boolean allStateStoresAvailable() {
+            public boolean isInitialized() {
                 return storesAvailable;
             }
         };

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/WrappingStoreProviderTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.NoOpWindowStore;
 import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;


### PR DESCRIPTION
Mark the store as open after the DB has been restored from the changelog.
Only add the store to the map in ProcessorStateManager post restore.
Make RocksDBWindowStore.Segment override openDB(..) as it needs to mark the Segment as open.
Throw InvalidStateStoreException if any stores in a KafkaStreams instance are not available.
