### PR TITLE
KAFKA-3438: Rack-aware replica assignment should warn of overloaded brokers

### DIFF
--- a/core/src/main/scala/kafka/admin/BrokerBalanceCheck.scala
+++ b/core/src/main/scala/kafka/admin/BrokerBalanceCheck.scala
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.admin
+
+import org.apache.kafka.common.TopicPartition
+
+import scala.collection.Map
+
+class BrokerBalanceCheck(val brokerMetadatas: Seq[BrokerMetadata],
+                         val assignment: Map[TopicPartition, Seq[Int]]) {
+
+  val brokerCount = brokerMetadatas.size
+
+  // map of broker id -> rack id
+  val brokerToRackMap = brokerMetadatas.collect {
+    case BrokerMetadata(id, Some(rack)) => id -> rack
+  }.toMap
+
+  // sorted broker ids
+  val brokers = brokerToRackMap.keys.toList.sortWith(_ < _)
+
+  // map of rack id -> array of broker ids
+  val rackToBrokersMap = brokerToRackMap groupBy{_._2} map {
+    case (key, value) => (key, value.unzip._1.toArray)
+  }
+
+  var minBrokersPerRack = Int.MaxValue
+  var maxBrokersPerRack = Int.MinValue
+  rackToBrokersMap.values.foreach { s =>
+    if (s.length < minBrokersPerRack)
+      minBrokersPerRack = s.length
+    else if (s.length > maxBrokersPerRack)
+      maxBrokersPerRack = s.length
+  }
+
+  var minBrokerReplicaCount = Int.MaxValue
+  var maxBrokerReplicaCount = Int.MinValue
+  var replicaCountToBrokersMap: Map[Int, Array[Int]] = Map()
+  var brokerToReplicaCountMap: Map[Int, Int] = Map()
+  var rackToReplicaCountMap: Map[String, Int] = Map()
+
+  // there is a better broker balance across racks only if one broker can be moved to another rack to provide a better balance
+  if (maxBrokersPerRack > minBrokersPerRack + 1) {
+    // map of broker id -> number of topic partition replicas in the broker
+    brokerToReplicaCountMap = assignment.values.toSet.flatten.map {
+      v => (v, assignment.keys.filter(assignment(_).contains(v)).size)
+    }.toMap
+
+    if (brokerToReplicaCountMap.size < brokerCount) {
+      brokers.toSet.diff(brokerToReplicaCountMap.keySet).foreach { b =>
+        brokerToReplicaCountMap = brokerToReplicaCountMap + (b -> 0)}
+    }
+
+    // map of rack id -> number of topic partition replicas in the rack
+    rackToReplicaCountMap = rackToBrokersMap map {
+      case (rack, brokers) => (rack, brokerToReplicaCountMap.filterKeys(brokers.contains).foldLeft(0)(_ + _._2))
+    }
+
+    // map of replica count -> brokers with that many replicas
+    replicaCountToBrokersMap = brokerToReplicaCountMap groupBy{_._2} map {
+      case (key, value) => (key, value.unzip._1.toArray)
+    }
+
+    // find minimum and maximum replica count in brokers
+    var replicaCountMsg = ""
+    brokers.foreach { b =>
+      val count = brokerToReplicaCountMap.get(b).get
+      replicaCountMsg = replicaCountMsg + "\t" + b + " -> " + count + "\n"
+      if (count < minBrokerReplicaCount)
+        minBrokerReplicaCount = count
+      else if (count > maxBrokerReplicaCount)
+        maxBrokerReplicaCount = count
+    }
+  }
+
+  def report(): Option[String] = {
+    if (maxBrokerReplicaCount <= minBrokerReplicaCount + 1)
+      return None
+
+    val msgBuilder = StringBuilder.newBuilder
+    msgBuilder.append("\n\nWarning: In the proposed assignment the most loaded broker (")
+    msgBuilder.append(replicaCountToBrokersMap.get(maxBrokerReplicaCount).get.toList.sortWith(_ < _).mkString(", "))
+    msgBuilder.append(") has ")
+
+    msgBuilder.append(minBrokerReplicaCount match {
+      case 0 => "many more replicas than "
+      case _ => f"${maxBrokerReplicaCount / (1.0 * minBrokerReplicaCount)}%.1f" + "x as many replicas as "
+    })
+
+    msgBuilder.append("the least loaded broker (")
+    msgBuilder.append(replicaCountToBrokersMap.get(minBrokerReplicaCount).get.toList.sortWith(_ < _).mkString(", "))
+    msgBuilder.append("). This is likely due to an uneven distribution of brokers across racks. You are advised to alter ")
+    msgBuilder.append("the rack configuration so there are approximately the same number of brokers per rack.\n\nStats ")
+    msgBuilder.append("for generated assignment:\n\n- Number of brokers per rack:\n")
+
+    rackToBrokersMap.toSeq.sortBy(_._1).foreach(t => msgBuilder.append("\t" + t._1 + " -> " + t._2.length + " (" + t._2.sortWith(_ < _).mkString(", ") + ")" + "\n"))
+    msgBuilder.append("\n- Number of replicas per broker:\n")
+
+    brokers.foreach { b =>
+      msgBuilder.append("\t" + b + " -> " + brokerToReplicaCountMap.get(b).get + "\n")
+    }
+
+    msgBuilder.append("\n- Number of replicas per rack:\n")
+    rackToReplicaCountMap.toSeq.sortBy(_._1).foreach(t => msgBuilder.append("\t" + t._1 + " -> " + t._2 + "\n"))
+    Some(msgBuilder.toString())
+  }
+}

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -12,11 +12,12 @@
   */
 package kafka.admin
 
-import kafka.utils.TestUtils
+import kafka.utils.{Logging, TestUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.junit.Test
+import org.junit.Assert.assertEquals
 
-class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with RackAwareTest {
+class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
 
   @Test
   def testRackAwareReassign() {
@@ -35,12 +36,103 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with RackAw
     kafka.admin.TopicCommand.createTopic(zkClient, createOpts)
 
     val topicJson = """{"topics": [{"topic": "foo"}], "version":1}"""
-    val (proposedAssignment, currentAssignment) = ReassignPartitionsCommand.generateAssignment(zkClient,
+    val (proposedAssignment, currentAssignment, _) = ReassignPartitionsCommand.generateAssignment(zkClient,
       rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = false)
 
     val assignment = proposedAssignment map { case (topicPartition, replicas) =>
       (topicPartition.partition, replicas)
     }
     checkReplicaDistribution(assignment, rackInfo, rackInfo.size, numPartitions, replicationFactor)
+  }
+
+  @Test
+  def testRackAwareReassignBalanceReportWithUnbalancedConfig() {
+    val rackInfo = Map(0 -> "rack1", 1 -> "rack1", 2 -> "rack1", 3 -> "rack2")
+    TestUtils.createBrokersInZk(toBrokerMetadata(rackInfo), zkClient)
+
+    val numPartitions = 10
+    val replicationFactor = 3
+
+    // create a non rack aware assignment topic first
+    val createOpts = new kafka.admin.TopicCommand.TopicCommandOptions(Array(
+      "--partitions", numPartitions.toString,
+      "--replication-factor", replicationFactor.toString,
+      "--disable-rack-aware",
+      "--topic", "foo"))
+    kafka.admin.TopicCommand.createTopic(zkClient, createOpts)
+
+    val topicJson = """{"topics": [{"topic": "foo"}], "version":1}"""
+    val (_, _, balanceReport1) = ReassignPartitionsCommand.generateAssignment(zkClient,
+      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = false)
+
+    // since there are three brokers in one rack and one in the other rack, the rack with one broker can get a maximum of 10
+    // replicas because otherwise two replicas of the same partition will be on the same broker. This means the three other
+    // brokers will get 7, 7, 6 replicas each in the most balanced case. But that is not the best balance overall, since one
+    // broker has quite a few more replicas (10 compared to 7 and 6). Therefore, there will be a broker balance report.
+    assertEquals(true, balanceReport1.nonEmpty)
+
+    val (_, _, balanceReport2) = ReassignPartitionsCommand.generateAssignment(zkClient,
+      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = true)
+
+    // if rack-aware is disabled there will be no broker balance report.
+    assertEquals(true, balanceReport2.isEmpty)
+  }
+
+  @Test
+  def testRackAwareReassignBalanceReportWithBalancedConfig() {
+    val rackInfo = Map(0 -> "rack1", 1 -> "rack1", 2 -> "rack2", 3 -> "rack2")
+    TestUtils.createBrokersInZk(toBrokerMetadata(rackInfo), zkClient)
+
+    val numPartitions = 15
+    val replicationFactor = 3
+
+    // create a non rack aware assignment topic first
+    val createOpts = new kafka.admin.TopicCommand.TopicCommandOptions(Array(
+      "--partitions", numPartitions.toString,
+      "--replication-factor", replicationFactor.toString,
+      "--disable-rack-aware",
+      "--topic", "foo"))
+    kafka.admin.TopicCommand.createTopic(zkClient, createOpts)
+
+    val topicJson = """{"topics": [{"topic": "foo"}], "version":1}"""
+    val (_, _, balanceReport1) = ReassignPartitionsCommand.generateAssignment(zkClient,
+      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = false)
+
+    assertEquals(true, balanceReport1.isEmpty)
+
+    val (_, _, balanceReport2) = ReassignPartitionsCommand.generateAssignment(zkClient,
+      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = true)
+
+    // if rack-aware is disabled there will be no broker balance report.
+    assertEquals(true, balanceReport2.isEmpty)
+  }
+
+  @Test
+  def testRackAwareReassignBalanceReportWithMinimalBalancedConfig() {
+    val rackInfo = Map(0 -> "rack1", 1 -> "rack2")
+    TestUtils.createBrokersInZk(toBrokerMetadata(rackInfo), zkClient)
+
+    val numPartitions = 1
+    val replicationFactor = 1
+
+    // create a non rack aware assignment topic first
+    val createOpts = new kafka.admin.TopicCommand.TopicCommandOptions(Array(
+      "--partitions", numPartitions.toString,
+      "--replication-factor", replicationFactor.toString,
+      "--disable-rack-aware",
+      "--topic", "foo"))
+    kafka.admin.TopicCommand.createTopic(zkClient, createOpts)
+
+    val topicJson = """{"topics": [{"topic": "foo"}], "version":1}"""
+    val (_, _, balanceReport1) = ReassignPartitionsCommand.generateAssignment(zkClient,
+      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = false)
+
+    assertEquals(true, balanceReport1.isEmpty)
+
+    val (_, _, balanceReport2) = ReassignPartitionsCommand.generateAssignment(zkClient,
+      rackInfo.keys.toSeq.sorted, topicJson, disableRackAware = true)
+
+    // if rack-aware is disabled there will be no broker balance report.
+    assertEquals(true, balanceReport2.isEmpty)
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/BrokerBalanceCheckTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/BrokerBalanceCheckTest.scala
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.admin
+
+import org.junit.Assert._
+import org.junit.Test
+import org.apache.kafka.common.TopicPartition
+
+class BrokerBalanceCheckTest {
+  val t1 = "topic1"
+  val t1p0 = new TopicPartition(t1, 0)
+  val t1p1 = new TopicPartition(t1, 1)
+  val t1p2 = new TopicPartition(t1, 2)
+  val t1p3 = new TopicPartition(t1, 3)
+
+
+  /**
+ 	* Config: three brokers on rack1 and one broker on rack 2
+ 	* Content: one topic with 4 partitions and 2 replicas
+ 	* Assignment: there are 8 replicas total, therefore each rack can get 4 replicas: 4 replicas for
+ 	* brokers 0, 1, 2, and 4 replicas for broker 3
+ 	* Balance: there is a more balanced config
+ 	*/
+  @Test
+  def testRackAwareBrokerBalanceWithUnbalancedConfig() {
+    val brokerMetadatas = Seq(
+        new BrokerMetadata(0, Some("rack1")),
+        new BrokerMetadata(1, Some("rack1")),
+        new BrokerMetadata(2, Some("rack1")),
+        new BrokerMetadata(3, Some("rack2"))
+    )
+    val assignment = Map(
+        t1p0 -> Seq(0, 3),
+        t1p1 -> Seq(1, 3),
+        t1p2 -> Seq(2, 3),
+        t1p3 -> Seq(0, 3)
+    )
+    val brokerBalanceCheck = new BrokerBalanceCheck(brokerMetadatas, assignment)
+    assertTrue(brokerBalanceCheck.report().nonEmpty)
+  }
+
+  /**
+ 	* Config: two brokers on rack1 and two brokers on rack 2
+ 	* Content: one topic with 4 partitions and 2 replicas
+ 	* Assignment: there are 8 replicas total, therefore each rack gets 4 replicas: 4 replicas for
+ 	* brokers 0, 1, and 4 replicas for brokers 2, 3
+ 	* Balance: the config is already balanced
+ 	*/
+  @Test
+  def testRackAwareBrokerBalanceWithBalancedConfig() {
+    val brokerMetadatas = Seq(
+        new BrokerMetadata(0, Some("rack1")),
+        new BrokerMetadata(1, Some("rack1")),
+        new BrokerMetadata(2, Some("rack2")),
+        new BrokerMetadata(3, Some("rack2"))
+    )
+    val assignment = Map(
+        t1p0 -> Seq(0, 2),
+        t1p1 -> Seq(1, 3),
+        t1p2 -> Seq(0, 2),
+        t1p3 -> Seq(1, 3)
+    )
+    val brokerBalanceCheck = new BrokerBalanceCheck(brokerMetadatas, assignment)
+    assertTrue(brokerBalanceCheck.report().isEmpty)
+  }
+
+  /**
+ 	* Config: two brokers on rack1 and one broker on rack 2
+ 	* Content: one topic with 4 partitions and 2 replicas
+ 	* Assignment: there are 8 replicas total, therefore each rack can get 4 replicas: 4 replicas for
+ 	* brokers 0, 1, and 4 replicas for broker 2
+ 	* Balance: there is no config that is more balanced
+ 	*/
+  @Test
+  def testRackAwareBrokerBalanceWithAlmostBalancedConfig() {
+    val brokerMetadatas = Seq(
+        new BrokerMetadata(0, Some("rack1")),
+        new BrokerMetadata(1, Some("rack1")),
+        new BrokerMetadata(2, Some("rack2"))
+    )
+    val assignment = Map(
+        t1p0 -> Seq(0, 2),
+        t1p1 -> Seq(1, 2),
+        t1p2 -> Seq(0, 2),
+        t1p3 -> Seq(1, 2)
+    )
+    val brokerBalanceCheck = new BrokerBalanceCheck(brokerMetadatas, assignment)
+    assertTrue(brokerBalanceCheck.report().isEmpty)
+  }
+}


### PR DESCRIPTION
When using the `--generate` option of the replica reassignment tool the balance of replicas across brokers is checked (only if rack-aware is enabled) and in case an imbalance is detected, a proper warning message is appended to the output of the tool (which is the suggested assignment).

An example warning message:

```
Warning: In the proposed assignment the most loaded broker (6) has 4.5x as many replicas as the least loaded broker (0). This is likely due to an uneven distribution of brokers across racks. You are advised to alter the rack configuration so there are approximately the same number of brokers per rack.

Stats for generated assignment:

- Number of brokers per rack:
    rack0 -> 3 (0, 1, 2)
    rack1 -> 3 (3, 4, 5)
    rack2 -> 1 (6)

- Number of replicas per broker:
    0 -> 2
    1 -> 5
    2 -> 3
    3 -> 4
    4 -> 4
    5 -> 3
    6 -> 9

- Number of replicas per rack:
    rack0 -> 10
    rack1 -> 11
    rack2 -> 9
```
