### PR TITLE
KAFKA-4554: Fix ReplicaBuffer.verifyChecksum to use iterators instead of iterables

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -21,12 +21,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.record.MemoryRecordsBuilder;
-import org.apache.kafka.common.record.Record;
-import org.apache.kafka.common.record.Records;
-import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Utils;
 
 import javax.xml.bind.DatatypeConverter;
@@ -178,24 +172,6 @@ public class TestUtils {
         });
 
         return file;
-    }
-
-    /**
-     * Create a records buffer including the offset and message size at the start, which is required if the buffer is to
-     * be sent as part of `ProduceRequest`. This is the reason why we can't use
-     * `Record(long timestamp, byte[] key, byte[] value, CompressionType type, int valueOffset, int valueSize)` as this
-     * constructor does not include either of these fields.
-     */
-    public static ByteBuffer partitionRecordsBuffer(final long offset, final CompressionType compressionType, final Record... records) {
-        int bufferSize = 0;
-        for (final Record record : records)
-            bufferSize += Records.LOG_OVERHEAD + record.sizeInBytes();
-        final ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
-        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, compressionType, TimestampType.CREATE_TIME);
-        long nextOffset = offset;
-        for (final Record record : records)
-            builder.append(nextOffset++, record);
-        return builder.build().buffer();
     }
 
     public static Properties producerConfig(final String bootstrapServers,

--- a/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
+++ b/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
@@ -1,0 +1,60 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.tools
+
+import kafka.api.FetchResponsePartitionData
+import kafka.common.TopicAndPartition
+import kafka.message.ByteBufferMessageSet
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.record.{MemoryRecords, Record}
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+class ReplicaVerificationToolTest {
+
+  @Test
+  def testReplicaBufferVerifyChecksum(): Unit = {
+    val sb = new StringBuilder
+
+    val expectedReplicasPerTopicAndPartition = Map(
+      TopicAndPartition("a", 0) -> 3,
+      TopicAndPartition("a", 1) -> 3,
+      TopicAndPartition("b", 0) -> 2
+    )
+
+    val replicaBuffer = new ReplicaBuffer(expectedReplicasPerTopicAndPartition, Map.empty, 2, Map.empty, 0, 0)
+    expectedReplicasPerTopicAndPartition.foreach { case (tp, numReplicas) =>
+      (0 until numReplicas).foreach { replicaId =>
+        val records = (0 to 5).map { index =>
+          Record.create(s"key $index".getBytes, s"value $index".getBytes)
+        }
+        val initialOffset = 4
+        val memoryRecords = MemoryRecords.withRecords(initialOffset, records: _*)
+        replicaBuffer.addFetchedData(tp, replicaId, new FetchResponsePartitionData(Errors.NONE.code(), hw = 20,
+          new ByteBufferMessageSet(memoryRecords.buffer)))
+      }
+    }
+
+    replicaBuffer.verifyCheckSum(line => sb.append(s"$line\n"))
+    val output = sb.toString.trim
+
+    assertTrue(s"Max lag information should be in output: `$output`",
+      output.endsWith(": max lag is 10 for partition [a,0] at offset 10 among 3 partitions"))
+  }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -271,7 +271,7 @@ public class KafkaStreamsTest {
 
         @Override
         public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
-            Long prevCount = this.mapStates.containsKey(newState) ? this.mapStates.get(newState) : 0;
+            long prevCount = this.mapStates.containsKey(newState) ? this.mapStates.get(newState) : 0;
             this.numChanges++;
             this.oldState = oldState;
             this.newState = newState;


### PR DESCRIPTION
This was changed in b58b6a1bef0 and caused the `ReplicaVerificationToolTest.test_replica_lags`
system test to start failing.

I also added a unit test and a couple of other minor clean-ups.