### PR TITLE
HOTFIX: logic in QuerybaleStateIntegrationTest.shouldBeAbleToQueryState incorrect

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -573,8 +573,8 @@ public class QueryableStateIntegrationTest {
         final Set<KeyValue<String, Long>> countState = new TreeSet<>(stringLongComparator);
 
         final long timeout = System.currentTimeMillis() + 30000;
-        while (windowState.size() < 5 &&
-            countState.size() < 5 &&
+        while ((windowState.size() < keys.length ||
+            countState.size() < keys.length) &&
             System.currentTimeMillis() < timeout) {
             Thread.sleep(10);
             for (final String key : keys) {


### PR DESCRIPTION
The logic in `verifyCanGetByKey` was incorrect. It was 

```
windowState.size() < keys.length &&
countState.size() < keys.length &&
System.currentTimeMillis() < timeout
```

but should be:

```
(windowState.size() < keys.length || countState.size() < keys.length) && System.currentTimeMillis() < timeout
```
