### PR TITLE
client fails trying to bind to jmx port already in use by server

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -45,6 +45,13 @@ should_include_file() {
   fi
 }
 
+# need to check if called to start server or client 
+# in order to correctly decide about JMX_PORT
+ISKAFKASERVER="false"
+if [[ "$*" =~ "kafka.Kafka" ]]; then
+    ISKAFKASERVER="true"
+fi
+
 base_dir=$(dirname $0)/..
 
 if [ -z "$SCALA_VERSION" ]; then
@@ -146,7 +153,7 @@ if [ -z "$KAFKA_JMX_OPTS" ]; then
 fi
 
 # JMX port to use
-if [  $JMX_PORT ]; then
+if [  $JMX_PORT ] && [ -z "$ISKAFKASERVER" ]; then
   KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT "
 fi
 


### PR DESCRIPTION
Enabling JMX_PORT causes Kafka clients to attempt to bind to a port already bound by server. Modified so as to distinguish if being called to launch server or client and choose accordingly whether to add JMX port option or not.
