### PR TITLE
KAFKA-4251: fix test driver not launching in Vagrant 1.8.6

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,9 +99,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if !cached_addresses.has_key?(vm.name)
         state_id = vm.state.id
         if state_id != :not_created && state_id != :stopped && vm.communicate.ready?
-          vm.communicate.execute("/sbin/ifconfig eth0 | grep 'inet addr' | tail -n 1 | egrep -o '[0-9\.]+' | head -n 1 2>&1") do |type, contents|
-            cached_addresses[vm.name] = contents.split("\n").first[/(\d+\.\d+\.\d+\.\d+)/, 1]
+          contents = ''
+          vm.communicate.execute("/sbin/ifconfig eth0 | grep 'inet addr' | tail -n 1 | egrep -o '[0-9\.]+' | head -n 1 2>&1") do |type, data|
+            contents << data
           end
+          cached_addresses[vm.name] = contents.split("\n").first[/(\d+\.\d+\.\d+\.\d+)/, 1]
         else
           cached_addresses[vm.name] = nil
         end


### PR DESCRIPTION
custom ip resolver in test driver makes incorrect assumption when calling vm.communicate.execute, causing driver to fail launching with Vagrant 1.8.6, due to https://github.com/mitchellh/vagrant/pull/7676
