### PR TITLE
KAFKA-4346: Add foreachValue method to KStream

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ForeachValueAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ForeachValueAction.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@link ForeachValueAction} interface for performing an action on a value.
+ * Note that this action is stateless. If stateful processing is required, consider
+ * using {@link KStream#transform(TransformerSupplier, String...)} or
+ * {@link KStream#process(ProcessorSupplier, String...)} instead.
+ *
+ * @param <V>   original value type
+ */
+public interface ForeachValueAction<V> {
+
+  /**
+   * Perform an action for each record of a stream.
+   *
+   * @param value  the value of the record
+   */
+  void apply(V value);
+}
+

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -245,6 +245,14 @@ public interface KStream<K, V> {
     void foreach(ForeachAction<K, V> action);
 
     /**
+     * Perform an action on the value of each element of {@link KStream}.
+     * Note that this is a terminal operation that returns void.
+     *
+     * @param action an action to perform on each element
+     */
+    void foreachValue(ForeachValueAction<V> action);
+
+    /**
      * Materialize this stream to a topic, also creates a new instance of {@link KStream} from the topic
      * using default serializers and deserializers and a customizable {@link StreamPartitioner} to determine the distribution of records to partitions.
      * This is equivalent to calling {@link #to(StreamPartitioner, String)} and {@link org.apache.kafka.streams.kstream.KStreamBuilder#stream(String...)}.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamForeachValue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamForeachValue.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.streams.kstream.ForeachValueAction;
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+
+class KStreamForeachValue<K, V> implements ProcessorSupplier<K, V> {
+
+    private final ForeachValueAction<V> action;
+
+    public KStreamForeachValue(ForeachValueAction<V> action) {
+        this.action = action;
+    }
+
+    @Override
+    public Processor<K, V> get() {
+        return new KStreamForeachProcessor();
+    }
+
+    private class KStreamForeachProcessor extends AbstractProcessor<K, V> {
+        @Override
+        public void process(K key, V value) {
+            action.apply(value);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.TopologyBuilderException;
 import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.ForeachValueAction;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;
@@ -308,6 +309,14 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         String name = topology.newName(FOREACH_NAME);
 
         topology.addProcessor(name, new KStreamForeach<>(action), this.name);
+    }
+
+    @Override
+    public void foreachValue(ForeachValueAction<V> action) {
+        Objects.requireNonNull(action, "action can't be null");
+        String name = topology.newName(FOREACH_NAME);
+
+        topology.addProcessor(name, new KStreamForeachValue<>(action), this.name);
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -20,6 +20,8 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.errors.TopologyBuilderException;
+import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.ForeachValueAction;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
@@ -269,4 +271,8 @@ public class KStreamImplTest {
         testStream.foreach(null);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullActionOnForEachValue() throws Exception {
+        testStream.foreachValue(null);
+    }
 }


### PR DESCRIPTION
This would be the value-only counterpart to foreach, similar to mapValues.

Adding this method would allow two things:
1. remove the need to de-serialize keys when operating directly on a source topic
2. enhance readability and allow for Java 8 syntactic sugar using method references without having to wrap existing methods that only operate on the value type.

   For instance, let's imagine I have an app that handles  notifications, I can now write

   ```
   notifications.foreachValue(pushNotification::send)
   ```

   instead of

   ```
   notifications.foreach((key, notification) -> pushNotification.send(notification))
   ```
