### PR TITLE
KAFKA-4497: LogCleaner appended the wrong offset to time index. Backport the fix to 0.10.1.

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -494,14 +494,15 @@ private[log] class Cleaner(val id: Int,
                 writeOriginalMessageSet = false
 
               retainedMessages += deepMessageAndOffset
-              // We need the max timestamp and last offset for time index
-              if (deepMessageAndOffset.message.timestamp > maxTimestamp)
+              // We need the max timestamp and message offset for time index
+              if (deepMessageAndOffset.message.timestamp > maxTimestamp) {
                 maxTimestamp = deepMessageAndOffset.message.timestamp
+                offsetOfMaxTimestamp = deepMessageAndOffset.offset
+              }
             } else {
               writeOriginalMessageSet = false
             }
           }
-          offsetOfMaxTimestamp = if (retainedMessages.nonEmpty) retainedMessages.last.offset else -1L
           // There are no messages compacted out and no message format conversion, write the original message set back
           if (writeOriginalMessageSet)
             ByteBufferMessageSet.writeMessage(writeBuffer, shallowMessage, shallowOffset)
@@ -758,7 +759,7 @@ private case class CleanerStats(time: Time = SystemTime) {
   def elapsedSecs = (endTime - startTime)/1000.0
   
   def elapsedIndexSecs = (mapCompleteTime - startTime)/1000.0
-  
+
   def clear() {
     startTime = time.milliseconds
     mapCompleteTime = -1L


### PR DESCRIPTION
The code in trunk has been changed, so we need to provide a different fix for this problem in 0.10.1. 

Some explanations. I was able to reproduce the initial issue with a unit test. I did not include the unit test here because the tests requires a lot of hard coded constants to precisely control the message size after compression, read buffer and which message is filtered out. In trunk I have added a unit test to `ByteBufferMessageSet.fliterInto()` which holds the current buggy logic. Given no one will be developing on 0.10.1 branch anymore except bug fixes, I think it is fine to leave the ugly unit test out of this patch. 