### PR TITLE
kafka-4295: ConsoleConsumer does not delete the temporary group in zookeeper

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -104,7 +104,10 @@ object ConsoleConsumer extends Logging {
     Runtime.getRuntime.addShutdownHook(new Thread() {
       override def run() {
         consumer.stop()
-
+        // if we generated a random group id (as none specified explicitly) then avoid polluting zookeeper with persistent group data, this is a hack
+        if (!conf.groupIdPassed && conf.options.has(conf.zkConnectOpt))
+          ZkUtils.maybeDeletePath(conf.options.valueOf(conf.zkConnectOpt), "/consumers/" + conf.consumerProps.get("group.id"))
+        
         shutdownLatch.await()
 
         if (conf.enableSystestEventsLogging) {


### PR DESCRIPTION
ConsoleConsumer does not delete the temporary group in zookeeper
Author: huxi_2b@hotmail.com
Since consumer stop logic and zk node removal code are in separate threads, so when two threads execute in an interleaving manner, persistent node '/consumers/' might not be removed for those console consumer groups which do not specify "group.id". This will pollute Zookeeper with lots of inactive console consumer offset information.
