### PR TITLE
KAFKA-4424: make serializer classes final

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteArrayDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteArrayDeserializer.java
@@ -15,7 +15,7 @@ package org.apache.kafka.common.serialization;
 
 import java.util.Map;
 
-public class ByteArrayDeserializer implements Deserializer<byte[]> {
+public final class ByteArrayDeserializer implements Deserializer<byte[]> {
 
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteArraySerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteArraySerializer.java
@@ -15,7 +15,7 @@ package org.apache.kafka.common.serialization;
 
 import java.util.Map;
 
-public class ByteArraySerializer implements Serializer<byte[]> {
+public final class ByteArraySerializer implements Serializer<byte[]> {
 
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferDeserializer.java
@@ -15,7 +15,7 @@ package org.apache.kafka.common.serialization;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-public class ByteBufferDeserializer implements Deserializer<ByteBuffer> {
+public final class ByteBufferDeserializer implements Deserializer<ByteBuffer> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
@@ -15,7 +15,7 @@ package org.apache.kafka.common.serialization;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-public class ByteBufferSerializer implements Serializer<ByteBuffer> {
+public final class ByteBufferSerializer implements Serializer<ByteBuffer> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/BytesDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/BytesDeserializer.java
@@ -16,7 +16,7 @@ import org.apache.kafka.common.utils.Bytes;
 
 import java.util.Map;
 
-public class BytesDeserializer implements Deserializer<Bytes> {
+public final class BytesDeserializer implements Deserializer<Bytes> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/BytesSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/BytesSerializer.java
@@ -16,7 +16,7 @@ import org.apache.kafka.common.utils.Bytes;
 
 import java.util.Map;
 
-public class BytesSerializer implements Serializer<Bytes> {
+public final class BytesSerializer implements Serializer<Bytes> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/DoubleDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/DoubleDeserializer.java
@@ -16,7 +16,7 @@ import org.apache.kafka.common.errors.SerializationException;
 
 import java.util.Map;
 
-public class DoubleDeserializer implements Deserializer<Double> {
+public final class DoubleDeserializer implements Deserializer<Double> {
 
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {

--- a/clients/src/main/java/org/apache/kafka/common/serialization/DoubleSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/DoubleSerializer.java
@@ -14,7 +14,7 @@ package org.apache.kafka.common.serialization;
 
 import java.util.Map;
 
-public class DoubleSerializer implements Serializer<Double> {
+public final class DoubleSerializer implements Serializer<Double> {
 
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {

--- a/clients/src/main/java/org/apache/kafka/common/serialization/IntegerDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/IntegerDeserializer.java
@@ -16,7 +16,7 @@ import org.apache.kafka.common.errors.SerializationException;
 
 import java.util.Map;
 
-public class IntegerDeserializer implements Deserializer<Integer> {
+public final class IntegerDeserializer implements Deserializer<Integer> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/IntegerSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/IntegerSerializer.java
@@ -14,7 +14,7 @@ package org.apache.kafka.common.serialization;
 
 import java.util.Map;
 
-public class IntegerSerializer implements Serializer<Integer> {
+public final class IntegerSerializer implements Serializer<Integer> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/LongDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/LongDeserializer.java
@@ -16,7 +16,7 @@ import org.apache.kafka.common.errors.SerializationException;
 
 import java.util.Map;
 
-public class LongDeserializer implements Deserializer<Long> {
+public final class LongDeserializer implements Deserializer<Long> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/LongSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/LongSerializer.java
@@ -14,7 +14,7 @@ package org.apache.kafka.common.serialization;
 
 import java.util.Map;
 
-public class LongSerializer implements Serializer<Long> {
+public final class LongSerializer implements Serializer<Long> {
 
     public void configure(Map<String, ?> configs, boolean isKey) {
         // nothing to do

--- a/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
@@ -21,7 +21,7 @@ import java.util.Map;
  *  String encoding defaults to UTF8 and can be customized by setting the property key.deserializer.encoding,
  *  value.deserializer.encoding or deserializer.encoding. The first two take precedence over the last.
  */
-public class StringDeserializer implements Deserializer<String> {
+public final class StringDeserializer implements Deserializer<String> {
     private String encoding = "UTF8";
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/serialization/StringSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/StringSerializer.java
@@ -21,7 +21,7 @@ import java.util.Map;
  *  String encoding defaults to UTF8 and can be customized by setting the property key.serializer.encoding,
  *  value.serializer.encoding or serializer.encoding. The first two take precedence over the last.
  */
-public class StringSerializer implements Serializer<String> {
+public final class StringSerializer implements Serializer<String> {
     private String encoding = "UTF8";
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -177,7 +177,7 @@ public class FetcherTest {
     public void testFetchedRecordsRaisesOnSerializationErrors() {
         // raise an exception from somewhere in the middle of the fetch response
         // so that we can verify that our position does not advance after raising
-        ByteArrayDeserializer deserializer = new ByteArrayDeserializer() {
+        Deserializer<byte[]> deserializer = new Deserializer<byte[]>() {
             int i = 0;
             @Override
             public byte[] deserialize(String topic, byte[] data) {
@@ -185,6 +185,10 @@ public class FetcherTest {
                     throw new SerializationException();
                 return data;
             }
+            @Override
+            public void close() { }
+            @Override
+            public void configure(Map<String, ?> configs, boolean isKey) { }
         };
 
         Fetcher<byte[], byte[]> fetcher = createFetcher(subscriptions, new Metrics(time), deserializer, deserializer);


### PR DESCRIPTION
implementations of simple serializers / deserializers should be final to prevent JVM method call overhead.
See also:
https://wiki.openjdk.java.net/display/HotSpot/VirtualCalls

edit: fixed test, this seems to break the API slightly (maybe include in 11.x though?)