### PR TITLE
MINOR: remove unused code from InternalTopicManager

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicManager.java
@@ -24,7 +24,6 @@ import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.I0Itec.zkclient.exception.ZkNodeExistsException;
 import org.I0Itec.zkclient.serialize.ZkSerializer;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
@@ -36,9 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 public class InternalTopicManager {
@@ -52,26 +49,12 @@ public class InternalTopicManager {
     private static final String ZK_ENTITY_CONFIG_PATH = "/config/topics";
     // TODO: the following LogConfig dependency should be removed after KIP-4
     public static final String CLEANUP_POLICY_PROP = "cleanup.policy";
-    private static final Set<String> CLEANUP_POLICIES = Utils.mkSet("compact", "delete");
     public static final String RETENTION_MS = "retention.ms";
     public static final Long WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT = TimeUnit.MILLISECONDS.convert(1, TimeUnit.DAYS);
 
     private final ZkClient zkClient;
     private final int replicationFactor;
     private final long windowChangeLogAdditionalRetention;
-
-    public static boolean isValidCleanupPolicy(final String cleanupPolicy) {
-        if (cleanupPolicy == null) {
-            return false;
-        }
-        final String[] policies = cleanupPolicy.toLowerCase(Locale.ROOT).split(",");
-        for (String policy : policies) {
-            if (!CLEANUP_POLICIES.contains(policy.trim())) {
-                return false;
-            }
-        }
-        return true;
-    }
 
     private class ZKStringSerializer implements ZkSerializer {
 


### PR DESCRIPTION
Remove isValidCleanupPolicy and related fields as they are never used. 
