### PR TITLE
KAFKA-4575: ensure topic created before starting sink for ConnectDistributedTest.test_pause_resume_sink

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSourceTask.java
@@ -122,6 +122,25 @@ public class VerifiableSourceTask extends SourceTask {
     }
 
     @Override
+    public void commitRecord(SourceRecord record) throws InterruptedException {
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", name);
+        data.put("task", id);
+        data.put("topic", this.topic);
+        data.put("time_ms", System.currentTimeMillis());
+        data.put("seqno", record.value());
+        data.put("committed", true);
+
+        String dataJson;
+        try {
+            dataJson = JSON_SERDE.writeValueAsString(data);
+        } catch (JsonProcessingException e) {
+            dataJson = "Bad data can't be written as json: " + e.getMessage();
+        }
+        System.out.println(dataJson);
+    }
+
+    @Override
     public void stop() {
         throttler.wakeup();
     }

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -328,6 +328,12 @@ class VerifiableSource(VerifiableConnector):
         self.topic = topic
         self.throughput = throughput
 
+    def committed_messages(self):
+        return filter(lambda m: 'committed' in m and m['committed'], self.messages())
+
+    def sent_messages(self):
+        return filter(lambda m: 'committed' not in m or not m['committed'], self.messages())
+
     def start(self):
         self.logger.info("Creating connector VerifiableSourceConnector %s", self.name)
         self.cc.create_connector({

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -238,7 +238,7 @@ class ConnectDistributedTest(Test):
         self.source = VerifiableSource(self.cc)
         self.source.start()
 
-        wait_until(lambda: len(self.source.messages()) > 0, timeout_sec=30,
+        wait_until(lambda: len(self.source.committed_messages()) > 0, timeout_sec=30,
                    err_msg="Timeout expired waiting for source task to produce a message")
 
         self.sink = VerifiableSink(self.cc)

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -238,6 +238,9 @@ class ConnectDistributedTest(Test):
         self.source = VerifiableSource(self.cc)
         self.source.start()
 
+        wait_until(lambda: len(self.source.messages()) > 0, timeout_sec=30,
+                   err_msg="Timeout expired waiting for source task to produce a message")
+
         self.sink = VerifiableSink(self.cc)
         self.sink.start()
 
@@ -264,7 +267,7 @@ class ConnectDistributedTest(Test):
 
         # after resuming, we should see records consumed again
         wait_until(lambda: len(self.sink.received_messages()) > num_messages, timeout_sec=30,
-                   err_msg="Failed to consume messages after resuming source connector")
+                   err_msg="Failed to consume messages after resuming sink connector")
 
     @cluster(num_nodes=5)
     def test_pause_state_persistent(self):


### PR DESCRIPTION
Otherwise in this test the sink task goes through the pause/resume cycle with 0 assigned partitions, since the default metadata refresh interval is quite long