### PR TITLE
Update `createFile` function of Uitls.scala

### DIFF
--- a/core/src/main/scala/kafka/utils/Utils.scala
+++ b/core/src/main/scala/kafka/utils/Utils.scala
@@ -491,9 +491,13 @@ object Utils extends Logging {
    */
   def createFile(path: String): File = {
     val f = new File(path)
-    val created = f.createNewFile()
-    if(!created)
-      throw new KafkaStorageException("Failed to create file %s.".format(path))
+    try {
+      val created = f.createNewFile()
+      if (!created)
+        throw new KafkaStorageException("Failed to create file %s.".format(path))
+    } catch {
+      case ex: IOException => throw new KafkaStorageException("Failed to create file %s.Maybe caused by permission denied".format(path))
+    }
     f
   }
   


### PR DESCRIPTION
Well,Now I'm reading the source code and try to learn better Scala:-D.The question I find is sometimes obvious,If I try to create file with out certain permission,**the exception will be throwes like this:`java.io.IOException: Permission denied at java.io.UnixFileSystem.createFileExclusively(Native Method)`.** People should take more care when create file.ahh...I think this is not about Kafka logic? Thanks for your reply:-D