### PR TITLE
HOTFIX: set sourceNodes to null for selectKey

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -132,7 +132,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
                 return new KeyValue(mapper.apply(key, value), value);
             }
         }), this.name);
-        return new KStreamImpl<>(topology, name, sourceNodes);
+        return new KStreamImpl<>(topology, name, null);
     }
 
     @Override


### PR DESCRIPTION
To indicate its source topic is no longer guaranteed to be partitioned on key.
