### PR TITLE
MINOR: Extract SCALA_BINARY_VERSION from SCALA_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The release file can be found inside `./core/build/distributions/`.
     ./gradlew clean
 
 ### Running a task on a particular version of Scala (either 2.10.6 or 2.11.8) ###
-*Note that if building the jars with a version other than 2.10, you need to set the `SCALA_BINARY_VERSION` variable or change it in `bin/kafka-run-class.sh` to run the quick start.*
+*Note that if building the jars with a version other than 2.10.6, you need to set the `SCALA_VERSION` variable or change it in `bin/kafka-run-class.sh` to run the quick start.*
 
 You can pass either the major version (eg 2.11) or the full version (eg 2.11.8):
 

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -52,7 +52,7 @@ if [ -z "$SCALA_VERSION" ]; then
 fi
 
 if [ -z "$SCALA_BINARY_VERSION" ]; then
-  SCALA_BINARY_VERSION=2.10
+  SCALA_BINARY_VERSION=$(echo $SCALA_VERSION | cut -f 1-2 -d '.')
 fi
 
 # run ./gradlew copyDependantLibs to get all dependant jars in a local dir

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -34,10 +34,10 @@ IF ["%SCALA_BINARY_VERSION%"] EQU [""] (
   for /f "tokens=1,2 delims=." %%a in ("%SCALA_VERSION%") do (
     set FIRST=%%a
     set SECOND=%%b
-    if ["%SECOND%"] EQU [""] (
-      set SCALA_BINARY_VERSION=%FIRST%
+    if ["!SECOND!"] EQU [""] (
+      set SCALA_BINARY_VERSION=!FIRST!
     ) else (
-      set SCALA_BINARY_VERSION=%FIRST%.%SECOND%
+      set SCALA_BINARY_VERSION=!FIRST!.!SECOND!
     )
   )
 )

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -31,7 +31,15 @@ IF ["%SCALA_VERSION%"] EQU [""] (
 )
 
 IF ["%SCALA_BINARY_VERSION%"] EQU [""] (
-  set SCALA_BINARY_VERSION=2.10
+  for /f "tokens=1,2 delims=." %%a in ("%SCALA_VERSION%") do (
+    set FIRST=%%a
+    set SECOND=%%b
+    if ["%SECOND%"] EQU [""] (
+      set SCALA_BINARY_VERSION=%FIRST%
+    ) else (
+      set SCALA_BINARY_VERSION=%FIRST%.%SECOND%
+    )
+  )
 )
 
 rem Classpath addition for kafka-core dependencies


### PR DESCRIPTION
Will allow users to set one fewer environment variable if they need to
change scala version. Still, SCALA_BINARY_VERSION can be explicitly set.