### PR TITLE
KAFKA-4395: Break static initialization order dependency between KafkaConfig and Logconfig

### DIFF
--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -201,7 +201,7 @@ object LogConfig {
   val FollowerReplicationThrottledReplicasDoc = "A list of replicas for which log replication should be throttled on the follower side. The list should describe a set of " +
     "replicas in the form [PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle all replicas for this topic."
 
-  class LogConfigDef extends ConfigDef {
+  private class LogConfigDef extends ConfigDef {
 
     private final val serverDefaultConfigNames = mutable.Map[String, String]()
 
@@ -238,7 +238,7 @@ object LogConfig {
     def serverConfigName(configName: String): Option[String] = serverDefaultConfigNames.get(configName)
   }
 
-  val configDef: LogConfigDef = {
+  private val configDef: LogConfigDef = {
     import org.apache.kafka.common.config.ConfigDef.Importance._
     import org.apache.kafka.common.config.ConfigDef.Range._
     import org.apache.kafka.common.config.ConfigDef.Type._

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -234,8 +234,8 @@ object LogConfig {
         case _ => super.getConfigValue(key, headerName)
       }
     }
-    
-    def configKeysMap = serverDefaultConfigNames.toMap 
+
+    def serverConfigName(configName: String): Option[String] = serverDefaultConfigNames.get(configName)
   }
 
   val configDef: LogConfigDef = {
@@ -300,6 +300,8 @@ object LogConfig {
   def apply(): LogConfig = LogConfig(new Properties())
 
   def configNames: Seq[String] = configDef.names.asScala.toSeq.sorted
+
+  def serverConfigName(configName: String): Option[String] = configDef.serverConfigName(configName)
 
   /**
    * Create a log config instance using the given properties and defaults

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -203,7 +203,7 @@ object LogConfig {
 
   class LogConfigDef extends ConfigDef {
 
-    final val serverDefaultConfigNames = mutable.Map[String, String]()
+    private final val serverDefaultConfigNames = mutable.Map[String, String]()
 
     def define(name: String, defType: ConfigDef.Type, defaultValue: Any, validator: Validator,
                importance: ConfigDef.Importance, doc: String, serverDefaultConfigName: String): LogConfigDef = {
@@ -234,6 +234,8 @@ object LogConfig {
         case _ => super.getConfigValue(key, headerName)
       }
     }
+    
+    def configKeysMap = serverDefaultConfigNames.toMap 
   }
 
   val configDef: LogConfigDef = {

--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -201,9 +201,9 @@ object LogConfig {
   val FollowerReplicationThrottledReplicasDoc = "A list of replicas for which log replication should be throttled on the follower side. The list should describe a set of " +
     "replicas in the form [PartitionId]:[BrokerId],[PartitionId]:[BrokerId]:... or alternatively the wildcard '*' can be used to throttle all replicas for this topic."
 
-  private class LogConfigDef extends ConfigDef {
+  class LogConfigDef extends ConfigDef {
 
-    private final val serverDefaultConfigNames = mutable.Map[String, String]()
+    final val serverDefaultConfigNames = mutable.Map[String, String]()
 
     def define(name: String, defType: ConfigDef.Type, defaultValue: Any, validator: Validator,
                importance: ConfigDef.Importance, doc: String, serverDefaultConfigName: String): LogConfigDef = {
@@ -236,7 +236,7 @@ object LogConfig {
     }
   }
 
-  private val configDef: LogConfigDef = {
+  val configDef: LogConfigDef = {
     import org.apache.kafka.common.config.ConfigDef.Importance._
     import org.apache.kafka.common.config.ConfigDef.Range._
     import org.apache.kafka.common.config.ConfigDef.Type._

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -266,7 +266,6 @@ object KafkaConfig {
   val LogFlushIntervalMsProp = "log.flush.interval.ms"
   val LogFlushOffsetCheckpointIntervalMsProp = "log.flush.offset.checkpoint.interval.ms"
   val LogPreAllocateProp = "log.preallocate"
-  //val LogMessageFormatVersionProp = LogConfigPrefix + kafka.log.LogConfig.MessageFormatVersionProp
   val LogMessageFormatVersionProp = LogConfigPrefix + "message.format.version"
   val LogMessageTimestampTypeProp = LogConfigPrefix + "message.timestamp.type"
   val LogMessageTimestampDifferenceMaxMsProp = LogConfigPrefix + "message.timestamp.difference.max.ms"

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -22,7 +22,6 @@ import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1}
 import kafka.cluster.EndPoint
 import kafka.consumer.ConsumerConfig
 import kafka.coordinator.OffsetConfig
-import kafka.log.LogConfig
 import kafka.message.{BrokerCompressionCodec, CompressionCodec, Message, MessageSet}
 import kafka.utils.CoreUtils
 import org.apache.kafka.clients.CommonClientConfigs
@@ -267,9 +266,10 @@ object KafkaConfig {
   val LogFlushIntervalMsProp = "log.flush.interval.ms"
   val LogFlushOffsetCheckpointIntervalMsProp = "log.flush.offset.checkpoint.interval.ms"
   val LogPreAllocateProp = "log.preallocate"
-  val LogMessageFormatVersionProp = LogConfigPrefix + LogConfig.MessageFormatVersionProp
-  val LogMessageTimestampTypeProp = LogConfigPrefix + LogConfig.MessageTimestampTypeProp
-  val LogMessageTimestampDifferenceMaxMsProp = LogConfigPrefix + LogConfig.MessageTimestampDifferenceMaxMsProp
+  //val LogMessageFormatVersionProp = LogConfigPrefix + kafka.log.LogConfig.MessageFormatVersionProp
+  val LogMessageFormatVersionProp = LogConfigPrefix + "message.format.version"
+  val LogMessageTimestampTypeProp = LogConfigPrefix + "message.timestamp.type"
+  val LogMessageTimestampDifferenceMaxMsProp = LogConfigPrefix + "message.timestamp.difference.max.ms"
   val NumRecoveryThreadsPerDataDirProp = "num.recovery.threads.per.data.dir"
   val AutoCreateTopicsEnableProp = "auto.create.topics.enable"
   val MinInSyncReplicasProp = "min.insync.replicas"

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -29,6 +29,21 @@ import org.scalatest.Assertions._
 class LogConfigTest {
 
   @Test
+  def ensureNoStaticInitializationOrderDependency() {
+    // KafkaConfig object should not depend on LogConfig. If it does (for val
+    // initialization in KafkaConfig) bad things happen due to static initialization 
+    // order dependencies. LogConfig.configDef ends up adding null values for
+    // serverDefaultConfigNames. We ensure mapping of keys from LogConfig 
+    // KafkaConfig are not missing values.
+    
+    // Access any KafkaConfig val to load KafkaConfig object before LogConfig.
+    val unused = KafkaConfig.LogRetentionTimeMillisProp
+    assertTrue(LogConfig.configDef.serverDefaultConfigNames.forall { 
+      case (key, value) => value != null 
+    }) 
+  }
+
+  @Test
   def testKafkaConfigToProps() {
     val millisInHour = 60L * 60L * 1000L
     val kafkaProps = TestUtils.createBrokerConfig(nodeId = 0, zkConnect = "")

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -40,7 +40,7 @@ class LogConfigTest {
   def ensureNoStaticInitializationOrderDependency() {
     // Access any KafkaConfig val to load KafkaConfig object before LogConfig.
     assertTrue(KafkaConfig.LogRetentionTimeMillisProp != null);
-    assertTrue(LogConfig.configDef.serverDefaultConfigNames.forall { 
+    assertTrue(LogConfig.configDef.configKeysMap.forall { 
       case (key, value) => value != null 
     }) 
   }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -40,8 +40,10 @@ class LogConfigTest {
   def ensureNoStaticInitializationOrderDependency() {
     // Access any KafkaConfig val to load KafkaConfig object before LogConfig.
     assertTrue(KafkaConfig.LogRetentionTimeMillisProp != null);
-    assertTrue(LogConfig.configDef.configKeysMap.forall { 
-      case (key, value) => value != null 
+    assertTrue(LogConfig.configNames.forall {
+      case config =>
+        val serverConfigOpt = LogConfig.serverConfigName(config)
+        serverConfigOpt.isDefined && (serverConfigOpt.get != null)
     }) 
   }
 

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -28,16 +28,18 @@ import org.scalatest.Assertions._
 
 class LogConfigTest {
 
+  /** 
+   * This test verifies that KafkaConfig object initialization does not depend on 
+   * LogConfig initialization. Bad things happen due to static initialization 
+   * order dependencies. For example, LogConfig.configDef ends up adding null 
+   * values in serverDefaultConfigNames. This test ensures that the mapping of 
+   * keys from LogConfig to KafkaConfig are not missing values.
+   */
+    
   @Test
   def ensureNoStaticInitializationOrderDependency() {
-    // KafkaConfig object should not depend on LogConfig. If it does (for val
-    // initialization in KafkaConfig) bad things happen due to static initialization 
-    // order dependencies. LogConfig.configDef ends up adding null values for
-    // serverDefaultConfigNames. We ensure mapping of keys from LogConfig 
-    // KafkaConfig are not missing values.
-    
     // Access any KafkaConfig val to load KafkaConfig object before LogConfig.
-    val unused = KafkaConfig.LogRetentionTimeMillisProp
+    assertTrue(KafkaConfig.LogRetentionTimeMillisProp != null);
     assertTrue(LogConfig.configDef.serverDefaultConfigNames.forall { 
       case (key, value) => value != null 
     }) 


### PR DESCRIPTION
Fixes static initialization order dependency between KafkaConfig and LogConfig. @jjkoshy please take a look.