### PR TITLE
KAFKA-4108: Improve DumpLogSegments offsets-decoder output format

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -337,8 +337,8 @@ object DumpLogSegments {
       val keyString = Json.encode(Map("metadata" -> groupId))
       val valueString = Json.encode(Map(
           "protocolType" -> protocolType,
-          "groupMetadata.protocol" -> group.protocol,
-          "groupMetadata.generationId" -> group.generationId,
+          "protocol" -> group.protocol,
+          "generationId" -> group.generationId,
           "assignment" -> assignment))
 
       (Some(keyString), Some(valueString))

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -334,8 +334,12 @@ object DumpLogSegments {
         }
       }.mkString("{", ",", "}")
 
-      val keyString = s"metadata::$groupId"
-      val valueString = s"$protocolType:${group.protocol}:${group.generationId}:$assignment"
+      val keyString = Json.encode(Map("metadata" -> groupId))
+      val valueString = Json.encode(Map(
+          "protocolType" -> protocolType,
+          "groupMetadata.protocol" -> group.protocol,
+          "groupMetadata.generationId" -> group.generationId,
+          "assignment" -> assignment))
 
       (Some(keyString), Some(valueString))
     }


### PR DESCRIPTION
This PR improves the output format of DumpLogSegments when the `--offset-decoder` option is used for consuming `__consumer_offsets`, especially when it comes to group metadata.

An example of the partial output with existing formatting:

```
key: metadata::console-consumer-40190 payload: consumer:range:1:{consumer-1-20240b92-fbf4-44d5-bf8c-66b6d70c9948=[foo-0]}
```

An example of the same output with suggested formatting:

```
key: {"metadata":"console-consumer-40190"} payload: {"protocolType":"consumer","protocol":"range","generationId":1,"assignment":"{consumer-1-20240b92-fbf4-44d5-bf8c-66b6d70c9948=[foo-0]}"}
```
