### PR TITLE
KAFKA-4131 :Multiple Regex KStream-Consumers cause Null pointer exception

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -263,7 +263,6 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         // 2. within each client, tasks are assigned to consumer clients in round-robin manner.
         Map<UUID, Set<String>> consumersByClient = new HashMap<>();
         Map<UUID, ClientState<TaskId>> states = new HashMap<>();
-        SubscriptionUpdates subscriptionUpdates = new SubscriptionUpdates();
         Map<UUID, HostInfo> consumerEndPointMap = new HashMap<>();
         // decode subscription info
         for (Map.Entry<String, Subscription> entry : subscriptions.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -176,6 +176,14 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         standbyTasks.removeAll(prevTasks);
         SubscriptionInfo data = new SubscriptionInfo(streamThread.processId, prevTasks, standbyTasks, this.userEndPointConfig);
 
+        if (streamThread.builder.sourceTopicPattern() != null) {
+            SubscriptionUpdates subscriptionUpdates = new SubscriptionUpdates();
+            log.debug("have {} topics matching regex", topics);
+            // update the topic groups with the returned subscription set for regex pattern subscriptions
+            subscriptionUpdates.updateTopics(topics);
+            streamThread.builder.updateSubscriptions(subscriptionUpdates);
+        }
+
         return new Subscription(new ArrayList<>(topics), data.encode());
     }
 
@@ -262,10 +270,6 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             String consumerId = entry.getKey();
             Subscription subscription = entry.getValue();
 
-            if (streamThread.builder.sourceTopicPattern() != null) {
-               // update the topic groups with the returned subscription list for regex pattern subscriptions
-                subscriptionUpdates.updateTopics(subscription.topics());
-            }
 
             SubscriptionInfo info = SubscriptionInfo.decode(subscription.userData());
             if (info.userEndPoint != null) {
@@ -291,7 +295,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             state.capacity = state.capacity + 1d;
         }
 
-        streamThread.builder.updateSubscriptions(subscriptionUpdates);
+
         this.topicGroups = streamThread.builder.topicGroups();
 
         // ensure the co-partitioning topics within the group have the same number of partitions,


### PR DESCRIPTION
Fix for bug outlined in KAFKA-4131
