### PR TITLE
Expose name of processor on KStream

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -367,8 +367,10 @@ public interface KStream<K, V> {
      *
      * @param processorSupplier         the supplier of {@link ProcessorSupplier} that generates {@link org.apache.kafka.streams.processor.Processor}
      * @param stateStoreNames           the names of the state store used by the processor
+     *
+     * @return processor                the name of the processor
      */
-    void process(ProcessorSupplier<K, V> processorSupplier, String... stateStoreNames);
+    String process(ProcessorSupplier<K, V> processorSupplier, String... stateStoreNames);
 
     /**
      * Combine element values of this stream with another {@link KStream}'s elements of the same key using windowed Inner Join.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -380,11 +380,13 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
     }
 
     @Override
-    public void process(final ProcessorSupplier<K, V> processorSupplier, String... stateStoreNames) {
+    public String process(final ProcessorSupplier<K, V> processorSupplier, String... stateStoreNames) {
         String name = topology.newName(PROCESSOR_NAME);
 
         topology.addProcessor(name, processorSupplier, this.name);
         topology.connectProcessorAndStateStores(name, stateStoreNames);
+
+        return name;
     }
 
     @Override


### PR DESCRIPTION
When connecting a processor on a KStream to downstream processors or sinks you need to know the generated name of the processor. This change exposes that name in the call to `process`.
