### PR TITLE
KAFKA-4283: records deleted from CachingKeyValueStore still appear in range and all queries

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -228,6 +228,13 @@ public class ThreadCache {
             return nextEntry.key;
         }
 
+        KeyValue<byte[], LRUCacheEntry> peekNext() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            return nextEntry;
+        }
+
         @Override
         public boolean hasNext() {
             if (nextEntry != null) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import static org.apache.kafka.streams.state.internals.ThreadCacheTest.memoryCacheEntrySize;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -127,6 +128,25 @@ public class CachingKeyValueStoreTest {
             results.add(range.next().key);
         }
         assertEquals(items, results.size());
+    }
+
+    @Test
+    public void shouldDeleteItemsFromCache() throws Exception {
+        store.put("a", "a");
+        store.delete("a");
+        assertNull(store.get("a"));
+        assertFalse(store.range("a", "b").hasNext());
+        assertFalse(store.all().hasNext());
+    }
+
+    @Test
+    public void shouldNotShowItemsDeletedFromCacheButFlushedToStoreBeforeDelete() throws Exception {
+        store.put("a", "a");
+        store.flush();
+        store.delete("a");
+        assertNull(store.get("a"));
+        assertFalse(store.range("a", "b").hasNext());
+        assertFalse(store.all().hasNext());
     }
 
     private int addItemsToCache() throws IOException {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
@@ -117,7 +117,7 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
     @Test
     public void shouldSkipAllDeletedFromCache() throws Exception {
         final byte[][] bytes = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}};
-        for (int i = 0; i < bytes.length; i += 2) {
+        for (int i = 0; i < bytes.length; i ++) {
             store.put(Bytes.wrap(bytes[i]), bytes[i]);
             cache.put(namespace, bytes[i], new LRUCacheEntry(bytes[i]));
         }
@@ -126,6 +126,16 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
         cache.put(namespace, bytes[3], new LRUCacheEntry(null));
         cache.put(namespace, bytes[8], new LRUCacheEntry(null));
         cache.put(namespace, bytes[11], new LRUCacheEntry(null));
+
+        final MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> iterator = createIterator();
+        assertArrayEquals(bytes[0], iterator.next().key);
+        assertArrayEquals(bytes[4], iterator.next().key);
+        assertArrayEquals(bytes[5], iterator.next().key);
+        assertArrayEquals(bytes[6], iterator.next().key);
+        assertArrayEquals(bytes[7], iterator.next().key);
+        assertArrayEquals(bytes[9], iterator.next().key);
+        assertArrayEquals(bytes[10], iterator.next().key);
+        assertFalse(iterator.hasNext());
 
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
@@ -30,13 +30,12 @@ import static org.junit.Assert.assertFalse;
 public class MergedSortedCacheKeyValueStoreIteratorTest {
 
     private final String namespace = "one";
-    private StateSerdes<byte[], byte[]> serdes;
+    private final StateSerdes<byte[], byte[]> serdes =  new StateSerdes<>(namespace, Serdes.ByteArray(), Serdes.ByteArray());
     private KeyValueStore<Bytes, byte[]> store;
     private ThreadCache cache;
 
     @Before
     public void setUp() throws Exception {
-        serdes = new StateSerdes<>(namespace, Serdes.ByteArray(), Serdes.ByteArray());
         store = new InMemoryKeyValueStore<>(namespace);
         cache = new ThreadCache(10000L);
     }
@@ -77,7 +76,7 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
     }
 
     @Test
-    public void shouldSkipLowerDeletedCachedValue() throws Exception {
+    public void shouldSkipSmallerDeletedCachedValue() throws Exception {
         final byte[][] bytes = {{0}, {1}};
         cache.put(namespace, bytes[0], new LRUCacheEntry(null));
         store.put(Bytes.wrap(bytes[1]), bytes[1]);
@@ -117,7 +116,7 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
     @Test
     public void shouldSkipAllDeletedFromCache() throws Exception {
         final byte[][] bytes = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}};
-        for (int i = 0; i < bytes.length; i ++) {
+        for (int i = 0; i < bytes.length; i++) {
             store.put(Bytes.wrap(bytes[i]), bytes[i]);
             cache.put(namespace, bytes[i], new LRUCacheEntry(bytes[i]));
         }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
@@ -21,29 +21,40 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StateSerdes;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
 
 public class MergedSortedCacheKeyValueStoreIteratorTest {
 
+    private final String namespace = "one";
+    private StateSerdes<byte[], byte[]> serdes;
+    private KeyValueStore<Bytes, byte[]> store;
+    private ThreadCache cache;
+
+    @Before
+    public void setUp() throws Exception {
+        serdes = new StateSerdes<>(namespace, Serdes.ByteArray(), Serdes.ByteArray());
+        store = new InMemoryKeyValueStore<>(namespace);
+        cache = new ThreadCache(10000L);
+    }
+
     @Test
     public void shouldIterateOverRange() throws Exception {
-        KeyValueStore<Bytes, byte[]> kv = new InMemoryKeyValueStore<>("one");
-        final ThreadCache cache = new ThreadCache(1000000L);
-        byte[][] bytes = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}};
-        final String namespace = "one";
-        for (int i = 0; i < bytes.length - 1; i += 2) {
-            kv.put(Bytes.wrap(bytes[i]), bytes[i]);
+        final byte[][] bytes = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}};
+        for (int i = 0; i < bytes.length; i += 2) {
+            store.put(Bytes.wrap(bytes[i]), bytes[i]);
             cache.put(namespace, bytes[i + 1], new LRUCacheEntry(bytes[i + 1]));
         }
 
         final Bytes from = Bytes.wrap(new byte[]{2});
         final Bytes to = Bytes.wrap(new byte[]{9});
-        final PeekingKeyValueIterator<Bytes, byte[]> storeIterator = new DelegatingPeekingKeyValueIterator<>(kv.range(from, to));
+        final PeekingKeyValueIterator<Bytes, byte[]> storeIterator = new DelegatingPeekingKeyValueIterator<>(store.range(from, to));
         final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.range(namespace, from.get(), to.get());
 
-        final MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> iterator = new MergedSortedCacheKeyValueStoreIterator<>(cacheIterator, storeIterator, new StateSerdes<>("name", Serdes.ByteArray(), Serdes.ByteArray()));
+        final MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> iterator = new MergedSortedCacheKeyValueStoreIterator<>(cacheIterator, storeIterator, serdes);
         byte[][] values = new byte[8][];
         int index = 0;
         int bytesIndex = 2;
@@ -53,5 +64,76 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
             assertArrayEquals(bytes[bytesIndex++], value);
         }
     }
+
+
+    @Test
+    public void shouldSkipLargerDeletedCacheValue() throws Exception {
+        final byte[][] bytes = {{0}, {1}};
+        store.put(Bytes.wrap(bytes[0]), bytes[0]);
+        cache.put(namespace, bytes[1], new LRUCacheEntry(null));
+        final MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> iterator = createIterator();
+        assertArrayEquals(bytes[0], iterator.next().key);
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void shouldSkipLowerDeletedCachedValue() throws Exception {
+        final byte[][] bytes = {{0}, {1}};
+        cache.put(namespace, bytes[0], new LRUCacheEntry(null));
+        store.put(Bytes.wrap(bytes[1]), bytes[1]);
+        final MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> iterator = createIterator();
+        assertArrayEquals(bytes[1], iterator.next().key);
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void shouldIgnoreIfDeletedInCacheButExistsInStore() throws Exception {
+        final byte[][] bytes = {{0}};
+        cache.put(namespace, bytes[0], new LRUCacheEntry(null));
+        store.put(Bytes.wrap(bytes[0]), bytes[0]);
+        final MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> iterator = createIterator();
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void shouldNotHaveNextIfAllCachedItemsDeleted() throws Exception {
+        final byte[][] bytes = {{0}, {1}, {2}};
+        for (int i = 0; i < bytes.length; i++) {
+            store.put(Bytes.wrap(bytes[i]), bytes[i]);
+            cache.put(namespace, bytes[i], new LRUCacheEntry(null));
+        }
+        assertFalse(createIterator().hasNext());
+    }
+
+    @Test
+    public void shouldNotHaveNextIfOnlyCacheItemsAndAllDeleted() throws Exception {
+        final byte[][] bytes = {{0}, {1}, {2}};
+        for (int i = 0; i < bytes.length; i++) {
+            cache.put(namespace, bytes[i], new LRUCacheEntry(null));
+        }
+        assertFalse(createIterator().hasNext());
+    }
+
+    @Test
+    public void shouldSkipAllDeletedFromCache() throws Exception {
+        final byte[][] bytes = {{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}, {10}, {11}};
+        for (int i = 0; i < bytes.length; i += 2) {
+            store.put(Bytes.wrap(bytes[i]), bytes[i]);
+            cache.put(namespace, bytes[i], new LRUCacheEntry(bytes[i]));
+        }
+        cache.put(namespace, bytes[1], new LRUCacheEntry(null));
+        cache.put(namespace, bytes[2], new LRUCacheEntry(null));
+        cache.put(namespace, bytes[3], new LRUCacheEntry(null));
+        cache.put(namespace, bytes[8], new LRUCacheEntry(null));
+        cache.put(namespace, bytes[11], new LRUCacheEntry(null));
+
+    }
+
+    private MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> createIterator() {
+        final ThreadCache.MemoryLRUCacheBytesIterator cacheIterator = cache.all(namespace);
+        final PeekingKeyValueIterator<Bytes, byte[]> storeIterator = new DelegatingPeekingKeyValueIterator<>(store.all());
+        return new MergedSortedCacheKeyValueStoreIterator<>(cacheIterator, storeIterator, serdes);
+    }
+
 
 }


### PR DESCRIPTION
Records that are deleted/removed from the CachingKeyValueStore shouldn't appear in range and all queries.
Modified the iterator such that it skips over the deleted records.
