### PR TITLE
KAFKA-4245: Don't swallow IOExceptions

### DIFF
--- a/core/src/main/scala/kafka/network/BlockingChannel.scala
+++ b/core/src/main/scala/kafka/network/BlockingChannel.scala
@@ -17,6 +17,7 @@
 
 package kafka.network
 
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.nio.channels._
 
@@ -82,7 +83,9 @@ class BlockingChannel( val host: String,
                          connectTimeoutMs))
 
       } catch {
-        case e: Throwable => disconnect()
+        case e: Throwable =>
+          disconnect()
+          throw new IOException("Connecting to %s:%d failed".format(host, port), e)
       }
     }
   }

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -494,8 +494,14 @@ class KafkaServer(val config: KafkaConfig, time: Time = SystemTime, threadNamePr
                   BlockingChannel.UseDefaultBufferSize,
                   BlockingChannel.UseDefaultBufferSize,
                   config.controllerSocketTimeoutMs)
-                channel.connect()
-                prevController = broker
+                try {
+                  channel.connect()
+                  prevController = broker
+                } catch {
+                  case ioe: IOException =>
+                    warn(ioe)
+                    channel = null
+                }
               }
             case None => //ignore and try again
           }

--- a/core/src/test/scala/unit/kafka/network/BlockingChannelTest.scala
+++ b/core/src/test/scala/unit/kafka/network/BlockingChannelTest.scala
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.network;
+
+import java.io.IOException
+
+import kafka.network.BlockingChannel
+
+import org.junit.Assert._
+import org.junit._
+import org.scalatest.junit.JUnitSuite
+
+class BlockingChannelTest extends JUnitSuite {
+
+  @Test
+  def testConnectFailure() {
+    val channel = new BlockingChannel("localhost", -1 /* Connecting on this port will fail */, 1024, 1024, 1000)
+    try {
+      channel.connect()
+      fail("Connecting to an invalid port should fail")
+    } catch {
+      case ioe: IOException => // Expected
+    }
+    assertFalse(channel.isConnected)
+  }
+
+}


### PR DESCRIPTION
Remove swallowing of exceptions from BlockingChannel#connect.

This commit also slightly reworks the handling of a
BlockingChannel in KafkaServer to correctly handle the possibility
of an IOException being thrown by BlockingChannel#connect().

Note that I'm totally new to Scala, so any advice on anything I might
be doing here that is unconventional or just plain wrong is 
certainly welcome.
