### PR TITLE
KAFKA-4213: First set of system tests for replication throttling, KIP-73.

### DIFF
--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -42,7 +42,7 @@ ZOOKEEPER_CONNECTION_TIMEOUT_MS = "zookeeper.connection.timeout.ms"
 INTER_BROKER_PROTOCOL_VERSION = "inter.broker.protocol.version"
 MESSAGE_FORMAT_VERSION = "log.message.format.version"
 MESSAGE_TIMESTAMP_TYPE = "message.timestamp.type"
-
+THROTTLING_REPLICATION_RATE_LIMIT = "replication.quota.throttled.rate"
 
 """
 From KafkaConfig.scala

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -137,45 +137,6 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         else:
             self.minikdc = None
 
-    def start_some(self, nodes_to_start, create_topics=True, add_principals=""):
-        """Starts a subset of alloted nodes.
-
-        Keyword arguments:
-            nodes_to_start -- a list of nodes to start. Node ids range from
-                [0 .. num_nodes)
-            create_topics -- whether or not to create the configured topics.
-         """
-        self.open_port(self.security_protocol)
-        self.open_port(self.interbroker_security_protocol)
-        self.start_minikdc(add_principals)
-        for node_id in nodes_to_start:
-            node = self.nodes[node_id]
-            # Added precaution - kill running processes, clean persistent files
-            # try/except for each step, since each of these steps may fail if
-            # there are no processes to kill or no files to remove
-            try:
-                self.stop_node(node)
-            except:
-                pass
-
-            try:
-                self.clean_node(node)
-            except:
-                pass
-
-            self.logger.debug("%s: starting node" % self.who_am_i(node))
-            self.start_node(node)
-
-        # Create topics if necessary
-        if create_topics is True:
-            if self.topics is not None:
-                for topic, topic_cfg in self.topics.items():
-                    if topic_cfg is None:
-                        topic_cfg = {}
-
-                    topic_cfg["topic"] = topic
-                    self.create_topic(topic_cfg)
-
     def start(self, add_principals=""):
         self.open_port(self.security_protocol)
         self.open_port(self.interbroker_security_protocol)

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -87,7 +87,6 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         wait_until(lambda: self.kafka.verify_reassign_partitions(partition_info), timeout_sec=self.timeout_sec, backoff_sec=.5)
 
     @parametrize(security_protocol="PLAINTEXT", bounce_brokers=False)
-    @parametrize(security_protocol="PLAINTEXT", bounce_brokers=True)
     def test_reassign_partitions(self, bounce_brokers, security_protocol):
         """Reassign partitions tests.
         Setup: 1 zk, 3 kafka nodes, 1 topic with partitions=3, replication-factor=3, and min.insync.replicas=2
@@ -106,5 +105,5 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         self.producer = VerifiableProducer(self.test_context, self.num_producers, self.kafka, self.topic, throughput=self.producer_throughput)
         self.consumer = ConsoleConsumer(self.test_context, self.num_consumers, self.kafka, self.topic, new_consumer=new_consumer, consumer_timeout_ms=60000, message_validator=is_int)
         self.kafka.start()
-        
+
         self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(bounce_brokers))

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -86,6 +86,7 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         # Wait until finished or timeout
         wait_until(lambda: self.kafka.verify_reassign_partitions(partition_info), timeout_sec=self.timeout_sec, backoff_sec=.5)
 
+    @parametrize(security_protocol="PLAINTEXT", bounce_brokers=True)
     @parametrize(security_protocol="PLAINTEXT", bounce_brokers=False)
     def test_reassign_partitions(self, bounce_brokers, security_protocol):
         """Reassign partitions tests.

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -69,13 +69,13 @@ class ThrottlingTest(ProduceConsumeValidateTest):
                                   })
         self.producer_throughput = 1000
         self.timeout_sec = 400
-        self.num_records = 5000
+        self.num_records = 2000
         self.record_size = 4096 * 100  # 400 KB
         # 1 MB per partition on average.
         self.partition_size = (self.num_records * self.record_size) / self.num_partitions
         self.num_producers = 2
         self.num_consumers = 1
-        self.throttle = 3 * 1024 * 1024  # 2 MB/s
+        self.throttle = 4 * 1024 * 1024  # 4 MB/s
 
     def setUp(self):
         self.zk.start()
@@ -96,9 +96,14 @@ class ThrottlingTest(ProduceConsumeValidateTest):
         self.logger.debug("Partitions before reassignment:" +
                           str(partition_info))
 
+
+        num_moves = 0
         for i in range(0, self.num_partitions):
-            partition_info["partitions"][i]["partition"] =\
-                (i+1) % self.num_partitions
+            old_replicas = set(partition_info["partitions"][i]["replicas"])
+            new_part = (i+1) % self.num_partitions
+            new_replicas = set(partition_info["partitions"][new_part]["replicas"])
+            num_moves = max(len(new_replicas - old_replicas), num_moves)
+            partition_info["partitions"][i]["partition"] = new_part
         self.logger.debug("Jumbled partitions: " + str(partition_info))
         # send reassign partitions command
 
@@ -110,8 +115,8 @@ class ThrottlingTest(ProduceConsumeValidateTest):
             self.clean_bounce_some_brokers()
 
         # Wait until finished or timeout
-        size_per_broker = self.partition_size
-        self.logger.debug("Amount of data transfer per broker: %fb",
+        size_per_broker = num_moves * self.partition_size
+        self.logger.debug("Max amount of data transfer per broker: %fb",
                           size_per_broker)
         estimated_throttled_time = math.ceil(float(size_per_broker) /
                                              self.throttle)
@@ -129,9 +134,9 @@ class ThrottlingTest(ProduceConsumeValidateTest):
                 estimated_throttled_time,
                 time_taken))
 
-    @parametrize(bounce_brokers=False, new_consumer=True)
-    @parametrize(bounce_brokers=False, new_consumer=False)
-    def test_throttled_reassignment(self, bounce_brokers, new_consumer):
+    @parametrize(bounce_brokers=False)
+    @parametrize(bounce_brokers=True)
+    def test_throttled_reassignment(self, bounce_brokers):
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol
         self.kafka.interbroker_security_protocol = security_protocol
@@ -155,7 +160,7 @@ class ThrottlingTest(ProduceConsumeValidateTest):
                                         self.num_consumers,
                                         self.kafka,
                                         self.topic,
-                                        new_consumer=new_consumer,
+                                        new_consumer=True,
                                         consumer_timeout_ms=60000,
                                         message_validator=is_int,
                                         from_beginning=False)

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -1,0 +1,173 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import math
+from ducktape.mark import parametrize
+from ducktape.utils.util import wait_until
+
+from kafkatest.services.performance import ProducerPerformanceService
+from kafkatest.services.zookeeper import ZookeeperService
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.console_consumer import ConsoleConsumer
+from kafkatest.tests.produce_consume_validate import ProduceConsumeValidateTest
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.utils import is_int
+
+
+class ThrottlingTest(ProduceConsumeValidateTest):
+    """
+    These tests validate partition reassignment.
+    Create a topic with few partitions, load some data, trigger partition
+    re-assignment with and without broker failure, check that partition
+    re-assignment can complete and there is no data loss.
+    """
+
+    def __init__(self, test_context):
+        """:type test_context: ducktape.tests.test.TestContext"""
+        super(ThrottlingTest, self).__init__(test_context=test_context)
+
+        self.topic = "test_topic"
+        self.zk = ZookeeperService(test_context, num_nodes=1)
+        # Because we are starting the producer/consumer/validate cycle _after_
+        # seeding the cluster with big data (to test throttling), we need to
+        # Start the consumer from the end of the stream. further, we need to
+        # ensure that the consumer is fully started before the producer starts
+        # so that we don't miss any messages. This delay ensures the sufficient
+        # condition.
+        self.delay_between_consumer_and_producer_start_sec = 10
+        self.num_brokers = 4
+        self.num_partitions = 4
+        self.kafka = KafkaService(test_context,
+                                  num_nodes=self.num_brokers,
+                                  zk=self.zk,
+                                  topics={
+                                      self.topic: {
+                                          "partitions": self.num_partitions,
+                                          "replication-factor": 1,
+                                          "configs": {
+                                              "segment.bytes": 64 * 1024 * 1024
+                                          }
+                                      }
+                                  })
+        self.producer_throughput = 1000
+        self.timeout_sec = 400
+        self.num_records = 5000
+        self.record_size = 4096 * 100  # 400 KB
+        # 1 MB per partition on average.
+        self.partition_size = (self.num_records * self.record_size) / self.num_partitions
+        self.num_producers = 2
+        self.num_consumers = 1
+        self.throttle = 4 * 1024 * 1024  # 2 MB/s
+
+    def setUp(self):
+        self.zk.start()
+
+    def min_cluster_size(self):
+        # Override this since we're adding services outside of the constructor
+        return super(ThrottlingTest, self).min_cluster_size() +\
+            self.num_producers + self.num_consumers
+
+    def clean_bounce_some_brokers(self):
+        """Bounce every other broker"""
+        for node in self.kafka.nodes[::2]:
+            self.kafka.restart_node(node, clean_shutdown=True)
+
+    def reassign_partitions(self, bounce_brokers, throttle):
+        partition_info = self.kafka.parse_describe_topic(
+            self.kafka.describe_topic(self.topic))
+        self.logger.debug("Partitions before reassignment:" +
+                          str(partition_info))
+
+        for i in range(0, self.num_partitions):
+            partition_info["partitions"][i]["partition"] =\
+                (i+1) % self.num_partitions
+        self.logger.debug("Jumbled partitions: " + str(partition_info))
+        # send reassign partitions command
+
+        self.kafka.execute_reassign_partitions(partition_info,
+                                               throttle=throttle)
+        start = time.time()
+        if bounce_brokers:
+            # bounce a few brokers at the same time
+            self.clean_bounce_some_brokers()
+
+        # Wait until finished or timeout
+        size_per_broker = self.partition_size
+        self.logger.debug("Amount of data transfer per broker: %fb",
+                          size_per_broker)
+        estimated_throttled_time = math.ceil(float(size_per_broker) /
+                                             self.throttle)
+        self.logger.debug("Waiting %ds for the reassignment to complete",
+                          estimated_throttled_time * 2)
+        wait_until(lambda: self.kafka.verify_reassign_partitions(partition_info),
+                   timeout_sec=estimated_throttled_time * 2, backoff_sec=.5)
+        stop = time.time()
+        time_taken = stop - start
+        self.logger.debug("Transfer took %d second. Estimated time : %ds",
+                          time_taken,
+                          estimated_throttled_time)
+        assert time_taken >= estimated_throttled_time, \
+            ("Expected rebalance to take at least %ds, but it took %ds" % (
+                estimated_throttled_time,
+                time_taken))
+
+    @parametrize(bounce_brokers=False, new_consumer=True)
+    @parametrize(bounce_brokers=False, new_consumer=False)
+    def test_throttled_reassignment(self, bounce_brokers, new_consumer):
+        """Tests throttled partition reassignment. This is essentially similar
+        to the reassign_partitions_test, except that we throttle the reassignment
+        and verify that it takes a sensible amount of time given the throttle
+        and the amount of data being moved.
+
+        Since the correctness is time dependent, this test also simplifies the
+        cluster topology. We have 4 brokers, 1 topic with 4 partitions, and a
+        replication-factor of 1. The reassignment moves every partition. Hence
+        the data transfer in and out of each broker is fixed, and we can make
+        very accurate predicitons about whether throttling is working or not.
+        """
+
+        security_protocol = 'PLAINTEXT'
+        self.kafka.security_protocol = security_protocol
+        self.kafka.interbroker_security_protocol = security_protocol
+
+        producer_id = 'bulk_producer'
+        bulk_producer = ProducerPerformanceService(
+            context=self.test_context, num_nodes=1, kafka=self.kafka,
+            topic=self.topic, num_records=self.num_records,
+            record_size=self.record_size, throughput=-1, client_id=producer_id,
+            jmx_object_names=['kafka.producer:type=producer-metrics,client-id=%s' % producer_id],
+            jmx_attributes=['outgoing-byte-rate'])
+
+
+        self.producer = VerifiableProducer(context=self.test_context,
+                                           num_nodes=1,
+                                           kafka=self.kafka, topic=self.topic,
+                                           message_validator=is_int,
+                                           throughput=self.producer_throughput)
+
+        self.consumer = ConsoleConsumer(self.test_context,
+                                        self.num_consumers,
+                                        self.kafka,
+                                        self.topic,
+                                        new_consumer=new_consumer,
+                                        consumer_timeout_ms=60000,
+                                        message_validator=is_int,
+                                        from_beginning=False)
+
+        self.kafka.start()
+        bulk_producer.run()
+        self.run_produce_consume_validate(core_test_action=
+                                          lambda: self.reassign_partitions(bounce_brokers, self.throttle))

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -52,7 +52,7 @@ class ThrottlingTest(ProduceConsumeValidateTest):
         # ensure that the consumer is fully started before the producer starts
         # so that we don't miss any messages. This delay ensures the sufficient
         # condition.
-        self.delay_between_consumer_and_producer_start_sec = 10
+        self.consumer_init_timeout_sec =  10
         self.num_brokers = 6
         self.num_partitions = 3
         self.kafka = KafkaService(test_context,

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -28,11 +28,16 @@ from kafkatest.utils import is_int
 
 
 class ThrottlingTest(ProduceConsumeValidateTest):
-    """
-    These tests validate partition reassignment.
-    Create a topic with few partitions, load some data, trigger partition
-    re-assignment with and without broker failure, check that partition
-    re-assignment can complete and there is no data loss.
+    """Tests throttled partition reassignment. This is essentially similar
+    to the reassign_partitions_test, except that we throttle the reassignment
+    and verify that it takes a sensible amount of time given the throttle
+    and the amount of data being moved.
+
+    Since the correctness is time dependent, this test also simplifies the
+    cluster topology. We have 4 brokers, 1 topic with 4 partitions, and a
+    replication-factor of 1. The reassignment moves every partition. Hence
+    the data transfer in and out of each broker is fixed, and we can make
+    very accurate predicitons about whether throttling is working or not.
     """
 
     def __init__(self, test_context):

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -50,7 +50,7 @@ class ThrottlingTest(ProduceConsumeValidateTest):
         # seeding the cluster with big data (to test throttling), we need to
         # Start the consumer from the end of the stream. further, we need to
         # ensure that the consumer is fully started before the producer starts
-        # so that we don't miss any messages. This delay ensures the sufficient
+        # so that we don't miss any messages. This timeout ensures the sufficient
         # condition.
         self.consumer_init_timeout_sec =  10
         self.num_brokers = 6

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 
@@ -50,7 +49,7 @@ class ProduceConsumeValidateTest(Test):
         if (self.delay_between_consumer_and_producer_start_sec > 0):
             self.logger.debug("Sleeping %ds between producer and consumer start",
                               self.delay_between_consumer_and_producer_start_sec)
-            wait_until(lambda: self.consumer.alive() is True,
+            wait_until(lambda: self.consumer.alive(self.consumer.nodes[0]) is True,
                        timeout_sec=self.delay_between_consumer_and_producer_start_sec,
                        err_msg="Consumer process took more than %d s to start" %\
                        self.delay_between_consumer_and_producer_start_sec)

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -32,13 +32,16 @@ class ProduceConsumeValidateTest(Test):
         # be overidden by inheriting classes.
         self.producer_start_timeout_sec = 20
 
+        # How long to wait for the consumer to start consuming messages?
+        self.consumer_start_timeout_sec = 60
+
         # How long to delay between the start of the producer and consumer? This
         # is important in the case when the consumer is starting from the end,
         # and we don't want it to miss any messages. The race condition this
         # timeout avoids is that the consumer is still starting after the
         # producer begins producing messages, in which case we will miss the
         # initial set of messages and get spurious test failures.
-        self.delay_between_consumer_and_producer_start_sec = 0
+        self.consumer_init_timeout_sec = 0
 
     def setup_producer_and_consumer(self):
         raise NotImplementedError("Subclasses should implement this")
@@ -46,13 +49,13 @@ class ProduceConsumeValidateTest(Test):
     def start_producer_and_consumer(self, async=False):
         # Start background producer and consumer
         self.consumer.start()
-        if (self.delay_between_consumer_and_producer_start_sec > 0):
+        if (self.consumer_init_timeout_sec > 0):
             self.logger.debug("Sleeping %ds between producer and consumer start",
-                              self.delay_between_consumer_and_producer_start_sec)
+                              self.consumer_init_timeout_sec)
             wait_until(lambda: self.consumer.alive(self.consumer.nodes[0]) is True,
-                       timeout_sec=self.delay_between_consumer_and_producer_start_sec,
+                       timeout_sec=self.consumer_init_timeout_sec,
                        err_msg="Consumer process took more than %d s to start" %\
-                       self.delay_between_consumer_and_producer_start_sec)
+                       self.consumer_init_timeout_sec)
 
         self.producer.start()
         wait_until(lambda: async or self.producer.num_acked > 5, timeout_sec=20,

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -108,7 +108,7 @@ class ProduceConsumeValidateTest(Test):
         if len(missing_list) < 20:
             msg += str(missing_list) + ". "
         else:
-            msg += ",".join(missing_list[:20])
+            msg += ", ".join(str(m) for m in missing_list[:20])
             msg += "...plus %s more. Total Acked: %s, Total Consumed: %s. " \
                    % (len(missing_list) - 20, len(set(acked)), len(set(consumed)))
         return msg

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import time
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
 
@@ -28,16 +30,32 @@ class ProduceConsumeValidateTest(Test):
 
     def __init__(self, test_context):
         super(ProduceConsumeValidateTest, self).__init__(test_context=test_context)
+        # How long to wait for the producer to declare itself healthy? This can
+        # be overidden by inheriting classes.
+        self.producer_start_timeout_sec = 60
+
+        # How long to delay between the start of the producer and consumer? This
+        # is important in the case when the consumer is starting from the end,
+        # and we don't want it to miss any messages. The race condition this
+        # timeout avoids is that the consumer is still starting after the
+        # producer begins producing messages, in which case we will miss the
+        # initial set of messages and get spurious test failures.
+        self.delay_between_consumer_and_producer_start_sec = 0
 
     def setup_producer_and_consumer(self):
         raise NotImplementedError("Subclasses should implement this")
 
     def start_producer_and_consumer(self, async=False):
         # Start background producer and consumer
+        self.consumer.start()
+        if (self.delay_between_consumer_and_producer_start_sec > 0):
+            self.logger.debug("Sleeping %ds between producer and consumer start",
+                              self.delay_between_consumer_and_producer_start_sec)
+
+        time.sleep(self.delay_between_consumer_and_producer_start_sec)
         self.producer.start()
         wait_until(lambda: async or self.producer.num_acked > 5, timeout_sec=20,
              err_msg="Producer failed to start in a reasonable amount of time.")
-        self.consumer.start()
         wait_until(lambda: async or len(self.consumer.messages_consumed[1]) > 0, timeout_sec=60,
              err_msg="Consumer failed to start in a reasonable amount of time.")
 
@@ -80,14 +98,16 @@ class ProduceConsumeValidateTest(Test):
 
     @staticmethod
     def annotate_missing_msgs(missing, acked, consumed, msg):
-        msg += "%s acked message did not make it to the Consumer. They are: " % len(missing)
-        if len(missing) < 20:
-            msg += str(missing) + ". "
+        missing_list = list(missing)
+        msg += "%s acked message did not make it to the Consumer. They are: " %\
+            len(missing_list)
+        if len(missing_list) < 20:
+            msg += str(missing_list) + ". "
         else:
             for i in range(20):
-                msg += str(missing.pop()) + ", "
+                msg += str(missing_list[i]) + ", "
             msg += "...plus %s more. Total Acked: %s, Total Consumed: %s. " \
-                   % (len(missing) - 20, len(set(acked)), len(set(consumed)))
+                   % (len(missing_list) - 20, len(set(acked)), len(set(consumed)))
         return msg
 
     @staticmethod


### PR DESCRIPTION
In this patch, we test `kafka-reassign-partitions` when throttling is active. 

This patch also fixes the following:
1. KafkaService.verify_reassign_partitions did not check whether
   partition reassignment actually completed successfully (KAFKA-4204).
   This patch works around those shortcomings so that we get the right
   signal from this method.
2. ProduceConsumeValidateTest.annotate_missing_messages would call
   `pop' on the list of missing messages, causing downstream methods to get
   incomplete data. We fix that in this patch as well.
