### PR TITLE
MINOR: Update the README.md to include a note about GRADLE_USER_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This is for `core`, `examples` and `clients`
 ### Publishing the jar for all version of Scala and for all projects to maven ###
     ./gradlew uploadArchivesAll
 
-Please note for this to work you should create/update `~/.gradle/gradle.properties` and assign the following variables
+Please note for this to work you should create/update `${GRADLE_USER_HOME}/gradle.properties` (typically, `~/.gradle/gradle.properties`) and assign the following variables
 
     mavenUrl=
     mavenUsername=


### PR DESCRIPTION
Trying to build the source and publish it to internal Maven repo, I ran into an issue that I explain in the mailing list discussion here https://www.mail-archive.com/dev@kafka.apache.org/msg56359.html. 

The commit here updates the README.md to make a note that the GRADLE_USER_HOME environment variable plays a role in deciding which file to add the maven configs to.
