### PR TITLE
KAFKA-4385-avoid-unnecessary-meta-request-overhead

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -542,8 +542,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         long elapsed = 0;
 
         // update metadata controlled by both maxWaitMs and maxMetaFetchCount
-        // when auto.create.topics.enable=true and sending a msg to non-exist topic
-        // setting maxMetaFetchCount will reduce many unnecessary metadata request
+        // when auto.create.topics.enable=false and sending a msg to non-exist topic
+        // setting maxMetaFetchCount=1 can reduce many unnecessary metadata request
         for (int i = 0; i < maxMetaFetchCount; ++i) {
             log.trace("Requesting metadata update for topic {}.", topic);
             int version = metadata.requestUpdate();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -55,6 +55,11 @@ public class ProducerConfig extends AbstractConfig {
                                                              + "host the topic's partitions. This config specifies the maximum time, in milliseconds, for this fetch "
                                                              + "to succeed before throwing an exception back to the client.";
 
+    public static final String METADATA_FETCH_MAX_COUNT_CONFIG = "metadata.fetch.max.count";
+    private static final String METADATA_FETCH_MAX_COUNT_DOC = "when fetching metadata for a topic, within the time of metadata.fetch.timeout.ms, "
+                                                             + " if the metadata response does not contain the topic's metadata, then it will keep sending the meta request until metadata.fetch.timeout.ms is exceeded"
+                                                             + " this will become too many overhead when broker side has configured auto.create.topics.enable=false and a msg is sent to non-exist topic ";
+
     /** <code>metadata.max.age.ms</code> */
     public static final String METADATA_MAX_AGE_CONFIG = CommonClientConfigs.METADATA_MAX_AGE_CONFIG;
     private static final String METADATA_MAX_AGE_DOC = CommonClientConfigs.METADATA_MAX_AGE_DOC;
@@ -251,6 +256,11 @@ public class ProducerConfig extends AbstractConfig {
                                         atLeast(0),
                                         Importance.LOW,
                                         METADATA_FETCH_TIMEOUT_DOC)
+                                .define(METADATA_FETCH_MAX_COUNT_CONFIG,
+                                        Type.INT,
+                                        Integer.MAX_VALUE,
+                                        Importance.LOW,
+                                        METADATA_FETCH_MAX_COUNT_DOC)
                                 .define(MAX_BLOCK_MS_CONFIG,
                                         Type.LONG,
                                         60 * 1000,

--- a/clients/src/main/java/org/apache/kafka/common/errors/MetadataNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/MetadataNotAvailableException.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class MetadataNotAvailableException extends RetriableException {
+
+    public MetadataNotAvailableException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
add a producer config: "metadata.fetch.max.count"
default to Integer.MAX_VALUE, then everything is the same as before;
when specified, the metadata request will be limited by both "metadata.fetch.timeout.ms" (time limit) and "metadata.fetch.max.count" (request count)

when "auto.create.topics.enable=false", "metadata.fetch.max.count" can be set as 1, so that it could avoid lots of unncessary duplicate metadata