### PR TITLE
Kafka 4180 - Shared authentification with multiple actives Kafka producers/consumers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SaslConfigs.java
@@ -32,6 +32,11 @@ public class SaslConfigs {
         + "Only GSSAPI is enabled by default.";
     public static final List<String> DEFAULT_SASL_ENABLED_MECHANISMS = Collections.singletonList(GSSAPI_MECHANISM);
 
+    /** Jaas configuration file format is described <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html">here</a> */
+    public static final String SASL_JAAS_CONFIG = "sasl.jaas.config";
+    public static final String SASL_JAAS_CONFIG_DOC = "JAAS login context parameters for SASL connections in the format used by JAAS configuration files. "
+        + "The format is: '<loginModuleClass> <controlFlag> (<optionName>=<optionValue>)*;'";
+
     public static final String SASL_KERBEROS_SERVICE_NAME = "sasl.kerberos.service.name";
     public static final String SASL_KERBEROS_SERVICE_NAME_DOC = "The Kerberos principal name that Kafka runs as. "
         + "This can be defined either in Kafka's JAAS config or in Kafka's config.";
@@ -66,6 +71,7 @@ public class SaslConfigs {
                 .define(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, ConfigDef.Type.DOUBLE, SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_WINDOW_FACTOR, ConfigDef.Importance.LOW, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC)
                 .define(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER, ConfigDef.Type.DOUBLE, SaslConfigs.DEFAULT_KERBEROS_TICKET_RENEW_JITTER, ConfigDef.Importance.LOW, SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER_DOC)
                 .define(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN, ConfigDef.Type.LONG, SaslConfigs.DEFAULT_KERBEROS_MIN_TIME_BEFORE_RELOGIN, ConfigDef.Importance.LOW, SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC)
-                .define(SaslConfigs.SASL_MECHANISM, ConfigDef.Type.STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, ConfigDef.Importance.MEDIUM, SaslConfigs.SASL_MECHANISM_DOC);
+                .define(SaslConfigs.SASL_MECHANISM, ConfigDef.Type.STRING, SaslConfigs.DEFAULT_SASL_MECHANISM, ConfigDef.Importance.MEDIUM, SaslConfigs.SASL_MECHANISM_DOC)
+                .define(SaslConfigs.SASL_JAAS_CONFIG, ConfigDef.Type.PASSWORD, null, ConfigDef.Importance.MEDIUM, SaslConfigs.SASL_JAAS_CONFIG_DOC);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
@@ -44,7 +44,11 @@ public class JaasUtils {
      * @return JAAS configuration object
      */
     public static String jaasConfig(String loginContextName, String key) throws IOException {
-        AppConfigurationEntry[] configurationEntries = Configuration.getConfiguration().getAppConfigurationEntry(loginContextName);
+        return jaasConfig(Configuration.getConfiguration(), loginContextName, key);
+    }
+
+    public static String jaasConfig(Configuration jaasConfig, String loginContextName, String key) throws IOException {
+        AppConfigurationEntry[] configurationEntries = jaasConfig.getAppConfigurationEntry(loginContextName);
         if (configurationEntries == null) {
             String errorMessage = "Could not find a '" + loginContextName + "' entry in this configuration.";
             throw new IOException(errorMessage);

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/JaasConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/JaasConfigProvider.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.security.auth;
+
+import java.io.IOException;
+import java.io.StreamTokenizer;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.network.LoginType;
+
+import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
+
+/*
+ * JAAS Configuration provider used to create or load JAAS configuration.
+ */
+public class JaasConfigProvider {
+
+    public static Configuration jaasConfig(LoginType loginType, Map<String, ?> configs) {
+        Password jaasConfigArgs = (Password) configs.get(SaslConfigs.SASL_JAAS_CONFIG);
+        if (jaasConfigArgs == null)
+            return Configuration.getConfiguration();
+        else
+            return new JaasConfig(loginType, jaasConfigArgs.value());
+    }
+
+    private static class JaasConfig extends Configuration {
+
+        private final String loginContextName;
+        private final AppConfigurationEntry[] appConfig;
+
+        public JaasConfig(LoginType loginType, String jaasConfigParams) {
+            StreamTokenizer tokenizer = new StreamTokenizer(new StringReader(jaasConfigParams));
+            tokenizer.slashSlashComments(true);
+            tokenizer.slashStarComments(true);
+            tokenizer.wordChars('-', '-');
+            tokenizer.wordChars('_', '_');
+            tokenizer.wordChars('$', '$');
+
+            try {
+                List<AppConfigurationEntry> entries = new ArrayList<>();
+                while (tokenizer.nextToken() != StreamTokenizer.TT_EOF) {
+                    entries.add(parseAppConfigurationEntry(tokenizer));
+                }
+                if (entries.size() == 0)
+                    throw new IllegalArgumentException("Login module not specified in jaas config");
+
+                this.loginContextName = loginType.contextName();
+                this.appConfig = entries.toArray(new AppConfigurationEntry[entries.size()]);
+
+            } catch (IOException e) {
+                throw new KafkaException("Unexpected exception while parsing Jaas configuration");
+            }
+        }
+
+        @Override
+        public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+            return this.loginContextName.equals(name) ? this.appConfig : null;
+        }
+
+        private LoginModuleControlFlag loginModuleControlFlag(String flag) {
+            LoginModuleControlFlag controlFlag;
+            switch (flag.toUpperCase(Locale.ROOT)) {
+                case "REQUIRED":
+                    controlFlag = LoginModuleControlFlag.REQUIRED;
+                    break;
+                case "REQUISITE":
+                    controlFlag = LoginModuleControlFlag.REQUISITE;
+                    break;
+                case "SUFFICIENT":
+                    controlFlag = LoginModuleControlFlag.SUFFICIENT;
+                    break;
+                case "OPTIONAL":
+                    controlFlag = LoginModuleControlFlag.OPTIONAL;
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid login module control flag " + flag);
+            }
+            return controlFlag;
+        }
+
+        private AppConfigurationEntry parseAppConfigurationEntry(StreamTokenizer tokenizer) throws IOException {
+            String loginModule = tokenizer.sval;
+            if (tokenizer.nextToken() == StreamTokenizer.TT_EOF)
+                throw new IllegalArgumentException("Login module control flag not specified in jaas config");
+            LoginModuleControlFlag controlFlag = loginModuleControlFlag(tokenizer.sval);
+            Map<String, String> options = new HashMap<>();
+            while (tokenizer.nextToken() != StreamTokenizer.TT_EOF && tokenizer.ttype != ';') {
+                String key = tokenizer.sval;
+                if (tokenizer.nextToken() != '=' || tokenizer.nextToken() == StreamTokenizer.TT_EOF || tokenizer.sval == null)
+                    throw new IllegalArgumentException("Value not specified for key '" + key + "' in jaas config");
+                String value = tokenizer.sval;
+                options.put(key, value);
+            }
+            if (tokenizer.ttype != ';')
+                throw new IllegalArgumentException("Configuration entry not terminated by semi-colon");
+            return new AppConfigurationEntry(loginModule, controlFlag, options);
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/Login.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/Login.java
@@ -21,6 +21,7 @@ package org.apache.kafka.common.security.auth;
 import java.util.Map;
 
 import javax.security.auth.Subject;
+import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
@@ -32,7 +33,7 @@ public interface Login {
     /**
      * Configures this login instance.
      */
-    void configure(Map<String, ?> configs, String loginContextName);
+    void configure(Map<String, ?> configs, Configuration jaasConfig, String loginContextName);
 
     /**
      * Performs login for each login module specified for the login context of this instance.

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -19,6 +19,7 @@
 package org.apache.kafka.common.security.authenticator;
 
 import javax.security.auth.Subject;
+import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
@@ -27,6 +28,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 import org.apache.kafka.common.network.LoginType;
+import org.apache.kafka.common.security.auth.JaasConfigProvider;
 import org.apache.kafka.common.security.auth.Login;
 import org.apache.kafka.common.security.kerberos.KerberosLogin;
 
@@ -38,11 +40,11 @@ public class LoginManager {
     private final LoginType loginType;
     private int refCount;
 
-    private LoginManager(LoginType loginType, boolean hasKerberos, Map<String, ?> configs) throws IOException, LoginException {
+    private LoginManager(LoginType loginType, boolean hasKerberos, Map<String, ?> configs, Configuration jaasConfig) throws IOException, LoginException {
         this.loginType = loginType;
         String loginContext = loginType.contextName();
         login = hasKerberos ? new KerberosLogin() : new DefaultLogin();
-        login.configure(configs, loginContext);
+        login.configure(configs, jaasConfig, loginContext);
         login.login();
     }
 
@@ -65,7 +67,8 @@ public class LoginManager {
         synchronized (LoginManager.class) {
             LoginManager loginManager = CACHED_INSTANCES.get(loginType);
             if (loginManager == null) {
-                loginManager = new LoginManager(loginType, hasKerberos, configs);
+                Configuration jaasConfig = JaasConfigProvider.jaasConfig(loginType, configs);
+                loginManager = new LoginManager(loginType, hasKerberos, configs, jaasConfig);
                 CACHED_INSTANCES.put(loginType, loginManager);
             }
             return loginManager.acquire();

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -24,9 +24,11 @@ import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.LoginType;
 import org.apache.kafka.common.security.auth.JaasConfigProvider;
 import org.apache.kafka.common.security.auth.Login;
@@ -34,14 +36,14 @@ import org.apache.kafka.common.security.kerberos.KerberosLogin;
 
 public class LoginManager {
 
-    private static final EnumMap<LoginType, LoginManager> CACHED_INSTANCES = new EnumMap<>(LoginType.class);
+    private static final Map<Object, LoginManager> CACHED_INSTANCES = new HashMap<>();
 
     private final Login login;
-    private final LoginType loginType;
+    private final Object cachingKey;
     private int refCount;
 
-    private LoginManager(LoginType loginType, boolean hasKerberos, Map<String, ?> configs, Configuration jaasConfig) throws IOException, LoginException {
-        this.loginType = loginType;
+    private LoginManager(LoginType loginType, Object cachingKey, boolean hasKerberos, Map<String, ?> configs, Configuration jaasConfig) throws IOException, LoginException {
+        this.cachingKey = cachingKey;
         String loginContext = loginType.contextName();
         login = hasKerberos ? new KerberosLogin() : new DefaultLogin();
         login.configure(configs, jaasConfig, loginContext);
@@ -52,24 +54,33 @@ public class LoginManager {
      * Returns an instance of `LoginManager` and increases its reference count.
      *
      * `release()` should be invoked when the `LoginManager` is no longer needed. This method will try to reuse an
-     * existing `LoginManager` for the provided `mode` if available. However, it expects `configs` to be the same for
-     * every invocation and it will ignore them in the case where it's returning a cached instance of `LoginManager`.
+     * existing `LoginManager` for the provided `mode` and `SaslConfigs.SASL_JAAS_CONFIG` in `configs`, if available. 
      *
      * This is a bit ugly and it would be nicer if we could pass the `LoginManager` to `ChannelBuilders.create` and
      * shut it down when the broker or clients are closed. It's straightforward to do the former, but it's more
      * complicated to do the latter without making the consumer API more complex.
      *
      * @param loginType the type of the login context, it should be SERVER for the broker and CLIENT for the clients
-     *                  (i.e. consumer and producer)
+     *                  (i.e. consumer and producer), determines which section of the JAAS configuration will be used
+     * @param hasKerberos whether the `KerberosLogin` or `DefaultLogin` is to be used
      * @param configs configuration as key/value pairs
      */
     public static final LoginManager acquireLoginManager(LoginType loginType, boolean hasKerberos, Map<String, ?> configs) throws IOException, LoginException {
         synchronized (LoginManager.class) {
-            LoginManager loginManager = CACHED_INSTANCES.get(loginType);
+            Object cachingKey = loginType;
+            //allowing multiple client logins in a single process
+            if (loginType == LoginType.CLIENT) {
+                Password jaasconf = (Password) configs.get(SaslConfigs.SASL_JAAS_CONFIG);
+                if (jaasconf != null) {
+                    cachingKey = jaasconf;
+                }
+            }
+            
+            LoginManager loginManager = CACHED_INSTANCES.get(cachingKey);
             if (loginManager == null) {
                 Configuration jaasConfig = JaasConfigProvider.jaasConfig(loginType, configs);
-                loginManager = new LoginManager(loginType, hasKerberos, configs, jaasConfig);
-                CACHED_INSTANCES.put(loginType, loginManager);
+                loginManager = new LoginManager(loginType, cachingKey, hasKerberos, configs, jaasConfig);
+                CACHED_INSTANCES.put(cachingKey, loginManager);
             }
             return loginManager.acquire();
         }
@@ -96,7 +107,7 @@ public class LoginManager {
             if (refCount == 0)
                 throw new IllegalStateException("release called on LoginManager with refCount == 0");
             else if (refCount == 1) {
-                CACHED_INSTANCES.remove(loginType);
+                CACHED_INSTANCES.remove(cachingKey);
                 login.close();
             }
             --refCount;
@@ -106,8 +117,8 @@ public class LoginManager {
     /* Should only be used in tests. */
     public static void closeAll() {
         synchronized (LoginManager.class) {
-            for (LoginType loginType : new ArrayList<>(CACHED_INSTANCES.keySet())) {
-                LoginManager loginManager = CACHED_INSTANCES.remove(loginType);
+            for (Object key : new ArrayList<>(CACHED_INSTANCES.keySet())) {
+                LoginManager loginManager = CACHED_INSTANCES.remove(key);
                 loginManager.login.close();
             }
         }

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -92,14 +92,14 @@ public class KerberosLogin extends AbstractLogin {
      * @throws javax.security.auth.login.LoginException
      *               Thrown if authentication fails.
      */
-    public void configure(Map<String, ?> configs, final String loginContextName) {
-        super.configure(configs, loginContextName);
+    public void configure(Map<String, ?> configs, Configuration jaasConfig, final String loginContextName) {
+        super.configure(configs, jaasConfig, loginContextName);
         this.loginContextName = loginContextName;
         this.ticketRenewWindowFactor = (Double) configs.get(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR);
         this.ticketRenewJitter = (Double) configs.get(SaslConfigs.SASL_KERBEROS_TICKET_RENEW_JITTER);
         this.minTimeBeforeRelogin = (Long) configs.get(SaslConfigs.SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN);
         this.kinitCmd = (String) configs.get(SaslConfigs.SASL_KERBEROS_KINIT_CMD);
-        this.serviceName = getServiceName(configs, loginContextName);
+        this.serviceName = getServiceName(jaasConfig, configs, loginContextName);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class KerberosLogin extends AbstractLogin {
         subject = loginContext.getSubject();
         isKrbTicket = !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
 
-        AppConfigurationEntry[] entries = Configuration.getConfiguration().getAppConfigurationEntry(loginContextName);
+        AppConfigurationEntry[] entries = jaasConfig().getAppConfigurationEntry(loginContextName);
         if (entries.length == 0) {
             isUsingTicketCache = false;
             principal = null;
@@ -290,10 +290,10 @@ public class KerberosLogin extends AbstractLogin {
         return serviceName;
     }
 
-    private String getServiceName(Map<String, ?> configs, String loginContext) {
+    private String getServiceName(Configuration jaasConfig, Map<String, ?> configs, String loginContext) {
         String jaasServiceName;
         try {
-            jaasServiceName = JaasUtils.jaasConfig(loginContext, JaasUtils.SERVICE_NAME);
+            jaasServiceName = JaasUtils.jaasConfig(jaasConfig, loginContext, JaasUtils.SERVICE_NAME);
         } catch (IOException e) {
             throw new KafkaException("Jaas configuration not found", e);
         }

--- a/clients/src/test/java/org/apache/kafka/common/security/auth/JaasConfigProviderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/auth/JaasConfigProviderTest.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.auth;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
+import javax.security.auth.login.Configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.network.LoginType;
+import org.apache.kafka.common.security.JaasUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests parsing of {@link SaslConfigs#SASL_JAAS_CONFIG} property and verifies that the format
+ * and parsing are consistent with JAAS configuration files loaded by the JRE.
+ *
+ */
+public class JaasConfigProviderTest {
+
+    private File jaasConfigFile;
+
+    @Before
+    public void setUp() throws IOException {
+        jaasConfigFile = File.createTempFile("jaas", ".conf");
+        jaasConfigFile.deleteOnExit();
+        Configuration.setConfiguration(null);
+        System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, jaasConfigFile.toString());
+    }
+
+    @After
+    public void tearDown() {
+        jaasConfigFile.delete();
+
+    }
+
+    @Test
+    public void testConfigNoOptions() throws Exception {
+        testConfiguration("test.testConfigNoOptions", LoginModuleControlFlag.REQUIRED, new HashMap<String, Object>());
+    }
+
+    @Test
+    public void testControlFlag() throws Exception {
+        LoginModuleControlFlag[] controlFlags = new LoginModuleControlFlag[] {
+            LoginModuleControlFlag.REQUIRED,
+            LoginModuleControlFlag.REQUISITE,
+            LoginModuleControlFlag.SUFFICIENT,
+            LoginModuleControlFlag.OPTIONAL
+        };
+        Map<String, Object> options = new HashMap<>();
+        options.put("propName", "propValue");
+        for (LoginModuleControlFlag controlFlag : controlFlags) {
+            testConfiguration("test.testControlFlag", controlFlag, options);
+        }
+    }
+
+    @Test
+    public void testSingleOption() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("propName", "propValue");
+        testConfiguration("test.testSingleOption", LoginModuleControlFlag.REQUISITE, options);
+    }
+
+    @Test
+    public void testMultipleOptions() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        for (int i = 0; i < 10; i++)
+            options.put("propName" + i, "propValue" + i);
+        testConfiguration("test.testMultipleOptions", LoginModuleControlFlag.SUFFICIENT, options);
+    }
+
+    @Test
+    public void testQuotedOptionValue() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("propName", "prop value");
+        options.put("propName2", "value1 = 1, value2 = 2");
+        String config = String.format("test.testQuotedOptionValue required propName=\"%s\" propName2=\"%s\";", options.get("propName"), options.get("propName2"));
+        testConfiguration(config, "test.testQuotedOptionValue", LoginModuleControlFlag.REQUIRED, options);
+    }
+
+    @Test
+    public void testQuotedOptionName() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("prop name", "propValue");
+        String config = "test.testQuotedOptionName required \"prop name\"=propValue;";
+        testConfiguration(config, "test.testQuotedOptionName", LoginModuleControlFlag.REQUIRED, options);
+    }
+
+    @Test
+    public void testMultipleLoginModules() throws Exception {
+        StringBuilder builder = new StringBuilder();
+        int moduleCount = 3;
+        Map<Integer, Map<String, Object>> moduleOptions = new HashMap<>();
+        for (int i = 0; i < moduleCount; i++) {
+            Map<String, Object> options = new HashMap<>();
+            options.put("index", "Index" + i);
+            options.put("module", "Module" + i);
+            moduleOptions.put(i, options);
+            String module = jaasConfigProp("test.Module" + i, LoginModuleControlFlag.REQUIRED, options);
+            builder.append(' ');
+            builder.append(module);
+        }
+        String jaasConfigProp = builder.toString();
+
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(SaslConfigs.SASL_JAAS_CONFIG, new Password(jaasConfigProp));
+        Configuration configuration = JaasConfigProvider.jaasConfig(LoginType.CLIENT, configs);
+        AppConfigurationEntry[] dynamicEntries = configuration.getAppConfigurationEntry(LoginType.CLIENT.contextName());
+        assertEquals(moduleCount, dynamicEntries.length);
+
+        for (int i = 0; i < moduleCount; i++) {
+            AppConfigurationEntry entry = dynamicEntries[i];
+            checkEntry(entry, "test.Module" + i, LoginModuleControlFlag.REQUIRED, moduleOptions.get(i));
+        }
+
+        writeConfiguration(LoginType.SERVER, jaasConfigProp);
+        AppConfigurationEntry[] staticEntries = Configuration.getConfiguration().getAppConfigurationEntry(LoginType.SERVER.contextName());
+        for (int i = 0; i < moduleCount; i++) {
+            AppConfigurationEntry staticEntry = staticEntries[i];
+            checkEntry(staticEntry, dynamicEntries[i].getLoginModuleName(), LoginModuleControlFlag.REQUIRED, dynamicEntries[i].getOptions());
+        }
+    }
+
+    @Test
+    public void testMissingLoginModule() throws Exception {
+        testInvalidConfiguration("  required option1=value1;");
+    }
+
+    @Test
+    public void testMissingControlFlag() throws Exception {
+        testInvalidConfiguration("test.loginModule option1=value1;");
+    }
+
+    @Test
+    public void testMissingOptionValue() throws Exception {
+        testInvalidConfiguration("loginModule required option1;");
+    }
+
+    @Test
+    public void testMissingSemicolon() throws Exception {
+        testInvalidConfiguration("test.testMissingSemicolon required option1=value1");
+    }
+
+    @Test
+    public void testNumericOptionWithoutQuotes() throws Exception {
+        testInvalidConfiguration("test.testNumericOptionWithoutQuotes required option1=3;");
+    }
+
+    @Test
+    public void testNumericOptionWithQuotes() throws Exception {
+        Map<String, Object> options = new HashMap<>();
+        options.put("option1", "3");
+        String config = "test.testNumericOptionWithQuotes required option1=\"3\";";
+        Configuration.setConfiguration(null);
+        testConfiguration(config, "test.testNumericOptionWithQuotes", LoginModuleControlFlag.REQUIRED, options);
+    }
+
+    private AppConfigurationEntry configurationEntry(LoginType loginType, String jaasConfigProp) {
+        Map<String, Object> configs = new HashMap<>();
+        if (jaasConfigProp != null)
+            configs.put(SaslConfigs.SASL_JAAS_CONFIG, new Password(jaasConfigProp));
+        Configuration configuration = JaasConfigProvider.jaasConfig(loginType, configs);
+        AppConfigurationEntry[] entry = configuration.getAppConfigurationEntry(loginType.contextName());
+        assertEquals(1, entry.length);
+        return entry[0];
+    }
+
+    private String controlFlag(LoginModuleControlFlag loginModuleControlFlag) {
+        // LoginModuleControlFlag.toString() has format "LoginModuleControlFlag: flag"
+        String[] tokens = loginModuleControlFlag.toString().split(" ");
+        return tokens[tokens.length - 1];
+    }
+
+    private String jaasConfigProp(String loginModule, LoginModuleControlFlag controlFlag, Map<String, Object> options) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(loginModule);
+        builder.append(' ');
+        builder.append(controlFlag(controlFlag));
+        for (Map.Entry<String, Object> entry : options.entrySet()) {
+            builder.append(' ');
+            builder.append(entry.getKey());
+            builder.append('=');
+            builder.append(entry.getValue());
+        }
+        builder.append(';');
+        return builder.toString();
+    }
+
+    private void writeConfiguration(LoginType loginType, String jaasConfigProp) throws IOException {
+        FileWriter writer = new FileWriter(jaasConfigFile);
+        writer.write(loginType.contextName() + " { ");
+        writer.write(jaasConfigProp);
+        writer.write("};");
+        writer.close();
+        Configuration.setConfiguration(null);
+    }
+
+    private void testConfiguration(String loginModule, LoginModuleControlFlag controlFlag, Map<String, Object> options) throws Exception {
+        String jaasConfigProp = jaasConfigProp(loginModule, controlFlag, options);
+        testConfiguration(jaasConfigProp, loginModule, controlFlag, options);
+    }
+
+    private void checkEntry(AppConfigurationEntry entry, String loginModule, LoginModuleControlFlag controlFlag, Map<String, ?> options) {
+        assertEquals(loginModule, entry.getLoginModuleName());
+        assertEquals(controlFlag, entry.getControlFlag());
+        assertEquals(options, entry.getOptions());
+    }
+
+    private void testConfiguration(String jaasConfigProp, String loginModule, LoginModuleControlFlag controlFlag, Map<String, Object> options) throws Exception {
+        AppConfigurationEntry dynamicEntry = configurationEntry(LoginType.CLIENT, jaasConfigProp);
+        checkEntry(dynamicEntry, loginModule, controlFlag, options);
+        assertNull("Static configuration updated", Configuration.getConfiguration().getAppConfigurationEntry(LoginType.CLIENT.contextName()));
+
+        writeConfiguration(LoginType.SERVER, jaasConfigProp);
+        AppConfigurationEntry jaasConfEntry = configurationEntry(LoginType.SERVER, null);
+        checkEntry(jaasConfEntry, loginModule, controlFlag, options);
+    }
+
+    private void testInvalidConfiguration(String jaasConfigProp) throws IOException {
+        try {
+            writeConfiguration(LoginType.SERVER, jaasConfigProp);
+            AppConfigurationEntry entry = configurationEntry(LoginType.SERVER, null);
+            fail("Invalid JAAS configuration file didn't throw exception, entry=" + entry);
+        } catch (SecurityException e) {
+            // Expected exception
+        }
+        try {
+            AppConfigurationEntry entry = configurationEntry(LoginType.CLIENT, jaasConfigProp);
+            fail("Invalid JAAS configuration property didn't throw exception, entry=" + entry);
+        } catch (IllegalArgumentException e) {
+            // Expected exception
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.requests.ResponseHeader;
 import org.apache.kafka.common.requests.SaslHandshakeRequest;
 import org.apache.kafka.common.requests.SaslHandshakeResponse;
 import org.apache.kafka.common.security.JaasUtils;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,9 +49,12 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import javax.security.auth.login.Configuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -493,6 +497,41 @@ public class SaslAuthenticatorTest {
     }
 
     /**
+     * Tests dynamic JAAS configuration property for SASL clients. Invalid client credentials
+     * are set in the static JVM-wide configuration instance to ensure that the dynamic
+     * property override is used during authentication.
+     */
+    @Test
+    public void testDynamicJaasConfiguration() throws Exception {
+        SecurityProtocol securityProtocol = SecurityProtocol.SASL_SSL;
+        saslClientConfigs.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+        saslServerConfigs.put(SaslConfigs.SASL_ENABLED_MECHANISMS, Arrays.asList("PLAIN"));
+        Map<String, Object> serverOptions = new HashMap<>();
+        serverOptions.put("user_user1", "user1-secret");
+        serverOptions.put("user_user2", "user2-secret");
+        TestJaasConfig staticJaasConfig = new TestJaasConfig();
+        staticJaasConfig.createOrUpdateEntry(JaasUtils.LOGIN_CONTEXT_SERVER, PlainLoginModule.class.getName(), serverOptions);
+        staticJaasConfig.setPlainClientOptions("user1", "invalidpassword");
+        Configuration.setConfiguration(staticJaasConfig);
+        server = NetworkTestUtils.createEchoServer(securityProtocol, saslServerConfigs);
+
+        // Check that client using static Jaas config does not connect since password is invalid
+        createAndCheckClientConnectionFailure(securityProtocol, "1");
+
+        // Check that 'user1' can connect with a Jaas config property override
+        saslClientConfigs.put(SaslConfigs.SASL_JAAS_CONFIG, TestJaasConfig.getJaasConfigProperty("PLAIN", "user1", "user1-secret"));
+        createAndCheckClientConnection(securityProtocol, "2");
+
+        // Check that invalid password specified as Jaas config property results in connection failure
+        saslClientConfigs.put(SaslConfigs.SASL_JAAS_CONFIG, TestJaasConfig.getJaasConfigProperty("PLAIN", "user1", "user2-secret"));
+        createAndCheckClientConnectionFailure(securityProtocol, "3");
+
+        // Check that another user 'user2' can also connect with a Jaas config override without any changes to static configuration
+        saslClientConfigs.put(SaslConfigs.SASL_JAAS_CONFIG, TestJaasConfig.getJaasConfigProperty("PLAIN", "user2", "user2-secret"));
+        createAndCheckClientConnection(securityProtocol, "4");
+    }
+
+    /**
      * Tests that Kafka ApiVersionsRequests are handled by the SASL server authenticator
      * prior to SASL handshake flow and that subsequent authentication succeeds
      * when transport layer is PLAINTEXT/SSL. This test uses a non-SASL client that simulates
@@ -580,6 +619,13 @@ public class SaslAuthenticatorTest {
     private void createAndCheckClientConnection(SecurityProtocol securityProtocol, String node) throws Exception {
         createClientConnection(securityProtocol, node);
         NetworkTestUtils.checkClientConnection(selector, node, 100, 10);
+        selector.close();
+        selector = null;
+    }
+
+    private void createAndCheckClientConnectionFailure(SecurityProtocol securityProtocol, String node) throws Exception {
+        createClientConnection(securityProtocol, node);
+        NetworkTestUtils.waitForChannelClose(selector, node);
         selector.close();
         selector = null;
     }

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/TestJaasConfig.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/TestJaasConfig.java
@@ -20,6 +20,7 @@ import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
 
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 
@@ -38,6 +39,10 @@ public class TestJaasConfig extends Configuration {
         }
         Configuration.setConfiguration(config);
         return config;
+    }
+
+    public static Password getJaasConfigProperty(String mechanism, String username, String password) {
+        return new Password(loginModule(mechanism) + " required username=" + username + " password=" + password + ";");
     }
 
     public void setPlainClientOptions(String clientUsername, String clientPassword) {

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -210,7 +210,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     consumeRecords(this.consumers.head, numRecords)
   }
 
-  private def setAclsAndProduce() {
+  protected def setAclsAndProduce() {
     AclCommand.main(produceAclArgs)
     AclCommand.main(consumeAclArgs)
     servers.foreach { s =>
@@ -276,8 +276,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
 
     AclCommand.main(deleteDescribeAclArgs)
     AclCommand.main(deleteWriteAclArgs)
-    servers.foreach { _ =>
-      TestUtils.waitAndVerifyAcls(GroupReadAcl, servers.head.apis.authorizer.get, groupResource)
+    servers.foreach { s =>
+      TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
   }
  
@@ -318,7 +318,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     AclCommand.main(groupAclArgs)
     servers.foreach { s =>
       TestUtils.waitAndVerifyAcls(TopicWriteAcl ++ TopicDescribeAcl, s.apis.authorizer.get, topicResource)
-      TestUtils.waitAndVerifyAcls(GroupReadAcl, servers.head.apis.authorizer.get, groupResource)
+      TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
     sendRecords(numRecords, tp)
   }
@@ -357,7 +357,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     }
   }
 
-  private def consumeRecords(consumer: Consumer[Array[Byte], Array[Byte]],
+  protected def consumeRecords(consumer: Consumer[Array[Byte], Array[Byte]],
                              numRecords: Int = 1,
                              startingOffset: Int = 0,
                              topic: String = topic,

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -16,7 +16,10 @@
   */
 package kafka.api
 
+import java.io.File
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.config.SaslConfigs
+import kafka.utils.JaasTestUtils
 
 class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
@@ -24,4 +27,13 @@ class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def kafkaServerSaslMechanisms = List("PLAIN")
   override val clientPrincipal = "testuser"
   override val kafkaPrincipal = "admin"
+
+  // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
+  override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
+      serverKeytabFile: Option[File] = None, clientKeytabFile: Option[File] = None) {
+    super.setJaasConfiguration(mode, kafkaServerSaslMechanisms, List()) // create static config without client login contexts
+    val clientLoginModule = JaasTestUtils.clientLoginModule(kafkaClientSaslMechanism, None)
+    producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
+    consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
+  }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -20,13 +20,22 @@ import java.io.File
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.kafka.common.config.SaslConfigs
 import kafka.utils.JaasTestUtils
+import org.junit.Test
+import java.util.Properties
+import scala.collection.immutable.List
+import scala.collection.JavaConverters._
+import kafka.utils.TestUtils
+import kafka.utils.JaasTestUtils.PlainLoginModule
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.errors.GroupAuthorizationException
 
 class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected def kafkaClientSaslMechanism = "PLAIN"
   override protected def kafkaServerSaslMechanisms = List("PLAIN")
-  override val clientPrincipal = "testuser"
-  override val kafkaPrincipal = "admin"
+  override val clientPrincipal = JaasTestUtils.KafkaPlainUser
+  override val kafkaPrincipal = JaasTestUtils.KafkaPlainAdmin
 
   // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
   override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
@@ -36,4 +45,38 @@ class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
     consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
   }
+
+  @Test
+  def testConsumer1AllowedConsumer2NotAllowed {
+    setAclsAndProduce()
+    val consumer1 = consumers.head
+
+    val consumer2Config = new Properties
+    consumer2Config.putAll(consumerConfig)
+    val clientLoginContext2 = PlainLoginModule(
+          JaasTestUtils.KafkaPlainUser2,
+          JaasTestUtils.KafkaPlainPassword2
+        ).toJaasModule.toString.stripMargin
+    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
+
+    val consumer2 = TestUtils.createNewConsumer(brokerList,
+                                  securityProtocol = this.securityProtocol,
+                                  trustStoreFile = this.trustStoreFile,
+                                  saslProperties = this.saslProperties,
+                                  props = Some(consumer2Config))
+    consumers += consumer2
+
+    consumer1.assign(List(tp).asJava)
+    consumer2.assign(List(tp).asJava)
+
+    consumeRecords(consumer1, numRecords)
+
+    try {
+      consumeRecords(consumer2, timeout = 5000)
+      fail("expected KafkaException as consumer2 has no access to topic")
+    } catch {
+      case e : GroupAuthorizationException => //expected
+    }
+  }
+
 }

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -54,8 +54,8 @@ trait SaslSetup {
       setJaasConfiguration(mode, kafkaServerSaslMechanisms, kafkaClientSaslMechanisms, Some(serverKeytabFile), Some(clientKeytabFile))
       kdc = new MiniKdc(kdcConf, workDir)
       kdc.start()
-      kdc.createPrincipal(serverKeytabFile, "kafka/localhost")
-      kdc.createPrincipal(clientKeytabFile, "client")
+      kdc.createPrincipal(serverKeytabFile, JaasTestUtils.KafkaServerPrincipalUnqualifiedName + "/localhost")
+      kdc.createPrincipal(clientKeytabFile, JaasTestUtils.KafkaClientPrincipalUnqualifiedName, JaasTestUtils.KafkaClientPrincipalUnqualifiedName2)
     } else {
       setJaasConfiguration(mode, kafkaServerSaslMechanisms, kafkaClientSaslMechanisms)
     }

--- a/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
@@ -16,17 +16,79 @@
   */
 package kafka.api
 
+import scala.collection.immutable.List
+import scala.collection.JavaConverters._
+
+import org.junit.Test
+import java.util.Properties
+import java.io.File
 import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.utils.JaasTestUtils
+import kafka.utils.JaasTestUtils.Krb5LoginModule
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.errors.GroupAuthorizationException
 
 class SaslSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
-  override val clientPrincipal = "client"
-  override val kafkaPrincipal = "kafka"
+  override val clientPrincipal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName
+  override val kafkaPrincipal = JaasTestUtils.KafkaServerPrincipalUnqualifiedName
+  
+  var clientKeytabFile: Option[File] = None
 
   // Configure brokers to require SSL client authentication in order to verify that SASL_SSL works correctly even if the
   // client doesn't have a keystore. We want to cover the scenario where a broker requires either SSL client
   // authentication or SASL authentication with SSL as the transport layer (but not both).
   serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
+
+  // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
+  override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
+      serverKeytabFile: Option[File] = None, clientKeytabFile: Option[File] = None) {
+    this.clientKeytabFile = clientKeytabFile;
+    super.setJaasConfiguration(mode, kafkaServerSaslMechanisms, List(), serverKeytabFile, clientKeytabFile)
+    val clientLoginContext = JaasTestUtils.clientLoginModule(kafkaClientSaslMechanism, clientKeytabFile)
+    producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+    consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+  }
+
+
+  @Test
+  def testConsumer1AllowedConsumer2NotAllowed {
+    setAclsAndProduce()
+    val consumer1 = consumers.head
+
+    val consumer2Config = new Properties
+    consumer2Config.putAll(consumerConfig)
+    val clientLoginContext2 = Krb5LoginModule(
+          useKeyTab = true,
+          storeKey = true,
+          keyTab = this.clientKeytabFile.getOrElse(throw new IllegalArgumentException("Keytab location not specified for GSSAPI")).getAbsolutePath,
+          principal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName2 + "@EXAMPLE.COM",
+          debug = true,
+          serviceName = Some("kafka")
+        ).toJaasModule.toString.stripMargin
+    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
+
+    val consumer2 = TestUtils.createNewConsumer(brokerList,
+                                  securityProtocol = this.securityProtocol,
+                                  trustStoreFile = this.trustStoreFile,
+                                  saslProperties = this.saslProperties,
+                                  props = Some(consumer2Config))
+    consumers += consumer2
+
+    consumer1.assign(List(tp).asJava)
+    consumer2.assign(List(tp).asJava)
+
+    consumeRecords(consumer1, numRecords)
+
+    try {
+      consumeRecords(consumer2, timeout = 5000)
+      fail("expected KafkaException as consumer2 has no access to topic")
+    } catch {
+      case e : GroupAuthorizationException => //expected
+    }
+  }
 
 }

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -114,6 +114,9 @@ object JaasTestUtils {
     jaasFile.getCanonicalPath
   }
 
+  def clientLoginModule(mechanism: String, keytabLocation: Option[File]): String =
+    kafkaClientModule(mechanism, keytabLocation).toString.stripMargin
+
   private def zkSections: Seq[JaasSection] = Seq(
     new JaasSection(ZkServerContextName, Seq(JaasModule(ZkModule, false, Map("user_super" -> ZkUserSuperPasswd, s"user_$ZkUser" -> ZkUserPassword)))),
     new JaasSection(ZkClientContextName, Seq(JaasModule(ZkModule, false, Map("username" -> ZkUser, "password" -> ZkUserPassword))))
@@ -140,8 +143,8 @@ object JaasTestUtils {
     new JaasSection(KafkaServerContextName, modules)
   }
 
-  private def kafkaClientSection(mechanisms: List[String], keytabLocation: Option[File]): JaasSection = {
-    val modules = mechanisms.map {
+  def kafkaClientModule(mechanism: String, keytabLocation: Option[File]): JaasModule = {
+    mechanism match {
       case "GSSAPI" =>
         Krb5LoginModule(
           useKeyTab = true,
@@ -158,7 +161,10 @@ object JaasTestUtils {
         ).toJaasModule
       case mechanism => throw new IllegalArgumentException("Unsupported client mechanism " + mechanism)
     }
-    new JaasSection(KafkaClientContextName, modules)
+  }
+
+  private def kafkaClientSection(mechanisms: List[String], keytabLocation: Option[File]): JaasSection = {
+    new JaasSection(KafkaClientContextName, mechanisms.map(m => kafkaClientModule(m, keytabLocation)))
   }
 
   private def jaasSectionsToString(jaasSections: Seq[JaasSection]): String =

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -85,13 +85,18 @@ object JaasTestUtils {
   private val ZkModule = "org.apache.zookeeper.server.auth.DigestLoginModule"
 
   private val KafkaServerContextName = "KafkaServer"
-  private val KafkaServerPrincipal = "kafka/localhost@EXAMPLE.COM"
+  val KafkaServerPrincipalUnqualifiedName = "kafka"
+  private val KafkaServerPrincipal = KafkaServerPrincipalUnqualifiedName + "/localhost@EXAMPLE.COM"
   private val KafkaClientContextName = "KafkaClient"
-  private val KafkaClientPrincipal = "client@EXAMPLE.COM"
+  val KafkaClientPrincipalUnqualifiedName = "client"
+  private val KafkaClientPrincipal = KafkaClientPrincipalUnqualifiedName + "@EXAMPLE.COM"
+  val KafkaClientPrincipalUnqualifiedName2 = "client2"
   
-  private val KafkaPlainUser = "testuser"
+  val KafkaPlainUser = "testuser"
   private val KafkaPlainPassword = "testuser-secret"
-  private val KafkaPlainAdmin = "admin"
+  val KafkaPlainUser2 = "testuser2"
+  val KafkaPlainPassword2 = "testuser2-secret"
+  val KafkaPlainAdmin = "admin"
   private val KafkaPlainAdminPassword = "admin-secret"
 
   def writeZkFile(): String = {
@@ -137,7 +142,7 @@ object JaasTestUtils {
           KafkaPlainAdmin,
           KafkaPlainAdminPassword,
           debug = false,
-          Map(KafkaPlainAdmin -> KafkaPlainAdminPassword, KafkaPlainUser -> KafkaPlainPassword)).toJaasModule
+          Map(KafkaPlainAdmin -> KafkaPlainAdminPassword, KafkaPlainUser -> KafkaPlainPassword, KafkaPlainUser2 -> KafkaPlainPassword2)).toJaasModule
       case mechanism => throw new IllegalArgumentException("Unsupported server mechanism " + mechanism)
     }
     new JaasSection(KafkaServerContextName, modules)


### PR DESCRIPTION
This PR builds on top of @rajinisivaram https://github.com/apache/kafka/pull/1979
codeveloped with @mimaison 

KAFKA-4180 : Authentication with multiple actives Kafka
producers/consumers

Changed caching in LoginManager to allow one LoginManager per client
JAAS configuration.
Added test to End2EndAuthorization for SASL Plain and Gssapi with two
consumers with different credentials.
