### PR TITLE
KAFKA-4216: Control Leader & Follower Throttled Replicas Separately

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -30,7 +30,7 @@ import kafka.utils.CoreUtils._
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.security.JaasUtils
 
-import scala.Seq
+import scala.{Iterable, Seq}
 
 object ReassignPartitionsCommand extends Logging {
 
@@ -321,7 +321,8 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, partitions: Map[TopicAndPartit
   }
 
   def assignThrottledReplicas(): Unit = {
-    val current = zkUtils.getReplicaAssignmentForTopics(partitions.map(_._1.topic).toSeq)
+    val topicsForMove = partitions.map { case (tp, _) => tp.topic }.toSeq
+    val current = zkUtils.getReplicaAssignmentForTopics(topicsForMove)
     assignThrottledReplicas(current, partitions)
   }
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -340,7 +340,9 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
       //Apply a follower throttle to all "move destinations".
       val follower = format(postRebalanceReplicasThatMoved(existing, proposed))
 
-      admin.changeTopicConfig(zkUtils, topic, propsWith((LeaderThrottledReplicasListProp, leader), (FollowerThrottledReplicasListProp, follower)))
+      admin.changeTopicConfig(zkUtils, topic, propsWith(
+        (LeaderThrottledReplicasListProp, leader),
+        (FollowerThrottledReplicasListProp, follower)))
 
       debug(s"Updated leader-throttled replicas for topic $topic with: $leader")
       debug(s"Updated follower-throttled replicas for topic $topic with: $follower")

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -352,14 +352,14 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   private def postRebalanceReplicasThatMoved(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     //For each partition in the proposed list, filter out any replicas that exist now (i.e. not moving)
     existing.map { case (tp, current) =>
-      tp -> proposed(tp).filterNot(current.toSet)
+      tp -> (proposed(tp).toSet -- current).toSeq
     }
   }
 
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     //Throttle all existing replicas (as any one might be a leader). So just filter out those which aren't moving
     existing.filter { case (tp, current) =>
-      proposed.get(tp).get.filterNot(current.toSet).size > 0
+      (proposed(tp).toSet -- current).nonEmpty
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -355,7 +355,6 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, partitions: Map[TopicAndPartit
     formatted
   }
 
-
   def filterBy(topic: String, allExisting: Map[TopicAndPartition, Seq[Int]], allProposed: Map[TopicAndPartition, Seq[Int]]): (Map[TopicAndPartition, Seq[Int]], Map[TopicAndPartition, Seq[Int]]) = {
     (allExisting.filter(_._1.topic == topic),
       allProposed.filter(_._1.topic == topic))

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -191,7 +191,7 @@ object ReassignPartitionsCommand extends Logging {
       throw new AdminCommandFailedException("Partition replica lists may not contain duplicate entries: %s".format(duplicatesMsg))
     }
     //Check that all partitions in the proposed assignment exist in the cluster
-    val proposedTopics = partitionsToBeReassigned.map { case (tp, _) => tp.topic }
+    val proposedTopics = partitionsToBeReassigned.map { case (tp, _) => tp.topic }.distinct
     val existingAssignment = zkUtils.getReplicaAssignmentForTopics(proposedTopics)
 
     if (!partitionsToBeReassigned.forall { case (tp, _) => existingAssignment.contains(tp) }) {
@@ -304,7 +304,7 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   extends Logging {
 
   def existingAssignment(): Map[TopicAndPartition, Seq[Int]] = {
-    val proposedTopics = proposedAssignment.map { case (tp, _) => tp.topic }.toSeq
+    val proposedTopics = proposedAssignment.keySet.map { tp => tp.topic }.toSeq.distinct
     zkUtils.getReplicaAssignmentForTopics(proposedTopics)
   }
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -20,13 +20,16 @@ import joptsimple.OptionParser
 import kafka.log.LogConfig
 import kafka.server.{DynamicConfig, ConfigType}
 import kafka.utils._
+
 import scala.collection._
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import kafka.common.{AdminCommandFailedException, TopicAndPartition}
+import kafka.log.LogConfig
 import kafka.log.LogConfig._
 import kafka.utils.CoreUtils._
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.security.JaasUtils
+
 import scala.Seq
 
 object ReassignPartitionsCommand extends Logging {

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -304,7 +304,7 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   extends Logging {
 
   def existingAssignment(): Map[TopicAndPartition, Seq[Int]] = {
-    val proposedTopics = proposedAssignment.keySet.map { tp => tp.topic }.toSeq.distinct
+    val proposedTopics = proposedAssignment.keySet.map { tp => tp.topic }.toSeq
     zkUtils.getReplicaAssignmentForTopics(proposedTopics)
   }
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -364,7 +364,9 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   }
 
   def format(moves: Map[TopicAndPartition, Seq[Int]]): String =
-    moves.map { case (tp, moves) => moves.map { replicaId => s"${tp.partition}:${replicaId}" } }.flatMap(x => x).mkString(",")
+    moves.flatMap { case (tp, moves) =>
+      moves.map(replicaId => s"${tp.partition}:${replicaId}")
+    }.mkString(",")
 
   def filterBy(topic: String, allExisting: Map[TopicAndPartition, Seq[Int]], allProposed: Map[TopicAndPartition, Seq[Int]]): (Map[TopicAndPartition, Seq[Int]], Map[TopicAndPartition, Seq[Int]]) = {
     (allExisting.filter(_._1.topic == topic),

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -17,10 +17,8 @@
 package kafka.admin
 
 import joptsimple.OptionParser
-import kafka.log.LogConfig
 import kafka.server.{DynamicConfig, ConfigType}
 import kafka.utils._
-
 import scala.collection._
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
 import kafka.common.{AdminCommandFailedException, TopicAndPartition}
@@ -29,8 +27,7 @@ import kafka.log.LogConfig._
 import kafka.utils.CoreUtils._
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.security.JaasUtils
-
-import scala.{Iterable, Seq}
+import scala.Seq
 
 object ReassignPartitionsCommand extends Logging {
 
@@ -336,7 +333,7 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, partitions: Map[TopicAndPartit
       //Apply a follower throttle to all "move destinations".
       val follower = format(postRebalanceReplicasThatMoved(existing, proposed))
 
-      admin.changeTopicConfig(zkUtils, topic, wrap((LeaderThrottledReplicasListProp, leader), (FollowerThrottledReplicasListProp, follower)))
+      admin.changeTopicConfig(zkUtils, topic, propsWith((LeaderThrottledReplicasListProp, leader), (FollowerThrottledReplicasListProp, follower)))
       info(s"Updated leader-throttled replicas for topic $topic with: $leader")
       info(s"Updated follower-throttled replicas for topic $topic with: $follower")
     }

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -17,20 +17,19 @@
 
 package kafka.log
 
-import java.util.Properties
+import java.util.{Collections, Locale, Properties}
 
 import scala.collection.JavaConverters._
 import kafka.api.ApiVersion
 import kafka.message.{BrokerCompressionCodec, Message}
-import kafka.server.{ThrottledReplicaListValidator, KafkaConfig}
+import kafka.server.{KafkaConfig, ThrottledReplicaListValidator}
 import org.apache.kafka.common.errors.InvalidConfigurationException
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef}
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.utils.Utils
-import java.util.Locale
 
 import scala.collection.mutable
-import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList,Validator}
+import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList, Validator}
 
 object Defaults {
   val SegmentSize = kafka.server.Defaults.LogSegmentBytes
@@ -55,8 +54,8 @@ object Defaults {
   val MessageFormatVersion = kafka.server.Defaults.LogMessageFormatVersion
   val MessageTimestampType = kafka.server.Defaults.LogMessageTimestampType
   val MessageTimestampDifferenceMaxMs = kafka.server.Defaults.LogMessageTimestampDifferenceMaxMs
-  val LeaderThrottledReplicasList = ""
-  val FollowerThrottledReplicasList = ""
+  val LeaderThrottledReplicasList = Collections.emptyList[String]()
+  val FollowerThrottledReplicasList = Collections.emptyList[String]()
 }
 
 case class LogConfig(props: java.util.Map[_, _]) extends AbstractConfig(LogConfig.configDef, props, false) {
@@ -87,8 +86,8 @@ case class LogConfig(props: java.util.Map[_, _]) extends AbstractConfig(LogConfi
   val messageFormatVersion = ApiVersion(getString(LogConfig.MessageFormatVersionProp))
   val messageTimestampType = TimestampType.forName(getString(LogConfig.MessageTimestampTypeProp))
   val messageTimestampDifferenceMaxMs = getLong(LogConfig.MessageTimestampDifferenceMaxMsProp).longValue
-  val leaderThrottledReplicasList = getString(LogConfig.LeaderThrottledReplicasListProp)
-  val followerThrottledReplicasList = getString(LogConfig.FollowerThrottledReplicasListProp)
+  val leaderThrottledReplicasList = getList(LogConfig.LeaderThrottledReplicasListProp)
+  val followerThrottledReplicasList = getList(LogConfig.FollowerThrottledReplicasListProp)
 
   def randomSegmentJitter: Long =
     if (segmentJitterMs == 0) 0 else Utils.abs(scala.util.Random.nextInt()) % math.min(segmentJitterMs, segmentMs)
@@ -290,8 +289,8 @@ object LogConfig {
         KafkaConfig.LogMessageTimestampTypeProp)
       .define(MessageTimestampDifferenceMaxMsProp, LONG, Defaults.MessageTimestampDifferenceMaxMs,
         atLeast(0), MEDIUM, MessageTimestampDifferenceMaxMsDoc, KafkaConfig.LogMessageTimestampDifferenceMaxMsProp)
-      .define(LeaderThrottledReplicasListProp, STRING, Defaults.LeaderThrottledReplicasList, ThrottledReplicaListValidator, MEDIUM, LeaderThrottledReplicasListDoc, LeaderThrottledReplicasListProp)
-      .define(FollowerThrottledReplicasListProp, STRING, Defaults.FollowerThrottledReplicasList, ThrottledReplicaListValidator, MEDIUM, FollowerThrottledReplicasListDoc, FollowerThrottledReplicasListProp)
+      .define(LeaderThrottledReplicasListProp, LIST, Defaults.LeaderThrottledReplicasList,ThrottledReplicaListValidator, MEDIUM, LeaderThrottledReplicasListDoc, LeaderThrottledReplicasListProp)
+      .define(FollowerThrottledReplicasListProp, LIST, Defaults.FollowerThrottledReplicasList, ThrottledReplicaListValidator, MEDIUM, FollowerThrottledReplicasListDoc, FollowerThrottledReplicasListProp)
   }
 
   def apply(): LogConfig = LogConfig(new Properties())

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -83,7 +83,7 @@ class TopicConfigHandler(private val logManager: LogManager, kafkaConfig: KafkaC
   def parseThrottledPartitions(topicConfig: Properties, brokerId: Int, prop: String): Seq[Int] = {
     val configValue = topicConfig.get(prop).toString.trim
     ThrottledReplicaListValidator.ensureValidString(prop, configValue)
-    configValue.trim match {
+    configValue match {
       case "" => Seq()
       case "*" => AllReplicas
       case _ => configValue.trim

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -22,7 +22,7 @@ import java.nio._
 import java.nio.channels._
 import java.util.concurrent.locks.{Lock, ReadWriteLock}
 import java.lang.management._
-import java.util.UUID
+import java.util.{Properties, UUID}
 import javax.management._
 import javax.xml.bind.DatatypeConverter
 
@@ -300,5 +300,11 @@ object CoreUtils extends Logging {
     val urlSafeBase64EncodedUUID = base64EncodedUUID.replace("+", "-").replace("/", "_")
     // Remove the "==" padding at the end.
     urlSafeBase64EncodedUUID.substring(0, urlSafeBase64EncodedUUID.length - 2)
+  }
+
+  def wrap(props: (String, String)*): Properties = {
+    val properties = new Properties()
+    props.foreach { prop => properties.put(prop._1, prop._2) }
+    properties
   }
 }

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -308,7 +308,7 @@ object CoreUtils extends Logging {
 
   def propsWith(props: (String, String)*): Properties = {
     val properties = new Properties()
-    props.foreach { prop => properties.put(prop._1, prop._2) }
+    props.foreach { case (k, v) => properties.put(k, v) }
     properties
   }
 }

--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -302,7 +302,11 @@ object CoreUtils extends Logging {
     urlSafeBase64EncodedUUID.substring(0, urlSafeBase64EncodedUUID.length - 2)
   }
 
-  def wrap(props: (String, String)*): Properties = {
+  def propsWith(key: String, value: String): Properties = {
+    propsWith((key, value))
+  }
+
+  def propsWith(props: (String, String)*): Properties = {
     val properties = new Properties()
     props.foreach { prop => properties.put(prop._1, prop._2) }
     properties

--- a/core/src/test/scala/unit/kafka/admin/AdminTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AdminTest.scala
@@ -440,7 +440,7 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
       checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1", quotaManagerIsThrottled = true)
 
       //Now ensure updating to "" removes the throttled replica list also
-      AdminUtils.changeTopicConfig(server.zkUtils, topic, TestUtils.wrap((LogConfig.FollowerThrottledReplicasListProp, ""), (LogConfig.LeaderThrottledReplicasListProp, "")))
+      AdminUtils.changeTopicConfig(server.zkUtils, topic, wrap((LogConfig.FollowerThrottledReplicasListProp, ""), (LogConfig.LeaderThrottledReplicasListProp, "")))
       checkConfig(Defaults.MaxMessageSize, Defaults.RetentionMs, Defaults.LeaderThrottledReplicasList, Defaults.LeaderThrottledReplicasList,  quotaManagerIsThrottled = false)
 
     } finally {

--- a/core/src/test/scala/unit/kafka/admin/AdminTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AdminTest.scala
@@ -34,6 +34,7 @@ import java.io.File
 import kafka.utils.TestUtils._
 import kafka.admin.AdminUtils._
 import scala.collection.{Map, immutable}
+import kafka.utils.CoreUtils._
 
 class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
 
@@ -440,7 +441,7 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
       checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1", quotaManagerIsThrottled = true)
 
       //Now ensure updating to "" removes the throttled replica list also
-      AdminUtils.changeTopicConfig(server.zkUtils, topic, wrap((LogConfig.FollowerThrottledReplicasListProp, ""), (LogConfig.LeaderThrottledReplicasListProp, "")))
+      AdminUtils.changeTopicConfig(server.zkUtils, topic, propsWith((LogConfig.FollowerThrottledReplicasListProp, ""), (LogConfig.LeaderThrottledReplicasListProp, "")))
       checkConfig(Defaults.MaxMessageSize, Defaults.RetentionMs, Defaults.LeaderThrottledReplicasList, Defaults.LeaderThrottledReplicasList,  quotaManagerIsThrottled = false)
 
     } finally {
@@ -467,12 +468,12 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
       val limit: Long = 1000000
 
       // Set the limit & check it is applied to the log
-      changeBrokerConfig(servers(0).zkUtils, brokerIds,  wrap((ThrottledReplicationRateLimitProp, limit.toString)))
+      changeBrokerConfig(servers(0).zkUtils, brokerIds,  propsWith(ThrottledReplicationRateLimitProp, limit.toString))
       checkConfig(limit)
 
       // Now double the config values for the topic and check that it is applied
       val newLimit = 2 * limit
-      changeBrokerConfig(servers(0).zkUtils, brokerIds,  wrap((ThrottledReplicationRateLimitProp, newLimit.toString)))
+      changeBrokerConfig(servers(0).zkUtils, brokerIds,  propsWith(ThrottledReplicationRateLimitProp, newLimit.toString))
       checkConfig(newLimit)
 
       // Verify that the same config can be read from ZK

--- a/core/src/test/scala/unit/kafka/admin/AdminTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AdminTest.scala
@@ -385,22 +385,24 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
     val topic = "my-topic"
     val server = TestUtils.createServer(KafkaConfig.fromProps(TestUtils.createBrokerConfig(0, zkConnect)))
 
-    def makeConfig(messageSize: Int, retentionMs: Long, throttledReplicas: String) = {
+    def makeConfig(messageSize: Int, retentionMs: Long, throttledLeaders: String, throttledFollowers: String) = {
       val props = new Properties()
       props.setProperty(LogConfig.MaxMessageBytesProp, messageSize.toString)
       props.setProperty(LogConfig.RetentionMsProp, retentionMs.toString)
-      props.setProperty(LogConfig.ThrottledReplicasListProp, throttledReplicas)
+      props.setProperty(LogConfig.LeaderThrottledReplicasListProp, throttledLeaders)
+      props.setProperty(LogConfig.FollowerThrottledReplicasListProp, throttledFollowers)
       props
     }
 
-    def checkConfig(messageSize: Int, retentionMs: Long, throttledReplicas: String, quotaManagerIsThrottled: Boolean) {
+    def checkConfig(messageSize: Int, retentionMs: Long, throttledLeaders: String, throttledFollowers: String, quotaManagerIsThrottled: Boolean) {
       TestUtils.retry(10000) {
         for(part <- 0 until partitions) {
           val log = server.logManager.getLog(TopicAndPartition(topic, part))
           assertTrue(log.isDefined)
           assertEquals(retentionMs, log.get.config.retentionMs)
           assertEquals(messageSize, log.get.config.maxMessageSize)
-          assertEquals(throttledReplicas, log.get.config.throttledReplicasList)
+          assertEquals(throttledLeaders, log.get.config.leaderThrottledReplicasList)
+          assertEquals(throttledFollowers, log.get.config.followerThrottledReplicasList)
           assertEquals(quotaManagerIsThrottled, server.quotaManagers.leader.isThrottled(new TopicAndPartition(topic, part)))
         }
       }
@@ -410,15 +412,20 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
       // create a topic with a few config overrides and check that they are applied
       val maxMessageSize = 1024
       val retentionMs = 1000 * 1000
-      AdminUtils.createTopic(server.zkUtils, topic, partitions, 1, makeConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0"))
+      AdminUtils.createTopic(server.zkUtils, topic, partitions, 1, makeConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1"))
 
-      //TODO - uncommenting this line reveals a bug. The quota manager is not updated when properties are added on topic creation.
-      //      checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", true)
+      //Standard topic configs will be propagated at topic creation time, but the quota manager will not have been updated.
+      checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1", false)
+
+      //Update dynamically and all properties should be applied
+      AdminUtils.changeTopicConfig(server.zkUtils, topic, makeConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1"))
+
+      checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1", true)
 
       // now double the config values for the topic and check that it is applied
-      val newConfig: Properties = makeConfig(2 * maxMessageSize, 2 * retentionMs, "*")
-      AdminUtils.changeTopicConfig(server.zkUtils, topic, makeConfig(2 * maxMessageSize, 2 * retentionMs, "*"))
-      checkConfig(2 * maxMessageSize, 2 * retentionMs, "*", quotaManagerIsThrottled = true)
+      val newConfig = makeConfig(2 * maxMessageSize, 2 * retentionMs, "*", "*")
+      AdminUtils.changeTopicConfig(server.zkUtils, topic, makeConfig(2 * maxMessageSize, 2 * retentionMs, "*", "*"))
+      checkConfig(2 * maxMessageSize, 2 * retentionMs, "*", "*", quotaManagerIsThrottled = true)
 
       // Verify that the same config can be read from ZK
       val configInZk = AdminUtils.fetchEntityConfig(server.zkUtils, ConfigType.Topic, topic)
@@ -426,15 +433,15 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
 
       //Now delete the config
       AdminUtils.changeTopicConfig(server.zkUtils, topic, new Properties)
-      checkConfig(Defaults.MaxMessageSize, Defaults.RetentionMs, Defaults.ThrottledReplicasList,  quotaManagerIsThrottled = false)
+      checkConfig(Defaults.MaxMessageSize, Defaults.RetentionMs, Defaults.LeaderThrottledReplicasList, Defaults.LeaderThrottledReplicasList, quotaManagerIsThrottled = false)
 
       //Add config back
-      AdminUtils.changeTopicConfig(server.zkUtils, topic, makeConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0"))
-      checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", quotaManagerIsThrottled = true)
+      AdminUtils.changeTopicConfig(server.zkUtils, topic, makeConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1"))
+      checkConfig(maxMessageSize, retentionMs, "0:0,1:0,2:0", "0:1,1:1,2:1", quotaManagerIsThrottled = true)
 
       //Now ensure updating to "" removes the throttled replica list also
-      AdminUtils.changeTopicConfig(server.zkUtils, topic, new Properties(){put(LogConfig.ThrottledReplicasListProp, "")})
-      checkConfig(Defaults.MaxMessageSize, Defaults.RetentionMs, Defaults.ThrottledReplicasList,  quotaManagerIsThrottled = false)
+      AdminUtils.changeTopicConfig(server.zkUtils, topic, TestUtils.wrap((LogConfig.FollowerThrottledReplicasListProp, ""), (LogConfig.LeaderThrottledReplicasListProp, "")))
+      checkConfig(Defaults.MaxMessageSize, Defaults.RetentionMs, Defaults.LeaderThrottledReplicasList, Defaults.LeaderThrottledReplicasList,  quotaManagerIsThrottled = false)
 
     } finally {
       server.shutdown()
@@ -460,12 +467,12 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
       val limit: Long = 1000000
 
       // Set the limit & check it is applied to the log
-      changeBrokerConfig(servers(0).zkUtils, brokerIds,  wrapInProps(ThrottledReplicationRateLimitProp, limit.toString))
+      changeBrokerConfig(servers(0).zkUtils, brokerIds,  wrap((ThrottledReplicationRateLimitProp, limit.toString)))
       checkConfig(limit)
 
       // Now double the config values for the topic and check that it is applied
       val newLimit = 2 * limit
-      changeBrokerConfig(servers(0).zkUtils, brokerIds,  wrapInProps(ThrottledReplicationRateLimitProp, newLimit.toString))
+      changeBrokerConfig(servers(0).zkUtils, brokerIds,  wrap((ThrottledReplicationRateLimitProp, newLimit.toString)))
       checkConfig(newLimit)
 
       // Verify that the same config can be read from ZK

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -127,7 +127,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     ReassignPartitionsCommand.executeAssignment(zkUtils, ZkUtils.formatAsReassignmentJson(newAssignment), initialThrottle)
 
     //Check throttle config. Should be throttling replica 0 on 100 and 102 only.
-    checkThrottleConfigAddedToZK(initialThrottle, servers, topicName, "0:100,0:102")
+    checkThrottleConfigAddedToZK(initialThrottle, servers, topicName, "0:100,0:101", "0:102")
 
     //Await completion
     waitForReassignmentToComplete()
@@ -177,8 +177,14 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     ReassignPartitionsCommand.executeAssignment(zkUtils, ZkUtils.formatAsReassignmentJson(newAssignment), throttle)
 
     //Check throttle config. Should be throttling specific replicas for each topic.
-    checkThrottleConfigAddedToZK(throttle, servers, "topic1", "1:101,1:102,0:101,0:102")
-    checkThrottleConfigAddedToZK(throttle, servers, "topic2", "1:103,1:104,0:103,0:104")
+    checkThrottleConfigAddedToZK(throttle, servers, "topic1",
+      "1:100,1:101,0:100,0:101", //All replicas for moving partitions should be leader-throttled
+      "1:102,0:102" //Move destinations should be follower throttled.
+    )
+    checkThrottleConfigAddedToZK(throttle, servers, "topic2",
+      "1:104,1:105,0:104,0:105", //All replicas for moving partitions should be leader-throttled
+      "1:103,0:103" //Move destinations should be follower throttled.
+    )
   }
 
   @Test
@@ -200,13 +206,13 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     ReassignPartitionsCommand.executeAssignment(zkUtils, ZkUtils.formatAsReassignmentJson(newAssignment), initialThrottle)
 
     //Check throttle config
-    checkThrottleConfigAddedToZK(initialThrottle, servers, topicName, "0:100,0:102")
+    checkThrottleConfigAddedToZK(initialThrottle, servers, topicName, "0:100,0:101", "0:102")
 
     //Ensure that running Verify, whilst the command is executing, should have no effect
     ReassignPartitionsCommand.verifyAssignment(zkUtils, ZkUtils.formatAsReassignmentJson(newAssignment))
 
     //Check throttle config again
-    checkThrottleConfigAddedToZK(initialThrottle, servers, topicName, "0:100,0:102")
+    checkThrottleConfigAddedToZK(initialThrottle, servers, topicName, "0:100,0:101", "0:102")
 
     //Now re-run the same assignment with a larger throttle, which should only act to increase the throttle and make progress
     val newThrottle = initialThrottle * 1000
@@ -214,7 +220,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     ReassignPartitionsCommand.executeAssignment(zkUtils, ZkUtils.formatAsReassignmentJson(newAssignment), newThrottle)
 
     //Check throttle was changed
-    checkThrottleConfigAddedToZK(newThrottle, servers, topicName, "0:100,0:102")
+    checkThrottleConfigAddedToZK(newThrottle, servers, topicName, "0:100,0:101", "0:102")
 
     //Await completion
     waitForReassignmentToComplete()

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -113,7 +113,7 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging wi
           case "topic2" =>
             assertEquals("0:100", configChange.get(FollowerThrottledReplicasListProp))
             assertEquals("0:101,0:102", configChange.get(LeaderThrottledReplicasListProp))
-          case _ => fail()
+          case _ => fail("Unexpected topic $topic")
         }
       }
     }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -60,12 +60,12 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging wi
     val proposed = Map(TopicAndPartition("topic1",0) -> Seq(101, 102), control)
 
       //When
-    val destinations = assigner.destinationReplicas(existing, proposed)
-    val sources = assigner.sourceReplicas(existing, proposed)
+    val moves = assigner.topicToLeaderAndFollowerThrottles(existing, proposed)
 
     //Then moving replicas should be throttled
-    assertEquals("0:102", destinations.get("topic1").get) //Should only follower throttle the moving replica
-    assertEquals("0:100,0:101", sources.get("topic1").get) //Should leader-throttle all existing (pre move) replicas
+    val (leader, follower) = moves.get("topic1").get
+    assertEquals("0:102", follower) //Should only follower throttle the moving replica
+    assertEquals("0:100,0:101", leader) //Should leader-throttle all existing (pre move) replicas
   }
 
   @Test
@@ -78,12 +78,12 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging wi
     val proposed = Map(TopicAndPartition("topic1",0) -> Seq(101, 102), TopicAndPartition("topic1",1) -> Seq(101, 102), control)
 
       //When
-    val destinations = assigner.destinationReplicas(existing, proposed)
-    val sources = assigner.sourceReplicas(existing, proposed)
+    val moves = assigner.topicToLeaderAndFollowerThrottles(existing, proposed)
 
     //Then moving replicas should be throttled
-    assertEquals("0:102,1:102", destinations.get("topic1").get) //Should only follower throttle the moving replica
-    assertEquals("0:100,0:101,1:100,1:101", sources.get("topic1").get) //Should leader-throttle all existing (pre move) replicas
+    val (leader, follower) = moves.get("topic1").get
+    assertEquals("0:102,1:102", follower) //Should only follower throttle the moving replica
+    assertEquals("0:100,0:101,1:100,1:101", leader) //Should leader-throttle all existing (pre move) replicas
   }
 
   @Test
@@ -96,14 +96,15 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging wi
     val proposed = Map(TopicAndPartition("topic1",0) -> Seq(101, 102), TopicAndPartition("topic2",0) -> Seq(101, 102), control)
 
     //When
-    val destinations = assigner.destinationReplicas(existing, proposed)
-    val sources = assigner.sourceReplicas(existing, proposed)
+    val moves = assigner.topicToLeaderAndFollowerThrottles(existing, proposed)
 
     //Then moving replicas should be throttled
-    assertEquals("0:102", destinations.get("topic1").get)
-    assertEquals("0:100,0:101", sources.get("topic1").get)
-    assertEquals("0:102", destinations.get("topic2").get)
-    assertEquals("0:100,0:101", sources.get("topic2").get)
+    val (leaderT1, followerT1) = moves.get("topic1").get
+    val (leaderT2, followerT2) = moves.get("topic2").get
+    assertEquals("0:102", followerT1)
+    assertEquals("0:100,0:101", leaderT1)
+    assertEquals("0:102", followerT2)
+    assertEquals("0:100,0:101", leaderT2)
   }
 
   @Test
@@ -125,14 +126,15 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging wi
     )
 
     //When
-    val destinations = assigner.destinationReplicas(existing, proposed)
-    val sources = assigner.sourceReplicas(existing, proposed)
+    val moves = assigner.topicToLeaderAndFollowerThrottles(existing, proposed)
 
     //Then moving replicas should be throttled
-    assertEquals("0:102,1:102", destinations.get("topic1").get)
-    assertEquals("0:100,0:101,1:100,1:101", sources.get("topic1").get)
-    assertEquals("0:102,1:102", destinations.get("topic2").get)
-    assertEquals("0:100,0:101,1:100,1:101", sources.get("topic2").get)
+    val (leaderT1, followerT1) = moves.get("topic1").get
+    val (leaderT2, followerT2) = moves.get("topic2").get
+    assertEquals("0:102,1:102", followerT1)
+    assertEquals("0:100,0:101,1:100,1:101", leaderT1)
+    assertEquals("0:102,1:102", followerT2)
+    assertEquals("0:100,0:101,1:100,1:101", leaderT2)
   }
 
   @Test
@@ -145,11 +147,11 @@ class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging wi
     val proposed = Map(TopicAndPartition("topic1",0) -> Seq(100, 101, 104, 105), control)
 
     //When
-    val destinations = assigner.destinationReplicas(existing, proposed)
-    val sources = assigner.sourceReplicas(existing, proposed)
+    val moves = assigner.topicToLeaderAndFollowerThrottles(existing, proposed)
 
     //Then moving replicas should be throttled
-    assertEquals( "0:104,0:105", destinations.get("topic1").get)
-    assertEquals( "0:100,0:101,0:102,0:103", sources.get("topic1").get)
+    val (leader, follower) = moves.get("topic1").get
+    assertEquals( "0:104,0:105", follower)
+    assertEquals( "0:100,0:101,0:102,0:103", leader)
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -1,19 +1,19 @@
 /**
-  * Licensed to the Apache Software Foundation (ASF) under one or more
-  * contributor license agreements.  See the NOTICE file distributed with
-  * this work for additional information regarding copyright ownership.
-  * The ASF licenses this file to You under the Apache License, Version 2.0
-  * (the "License"); you may not use this file except in compliance with
-  * the License.  You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.admin
 
 import java.util.Properties

--- a/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
@@ -27,12 +27,13 @@ object ReplicationQuotaUtils {
         !brokerConfig.contains(DynamicConfig.Broker.ThrottledReplicationRateLimitProp)
       }
       val topicConfig = AdminUtils.fetchEntityConfig(servers(0).zkUtils, ConfigType.Topic, topic)
-      val topicReset = !topicConfig.contains(LogConfig.ThrottledReplicasListProp)
-      brokerReset && topicReset
+      val topicReset = ! (topicConfig.contains(LogConfig.LeaderThrottledReplicasListProp)
+        || topicConfig.contains(LogConfig.FollowerThrottledReplicasListProp))
+        brokerReset && topicReset
     }, "Throttle limit/replicas was not unset")
   }
 
-  def checkThrottleConfigAddedToZK(expectedThrottleRate: Long, servers: Seq[KafkaServer], topic: String, throttledReplicas: String): Boolean = {
+  def checkThrottleConfigAddedToZK(expectedThrottleRate: Long, servers: Seq[KafkaServer], topic: String, throttledLeaders: String, throttledFollowers: String): Boolean = {
     TestUtils.waitUntilTrue(() => {
       //Check for limit in ZK
       val brokerConfigAvailable = servers.forall { server =>
@@ -42,9 +43,9 @@ object ReplicationQuotaUtils {
       }
       //Check replicas assigned
       val topicConfig = AdminUtils.fetchEntityConfig(servers(0).zkUtils, ConfigType.Topic, topic)
-      val property: String = topicConfig.getProperty(LogConfig.ThrottledReplicasListProp)
-      println(topic + "we found "+property)
-      val topicConfigAvailable = property == throttledReplicas
+      val leader = topicConfig.getProperty(LogConfig.LeaderThrottledReplicasListProp)
+      val follower = topicConfig.getProperty(LogConfig.FollowerThrottledReplicasListProp)
+      val topicConfigAvailable = (leader == throttledLeaders && follower ==throttledFollowers)
       brokerConfigAvailable && topicConfigAvailable
     }, "throttle limit/replicas was not set")
   }

--- a/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReplicationQuotaUtils.scala
@@ -27,9 +27,9 @@ object ReplicationQuotaUtils {
         !brokerConfig.contains(DynamicConfig.Broker.ThrottledReplicationRateLimitProp)
       }
       val topicConfig = AdminUtils.fetchEntityConfig(servers(0).zkUtils, ConfigType.Topic, topic)
-      val topicReset = ! (topicConfig.contains(LogConfig.LeaderThrottledReplicasListProp)
+      val topicReset = !(topicConfig.contains(LogConfig.LeaderThrottledReplicasListProp)
         || topicConfig.contains(LogConfig.FollowerThrottledReplicasListProp))
-        brokerReset && topicReset
+      brokerReset && topicReset
     }, "Throttle limit/replicas was not unset")
   }
 
@@ -45,7 +45,7 @@ object ReplicationQuotaUtils {
       val topicConfig = AdminUtils.fetchEntityConfig(servers(0).zkUtils, ConfigType.Topic, topic)
       val leader = topicConfig.getProperty(LogConfig.LeaderThrottledReplicasListProp)
       val follower = topicConfig.getProperty(LogConfig.FollowerThrottledReplicasListProp)
-      val topicConfigAvailable = (leader == throttledLeaders && follower ==throttledFollowers)
+      val topicConfigAvailable = (leader == throttledLeaders && follower == throttledFollowers)
       brokerConfigAvailable && topicConfigAvailable
     }, "throttle limit/replicas was not set")
   }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -74,18 +74,21 @@ class LogConfigTest {
     assertTrue(isValid("100:10,12:10"))
     assertTrue(isValid("100:10,12:10,15:1"))
     assertTrue(isValid("100:10,12:10,15:1  "))
+    assertTrue(isValid("100:0,"))
 
     assertFalse(isValid("100"))
     assertFalse(isValid("100:"))
-    assertFalse(isValid("100:0,"))
     assertFalse(isValid("100:0,10"))
     assertFalse(isValid("100:0,10:"))
     assertFalse(isValid("100:0,10:   "))
+    assertFalse(isValid("100 :0,10:   "))
+    assertFalse(isValid("100: 0,10:   "))
+    assertFalse(isValid("100:0,10 :   "))
   }
 
   private def isValid(configValue: String): Boolean = {
     try {
-      ThrottledReplicaListValidator.ensureValid("", configValue)
+      ThrottledReplicaListValidator.ensureValidString("", configValue)
     } catch {
       case e: ConfigException => return false
     }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -19,7 +19,7 @@ package kafka.log
 
 import java.util.Properties
 
-import kafka.server.{ThrottledReplicaValidator, KafkaConfig, KafkaServer}
+import kafka.server.{ThrottledReplicaListValidator, KafkaConfig, KafkaServer}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.config.ConfigException
 import org.junit.{Assert, Test}
@@ -85,7 +85,7 @@ class LogConfigTest {
 
   private def isValid(configValue: String): Boolean = {
     try {
-      ThrottledReplicaValidator.ensureValid("", configValue)
+      ThrottledReplicaListValidator.ensureValid("", configValue)
     } catch {
       case e: ConfigException => return false
     }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -239,4 +239,18 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     //Then
     assertEquals(Seq(), result)
   }
+
+  @Test
+  def shouldParseRegardlessOfWhitespaceAroundValues() {
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null)
+    assertEquals(AllReplicas, parse(configHandler, "* "))
+    assertEquals(Seq(), parse(configHandler, " "))
+    assertEquals(Seq(6), parse(configHandler, "6:102"))
+    assertEquals(Seq(6), parse(configHandler, "6:102 "))
+    assertEquals(Seq(6), parse(configHandler, " 6:102"))
+  }
+
+  def parse(configHandler: TopicConfigHandler, value: String): Seq[Int] = {
+    configHandler.parseThrottledPartitions(CoreUtils.propsWith(LeaderThrottledReplicasListProp, value), 102, LeaderThrottledReplicasListProp)
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -231,7 +231,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val props: Properties = new Properties()
 
     //Given
-    props.put(LeaderThrottledReplicasListProp, "")
+    props.put(FollowerThrottledReplicasListProp, "")
 
     //When
     val result = configHandler.parseThrottledPartitions(props, 102, FollowerThrottledReplicasListProp)

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -234,7 +234,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     props.put(LeaderThrottledReplicasListProp, "")
 
     //When
-    val result = configHandler.parseThrottledPartitions(props, 102, LeaderThrottledReplicasListProp)
+    val result = configHandler.parseThrottledPartitions(props, 102, FollowerThrottledReplicasListProp)
 
     //Then
     assertEquals(Seq(), result)

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -203,11 +203,11 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val props: Properties = new Properties()
 
     //Given
-    props.put(ThrottledReplicasListProp, "0:101,0:102,1:101,1:102")
+    props.put(LeaderThrottledReplicasListProp, "0:101,0:102,1:101,1:102")
 
     //When/Then
-    assertEquals(Seq(0,1), configHandler.parseThrottledPartitions(props, 102))
-    assertEquals(Seq(), configHandler.parseThrottledPartitions(props, 103))
+    assertEquals(Seq(0,1), configHandler.parseThrottledPartitions(props, 102, LeaderThrottledReplicasListProp))
+    assertEquals(Seq(), configHandler.parseThrottledPartitions(props, 103, LeaderThrottledReplicasListProp))
   }
 
   @Test
@@ -216,10 +216,10 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val props: Properties = new Properties()
 
     //Given
-    props.put(ThrottledReplicasListProp, "*")
+    props.put(LeaderThrottledReplicasListProp, "*")
 
     //When
-    val result = configHandler.parseThrottledPartitions(props, 102)
+    val result = configHandler.parseThrottledPartitions(props, 102, LeaderThrottledReplicasListProp)
 
     //Then
     assertEquals(AllReplicas, result)
@@ -231,10 +231,10 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
     val props: Properties = new Properties()
 
     //Given
-    props.put(ThrottledReplicasListProp, "")
+    props.put(LeaderThrottledReplicasListProp, "")
 
     //When
-    val result = configHandler.parseThrottledPartitions(props, 102)
+    val result = configHandler.parseThrottledPartitions(props, 102, LeaderThrottledReplicasListProp)
 
     //Then
     assertEquals(Seq(), result)

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -17,12 +17,12 @@
 package kafka.server
 
 import kafka.admin.AdminUtils
-import kafka.utils.TestUtils._
 import kafka.utils.ZkUtils
 import org.I0Itec.zkclient.ZkClient
 import org.apache.kafka.common.config._
 import org.easymock.EasyMock
 import org.junit.{Before, Test}
+import kafka.utils.CoreUtils._
 
 class DynamicConfigTest {
   private final val nonExistentConfig: String = "some.config.that.does.not.exist"
@@ -38,21 +38,21 @@ class DynamicConfigTest {
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailWhenChangingBrokerUnknownConfig() {
-    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), wrap((nonExistentConfig, someValue)))
+    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), propsWith(nonExistentConfig, someValue))
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailWhenChangingClientIdUnknownConfig() {
-    AdminUtils.changeClientIdConfig(zkUtils, "ClientId", wrap((nonExistentConfig, someValue)))
+    AdminUtils.changeClientIdConfig(zkUtils, "ClientId", propsWith(nonExistentConfig, someValue))
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailWhenChangingUserUnknownConfig() {
-    AdminUtils.changeUserOrUserClientIdConfig(zkUtils, "UserId", wrap((nonExistentConfig, someValue)))
+    AdminUtils.changeUserOrUserClientIdConfig(zkUtils, "UserId", propsWith(nonExistentConfig, someValue))
   }
 
   @Test(expected = classOf[ConfigException])
   def shouldFailConfigsWithInvalidValues() {
-    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), wrap((DynamicConfig.Broker.ThrottledReplicationRateLimitProp, "-100")))
+    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), propsWith(DynamicConfig.Broker.ThrottledReplicationRateLimitProp, "-100"))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigTest.scala
@@ -38,21 +38,21 @@ class DynamicConfigTest {
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailWhenChangingBrokerUnknownConfig() {
-    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), wrapInProps(nonExistentConfig, someValue))
+    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), wrap((nonExistentConfig, someValue)))
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailWhenChangingClientIdUnknownConfig() {
-    AdminUtils.changeClientIdConfig(zkUtils, "ClientId", wrapInProps(nonExistentConfig, someValue))
+    AdminUtils.changeClientIdConfig(zkUtils, "ClientId", wrap((nonExistentConfig, someValue)))
   }
 
   @Test(expected = classOf[IllegalArgumentException])
   def shouldFailWhenChangingUserUnknownConfig() {
-    AdminUtils.changeUserOrUserClientIdConfig(zkUtils, "UserId", wrapInProps(nonExistentConfig, someValue))
+    AdminUtils.changeUserOrUserClientIdConfig(zkUtils, "UserId", wrap((nonExistentConfig, someValue)))
   }
 
   @Test(expected = classOf[ConfigException])
   def shouldFailConfigsWithInvalidValues() {
-    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), wrapInProps(DynamicConfig.Broker.ThrottledReplicationRateLimitProp, "-100"))
+    AdminUtils.changeBrokerConfig(zkUtils, Seq(0), wrap((DynamicConfig.Broker.ThrottledReplicationRateLimitProp, "-100")))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -25,8 +25,8 @@ import kafka.common._
 import kafka.log.LogConfig._
 import kafka.server.KafkaConfig.fromProps
 import kafka.server.QuotaType._
-import kafka.utils.TestUtils
 import kafka.utils.TestUtils._
+import kafka.utils.CoreUtils._
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.junit.Assert._
@@ -105,14 +105,14 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
     //Set the throttle limit on all 8 brokers, but only assign throttled replicas to the six leaders, or two followers
     (100 to 107).foreach { brokerId =>
-      changeBrokerConfig(zkUtils, Seq(brokerId), wrap((DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString)))
+      changeBrokerConfig(zkUtils, Seq(brokerId), propsWith(DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString))
     }
 
     //Either throttle the six leaders or the two followers
     if (leaderThrottle)
-      changeTopicConfig(zkUtils, topic, wrap((LeaderThrottledReplicasListProp, "0:100,1:101,2:102,3:103,4:104,5:105" )))
+      changeTopicConfig(zkUtils, topic, propsWith(LeaderThrottledReplicasListProp, "0:100,1:101,2:102,3:103,4:104,5:105" ))
     else
-      changeTopicConfig(zkUtils, topic, wrap((FollowerThrottledReplicasListProp, "0:106,1:106,2:106,3:107,4:107,5:107")))
+      changeTopicConfig(zkUtils, topic, propsWith(FollowerThrottledReplicasListProp, "0:106,1:106,2:106,3:107,4:107,5:107"))
 
     //Add data equally to each partition
     producer = createNewProducer(getBrokerListStrFromServers(brokers), retries = 5, acks = 0)
@@ -189,8 +189,8 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     val throttle: Long = msg.length * msgCount / expectedDuration
 
     //Set the throttle limit leader
-    changeBrokerConfig(zkUtils, Seq(100), wrap((DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString)))
-    changeTopicConfig(zkUtils, topic, wrap((LeaderThrottledReplicasListProp, "0:100")))
+    changeBrokerConfig(zkUtils, Seq(100), propsWith(DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString))
+    changeTopicConfig(zkUtils, topic, propsWith(LeaderThrottledReplicasListProp, "0:100"))
 
     //Add data
     addData(msgCount, msg)

--- a/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicationQuotasTest.scala
@@ -105,12 +105,14 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
 
     //Set the throttle limit on all 8 brokers, but only assign throttled replicas to the six leaders, or two followers
     (100 to 107).foreach { brokerId =>
-      changeBrokerConfig(zkUtils, Seq(brokerId), wrapInProps(DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString))
+      changeBrokerConfig(zkUtils, Seq(brokerId), wrap((DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString)))
     }
 
     //Either throttle the six leaders or the two followers
-    val throttledReplicas = if (leaderThrottle) "0:100,1:101,2:102,3:103,4:104,5:105" else "0:106,1:106,2:106,3:107,4:107,5:107"
-    changeTopicConfig(zkUtils, topic, wrapInProps(ThrottledReplicasListProp, throttledReplicas))
+    if (leaderThrottle)
+      changeTopicConfig(zkUtils, topic, wrap((LeaderThrottledReplicasListProp, "0:100,1:101,2:102,3:103,4:104,5:105" )))
+    else
+      changeTopicConfig(zkUtils, topic, wrap((FollowerThrottledReplicasListProp, "0:106,1:106,2:106,3:107,4:107,5:107")))
 
     //Add data equally to each partition
     producer = createNewProducer(getBrokerListStrFromServers(brokers), retries = 5, acks = 0)
@@ -187,8 +189,8 @@ class ReplicationQuotasTest extends ZooKeeperTestHarness {
     val throttle: Long = msg.length * msgCount / expectedDuration
 
     //Set the throttle limit leader
-    changeBrokerConfig(zkUtils, Seq(100), wrapInProps(DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString))
-    changeTopicConfig(zkUtils, topic, wrapInProps(ThrottledReplicasListProp, "0:100"))
+    changeBrokerConfig(zkUtils, Seq(100), wrap((DynamicConfig.Broker.ThrottledReplicationRateLimitProp, throttle.toString)))
+    changeTopicConfig(zkUtils, topic, wrap((LeaderThrottledReplicasListProp, "0:100")))
 
     //Add data
     addData(msgCount, msg)

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1125,12 +1125,6 @@ object TestUtils extends Logging {
     assertTrue(s"$message failed with exception(s) $exceptions", exceptions.isEmpty)
 
   }
-
-  def wrap(props: (String, String)*): Properties = {
-    val properties = new Properties()
-    props.foreach{prop => properties.put(prop._1, prop._2)}
-    properties
-  }
 }
 
 class IntEncoder(props: VerifiableProperties = null) extends Encoder[Int] {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1126,12 +1126,11 @@ object TestUtils extends Logging {
 
   }
 
-  def wrapInProps(key: String, value: String): Properties = {
-    val props: Properties = new Properties()
-    props.put(key, value)
-    props
+  def wrap(props: (String, String)*): Properties = {
+    val properties = new Properties()
+    props.foreach{prop => properties.put(prop._1, prop._2)}
+    properties
   }
-
 }
 
 class IntEncoder(props: VerifiableProperties = null) extends Encoder[Int] {


### PR DESCRIPTION
Splits the throttled replica configuration (the list of which replicas should be throttled for each topic) into two. One for the leader throttle, one for the follower throttle.

So:
 quota.replication.throttled.replicas
=> 
quota.leader.replication.throttled.replicas & quota.follower.replication.throttled.replicas
