### PR TITLE
KAFKA-4537: StreamPartitionAssignor incorrectly adds standby partitions to the partitionsByHostState map

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -481,7 +481,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                 final Set<TopicPartition> topicPartitions = new HashSet<>();
                 final ClientState<TaskId> state = entry.getValue().state;
 
-                for (TaskId id : state.assignedTasks) {
+                for (TaskId id : state.activeTasks) {
                     topicPartitions.addAll(partitionsForTask.get(id));
                 }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -890,7 +890,7 @@ public class StreamPartitionAssignorTest {
     }
 
     @Test
-    public void shouldDoSomethingCorrectlyWithStandbyTasks() throws Exception {
+    public void shouldNotAddStandbyTaskPartitionsToPartitionsForHost() throws Exception {
         final Properties props = configProps();
         props.setProperty(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, "1");
         final StreamsConfig config = new StreamsConfig(props);


### PR DESCRIPTION
If a KafkaStreams app is using Standby Tasks then `StreamPartitionAssignor` will add the standby partitions to the partitionsByHostState map for each host. This is incorrect as the partitionHostState map is used to resolve which host is hosting a particular store for a key. 
The result is that doing metadata lookups for interactive queries can return an incorrect host