### PR TITLE
MINOR: Add `KafkaServerStartable` constructor overload for compatibility

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServerStartable.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerStartable.scala
@@ -32,6 +32,8 @@ object KafkaServerStartable {
 class KafkaServerStartable(val serverConfig: KafkaConfig, reporters: Seq[KafkaMetricsReporter]) extends Logging {
   private val server = new KafkaServer(serverConfig, kafkaMetricsReporters = reporters)
 
+  def this(serverConfig: KafkaConfig) = this(serverConfig, Seq.empty)
+
   def startup() {
     try {
       server.startup()


### PR DESCRIPTION
We added the `reporters` parameter as part of KIP-74: Cluster Id.
