### PR TITLE
KAFKA-4455; ensure tasks are closed after CommitFailedException

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -389,8 +389,7 @@ public class StreamThread extends Thread {
     private void closeAllTasksOrTaskTopologies(boolean closeTopology) {
         if (closeTopology) {
             closeAllTasksTopologies();
-        }
-        else {
+        } else {
             closeAllTasks();
         }
     }


### PR DESCRIPTION
Details can be found in the task: [KAFKA-4455](https://issues.apache.org/jira/browse/KAFKA-4455)

Some discussion was also here: [stream shut down due to no locks for state store](https://groups.google.com/forum/#!topic/confluent-platform/i5cwYhpUtx4)

@dguy @enothereska chek it out.