### PR TITLE
KAFKA-4526 - Disable throttling test until it can be fixed correctly.

### DIFF
--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -15,7 +15,7 @@
 
 import time
 import math
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize,ignore
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
@@ -138,6 +138,7 @@ class ThrottlingTest(ProduceConsumeValidateTest):
                 estimated_throttled_time,
                 time_taken))
 
+    @ignore
     @cluster(num_nodes=10)
     @parametrize(bounce_brokers=False)
     @parametrize(bounce_brokers=True)


### PR DESCRIPTION
At present, the test is fragile in the sense that the console consumer
has to start and be initialized before the verifiable producer begins
producing in the produce-consume-validate loop.

If this doesn't happen, the consumer will miss messages at the head of
the log and the test will fail.

At present, the consumer is considered inited once it has a PID. This is
a weak assumption. The plan is to poll appropriate metrics (like
partition assignment), and use those as a proxy for consumer
initialization. That work will be tracked in a separate ticket. For now,
we will disable the tests so that we can get the builds healthy again.