### PR TITLE
MINOR: Sync up 'kafka-run-class.bat' with 'kafka-run-class.sh'

### DIFF
--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -47,19 +47,46 @@ for %%i in (%BASE_DIR%\core\build\dependant-libs-%SCALA_VERSION%\*.jar) do (
 	call :concat %%i
 )
 
-rem Classpath addition for kafka-perf dependencies
-for %%i in (%BASE_DIR%\perf\build\dependant-libs-%SCALA_VERSION%\*.jar) do (
+rem Classpath addition for kafka-examples
+for %%i in (%BASE_DIR%\examples\build\libs\kafka-examples*.jar) do (
 	call :concat %%i
 )
 
 rem Classpath addition for kafka-clients
-for %%i in (%BASE_DIR%\clients\build\libs\kafka-clients-*.jar) do (
+for %%i in (%BASE_DIR%\clients\build\libs\kafka-clients*.jar) do (
 	call :concat %%i
 )
 
-rem Classpath addition for kafka-examples
-for %%i in (%BASE_DIR%\examples\build\libs\kafka-examples-*.jar) do (
+rem Classpath addition for kafka-streams
+for %%i in (%BASE_DIR%\streams\build\libs\kafka-streams*.jar) do (
 	call :concat %%i
+)
+
+rem Classpath addition for kafka-streams-examples
+for %%i in (%BASE_DIR%\streams\examples\build\libs\kafka-streams-examples*.jar) do (
+	call :concat %%i
+)
+
+for %%i in (%BASE_DIR%\streams\build\dependant-libs-%SCALA_VERSION%\rocksdb*.jar) do (
+	call :concat %%i
+)
+
+rem Classpath addition for kafka tools
+for %%i in (%BASE_DIR%\tools\build\libs\kafka-tools*.jar) do (
+	call :concat %%i
+)
+
+for %%i in (%BASE_DIR%\tools\build\dependant-libs-%SCALA_VERSION%\*.jar) do (
+	call :concat %%i
+)
+
+for %%p in (api runtime file json tools) do (
+	for %%i in (%BASE_DIR%\connect\%%p\build\libs\connect-%%p*.jar) do (
+		call :concat %%i
+	)
+	if exist "%BASE_DIR%\connect\%%p\build\dependant-libs\*" (
+		call :concat %BASE_DIR%\connect\%%p\build\dependant-libs\*
+	)
 )
 
 rem Classpath addition for release


### PR DESCRIPTION
Some of the recent changes to `kafka-run-class.sh` have not been applied to `kafka-run-class.bat`.
These recent changes include setting proper streams or connect classpaths. So any streams or connect use case that leverages `kafka-run-class.bat` would fail with an error like
```
Error: Could not find or load main class org.apache.kafka.streams.???
```