### PR TITLE
KAFKA-4227: Shutdown AdminManager when KafkaServer is shutdown

### DIFF
--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -155,4 +155,8 @@ class AdminManager(val config: KafkaConfig,
       topicPurgatory.tryCompleteElseWatch(delayedDelete, delayedDeleteKeys)
     }
   }
+
+  def shutdown() {
+    topicPurgatory.shutdown()
+  }
 }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -589,6 +589,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
         CoreUtils.swallow(authorizer.foreach(_.close()))
         if(replicaManager != null)
           CoreUtils.swallow(replicaManager.shutdown())
+        if (adminManager != null)
+          CoreUtils.swallow(adminManager.shutdown())
         if(logManager != null)
           CoreUtils.swallow(logManager.shutdown())
         if(groupCoordinator != null)


### PR DESCRIPTION
Terminate topic purgatory thread in AdminManager during server shutdown to avoid threads being left around in unit tests.
