### PR TITLE
MINOR: fix incorrect logging in StreamThread

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -713,7 +713,7 @@ public class StreamThread extends Thread {
                     for (TopicPartition partition : partitions)
                         activeTasksByPartition.put(partition, task);
                 } catch (StreamsException e) {
-                    log.error(String.format("%s Failed to create an active task %s: ", logPrefix, taskId), e);
+                    log.error("{} Failed to create an active task {}: ", logPrefix, taskId, e);
                     throw e;
                 }
             } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -713,7 +713,7 @@ public class StreamThread extends Thread {
                     for (TopicPartition partition : partitions)
                         activeTasksByPartition.put(partition, task);
                 } catch (StreamsException e) {
-                    log.error("{} Failed to create an active task %s: ", logPrefix, taskId, e);
+                    log.error(String.format("%s Failed to create an active task %s: ", logPrefix, taskId), e);
                     throw e;
                 }
             } else {


### PR DESCRIPTION
Fix incorrect logging when unable to create an active task. The output was: Failed to create an active task %s: 
It should have the taskId.