### PR TITLE
KAFKA-4603 the argument of shell in doc wrong and command parsed error

### DIFF
--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -65,7 +65,7 @@ object ZkSecurityMigrator extends Logging {
 
   def run(args: Array[String]) {
     var jaasFile = System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)
-    val parser = new OptionParser(false)
+    val parser = new OptionParser
     val zkAclOpt = parser.accepts("zookeeper.acl", "Indicates whether to make the Kafka znodes in ZooKeeper secure or unsecure."
         + " The options are 'secure' and 'unsecure'").withRequiredArg().ofType(classOf[String])
     val zkUrlOpt = parser.accepts("zookeeper.connect", "Sets the ZooKeeper connect string (ensemble). This parameter " +

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -46,9 +46,9 @@ import scala.concurrent.duration._
  * 2- Perform a second rolling upgrade keeping the system property for the login file
  * and now setting zookeeper.set.acl to true
  * 3- Finally run this tool. There is a script under ./bin. Run 
- *   ./bin/zookeeper-security-migration --help
+ *   ./bin/zookeeper-security-migration.sh --help
  * to see the configuration parameters. An example of running it is the following:
- *  ./bin/zookeeper-security-migration --zookeeper.acl=secure --zookeeper.connection=localhost:2181
+ *  ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=localhost:2181
  * 
  * To convert a cluster from secure to unsecure, we need to perform the following
  * steps:

--- a/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
+++ b/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala
@@ -65,7 +65,7 @@ object ZkSecurityMigrator extends Logging {
 
   def run(args: Array[String]) {
     var jaasFile = System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)
-    val parser = new OptionParser()
+    val parser = new OptionParser(false)
     val zkAclOpt = parser.accepts("zookeeper.acl", "Indicates whether to make the Kafka znodes in ZooKeeper secure or unsecure."
         + " The options are 'secure' and 'unsecure'").withRequiredArg().ofType(classOf[String])
     val zkUrlOpt = parser.accepts("zookeeper.connect", "Sets the ZooKeeper connect string (ensemble). This parameter " +

--- a/docs/security.html
+++ b/docs/security.html
@@ -733,11 +733,11 @@
     </ol>
     Here is an example of how to run the migration tool:
     <pre>
-    ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=localhost:2181
+    ./bin/zookeeper-security-migration --zookeeper.acl=secure --zookeeper.connection=localhost:2181
     </pre>
     <p>Run this to see the full list of parameters:</p>
     <pre>
-    ./bin/zookeeper-security-migration.sh --help
+    ./bin/zookeeper-security-migration --help
     </pre>
     <h4><a id="zk_authz_ensemble" href="#zk_authz_ensemble">7.6.3 Migrating the ZooKeeper ensemble</a></h4>
     It is also necessary to enable authentication on the ZooKeeper ensemble. To do it, we need to perform a rolling restart of the server and set a few properties. Please refer to the ZooKeeper documentation for more detail:

--- a/docs/security.html
+++ b/docs/security.html
@@ -733,11 +733,11 @@
     </ol>
     Here is an example of how to run the migration tool:
     <pre>
-    ./bin/zookeeper-security-migration --zookeeper.acl=secure --zookeeper.connection=localhost:2181
+    ./bin/zookeeper-security-migration.sh --zookeeper.acl=secure --zookeeper.connect=localhost:2181
     </pre>
     <p>Run this to see the full list of parameters:</p>
     <pre>
-    ./bin/zookeeper-security-migration --help
+    ./bin/zookeeper-security-migration.sh --help
     </pre>
     <h4><a id="zk_authz_ensemble" href="#zk_authz_ensemble">7.6.3 Migrating the ZooKeeper ensemble</a></h4>
     It is also necessary to enable authentication on the ZooKeeper ensemble. To do it, we need to perform a rolling restart of the server and set a few properties. Please refer to the ZooKeeper documentation for more detail:


### PR DESCRIPTION
    KAFKA-4603 the argument of shell in doc wrong and command parsed error
    In "7.6.2 Migrating clusters" of document security.html, the argument "--zookeeper.connection" of shell "zookeeper-security-migrat.sh"   is wrong  and the using of OptionParser is not correct
    This patch corrected the doc and changed the OptionParser constructor
	
	