### PR TITLE
Changes for supporting unsgined tinyint values

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -44,7 +44,7 @@ public class ConnectSchema implements Schema {
     private static final Map<Class<?>, Type> JAVA_CLASS_SCHEMA_TYPES = new HashMap<>();
 
     static {
-        SCHEMA_TYPE_CLASSES.put(Type.INT8, Arrays.asList((Class) Byte.class));
+        SCHEMA_TYPE_CLASSES.put(Type.INT8, Arrays.asList((Class) Byte.class,(Class) Short.class));
         SCHEMA_TYPE_CLASSES.put(Type.INT16, Arrays.asList((Class) Short.class));
         SCHEMA_TYPE_CLASSES.put(Type.INT32, Arrays.asList((Class) Integer.class));
         SCHEMA_TYPE_CLASSES.put(Type.INT64, Arrays.asList((Class) Long.class));

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -44,7 +44,7 @@ public class ConnectSchema implements Schema {
     private static final Map<Class<?>, Type> JAVA_CLASS_SCHEMA_TYPES = new HashMap<>();
 
     static {
-        SCHEMA_TYPE_CLASSES.put(Type.INT8, Arrays.asList((Class) Byte.class,(Class) Short.class));
+        SCHEMA_TYPE_CLASSES.put(Type.INT8, Arrays.asList((Class) Byte.class, (Class) Short.class));
         SCHEMA_TYPE_CLASSES.put(Type.INT16, Arrays.asList((Class) Short.class));
         SCHEMA_TYPE_CLASSES.put(Type.INT32, Arrays.asList((Class) Integer.class));
         SCHEMA_TYPE_CLASSES.put(Type.INT64, Arrays.asList((Class) Long.class));


### PR DESCRIPTION
Based upon the theory provided in the official jdbc documentation, I have added a condition to include both Short and Byte as INT8 types in ConnectSchema.
(https://docs.oracle.com/javase/6/docs/technotes/guides/jdbc/getstart/mapping.html)
Here's the doc:

> 8.3.5 SMALLINT
> 
> The JDBC type SMALLINT represents a 16-bit signed integer value between -32768 and 32767.
> 
> The corresponding SQL type, SMALLINT, is defined in SQL-92 and is supported by all the major databases. The SQL-92 standard leaves the precision of SMALLINT up to the implementation, but in practice, all the major databases support at least 16 bits.
> 
> The recommended Java mapping for the JDBC SMALLINT type is as a Java short.

This would allow kafka-connect-jdbc to allow both signed and unsigned values. Currently it fails for unsigned values(i.e values > 127). This is specifically needed when fetching unsigned tinyint values from dbs using kafka-connect-jdbc. I have sent the PR to them and schema-registry as well to address the issue.
