### PR TITLE
MINOR: Increase `zkConnectionTimeout` and timeout in `testReachableServer`

### DIFF
--- a/core/src/test/scala/unit/kafka/producer/SyncProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/producer/SyncProducerTest.scala
@@ -64,7 +64,7 @@ class SyncProducerTest extends KafkaServerTestHarness {
       case e: Exception => fail("Unexpected failure sending message to broker. " + e.getMessage)
     }
     val firstEnd = SystemTime.milliseconds
-    assertTrue((firstEnd-firstStart) < 500)
+    assertTrue((firstEnd-firstStart) < 2000)
     val secondStart = SystemTime.milliseconds
     try {
       val response = producer.send(produceRequest("test", 0,
@@ -74,7 +74,7 @@ class SyncProducerTest extends KafkaServerTestHarness {
       case e: Exception => fail("Unexpected failure sending message to broker. " + e.getMessage)
     }
     val secondEnd = SystemTime.milliseconds
-    assertTrue((secondEnd-secondStart) < 500)
+    assertTrue((secondEnd-secondStart) < 2000)
     try {
       val response = producer.send(produceRequest("test", 0,
         new ByteBufferMessageSet(compressionCodec = NoCompressionCodec, messages = new Message(messageBytes)), acks = 1))

--- a/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.common.security.JaasUtils
 
 trait ZooKeeperTestHarness extends JUnitSuite with Logging {
 
-  val zkConnectionTimeout = 6000
+  val zkConnectionTimeout = 10000
   val zkSessionTimeout = 6000
 
   var zkUtils: ZkUtils = null


### PR DESCRIPTION
We had a number of failures recently due to these timeouts being too low. It's a particular problem if multiple forks are used while running the tests.
