### PR TITLE
Fix vagrant rsync exclude argument

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -135,7 +135,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     # Exclude some directories that can grow very large from syncing
-    override.vm.synced_folder ".", "/vagrant", type: "rsync", :rsync_excludes => ['.git', 'core/data/', 'logs/', 'tests/results/', 'results/']
+    override.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ['.git', 'core/data/', 'logs/', 'tests/results/', 'results/']
   end
 
   def name_node(node, name, ec2_instance_name_prefix)


### PR DESCRIPTION
Existing VMs will need to be re-provisioned or re-created to pick up this change.

Reference docs:
https://www.vagrantup.com/docs/synced-folders/rsync.html
