### PR TITLE
KAFKA-4387: Fix KafkaConsumer not responding correctly to interrupts,…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -455,10 +455,10 @@ import org.apache.kafka.common.errors.InterruptException;
  *
  * Note that while methods that can throw {@link org.apache.kafka.common.errors.WakeupException} in response to {@link #wakeup()}
  * can also throw {@link org.apache.kafka.common.errors.InterruptException} in response to the calling thread being interrupted,
- * it is discouraged to use thread interrupts to stop/signal a consumer thread. Preferring {@link #wakeup()} will in some cases
- * allow for a cleaner shutdown than interrupts. {@link #commitSync()} will for example be allowed to finish committing offsets
- * if the consumer is awakened, while interrupts will cause {@link #commitSync()} to stop immediately. Interrupts are mainly supported
- * for those cases where using {@link #wakeup()} is impossible, e.g. when a consumer thread is managed by code that is unaware of Kafka.
+ * it is discouraged to use thread interrupts to stop/signal a consumer thread. {@link #wakeup()} will be ignored while shutting down the consumer,
+ * so in some cases {@link #wakeup()} allows for a cleaner shutdown over interrupts.
+ * Interrupts are mainly supported for those cases where using {@link #wakeup()} is impossible, e.g. when a consumer thread is managed by code that
+ * is unaware of Kafka.
  * 
  * <p>
  * We have intentionally avoided implementing a particular threading model for processing. This leaves several
@@ -1483,6 +1483,9 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     /**
      * Close the consumer, waiting indefinitely for any needed cleanup. If auto-commit is enabled, this
      * will commit the current offsets. Note that {@link #wakeup()} cannot be use to interrupt close.
+     * 
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted
+     * before or while this function is called
      */
     @Override
     public void close() {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -453,6 +453,13 @@ import org.apache.kafka.common.errors.InterruptException;
  *     consumer.wakeup();
  * </pre>
  *
+ * Note that while methods that can throw {@link org.apache.kafka.common.errors.WakeupException} in response to {@link #wakeup()}
+ * can also throw {@link org.apache.kafka.common.errors.InterruptException} in response to the calling thread being interrupted,
+ * it is discouraged to use thread interrupts to stop/signal a consumer thread. Preferring {@link #wakeup()} will in some cases
+ * allow for a cleaner shutdown than interrupts. {@link #commitSync()} will for example be allowed to finish committing offsets
+ * if the consumer is awakened, while interrupts will cause {@link #commitSync()} to stop immediately. Interrupts are mainly supported
+ * for those cases where using {@link #wakeup()} is impossible, e.g. when a consumer thread is managed by code that is unaware of Kafka.
+ * 
  * <p>
  * We have intentionally avoided implementing a particular threading model for processing. This leaves several
  * options for implementing multi-threaded processing of records.

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -954,6 +954,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             partitions is undefined or out of range and no offset reset policy has been configured
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if caller lacks Read access to any of the subscribed
      *             topics or to the configured groupId
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors (e.g. invalid groupId or
@@ -1060,6 +1062,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             or if there is an active group with the same groupId which is using group management.
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
      *             configured groupId
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors (e.g. if offset metadata
@@ -1092,6 +1096,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             or if there is an active group with the same groupId which is using group management.
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
      *             configured groupId
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors (e.g. if offset metadata
@@ -1228,6 +1234,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      *             the partition
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
      *             configured groupId
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors
@@ -1259,6 +1267,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @return The last committed offset and metadata or null if there was no prior commit
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
      *             configured groupId
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors
@@ -1301,6 +1311,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @return The list of partitions
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the specified topic
      * @throws org.apache.kafka.common.errors.TimeoutException if the topic metadata could not be fetched before
      *             expiration of the configured request timeout
@@ -1329,6 +1341,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @return The map of topics and its partitions
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.TimeoutException if the topic metadata could not be fetched before
      *             expiration of the configured request timeout
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetCommitCallback.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetCommitCallback.java
@@ -35,6 +35,8 @@ public interface OffsetCommitCallback {
      *             or if there is an active group with the same groupId which is using group management.
      * @throws org.apache.kafka.common.errors.WakeupException if {@link KafkaConsumer#wakeup()} is called before or while this
      *             function is called
+     * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted before or while
+     *             this function is called
      * @throws org.apache.kafka.common.errors.AuthorizationException if not authorized to the topic or to the
      *             configured groupId
      * @throws org.apache.kafka.common.KafkaException for any other unrecoverable errors (e.g. if offset metadata

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.kafka.common.errors.InterruptException;
 
 /**
  * AbstractCoordinator implements group management for a single group member by interacting with
@@ -911,7 +912,8 @@ public abstract class AbstractCoordinator implements Closeable {
                         }
                     }
                 }
-            } catch (InterruptedException e) {
+            } catch (InterruptedException | InterruptException e) {
+                Thread.interrupted();
                 log.error("Unexpected interrupt received in heartbeat thread for group {}", groupId, e);
                 this.failed.set(new RuntimeException(e));
             } catch (RuntimeException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -227,7 +227,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         try {
             Set<TopicPartition> assigned = new HashSet<>(subscriptions.assignedPartitions());
             listener.onPartitionsAssigned(assigned);
-        } catch (WakeupException e) {
+        } catch (WakeupException | InterruptException e) {
             throw e;
         } catch (Exception e) {
             log.error("User provided listener {} for group {} failed on partition assignment",
@@ -335,7 +335,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         try {
             Set<TopicPartition> revoked = new HashSet<>(subscriptions.assignedPartitions());
             listener.onPartitionsRevoked(revoked);
-        } catch (WakeupException e) {
+        } catch (WakeupException | InterruptException e) {
             throw e;
         } catch (Exception e) {
             log.error("User provided listener {} for group {} failed on partition revocation",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.kafka.common.errors.InterruptException;
 
 /**
  * This class manages the coordination process with the consumer coordinator.
@@ -546,7 +547,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
         if (autoCommitEnabled) {
             try {
                 commitOffsetsSync(subscriptions.allConsumed());
-            } catch (WakeupException e) {
+            } catch (WakeupException | InterruptException e) {
                 // rethrow wakeups since they are triggered by the user
                 throw e;
             } catch (Exception e) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -248,7 +248,7 @@ public class ConsumerNetworkClient implements Closeable {
             // to be fired on the next call to poll()
             maybeTriggerWakeup();
             
-            //Throw InterruptException if this thread is interrupted
+            // throw InterruptException if this thread is interrupted
             maybeThrowInterruptException();
 
             // try again to send requests since buffer space may have been

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.common.errors.InterruptException;
 
 /**
  * Higher level consumer access to the network layer with basic support for request futures. This class
@@ -174,6 +175,7 @@ public class ConsumerNetworkClient implements Closeable {
      * Block indefinitely until the given request future has finished.
      * @param future The request future to await.
      * @throws WakeupException if {@link #wakeup()} is called from another thread
+     * @throws InterruptException if the calling thread is interrupted
      */
     public void poll(RequestFuture<?> future) {
         while (!future.isDone())
@@ -186,6 +188,7 @@ public class ConsumerNetworkClient implements Closeable {
      * @param timeout The maximum duration (in ms) to wait for the request
      * @return true if the future is done, false otherwise
      * @throws WakeupException if {@link #wakeup()} is called from another thread
+     * @throws InterruptException if the calling thread is interrupted
      */
     public boolean poll(RequestFuture<?> future, long timeout) {
         long begin = time.milliseconds();
@@ -204,6 +207,7 @@ public class ConsumerNetworkClient implements Closeable {
      * Poll for any network IO.
      * @param timeout The maximum time to wait for an IO event.
      * @throws WakeupException if {@link #wakeup()} is called from another thread
+     * @throws InterruptException if the calling thread is interrupted
      */
     public void poll(long timeout) {
         poll(timeout, time.milliseconds(), null);
@@ -243,6 +247,9 @@ public class ConsumerNetworkClient implements Closeable {
             // trigger wakeups after checking for disconnects so that the callbacks will be ready
             // to be fired on the next call to poll()
             maybeTriggerWakeup();
+            
+            //Throw InterruptException if this thread is interrupted
+            maybeThrowInterruptException();
 
             // try again to send requests since buffer space may have been
             // cleared or a connect finished in the poll
@@ -402,6 +409,12 @@ public class ConsumerNetworkClient implements Closeable {
         if (wakeupDisabledCount == 0 && wakeup.get()) {
             wakeup.set(false);
             throw new WakeupException();
+        }
+    }
+    
+    private void maybeThrowInterruptException() {
+        if (Thread.interrupted()) {
+            throw new InterruptException(new InterruptedException());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
@@ -66,8 +65,8 @@ public class MockClient implements KafkaClient {
     private Node node = null;
     private final Set<String> ready = new HashSet<>();
     private final Map<Node, Long> blackedOut = new HashMap<>();
-    private final Queue<ClientRequest> requests = new ConcurrentLinkedDeque<>();
-    private final Queue<ClientResponse> responses = new ConcurrentLinkedDeque<>();
+    private final Queue<ClientRequest> requests = new ArrayDeque<>();
+    private final Queue<ClientResponse> responses = new ArrayDeque<>();
     private final Queue<FutureResponse> futureResponses = new ArrayDeque<>();
     private final Queue<Cluster> metadataUpdates = new ArrayDeque<>();
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
@@ -65,8 +66,8 @@ public class MockClient implements KafkaClient {
     private Node node = null;
     private final Set<String> ready = new HashSet<>();
     private final Map<Node, Long> blackedOut = new HashMap<>();
-    private final Queue<ClientRequest> requests = new ArrayDeque<>();
-    private final Queue<ClientResponse> responses = new ArrayDeque<>();
+    private final Queue<ClientRequest> requests = new ConcurrentLinkedDeque<>();
+    private final Queue<ClientResponse> responses = new ConcurrentLinkedDeque<>();
     private final Queue<FutureResponse> futureResponses = new ArrayDeque<>();
     private final Queue<Cluster> metadataUpdates = new ArrayDeque<>();
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -22,7 +22,11 @@ can upgrade the brokers one at a time: shut down the broker, update the code, an
 
 <h5><a id="upgrade_10_2_0_breaking" href="#upgrade_10_2_0_breaking">Potential breaking changes in 0.10.2.0</a></h5>
 <ul>
-    <li>Several methods on the new Java consumer may now throw <code>InterruptException</code> if the calling thread is interrupted.</li>
+    <li>Several methods on the new Java consumer may now throw <code>InterruptException</code> if the calling thread is interrupted. 
+        This change is not intended to replace using <code>KafkaConsumer.wakeup()</code> for thread coordination, but is intended to support shutdown of consuming threads in situations where using the wakeup function is not possible (e.g. the KafkaConsumer is being used in a thread managed by a framework that is unaware of Kafka).
+        Using interrupts instead of <code>KafkaConsumer.wakeup()</code> for general purpose signaling to a consuming thread is discouraged.
+        In cases where using <code>KafkaConsumer.wakeup()</code> is possible, there is no reason to explicitly handle <code>InterruptException</code>, since it can be treated the same as other types of <code>KafkaException</code>.
+        In the few cases where interrupting a consuming thread is necessary, the interrupt is likely used for signaling shutdown. The consuming thread should reinterrupt itself, and attempt to shut down.</li>
 </ul>
 
 <h4><a id="upgrade_10_1" href="#upgrade_10_1">Upgrading from 0.8.x, 0.9.x or 0.10.0.X to 0.10.1.0</a></h4>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -14,6 +14,16 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+<h4><a id="upgrade_10_2_0" href="#upgrade_10_2_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x or 0.10.1.0 to 0.10.2.0</a></h4>
+Users upgrading from versions prior to 0.10.1.0 should follow the upgrade guide <a href="#upgrade_10_1">here</a>. Users upgrading from 0.10.1.0
+can upgrade the brokers one at a time: shut down the broker, update the code, and restart it.
+<br/>
+0.10.2.0 has <a href="#upgrade_10_2_0_breaking">Potential breaking changes</a> (Please review before upgrading).
+
+<h5><a id="upgrade_10_2_0_breaking" href="#upgrade_10_2_0_breaking">Potential breaking changes in 0.10.2.0</a></h5>
+<ul>
+    <li>Several methods on the new Java consumer may now throw <code>InterruptException</code> if the calling thread is interrupted.</li>
+</ul>
 
 <h4><a id="upgrade_10_1" href="#upgrade_10_1">Upgrading from 0.8.x, 0.9.x or 0.10.0.X to 0.10.1.0</a></h4>
 0.10.1.0 has wire protocol changes. By following the recommended rolling upgrade plan below, you guarantee no downtime during the upgrade.

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -23,10 +23,7 @@ can upgrade the brokers one at a time: shut down the broker, update the code, an
 <h5><a id="upgrade_10_2_0_breaking" href="#upgrade_10_2_0_breaking">Potential breaking changes in 0.10.2.0</a></h5>
 <ul>
     <li>Several methods on the new Java consumer may now throw <code>InterruptException</code> if the calling thread is interrupted. 
-        This change is not intended to replace using <code>KafkaConsumer.wakeup()</code> for thread coordination, but is intended to support shutdown of consuming threads in situations where using the wakeup function is not possible (e.g. the KafkaConsumer is being used in a thread managed by a framework that is unaware of Kafka).
-        Using interrupts instead of <code>KafkaConsumer.wakeup()</code> for general purpose signaling to a consuming thread is discouraged.
-        In cases where using <code>KafkaConsumer.wakeup()</code> is possible, there is no reason to explicitly handle <code>InterruptException</code>, since it can be treated the same as other types of <code>KafkaException</code>.
-        In the few cases where interrupting a consuming thread is necessary, the interrupt is likely used for signaling shutdown. The consuming thread should reinterrupt itself, and attempt to shut down.</li>
+        Please refer to the <code>KafkaConsumer</code> Javadoc for a more in-depth explanation of this change</li>
 </ul>
 
 <h4><a id="upgrade_10_1" href="#upgrade_10_1">Upgrading from 0.8.x, 0.9.x or 0.10.0.X to 0.10.1.0</a></h4>


### PR DESCRIPTION
... throw InterruptException from blocking methods when interrupted

See https://issues.apache.org/jira/browse/KAFKA-4387