### PR TITLE
KAFKA-4453: add request prioritization

### DIFF
--- a/core/src/main/scala/kafka/network/PrioritizationAwareBlockingQueue.scala
+++ b/core/src/main/scala/kafka/network/PrioritizationAwareBlockingQueue.scala
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.network
+
+import java.util.ArrayDeque
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.{Condition, ReentrantLock}
+
+/**
+ * A blocking queue that is prioritization-aware.
+ *
+ * Prioritized elements in the queue get polled before regular elements in the queue.
+ */
+private[network] class PrioritizationAwareBlockingQueue[E](private val capacity: Int) {
+  private var count: Int = 0
+  private val prioritizedElements: ArrayDeque[E] = new ArrayDeque[E]()
+  private val regularElements: ArrayDeque[E] = new ArrayDeque[E]()
+  private val lock: ReentrantLock = new ReentrantLock()
+  private val notFull: Condition = lock.newCondition()
+  private val notEmpty: Condition = lock.newCondition()
+
+  /**
+   * Inserts the potentially prioritized element into the queue, blocking if space is unavailable.
+   *
+   * @param e - non-null element to be inserted
+   * @param prioritized - flag indicating whether the element should be prioritized
+   * @throws InterruptedException
+   */
+  def put(e: E, prioritized: Boolean): Unit = {
+    if (e == null) {
+      throw new NullPointerException()
+    }
+    lock.lockInterruptibly()
+    try {
+      while (count == capacity) {
+        notFull.await()
+      }
+      enqueue(e, prioritized)
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /**
+   * Return and remove elements from the head of the queue in a priority-aware manner, blocking up to the provided
+   * timeout for elements.
+   *
+   * That is, prioritized elements in the queue get polled before regular elements in the queue.
+   *
+   * @param timeout - the maximum amount of time to wait for an item to be polled from the queue
+   * @param timeUnit - the unit of time
+   * @return potentially prioritized element from the head of the queue
+   * @throws InterruptedException
+   */
+  def poll(timeout: Long, timeUnit: TimeUnit): E = {
+    var nanos = timeUnit.toNanos(timeout)
+    lock.lockInterruptibly()
+    try {
+      while (count == 0) {
+        if (nanos <= 0) {
+          return null.asInstanceOf[E]
+        }
+        nanos = notEmpty.awaitNanos(nanos)
+      }
+      dequeue
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  /**
+   * Inserts the potentially prioritized element into the queue.
+   *
+   * Call only within the lock when count < capacity.
+   *
+   * @param e - non-null element to be inserted
+   * @param prioritized - flag indicating whether the element should be prioritized
+   */
+  private def enqueue(e: E, prioritized: Boolean): Unit = {
+    if (prioritized) {
+      prioritizedElements.add(e)
+    } else {
+      regularElements.add(e)
+    }
+    count += 1
+    notEmpty.signal
+  }
+
+  /**
+   * Return and remove elements from the head of the queue in a priority-aware manner.
+   *
+   * Call only within the lock when count > 0.
+   * Since count > 0, it's guaranteed that one of the queues is nonempty.
+   *
+   * @return potentially prioritized element from the head of the queue
+   */
+  private def dequeue: E = {
+    val e = if (prioritizedElements.isEmpty) regularElements.poll else prioritizedElements.poll
+    count -= 1
+    notFull.signal
+    e
+  }
+
+  def size: Int = {
+    lock.lock()
+    try {
+      count
+    } finally {
+      lock.unlock()
+    }
+  }
+
+  def clear(): Unit = {
+    lock.lock()
+    try {
+      prioritizedElements.clear()
+      regularElements.clear()
+      count = 0
+      notFull.signalAll()
+    } finally {
+      lock.unlock()
+    }
+  }
+}

--- a/core/src/test/scala/unit/kafka/network/PrioritizationAwareBlockingQueueTest.scala
+++ b/core/src/test/scala/unit/kafka/network/PrioritizationAwareBlockingQueueTest.scala
@@ -1,0 +1,117 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.network
+
+import java.util.concurrent.TimeUnit
+
+import org.junit.Assert._
+import org.junit.{Before, Test}
+
+class PrioritizationAwareBlockingQueueTest {
+
+  val capacity = Int.MaxValue
+  var queue: PrioritizationAwareBlockingQueue[Int] = null
+
+  @Before
+  def setUp() {
+    queue = new PrioritizationAwareBlockingQueue[Int](capacity)
+  }
+
+  @Test
+  def testPollEmptyQueue() {
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testPollSingleRegularElement() {
+    queue.put(2, false)
+    assertEquals(2, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testPollSinglePrioritizedElement() {
+    queue.put(2, true)
+    assertEquals(2, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testPollMultipleRegularElements() {
+    queue.put(2, false)
+    queue.put(20, false)
+    assertEquals(2, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertEquals(20, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testPollMultiplePrioritizedElements() {
+    queue.put(2, true)
+    queue.put(20, true)
+    assertEquals(2, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertEquals(20, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testPollRegularAndPrioritizedElements() {
+    queue.put(2, false)
+    queue.put(20, true)
+    queue.put(4, false)
+    queue.put(15, true)
+    assertEquals(20, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertEquals(15, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertEquals(2, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertEquals(4, queue.poll(0, TimeUnit.MILLISECONDS))
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testClear() {
+    queue.put(2, false)
+    queue.put(20, true)
+    queue.put(4, false)
+    queue.put(15, true)
+    queue.clear()
+    assertNull(queue.poll(0, TimeUnit.MILLISECONDS))
+  }
+
+  @Test
+  def testSize() {
+    assertEquals(0, queue.size)
+    queue.poll(0, TimeUnit.MILLISECONDS)
+    assertEquals(0, queue.size)
+    queue.put(2, false)
+    assertEquals(1, queue.size)
+    queue.put(20, true)
+    assertEquals(2, queue.size)
+    queue.put(4, false)
+    assertEquals(3, queue.size)
+    queue.poll(0, TimeUnit.MILLISECONDS)
+    assertEquals(2, queue.size)
+    queue.put(15, true)
+    assertEquals(3, queue.size)
+    queue.poll(0, TimeUnit.MILLISECONDS)
+    assertEquals(2, queue.size)
+    queue.poll(0, TimeUnit.MILLISECONDS)
+    assertEquals(1, queue.size)
+    queue.poll(0, TimeUnit.MILLISECONDS)
+    assertEquals(0, queue.size)
+  }
+}


### PR DESCRIPTION
Today all requests (client requests, broker requests, controller requests) to a broker are put into the same queue. They all have the same priority. So a backlog of requests ahead of the controller request will delay the processing of controller requests. This causes requests infront of the controller request to get processed based on stale state.

Side effects may include giving clients stale metadata, rejecting ProduceRequests and FetchRequests, and data loss (for some unofficial definition of data loss in terms of messages beyond the high watermark).

We'd like to minimize the number of requests processed based on stale state. With request prioritization, controller requests get processed before regular queued up requests, so requests can get processed with up-to-date state.

Request prioritization can happen at the network layer with the RequestChannel. The RequestChannel can categorize the request as regular or prioritized based on the request id. If the incoming request id matches that of UpdateMetadataRequest, LeaderAndIsrRequest, and StopReplicaRequest, the request can get prioritized.

One solution is to simply add a prioritized request queue to supplement the existing request queue in the RequestChannel and add request prioritization-aware logic to both the sendRequest and receiveRequest operations of RequestChannel. sendRequest puts the request into the respective queue based on whether the request is prioritized or not. receiveRequest can optimistically check the prioritized request queue and otherwise fallback to the regular request queue. One subtlety here is whether to do a timed poll on just the regular request queue or on both the prioritized request queue and regular request queue sequentially. Only applying the timed poll to the regular request queue punishes a prioritized request that arrives before a regular request but moments after the prioritized request check. Applying the timed poll to both queues sequentially results in a guaranteed latency increase on a regular request.

An alternative is to replace RequestChannel’s existing request queue with a prioritization-aware blocking queue. This approach avoids the earlier stated subtlety by allowing the timed poll to apply to either prioritized or regular requests in low-throughput scenarios while still allowing queued prioritized requests to go ahead of queued regular requests.

This patch goes with the latter approach to avoid punishing late arriving prioritized requests.