### PR TITLE
KAFKA-3703: Graceful close for consumers and producer with acks=0

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -408,6 +408,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         } finally {
             super.close();
         }
+        Node coordinator;
+        while ((coordinator = coordinator()) != null && client.pendingRequestCount(coordinator) > 0) {
+            client.poll(Long.MAX_VALUE);
+        }
     }
 
     // visible for testing

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -409,13 +409,15 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             maybeAutoCommitOffsetsSync();
 
             Node coordinator;
-            long endTimeMs = System.currentTimeMillis() + CLOSE_TIMEOUT_MS;
+            long endTimeMs = time.milliseconds() + CLOSE_TIMEOUT_MS;
             while ((coordinator = coordinator()) != null && client.pendingRequestCount(coordinator) > 0) {
-                long remainingTimeMs = endTimeMs - System.currentTimeMillis();
+                long remainingTimeMs = endTimeMs - time.milliseconds();
                 if (remainingTimeMs > 0)
                     client.poll(remainingTimeMs);
-                else
+                else {
+                    log.warn("Close timed out with {} pending requests to coordinator, terminating client connections for group {}.", client.pendingRequestCount(coordinator), groupId);
                     break;
+                }
             }
         } finally {
             super.close();

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -101,11 +101,11 @@ public class KafkaChannel {
         muted = false;
     }
 
+    /**
+     * Returns true if this channel has been explicitly muted using {@link KafkaChannel#mute()}
+     */
     public boolean isMute() {
-        if (!disconnected)
-            return transportLayer.isMute();
-        else
-            return muted;
+        return muted;
     }
 
     public boolean ready() {

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -35,15 +35,22 @@ public class KafkaChannel {
     private final int maxReceiveSize;
     private NetworkReceive receive;
     private Send send;
+    // Track connection and mute state of channels to enable outstanding requests on channels to be
+    // processed after the channel is disconnected.
+    private boolean disconnected;
+    private boolean muted;
 
     public KafkaChannel(String id, TransportLayer transportLayer, Authenticator authenticator, int maxReceiveSize) throws IOException {
         this.id = id;
         this.transportLayer = transportLayer;
         this.authenticator = authenticator;
         this.maxReceiveSize = maxReceiveSize;
+        this.disconnected = false;
+        this.muted = false;
     }
 
     public void close() throws IOException {
+        this.disconnected = true;
         Utils.closeAll(transportLayer, authenticator);
     }
 
@@ -65,6 +72,7 @@ public class KafkaChannel {
     }
 
     public void disconnect() {
+        disconnected = true;
         transportLayer.disconnect();
     }
 
@@ -82,15 +90,22 @@ public class KafkaChannel {
     }
 
     public void mute() {
-        transportLayer.removeInterestOps(SelectionKey.OP_READ);
+        if (!disconnected)
+            transportLayer.removeInterestOps(SelectionKey.OP_READ);
+        muted = true;
     }
 
     public void unmute() {
-        transportLayer.addInterestOps(SelectionKey.OP_READ);
+        if (!disconnected)
+            transportLayer.addInterestOps(SelectionKey.OP_READ);
+        muted = false;
     }
 
     public boolean isMute() {
-        return transportLayer.isMute();
+        if (!disconnected)
+            return transportLayer.isMute();
+        else
+            return muted;
     }
 
     public boolean ready() {

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -546,7 +546,7 @@ public class Selector implements Selectable {
 
     private KafkaChannel channelOrFail(String id, boolean maybeClosing) {
         KafkaChannel channel = this.channels.get(id);
-        if (channel == null)
+        if (channel == null && maybeClosing)
             channel = this.closingChannels.get(id);
         if (channel == null)
             throw new IllegalStateException("Attempt to retrieve channel for which there is no connection. Connection id " + id + " existing connections " + channels.keySet());

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -491,6 +491,12 @@ public class Selector implements Selectable {
         } catch (IOException e) {
             log.error("Exception closing connection to node {}:", channel.id(), e);
         }
+
+        // Keep track of closed channels with pending receives so that all received records
+        // may be processed. For example, when producer with acks=0 sends some records and
+        // closes its connections, a single poll() in the broker may receive records and
+        // handle close(). Closed channels are retained until the current poll() processing
+        // completes to enable all records received on the channel to be processed.
         Deque<NetworkReceive> deque = this.stagedReceives.remove(channel);
         if (deque != null) {
             while (!deque.isEmpty()) {

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -489,8 +489,10 @@ public class SslTransportLayer implements TransportLayer {
                     break;
                 } else if (unwrapResult.getStatus() == Status.CLOSED) {
                     // If data has been read and unwrapped, return the data. Close will be handled on the next poll.
-                    if (!appReadBuffer.hasRemaining())
+                    if (appReadBuffer.position() == 0 && read == 0)
                         throw new EOFException();
+                    else
+                        break;
                 }
             } while (netReadBuffer.position() != 0);
         }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -447,7 +447,7 @@ public class SslTransportLayer implements TransportLayer {
             netReadBuffer = Utils.ensureCapacity(netReadBuffer, netReadBufferSize());
             if (netReadBuffer.remaining() > 0) {
                 int netread = socketChannel.read(netReadBuffer);
-                if (netread == 0 && netReadBuffer.position() == 0) return netread;
+                if (netread == 0 && netReadBuffer.position() == 0) return read;
                 else if (netread < 0) throw new EOFException("EOF during read");
             }
             do {
@@ -488,7 +488,9 @@ public class SslTransportLayer implements TransportLayer {
                     }
                     break;
                 } else if (unwrapResult.getStatus() == Status.CLOSED) {
-                    throw new EOFException();
+                    // If data has been read and unwrapped, return the data. Close will be handled on the next poll.
+                    if (!appReadBuffer.hasRemaining())
+                        throw new EOFException();
                 }
             } while (netReadBuffer.position() != 0);
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -831,6 +831,7 @@ public class KafkaConsumerTest {
         assertTrue(consumer.subscription().isEmpty());
         assertTrue(consumer.assignment().isEmpty());
 
+        client.requests().clear();
         consumer.close();
     }
 
@@ -905,6 +906,7 @@ public class KafkaConsumerTest {
         for (ClientRequest req: client.requests())
             assertTrue(req.header().apiKey() != ApiKeys.OFFSET_COMMIT.id);
 
+        client.requests().clear();
         consumer.close();
     }
 
@@ -969,6 +971,7 @@ public class KafkaConsumerTest {
         // verify that the offset commits occurred as expected
         assertTrue(commitReceived.get());
 
+        client.requests().clear();
         consumer.close();
     }
 
@@ -1032,6 +1035,7 @@ public class KafkaConsumerTest {
         for (ClientRequest req : client.requests())
             assertTrue(req.header().apiKey() != ApiKeys.OFFSET_COMMIT.id);
 
+        client.requests().clear();
         consumer.close();
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -16,10 +16,12 @@ import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 
@@ -32,6 +34,8 @@ import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.test.TestCondition;
+import org.apache.kafka.test.TestUtils;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.After;
 import org.junit.Before;
@@ -390,7 +394,49 @@ public class SslTransportLayerTest {
 
         NetworkTestUtils.checkClientConnection(selector, node, 64000, 10);
     }
-    
+
+    @Test
+    public void testCloseSsl() throws Exception {
+        testClose(SecurityProtocol.SSL, new SslChannelBuilder(Mode.CLIENT));
+    }
+
+    @Test
+    public void testClosePlaintext() throws Exception {
+        testClose(SecurityProtocol.PLAINTEXT, new PlaintextChannelBuilder());
+    }
+
+    private void testClose(SecurityProtocol securityProtocol, ChannelBuilder clientChannelBuilder) throws Exception {
+        String node = "0";
+        server = NetworkTestUtils.createEchoServer(securityProtocol, sslServerConfigs);
+        clientChannelBuilder.configure(sslClientConfigs);
+        this.selector = new Selector(5000, new Metrics(), new MockTime(), "MetricGroup", clientChannelBuilder);
+        InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
+        selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
+
+        NetworkTestUtils.waitForChannelReady(selector, node);
+
+        final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        server.outputChannel(Channels.newChannel(bytesOut));
+        server.selector().muteAll();
+        byte[] message = TestUtils.randomString(100).getBytes();
+        int count = 20;
+        final int totalSendSize = count * (message.length + 4);
+        for (int i = 0; i < count; i++) {
+            selector.send(new NetworkSend(node, ByteBuffer.wrap(message)));
+            do {
+                selector.poll(0L);
+            } while (selector.completedSends().size() == 0);
+        }
+        server.selector().unmuteAll();
+        selector.close(node);
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                return bytesOut.toByteArray().length == totalSendSize;
+            }
+        }, 5000, "All requests sent were not processed");
+    }
+
     private void createSelector(Map<String, Object> sslClientConfigs) {
         createSelector(sslClientConfigs, null, null, null);
     }      

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -425,7 +425,7 @@ public class SslTransportLayerTest {
             selector.send(new NetworkSend(node, ByteBuffer.wrap(message)));
             do {
                 selector.poll(0L);
-            } while (selector.completedSends().size() == 0);
+            } while (selector.completedSends().isEmpty());
         }
         server.selector().unmuteAll();
         selector.close(node);

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -443,8 +443,9 @@ private[kafka] class Processor(val id: Int,
             // that are sitting in the server's socket buffer
             curr.request.updateRequestMetrics
             trace("Socket server received empty response to send, registering for read: " + curr)
-            if (selector.channel(curr.request.connectionId) != null)
-                selector.unmute(curr.request.connectionId)
+            val channelId = curr.request.connectionId
+            if (selector.channel(channelId) != null || selector.closedChannel(channelId) != null)
+                selector.unmute(channelId)
           case RequestChannel.SendAction =>
             sendResponse(curr)
           case RequestChannel.CloseConnectionAction =>
@@ -489,13 +490,13 @@ private[kafka] class Processor(val id: Int,
       try {
         val openChannel = selector.channel(receive.source)
         val session = {
+          // Only methods that are safe to call on a closed channel should be invoked on 'channel'.
           val channel = if (openChannel != null) openChannel else selector.closedChannel(receive.source)
           RequestChannel.Session(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, channel.principal.getName), channel.socketAddress)
         }
         val req = RequestChannel.Request(processor = id, connectionId = receive.source, session = session, buffer = receive.payload, startTimeMs = time.milliseconds, securityProtocol = protocol)
         requestChannel.sendRequest(req)
-        if (openChannel != null)
-            selector.mute(receive.source)
+        selector.mute(receive.source)
       } catch {
         case e @ (_: InvalidRequestException | _: SchemaException) =>
           // note that even though we got an exception, we can assume that receive.source is valid. Issues with constructing a valid receive object were handled earlier

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -163,6 +163,21 @@ class SocketServerTest extends JUnitSuite {
   }
 
   @Test
+  def testGracefulClose() {
+    val plainSocket = connect(protocol = SecurityProtocol.PLAINTEXT)
+    val serializedBytes = producerRequestBytes
+
+    for (i <- 0 until 10)
+      sendRequest(plainSocket, serializedBytes)
+    plainSocket.close()
+    for (i <- 0 until 10) {
+      val request = server.requestChannel.receiveRequest(2000)
+      assertNotNull("receiveRequest timed out", request)
+      server.requestChannel.noOperation(request.processor, request)
+    }
+  }
+
+  @Test
   def testSocketsCloseOnShutdown() {
     // open a connection
     val plainSocket = connect(protocol = SecurityProtocol.PLAINTEXT)


### PR DESCRIPTION
Process requests received from channels before they were closed. For consumers, wait for coordinator requests to complete before returning from close.
