### PR TITLE
MINOR: PartitionInfo toString corrected

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
+++ b/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
@@ -72,13 +72,13 @@ public class PartitionInfo {
         return String.format("Partition(topic = %s, partition = %d, leader = %s, replicas = %s, isr = %s)",
                              topic,
                              partition,
-                             leader == null ? "none" : leader.id(),
-                             fmtNodeIds(replicas),
-                             fmtNodeIds(inSyncReplicas));
+                             leader == null ? "none" : leader.idString(),
+                             formatNodeIds(replicas),
+                             formatNodeIds(inSyncReplicas));
     }
 
     /* Extract the node ids from each item in the array and format for display */
-    private String fmtNodeIds(Node[] nodes) {
+    private String formatNodeIds(Node[] nodes) {
         StringBuilder b = new StringBuilder("[");
         for (int i = 0; i < nodes.length; i++) {
             b.append(nodes[i].idString());

--- a/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
+++ b/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
@@ -80,13 +80,10 @@ public class PartitionInfo {
     /* Extract the node ids from each item in the array and format for display */
     private String fmtNodeIds(Node[] nodes) {
         StringBuilder b = new StringBuilder("[");
-        for (int i = 0; i < nodes.length - 1; i++) {
-            b.append(Integer.toString(nodes[i].id()));
-            b.append(',');
-        }
-        if (nodes.length > 0) {
-            b.append(Integer.toString(nodes[nodes.length - 1].id()));
-            b.append(',');
+        for (int i = 0; i < nodes.length; i++) {
+            b.append(nodes[i].idString());
+            if (i < nodes.length - 1)
+                b.append(',');
         }
         b.append("]");
         return b.toString();

--- a/clients/src/test/java/org/apache/kafka/common/PartitionInfoTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/PartitionInfoTest.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PartitionInfoTest {
+    
+    @Test
+    public void testToString() {
+        String topic = "sample";
+        int partition = 0;
+        Node leader = new Node(0, "localhost", 9092);
+        Node r1 = new Node(1, "localhost", 9093);
+        Node r2 = new Node(2, "localhost", 9094); 
+        Node[] replicas = new Node[] {leader, r1, r2};
+        Node[] inSyncReplicas = new Node[] {leader, r1, r2};
+        PartitionInfo partitionInfo = new PartitionInfo(topic, partition, leader, replicas, inSyncReplicas);
+        
+        String expected = String.format("Partition(topic = %s, partition = %d, leader = %s, replicas = %s, isr = %s)",
+                topic, partition, leader.idString(), "[0,1,2]", "[0,1,2]");
+        assertEquals(expected, partitionInfo.toString());
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/PartitionInfoTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/PartitionInfoTest.java
@@ -12,9 +12,8 @@
  */
 package org.apache.kafka.common;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 public class PartitionInfoTest {
     
@@ -31,7 +30,7 @@ public class PartitionInfoTest {
         
         String expected = String.format("Partition(topic = %s, partition = %d, leader = %s, replicas = %s, isr = %s)",
                 topic, partition, leader.idString(), "[0,1,2]", "[0,1,2]");
-        assertEquals(expected, partitionInfo.toString());
+        Assert.assertEquals(expected, partitionInfo.toString());
     }
 
 }


### PR DESCRIPTION
- Removed the extra ',' character while printing the replicas / in-sync replicas identifier