### PR TITLE
KAFKA-4197: Make ReassignPartitionsTest System Test move data

### DIFF
--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -37,7 +37,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
 
         self.topic = "test_topic"
         self.zk = ZookeeperService(test_context, num_nodes=1)
-        self.kafka = KafkaService(test_context, num_nodes=3, zk=self.zk, topics={self.topic: {
+        self.kafka = KafkaService(test_context, num_nodes=4, zk=self.zk, topics={self.topic: {
                                                                     "partitions": 20,
                                                                     "replication-factor": 3,
                                                                     'configs': {"min.insync.replicas": 2}}


### PR DESCRIPTION
The ReassignPartitionsTest system tests doesn't reassign any replicas (i.e. move data). 

This is a simple issue. It uses a 3 node cluster with replication factor of 3, so whilst the replicas are jumbled around, nothing actually is moved from machine to machine when the assignment is executed. 

This fix just ups the number of nodes to 4 so things move. 

Tests pass locally. 
There are runs pending on the two branch builders

Passes:
https://jenkins.confluent.io/job/system-test-kafka-branch-builder/551/
https://jenkins.confluent.io/job/system-test-kafka-branch-builder-2/94/
https://jenkins.confluent.io/job/system-test-kafka-branch-builder/553/
https://jenkins.confluent.io/job/system-test-kafka-branch-builder/554/
https://jenkins.confluent.io/job/system-test-kafka-branch-builder-2/95

Failures:
https://jenkins.confluent.io/job/system-test-kafka-branch-builder/552 => _RuntimeError: There aren't enough available nodes to satisfy the resource request. Total cluster size: 1, Requested: 4, Already allocated: 1, Available: 0._ Which I assume to do with the test env. 
