### PR TITLE
KAFKA-4476: Kafka Streams gets stuck if metadata is missing

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -59,6 +59,9 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
     private static final Logger log = LoggerFactory.getLogger(StreamPartitionAssignor.class);
 
+    public final static int UNKNOWN = -1;
+    public final static int NOT_AVAILABLE = -2;
+
     private static class AssignedPartition implements Comparable<AssignedPartition> {
         public final TaskId taskId;
         public final TopicPartition partition;
@@ -128,7 +131,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
         InternalTopicMetadata(final InternalTopicConfig config) {
             this.config = config;
-            this.numPartitions = -1;
+            this.numPartitions = UNKNOWN;
         }
     }
 
@@ -140,7 +143,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             if (result != 0) {
                 return result;
             } else {
-                return p1.partition() < p2.partition() ? -1 : (p1.partition() > p2.partition() ? 1 : 0);
+                return p1.partition() < p2.partition() ? UNKNOWN : (p1.partition() > p2.partition() ? 1 : 0);
             }
         }
     };
@@ -311,7 +314,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                     int numPartitions = repartitionTopicMetadata.get(topicName).numPartitions;
 
                     // try set the number of partitions for this repartition topic if it is not set yet
-                    if (numPartitions == -1) {
+                    if (numPartitions == UNKNOWN) {
                         for (TopologyBuilder.TopicsInfo otherTopicsInfo : topicGroups.values()) {
                             Set<String> otherSinkTopics = otherTopicsInfo.sinkTopics;
 
@@ -326,6 +329,9 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                                         numPartitionsCandidate = repartitionTopicMetadata.get(sourceTopicName).numPartitions;
                                     } else {
                                         numPartitionsCandidate = metadata.partitionCountForTopic(sourceTopicName);
+                                        if (numPartitionsCandidate == null) {
+                                            repartitionTopicMetadata.get(topicName).numPartitions = NOT_AVAILABLE;
+                                        }
                                     }
 
                                     if (numPartitionsCandidate != null && numPartitionsCandidate > numPartitions) {
@@ -337,7 +343,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
                         // if we still have not find the right number of partitions,
                         // another iteration is needed
-                        if (numPartitions == -1)
+                        if (numPartitions == UNKNOWN)
                             numPartitionsNeeded = true;
                         else
                             repartitionTopicMetadata.get(topicName).numPartitions = numPartitions;
@@ -429,7 +435,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
             for (InternalTopicConfig topicConfig : stateChangelogTopics.values()) {
                 // the expected number of partitions is the max value of TaskId.partition + 1
-                int numPartitions = -1;
+                int numPartitions = UNKNOWN;
                 if (tasksByTopicGroup.get(topicGroupId) != null) {
                     for (TaskId task : tasksByTopicGroup.get(topicGroupId)) {
                         if (numPartitions < task.partition + 1)
@@ -607,8 +613,12 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                 InternalTopicConfig topic = entry.getValue().config;
                 Integer numPartitions = entry.getValue().numPartitions;
 
-                if (numPartitions < 0)
+                if (numPartitions == NOT_AVAILABLE) {
+                    continue;
+                }
+                if (numPartitions < 0) {
                     throw new TopologyBuilderException(String.format("stream-thread [%s] Topic [%s] number of partitions not defined", streamThread.getName(), topic.name()));
+                }
 
                 internalTopicManager.makeReady(topic, numPartitions);
 
@@ -647,7 +657,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
     private void ensureCopartitioning(Set<String> copartitionGroup,
                                       Map<String, InternalTopicMetadata> allRepartitionTopicsNumPartitions,
                                       Cluster metadata) {
-        int numPartitions = -1;
+        int numPartitions = UNKNOWN;
 
         for (String topic : copartitionGroup) {
             if (!allRepartitionTopicsNumPartitions.containsKey(topic)) {
@@ -656,7 +666,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                 if (partitions == null)
                     throw new TopologyBuilderException(String.format("stream-thread [%s] Topic not found: %s", streamThread.getName(), topic));
 
-                if (numPartitions == -1) {
+                if (numPartitions == UNKNOWN) {
                     numPartitions = partitions;
                 } else if (numPartitions != partitions) {
                     String[] topics = copartitionGroup.toArray(new String[copartitionGroup.size()]);
@@ -668,7 +678,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
         // if all topics for this co-partition group is repartition topics,
         // then set the number of partitions to be the maximum of the number of partitions.
-        if (numPartitions == -1) {
+        if (numPartitions == UNKNOWN) {
             for (Map.Entry<String, InternalTopicMetadata> entry: allRepartitionTopicsNumPartitions.entrySet()) {
                 if (copartitionGroup.contains(entry.getKey())) {
                     int partitions = entry.getValue().numPartitions;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -28,6 +28,11 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
@@ -51,9 +56,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 public class StreamPartitionAssignorTest {
 
@@ -812,7 +819,74 @@ public class StreamPartitionAssignorTest {
         final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
         final Cluster cluster = partitionAssignor.clusterMetadata();
         assertNotNull(cluster);
+    }
 
+    @Test
+    public void shouldNotLoopInfinitelyOnMissingMetadataAndShouldNotCreateRelatedTasks() {
+        final String applicationId = "application-id";
+
+        final KStreamBuilder builder = new KStreamBuilder();
+        builder.setApplicationId(applicationId);
+
+        KStream<Object, Object> stream1 = builder
+            .stream("topic1")
+            .selectKey(new KeyValueMapper<Object, Object, Object>() {
+                @Override
+                public Object apply(Object key, Object value) {
+                    return null;
+                }
+            })
+            .through("topic2");
+        stream1.to("topic3");
+        builder
+            .stream("unknownTopic")
+            .selectKey(new KeyValueMapper<Object, Object, Object>() {
+                @Override
+                public Object apply(Object key, Object value) {
+                    return null;
+                }
+            })
+            .join(
+                stream1,
+                new ValueJoiner() {
+                    @Override
+                    public Object apply(Object value1, Object value2) {
+                        return null;
+                    }
+                },
+                JoinWindows.of(0)
+            );
+
+        final UUID uuid = UUID.randomUUID();
+        final String client = "client1";
+
+        final StreamsConfig config = new StreamsConfig(configProps());
+        final StreamThread streamThread = new StreamThread(builder, config, new MockClientSupplier(), applicationId, client, uuid, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder));
+
+        final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
+        partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client));
+
+        final Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
+        final Set<TaskId> emptyTasks = Collections.<TaskId>emptySet();
+        subscriptions.put(
+            client,
+            new PartitionAssignor.Subscription(
+                Collections.singletonList("unknownTopic"),
+                new SubscriptionInfo(uuid, emptyTasks, emptyTasks, userEndPoint).encode()
+            )
+        );
+
+        final Map<String, PartitionAssignor.Assignment> assignment = partitionAssignor.assign(metadata, subscriptions);
+
+        final List<TopicPartition> expectedAssignment = Arrays.asList(
+            new TopicPartition("topic1", 0),
+            new TopicPartition("topic1", 1),
+            new TopicPartition("topic1", 2),
+            new TopicPartition("topic2", 0),
+            new TopicPartition("topic2", 1),
+            new TopicPartition("topic2", 2)
+        );
+        assertThat(expectedAssignment, equalTo(assignment.get(client).partitions()));
     }
 
     private AssignmentInfo checkAssignment(Set<String> expectedTopics, PartitionAssignor.Assignment assignment) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -837,7 +837,6 @@ public class StreamPartitionAssignorTest {
                 }
             })
             .through("topic2");
-        stream1.to("topic3");
         builder
             .stream("unknownTopic")
             .selectKey(new KeyValueMapper<Object, Object, Object>() {


### PR DESCRIPTION
 - break loop in StreamPartitionAssigner.assign() in case partition metadata is missing
 - fit state transition issue (follow up to KAFKA-3637: Add method that checks if streams are initialised)
 - some test improvements