### PR TITLE
KAFKA-4516: When a CachingStateStore is closed it should clear its associated NamedCache

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -296,6 +296,14 @@ class NamedCache {
         return dirtyKeys.size();
     }
 
+    synchronized void close() {
+        head = tail = null;
+        listener = null;
+        currentSizeBytes = 0;
+        dirtyKeys.clear();
+        cache.clear();
+    }
+
     /**
      * A simple wrapper class to implement a doubly-linked list around MemoryLRUCacheBytesEntry
      */

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -49,6 +49,8 @@ public class ThreadCache {
     private long numEvicts = 0;
     private long numFlushes = 0;
 
+
+
     public interface DirtyEntryFlushListener {
         void apply(final List<DirtyEntry> dirty);
     }
@@ -189,6 +191,13 @@ public class ThreadCache {
             sizeInBytes += namedCache.sizeInBytes();
         }
         return sizeInBytes;
+    }
+
+    synchronized void close(final String namespace) {
+        final NamedCache removed = caches.remove(namespace);
+        if (removed != null) {
+            removed.close();
+        }
     }
 
     private void maybeEvict(final String namespace) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -59,7 +59,7 @@ public class CachingKeyValueStoreTest {
         cacheFlushListener = new CacheFlushListenerStub<>();
         store = new CachingKeyValueStore<>(underlyingStore, Serdes.String(), Serdes.String());
         store.setFlushListener(cacheFlushListener);
-        cache = new ThreadCache(150);
+        cache = new ThreadCache(maxCacheSizeBytes);
         final MockProcessorContext context = new MockProcessorContext(null, null, null, null, (RecordCollector) null, cache);
         topic = "topic";
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, topic));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -19,6 +19,8 @@ package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.internals.CacheFlushListener;
 import org.apache.kafka.streams.kstream.internals.Change;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
@@ -30,6 +32,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,10 +45,10 @@ import static org.junit.Assert.assertNull;
 
 public class CachingKeyValueStoreTest {
 
+    private final int maxCacheSizeBytes = 150;
     private CachingKeyValueStore<String, String> store;
     private InMemoryKeyValueStore<Bytes, byte[]> underlyingStore;
     private ThreadCache cache;
-    private int maxCacheSizeBytes;
     private CacheFlushListenerStub<String> cacheFlushListener;
     private String topic;
 
@@ -56,8 +59,7 @@ public class CachingKeyValueStoreTest {
         cacheFlushListener = new CacheFlushListenerStub<>();
         store = new CachingKeyValueStore<>(underlyingStore, Serdes.String(), Serdes.String());
         store.setFlushListener(cacheFlushListener);
-        maxCacheSizeBytes = 150;
-        cache = new ThreadCache(maxCacheSizeBytes);
+        cache = new ThreadCache(150);
         final MockProcessorContext context = new MockProcessorContext(null, null, null, null, (RecordCollector) null, cache);
         topic = "topic";
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, topic));
@@ -147,6 +149,62 @@ public class CachingKeyValueStoreTest {
         assertNull(store.get("a"));
         assertFalse(store.range("a", "b").hasNext());
         assertFalse(store.all().hasNext());
+    }
+
+    @Test
+    public void shouldClearNamespaceCacheOnClose() throws Exception {
+        store.put("a", "a");
+        assertEquals(1, cache.size());
+        store.close();
+        assertEquals(0, cache.size());
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToGetFromClosedCachingStore() throws Exception {
+        store.close();
+        store.get("a");
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToWriteToClosedCachingStore() throws Exception {
+        store.close();
+        store.put("a", "a");
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToDoRangeQueryOnClosedCachingStore() throws Exception {
+        store.close();
+        store.range("a", "b");
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToDoAllQueryOnClosedCachingStore() throws Exception {
+        store.close();
+        store.all();
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToDoGetApproxSizeOnClosedCachingStore() throws Exception {
+        store.close();
+        store.approximateNumEntries();
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToDoPutAllClosedCachingStore() throws Exception {
+        store.close();
+        store.putAll(Collections.singletonList(KeyValue.pair("a", "a")));
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToDoPutIfAbsentClosedCachingStore() throws Exception {
+        store.close();
+        store.putIfAbsent("b", "c");
+    }
+
+    @Test(expected = InvalidStateStoreException.class)
+    public void shouldThrowIfTryingToDeleteFromClosedCachingStore() throws Exception {
+        store.close();
+        store.delete("key");
     }
 
     private int addItemsToCache() throws IOException {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -493,6 +493,17 @@ public class ThreadCacheTest {
         threadCache.put("name", new byte[]{2}, dirtyEntry(new byte[remaining + 100]));
     }
 
+    @Test
+    public void shouldCleanupNamedCacheOnClose() throws Exception {
+        final ThreadCache cache = new ThreadCache(100000);
+        cache.put("one", new byte[]{1}, cleanEntry(new byte[] {1}));
+        cache.put("two", new byte[]{1}, cleanEntry(new byte[] {1}));
+        assertEquals(cache.size(), 2);
+        cache.close("two");
+        assertEquals(cache.size(), 1);
+        assertNull(cache.get("two", new byte[] {1}));
+    }
+
     private LRUCacheEntry dirtyEntry(final byte[] key) {
         return new LRUCacheEntry(key, true, -1, -1, -1, "");
     }


### PR DESCRIPTION
Clear and remove the NamedCache from the ThreadCache when a CachingKeyValueStore or CachingWindowStore is closed.
Validate that the store is open when doing any queries or writes to Caching State Stores.