### PR TITLE
KAFKA-4349: Handle 'PreparingRebalance' and 'AwaitingSync' states in consumer group describe

### DIFF
--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -149,9 +149,15 @@ class AdminClient(val time: Time,
 
     Errors.forCode(metadata.errorCode()).maybeThrow()
     val consumers = metadata.members.map { consumer =>
-      val assignment = ConsumerProtocol.deserializeAssignment(ByteBuffer.wrap(Utils.readBytes(consumer.memberAssignment)))
-      ConsumerSummary(consumer.memberId, consumer.clientId, consumer.clientHost, assignment.partitions.toList)
+      ConsumerSummary(consumer.memberId, consumer.clientId, consumer.clientHost, metadata.state match {
+        case "Stable" =>
+          val assignment = ConsumerProtocol.deserializeAssignment(ByteBuffer.wrap(Utils.readBytes(consumer.memberAssignment)))
+          assignment.partitions.toList
+        case _ =>
+          List()
+      })
     }.toList
+
     ConsumerGroupSummary(metadata.state, metadata.protocol, Some(consumers), coordinator)
   }
 


### PR DESCRIPTION
The edge case where consumer group state is `PreparingRebalance` or `AwaitingSync` will be separately handled as the group assignment is not yet determined.
