### PR TITLE
HOTFIX: fix npe in StreamsMetadataState when onChange has not been called

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -234,7 +234,7 @@ public class StreamsMetadataState {
     }
 
     private boolean isInitialized() {
-        return !clusterMetadata.topics().isEmpty();
+        return clusterMetadata != null && !clusterMetadata.topics().isEmpty();
     }
 
     private class SourceTopicsInfo {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -115,6 +115,11 @@ public class StreamsMetadataStateTest {
     }
 
     @Test
+    public void shouldNotThrowNPEWhenOnChangeNotCalled() throws Exception {
+        new StreamsMetadataState(builder).getAllMetadataForStore("store");
+    }
+
+    @Test
     public void shouldGetAllStreamInstances() throws Exception {
         final StreamsMetadata one = new StreamsMetadata(hostOne, Utils.mkSet("table-one", "table-two", "merged-table"),
                 Utils.mkSet(topic1P0, topic2P1, topic4P0));


### PR DESCRIPTION
If some StreamsMetadataState methods are called before the onChange method is called a NullPointerException was being thrown. Added null check for cluster in isInitialized method
