### PR TITLE
MINOR: Fix NPE when Connect offset contains non-primitive type

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetUtils.java
@@ -48,6 +48,8 @@ public class OffsetUtils {
             if (value == null)
                 continue;
             Schema.Type schemaType = ConnectSchema.schemaType(value.getClass());
+            if (schemaType == null)
+                throw new DataException("Offsets may only contain primitive types as values, but field " + entry.getKey() + " contains " + value.getClass());
             if (!schemaType.isPrimitive())
                 throw new DataException("Offsets may only contain primitive types as values, but field " + entry.getKey() + " contains " + schemaType);
         }


### PR DESCRIPTION
When storing a non-primitive type in a Connect offset, the following NullPointerException will occur:

```
07:18:23.702 [pool-3-thread-1] ERROR o.a.k.c.storage.OffsetStorageWriter - CRITICAL: Failed to serialize offset data, making it impossible to commit offsets under namespace tenant-db-bootstrap-source. This likely won't recover unless the unserializable partition or offset information is overwritten.
07:18:23.702 [pool-3-thread-1] ERROR o.a.k.c.storage.OffsetStorageWriter - Cause of serialization failure:
java.lang.NullPointerException: null
	at org.apache.kafka.connect.storage.OffsetUtils.validateFormat(OffsetUtils.java:51)
	at org.apache.kafka.connect.storage.OffsetStorageWriter.doFlush(OffsetStorageWriter.java:143)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.commitOffsets(WorkerSourceTask.java:319)
... snip ...
```

The attached patch fixes the specific case where OffsetUtils.validateFormat is attempting to provide a useful error message, but fails to because the schemaType method could return null.

This contribution is my original work and I license the work to the project under the project's open source license.