### PR TITLE
KAFKA-3284: Remove beta label from security documentation

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -17,7 +17,7 @@
 
 <script id="security-template" type="text/x-handlebars-template">
     <h3><a id="security_overview" href="#security_overview">7.1 Security Overview</a></h3>
-    In release 0.9.0.0, the Kafka community added a number of features that, used either separately or together, increases security in a Kafka cluster. These features are considered to be of beta quality. The following security measures are currently supported:
+    In release 0.9.0.0, the Kafka community added a number of features that, used either separately or together, increases security in a Kafka cluster. The following security measures are currently supported:
     <ol>
         <li>Authentication of connections to brokers from clients (producers and consumers), other brokers and tools, using either SSL or SASL (Kerberos).
         SASL/PLAIN can also be used from release 0.10.0.0 onwards.</li>


### PR DESCRIPTION
4 release cycles (0.9.0.0, 0.10.0.0, 0.10.1.0, 0.10.2.0) should be enough
to remove the beta label.