### PR TITLE
KAFKA-4534: StreamPartitionAssignor only ever updates the partitionsByHostState and metadataWithInternalTopics on first assignment.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -692,9 +692,9 @@ public class TopologyBuilder {
     private void connectStateStoreNameToSourceTopics(final String stateStoreName,
                                                      final ProcessorNodeFactory processorNodeFactory) {
 
-        // we should never update the mapping for a stateStoreName, but this is called
-        // from connectProcessorAndStateStores which is not always called in the context
-        // of adding a new state store.
+        // we should never update the mapping from state store names to source topics if the store name already exists
+        // in the map; this scenario is possible, for example, that a state store underlying a source KTable is
+        // connecting to a join operator whose source topic is not the original KTable's source topic but an internal repartition topic.
         if (stateStoreNameToSourceTopics.containsKey(stateStoreName)) {
             return;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -692,6 +692,13 @@ public class TopologyBuilder {
     private void connectStateStoreNameToSourceTopics(final String stateStoreName,
                                                      final ProcessorNodeFactory processorNodeFactory) {
 
+        // we should never update the mapping for a stateStoreName, but this is called
+        // from connectProcessorAndStateStores which is not always called in the context
+        // of adding a new state store.
+        if (stateStoreNameToSourceTopics.containsKey(stateStoreName)) {
+            return;
+        }
+
         final Set<String> sourceTopics = findSourceTopicsForProcessorParents(processorNodeFactory.parents);
         if (sourceTopics.isEmpty()) {
             throw new TopologyBuilderException("can't find source topic for state store " +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -577,26 +577,20 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             assignedPartitions.add(partition);
         }
 
-        // only need to update the host partitions map if it is not leader
-        if (this.partitionsByHostState == null) {
-            this.partitionsByHostState = info.partitionsByHost;
-        }
+        this.partitionsByHostState = info.partitionsByHost;
 
-        // only need to build if it is not leader
-        if (metadataWithInternalTopics == null) {
-            final Collection<Set<TopicPartition>> values = partitionsByHostState.values();
-            final Map<TopicPartition, PartitionInfo> topicToPartitionInfo = new HashMap<>();
-            for (Set<TopicPartition> value : values) {
-                for (TopicPartition topicPartition : value) {
-                    topicToPartitionInfo.put(topicPartition, new PartitionInfo(topicPartition.topic(),
-                                                                               topicPartition.partition(),
-                                                                               null,
-                                                                               new Node[0],
-                                                                               new Node[0]));
-                }
+        final Collection<Set<TopicPartition>> values = partitionsByHostState.values();
+        final Map<TopicPartition, PartitionInfo> topicToPartitionInfo = new HashMap<>();
+        for (Set<TopicPartition> value : values) {
+            for (TopicPartition topicPartition : value) {
+                topicToPartitionInfo.put(topicPartition, new PartitionInfo(topicPartition.topic(),
+                                                                           topicPartition.partition(),
+                                                                           null,
+                                                                           new Node[0],
+                                                                           new Node[0]));
             }
-            metadataWithInternalTopics = Cluster.empty().withPartitions(topicToPartitionInfo);
         }
+        metadataWithInternalTopics = Cluster.empty().withPartitions(topicToPartitionInfo);
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
@@ -154,7 +154,7 @@ public class KStreamBuilderTest {
     }
 
     @Test
-    public void shouldNotModifyStateStoreSourceIfItExistsAndAnotherProcessorConnectingToIt() throws Exception {
+    public void shouldMapStateStoresToCorrectSourceTopics() throws Exception {
         final KStreamBuilder builder = new KStreamBuilder();
         builder.setApplicationId("app-id");
 
@@ -162,20 +162,6 @@ public class KStreamBuilderTest {
 
         final KTable<String, String> table = builder.table("table-topic", "table-store");
         assertEquals(Collections.singleton("table-topic"), builder.stateStoreNameToSourceTopics().get("table-store"));
-
-        final KStream<String, String> mapped = playEvents.map(MockKeyValueMapper.<String, String>SelectValueKeyValueMapper());
-        mapped.leftJoin(table, MockValueJoiner.STRING_JOINER);
-        assertEquals(Collections.singleton("table-topic"), builder.stateStoreNameToSourceTopics().get("table-store"));
-    }
-
-    @Test
-    public void shouldMapStateStoreToRepartitionTopic() throws Exception {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId("app-id");
-
-        final KStream<String, String> playEvents = builder.stream("events");
-
-        final KTable<String, String> table = builder.table("table-topic", "table-store");
 
         final KStream<String, String> mapped = playEvents.map(MockKeyValueMapper.<String, String>SelectValueKeyValueMapper());
         mapped.leftJoin(table, MockValueJoiner.STRING_JOINER).groupByKey().count("count");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
@@ -22,10 +22,13 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.kstream.internals.KStreamImpl;
 import org.apache.kafka.streams.errors.TopologyBuilderException;
 import org.apache.kafka.test.KStreamTestDriver;
+import org.apache.kafka.test.MockKeyValueMapper;
 import org.apache.kafka.test.MockProcessorSupplier;
+import org.apache.kafka.test.MockValueJoiner;
 import org.junit.After;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -148,6 +151,36 @@ public class KStreamBuilderTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionWhenTopicNamesAreNull() throws Exception {
         new KStreamBuilder().stream(Serdes.String(), Serdes.String(), null, null);
+    }
+
+    @Test
+    public void shouldNotModifyStateStoreSourceIfItExistsAndAnotherProcessorConnectingToIt() throws Exception {
+        final KStreamBuilder builder = new KStreamBuilder();
+        builder.setApplicationId("app-id");
+
+        final KStream<String, String> playEvents = builder.stream("events");
+
+        final KTable<String, String> table = builder.table("table-topic", "table-store");
+        assertEquals(Collections.singleton("table-topic"), builder.stateStoreNameToSourceTopics().get("table-store"));
+
+        final KStream<String, String> mapped = playEvents.map(MockKeyValueMapper.<String, String>SelectValueKeyValueMapper());
+        mapped.leftJoin(table, MockValueJoiner.STRING_JOINER);
+        assertEquals(Collections.singleton("table-topic"), builder.stateStoreNameToSourceTopics().get("table-store"));
+    }
+
+    @Test
+    public void shouldMapStateStoreToRepartitionTopic() throws Exception {
+        final KStreamBuilder builder = new KStreamBuilder();
+        builder.setApplicationId("app-id");
+
+        final KStream<String, String> playEvents = builder.stream("events");
+
+        final KTable<String, String> table = builder.table("table-topic", "table-store");
+
+        final KStream<String, String> mapped = playEvents.map(MockKeyValueMapper.<String, String>SelectValueKeyValueMapper());
+        mapped.leftJoin(table, MockValueJoiner.STRING_JOINER).groupByKey().count("count");
+        assertEquals(Collections.singleton("table-topic"), builder.stateStoreNameToSourceTopics().get("table-store"));
+        assertEquals(Collections.singleton("app-id-KSTREAM-MAP-0000000003-repartition"), builder.stateStoreNameToSourceTopics().get("count"));
     }
 
 }


### PR DESCRIPTION
`partitionsByHostState` and `metadataWithInternalTopics` need to be updated on each call to `onAssignment()` otherwise they contain invalid/stale metadata. 