### PR TITLE
KAFKA-4535: http://kafka.apache.org/quickstart Step 8  missing  argument

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -366,6 +366,7 @@ We can now inspect the output of the WordCount demo application by reading from 
 &gt; <b>bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 \</b>
             <b>--topic streams-wordcount-output \</b>
             <b>--from-beginning \</b>
+            <b>--new-consumer \</b>
             <b>--formatter kafka.tools.DefaultMessageFormatter \</b>
             <b>--property print.key=true \</b>
             <b>--property print.value=true \</b>


### PR DESCRIPTION
consumer missing argument
This patch corrects the error.
Signed-off-by: aurora777 <xin.lihua1@zte.com.cn>