### PR TITLE
MINOR: Reduce the log level when the peer isn't authenticated but is using SSL

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -628,7 +628,7 @@ public class SslTransportLayer implements TransportLayer {
         try {
             return sslEngine.getSession().getPeerPrincipal();
         } catch (SSLPeerUnverifiedException se) {
-            log.warn("SSL peer is not authenticated, returning ANONYMOUS instead");
+            log.debug("SSL peer is not authenticated, returning ANONYMOUS instead");
             return KafkaPrincipal.ANONYMOUS;
         }
     }


### PR DESCRIPTION
The commit here changes the log level of a log message from WARN to DEBUG. As noted in the mail discussion here https://www.mail-archive.com/dev@kafka.apache.org/msg56035.html, in a pretty straightforward/typical and valid setup, the broker logs get flooded with the following message:

```
           [2016-09-02 08:07:13,773] WARN SSL peer is not authenticated, returning ANONYMOUS instead (org.apache.kafka.common.network.SslTransportLayer)
    [2016-09-02 08:07:15,710] WARN SSL peer is not authenticated, returning ANONYMOUS instead (org.apache.kafka.common.network.SslTransportLayer)
    [2016-09-02 08:07:15,711] WARN SSL peer is not authenticated, returning ANONYMOUS instead (org.apache.kafka.common.network.SslTransportLayer)
    [2016-09-02 08:07:15,711] WARN SSL peer is not authenticated, returning ANONYMOUS instead (org.apache.kafka.common.network.SslTransportLayer)
    [2016-09-02 08:07:15,712] WARN SSL peer is not authenticated, returning ANONYMOUS instead (org.apache.kafka.common.network.SslTransportLayer) 
    ....
```

and it goes on forever. 

Personally, I would like to remove this log message altogether for two reasons:
- It's a valid case for the peer to be not authenticated but still using SSL and the code rightly handles it to return anonymous principal
- The fact that this method gets called way too frequently and irrespective of what log level it gets logged at, it will end up flooding the log if that level is enabled.

Having said that I don't know if there will be an agreement on removing this log message altogether, hence just lowering the level for now.
