### PR TITLE
KAFKA-4180 : Authentication with multiple actives Kafka

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/LoginManager.java
@@ -24,23 +24,25 @@ import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.network.LoginType;
 import org.apache.kafka.common.security.auth.Login;
 import org.apache.kafka.common.security.kerberos.KerberosLogin;
 
 public class LoginManager {
 
-    private static final EnumMap<LoginType, LoginManager> CACHED_INSTANCES = new EnumMap<>(LoginType.class);
+    private static final Map<Object, LoginManager> CACHED_INSTANCES = new HashMap<>();
 
     private final Login login;
-    private final LoginType loginType;
+    private final Object cachingKey;
     private int refCount;
 
-    private LoginManager(LoginType loginType, boolean hasKerberos, Map<String, ?> configs, Configuration jaasConfig) throws IOException, LoginException {
-        this.loginType = loginType;
+    private LoginManager(LoginType loginType, Object cachingKey, boolean hasKerberos, Map<String, ?> configs, Configuration jaasConfig) throws IOException, LoginException {
+        this.cachingKey = cachingKey;
         String loginContext = loginType.contextName();
         login = hasKerberos ? new KerberosLogin() : new DefaultLogin();
         login.configure(configs, jaasConfig, loginContext);
@@ -51,8 +53,7 @@ public class LoginManager {
      * Returns an instance of `LoginManager` and increases its reference count.
      *
      * `release()` should be invoked when the `LoginManager` is no longer needed. This method will try to reuse an
-     * existing `LoginManager` for the provided `mode` if available. However, it expects `configs` to be the same for
-     * every invocation and it will ignore them in the case where it's returning a cached instance of `LoginManager`.
+     * existing `LoginManager` for the provided `mode` and `SaslConfigs.SASL_JAAS_CONFIG` in `configs`, if available. 
      *
      * This is a bit ugly and it would be nicer if we could pass the `LoginManager` to `ChannelBuilders.create` and
      * shut it down when the broker or clients are closed. It's straightforward to do the former, but it's more
@@ -60,14 +61,25 @@ public class LoginManager {
      *
      * @param loginType the type of the login context, it should be SERVER for the broker and CLIENT for the clients
      *                  (i.e. consumer and producer)
+     * @param hasKerberos 
      * @param configs configuration as key/value pairs
+     * @param jaasConfig JAAS Configuration object
      */
     public static final LoginManager acquireLoginManager(LoginType loginType, boolean hasKerberos, Map<String, ?> configs, Configuration jaasConfig) throws IOException, LoginException {
         synchronized (LoginManager.class) {
-            LoginManager loginManager = CACHED_INSTANCES.get(loginType);
+            Object cachingKey = loginType;
+            // allow multiple client logins in a single process
+            if (loginType == LoginType.CLIENT) {
+                Password jaasconf = (Password) configs.get(SaslConfigs.SASL_JAAS_CONFIG);
+                if (jaasconf != null) {
+                    cachingKey = jaasconf;
+                }
+            }
+            
+            LoginManager loginManager = CACHED_INSTANCES.get(cachingKey);
             if (loginManager == null) {
-                loginManager = new LoginManager(loginType, hasKerberos, configs, jaasConfig);
-                CACHED_INSTANCES.put(loginType, loginManager);
+                loginManager = new LoginManager(loginType, cachingKey, hasKerberos, configs, jaasConfig);
+                CACHED_INSTANCES.put(cachingKey, loginManager);
             }
             return loginManager.acquire();
         }
@@ -94,7 +106,7 @@ public class LoginManager {
             if (refCount == 0)
                 throw new IllegalStateException("release called on LoginManager with refCount == 0");
             else if (refCount == 1) {
-                CACHED_INSTANCES.remove(loginType);
+                CACHED_INSTANCES.remove(cachingKey);
                 login.close();
             }
             --refCount;
@@ -104,8 +116,8 @@ public class LoginManager {
     /* Should only be used in tests. */
     public static void closeAll() {
         synchronized (LoginManager.class) {
-            for (LoginType loginType : new ArrayList<>(CACHED_INSTANCES.keySet())) {
-                LoginManager loginManager = CACHED_INSTANCES.remove(loginType);
+            for (Object key : new ArrayList<>(CACHED_INSTANCES.keySet())) {
+                LoginManager loginManager = CACHED_INSTANCES.remove(key);
                 loginManager.login.close();
             }
         }

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -140,7 +140,7 @@ public class KerberosLogin extends AbstractLogin {
         // TGT's existing expiry date and the configured minTimeBeforeRelogin. For testing and development,
         // you can decrease the interval of expiration of tickets (for example, to 3 minutes) by running:
         //  "modprinc -maxlife 3mins <principal>" in kadmin.
-        t = Utils.newThread("kafka-kerberos-refresh-thread-" + principal, new Runnable() {
+        t = Utils.newThread(String.format("kafka-kerberos-refresh-thread-%s", principal), new Runnable() {
             public void run() {
                 log.info("Principal={} - TGT refresh thread started.", principal);
                 while (true) {  // renewal thread's main loop. if it exits from here, thread will exit.
@@ -229,8 +229,9 @@ public class KerberosLogin extends AbstractLogin {
                                         return;
                                     }
                                 } else {
-                                    log.warn("Principal={} - Could not renew TGT due to problem running shell command: '" + kinitCmd
-                                            + " " + kinitArgs + "'" + "; exception was: " + e + ". Exiting refresh thread.", principal, e);
+                                    log.warn(String.format("Principal=%s - Could not renew TGT due to problem running shell command: '%s %s'; " +
+                                            "exception was: %s. Exiting refresh thread.", 
+                                            principal, kinitCmd, kinitArgs, e), e);
                                     return;
                                 }
                             }
@@ -249,16 +250,16 @@ public class KerberosLogin extends AbstractLogin {
                                     try {
                                         Thread.sleep(10 * 1000);
                                     } catch (InterruptedException e) {
-                                        log.error("Principal={} - Interrupted during login retry after LoginException:", principal, le);
+                                        log.error(String.format("Principal=%s - Interrupted during login retry after LoginException:", principal), le);
                                         throw le;
                                     }
                                 } else {
-                                    log.error("Principal={} - Could not refresh TGT for principal: " + principal + ".", principal, le);
+                                    log.error(String.format("Principal=%s - Could not refresh TGT.", principal), le);
                                 }
                             }
                         }
                     } catch (LoginException le) {
-                        log.error("Principal={} - Failed to refresh TGT: refresh thread exiting now.", principal, le);
+                        log.error(String.format("Principal=%s - Failed to refresh TGT: refresh thread exiting now.", principal), le);
                         return;
                     }
                 }
@@ -275,7 +276,7 @@ public class KerberosLogin extends AbstractLogin {
             try {
                 t.join();
             } catch (InterruptedException e) {
-                log.warn("Principal={} - Error while waiting for Login thread to shutdown: " + e, principal, e);
+                log.warn(String.format("Principal=%s - Error while waiting for Login thread to shutdown: %s", principal, e), e);
                 Thread.currentThread().interrupt();
             }
         }
@@ -300,8 +301,8 @@ public class KerberosLogin extends AbstractLogin {
         }
         String configServiceName = (String) configs.get(SaslConfigs.SASL_KERBEROS_SERVICE_NAME);
         if (jaasServiceName != null && configServiceName != null && !jaasServiceName.equals(configServiceName)) {
-            String message = "Conflicting serviceName values found in JAAS and Kafka configs " +
-                "value in JAAS file " + jaasServiceName + ", value in Kafka config " + configServiceName;
+            String message = String.format("Conflicting serviceName values found in JAAS and Kafka configs " +
+                "value in JAAS file %s, value in Kafka config %s", jaasServiceName, configServiceName);
             throw new IllegalArgumentException(message);
         }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -129,20 +129,20 @@ public class KerberosLogin extends AbstractLogin {
         }
 
         if (!isKrbTicket) {
-            log.debug("It is not a Kerberos ticket");
+            log.debug("Principal={} - It is not a Kerberos ticket", principal);
             t = null;
             // if no TGT, do not bother with ticket management.
             return loginContext;
         }
-        log.debug("It is a Kerberos ticket");
+        log.debug("Principal={} - It is a Kerberos ticket", principal);
 
         // Refresh the Ticket Granting Ticket (TGT) periodically. How often to refresh is determined by the
         // TGT's existing expiry date and the configured minTimeBeforeRelogin. For testing and development,
         // you can decrease the interval of expiration of tickets (for example, to 3 minutes) by running:
         //  "modprinc -maxlife 3mins <principal>" in kadmin.
-        t = Utils.newThread("kafka-kerberos-refresh-thread", new Runnable() {
+        t = Utils.newThread("kafka-kerberos-refresh-thread-" + principal, new Runnable() {
             public void run() {
-                log.info("TGT refresh thread started.");
+                log.info("Principal={} - TGT refresh thread started.", principal);
                 while (true) {  // renewal thread's main loop. if it exits from here, thread will exit.
                     KerberosTicket tgt = getTGT();
                     long now = currentWallTime();
@@ -151,7 +151,7 @@ public class KerberosLogin extends AbstractLogin {
                     if (tgt == null) {
                         nextRefresh = now + minTimeBeforeRelogin;
                         nextRefreshDate = new Date(nextRefresh);
-                        log.warn("No TGT found: will try again at {}", nextRefreshDate);
+                        log.warn("Principal={} - No TGT found: will try again at {}", principal, nextRefreshDate);
                     } else {
                         nextRefresh = getRefreshTime(tgt);
                         long expiry = tgt.getEndTime().getTime();
@@ -173,41 +173,41 @@ public class KerberosLogin extends AbstractLogin {
                         // would cause ticket expiration.
                         if ((nextRefresh > expiry) || (now + minTimeBeforeRelogin > expiry)) {
                             // expiry is before next scheduled refresh).
-                            log.info("Refreshing now because expiry is before next scheduled refresh time.");
+                            log.info("Principal={} - Refreshing now because expiry is before next scheduled refresh time.", principal);
                             nextRefresh = now;
                         } else {
                             if (nextRefresh < (now + minTimeBeforeRelogin)) {
                                 // next scheduled refresh is sooner than (now + MIN_TIME_BEFORE_LOGIN).
                                 Date until = new Date(nextRefresh);
                                 Date newUntil = new Date(now + minTimeBeforeRelogin);
-                                log.warn("TGT refresh thread time adjusted from {} to {} since the former is sooner " +
+                                log.warn("Principal={} - TGT refresh thread time adjusted from {} to {} since the former is sooner " +
                                         "than the minimum refresh interval ({} seconds) from now.",
-                                        until, newUntil, minTimeBeforeRelogin / 1000);
+                                        principal, until, newUntil, minTimeBeforeRelogin / 1000);
                             }
                             nextRefresh = Math.max(nextRefresh, now + minTimeBeforeRelogin);
                         }
                         nextRefreshDate = new Date(nextRefresh);
                         if (nextRefresh > expiry) {
-                            log.error("Next refresh: {} is later than expiry {}. This may indicate a clock skew problem." +
+                            log.error("Principal={} - Next refresh: {} is later than expiry {}. This may indicate a clock skew problem." +
                                     "Check that this host and the KDC hosts' clocks are in sync. Exiting refresh thread.",
-                                    nextRefreshDate, expiryDate);
+                                    principal, nextRefreshDate, expiryDate);
                             return;
                         }
                     }
                     if (now < nextRefresh) {
                         Date until = new Date(nextRefresh);
-                        log.info("TGT refresh sleeping until: {}", until);
+                        log.info("Principal={} - TGT refresh sleeping until: {}", principal, until);
                         try {
                             Thread.sleep(nextRefresh - now);
                         } catch (InterruptedException ie) {
-                            log.warn("TGT renewal thread has been interrupted and will exit.");
+                            log.warn("Principal={} - TGT renewal thread has been interrupted and will exit.", principal);
                             return;
                         }
                     } else {
-                        log.error("NextRefresh: {} is in the past: exiting refresh thread. Check"
+                        log.error("Principal={} - NextRefresh: {} is in the past: exiting refresh thread. Check"
                                 + " clock sync between this host and KDC - (KDC's clock is likely ahead of this host)."
                                 + " Manual intervention will be required for this client to successfully authenticate."
-                                + " Exiting refresh thread.", nextRefreshDate);
+                                + " Exiting refresh thread.", principal, nextRefreshDate);
                         return;
                     }
                     if (isUsingTicketCache) {
@@ -215,7 +215,7 @@ public class KerberosLogin extends AbstractLogin {
                         int retry = 1;
                         while (retry >= 0) {
                             try {
-                                log.debug("Running ticket cache refresh command: {} {}", kinitCmd, kinitArgs);
+                                log.debug("Principal={} - Running ticket cache refresh command: {} {}", principal, kinitCmd, kinitArgs);
                                 Shell.execCommand(kinitCmd, kinitArgs);
                                 break;
                             } catch (Exception e) {
@@ -225,12 +225,12 @@ public class KerberosLogin extends AbstractLogin {
                                     try {
                                         Thread.sleep(10 * 1000);
                                     } catch (InterruptedException ie) {
-                                        log.error("Interrupted while renewing TGT, exiting Login thread");
+                                        log.error("Principal={} - Interrupted while renewing TGT, exiting Login thread", principal);
                                         return;
                                     }
                                 } else {
-                                    log.warn("Could not renew TGT due to problem running shell command: '" + kinitCmd
-                                            + " " + kinitArgs + "'" + "; exception was: " + e + ". Exiting refresh thread.", e);
+                                    log.warn("Principal={} - Could not renew TGT due to problem running shell command: '" + kinitCmd
+                                            + " " + kinitArgs + "'" + "; exception was: " + e + ". Exiting refresh thread.", principal, e);
                                     return;
                                 }
                             }
@@ -249,16 +249,16 @@ public class KerberosLogin extends AbstractLogin {
                                     try {
                                         Thread.sleep(10 * 1000);
                                     } catch (InterruptedException e) {
-                                        log.error("Interrupted during login retry after LoginException:", le);
+                                        log.error("Principal={} - Interrupted during login retry after LoginException:", principal, le);
                                         throw le;
                                     }
                                 } else {
-                                    log.error("Could not refresh TGT for principal: " + principal + ".", le);
+                                    log.error("Principal={} - Could not refresh TGT for principal: " + principal + ".", principal, le);
                                 }
                             }
                         }
                     } catch (LoginException le) {
-                        log.error("Failed to refresh TGT: refresh thread exiting now.", le);
+                        log.error("Principal={} - Failed to refresh TGT: refresh thread exiting now.", principal, le);
                         return;
                     }
                 }
@@ -275,7 +275,7 @@ public class KerberosLogin extends AbstractLogin {
             try {
                 t.join();
             } catch (InterruptedException e) {
-                log.warn("Error while waiting for Login thread to shutdown: " + e, e);
+                log.warn("Principal={} - Error while waiting for Login thread to shutdown: " + e, principal, e);
                 Thread.currentThread().interrupt();
             }
         }
@@ -317,8 +317,8 @@ public class KerberosLogin extends AbstractLogin {
     private long getRefreshTime(KerberosTicket tgt) {
         long start = tgt.getStartTime().getTime();
         long expires = tgt.getEndTime().getTime();
-        log.info("TGT valid starting at: {}", tgt.getStartTime());
-        log.info("TGT expires: {}", tgt.getEndTime());
+        log.info("Principal={} - TGT valid starting at: {}", principal, tgt.getStartTime());
+        log.info("Principal={} - TGT expires: {}", principal, tgt.getEndTime());
         long proposedRefresh = start + (long) ((expires - start) *
                 (ticketRenewWindowFactor + (ticketRenewJitter * RNG.nextDouble())));
 
@@ -345,8 +345,8 @@ public class KerberosLogin extends AbstractLogin {
     private boolean hasSufficientTimeElapsed() {
         long now = currentElapsedTime();
         if (now - lastLogin < minTimeBeforeRelogin) {
-            log.warn("Not attempting to re-login since the last re-login was attempted less than {} seconds before.",
-                    minTimeBeforeRelogin / 1000);
+            log.warn("Principal={} - Not attempting to re-login since the last re-login was attempted less than {} seconds before.",
+                    principal, minTimeBeforeRelogin / 1000);
             return false;
         }
         return true;

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -18,7 +18,7 @@
 package kafka.api
 
 import java.io.File
-import java.util.{ArrayList,Properties}
+import java.util.ArrayList
 import java.util.concurrent.ExecutionException
 
 import kafka.admin.AclCommand

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -333,7 +333,6 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
         assertEquals(group, e.groupId())
     }
   }
-  
 
   private def sendRecords(numRecords: Int, tp: TopicPartition) {
     val futures = (0 until numRecords).map { i =>

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -210,7 +210,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     consumeRecords(this.consumers.head, numRecords)
   }
 
-  private def setAclsAndProduce() {
+  protected def setAclsAndProduce() {
     AclCommand.main(produceAclArgs)
     AclCommand.main(consumeAclArgs)
     servers.foreach { s =>
@@ -276,8 +276,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
 
     AclCommand.main(deleteDescribeAclArgs)
     AclCommand.main(deleteWriteAclArgs)
-    servers.foreach { _ =>
-      TestUtils.waitAndVerifyAcls(GroupReadAcl, servers.head.apis.authorizer.get, groupResource)
+    servers.foreach { s =>
+      TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
   }
  
@@ -318,7 +318,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     AclCommand.main(groupAclArgs)
     servers.foreach { s =>
       TestUtils.waitAndVerifyAcls(TopicWriteAcl ++ TopicDescribeAcl, s.apis.authorizer.get, topicResource)
-      TestUtils.waitAndVerifyAcls(GroupReadAcl, servers.head.apis.authorizer.get, groupResource)
+      TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
     sendRecords(numRecords, tp)
   }
@@ -357,7 +357,7 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     }
   }
 
-  private def consumeRecords(consumer: Consumer[Array[Byte], Array[Byte]],
+  protected def consumeRecords(consumer: Consumer[Array[Byte], Array[Byte]],
                              numRecords: Int = 1,
                              startingOffset: Int = 0,
                              topic: String = topic,

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -54,7 +54,7 @@ import scala.collection.JavaConverters._
   * SaslTestHarness here directly because it extends ZooKeeperTestHarness, and we
   * would end up with ZooKeeperTestHarness twice.
   */
-abstract class EndToEndAuthorizationTest extends IntegrationTestHarness  with SaslSetup {
+abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with SaslSetup {
   override val producerCount = 1
   override val consumerCount = 2
   override val serverCount = 3

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -33,8 +33,8 @@ abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected val saslProperties = Some(kafkaSaslProperties(kafkaClientSaslMechanism, Some(kafkaServerSaslMechanisms)))
   protected var clientKeytabFile: Option[File] = None
   
-  protected def kafkaClientSaslMechanism : String
-  protected def kafkaServerSaslMechanisms : List[String]
+  protected def kafkaClientSaslMechanism: String
+  protected def kafkaServerSaslMechanisms: List[String]
 
   
   @Before
@@ -60,8 +60,8 @@ abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
     * The first consumer succeeds because it is allowed by the ACL, 
     * the second one connects ok, but fails to consume messages due to the ACL.
     */
-  @Test(timeout=20000L)
-  def testTwoConsumersWithDifferentSASLCredentials {
+  @Test(timeout=5000L)
+  def testTwoConsumersWithDifferentSaslCredentials {
     setAclsAndProduce()
     val consumer1 = consumers.head
 

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -20,6 +20,7 @@ import java.io.File
 import java.util.Properties
 
 import kafka.utils.{JaasTestUtils,TestUtils}
+import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.errors.GroupAuthorizationException
 import org.junit.{Before,Test}
@@ -28,7 +29,7 @@ import scala.collection.immutable.List
 import scala.collection.JavaConverters._
 
 abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
-
+  override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected val saslProperties = Some(kafkaSaslProperties(kafkaClientSaslMechanism, Some(kafkaServerSaslMechanisms)))
   protected var clientKeytabFile: Option[File] = None
   
@@ -59,7 +60,7 @@ abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
     * The first consumer succeeds because it is allowed by the ACL, 
     * the second one connects ok, but fails to consume messages due to the ACL.
     */
-  @Test
+  @Test(timeout=20000L)
   def testTwoConsumersWithDifferentSASLCredentials {
     setAclsAndProduce()
     val consumer1 = consumers.head

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -1,0 +1,89 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package kafka.api
+
+import java.io.File
+import java.util.Properties
+
+import kafka.utils.{JaasTestUtils,TestUtils}
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.errors.GroupAuthorizationException
+import org.junit.{Before,Test}
+
+import scala.collection.immutable.List
+import scala.collection.JavaConverters._
+
+abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
+
+  override protected val saslProperties = Some(kafkaSaslProperties(kafkaClientSaslMechanism, Some(kafkaServerSaslMechanisms)))
+  protected var clientKeytabFile: Option[File] = None
+  
+  protected def kafkaClientSaslMechanism : String
+  protected def kafkaServerSaslMechanisms : List[String]
+  protected def clientLoginContext2 : String
+
+  
+  @Before
+  override def setUp {
+    startSasl(Both, List(kafkaClientSaslMechanism), kafkaServerSaslMechanisms)
+    super.setUp
+  }
+
+  // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
+  override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
+      serverKeytabFile: Option[File] = None, clientKeytabFile: Option[File] = None) {
+    this.clientKeytabFile = clientKeytabFile
+    super.setJaasConfiguration(mode, kafkaServerSaslMechanisms, List(), serverKeytabFile, clientKeytabFile)
+    val clientLoginContext = JaasTestUtils.clientLoginModule(kafkaClientSaslMechanism, clientKeytabFile)
+    producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+    consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+  }
+
+  /**
+    * Tests with two consumers with different SASL credentials, the first one with proper ACLs succeeds, 
+    * while a second fails to consume messages.
+    */
+  @Test
+  def testConsumer1AllowedConsumer2NotAllowed {
+    setAclsAndProduce()
+    val consumer1 = consumers.head
+
+    val consumer2Config = new Properties
+    consumer2Config.putAll(consumerConfig)
+
+    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
+
+    val consumer2 = TestUtils.createNewConsumer(brokerList,
+                                  securityProtocol = this.securityProtocol,
+                                  trustStoreFile = this.trustStoreFile,
+                                  saslProperties = this.saslProperties,
+                                  props = Some(consumer2Config))
+    consumers += consumer2
+
+    consumer1.assign(List(tp).asJava)
+    consumer2.assign(List(tp).asJava)
+
+    consumeRecords(consumer1, numRecords)
+
+    try {
+      consumeRecords(consumer2, timeout = 5000)
+      fail("expected KafkaException as consumer2 has no access to group")
+    } catch {
+      case e : GroupAuthorizationException => //expected
+    }
+  }
+}

--- a/core/src/test/scala/integration/kafka/api/SaslGssapiEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslGssapiEndToEndAuthorizationTest.scala
@@ -18,12 +18,10 @@ package kafka.api
 
 import kafka.server.KafkaConfig
 import kafka.utils.JaasTestUtils
-import org.apache.kafka.common.protocol.SecurityProtocol
 
 import scala.collection.immutable.List
 
-class SaslSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
-  override protected def securityProtocol = SecurityProtocol.SASL_SSL
+class SaslGssapiEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override val clientPrincipal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName
   override val kafkaPrincipal = JaasTestUtils.KafkaServerPrincipalUnqualifiedName
   

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -16,11 +16,9 @@
   */
 package kafka.api
 
-import org.apache.kafka.common.protocol.SecurityProtocol
 import kafka.utils.JaasTestUtils
 
 class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
-  override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected def kafkaClientSaslMechanism = "PLAIN"
   override protected def kafkaServerSaslMechanisms = List("PLAIN")
   override val clientPrincipal = JaasTestUtils.KafkaPlainUser

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -16,10 +16,8 @@
   */
 package kafka.api
 
-import java.io.File
 import org.apache.kafka.common.protocol.SecurityProtocol
 import kafka.utils.JaasTestUtils
-import kafka.utils.JaasTestUtils.PlainLoginModule
 
 class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
@@ -27,9 +25,4 @@ class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTes
   override protected def kafkaServerSaslMechanisms = List("PLAIN")
   override val clientPrincipal = JaasTestUtils.KafkaPlainUser
   override val kafkaPrincipal = JaasTestUtils.KafkaPlainAdmin
-
-  override protected def clientLoginContext2 = PlainLoginModule(
-          JaasTestUtils.KafkaPlainUser2,
-          JaasTestUtils.KafkaPlainPassword2
-        ).toJaasModule.toString.stripMargin
 }

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -18,65 +18,18 @@ package kafka.api
 
 import java.io.File
 import org.apache.kafka.common.protocol.SecurityProtocol
-import org.apache.kafka.common.config.SaslConfigs
 import kafka.utils.JaasTestUtils
-import org.junit.Test
-import java.util.Properties
-import scala.collection.immutable.List
-import scala.collection.JavaConverters._
-import kafka.utils.TestUtils
 import kafka.utils.JaasTestUtils.PlainLoginModule
-import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.common.security.auth.KafkaPrincipal
-import org.apache.kafka.common.errors.GroupAuthorizationException
 
-class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
+class SaslPlainSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected def kafkaClientSaslMechanism = "PLAIN"
   override protected def kafkaServerSaslMechanisms = List("PLAIN")
   override val clientPrincipal = JaasTestUtils.KafkaPlainUser
   override val kafkaPrincipal = JaasTestUtils.KafkaPlainAdmin
 
-  // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
-  override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
-      serverKeytabFile: Option[File] = None, clientKeytabFile: Option[File] = None) {
-    super.setJaasConfiguration(mode, kafkaServerSaslMechanisms, List()) // create static config without client login contexts
-    val clientLoginModule = JaasTestUtils.clientLoginModule(kafkaClientSaslMechanism, None)
-    producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
-    consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
-  }
-
-  @Test
-  def testConsumer1AllowedConsumer2NotAllowed {
-    setAclsAndProduce()
-    val consumer1 = consumers.head
-
-    val consumer2Config = new Properties
-    consumer2Config.putAll(consumerConfig)
-    val clientLoginContext2 = PlainLoginModule(
+  override protected def clientLoginContext2 = PlainLoginModule(
           JaasTestUtils.KafkaPlainUser2,
           JaasTestUtils.KafkaPlainPassword2
         ).toJaasModule.toString.stripMargin
-    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
-
-    val consumer2 = TestUtils.createNewConsumer(brokerList,
-                                  securityProtocol = this.securityProtocol,
-                                  trustStoreFile = this.trustStoreFile,
-                                  saslProperties = this.saslProperties,
-                                  props = Some(consumer2Config))
-    consumers += consumer2
-
-    consumer1.assign(List(tp).asJava)
-    consumer2.assign(List(tp).asJava)
-
-    consumeRecords(consumer1, numRecords)
-
-    try {
-      consumeRecords(consumer2, timeout = 5000)
-      fail("expected KafkaException as consumer2 has no access to topic")
-    } catch {
-      case e : GroupAuthorizationException => //expected
-    }
-  }
-
 }

--- a/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslPlainSslEndToEndAuthorizationTest.scala
@@ -20,13 +20,22 @@ import java.io.File
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.kafka.common.config.SaslConfigs
 import kafka.utils.JaasTestUtils
+import org.junit.Test
+import java.util.Properties
+import scala.collection.immutable.List
+import scala.collection.JavaConverters._
+import kafka.utils.TestUtils
+import kafka.utils.JaasTestUtils.PlainLoginModule
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.apache.kafka.common.errors.GroupAuthorizationException
 
 class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected def kafkaClientSaslMechanism = "PLAIN"
   override protected def kafkaServerSaslMechanisms = List("PLAIN")
-  override val clientPrincipal = "testuser"
-  override val kafkaPrincipal = "admin"
+  override val clientPrincipal = JaasTestUtils.KafkaPlainUser
+  override val kafkaPrincipal = JaasTestUtils.KafkaPlainAdmin
 
   // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
   override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
@@ -36,4 +45,38 @@ class SaslPlainSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
     consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginModule)
   }
+
+  @Test
+  def testConsumer1AllowedConsumer2NotAllowed {
+    setAclsAndProduce()
+    val consumer1 = consumers.head
+
+    val consumer2Config = new Properties
+    consumer2Config.putAll(consumerConfig)
+    val clientLoginContext2 = PlainLoginModule(
+          JaasTestUtils.KafkaPlainUser2,
+          JaasTestUtils.KafkaPlainPassword2
+        ).toJaasModule.toString.stripMargin
+    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
+
+    val consumer2 = TestUtils.createNewConsumer(brokerList,
+                                  securityProtocol = this.securityProtocol,
+                                  trustStoreFile = this.trustStoreFile,
+                                  saslProperties = this.saslProperties,
+                                  props = Some(consumer2Config))
+    consumers += consumer2
+
+    consumer1.assign(List(tp).asJava)
+    consumer2.assign(List(tp).asJava)
+
+    consumeRecords(consumer1, numRecords)
+
+    try {
+      consumeRecords(consumer2, timeout = 5000)
+      fail("expected KafkaException as consumer2 has no access to topic")
+    } catch {
+      case e : GroupAuthorizationException => //expected
+    }
+  }
+
 }

--- a/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslScramSslEndToEndAuthorizationTest.scala
@@ -16,15 +16,13 @@
   */
 package kafka.api
 
-import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.kafka.common.security.scram.ScramMechanism
 import kafka.utils.JaasTestUtils
 import kafka.admin.ConfigCommand
 import kafka.utils.ZkUtils
 import scala.collection.JavaConverters._
 
-class SaslScramSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
-  override protected def securityProtocol = SecurityProtocol.SASL_SSL
+class SaslScramSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override protected def kafkaClientSaslMechanism = "SCRAM-SHA-256"
   override protected def kafkaServerSaslMechanisms = ScramMechanism.mechanismNames.asScala.toList
   override val clientPrincipal = JaasTestUtils.KafkaScramUser
@@ -45,5 +43,6 @@ class SaslScramSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
     }
     ConfigCommand.main(configCommandArgs(kafkaPrincipal, kafkaPassword))
     ConfigCommand.main(configCommandArgs(clientPrincipal, clientPassword))
+    ConfigCommand.main(configCommandArgs(JaasTestUtils.KafkaScramUser2, JaasTestUtils.KafkaScramPassword2))
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslSetup.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSetup.scala
@@ -54,8 +54,8 @@ trait SaslSetup {
       setJaasConfiguration(mode, kafkaServerSaslMechanisms, kafkaClientSaslMechanisms, Some(serverKeytabFile), Some(clientKeytabFile))
       kdc = new MiniKdc(kdcConf, workDir)
       kdc.start()
-      kdc.createPrincipal(serverKeytabFile, "kafka/localhost")
-      kdc.createPrincipal(clientKeytabFile, "client")
+      kdc.createPrincipal(serverKeytabFile, JaasTestUtils.KafkaServerPrincipalUnqualifiedName + "/localhost")
+      kdc.createPrincipal(clientKeytabFile, JaasTestUtils.KafkaClientPrincipalUnqualifiedName, JaasTestUtils.KafkaClientPrincipalUnqualifiedName2)
     } else {
       setJaasConfiguration(mode, kafkaServerSaslMechanisms, kafkaClientSaslMechanisms)
     }

--- a/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
@@ -16,17 +16,79 @@
   */
 package kafka.api
 
+import scala.collection.immutable.List
+import scala.collection.JavaConverters._
+
+import org.junit.Test
+import java.util.Properties
+import java.io.File
 import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.utils.JaasTestUtils
+import kafka.utils.JaasTestUtils.Krb5LoginModule
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.apache.kafka.common.KafkaException
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.errors.GroupAuthorizationException
 
 class SaslSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
-  override val clientPrincipal = "client"
-  override val kafkaPrincipal = "kafka"
+  override val clientPrincipal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName
+  override val kafkaPrincipal = JaasTestUtils.KafkaServerPrincipalUnqualifiedName
+  
+  var clientKeytabFile: Option[File] = None
 
   // Configure brokers to require SSL client authentication in order to verify that SASL_SSL works correctly even if the
   // client doesn't have a keystore. We want to cover the scenario where a broker requires either SSL client
   // authentication or SASL authentication with SSL as the transport layer (but not both).
   serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
+
+  // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
+  override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
+      serverKeytabFile: Option[File] = None, clientKeytabFile: Option[File] = None) {
+    this.clientKeytabFile = clientKeytabFile;
+    super.setJaasConfiguration(mode, kafkaServerSaslMechanisms, List(), serverKeytabFile, clientKeytabFile)
+    val clientLoginContext = JaasTestUtils.clientLoginModule(kafkaClientSaslMechanism, clientKeytabFile)
+    producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+    consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
+  }
+
+
+  @Test
+  def testConsumer1AllowedConsumer2NotAllowed {
+    setAclsAndProduce()
+    val consumer1 = consumers.head
+
+    val consumer2Config = new Properties
+    consumer2Config.putAll(consumerConfig)
+    val clientLoginContext2 = Krb5LoginModule(
+          useKeyTab = true,
+          storeKey = true,
+          keyTab = this.clientKeytabFile.getOrElse(throw new IllegalArgumentException("Keytab location not specified for GSSAPI")).getAbsolutePath,
+          principal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName2 + "@EXAMPLE.COM",
+          debug = true,
+          serviceName = Some("kafka")
+        ).toJaasModule.toString.stripMargin
+    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
+
+    val consumer2 = TestUtils.createNewConsumer(brokerList,
+                                  securityProtocol = this.securityProtocol,
+                                  trustStoreFile = this.trustStoreFile,
+                                  saslProperties = this.saslProperties,
+                                  props = Some(consumer2Config))
+    consumers += consumer2
+
+    consumer1.assign(List(tp).asJava)
+    consumer2.assign(List(tp).asJava)
+
+    consumeRecords(consumer1, numRecords)
+
+    try {
+      consumeRecords(consumer2, timeout = 5000)
+      fail("expected KafkaException as consumer2 has no access to topic")
+    } catch {
+      case e : GroupAuthorizationException => //expected
+    }
+  }
 
 }

--- a/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
@@ -17,9 +17,7 @@
 package kafka.api
 
 import kafka.server.KafkaConfig
-import kafka.utils.TestUtils
 import kafka.utils.JaasTestUtils
-import kafka.utils.JaasTestUtils.Krb5LoginModule
 import org.apache.kafka.common.protocol.SecurityProtocol
 
 import scala.collection.immutable.List
@@ -37,12 +35,4 @@ class SaslSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   // authentication or SASL authentication with SSL as the transport layer (but not both).
   serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
 
-  override protected def clientLoginContext2 = Krb5LoginModule(
-          useKeyTab = true,
-          storeKey = true,
-          keyTab = this.clientKeytabFile.getOrElse(throw new IllegalArgumentException("Keytab location not specified for GSSAPI")).getAbsolutePath,
-          principal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName2 + "@EXAMPLE.COM",
-          debug = true,
-          serviceName = Some("kafka")
-        ).toJaasModule.toString.stripMargin
 }

--- a/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslEndToEndAuthorizationTest.scala
@@ -16,52 +16,28 @@
   */
 package kafka.api
 
-import scala.collection.immutable.List
-import scala.collection.JavaConverters._
-
-import org.junit.Test
-import java.util.Properties
-import java.io.File
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 import kafka.utils.JaasTestUtils
 import kafka.utils.JaasTestUtils.Krb5LoginModule
 import org.apache.kafka.common.protocol.SecurityProtocol
-import org.apache.kafka.common.KafkaException
-import org.apache.kafka.common.config.SaslConfigs
-import org.apache.kafka.common.errors.GroupAuthorizationException
 
-class SaslSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
+import scala.collection.immutable.List
+
+class SaslSslEndToEndAuthorizationTest extends SaslEndToEndAuthorizationTest {
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override val clientPrincipal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName
   override val kafkaPrincipal = JaasTestUtils.KafkaServerPrincipalUnqualifiedName
   
-  var clientKeytabFile: Option[File] = None
-
+  override protected def kafkaClientSaslMechanism = "GSSAPI"
+  override protected def kafkaServerSaslMechanisms = List("GSSAPI")
+  
   // Configure brokers to require SSL client authentication in order to verify that SASL_SSL works correctly even if the
   // client doesn't have a keystore. We want to cover the scenario where a broker requires either SSL client
   // authentication or SASL authentication with SSL as the transport layer (but not both).
   serverConfig.put(KafkaConfig.SslClientAuthProp, "required")
 
-  // Use JAAS configuration properties for clients so that dynamic JAAS configuration is also tested by this set of tests
-  override protected def setJaasConfiguration(mode: SaslSetupMode, serverMechanisms: List[String], clientMechanisms: List[String],
-      serverKeytabFile: Option[File] = None, clientKeytabFile: Option[File] = None) {
-    this.clientKeytabFile = clientKeytabFile;
-    super.setJaasConfiguration(mode, kafkaServerSaslMechanisms, List(), serverKeytabFile, clientKeytabFile)
-    val clientLoginContext = JaasTestUtils.clientLoginModule(kafkaClientSaslMechanism, clientKeytabFile)
-    producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
-    consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext)
-  }
-
-
-  @Test
-  def testConsumer1AllowedConsumer2NotAllowed {
-    setAclsAndProduce()
-    val consumer1 = consumers.head
-
-    val consumer2Config = new Properties
-    consumer2Config.putAll(consumerConfig)
-    val clientLoginContext2 = Krb5LoginModule(
+  override protected def clientLoginContext2 = Krb5LoginModule(
           useKeyTab = true,
           storeKey = true,
           keyTab = this.clientKeytabFile.getOrElse(throw new IllegalArgumentException("Keytab location not specified for GSSAPI")).getAbsolutePath,
@@ -69,26 +45,4 @@ class SaslSslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
           debug = true,
           serviceName = Some("kafka")
         ).toJaasModule.toString.stripMargin
-    consumer2Config.setProperty(SaslConfigs.SASL_JAAS_CONFIG, clientLoginContext2)
-
-    val consumer2 = TestUtils.createNewConsumer(brokerList,
-                                  securityProtocol = this.securityProtocol,
-                                  trustStoreFile = this.trustStoreFile,
-                                  saslProperties = this.saslProperties,
-                                  props = Some(consumer2Config))
-    consumers += consumer2
-
-    consumer1.assign(List(tp).asJava)
-    consumer2.assign(List(tp).asJava)
-
-    consumeRecords(consumer1, numRecords)
-
-    try {
-      consumeRecords(consumer2, timeout = 5000)
-      fail("expected KafkaException as consumer2 has no access to topic")
-    } catch {
-      case e : GroupAuthorizationException => //expected
-    }
-  }
-
 }

--- a/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
@@ -19,8 +19,6 @@ package kafka.api
 
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.protocol.SecurityProtocol
-import org.junit.Ignore
-import org.junit.Test
 import org.junit.Before
 
 

--- a/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SslEndToEndAuthorizationTest.scala
@@ -19,6 +19,9 @@ package kafka.api
 
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.protocol.SecurityProtocol
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.Before
 
 
 class SslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
@@ -26,4 +29,10 @@ class SslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   this.serverConfig.setProperty(SslConfigs.SSL_CLIENT_AUTH_CONFIG, "required")
   override val clientPrincipal = "O=A client,CN=localhost"
   override val kafkaPrincipal = "O=A server,CN=localhost"
+
+  @Before
+  override def setUp {
+    startSasl(ZkSasl, null, null)
+    super.setUp
+  }
 }

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -19,6 +19,7 @@ import java.util.Properties
 
 import kafka.admin.AdminUtils
 import kafka.server.{KafkaConfig, ConfigEntityName, QuotaId}
+import kafka.utils.JaasTestUtils
 
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.junit.Before
@@ -30,7 +31,7 @@ class UserQuotaTest extends BaseQuotaTest with SaslTestHarness {
   override protected val zkSaslEnabled = false
   override protected val saslProperties = Some(kafkaSaslProperties(kafkaClientSaslMechanism, Some(kafkaServerSaslMechanisms)))
 
-  override val userPrincipal = "client"
+  override val userPrincipal = JaasTestUtils.KafkaClientPrincipalUnqualifiedName2
   override val producerQuotaId = QuotaId(Some(userPrincipal), None)
   override val consumerQuotaId = QuotaId(Some(userPrincipal), None)
 

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -101,13 +101,18 @@ object JaasTestUtils {
   private val ZkModule = "org.apache.zookeeper.server.auth.DigestLoginModule"
 
   private val KafkaServerContextName = "KafkaServer"
-  private val KafkaServerPrincipal = "kafka/localhost@EXAMPLE.COM"
+  val KafkaServerPrincipalUnqualifiedName = "kafka"
+  private val KafkaServerPrincipal = KafkaServerPrincipalUnqualifiedName + "/localhost@EXAMPLE.COM"
   private val KafkaClientContextName = "KafkaClient"
-  private val KafkaClientPrincipal = "client@EXAMPLE.COM"
+  val KafkaClientPrincipalUnqualifiedName = "client"
+  private val KafkaClientPrincipal = KafkaClientPrincipalUnqualifiedName + "@EXAMPLE.COM"
+  val KafkaClientPrincipalUnqualifiedName2 = "client2"
   
-  private val KafkaPlainUser = "testuser"
+  val KafkaPlainUser = "testuser"
   private val KafkaPlainPassword = "testuser-secret"
-  private val KafkaPlainAdmin = "admin"
+  val KafkaPlainUser2 = "testuser2"
+  val KafkaPlainPassword2 = "testuser2-secret"
+  val KafkaPlainAdmin = "admin"
   private val KafkaPlainAdminPassword = "admin-secret"
 
   val KafkaScramUser = "scram-user"
@@ -158,7 +163,7 @@ object JaasTestUtils {
           KafkaPlainAdmin,
           KafkaPlainAdminPassword,
           debug = false,
-          Map(KafkaPlainAdmin -> KafkaPlainAdminPassword, KafkaPlainUser -> KafkaPlainPassword)).toJaasModule
+          Map(KafkaPlainAdmin -> KafkaPlainAdminPassword, KafkaPlainUser -> KafkaPlainPassword, KafkaPlainUser2 -> KafkaPlainPassword2)).toJaasModule
       case "SCRAM-SHA-256" | "SCRAM-SHA-512" =>
         ScramLoginModule(
           KafkaScramAdmin,


### PR DESCRIPTION
producers/consumers

Changed caching in LoginManager to allow one LoginManager per client
JAAS configuration.
Added test to End2EndAuthorization for SASL Plain and Gssapi with two
consumers with different credentials.

developed with @mimaison