### PR TITLE
MINOR: add javadoc comment to PersistenKeyValueFactory.enableCaching

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -399,6 +399,10 @@ public class Stores {
          */
         PersistentKeyValueFactory<K, V> disableLogging();
 
+        /**
+         * Caching should be enabled on the created store.
+         * @return the factory to create a persistent key-value store
+         */
         PersistentKeyValueFactory<K, V> enableCaching();
         /**
          * Return the instance of StateStoreSupplier of new key-value store.


### PR DESCRIPTION
missing javadoc on public API method PersistenKeyValueFactory.enableCaching
