### PR TITLE
KAFKA-4311: Multi layer cache eviction causes forwarding to incorrect ProcessorNode

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ForwardingCacheFlushListener.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ForwardingCacheFlushListener.java
@@ -17,22 +17,32 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
 
 class ForwardingCacheFlushListener<K, V> implements CacheFlushListener<K, V> {
-    private final ProcessorContext context;
+    private final InternalProcessorContext context;
     private final boolean sendOldValues;
+    private final ProcessorNode myNode;
 
     ForwardingCacheFlushListener(final ProcessorContext context, final boolean sendOldValues) {
-        this.context = context;
+        this.context = (InternalProcessorContext) context;
+        myNode = this.context.currentNode();
         this.sendOldValues = sendOldValues;
     }
 
     @Override
     public void apply(final K key, final V newValue, final V oldValue) {
-        if (sendOldValues) {
-            context.forward(key, new Change<>(newValue, oldValue));
-        } else {
-            context.forward(key, new Change<>(newValue, null));
+        final ProcessorNode prev = context.currentNode();
+        context.setCurrentNode(myNode);
+        try {
+            if (sendOldValues) {
+                context.forward(key, new Change<>(newValue, oldValue));
+            } else {
+                context.forward(key, new Change<>(newValue, null));
+            }
+        } finally {
+            context.setCurrentNode(prev);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -42,6 +42,7 @@ public interface InternalProcessorContext extends ProcessorContext {
      */
     void setCurrentNode(ProcessorNode currentNode);
 
+    ProcessorNode currentNode();
     /**
      * Get the thread-global cache
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -127,13 +127,11 @@ public class ProcessorContextImpl implements InternalProcessorContext, RecordCol
      */
     @Override
     public StateStore getStateStore(String name) {
-        ProcessorNode node = task.node();
-
-        if (node == null)
+        if (currentNode == null)
             throw new TopologyBuilderException("Accessing from an unknown node");
 
-        if (!node.stateStores.contains(name)) {
-            throw new TopologyBuilderException("Processor " + node.name() + " has no access to StateStore " + name);
+        if (!currentNode.stateStores.contains(name)) {
+            throw new TopologyBuilderException("Processor " + currentNode.name() + " has no access to StateStore " + name);
         }
 
         return stateMgr.getStore(name);
@@ -267,5 +265,10 @@ public class ProcessorContextImpl implements InternalProcessorContext, RecordCol
     @Override
     public void setCurrentNode(final ProcessorNode currentNode) {
         this.currentNode = currentNode;
+    }
+
+    @Override
+    public ProcessorNode currentNode() {
+        return currentNode;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -222,4 +222,9 @@ public class StandbyContextImpl implements InternalProcessorContext, RecordColle
     public void setCurrentNode(final ProcessorNode currentNode) {
         // no-op. can't throw as this is called on commit when the StateStores get flushed.
     }
+
+    @Override
+    public ProcessorNode currentNode() {
+        throw new UnsupportedOperationException("this should not happen: currentNode not supported in standby tasks.");
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -59,7 +59,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
     private boolean commitRequested = false;
     private boolean commitOffsetNeeded = false;
-    private ProcessorNode currNode = null;
 
     private boolean requiresPoll = true;
 
@@ -122,11 +121,11 @@ public class StreamTask extends AbstractTask implements Punctuator {
         // initialize the task by initializing all its processor nodes in the topology
         log.info("{} Initializing processor nodes of the topology", logPrefix);
         for (ProcessorNode node : this.topology.processors()) {
-            this.currNode = node;
+            processorContext.setCurrentNode(node);
             try {
                 node.init(this.processorContext);
             } finally {
-                this.currNode = null;
+                processorContext.setCurrentNode(null);
             }
         }
 
@@ -172,13 +171,13 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
         try {
             // process the record by passing to the source node of the topology
-            this.currNode = recordInfo.node();
+            final ProcessorNode currNode = recordInfo.node();
             TopicPartition partition = recordInfo.partition();
 
             log.trace("{} Start processing one record [{}]", logPrefix, record);
             final ProcessorRecordContext recordContext = createRecordContext(record);
             updateProcessorContext(recordContext, currNode);
-            this.currNode.process(record.key(), record.value());
+            currNode.process(record.key(), record.value());
 
             log.trace("{} Completed processing one record [{}]", logPrefix, record);
 
@@ -199,14 +198,13 @@ public class StreamTask extends AbstractTask implements Punctuator {
         } catch (KafkaException ke) {
             throw new StreamsException(format("Exception caught in process. taskId=%s, processor=%s, topic=%s, partition=%d, offset=%d",
                                               id.toString(),
-                                              currNode.name(),
+                                              processorContext.currentNode().name(),
                                               record.topic(),
                                               record.partition(),
                                               record.offset()
                                               ), ke);
         } finally {
             processorContext.setCurrentNode(null);
-            this.currNode = null;
         }
 
         return partitionGroup.numBuffered();
@@ -241,10 +239,9 @@ public class StreamTask extends AbstractTask implements Punctuator {
      */
     @Override
     public void punctuate(ProcessorNode node, long timestamp) {
-        if (currNode != null)
+        if (processorContext.currentNode() != null)
             throw new IllegalStateException(String.format("%s Current node is not null", logPrefix));
 
-        currNode = node;
         final StampedRecord stampedRecord = new StampedRecord(DUMMY_RECORD, timestamp);
         updateProcessorContext(createRecordContext(stampedRecord), node);
 
@@ -256,13 +253,12 @@ public class StreamTask extends AbstractTask implements Punctuator {
             throw new StreamsException(String.format("Exception caught in punctuate. taskId=%s processor=%s", id,  node.name()), ke);
         } finally {
             processorContext.setCurrentNode(null);
-            currNode = null;
         }
     }
 
 
     public ProcessorNode node() {
-        return this.currNode;
+        return this.processorContext.currentNode();
     }
 
     /**
@@ -322,10 +318,10 @@ public class StreamTask extends AbstractTask implements Punctuator {
      * @throws IllegalStateException if the current node is not null
      */
     public void schedule(long interval) {
-        if (currNode == null)
+        if (processorContext.currentNode() == null)
             throw new IllegalStateException(String.format("%s Current node is null", logPrefix));
 
-        punctuationQueue.schedule(new PunctuationSchedule(currNode, interval));
+        punctuationQueue.schedule(new PunctuationSchedule(processorContext.currentNode(), interval));
     }
 
     /**
@@ -342,13 +338,13 @@ public class StreamTask extends AbstractTask implements Punctuator {
         // make sure close() is called for each node even when there is a RuntimeException
         RuntimeException exception = null;
         for (ProcessorNode node : this.topology.processors()) {
-            currNode = node;
+            processorContext.setCurrentNode(node);
             try {
                 node.close();
             } catch (RuntimeException e) {
                 exception = e;
             } finally {
-                currNode = null;
+                processorContext.setCurrentNode(null);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -257,10 +257,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
     }
 
 
-    public ProcessorNode node() {
-        return this.processorContext.currentNode();
-    }
-
     /**
      * Commit the current task state
      */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -40,6 +40,7 @@ class NamedCache {
     private LRUNode head;
     private long currentSizeBytes;
     private ThreadCacheMetrics metrics;
+    private final List<String> callStack  = new ArrayList<>();
 
     // JMX stats
     private Sensor hitRatio = null;
@@ -109,7 +110,7 @@ class NamedCache {
         for (Bytes key : dirtyKeys) {
             final LRUNode node = getInternal(key);
             if (node == null) {
-                throw new IllegalStateException("Key found in dirty key set, but entry is null");
+                throw new IllegalStateException("Key = " + key + " found in dirty key set, but entry is null");
             }
             entries.add(new ThreadCache.DirtyEntry(key, node.entry.value, node.entry));
             node.entry.markClean();
@@ -200,6 +201,7 @@ class NamedCache {
         }
         remove(eldest);
         cache.remove(eldest.key);
+        dirtyKeys.remove(eldest.key);
     }
 
     synchronized LRUCacheEntry putIfAbsent(final Bytes key, final LRUCacheEntry value) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -40,7 +40,6 @@ class NamedCache {
     private LRUNode head;
     private long currentSizeBytes;
     private ThreadCacheMetrics metrics;
-    private final List<String> callStack  = new ArrayList<>();
 
     // JMX stats
     private Sensor hitRatio = null;
@@ -207,7 +206,6 @@ class NamedCache {
         }
         remove(eldest);
         cache.remove(eldest.key);
-        dirtyKeys.remove(eldest.key);
     }
 
     synchronized LRUCacheEntry putIfAbsent(final Bytes key, final LRUCacheEntry value) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -121,6 +121,12 @@ class NamedCache {
 
 
     synchronized void put(final Bytes key, final LRUCacheEntry value) {
+        if (!value.isDirty && dirtyKeys.contains(key)) {
+            throw new IllegalStateException(String.format("Attempting to put a clean entry for key [%s] " +
+                                                                  "into NamedCache [%s] when it already contains " +
+                                                                  "a dirty entry for the same key",
+                                                          key, name));
+        }
         LRUNode node = cache.get(key);
         if (node != null) {
             numOverwrites++;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableAggregateTest.java
@@ -22,10 +22,14 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Aggregator;
+import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.test.KStreamTestDriver;
 import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
@@ -39,6 +43,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -319,5 +325,71 @@ public class KTableAggregateTest {
                  "1:2",
                  "1:2"
                  ), proc.processed);
+    }
+
+    @Test
+    public void shouldForwardToCorrectProcessorNodeWhenMultiCacheEvictions() throws Exception {
+        final String tableOne = "tableOne";
+        final String tableTwo = "tableTwo";
+        final KStreamBuilder builder = new KStreamBuilder();
+        final String reduceTopic = "TestDriver-reducer-store-repartition";
+        final Map<String, Long> reduceResults = new HashMap<>();
+
+        final KTable<String, String> one = builder.table(Serdes.String(), Serdes.String(), tableOne, tableOne);
+        final KTable<Long, String> two = builder.table(Serdes.Long(), Serdes.String(), tableTwo, tableTwo);
+
+
+        final KTable<String, Long> reduce = two.groupBy(new KeyValueMapper<Long, String, KeyValue<String, Long>>() {
+            @Override
+            public KeyValue<String, Long> apply(final Long key, final String value) {
+                return new KeyValue<>(value, key);
+            }
+        }, Serdes.String(), Serdes.Long())
+                .reduce(new Reducer<Long>() {
+                    @Override
+                    public Long apply(final Long value1, final Long value2) {
+                        return value1 + value2;
+                    }
+                }, new Reducer<Long>() {
+                    @Override
+                    public Long apply(final Long value1, final Long value2) {
+                        return value1 - value2;
+                    }
+                }, "reducer-store");
+
+        reduce.foreach(new ForeachAction<String, Long>() {
+            @Override
+            public void apply(final String key, final Long value) {
+                reduceResults.put(key, value);
+            }
+        });
+
+        one.leftJoin(reduce, new ValueJoiner<String, Long, String>() {
+            @Override
+            public String apply(final String value1, final Long value2) {
+                return value1 + ":" + value2;
+            }
+        })
+                .mapValues(new ValueMapper<String, String>() {
+                    @Override
+                    public String apply(final String value) {
+                        return value;
+                    }
+                });
+
+        final KStreamTestDriver driver = new KStreamTestDriver(builder, stateDir, 111);
+        driver.process(reduceTopic, "1", new Change<>(1L, null));
+        driver.process("tableOne", "2", "2");
+        // this should trigger eviction on the reducer-store topic
+        driver.process(reduceTopic, "2", new Change<>(2L, null));
+        // this wont as it is the same value
+        driver.process(reduceTopic, "2", new Change<>(2L, null));
+        assertEquals(Long.valueOf(2L), reduceResults.get("2"));
+
+        // this will trigger eviction on the tableOne topic
+        // that in turn will cause an eviction on reducer-topic. It will flush
+        // key 2 as it is the only dirty entry in the cache
+        driver.process("tableOne", "1", "5");
+        assertEquals(Long.valueOf(4L), reduceResults.get("2"));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -280,6 +280,7 @@ public class ProcessorTopologyTest {
                 .addSink("sink-2", OUTPUT_TOPIC_2, constantPartitioner(partition), "processor-2");
     }
 
+
     /**
      * A processor that simply forwards all messages to all children.
      */

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -32,6 +32,7 @@ import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.apache.kafka.test.MockProcessorContext;
@@ -269,6 +270,12 @@ public class KeyValueStoreTestDriver<K, V> {
             public Map<String, Object> appConfigsWithPrefix(String prefix) {
                 return new StreamsConfig(props).originalsWithPrefix(prefix);
             }
+
+            @Override
+            public ProcessorNode currentNode() {
+                return null;
+            }
+
             @Override
             public ThreadCache getCache() {
                 return cache;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/NamedCacheTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 public class NamedCacheTest {
 
@@ -193,23 +192,9 @@ public class NamedCacheTest {
         cache.evict();
     }
 
-    @Test
-    public void shouldRemoveKeyFromDirtyKeSetOnEvict() throws Exception {
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowIllegalStateExceptionWhenTryingToOverwriteDirtyEntryWithCleanEntry() throws Exception {
         cache.put(Bytes.wrap(new byte[]{0}), new LRUCacheEntry(new byte[]{10}, true, 0, 0, 0, ""));
         cache.put(Bytes.wrap(new byte[]{0}), new LRUCacheEntry(new byte[]{10}, false, 0, 0, 0, ""));
-
-        cache.setListener(new ThreadCache.DirtyEntryFlushListener() {
-            @Override
-            public void apply(final List<ThreadCache.DirtyEntry> dirty) {
-                fail("Shouldn't happen here as there should be no dirty keys");
-            }
-        });
-        cache.evict();
-        try {
-            cache.flush();
-        } catch (IllegalStateException e) {
-            fail("Shouldn't happen as there should be no dirty keys");
-        }
-
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -51,6 +51,7 @@ public class MockProcessorContext implements InternalProcessorContext, RecordCol
 
     long timestamp = -1L;
     private RecordContext recordContext;
+    private ProcessorNode currentNode;
 
     public MockProcessorContext(StateSerdes<?, ?> serdes, RecordCollector collector) {
         this(null, null, serdes.keySerde(), serdes.valueSerde(), collector, null);
@@ -248,7 +249,13 @@ public class MockProcessorContext implements InternalProcessorContext, RecordCol
 
     @Override
     public void setCurrentNode(final ProcessorNode currentNode) {
+        this.currentNode  = currentNode;
+        driver.setCurrentNode(currentNode);
+    }
 
+    @Override
+    public ProcessorNode currentNode() {
+        return currentNode;
     }
 
 }


### PR DESCRIPTION
Given a topology like the one below. If a record arriving in `tableOne` causes a cache eviction, it will trigger the `leftJoin` that will do a `get` from `reducer-store`. If the key is not currently cached in `reducer-store`, but is in the backing store, it will be put into the cache, and it may also trigger an eviction. If it does trigger an eviction and the eldest entry is dirty it will flush the dirty keys. It is at this point that a ClassCastException is thrown. This occurs because the ProcessorContext is still set to the context of the `leftJoin` and the next child in the topology is `mapValues`.
We need to set the correct `ProcessorNode`, on the context, in the `ForwardingCacheFlushListener` prior to calling `context.forward`. We also need to  remember to reset the `ProcessorNode` to the previous node once `context.forward` has completed.

```
       final KTable<String, String> one = builder.table(Serdes.String(), Serdes.String(), tableOne, tableOne);
        final KTable<Long, String> two = builder.table(Serdes.Long(), Serdes.String(), tableTwo, tableTwo);
        final KTable<String, Long> reduce = two.groupBy(new KeyValueMapper<Long, String, KeyValue<String, Long>>() {
            @Override
            public KeyValue<String, Long> apply(final Long key, final String value) {
                return new KeyValue<>(value, key);
            }
        }, Serdes.String(), Serdes.Long())
                .reduce(new Reducer<Long>() {..}, new Reducer<Long>() {..}, "reducer-store");

    one.leftJoin(reduce, new ValueJoiner<String, Long, String>() {..})
        .mapValues(new ValueMapper<String, String>() {..});

```
