### PR TITLE
KAFKA-4184:  Intermitant failures in ReplicationQuotasTest.shouldBootstrapTwoBrokersWithFollowerThrottle

### DIFF
--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotaManagerTest.scala
@@ -14,13 +14,12 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-package unit.kafka.server
+package kafka.server
 
 import java.util.Collections
 
 import kafka.common.TopicAndPartition
 import kafka.server.QuotaType._
-import kafka.server.{QuotaType, ReplicationQuotaManager, ReplicationQuotaManagerConfig}
 import org.apache.kafka.common.metrics.{Quota, MetricConfig, Metrics}
 import org.apache.kafka.common.utils.MockTime
 import org.junit.Assert.{assertFalse, assertTrue, assertEquals}

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -100,7 +100,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
     val msg = msg100KB
     val msgCount = 100
-    val expectedDuration = 5 //Keep the test to N seconds
+    val expectedDuration = 10 //Keep the test to N seconds
     var throttle: Long = msgCount * msg.length / expectedDuration
     if (!leaderThrottle) throttle = throttle * 3 //Follower throttle needs to replicate 3x as fast to get the same duration as there are three replicas to replicate for each of the two follower brokers
 
@@ -153,7 +153,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
     //Check the times for throttled/unthrottled are each side of what we expect
     val throttledLowerBound = expectedDuration * 1000 * 0.9
-    val throttledUpperBound = expectedDuration * 1000 * 1.5
+    val throttledUpperBound = expectedDuration * 1000 * 3
     assertTrue(s"Expected $unthrottledTook < $throttledLowerBound", unthrottledTook < throttledLowerBound)
     assertTrue(s"Expected $throttledTook > $throttledLowerBound", throttledTook > throttledLowerBound)
     assertTrue(s"Expected $throttledTook < $throttledUpperBound", throttledTook < throttledUpperBound)

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -85,7 +85,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
     brokers = (100 to 105).map { id => TestUtils.createServer(fromProps(createBrokerConfig(id, zkConnect))) }
 
-    //Given six partitions, lead on nodes 0,1,2,3,4,5 but will followers on node 6,7 (not started yet)
+    //Given six partitions, led on nodes 0,1,2,3,4,5 but will followers on node 6,7 (not started yet)
     //And two extra partitions 6,7, which we don't intend on throttling.
     AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(zkUtils, topic, Map(
       0 -> Seq(100, 106), //Throttled
@@ -109,7 +109,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
       changeBrokerConfig(zkUtils, Seq(brokerId), property(KafkaConfig.ThrottledReplicationRateLimitProp, throttle.toString))
     }
 
-    //Either throttle the six leaders or the two follower
+    //Either throttle the six leaders or the two followers
     val throttledReplicas = if (leaderThrottle) "0:100,1:101,2:102,3:103,4:104,5:105" else "0:106,1:106,2:106,3:107,4:107,5:107"
     changeTopicConfig(zkUtils, topic, property(ThrottledReplicasListProp, throttledReplicas))
 

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -87,7 +87,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     brokers = (100 to 105).map { id => TestUtils.createServer(fromProps(createBrokerConfig(id, zkConnect))) }
 
     //Given six partitions, lead on nodes 0,1,2,3,4,5 but will followers on node 6,7 (not started yet)
-    //And two extra partitions 6,7, which we don't intend on throttling
+    //And two extra partitions 6,7, which we don't intend on throttling.
     AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(zkUtils, topic, Map(
       0 -> Seq(100, 106), //Throttled
       1 -> Seq(101, 106), //Throttled

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -87,7 +87,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     brokers = (100 to 105).map { id => TestUtils.createServer(fromProps(createBrokerConfig(id, zkConnect))) }
 
     //Given six partitions, lead on nodes 0,1,2,3,4,5 but will followers on node 6,7 (not started yet)
-    //And two extra partitions 6,7, which we don't intend on throttling.
+    //And two extra partitions 6,7, which we don't intend on throttling
     AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(zkUtils, topic, Map(
       0 -> Seq(100, 106), //Throttled
       1 -> Seq(101, 106), //Throttled

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -231,18 +231,18 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
   private def brokerFor(id: Int): KafkaServer = brokers.filter(_.config.brokerId == id)(0)
 
-  def createBrokers(brokerIds: Inclusive): Unit = {
+  def createBrokers(brokerIds: Seq[Int]): Unit = {
     brokerIds.foreach { id =>
       brokers = brokers :+ TestUtils.createServer(fromProps(createBrokerConfig(id, zkConnect)))
     }
   }
 
   private def avRate(replicationType: QuotaType, brokers: Inclusive): Double = {
-    brokers.map(brokerFor(_)).map(measuredRate(_, replicationType)).sum / brokers.length
+    brokers.map(brokerFor).map(measuredRate(_, replicationType)).sum / brokers.length
   }
 
   private def measuredRate(broker: KafkaServer, repType: QuotaType): Double = {
-    val metricName = broker.metrics.metricName("byte-rate", repType.toString, s"Tracking byte-rate for ${repType}")
-    broker.metrics.metrics.asScala(metricName).value()
+    val metricName = broker.metrics.metricName("byte-rate", repType.toString)
+    broker.metrics.metrics.asScala(metricName).value
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -85,7 +85,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
     brokers = (100 to 105).map { id => TestUtils.createServer(fromProps(createBrokerConfig(id, zkConnect))) }
 
-    //Given six partitions, led on nodes 0,1,2,3,4,5 but will followers on node 6,7 (not started yet)
+    //Given six partitions, led on nodes 0,1,2,3,4,5 but with followers on node 6,7 (not started yet)
     //And two extra partitions 6,7, which we don't intend on throttling.
     AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(zkUtils, topic, Map(
       0 -> Seq(100, 106), //Throttled
@@ -167,9 +167,7 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     assertTrue(s"Expected ${rate} > $rateLowerBound", rate > rateLowerBound)
   }
 
-  def tp(partition: Int): TopicAndPartition = {
-    new TopicAndPartition(topic, partition)
-  }
+  def tp(partition: Int): TopicAndPartition = new TopicAndPartition(topic, partition)
 
   @Test
   def shouldThrottleOldSegments(): Unit = {


### PR DESCRIPTION
Build is unstable, so it's hard to validate this change. Of the various builds up until 11am BST the test ran twice and passed twice. 
