### PR TITLE
MINOR: catch InvalidStateStoreException in QueryableStateIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -274,6 +274,9 @@ public class QueryableStateIntegrationTest {
                     } catch (final IllegalStateException e) {
                         // Kafka Streams instance may have closed but rebalance hasn't happened
                         return false;
+                    } catch (InvalidStateStoreException e) {
+                        // rebalance
+                        return false;
                     }
                     return store != null && store.fetch(key, from, to) != null;
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -247,7 +247,11 @@ public class QueryableStateIntegrationTest {
                     } catch (final IllegalStateException e) {
                         // Kafka Streams instance may have closed but rebalance hasn't happened
                         return false;
+                    } catch (final InvalidStateStoreException e) {
+                        // rebalance
+                        return false;
                     }
+
                     return store != null && store.get(key) != null;
                 }
             }, 30000, "waiting for metadata, store and value to be non null");


### PR DESCRIPTION
A couple of the tests may transiently fail in QueryableStateIntegrationTest as they are not catching InvalidStateStoreException. This exception is expected during rebalance.
