### PR TITLE
KAFKA-4190 kafka-reassign-partitions does not report syntax problem in json

### DIFF
--- a/core/src/main/scala/kafka/admin/AdminUtils.scala
+++ b/core/src/main/scala/kafka/admin/AdminUtils.scala
@@ -577,6 +577,7 @@ object AdminUtils extends Logging with AdminUtilities {
     if (str != null) {
       Json.parseFull(str) match {
         case None => // there are no config overrides
+          // TODO: are any non-empty non-json strings valid here?
         case Some(mapAnon: Map[_, _]) =>
           val map = mapAnon collect { case (k: String, v: Any) => k -> v }
           require(map("version") == 1)

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -94,9 +94,9 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
             if (duplicatePartitions.nonEmpty)
               throw new AdminOperationException("Preferred replica election data contains duplicate partitions: %s".format(duplicatePartitions.mkString(",")))
             partitionsSet
-          case None => throw new AdminOperationException("Preferred replica election data is empty")
+          case None => throw new AdminOperationException("Preferred replica election data is empty or has invalid format")
         }
-      case None => throw new AdminOperationException("Preferred replica election data is empty")
+      case None => throw new AdminOperationException("Preferred replica election data is empty or contains invalid json")
     }
   }
 

--- a/core/src/main/scala/kafka/cluster/Broker.scala
+++ b/core/src/main/scala/kafka/cluster/Broker.scala
@@ -91,7 +91,7 @@ object Broker {
           val rack = brokerInfo.get("rack").filter(_ != null).map(_.asInstanceOf[String])
           new Broker(id, endpoints, rack)
         case None =>
-          throw new BrokerNotAvailableException(s"Broker id $id does not exist")
+          throw new BrokerNotAvailableException(s"Broker info for $id contains invalid json")
       }
     } catch {
       case t: Throwable =>

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -156,12 +156,13 @@ object ZkUtils {
           case Some(partitionsSeq) =>
             val mapPartitionSeq = partitionsSeq.asInstanceOf[Seq[Map[String, Any]]]
             mapPartitionSeq.foreach(p => {
-              val topic = p.get("topic").get.asInstanceOf[String]
+              val topic = p("topic").asInstanceOf[String]
               topics ++= List(topic)
             })
           case None =>
         }
       case None =>
+        throw new KafkaException("Can't parse json string: %s".format(jsonData))
     }
     topics
   }

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -132,16 +132,16 @@ object ZkUtils {
         m.asInstanceOf[Map[String, Any]].get("partitions") match {
           case Some(partitionsSeq) =>
             partitionsSeq.asInstanceOf[Seq[Map[String, Any]]].map(p => {
-              val topic = p.get("topic").get.asInstanceOf[String]
-              val partition = p.get("partition").get.asInstanceOf[Int]
-              val newReplicas = p.get("replicas").get.asInstanceOf[Seq[Int]]
+              val topic = p("topic").asInstanceOf[String]
+              val partition = p("partition").asInstanceOf[Int]
+              val newReplicas = p("replicas").asInstanceOf[Seq[Int]]
               TopicAndPartition(topic, partition) -> newReplicas
             })
           case None =>
             Seq.empty
         }
       case None =>
-        Seq.empty
+        throw new KafkaException("Can't parse json string: %s".format(jsonData))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -58,4 +58,27 @@ class ZkUtilsTest extends ZooKeeperTestHarness {
     val clusterId = "test"
     assertEquals(zkUtils.ClusterId.fromJson(zkUtils.ClusterId.toJson(clusterId)), clusterId)
   }
+
+  @Test
+  def testInvalidPartitionJson(): Unit = {
+    try {
+      ZkUtils.parsePartitionReassignmentDataWithoutDedup("""{"partitions": [{"topic": "foo"},], "version": 1}""")
+      assert(false, "Invalid json should throw an exception")
+    } catch {
+      case e: Exception =>
+    }
+  }
+
+  @Test
+  def testMissingKeyPartitionJson(): Unit = {
+    try {
+      ZkUtils.parsePartitionReassignmentDataWithoutDedup("""{"partitions": [{"topic": "foo"}], "version": 1}""")
+      assert(false, "Invalid format should throw an exception")
+    } catch {
+      case e: Exception =>
+        assertTrue("Exception should explain which key is missing, got: %s".format(e.getMessage),
+          e.getMessage.contains("partition"))
+    }
+  }
+
 }


### PR DESCRIPTION
When specifying invalid json file, kafka-reassign-partitions fails with error "file is empty" instead of reporting syntax error.
