### PR TITLE
KAFKA-4449: Add Serializer/Deserializer for POJO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -589,6 +589,7 @@ project(':clients') {
     compile libs.lz4
     compile libs.snappy
     compile libs.slf4jApi
+    compile libs.jacksonDatabind
 
     testCompile libs.bcpkix
     testCompile libs.junit

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -100,6 +100,7 @@
 
     <subpackage name="serialization">
       <allow class="org.apache.kafka.common.errors.SerializationException" />
+      <allow class="com.fasterxml.jackson.databind.ObjectMapper" />
     </subpackage>
   </subpackage>
 

--- a/clients/src/main/java/org/apache/kafka/common/serialization/GenericDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/GenericDeserializer.java
@@ -1,0 +1,65 @@
+package org.apache.kafka.common.serialization;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This deserializer can deserialize any object of POJO class
+ * 
+ * @author Jason Guo <habren@163.com>
+ *
+ * @param <T>
+ *            POJO class. The class should have a constructor without any
+ *            arguments and have setter and getter for every member variable
+ * 
+ */
+
+public class GenericDeserializer<T> implements Deserializer<T> {
+
+	private Class<T> type;
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	public GenericDeserializer() {}
+	
+	public GenericDeserializer(Class<T> type) {
+		this.type = type;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		if(type != null) {
+			return;
+		}
+		
+		String typeProp = isKey ? "key.deserializer.type" : "value.deserializer.type";
+		String typeName = (String)configs.get(typeProp);
+		try {
+			type = (Class<T>)Class.forName(typeName);
+		} catch (Exception ex) {
+			throw new SerializationException("Failed to initialize GenericDeserializer for " + typeName, ex);
+		}
+	}
+
+	@Override
+	public T deserialize(String topic, byte[] data) {
+		if (data == null) {
+			return null;
+		}
+		try {
+			return this.objectMapper.readValue(data, type);
+		} catch (IOException ex) {
+			throw new SerializationException(ex);
+		}
+	}
+
+	@Override
+	public void close() {
+	}
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/GenericDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/GenericDeserializer.java
@@ -1,10 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package org.apache.kafka.common.serialization;
 
 import java.io.IOException;
 import java.util.Map;
 
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.Deserializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -21,45 +33,46 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class GenericDeserializer<T> implements Deserializer<T> {
 
-	private Class<T> type;
-	private ObjectMapper objectMapper = new ObjectMapper();
+    private Class<T> type;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
-	public GenericDeserializer() {}
-	
-	public GenericDeserializer(Class<T> type) {
-		this.type = type;
-	}
+    public GenericDeserializer() {
+    }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public void configure(Map<String, ?> configs, boolean isKey) {
-		if(type != null) {
-			return;
-		}
-		
-		String typeProp = isKey ? "key.deserializer.type" : "value.deserializer.type";
-		String typeName = (String)configs.get(typeProp);
-		try {
-			type = (Class<T>)Class.forName(typeName);
-		} catch (Exception ex) {
-			throw new SerializationException("Failed to initialize GenericDeserializer for " + typeName, ex);
-		}
-	}
+    public GenericDeserializer(Class<T> type) {
+        this.type = type;
+    }
 
-	@Override
-	public T deserialize(String topic, byte[] data) {
-		if (data == null) {
-			return null;
-		}
-		try {
-			return this.objectMapper.readValue(data, type);
-		} catch (IOException ex) {
-			throw new SerializationException(ex);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (type != null) {
+            return;
+        }
 
-	@Override
-	public void close() {
-	}
+        String typeProp = isKey ? "key.deserializer.type" : "value.deserializer.type";
+        String typeName = (String) configs.get(typeProp);
+        try {
+            type = (Class<T>) Class.forName(typeName);
+        } catch (Exception ex) {
+            throw new SerializationException("Failed to initialize GenericDeserializer for " + typeName, ex);
+        }
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+        try {
+            return this.objectMapper.readValue(data, type);
+        } catch (IOException ex) {
+            throw new SerializationException(ex);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/GenericSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/GenericSerializer.java
@@ -1,0 +1,64 @@
+package org.apache.kafka.common.serialization;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * This serializer can serialize any object of POJO class
+ * 
+ * @author Jason Guo <habren@163.com>
+ *
+ * @param <T>
+ *            POJO class. The class should have a constructor without any
+ *            arguments and have setter and getter for every member variable
+ *            
+ */
+
+public class GenericSerializer<T> implements Serializer<T> {
+
+	private Class<T> type;
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	public GenericSerializer() {}
+	
+	public GenericSerializer(Class<T> type) {
+		this.type = type;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		if(type != null) {
+			return;
+		}
+		String typeProp = isKey ? "key.serializer.type" : "value.serializer.type";
+		String typeName = (String)configs.get(typeProp);
+		try {
+			type = (Class<T>)Class.forName(typeName);
+		} catch (Exception ex) {
+			throw new SerializationException("Failed to initialize GenericSerializer for " + typeName, ex);
+		}
+	}
+
+	@Override
+	public byte[] serialize(String topic, T object) {
+		if (object == null) {
+			return null;
+		}
+		try {
+			return this.objectMapper.writerFor(type).writeValueAsBytes(object);
+		} catch (IOException ex) {
+			throw new SerializationException(ex);
+		}
+	}
+
+	@Override
+	public void close() {
+	}
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/GenericSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/GenericSerializer.java
@@ -1,10 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package org.apache.kafka.common.serialization;
 
 import java.io.IOException;
 import java.util.Map;
 
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.Serializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -21,44 +33,45 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class GenericSerializer<T> implements Serializer<T> {
 
-	private Class<T> type;
-	private ObjectMapper objectMapper = new ObjectMapper();
+    private Class<T> type;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
-	public GenericSerializer() {}
-	
-	public GenericSerializer(Class<T> type) {
-		this.type = type;
-	}
+    public GenericSerializer() {
+    }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public void configure(Map<String, ?> configs, boolean isKey) {
-		if(type != null) {
-			return;
-		}
-		String typeProp = isKey ? "key.serializer.type" : "value.serializer.type";
-		String typeName = (String)configs.get(typeProp);
-		try {
-			type = (Class<T>)Class.forName(typeName);
-		} catch (Exception ex) {
-			throw new SerializationException("Failed to initialize GenericSerializer for " + typeName, ex);
-		}
-	}
+    public GenericSerializer(Class<T> type) {
+        this.type = type;
+    }
 
-	@Override
-	public byte[] serialize(String topic, T object) {
-		if (object == null) {
-			return null;
-		}
-		try {
-			return this.objectMapper.writerFor(type).writeValueAsBytes(object);
-		} catch (IOException ex) {
-			throw new SerializationException(ex);
-		}
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (type != null) {
+            return;
+        }
+        String typeProp = isKey ? "key.serializer.type" : "value.serializer.type";
+        String typeName = (String) configs.get(typeProp);
+        try {
+            type = (Class<T>) Class.forName(typeName);
+        } catch (Exception ex) {
+            throw new SerializationException("Failed to initialize GenericSerializer for " + typeName, ex);
+        }
+    }
 
-	@Override
-	public void close() {
-	}
+    @Override
+    public byte[] serialize(String topic, T object) {
+        if (object == null) {
+            return null;
+        }
+        try {
+            return this.objectMapper.writerFor(type).writeValueAsBytes(object);
+        } catch (IOException ex) {
+            throw new SerializationException(ex);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/Serdes.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Serdes.java
@@ -98,8 +98,8 @@ public class Serdes {
     }
     
     static public final class GenericSerde<T> extends WrapperSerde<T> {
-        public GenericSerde() {
-            super(new GenericSerializer<T>(), new GenericDeserializer<T>());
+        public GenericSerde(Class<T> type) {
+            super(new GenericSerializer<T>(type), new GenericDeserializer<T>(type));
         }
     }
 
@@ -133,7 +133,7 @@ public class Serdes {
             return (Serde<T>) Bytes();
         }
 
-        return new GenericSerde<T>();
+        return new GenericSerde<T>(type);
         // throw new IllegalArgumentException("Unknown class for built-in serializer");
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/serialization/Serdes.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/Serdes.java
@@ -96,6 +96,12 @@ public class Serdes {
             super(new ByteArraySerializer(), new ByteArrayDeserializer());
         }
     }
+    
+    static public final class GenericSerde<T> extends WrapperSerde<T> {
+        public GenericSerde() {
+            super(new GenericSerializer<T>(), new GenericDeserializer<T>());
+        }
+    }
 
     @SuppressWarnings("unchecked")
     static public <T> Serde<T> serdeFrom(Class<T> type) {
@@ -127,8 +133,8 @@ public class Serdes {
             return (Serde<T>) Bytes();
         }
 
-        // TODO: we can also serializes objects of type T using generic Java serialization by default
-        throw new IllegalArgumentException("Unknown class for built-in serializer");
+        return new GenericSerde<T>();
+        // throw new IllegalArgumentException("Unknown class for built-in serializer");
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -61,8 +61,6 @@ public class SerializationTest {
         Serializer<DummyPOJO> serializer = serde.serializer();
         Deserializer<DummyPOJO> deserializer = serde.deserializer();
         byte[] serBytes = serializer.serialize(topic, pojo);
-        System.out.println("length=" + serBytes.length);
-        System.out.println("JSON=" + new String(serBytes));
         DummyPOJO newPOJO = deserializer.deserialize(topic, serBytes);
         assertEquals(pojo.getAge(), newPOJO.getAge());
     }

--- a/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/serialization/SerializationTest.java
@@ -26,8 +26,18 @@ public class SerializationTest {
 
     final private String topic = "testTopic";
 
-    private class DummyClass {
+    private static class DummyPOJO {
+        private int age;
 
+        public DummyPOJO() {}
+        
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
     }
 
     @Test
@@ -43,9 +53,18 @@ public class SerializationTest {
                 value, otherSerde.deserializer().deserialize(topic, thisSerde.serializer().serialize(topic, value)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testSerdeFromUnknown() {
-        Serdes.serdeFrom(DummyClass.class);
+    @Test
+    public void testSerdeFromPOJO() {
+        DummyPOJO pojo = new DummyPOJO();
+        pojo.setAge(23);
+        Serde<DummyPOJO> serde = Serdes.serdeFrom(DummyPOJO.class);
+        Serializer<DummyPOJO> serializer = serde.serializer();
+        Deserializer<DummyPOJO> deserializer = serde.deserializer();
+        byte[] serBytes = serializer.serialize(topic, pojo);
+        System.out.println("length=" + serBytes.length);
+        System.out.println("JSON=" + new String(serBytes));
+        DummyPOJO newPOJO = deserializer.deserialize(topic, serBytes);
+        assertEquals(pojo.getAge(), newPOJO.getAge());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Currently, there are only build-in serializer/deserializer for basic data type (String, Long, etc). It's better to have serializer/deserializer for POJO.

If we had this, user can serialize/deserialize all of their POJO with it. Otherwise, user may need to create e pair of serializer and deserializer for each kind of POJO, just like the implementation in the stream example PageViewTypeDemo
https://github.com/apache/kafka/blob/trunk/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/PageViewTypedDemo.java

Let's take above streams-example as an example, Serde was created for PageView as below


        final Serializer<PageView> pageViewSerializer = new JsonPOJOSerializer<>();
        serdeProps.put("JsonPOJOClass", PageView.class);
        pageViewSerializer.configure(serdeProps, false);

        final Deserializer<PageView> pageViewDeserializer = new JsonPOJODeserializer<>();
        serdeProps.put("JsonPOJOClass", PageView.class);
        pageViewDeserializer.configure(serdeProps, false);

        final Serde<PageView> pageViewSerde = Serdes.serdeFrom(pageViewSerializer, pageViewDeserializer);


If we use this POJO serializer/deserializer, the Serde can be created with only one line
    
    Serdes.serdeFrom(PageView.class)
    
