### PR TITLE
Remove failing ConnectDistributedTest.test_bad_connector_class

### DIFF
--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -155,43 +155,6 @@ class ConnectDistributedTest(Test):
         wait_until(lambda: self.connector_is_running(self.sink), timeout_sec=10,
                    err_msg="Failed to see connector transition to the RUNNING state")
 
-    @matrix(delete_before_reconfig=[False, True])
-    def test_bad_connector_class(self, delete_before_reconfig):
-        """
-        For the same connector name, first configure it with a bad connector class name such that it fails to start, verify that it enters a FAILED state.
-        Restart should also fail.
-        Then try to rectify by reconfiguring it as a MockConnector and verifying it successfully transitions to RUNNING.
-        """
-        self.setup_services()
-        self.cc.set_configs(lambda node: self.render("connect-distributed.properties", node=node))
-        self.cc.start()
-
-        connector_name = 'bad-to-good-test'
-
-        connector = namedtuple('BadConnector', ['name', 'tasks'])(connector_name, 1)
-        config = {
-            'name': connector.name,
-            'tasks.max': connector.tasks,
-            'connector.class': 'java.util.HashMap'
-        }
-        self.cc.create_connector(config)
-
-        wait_until(lambda: self.connector_is_failed(connector), timeout_sec=10, err_msg="Failed to see connector transition to FAILED state")
-
-        try:
-            self.cc.restart_connector(connector_name)
-        except ConnectRestError:
-            pass
-        else:
-            raise AssertionError("Expected restart of %s to fail" % connector_name)
-
-        if delete_before_reconfig:
-            self.cc.delete_connector(connector_name)
-
-        config['connector.class'] = 'org.apache.kafka.connect.tools.MockSourceConnector'
-        self.cc.set_connector_config(connector_name, config)
-        wait_until(lambda: self.connector_is_running(connector), timeout_sec=10, err_msg="Failed to see connector transition to the RUNNING state")
-
     @matrix(connector_type=["source", "sink"])
     def test_restart_failed_task(self, connector_type):
         self.setup_services()


### PR DESCRIPTION
Since #1911 was merged it is hard to externally test a connector transitioning to FAILED state due to an initialization failure, which is what this test was attempting to verify.

The unit test added in #1778 already exercises exception-handling around Connector instantiation.