### PR TITLE
KAFKA-4364: Remove secrets from DEBUG logging

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TaskConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TaskConfig.java
@@ -49,6 +49,6 @@ public class TaskConfig extends AbstractConfig {
     }
 
     public TaskConfig(Map<String, ?> props) {
-        super(config, props);
+        super(config, props,true);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -210,7 +210,7 @@ class WorkerSinkTask extends WorkerTask {
      * Initializes and starts the SinkTask.
      */
     protected void initializeAndStart() {
-        log.debug("Initializing task {} with config {}", id, taskConfig);
+        log.debug("Initializing task {} ", id);
         String topicsStr = taskConfig.get(SinkTask.TOPICS_CONFIG);
         if (topicsStr == null || topicsStr.isEmpty())
             throw new ConnectException("Sink tasks require a list of topics.");


### PR DESCRIPTION
leverage fix from KAFKA-2690 to remove secrets from task logging 