### PR TITLE
KAFKA-4271: Fix the server start script for Windows 32-bit OS

### DIFF
--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -24,7 +24,15 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
     set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%~dp0../../config/log4j.properties
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
-    set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G
+    rem detect OS architecture
+    wmic os get osarchitecture | find /i "32-bit" >nul 2>&1
+    IF NOT ERRORLEVEL 1 (
+        rem 32-bit OS
+        set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
+    ) ELSE (
+        rem 64-bit OS
+        set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G
+    )
 )
 %~dp0kafka-run-class.bat kafka.Kafka %*
 EndLocal


### PR DESCRIPTION
Without this fix the new consumer fails to run on a 32-bit Windows OS.