### PR TITLE
KAFKA-4273 - Add TTL support for RocksDB

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -770,10 +770,15 @@ public class ConfigDef {
     public static class Range implements Validator {
         private final Number min;
         private final Number max;
+        private final boolean allowNulls;
 
         private Range(Number min, Number max) {
+            this(min, max, false);
+        }
+        private Range(Number min, Number max, boolean allowNulls) {
             this.min = min;
             this.max = max;
+            this.allowNulls = allowNulls;
         }
 
         /**
@@ -786,6 +791,15 @@ public class ConfigDef {
         }
 
         /**
+         * A numeric range that checks only the lower bound, but allows null values.
+         *
+         * @param min The minimum acceptable value
+         */
+        public static Range atLeastOrNull(Number min) {
+            return new Range(min, null, true);
+        }
+
+        /**
          * A numeric range that checks both the upper and lower bound
          */
         public static Range between(Number min, Number max) {
@@ -793,8 +807,10 @@ public class ConfigDef {
         }
 
         public void ensureValid(String name, Object o) {
-            if (o == null)
+            if (o == null && !allowNulls)
                 throw new ConfigException(name, o, "Value must be non-null");
+            if (o == null && allowNulls)
+                return;
             Number n = (Number) o;
             if (min != null && n.doubleValue() < min.doubleValue())
                 throw new ConfigException(name, o, "Value must be at least " + min);
@@ -804,11 +820,11 @@ public class ConfigDef {
 
         public String toString() {
             if (min == null)
-                return "[...," + max + "]";
+                return "range=[...," + max + "], allowNulls=" + allowNulls;
             else if (max == null)
-                return "[" + min + ",...]";
+                return "range=[" + min + ",...], allowNulls=" + allowNulls;
             else
-                return "[" + min + ",...," + max + "]";
+                return "range=[" + min + ",...," + max + "], allowNulls=" + allowNulls;
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeastOrNull;
 
 /**
  * Configuration for Kafka Streams. Documentation for these configurations can be found in the <a
@@ -132,6 +133,14 @@ public class StreamsConfig extends AbstractConfig {
     /** <code>rocksdb.config.setter</code> */
     public static final String ROCKSDB_CONFIG_SETTER_CLASS_CONFIG = "rocksdb.config.setter";
     public static final String ROCKSDB_CONFIG_SETTER_CLASS_DOC = "A Rocks DB config setter class that implements the <code>RocksDBConfigSetter</code> interface";
+
+    /** <code>rocksdb.ttl.sec</code> */
+    public static final String ROCKSDB_TTL_SEC_CONFIG = "rocksdb.ttl.sec";
+    public static final String ROCKSDB_TTL_SEC_DOC = "A Rocks DB TTL value in seconds. It's used for all state stores. Must be greater than zero. " +
+                                                     "If the value is null no TTL will be used. This config should be used when inserted key-values " +
+                                                     "are meant to be removed from the db in a non-strict 'ttl' amount of time. " +
+                                                     "Therefore, this guarantees that key-values inserted will remain in the db for >= ttl amount of time " +
+                                                     "and the db will make efforts to remove the key-values as soon as possible after ttl seconds of their insertion.";
 
     /** <code>windowstore.changelog.additional.retention.ms</code> */
     public static final String WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG = "windowstore.changelog.additional.retention.ms";
@@ -247,6 +256,12 @@ public class StreamsConfig extends AbstractConfig {
                                         null,
                                         Importance.LOW,
                                         ROCKSDB_CONFIG_SETTER_CLASS_DOC)
+                                .define(ROCKSDB_TTL_SEC_CONFIG,
+                                        Type.INT,
+                                        null,
+                                        atLeastOrNull(1),
+                                        Importance.LOW,
+                                        ROCKSDB_TTL_SEC_DOC)
                                 .define(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG,
                                         Type.LONG,
                                         24 * 60 * 60 * 1000,


### PR DESCRIPTION
Since Streams DSL doesn't support fine grained configurations of state stores (it uses only RocksDB) - I have added  new StreamsConfig called `rocksdb.ttl.sec` - which allows you to set TTL for all state stores used by the topology. To make it short, if you set property to a value `>=1`, it will use TtlDB instead of RocksDB and this will lead to records getting expired after this defined period.

This should help users to bound their disk usage and provide a configuration for use cases where your data has natural TTL/retention. For example, when you process data only for one hour, and after that you don't need the data in state stores anymore.

I have added a [test](https://github.com/apache/kafka/compare/trunk...dpoldrugo:KAFKA-4273-ttl-support?expand=1#diff-d908a80c770d196ac823752da3b3a864R117) to check if TtlDB is expiring records, but I can't make TtlDB expire records within a reasonable window (1 minute). So I have **@Ignore**d the test. Do you have any suggestions how to force TtlDB to expire records more quickly?

Since I'm using Kafka and Kafka Streams 0.10.1.0, I have also added this code to the [0.10.1](https://github.com/dpoldrugo/kafka/tree/0.10.1-KAFKA-4273-ttl-support) branch, and if the review goes well I hope it can be added to the 0.10.1.1 release.
The patch is here: [KAFKA_4273_Add_TTL_support_for_RocksDB_v1.patch.txt](https://github.com/apache/kafka/files/607665/KAFKA_4273_Add_TTL_support_for_RocksDB_v1.patch.txt)


**Suggestion for future work**
Since this config/feature applies to all state stores, it would be nice to provide an API for users to configure TTL for every state store individually, for example during toplogy building with KStreamBuilder.

Now: KStreamBuilder#table(String topic, final String storeName)
Suggestion: KStreamBuilder#table(String topic, final String storeName, **_StoreOptions_ storeOptions**)
Where **_StoreOptions_** would be something like this: `{ ttlSeconds: int }`

More details: [KAFKA-4273](https://issues.apache.org/jira/browse/KAFKA-4273)

@guozhangwang @dguy @mjsax @norwood @enothereska @ijuma    - could you check this out?