### PR TITLE
KAFKA-3175 (Rebased) : topic not accessible after deletion even when delete.topic.enable is disabled

### DIFF
--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -87,8 +87,16 @@ class TopicDeletionManager(controller: KafkaController,
   var deleteTopicsThread: DeleteTopicsThread = null
   val isDeleteTopicEnabled = controller.config.deleteTopicEnable
   val topicsToBeDeleted: mutable.Set[String] = mutable.Set.empty[String]
-  if (isDeleteTopicEnabled)
+  if (isDeleteTopicEnabled) {
     topicsToBeDeleted ++= initialTopicsToBeDeleted
+  }
+  else {
+    // if delete topic is disabled clean the topic entries under /admin/delete_topics
+    for (topic <- initialTopicsToBeDeleted) {
+      cleanZkStateForDeleteTopic(topic)
+    }
+  }
+
   val partitionsToBeDeleted: mutable.Set[TopicAndPartition] = topicsToBeDeleted.flatMap(controllerContext.partitionsForTopic)
 
   /**


### PR DESCRIPTION
Rebased the patch with current trunk.
