### PR TITLE
KAFKA-4300: NamedCache throws an NPE when evict is called and the cache is empty

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -190,6 +190,9 @@ class NamedCache {
     }
 
     synchronized void evict() {
+        if (tail == null) {
+            return;
+        }
         final LRUNode eldest = tail;
         currentSizeBytes -= eldest.size();
         if (eldest.entry.isDirty()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -186,4 +186,9 @@ public class NamedCacheTest {
         assertEquals(Bytes.wrap(new byte[]{2}), iterator.next());
         assertFalse(iterator.hasNext());
     }
+
+    @Test
+    public void shouldNotThrowNullPointerWhenCacheIsEmptyAndEvictionCalled() throws Exception {
+        cache.evict();
+    }
 }


### PR DESCRIPTION
If evict is called on a NamedCache and the cache is empty an NPE is thrown. This was reported on the user list from a developer running 0.10.1.
