### PR TITLE
KAFKA-4253: Fix Kafka Stream thread shutting down process ordering

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -111,10 +111,12 @@ public abstract class AbstractTask {
 
     public abstract void close();
 
+    public abstract void commitOffsets();
+
     /**
      * @throws ProcessorStateException if there is an error while closing the state manager
      */
-    public void closeStateManager() {
+    void closeStateManager() {
         try {
             stateMgr.close(recordCollectorOffsets());
         } catch (IOException e) {
@@ -170,5 +172,12 @@ public abstract class AbstractTask {
 
         sb.append("\n");
         return sb.toString();
+    }
+
+    /**
+     * Flush all state stores owned by this task
+     */
+    public void flushState() {
+        stateMgr.flush((InternalProcessorContext) this.context());
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -108,10 +108,13 @@ public abstract class AbstractTask {
 
     public abstract void commit();
 
+
+    public abstract void close();
+
     /**
      * @throws ProcessorStateException if there is an error while closing the state manager
      */
-    public void close() {
+    public void closeStateManager() {
         try {
             stateMgr.close(recordCollectorOffsets());
         } catch (IOException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -326,18 +326,17 @@ public class ProcessorStateManager {
     }
 
     /**
-     * @throws IOException if any error happens when flushing or closing the state stores
+     * @throws IOException if any error happens when closing the state stores
      */
     public void close(Map<TopicPartition, Long> ackedOffsets) throws IOException {
         try {
-            // attempting to flush and close the stores, just in case they
+            // attempting to close the stores, just in case they
             // are not closed by a ProcessorNode yet
             if (!stores.isEmpty()) {
                 log.debug("task [{}] Closing stores.", taskId);
                 for (Map.Entry<String, StateStore> entry : stores.entrySet()) {
                     log.debug("task [{}} Closing storage engine {}", taskId, entry.getKey());
                     try {
-                        entry.getValue().flush();
                         entry.getValue().close();
                     } catch (Exception e) {
                         throw new ProcessorStateException(String.format("task [%s] Failed to close state store %s", taskId, entry.getKey()), e);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -98,6 +98,11 @@ public class StandbyTask extends AbstractTask {
         initializeOffsetLimits();
     }
 
+    @Override
+    public void close() {
+        //no-op
+    }
+
     /**
      * Produces a string representation contain useful information about a StreamTask.
      * This is useful in debugging scenarios.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -103,6 +103,11 @@ public class StandbyTask extends AbstractTask {
         //no-op
     }
 
+    @Override
+    public void commitOffsets() {
+        // no-op
+    }
+
     /**
      * Produces a string representation contain useful information about a StreamTask.
      * This is useful in debugging scenarios.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -333,10 +333,9 @@ public class StreamTask extends AbstractTask implements Punctuator {
             }
         }
 
-        super.close();
-
-        if (exception != null)
+        if (exception != null) {
             throw exception;
+        }
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -269,6 +269,14 @@ public class StreamTask extends AbstractTask implements Punctuator {
         recordCollector.flush();
 
         // 3) commit consumed offsets if it is dirty already
+        commitOffsets();
+    }
+
+    /**
+     * commit consumed offsets if needed
+     */
+    @Override
+    public void commitOffsets() {
         if (commitOffsetNeeded) {
             Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
             for (Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -395,7 +395,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         }
         open = false;
         closeOpenIterators();
-        flush();
         options.close();
         wOptions.close();
         fOptions.close();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -82,6 +82,11 @@ public class AbstractTaskTest {
             public void close() {
 
             }
+
+            @Override
+            public void commitOffsets() {
+                // do nothing
+            }
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -77,6 +77,11 @@ public class AbstractTaskTest {
             public void commit() {
                 // do nothing
             }
+
+            @Override
+            public void close() {
+
+            }
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -31,8 +31,11 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
+import org.apache.kafka.test.MockProcessorContext;
 import org.apache.kafka.test.MockStateStoreSupplier;
+import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -408,7 +411,7 @@ public class ProcessorStateManagerTest {
     }
 
     @Test
-    public void testClose() throws IOException {
+    public void testFlushAndClose() throws IOException {
         final TaskId taskId = new TaskId(0, 1);
         File checkpointFile = new File(stateDirectory.directoryForTask(taskId), ProcessorStateManager.CHECKPOINT_FILE_NAME);
         // write an empty checkpoint file
@@ -445,6 +448,7 @@ public class ProcessorStateManagerTest {
             stateMgr.register(nonPersistentStore, true, nonPersistentStore.stateRestoreCallback);
         } finally {
             // close the state manager with the ack'ed offsets
+            stateMgr.flush(new MockProcessorContext(StateSerdes.withBuiltinTypes("foo", String.class, String.class), new NoOpRecordCollector()));
             stateMgr.close(ackedOffsets);
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -199,7 +199,7 @@ public class StandbyTaskTest {
         assertEquals(Collections.emptyList(), store1.keys);
         assertEquals(Utils.mkList(1, 2, 3), store2.keys);
 
-        task.close();
+        task.closeStateManager();
 
         File taskDir = stateDirectory.directoryForTask(taskId);
         OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(taskDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));
@@ -292,7 +292,7 @@ public class StandbyTaskTest {
         remaining = task.update(ktable, remaining);
         assertNull(remaining);
 
-        task.close();
+        task.closeStateManager();
 
         File taskDir = stateDirectory.directoryForTask(taskId);
         OffsetCheckpoint checkpoint = new OffsetCheckpoint(new File(taskDir, ProcessorStateManager.CHECKPOINT_FILE_NAME));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -143,6 +143,12 @@ public class StreamThreadTest {
         }
 
         @Override
+        public void commitOffsets() {
+            super.commitOffsets();
+            committed = true;
+        }
+
+        @Override
         protected void initializeOffsetLimits() {
             // do nothing
         }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreTestUtils.java
@@ -16,18 +16,15 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.NoOpRecordCollector;
 
 import java.util.Collections;
 
@@ -47,32 +44,6 @@ public class StateStoreTestUtils {
                 new NoOpRecordCollector()), stateStore);
         return (KeyValueStore<K, V>) stateStore;
 
-    }
-
-    static class NoOpRecordCollector extends RecordCollector {
-        public NoOpRecordCollector() {
-            super(null, "StateStoreTestUtils");
-        }
-
-        @Override
-        public <K, V> void send(final ProducerRecord<K, V> record, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) {
-            // no-op
-        }
-
-        @Override
-        public <K, V> void send(final ProducerRecord<K, V> record, final Serializer<K> keySerializer, final Serializer<V> valueSerializer, final StreamPartitioner<K, V> partitioner) {
-            // no-op
-        }
-
-        @Override
-        public void flush() {
-            //no-op
-        }
-
-        @Override
-        public void close() {
-            //no-op
-        }
     }
 
     static class NoOpReadOnlyStore<K, V>

--- a/streams/src/test/java/org/apache/kafka/test/NoOpRecordCollector.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpRecordCollector.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.internals.RecordCollector;
+
+public class NoOpRecordCollector extends RecordCollector {
+    public NoOpRecordCollector() {
+        super(null, "NoOpRecordCollector");
+    }
+
+    @Override
+    public <K, V> void send(final ProducerRecord<K, V> record, final Serializer<K> keySerializer, final Serializer<V> valueSerializer) {
+        // no-op
+    }
+
+    @Override
+    public <K, V> void send(final ProducerRecord<K, V> record, final Serializer<K> keySerializer, final Serializer<V> valueSerializer, final StreamPartitioner<K, V> partitioner) {
+        // no-op
+    }
+
+    @Override
+    public void flush() {
+        //no-op
+    }
+
+    @Override
+    public void close() {
+        //no-op
+    }
+}


### PR DESCRIPTION
Changed the ordering in `StreamThread.shutdown`
1. commitAll (we need to commit so that any cached data is flushed through the topology)
2. close all tasks
3. producer.flush() - so any records produced during close are flushed and we have offsets for them
4. close all state managers
5. close producers/consumers
6. remove the tasks

Also in `onPartitionsRevoked`
1. commitAll
2. close all tasks
3. producer.flush
4. close all state managers
