### PR TITLE
AN-75711 Spike for Kafka server side changes to prevent a broker from being leader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ ext {
   shouldSign = !skipSigning && !version.endsWith("SNAPSHOT") && project.gradle.startParameter.taskNames.any { it.contains("upload") }
 
   mavenUrl = project.hasProperty('mavenUrl') ? project.mavenUrl : ''
-  mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : ''
-  mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : ''
+  mavenUsername = project.hasProperty('mavenUsername') ? project.mavenUsername : appianRepoDevUsername
+  mavenPassword = project.hasProperty('mavenPassword') ? project.mavenPassword : new String(appianRepoDevPassword.decodeBase64())
 
   userShowStandardStreams = project.hasProperty("showStandardStreams") ? showStandardStreams : null
 

--- a/config/server.properties
+++ b/config/server.properties
@@ -20,6 +20,8 @@
 # The id of the broker. This must be set to a unique integer for each broker.
 broker.id=0
 
+leader.ineligible.broker.id=2
+
 # Switch to enable topic deletion or not, default value is false
 #delete.topic.enable=true
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -59,6 +59,7 @@ class ControllerContext(val zkUtils: ZkUtils,
   var partitionLeadershipInfo: mutable.Map[TopicAndPartition, LeaderIsrAndControllerEpoch] = mutable.Map.empty
   val partitionsBeingReassigned: mutable.Map[TopicAndPartition, ReassignedPartitionsContext] = new mutable.HashMap
   val partitionsUndergoingPreferredReplicaElection: mutable.Set[TopicAndPartition] = new mutable.HashSet
+  var leaderIneligibleBrokerId: Int = -1
 
   private var liveBrokersUnderlying: Set[Broker] = Set.empty
   private var liveBrokerIdsUnderlying: Set[Int] = Set.empty
@@ -736,6 +737,8 @@ class KafkaController(val config : KafkaConfig, zkUtils: ZkUtils, val brokerStat
     controllerContext.partitionReplicaAssignment = zkUtils.getReplicaAssignmentForTopics(controllerContext.allTopics.toSeq)
     controllerContext.partitionLeadershipInfo = new mutable.HashMap[TopicAndPartition, LeaderIsrAndControllerEpoch]
     controllerContext.shuttingDownBrokerIds = mutable.Set.empty[Int]
+    controllerContext.leaderIneligibleBrokerId = config.leaderIneligibleBrokerId
+
     // update the leader and isr cache for all existing partitions from Zookeeper
     updateLeaderAndIsrCache()
     // start the channel manager

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -51,6 +51,7 @@ object Defaults {
   val NumIoThreads = 8
   val BackgroundThreads = 10
   val QueuedMaxRequests = 500
+  val BrokerLeaderEligible = true
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassName = ""
@@ -213,6 +214,7 @@ object KafkaConfig {
   val BackgroundThreadsProp = "background.threads"
   val QueuedMaxRequestsProp = "queued.max.requests"
   val RequestTimeoutMsProp = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG
+  val LeaderIneligibleBrokerId = "leader.ineligible.broker.id"
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameProp = "authorizer.class.name"
   /** ********* Socket Server Configuration ***********/
@@ -376,6 +378,7 @@ object KafkaConfig {
   val BackgroundThreadsDoc = "The number of threads to use for various background processing tasks"
   val QueuedMaxRequestsDoc = "The number of queued requests allowed before blocking the network threads"
   val RequestTimeoutMsDoc = CommonClientConfigs.REQUEST_TIMEOUT_MS_DOC
+  val BrokerLeaderEligibleDoc = "Enable/disable the ability of this broker to take leadership for topic partitions"
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameDoc = "The authorizer class that should be used for authorization"
   /** ********* Socket Server Configuration ***********/
@@ -603,6 +606,8 @@ object KafkaConfig {
       .define(BackgroundThreadsProp, INT, Defaults.BackgroundThreads, atLeast(1), HIGH, BackgroundThreadsDoc)
       .define(QueuedMaxRequestsProp, INT, Defaults.QueuedMaxRequests, atLeast(1), HIGH, QueuedMaxRequestsDoc)
       .define(RequestTimeoutMsProp, INT, Defaults.RequestTimeoutMs, HIGH, RequestTimeoutMsDoc)
+      .define(BrokerLeaderEligibleProp, BOOLEAN, Defaults.BrokerLeaderEligible, HIGH, BrokerLeaderEligibleDoc)
+      .define(LeaderIneligibleBrokerId, INT, Defaults.BrokerId, HIGH, BrokerIdDoc)
 
       /************* Authorizer Configuration ***********/
       .define(AuthorizerClassNameProp, STRING, Defaults.AuthorizerClassName, LOW, AuthorizerClassNameDoc)
@@ -814,6 +819,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends Abstra
   val numIoThreads = getInt(KafkaConfig.NumIoThreadsProp)
   val messageMaxBytes = getInt(KafkaConfig.MessageMaxBytesProp)
   val requestTimeoutMs = getInt(KafkaConfig.RequestTimeoutMsProp)
+  val leaderIneligibleBrokerId = getInt(KafkaConfig.LeaderIneligibleBrokerId)
 
   /************* Authorizer Configuration ***********/
   val authorizerClassName: String = getString(KafkaConfig.AuthorizerClassNameProp)


### PR DESCRIPTION
For basic proof of concept, 
1. Added Kafka configuration to blacklist a specific Kafka broker from becoming a leader for any partition.
2. The blacklisted broker is passed down the chain to all different PartitionLeaderSelectors and the selectors prevent that broker from being elected as leader during the partition state changes.

Notes from JIRA below (added by Jason) -

Potential Issues:
- Leader value for the partition in Zookeeper does not null out (i.e. it remains 1 even if the hot broker with id 1 goes down).  May not be a problem.
- When creating a topic, the initial leader may be the prohibited one.  Need to figure out how this works, but shouldn't matter for Komodo as we guarantee that the hot node is the leader before we do anything.
- Not 100% positive that there are no ripple effects, but relatively sure. 

What's needed before we propose it to the community:
- Mark a broker as ineligible and have it set state in Zookeeper
- LeaderSelector should use that state in Zookeeper to filter leader selection instead of the configuration
