### PR TITLE
KAFKA-4293 - improve ByteBufferMessageSet.deepIterator() performance by relying on underlying stream's available() implementation

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -46,6 +46,7 @@
     <disallow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.common" exact-match="true" />
     <allow pkg="org.apache.kafka.test" />
+    <allow pkg="org.xerial.snappy" />
 
     <subpackage name="config">
       <allow pkg="org.apache.kafka.common.config" />

--- a/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java
@@ -259,9 +259,8 @@ public final class KafkaLZ4BlockOutputStream extends FilterOutputStream {
     @Override
     public void close() throws IOException {
         if (!finished) {
-            writeEndMark();
             flush();
-            finished = true;
+            writeEndMark(); //write the end block only after flush() wrote the block. also sets finish = true
         }
         if (out != null) {
             out.close();

--- a/clients/src/test/java/org/apache/kafka/common/record/CompressionCodecsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/CompressionCodecsTest.java
@@ -1,0 +1,217 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.xerial.snappy.SnappyInputStream;
+import org.xerial.snappy.SnappyOutputStream;
+
+
+public class CompressionCodecsTest {
+    @Rule
+    public PrintRandomSeed printRule = new PrintRandomSeed();
+    private long seed;
+    private Random random;
+
+    @Before
+    public void setup() {
+        seed = System.currentTimeMillis();
+        random = new Random(seed);
+    }
+
+    @Test
+    public void testByteArrayInputStream() throws Exception {
+        testCodec(
+            new InputStreamWrapper() {
+                @Override
+                public InputStream wrap(InputStream underlying) throws Exception {
+                    //noinspection RedundantCast - serves as assertion
+                    return (ByteArrayInputStream) underlying;
+                }
+            },
+            new OutputStreamWrapper() {
+                @Override
+                public OutputStream wrap(OutputStream underlying) throws Exception {
+                    //noinspection RedundantCast - serves as assertion
+                    return (ByteArrayOutputStream) underlying;
+                }
+            });
+    }
+
+    @Test
+    public void testByteBufferInputStream() throws Exception {
+        byte[] blob = generateRandomData();
+        ByteBufferInputStream is = new ByteBufferInputStream(ByteBuffer.wrap(blob));
+        testCodec(blob, is);
+    }
+
+    @Test(expected = AssertionError.class) //vanilla gzip has a bad impl of available()
+    public void testVanillaGzip() throws Exception {
+        testCodec(
+            new InputStreamWrapper() {
+                @Override
+                public InputStream wrap(InputStream underlying) throws Exception {
+                    return new GZIPInputStream(underlying);
+                }
+            },
+            new OutputStreamWrapper() {
+                @Override
+                public OutputStream wrap(OutputStream underlying) throws Exception {
+                    return new GZIPOutputStream(underlying);
+                }
+            });
+    }
+
+    @Test
+    public void testKafkaGzip() throws Exception {
+        testCodec(
+            new InputStreamWrapper() {
+                @Override
+                public InputStream wrap(InputStream underlying) throws Exception {
+                    return new KafkaGZIPInputStream(underlying);
+                }
+            },
+            new OutputStreamWrapper() {
+                @Override
+                public OutputStream wrap(OutputStream underlying) throws Exception {
+                    return new GZIPOutputStream(underlying); //use vanilla
+                }
+            });
+    }
+
+    @Test
+    public void testSnappy() throws Exception {
+        testCodec(
+            new InputStreamWrapper() {
+                @Override
+                public InputStream wrap(InputStream underlying) throws Exception {
+                    return new SnappyInputStream(underlying);
+                }
+            },
+            new OutputStreamWrapper() {
+                @Override
+                public OutputStream wrap(OutputStream underlying) throws Exception {
+                    return new SnappyOutputStream(underlying);
+                }
+            });
+    }
+
+    @Test
+    public void testKafkaLz4Legacy() throws Exception {
+        testCodec(
+            new InputStreamWrapper() {
+                @Override
+                public InputStream wrap(InputStream underlying) throws Exception {
+                    return new KafkaLZ4BlockInputStream(underlying, true);
+                }
+            },
+            new OutputStreamWrapper() {
+                @Override
+                public OutputStream wrap(OutputStream underlying) throws Exception {
+                    return new KafkaLZ4BlockOutputStream(underlying, true);
+                }
+            });
+    }
+
+    @Test
+    public void testKafkaLz4() throws Exception {
+        testCodec(
+            new InputStreamWrapper() {
+                @Override
+                public InputStream wrap(InputStream underlying) throws Exception {
+                    return new KafkaLZ4BlockInputStream(underlying, false);
+                }
+            },
+            new OutputStreamWrapper() {
+                @Override
+                public OutputStream wrap(OutputStream underlying) throws Exception {
+                    return new KafkaLZ4BlockOutputStream(underlying, false);
+                }
+            });
+    }
+
+    public void testCodec(InputStreamWrapper inputStreamWrapper, OutputStreamWrapper outputStreamWrapper) throws Exception {
+
+        //1. generate random data
+        byte[] blob = generateRandomData();
+
+        //2. encode (compress) data
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        OutputStream encoderStream = outputStreamWrapper.wrap(baos);
+        encoderStream.write(blob);
+        encoderStream.close(); //implies flush
+        baos.close();
+        byte[] encoded = baos.toByteArray();
+
+        //3. create a decode stream reading the compressed data
+        ByteArrayInputStream bais = new ByteArrayInputStream(encoded);
+        InputStream decoderStream = inputStreamWrapper.wrap(bais);
+
+        testCodec(blob, decoderStream);
+    }
+
+    public void testCodec(byte[] expected, InputStream is) throws Exception {
+        //read byte by byte and compare with original data
+        int available;
+        int bytesRead = 0;
+        while ((available = is.available()) > 0) {
+            int read = is.read();
+            //make sure we didnt get -1
+            Assert.assertTrue("decoder returned available() = " + available + " but subsequent read() returned " + read, read >= 0);
+            //make sure output matches input
+            Assert.assertTrue("decoded is longer than original", bytesRead < expected.length);
+            Assert.assertTrue("decoded differs from source at offset " + bytesRead, expected[bytesRead] == (byte) read);
+            bytesRead++;
+        }
+        Assert.assertEquals("decoder returned available() = 0 too early after " + bytesRead + " bytes", bytesRead, expected.length);
+    }
+
+    private byte[] generateRandomData() {
+        int length = 1 + random.nextInt(4096); //[1, 4096]
+        byte[] blob = new byte[length];
+        random.nextBytes(blob);
+        return blob;
+    }
+
+    private interface InputStreamWrapper {
+        InputStream wrap(InputStream underlying) throws Exception;
+    }
+
+    private interface OutputStreamWrapper {
+        OutputStream wrap(OutputStream underlying) throws Exception;
+    }
+
+    private class PrintRandomSeed extends TestWatcher {
+        @Override
+        protected void failed(Throwable e, Description description) {
+            Assert.fail("random seed was " + seed); //to assist with reproduction
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/record/KafkaLZ4Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/KafkaLZ4Test.java
@@ -134,4 +134,22 @@ public class KafkaLZ4Test {
             assertTrue(this.useBrokenFlagDescriptorChecksum && !this.ignoreFlagDescriptorChecksum);
         }
     }
+
+    @Test
+    public void testCloseImpliesFlush() throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        KafkaLZ4BlockOutputStream lz4 = new KafkaLZ4BlockOutputStream(output, this.useBrokenFlagDescriptorChecksum);
+        lz4.write(this.payload);
+        lz4.close();
+        byte[] arr1 = output.toByteArray();
+
+        output = new ByteArrayOutputStream();
+        lz4 = new KafkaLZ4BlockOutputStream(output, this.useBrokenFlagDescriptorChecksum);
+        lz4.write(this.payload);
+        lz4.flush();
+        lz4.close();
+        byte[] arr2 = output.toByteArray();
+
+        assertArrayEquals(arr2, arr1);
+    }
 }

--- a/core/src/main/scala/kafka/message/ByteBufferBackedInputStream.scala
+++ b/core/src/main/scala/kafka/message/ByteBufferBackedInputStream.scala
@@ -37,4 +37,8 @@ class ByteBufferBackedInputStream(buffer:ByteBuffer) extends InputStream {
     } else
       -1
   }
+
+  override def available(): Int = {
+    buffer.remaining()
+  }
 }

--- a/core/src/main/scala/kafka/message/ByteBufferMessageSet.scala
+++ b/core/src/main/scala/kafka/message/ByteBufferMessageSet.scala
@@ -107,7 +107,7 @@ object ByteBufferMessageSet {
 
         val innerMessageAndOffsets = new ArrayDeque[MessageAndOffset]()
         try {
-          while (true)
+          while (compressed.available() > 0)
             innerMessageAndOffsets.add(readMessageFromStream(compressed))
         } catch {
           case eofe: EOFException =>

--- a/core/src/main/scala/kafka/message/CompressionFactory.scala
+++ b/core/src/main/scala/kafka/message/CompressionFactory.scala
@@ -19,10 +19,9 @@ package kafka.message
 
 import java.io.OutputStream
 import java.util.zip.GZIPOutputStream
-import java.util.zip.GZIPInputStream
 import java.io.InputStream
 
-import org.apache.kafka.common.record.{KafkaLZ4BlockInputStream, KafkaLZ4BlockOutputStream}
+import org.apache.kafka.common.record.{KafkaGZIPInputStream, KafkaLZ4BlockInputStream, KafkaLZ4BlockOutputStream}
 
 object CompressionFactory {
   
@@ -42,8 +41,8 @@ object CompressionFactory {
   
   def apply(compressionCodec: CompressionCodec, messageVersion: Byte, stream: InputStream): InputStream = {
     compressionCodec match {
-      case DefaultCompressionCodec => new GZIPInputStream(stream)
-      case GZIPCompressionCodec => new GZIPInputStream(stream)
+      case DefaultCompressionCodec => new KafkaGZIPInputStream(stream)
+      case GZIPCompressionCodec => new KafkaGZIPInputStream(stream)
       case SnappyCompressionCodec => 
         import org.xerial.snappy.SnappyInputStream
         new SnappyInputStream(stream)

--- a/core/src/test/scala/unit/kafka/message/ByteBufferMessageSetTest.scala
+++ b/core/src/test/scala/unit/kafka/message/ByteBufferMessageSetTest.scala
@@ -422,6 +422,22 @@ class ByteBufferMessageSetTest extends BaseMessageSetTestCases {
     checkWriteFullyToWithMessageSet(createMessageSet(messages))
   }
 
+  @Test
+  def testIterationOverCompressedSet(): Unit = {
+    val messageCount = 100
+    val messages = (1 to messageCount).map(m => {
+      new Message(s"message num $m".getBytes)
+    })
+    var messageSet = new ByteBufferMessageSet(GZIPCompressionCodec, messages:_*)
+    assertEquals(messageCount, messageSet.size)
+    messageSet = new ByteBufferMessageSet(LZ4CompressionCodec, messages:_*)
+    assertEquals(messageCount, messageSet.size)
+    messageSet = new ByteBufferMessageSet(SnappyCompressionCodec, messages:_*)
+    assertEquals(messageCount, messageSet.size)
+    messageSet = new ByteBufferMessageSet(NoCompressionCodec, messages:_*)
+    assertEquals(messageCount, messageSet.size)
+  }
+
   def checkWriteFullyToWithMessageSet(messageSet: ByteBufferMessageSet) {
     checkWriteWithMessageSet(messageSet, messageSet.writeFullyTo)
   }


### PR DESCRIPTION
also:
provided better available() for ByteBufferInputStream
provided better available() for KafkaLZ4BlockInputStream
added KafkaGZIPInputStream with a better available()
fixed KafkaLZ4BlockOutputStream.close() to properly flush

Signed-off-by: radai-rosenblatt radai.rosenblatt@gmail.com
