### PR TITLE
KAFKA-4289 - moved short-lived loggers to companion objects

### DIFF
--- a/core/src/main/scala/kafka/log/FileMessageSet.scala
+++ b/core/src/main/scala/kafka/log/FileMessageSet.scala
@@ -47,8 +47,8 @@ class FileMessageSet private[kafka](@volatile var file: File,
                                     private[log] val channel: FileChannel,
                                     private[log] val start: Int,
                                     private[log] val end: Int,
-                                    isSlice: Boolean) extends MessageSet with Logging {
-
+                                    isSlice: Boolean) extends MessageSet {
+  import FileMessageSet._
   /* the size of the message set in bytes */
   private val _size =
     if(isSlice)
@@ -430,8 +430,11 @@ class FileMessageSet private[kafka](@volatile var file: File,
 
 }
 
-object FileMessageSet
+object FileMessageSet extends Logging
 {
+  //preserve the previous logger name after moving logger aspect from FileMessageSet to companion
+  override val loggerName = classOf[FileMessageSet].getName
+
   /**
    * Open a channel for the given file
    * For windows NTFS and some old LINUX file system, set preallocate to true and initFileSize

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -38,6 +38,7 @@ import org.apache.log4j.Logger
 
 object RequestChannel extends Logging {
   val AllDone = new Request(processor = 1, connectionId = "2", new Session(KafkaPrincipal.ANONYMOUS, InetAddress.getLocalHost()), buffer = getShutdownReceive(), startTimeMs = 0, securityProtocol = SecurityProtocol.PLAINTEXT)
+  private val requestLogger = Logger.getLogger("kafka.request.logger")
 
   def getShutdownReceive() = {
     val emptyRequestHeader = new RequestHeader(ApiKeys.PRODUCE.id, "", 0)
@@ -102,7 +103,6 @@ object RequestChannel extends Logging {
         null
 
     buffer = null
-    private val requestLogger = Logger.getLogger("kafka.request.logger")
 
     def requestDesc(details: Boolean): String = {
       if (requestObj != null)


### PR DESCRIPTION
Signed-off-by: radai-rosenblatt radai.rosenblatt@gmail.com
