### PR TITLE
KAFKA-4492: java.lang.IllegalStateException: Attempting to put a clean entry for key... into NamedCache

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -39,9 +39,9 @@ import java.util.NoSuchElementException;
 public class ThreadCache {
     private static final Logger log = LoggerFactory.getLogger(ThreadCache.class);
     private final String name;
+    private final long maxCacheSizeBytes;
     private final Map<String, NamedCache> caches = new HashMap<>();
     private final ThreadCacheMetrics metrics;
-    private long maxCacheSizeBytes;
 
     // internal stats
     private long numPuts = 0;
@@ -100,7 +100,7 @@ public class ThreadCache {
         cache.flush();
 
         log.debug("Thread {} cache stats on flush: #puts={}, #gets={}, #evicts={}, #flushes={}",
-            name, puts(), gets(), evicts(), flushes());
+                  name, puts(), gets(), evicts(), flushes());
     }
 
     public LRUCacheEntry get(final String namespace, byte[] key) {
@@ -330,8 +330,4 @@ public class ThreadCache {
 
     }
 
-    // visible for testing
-    void setMaxCacheSizeBytes(final long maxCacheSizeBytes) {
-        this.maxCacheSizeBytes = maxCacheSizeBytes;
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -118,8 +118,6 @@ public class ThreadCache {
         final NamedCache cache = getOrCreateCache(namespace);
         cache.put(Bytes.wrap(key), value);
         maybeEvict(namespace);
-        final long x = sizeBytes();
-        System.out.println(x);
     }
 
     public LRUCacheEntry putIfAbsent(final String namespace, byte[] key, LRUCacheEntry value) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -39,9 +39,9 @@ import java.util.NoSuchElementException;
 public class ThreadCache {
     private static final Logger log = LoggerFactory.getLogger(ThreadCache.class);
     private final String name;
-    private final long maxCacheSizeBytes;
     private final Map<String, NamedCache> caches = new HashMap<>();
     private final ThreadCacheMetrics metrics;
+    private long maxCacheSizeBytes;
 
     // internal stats
     private long numPuts = 0;
@@ -195,9 +195,11 @@ public class ThreadCache {
     private void maybeEvict(final String namespace) {
         while (sizeBytes() > maxCacheSizeBytes) {
             final NamedCache cache = getOrCreateCache(namespace);
+            if (cache.size() == 0) {
+                return;
+            }
             log.trace("Thread {} evicting cache {}", name, namespace);
             cache.evict();
-
             numEvicts++;
         }
     }
@@ -323,5 +325,10 @@ public class ThreadCache {
             // do nothing
         }
 
+    }
+
+    // visible for testing
+    void setMaxCacheSizeBytes(final long maxCacheSizeBytes) {
+        this.maxCacheSizeBytes = maxCacheSizeBytes;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -115,10 +115,11 @@ public class ThreadCache {
 
     public void put(final String namespace, byte[] key, LRUCacheEntry value) {
         numPuts++;
-
         final NamedCache cache = getOrCreateCache(namespace);
         cache.put(Bytes.wrap(key), value);
         maybeEvict(namespace);
+        final long x = sizeBytes();
+        System.out.println(x);
     }
 
     public LRUCacheEntry putIfAbsent(final String namespace, byte[] key, LRUCacheEntry value) {
@@ -195,6 +196,10 @@ public class ThreadCache {
     private void maybeEvict(final String namespace) {
         while (sizeBytes() > maxCacheSizeBytes) {
             final NamedCache cache = getOrCreateCache(namespace);
+            // we abort here as the put on this cache may have triggered
+            // a put on another cache. So even though the sizeInBytes() is
+            // still > maxCacheSizeBytes there is nothing to evict from this
+            // namespaced cache.
             if (cache.size() == 0) {
                 return;
             }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -37,10 +37,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -346,8 +344,6 @@ public class KTableKTableLeftJoinTest {
         final String[] inputs = {agg, tableOne, tableTwo, tableThree, tableFour, tableFive, tableSix};
 
         final KStreamBuilder builder = new KStreamBuilder();
-        final Map<Long, String> joinResults = new HashMap<>();
-
         final KTable<Long, String> aggTable = builder.table(Serdes.Long(), Serdes.String(), agg, agg)
                 .groupBy(new KeyValueMapper<Long, String, KeyValue<Long, String>>() {
                     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoinTest.java
@@ -22,8 +22,11 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.test.KStreamTestDriver;
 import org.apache.kafka.test.MockProcessorSupplier;
+import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -34,7 +37,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -320,6 +327,75 @@ public class KTableKTableLeftJoinTest {
         }
         driver.flushState();
         proc.checkAndClearProcessResult("0:(XX0+null<-X0+null)", "1:(XX1+null<-X1+null)", "2:(XX2+YY2<-X2+YY2)", "3:(XX3+YY3<-X3+YY3)");
+    }
+
+    /**
+     * This test was written to reproduce https://issues.apache.org/jira/browse/KAFKA-4492
+     * It is based on a fairly complicated join used by the developer that reported the bug.
+     * Before the fix this would trigger an IllegalStateException.
+     */
+    @Test
+    public void shouldNotThrowIllegalStateExceptionWhenMultiCacheEvictions() throws Exception {
+        final String agg = "agg";
+        final String tableOne = "tableOne";
+        final String tableTwo = "tableTwo";
+        final String tableThree = "tableThree";
+        final String tableFour = "tableFour";
+        final String tableFive = "tableFive";
+        final String tableSix = "tableSix";
+        final String[] inputs = {agg, tableOne, tableTwo, tableThree, tableFour, tableFive, tableSix};
+
+        final KStreamBuilder builder = new KStreamBuilder();
+        final Map<Long, String> joinResults = new HashMap<>();
+
+        final KTable<Long, String> aggTable = builder.table(Serdes.Long(), Serdes.String(), agg, agg)
+                .groupBy(new KeyValueMapper<Long, String, KeyValue<Long, String>>() {
+                    @Override
+                    public KeyValue<Long, String> apply(final Long key, final String value) {
+                        return new KeyValue<>(key, value);
+                    }
+                }, Serdes.Long(), Serdes.String()).reduce(MockReducer.STRING_ADDER, MockReducer.STRING_ADDER, "agg-store");
+
+        final KTable<Long, String> one = builder.table(Serdes.Long(), Serdes.String(), tableOne, tableOne);
+        final KTable<Long, String> two = builder.table(Serdes.Long(), Serdes.String(), tableTwo, tableTwo);
+        final KTable<Long, String> three = builder.table(Serdes.Long(), Serdes.String(), tableThree, tableThree);
+        final KTable<Long, String> four = builder.table(Serdes.Long(), Serdes.String(), tableFour, tableFour);
+        final KTable<Long, String> five = builder.table(Serdes.Long(), Serdes.String(), tableFive, tableFive);
+        final KTable<Long, String> six = builder.table(Serdes.Long(), Serdes.String(), tableSix, tableSix);
+
+        final ValueMapper<String, String> mapper = new ValueMapper<String, String>() {
+            @Override
+            public String apply(final String value) {
+                return value.toUpperCase(Locale.ROOT);
+            }
+        };
+        final KTable<Long, String> seven = one.mapValues(mapper);
+
+
+        final KTable<Long, String> eight = six.leftJoin(seven, MockValueJoiner.STRING_JOINER);
+
+        aggTable.leftJoin(one, MockValueJoiner.STRING_JOINER)
+                .leftJoin(two, MockValueJoiner.STRING_JOINER)
+                .leftJoin(three, MockValueJoiner.STRING_JOINER)
+                .leftJoin(four, MockValueJoiner.STRING_JOINER)
+                .leftJoin(five, MockValueJoiner.STRING_JOINER)
+                .leftJoin(eight, MockValueJoiner.STRING_JOINER)
+                .mapValues(mapper);
+
+        final KStreamTestDriver driver = new KStreamTestDriver(builder, stateDir, 250);
+
+        final String[] values = {"a", "AA", "BBB", "CCCC", "DD", "EEEEEEEE", "F", "GGGGGGGGGGGGGGG", "HHH", "IIIIIIIIII",
+                                 "J", "KK", "LLLL", "MMMMMMMMMMMMMMMMMMMMMM", "NNNNN", "O", "P", "QQQQQ", "R", "SSSS",
+                                 "T", "UU", "VVVVVVVVVVVVVVVVVVV"};
+
+        final Random random = new Random();
+        for (int i = 0; i < 1000; i++) {
+            for (String input : inputs) {
+                final Long key = Long.valueOf(random.nextInt(1000));
+                final String value = values[random.nextInt(values.length)];
+                driver.process(input, key, value);
+            }
+        }
     }
 
     private KeyValue<Integer, String> kv(Integer key, String value) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -459,6 +459,20 @@ public class ThreadCacheTest {
         assertEquals(cache.evicts(), 3);
     }
 
+    @Test
+    public void shouldNotLoopForEverWhenEvictingAndCurrentCacheIsEmpty() throws Exception {
+        final ThreadCache threadCache = new ThreadCache(51);
+        threadCache.addDirtyEntryFlushListener("other", new ThreadCache.DirtyEntryFlushListener() {
+            @Override
+            public void apply(final List<ThreadCache.DirtyEntry> dirty) {
+                //
+            }
+        });
+        threadCache.put("namespace", new byte[]{0}, dirtyEntry(new byte[5]));
+        threadCache.setMaxCacheSizeBytes(50); // single entry is 51
+        threadCache.put("other", new byte[]{1}, dirtyEntry(new byte[1]));
+    }
+
     private LRUCacheEntry dirtyEntry(final byte[] key) {
         return new LRUCacheEntry(key, true, -1, -1, -1, "");
     }


### PR DESCRIPTION
The NamedCache wasn't correctly dealing with its re-entrant nature. This would result in the LRU becoming corrupted, and the above exception occurring during eviction. For example:
Cache A: dirty key 1
eviction runs on Cache A
Node for key 1 gets marked as clean
Entry for key 1 gets flushed downstream
Downstream there is a processor that also refers to the table fronted by Cache A
Downstream processor puts key 2 into Cache A
This triggers an eviction of key 1 again ( it is still the oldest node as hasn't been removed from the LRU)
As the Node for key 1 is clean flush doesn't run and it is immediately removed from the cache. 
So now we have dirtyKey set with key =1, but the value doesn't exist in the cache.
Downstream processor tries to put key = 1 into the cache, it fails as key =1 is in the dirtyKeySet.