### PR TITLE
MINOR: Add Replication Quotas Test Rig

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -393,7 +393,6 @@ project(':core') {
     compile libs.slf4jlog4j
     compile libs.zkclient
     compile libs.zookeeper
-    compile libs.jfreechart
     // These modules were broken out of core scala in 2.10. We can remove special handling when 2.10 support is dropped.
     if (versions.baseScala != '2.10') {
       compile libs.scalaParserCombinators
@@ -415,6 +414,7 @@ project(':core') {
     testCompile libs.apachedsJdbmPartition
     testCompile libs.junit
     testCompile libs.scalaTest
+    testCompile libs.jfreechart
 
     scoverage libs.scoveragePlugin
     scoverage libs.scoverageRuntime

--- a/build.gradle
+++ b/build.gradle
@@ -393,6 +393,7 @@ project(':core') {
     compile libs.slf4jlog4j
     compile libs.zkclient
     compile libs.zookeeper
+    compile libs.jfreechart
     // These modules were broken out of core scala in 2.10. We can remove special handling when 2.10 support is dropped.
     if (versions.baseScala != '2.10') {
       compile libs.scalaParserCombinators

--- a/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
@@ -36,10 +36,6 @@ import org.jfree.data.xy.{XYSeries, XYSeriesCollection}
 import scala.collection.JavaConverters._
 import scala.collection.{Seq, mutable}
 
-/**
-  * This requires the JFreechart libraries on the classpath (I lazily never added them to the build) https://sourceforge.net/projects/jfreechart/files/1.%20JFreeChart/
-  */
-
 object ReplicationQuotasPerformance {
   new File("Experiments").mkdir()
   val dir = "Experiments/Run" + System.currentTimeMillis().toString.substring(8)

--- a/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
@@ -109,7 +109,6 @@ object ReplicationQuotasPerformance {
       super.tearDown()
     }
 
-
     def run(config: Config) {
       experimentName = config.name
       val replicaSpread = config.brokers
@@ -180,7 +179,7 @@ object ReplicationQuotasPerformance {
         printRateMetrics()
         val success = !zkUtils.pathExists(ReassignPartitionsPath)
         success
-      }, s"Znode ${ZkUtils.ReassignPartitionsPath} wasn't deleted after " + (200), Int.MaxValue)
+      }, s"Znode ${ZkUtils.ReassignPartitionsPath} wasn't deleted", Int.MaxValue, pause = 1000L)
 
       println("Showing leader chart")
       showChart(leaderRates, "Leader")

--- a/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
@@ -1,0 +1,272 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package other.kafka
+
+import java.awt.image.BufferedImage
+import java.io.{FileOutputStream, PrintWriter, File}
+import javax.imageio.ImageIO
+
+import kafka.admin.ReassignPartitionsCommand
+import kafka.common.TopicAndPartition
+import kafka.server.{KafkaConfig, KafkaServer, QuotaType}
+import kafka.utils.TestUtils._
+import kafka.utils.ZkUtils._
+import kafka.utils.{CoreUtils, Logging, TestUtils, ZkUtils}
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.jfree.chart.plot.PlotOrientation
+import org.jfree.chart.{ChartFactory, ChartFrame, JFreeChart}
+import org.jfree.data.xy.{XYSeries, XYSeriesCollection}
+
+import scala.collection.JavaConverters._
+import scala.collection.{Seq, mutable}
+
+/**
+  * This requires the JFreechart libraries on the classpath (I lazily never added them to the build) https://sourceforge.net/projects/jfreechart/files/1.%20JFreeChart/
+  */
+
+object ReplicationQuotasPerformance {
+  new File("Experiments").mkdir()
+  val dir = "Experiments/Run" + System.currentTimeMillis().toString.substring(8)
+  new File(dir).mkdir()
+
+
+  def main(args: Array[String]): Unit = {
+    val configs = Seq(
+      new Config("Experiment1", brokers = 5, partitions = 50, throttle = 1000 * 1000, msgCount = 100, msgSize = 100 * 1000),
+      new Config("Experiment2", brokers = 5, partitions = 50, throttle = 10 * 1000 * 1000, msgCount = 10 * 100, msgSize = 100 * 1000),
+      new Config("Experiment3", brokers = 50, partitions = 50, throttle = 2 * 1000 * 1000, msgCount = 10 * 100, msgSize = 100 * 1000),
+      new Config("Experiment4", brokers = 25, partitions = 100, throttle = 4 * 1000 * 1000, msgCount = 1 * 1000, msgSize = 100 * 1000),
+      new Config("Experiment5", brokers = 5, partitions = 50, throttle = 50 * 1000 * 1000, msgCount = 1 * 1000, msgSize = 100 * 1000)
+
+    )
+//    System.exit(0)
+    configs.foreach(run(_))
+  }
+
+  def run(config: Config) {
+    val experiment = new Experiment()
+    try {
+      experiment.setUp
+      experiment.run(config)
+    } finally {
+      experiment.tearDown
+    }
+  }
+
+  case class Config(name: String, brokers: Int, partitions: Int, throttle: Long, msgCount: Int, msgSize: Int) {
+    val targetBytesPerBrokerMB: Long = msgCount.toLong * msgSize.toLong * partitions.toLong / brokers.toLong / 1000000
+    val file = new File(s"$dir/Log.txt")
+    writeToFile
+
+    def writeToFile(): Unit = {
+      val stream = new FileOutputStream(
+        file,
+        true)
+      val message = s"\n\n$name " +
+        s"\n\t- BrokerCount: $brokers" +
+        s"\n\t- PartitionCount: $partitions" +
+        f"\n\t- Throttle: $throttle%,.0f MB/s" +
+        f"\n\t- MsgCount: $msgCount%,.0f " +
+        f"\n\t- MsgSize: $msgSize%,.0f " +
+        s"\n\t- TargetBytesPerBrokerMB: $targetBytesPerBrokerMB\n\n"
+
+      new PrintWriter(stream) {
+        append(message)
+        close
+      }
+      println(message)
+    }
+  }
+
+  class Experiment extends ZooKeeperTestHarness with Logging {
+    val topicName = "my-topic"
+    var experimentName = "unset"
+    val partitionId = 0
+    var servers: Seq[KafkaServer] = null
+    val leaderRates = mutable.Map[Int, Array[Double]]()
+    val followerRates = mutable.Map[Int, Array[Double]]()
+
+    def startBrokers(brokerIds: Seq[Int]) {
+      servers = brokerIds.map(i => createBrokerConfig(i, zkConnect))
+        .map(c => createServer(KafkaConfig.fromProps(c)))
+    }
+
+    override def tearDown() {
+      servers.par.foreach(_.shutdown())
+      servers.par.foreach(server => CoreUtils.delete(server.config.logDirs))
+      super.tearDown()
+    }
+
+
+    def run(config: Config) {
+      experimentName = config.name
+      val replicaSpread = config.brokers
+      val brokers = (100 to 100 + config.brokers)
+
+      var count = 0
+      def nextReplicaRoundRobin(): Int = {
+        count = count + 1
+        if (count == replicaSpread) count = 0
+        100 + count
+      }
+      val replicas = (0 to config.partitions).map(partition => partition -> Seq(nextReplicaRoundRobin())).toMap
+
+      println("Starting Brokers")
+      startBrokers(brokers)
+      createTopic(zkUtils, topicName, replicas, servers)
+      println("Writing Data")
+      val producer = TestUtils.createNewProducer(TestUtils.getBrokerListStrFromServers(servers), retries = 5, acks = 0)
+      (0 to config.msgCount).foreach { x =>
+        (0 to config.partitions).foreach { partition =>
+          producer.send(new ProducerRecord(topicName, partition, null, new Array[Byte](config.msgSize)))
+        }
+      }
+      println("Starting Reassignment")
+
+      val newAssignment = ReassignPartitionsCommand.generateAssignment(zkUtils, brokers, json(topicName), true)._1
+      ReassignPartitionsCommand.executeAssignment(zkUtils, ZkUtils.formatAsReassignmentJson(newAssignment), config.throttle)
+
+      //Await completion
+      waitForReassignmentToComplete()
+
+      //Logging
+      val actual = zkUtils.getPartitionAssignmentForTopics(Seq(topicName))(topicName)
+      val existing = zkUtils.getReplicaAssignmentForTopics(newAssignment.map(_._1.topic).toSeq)
+      val moves = new ReassignPartitionsCommand(zkUtils, newAssignment).replicaMoves(existing, newAssignment)
+      val allMoves = moves.get(topicName)
+      val physicalMoves = allMoves.get.split(",").size / 2
+
+
+      //Long stats
+      println("Creating replicas: " + replicas)
+      println("This is the current replica assignment:\n" + actual.toSeq)
+      println("moves are: " + allMoves)
+      println("This is the assigment we eneded up with" + actual)
+
+      //Test Stats
+      println(s"numBrokers: ${config.brokers}")
+      println(s"numPartitions: ${config.partitions}")
+      println(s"throttle: ${config.throttle}")
+      println(s"numMessages: ${config.msgCount}")
+      println(s"msgSize: ${config.msgSize}")
+      println(s"We will write ${config.targetBytesPerBrokerMB / 1000000}MB of data per broker")
+      println("Worst case duration is " + config.targetBytesPerBrokerMB / config.throttle)
+      println("move count is : " + physicalMoves)
+    }
+
+
+    private def waitForOffsetsToMatch(offset: Int, partitionId: Int, broker: KafkaServer, topic: String): Boolean = {
+      waitUntilTrue(() => {
+        offset == broker.getLogManager.getLog(TopicAndPartition(topic, partitionId))
+          .map(_.logEndOffset).getOrElse(0)
+      }, s"Offsets did not match for partition $partitionId on broker ${broker.config.brokerId}", 60000)
+    }
+
+
+    def waitForReassignmentToComplete() {
+      waitUntilTrue(() => {
+        printRateMetrics()
+        val success = !zkUtils.pathExists(ReassignPartitionsPath)
+        success
+      }, s"Znode ${ZkUtils.ReassignPartitionsPath} wasn't deleted after " + (200), Int.MaxValue)
+
+      println("Showing leader chart")
+      showChart(leaderRates, "Leader")
+      println("Showing follower chart")
+      showChart(followerRates, "Follower")
+    }
+
+    def showChart(data: mutable.Map[Int, Array[Double]], name: String): Unit = {
+      val dataset = new XYSeriesCollection
+
+      data.foreach { case (broker, values) =>
+        println("Found values for broker " + broker + " = " + values.map(_.toString).toSeq)
+        val series = new XYSeries("Broker:" + broker)
+        var x = 0
+        values.foreach { value =>
+          series.add(x, value)
+          x = x + 1
+        }
+        dataset.addSeries(series)
+      }
+
+      val chart: JFreeChart = ChartFactory.createXYLineChart(
+        experimentName + " - " + name + " Throttling Performance",
+        "Time (s)",
+        "Throttle Throughput (B/s)",
+        dataset
+        , PlotOrientation.VERTICAL, false, true, false
+      )
+      val frame = new ChartFrame(
+        experimentName,
+        chart
+      )
+
+      saveToFile(chart.createBufferedImage(1000, 700), experimentName + "-" + name)
+      frame.pack()
+      frame.setVisible(true)
+    }
+
+    def saveToFile(img: BufferedImage, name: String) {
+      val out = new File(dir + "/" + name + ".png")
+      ImageIO.write(img, "png", out)
+    }
+
+    def record(rates: mutable.Map[Int, Array[Double]], brokerId: Int, currentRate: Double) = {
+      var leaderRatesBroker: Array[Double] = rates.getOrElse(brokerId, Array[Double]())
+      leaderRatesBroker = leaderRatesBroker ++ Array(currentRate)
+      rates.put(brokerId, leaderRatesBroker)
+    }
+
+    def printRateMetrics() {
+      //    println("Printing rates on servers "+ servers)
+      for (broker <- servers) {
+        val leaderRate: Double = measuredRate(broker, QuotaType.LeaderReplication)
+
+        if (broker.config.brokerId == 100)
+          warn("waiting... Leader rate on 101 is " + leaderRate)
+
+        record(leaderRates, broker.config.brokerId, leaderRate)
+        if (leaderRate > 0)
+          trace("Leader Rate on " + broker.config.brokerId + " is " + leaderRate)
+
+        val followerRate: Double = measuredRate(broker, QuotaType.FollowerReplication)
+        record(followerRates, broker.config.brokerId, followerRate)
+        if (followerRate > 0)
+          trace("Follower Rate on " + broker.config.brokerId + " is " + followerRate)
+      }
+
+    }
+
+    private def measuredRate(broker: KafkaServer, repType: QuotaType): Double = {
+      val metricName = broker.metrics.metricName("byte-rate", repType.toString)
+      if (broker.metrics.metrics.asScala.contains(metricName))
+        broker.metrics.metrics.asScala(metricName).value
+      else -1
+    }
+
+    def json(topic: String*): String = {
+      val topicStr = topic.map {
+        t => "{\"topic\": \"" + t + "\"}"
+      }.mkString(",")
+      s"""{"topics": [$topicStr],"version":1}"""
+    }
+  }
+}
+

--- a/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasPerformance.scala
@@ -41,18 +41,21 @@ object ReplicationQuotasPerformance {
   private val dir = "Experiments/Run" + System.currentTimeMillis().toString.substring(8)
   new File(dir).mkdir()
   private val log = new File(dir, "Log.txt")
-  private val showGraphsOnExperimentCompletion = true
+  private var showGraphsOnExperimentCompletion = false
 
   def main(args: Array[String]): Unit = {
+    if (args.length > 0 && args(0) == "graph") showGraphsOnExperimentCompletion = true
+
     val configs = Seq(
-      new Config("Experiment1", brokers = 5, partitions = 50, throttle = 1000 * 1000, msgCount = 100, msgSize = 100 * 1000),
+      new Config("Experiment1", brokers = 5, partitions = 5, throttle = 1000 * 1000, msgCount = 100, msgSize = 100 * 1000),
       new Config("Experiment2", brokers = 5, partitions = 50, throttle = 10 * 1000 * 1000, msgCount = 10 * 100, msgSize = 100 * 1000),
       new Config("Experiment3", brokers = 50, partitions = 50, throttle = 2 * 1000 * 1000, msgCount = 10 * 100, msgSize = 100 * 1000),
       new Config("Experiment4", brokers = 25, partitions = 100, throttle = 4 * 1000 * 1000, msgCount = 1 * 1000, msgSize = 100 * 1000),
       new Config("Experiment5", brokers = 5, partitions = 50, throttle = 50 * 1000 * 1000, msgCount = 1 * 1000, msgSize = 100 * 1000)
-
     )
     configs.foreach(run(_))
+    if(!showGraphsOnExperimentCompletion)
+      System.exit(0)
   }
 
   def run(config: Config) {
@@ -60,16 +63,18 @@ object ReplicationQuotasPerformance {
     try {
       experiment.setUp
       experiment.run(config)
-    } finally {
+    }
+    catch {case e: Exception => e.printStackTrace()}
+    finally {
       experiment.tearDown
     }
   }
 
   case class Config(name: String, brokers: Int, partitions: Int, throttle: Long, msgCount: Int, msgSize: Int) {
     val targetBytesPerBrokerMB: Long = msgCount.toLong * msgSize.toLong * partitions.toLong / brokers.toLong / 1000000
-    writeToFile
+    appendToJournal
 
-    def writeToFile(): Unit = {
+    def appendToJournal(): Unit = {
       val stream = new FileOutputStream(
         log,
         true)
@@ -98,6 +103,7 @@ object ReplicationQuotasPerformance {
     val followerRates = mutable.Map[Int, Array[Double]]()
 
     def startBrokers(brokerIds: Seq[Int]) {
+      println("Starting Brokers")
       servers = brokerIds.map(i => createBrokerConfig(i, zkConnect))
         .map(c => createServer(KafkaConfig.fromProps(c)))
     }
@@ -111,17 +117,15 @@ object ReplicationQuotasPerformance {
     def run(config: Config) {
       experimentName = config.name
       val brokers = (100 to 100 + config.brokers)
-
       var count = 0
       val shift = Math.round(config.brokers / 2)
+
       def nextReplicaRoundRobin(): Int = {
         count = count + 1
         100 + (count + shift) % config.brokers
       }
       val replicas = (0 to config.partitions).map(partition => partition -> Seq(nextReplicaRoundRobin())).toMap
 
-
-      println("Starting Brokers")
       startBrokers(brokers)
       createTopic(zkUtils, topicName, replicas, servers)
 
@@ -140,6 +144,8 @@ object ReplicationQuotasPerformance {
       //Await completion
       waitForReassignmentToComplete()
 
+      renderChart(leaderRates, "Leader")
+      renderChart(followerRates, "Follower")
       logOutput(config, replicas, newAssignment)
     }
 
@@ -164,8 +170,8 @@ object ReplicationQuotasPerformance {
       println(s"numMessages: ${config.msgCount}")
       println(s"msgSize: ${config.msgSize}")
       println(s"We will write ${config.targetBytesPerBrokerMB / 1000000}MB of data per broker")
-      println("Worst case duration is " + config.targetBytesPerBrokerMB / config.throttle)
-      println("move count is : " + physicalMoves)
+      println(s"Worst case duration is ${config.targetBytesPerBrokerMB / config.throttle}")
+      println(s"Move count is : $physicalMoves")
     }
 
     private def waitForOffsetsToMatch(offset: Int, partitionId: Int, broker: KafkaServer, topic: String): Boolean = {
@@ -181,9 +187,6 @@ object ReplicationQuotasPerformance {
         val success = !zkUtils.pathExists(ReassignPartitionsPath)
         success
       }, s"Znode ${ZkUtils.ReassignPartitionsPath} wasn't deleted", Int.MaxValue, pause = 1000L)
-
-      renderChart(leaderRates, "Leader")
-      renderChart(followerRates, "Follower")
     }
 
     def renderChart(data: mutable.Map[Int, Array[Double]], name: String): Unit = {
@@ -250,7 +253,6 @@ object ReplicationQuotasPerformance {
         if (followerRate > 0)
           trace("Follower Rate on " + broker.config.brokerId + " is " + followerRate)
       }
-
     }
 
     private def measuredRate(broker: KafkaServer, repType: QuotaType): Double = {

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -56,11 +56,16 @@ object ReplicationQuotasTestRig {
     val journal = new Journal()
 
     val experiments = Seq(
-      new ExperimentDef("Experiment1", brokers = 5, partitions = 20, throttle = 10 * k, msgsPerPartition = 500, msgSize = 100 * 1000),   //1GB total data written
-      new ExperimentDef("Experiment2", brokers = 5, partitions = 50, throttle = 100 * k, msgsPerPartition = 1000, msgSize = 100 * 1000), //5GB total data written
-      new ExperimentDef("Experiment3", brokers = 50, partitions = 50, throttle = 20 * k, msgsPerPartition = 1000, msgSize = 100 * 1000), //5GB total data written
-      new ExperimentDef("Experiment4", brokers = 25, partitions = 100, throttle = 40 * k, msgsPerPartition = 1000, msgSize = 100 * 1000),//10GB total data written
-      new ExperimentDef("Experiment5", brokers = 5, partitions = 50, throttle = 500 * k, msgsPerPartition = 4000, msgSize = 100 * 1000)  //20GB total data written
+      //1GB total data written, will take 210s
+      new ExperimentDef("Experiment1", brokers = 5, partitions = 20, throttle = 1 * k, msgsPerPartition = 500, msgSize = 100 * 1000),
+      //5GB total data written, will take 110s
+      new ExperimentDef("Experiment2", brokers = 5, partitions = 50, throttle = 10 * k, msgsPerPartition = 1000, msgSize = 100 * 1000),
+      //5GB total data written, will take 110s
+      new ExperimentDef("Experiment3", brokers = 50, partitions = 50, throttle = 2 * k, msgsPerPartition = 1000, msgSize = 100 * 1000),
+      //10GB total data written, will take 110s
+      new ExperimentDef("Experiment4", brokers = 25, partitions = 100, throttle = 4 * k, msgsPerPartition = 1000, msgSize = 100 * 1000),
+      //10GB total data written, will take 80s
+      new ExperimentDef("Experiment5", brokers = 5, partitions = 50, throttle = 50 * k, msgsPerPartition = 4000, msgSize = 100 * 1000)
     )
     experiments.foreach(run(_, journal, displayChartsOnScreen))
 
@@ -176,7 +181,7 @@ object ReplicationQuotasTestRig {
       println(s"numBrokers: ${config.brokers}")
       println(s"numPartitions: ${config.partitions}")
       println(s"throttle: ${config.throttle}")
-      println(s"numMessages: ${config.msgsPerPartition}")
+      println(s"numMessagesPerPartition: ${config.msgsPerPartition}")
       println(s"msgSize: ${config.msgSize}")
       println(s"We will write ${config.targetBytesPerBrokerMB}MB of data per broker")
       println(s"Worst case duration is ${config.targetBytesPerBrokerMB * 1000 * 1000/ config.throttle}")

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -54,11 +54,11 @@ object ReplicationQuotasTestRig {
     val journal = new Journal()
 
     val experiments = Seq(
-      new ExperimentDef("Experiment1", brokers = 5, partitions = 20, throttle = 1000 * 1000, msgsPerPartition = 100, msgSize = 100 * 1000),            //200MB total data written
-      new ExperimentDef("Experiment2", brokers = 5, partitions = 50, throttle = 10 * 1000 * 1000, msgsPerPartition = 10 * 100, msgSize = 100 * 1000),  //5GB total data written
-      new ExperimentDef("Experiment3", brokers = 50, partitions = 50, throttle = 2 * 1000 * 1000, msgsPerPartition = 10 * 100, msgSize = 100 * 1000),  //5GB total data written
-      new ExperimentDef("Experiment4", brokers = 25, partitions = 100, throttle = 4 * 1000 * 1000, msgsPerPartition = 1 * 1000, msgSize = 100 * 1000), //10GB total data written
-      new ExperimentDef("Experiment5", brokers = 5, partitions = 50, throttle = 50 * 1000 * 1000, msgsPerPartition = 4 * 1000, msgSize = 100 * 1000)   //20GB total data written
+      new ExperimentDef("Experiment1", brokers = 5, partitions = 20, throttle = 1000 * 1000, msgsPerPartition = 100, msgSize = 100 * 1000),           //200MB total data written
+      new ExperimentDef("Experiment2", brokers = 5, partitions = 50, throttle = 10 * 1000 * 1000, msgsPerPartition = 10 * 100, msgSize = 100 * 1000), //5GB total data written
+      new ExperimentDef("Experiment3", brokers = 50, partitions = 50, throttle = 2 * 1000 * 1000, msgsPerPartition = 10 * 100, msgSize = 100 * 1000), //5GB total data written
+      new ExperimentDef("Experiment4", brokers = 25, partitions = 100, throttle = 4 * 1000 * 1000, msgsPerPartition = 1 * 1000, msgSize = 100 * 1000),//10GB total data written
+      new ExperimentDef("Experiment5", brokers = 5, partitions = 50, throttle = 50 * 1000 * 1000, msgsPerPartition = 4 * 1000, msgSize = 100 * 1000)  //20GB total data written
     )
     experiments.foreach(run(_, journal, displayChartsOnScreen))
 
@@ -267,7 +267,6 @@ object ReplicationQuotasTestRig {
     }
   }
 
-
   class Journal {
     private val log = new File(dir, "Log.html")
     header()
@@ -313,5 +312,6 @@ object ReplicationQuotasTestRig {
       log.getAbsolutePath
     }
   }
+
 }
 

--- a/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
+++ b/core/src/test/scala/other/kafka/ReplicationQuotasTestRig.scala
@@ -54,9 +54,9 @@ object ReplicationQuotasTestRig {
     val journal = new Journal()
 
     val experiments = Seq(
-      new ExperimentDef("Experiment1", brokers = 5, partitions = 20, throttle = 1000 * 1000, msgsPerPartition = 100, msgSize = 100 * 1000),           //200MB total data written
+      new ExperimentDef("Experiment1", brokers = 5, partitions = 20, throttle = 1000 * 1000, msgsPerPartition = 500, msgSize = 100 * 1000),           //200MB total data written
       new ExperimentDef("Experiment2", brokers = 5, partitions = 50, throttle = 10 * 1000 * 1000, msgsPerPartition = 10 * 100, msgSize = 100 * 1000), //5GB total data written
-      new ExperimentDef("Experiment3", brokers = 50, partitions = 50, throttle = 2 * 1000 * 1000, msgsPerPartition = 10 * 100, msgSize = 100 * 1000), //5GB total data written
+      new ExperimentDef("Experiment3", brokers = 50, partitions = 50, throttle = 2 * 1000 * 1000, msgsPerPartition = 20 * 100, msgSize = 100 * 1000), //5GB total data written
       new ExperimentDef("Experiment4", brokers = 25, partitions = 100, throttle = 4 * 1000 * 1000, msgsPerPartition = 1 * 1000, msgSize = 100 * 1000),//10GB total data written
       new ExperimentDef("Experiment5", brokers = 5, partitions = 50, throttle = 50 * 1000 * 1000, msgsPerPartition = 4 * 1000, msgSize = 100 * 1000)  //20GB total data written
     )

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -784,7 +784,7 @@ object TestUtils extends Logging {
    * @return The leader of the partition.
    */
   def waitUntilMetadataIsPropagated(servers: Seq[KafkaServer], topic: String, partition: Int,
-                                    timeout: Long = 90000): Int = {  //DO NOT COMMIT THIS CHANGE
+                                    timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
     var leader: Int = -1
     TestUtils.waitUntilTrue(() =>
       servers.foldLeft(true) {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -747,14 +747,14 @@ object TestUtils extends Logging {
   /**
    * Wait until the given condition is true or throw an exception if the given wait time elapses.
    */
-  def waitUntilTrue(condition: () => Boolean, msg: String, waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Boolean = {
+  def waitUntilTrue(condition: () => Boolean, msg: String, waitTime: Long = JTestUtils.DEFAULT_MAX_WAIT_MS, pause: Long = 100L): Boolean = {
     val startTime = System.currentTimeMillis()
     while (true) {
       if (condition())
         return true
       if (System.currentTimeMillis() > startTime + waitTime)
         fail(msg)
-      Thread.sleep(waitTime.min(100L))
+      Thread.sleep(waitTime.min(pause))
     }
     // should never hit here
     throw new RuntimeException("unexpected error")
@@ -784,7 +784,7 @@ object TestUtils extends Logging {
    * @return The leader of the partition.
    */
   def waitUntilMetadataIsPropagated(servers: Seq[KafkaServer], topic: String, partition: Int,
-                                    timeout: Long = JTestUtils.DEFAULT_MAX_WAIT_MS): Int = {
+                                    timeout: Long = 90000): Int = {  //DO NOT COMMIT THIS CHANGE
     var leader: Int = -1
     TestUtils.waitUntilTrue(() =>
       servers.foldLeft(true) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -109,5 +109,5 @@ libs += [
   snappy: "org.xerial.snappy:snappy-java:$versions.snappy",
   zkclient: "com.101tec:zkclient:$versions.zkclient",
   zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
-  jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
+  jfreechart: "jfreechart:jfreechart:$versions.jfreechart"
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,6 +46,7 @@ versions += [
   snappy: "1.1.2.6",
   zkclient: "0.10",
   zookeeper: "3.4.9",
+  jfreechart: "1.0.0",
 ]
 
 // Add Scala version
@@ -107,5 +108,6 @@ libs += [
   slf4jlog4j: "org.slf4j:slf4j-log4j12:$versions.slf4j",
   snappy: "org.xerial.snappy:snappy-java:$versions.snappy",
   zkclient: "com.101tec:zkclient:$versions.zkclient",
-  zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper"
+  zookeeper: "org.apache.zookeeper:zookeeper:$versions.zookeeper",
+  jfreechart: "jfreechart:jfreechart:$versions.jfreechart",
 ]


### PR DESCRIPTION
This test rig lives in the other.kafka package so isn't part of our standard tests. It provides a convenient mechanism for measuring throttling performance over time. Measurements for each experiment are charted and presented to the user in an html file. The output looks like this:

**Experiment4**
- BrokerCount: 25
- PartitionCount: 100
- Throttle: 4,000,000 B/s
- MsgCount: 1,000
- MsgSize: 100,000
- TargetBytesPerBrokerMB: 400

![image](https://cloud.githubusercontent.com/assets/1297498/19070450/3251bc52-8a23-11e6-88fe-94de6b9147c2.png)
![image](https://cloud.githubusercontent.com/assets/1297498/19070467/4c19f38e-8a23-11e6-986a-ba19d16819ca.png)
