### PR TITLE
MINOR: Upgrade Gradle to 3.2.1 and Scala to 2.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "3.2"
+  gradleVersion = "3.2.1"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,7 +51,7 @@ versions += [
 // Add Scala version
 def defaultScala210Version = '2.10.6'
 def defaultScala211Version = '2.11.8'
-def defaultScala212Version = '2.12.0'
+def defaultScala212Version = '2.12.1'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.10') {
     versions["scala"] = defaultScala210Version


### PR DESCRIPTION
There were a couple of important issues fixed in Gradle 3.2.1:
* [GRADLE-3582] - Gradle wrapper fails to escape arguments with nested quotes
* [GRADLE-3583] - Newlines in JAVA_OPTS breaks application plugin shell script in Gradle 3.2

And a lot of important issues fixed in Scala 2.12.1:
* http://www.scala-lang.org/news/2.12.1