### PR TITLE
KAFKA-4416: Add a `--group` option to console consumer

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -462,14 +462,15 @@ object ConsoleConsumer extends Logging {
 
     // if the group id is provided in more than place (through different means) all values must be the same
     val groupIdsProvided = Set(
-        options.valueOf(groupIdOpt),                           // via --group
-        consumerProps.get(ConsumerConfig.GROUP_ID_CONFIG),     // via --consumer-property
-        extraConsumerProps.get(ConsumerConfig.GROUP_ID_CONFIG) // via --cosumer.config
-      ).filter(_ != null)
+        Option(options.valueOf(groupIdOpt)),                           // via --group
+        Option(consumerProps.get(ConsumerConfig.GROUP_ID_CONFIG)),     // via --consumer-property
+        Option(extraConsumerProps.get(ConsumerConfig.GROUP_ID_CONFIG)) // via --cosumer.config
+      ).flatten
 
     if (groupIdsProvided.size > 1) {
       CommandLineUtils.printUsageAndDie(parser, "The group ids provided in different places (directly using '--group', "
-                                              + "via '--consumer-property', or via '--consumer.config') do not match.")
+                                              + "via '--consumer-property', or via '--consumer.config') do not match. "
+                                              + s"Detected group ids: ${groupIdsProvided.mkString("'", "', '", "'")}")
     }
 
     groupIdsProvided.headOption match {


### PR DESCRIPTION
This simplifies running a console consumer as part of a custom group. Note that group id can be provided via only one of the three possible means: directly using `--group ` option (as part of this PR), as property via `--consumer-property` option,  or inside a config file via `--consumer.config` option.