### PR TITLE
KAFKA-4228 - make producer close on sender thread death, make consumer shutdown on failure to rebalance, and make MM die on any of the above.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -323,6 +323,17 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                     this.requestTimeoutMs);
             String ioThreadName = "kafka-producer-network-thread" + (clientId.length() > 0 ? " | " + clientId : "");
             this.ioThread = new KafkaThread(ioThreadName, this.sender, true);
+            this.ioThread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    try {
+                        log.error("Thread " + t.getName() + " died due to uncaught exception", e);
+                    } finally {
+                        close(0, TimeUnit.MILLISECONDS); //cant wait to properly flush, because the thread doing the flushing just died
+                    }
+
+                }
+            });
             this.ioThread.start();
 
             this.errors = this.metrics.sensor("errors");

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -126,41 +126,51 @@ public class Sender implements Runnable {
      * The main run loop for the sender thread
      */
     public void run() {
-        log.debug("Starting Kafka producer I/O thread.");
-
-        // main loop, runs until close is called
-        while (running) {
-            try {
-                run(time.milliseconds());
-            } catch (Exception e) {
-                log.error("Uncaught error in kafka producer I/O thread: ", e);
-            }
-        }
-
-        log.debug("Beginning shutdown of Kafka producer I/O thread, sending remaining records.");
-
-        // okay we stopped accepting requests but there may still be
-        // requests in the accumulator or waiting for acknowledgment,
-        // wait until these are completed.
-        while (!forceClose && (this.accumulator.hasUnsent() || this.client.inFlightRequestCount() > 0)) {
-            try {
-                run(time.milliseconds());
-            } catch (Exception e) {
-                log.error("Uncaught error in kafka producer I/O thread: ", e);
-            }
-        }
-        if (forceClose) {
-            // We need to fail all the incomplete batches and wake up the threads waiting on
-            // the futures.
-            this.accumulator.abortIncompleteBatches();
-        }
+        boolean gracefulShutdown = false;
         try {
-            this.client.close();
-        } catch (Exception e) {
-            log.error("Failed to close network client", e);
-        }
+            log.debug("Starting Kafka producer I/O thread.");
 
-        log.debug("Shutdown of Kafka producer I/O thread has completed.");
+            // main loop, runs until close is called
+            while (running) {
+                try {
+                    run(time.milliseconds());
+                } catch (Exception e) {
+                    log.error("Uncaught error in kafka producer I/O thread: ", e);
+                }
+            }
+
+            log.debug("Beginning shutdown of Kafka producer I/O thread, sending remaining records.");
+
+            // okay we stopped accepting requests but there may still be
+            // requests in the accumulator or waiting for acknowledgment,
+            // wait until these are completed.
+            while (!forceClose && (this.accumulator.hasUnsent() || this.client.inFlightRequestCount() > 0)) {
+                try {
+                    run(time.milliseconds());
+                } catch (Exception e) {
+                    log.error("Uncaught error in kafka producer I/O thread: ", e);
+                }
+            }
+            if (forceClose) {
+                // We need to fail all the incomplete batches and wake up the threads waiting on
+                // the futures.
+                this.accumulator.abortIncompleteBatches();
+            }
+            try {
+                this.client.close();
+            } catch (Exception e) {
+                log.error("Failed to close network client", e);
+            }
+
+            log.debug("Shutdown of Kafka producer I/O thread has completed.");
+            gracefulShutdown = true;
+        } finally {
+            //make sure to clean up any pending batches. this is a nop on graceful shutdown
+            if (!gracefulShutdown) {
+                forceClose();
+                this.accumulator.abortIncompleteBatches();
+            }
+        }
     }
 
     /**

--- a/core/src/main/scala/kafka/consumer/ZookeeperConsumerConnector.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperConsumerConnector.scala
@@ -588,7 +588,9 @@ private[kafka] class ZookeeperConsumerConnector(val config: ConsumerConfig,
             if (doRebalance)
               syncedRebalance
           } catch {
-            case t: Throwable => error("error during syncedRebalance", t)
+            case t: Throwable =>
+              error("Error during syncedRebalance", t)
+              shutdown()
           }
         }
         info("stopping watcher executor thread for consumer " + consumerIdString)

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -434,6 +434,10 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
               records.foreach(producer.send)
               maybeFlushAndCommitOffsets()
             }
+            if (!mirrorMakerConsumer.hasData && !shuttingDown && !exitingOnSendFailure) {
+              //consumer has closed (due to error)
+              throw new IllegalStateException("Consumer has shut down")
+            }
           } catch {
             case cte: ConsumerTimeoutException =>
               trace("Caught ConsumerTimeoutException, continue iteration.")


### PR DESCRIPTION
the JIRA issue (https://issues.apache.org/jira/browse/KAFKA-4228) details a cascade of failures that resulted in an entire mirror maker cluster stalling due to an OOM death on one mm instance.

this patch makes producers and consumers close themselves on the errors encountered, and mm to shut down if anything happens to producers or consumers.

Signed-off-by: radai-rosenblatt radai.rosenblatt@gmail.com
