### PR TITLE
Fix for kafka-4295: kafka-console-consumer.sh does not delete the temporary group in zookeeper

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -74,14 +74,9 @@ object ConsoleConsumer extends Logging {
     try {
       process(conf.maxMessages, conf.formatter, consumer, System.out, conf.skipMessageOnError)
     } finally {
-      consumer.cleanup()
       conf.formatter.close()
       reportRecordCount()
-
-      // if we generated a random group id (as none specified explicitly) then avoid polluting zookeeper with persistent group data, this is a hack
-      if (!conf.groupIdPassed)
-        ZkUtils.maybeDeletePath(conf.options.valueOf(conf.zkConnectOpt), "/consumers/" + conf.consumerProps.get("group.id"))
-
+      shutDownConsumerAndRemoveItsConsumersNode(consumer, conf)
       shutdownLatch.countDown()
     }
   }
@@ -103,7 +98,7 @@ object ConsoleConsumer extends Logging {
   def addShutdownHook(consumer: BaseConsumer, conf: ConsumerConfig) {
     Runtime.getRuntime.addShutdownHook(new Thread() {
       override def run() {
-        consumer.stop()
+        shutDownConsumerAndRemoveItsConsumersNode(consumer, conf)
 
         shutdownLatch.await()
 
@@ -112,6 +107,13 @@ object ConsoleConsumer extends Logging {
         }
       }
     })
+  }
+
+  def shutDownConsumerAndRemoveItsConsumersNode(consumer: BaseConsumer, conf: ConsumerConfig): Unit = {
+    consumer.stop();
+    // if we generated a random group id (as none specified explicitly) then avoid polluting zookeeper with persistent group data, this is a hack
+    if (!conf.groupIdPassed)
+      ZkUtils.maybeDeletePath(conf.options.valueOf(conf.zkConnectOpt), "/consumers/" + conf.consumerProps.get("group.id"))
   }
 
   def process(maxMessages: Integer, formatter: MessageFormatter, consumer: BaseConsumer, output: PrintStream, skipMessageOnError: Boolean) {


### PR DESCRIPTION
Since consumer stop logic and zk node removal code are in separate threads, so when two threads execute in an interleaving manner, persistent node '/consumers/<consumer-group>' might not be removed for those console consumer groups which do not specify "group.id". This will pollute Zookeeper with lots of inactive console consumer offset information.
