### PR TITLE
KAFKA-4580: Use sasl.jaas.config for some system tests

### DIFF
--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -150,7 +150,8 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
 
         # Add security properties to the config. If security protocol is not specified,
         # use the default in the template properties.
-        self.security_config = self.kafka.security_config.client_config_setup(node, prop_file)
+        self.security_config = self.kafka.security_config.client_config(prop_file, node)
+        self.security_config.setup_node(node)
 
         prop_file += str(self.security_config)
         return prop_file

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -150,7 +150,7 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
 
         # Add security properties to the config. If security protocol is not specified,
         # use the default in the template properties.
-        self.security_config = self.kafka.security_config.client_config(prop_file)
+        self.security_config = self.kafka.security_config.client_config_setup(node, prop_file)
 
         prop_file += str(self.security_config)
         return prop_file
@@ -231,7 +231,6 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
         prop_file = self.prop_file(node)
         self.logger.info(prop_file)
         node.account.create_file(ConsoleConsumer.CONFIG_FILE, prop_file)
-        self.security_config.setup_node(node)
 
         # Create and upload log properties
         log_config = self.render('tools_log4j.properties', log_file=ConsoleConsumer.LOG_FILE)

--- a/tests/kafkatest/services/security/security_config.py
+++ b/tests/kafkatest/services/security/security_config.py
@@ -187,7 +187,7 @@ class SecurityConfig(TemplateRenderer):
         if self.static_jaas_conf:
             node.account.create_file(SecurityConfig.JAAS_CONF_PATH, jaas_conf)
         else:
-            self.properties['sasl.jaas.config'] = jaas_conf.replace("\n", "\\\n")
+            self.properties['sasl.jaas.config'] = jaas_conf.replace("\n", " \\\n")
         if self.has_sasl_kerberos:
             node.account.copy_to(MiniKdc.LOCAL_KEYTAB_FILE, SecurityConfig.KEYTAB_PATH)
             node.account.copy_to(MiniKdc.LOCAL_KRB5CONF_FILE, SecurityConfig.KRB5CONF_PATH)

--- a/tests/kafkatest/services/security/templates/jaas.conf
+++ b/tests/kafkatest/services/security/templates/jaas.conf
@@ -12,7 +12,9 @@
   */
 
 
+{% if static_jaas_conf %}
 KafkaClient {
+{% endif %}
 {% if client_sasl_mechanism == "GSSAPI" %}
 {% if is_ibm_jdk %}
     com.ibm.security.auth.module.Krb5LoginModule required debug=false
@@ -37,6 +39,7 @@ KafkaClient {
 	password="{{ SecurityConfig.SCRAM_CLIENT_PASSWORD }}";
 {% endif %}
 
+{% if static_jaas_conf %}
 };
 
 KafkaServer {
@@ -101,4 +104,5 @@ Server {
    principal="zookeeper/{{ node.account.hostname }}@EXAMPLE.COM";
 {% endif %}
 };
+{% endif %}
 {% endif %}

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -169,8 +169,8 @@ class VerifiableConsumer(KafkaPathResolverMixin, BackgroundThreadService):
         node.account.create_file(VerifiableConsumer.LOG4J_CONFIG, log_config)
 
         # Create and upload config file
-	self.security_config = self.kafka.security_config.client_config(self.prop_file, node)
-	self.security_config.setup_node(node)
+        self.security_config = self.kafka.security_config.client_config(self.prop_file, node)
+        self.security_config.setup_node(node)
         self.prop_file += str(self.security_config)
         self.logger.info("verifiable_consumer.properties:")
         self.logger.info(self.prop_file)

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -148,8 +148,6 @@ class VerifiableConsumer(KafkaPathResolverMixin, BackgroundThreadService):
         self.enable_autocommit = enable_autocommit
         self.assignment_strategy = assignment_strategy
         self.prop_file = ""
-        self.security_config = kafka.security_config.client_config(self.prop_file)
-        self.prop_file += str(self.security_config)
         self.stop_timeout_sec = stop_timeout_sec
 
         self.event_handlers = {}
@@ -171,6 +169,8 @@ class VerifiableConsumer(KafkaPathResolverMixin, BackgroundThreadService):
         node.account.create_file(VerifiableConsumer.LOG4J_CONFIG, log_config)
 
         # Create and upload config file
+        self.security_config = self.kafka.security_config.client_config_setup(node, self.prop_file)
+        self.prop_file += str(self.security_config)
         self.logger.info("verifiable_consumer.properties:")
         self.logger.info(self.prop_file)
         node.account.create_file(VerifiableConsumer.CONFIG_FILE, self.prop_file)

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -169,7 +169,8 @@ class VerifiableConsumer(KafkaPathResolverMixin, BackgroundThreadService):
         node.account.create_file(VerifiableConsumer.LOG4J_CONFIG, log_config)
 
         # Create and upload config file
-        self.security_config = self.kafka.security_config.client_config_setup(node, self.prop_file)
+	self.security_config = self.kafka.security_config.client_config(self.prop_file, node)
+	self.security_config.setup_node(node)
         self.prop_file += str(self.security_config)
         self.logger.info("verifiable_consumer.properties:")
         self.logger.info(self.prop_file)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -83,10 +83,6 @@ class VerifiableProducer(KafkaPathResolverMixin, BackgroundThreadService):
         self.acks = acks
         self.stop_timeout_sec = stop_timeout_sec
 
-    @property
-    def security_config(self):
-        return self.kafka.security_config.client_config()
-
     def prop_file(self, node):
         idx = self.idx(node)
         prop_file = str(self.security_config)
@@ -104,6 +100,9 @@ class VerifiableProducer(KafkaPathResolverMixin, BackgroundThreadService):
         log_config = self.render('tools_log4j.properties', log_file=VerifiableProducer.LOG_FILE)
         node.account.create_file(VerifiableProducer.LOG4J_CONFIG, log_config)
 
+        # Configure security
+        self.security_config = self.kafka.security_config.client_config_setup(node)
+
         # Create and upload config file
         producer_prop_file = self.prop_file(node)
         if self.acks is not None:
@@ -112,7 +111,6 @@ class VerifiableProducer(KafkaPathResolverMixin, BackgroundThreadService):
         self.logger.info("verifiable_producer.properties:")
         self.logger.info(producer_prop_file)
         node.account.create_file(VerifiableProducer.CONFIG_FILE, producer_prop_file)
-        self.security_config.setup_node(node)
 
         cmd = self.start_cmd(node, idx)
         self.logger.debug("VerifiableProducer %d command: %s" % (idx, cmd))

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -101,7 +101,8 @@ class VerifiableProducer(KafkaPathResolverMixin, BackgroundThreadService):
         node.account.create_file(VerifiableProducer.LOG4J_CONFIG, log_config)
 
         # Configure security
-        self.security_config = self.kafka.security_config.client_config_setup(node)
+        self.security_config = self.kafka.security_config.client_config(node=node)
+	self.security_config.setup_node(node)
 
         # Create and upload config file
         producer_prop_file = self.prop_file(node)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -102,7 +102,7 @@ class VerifiableProducer(KafkaPathResolverMixin, BackgroundThreadService):
 
         # Configure security
         self.security_config = self.kafka.security_config.client_config(node=node)
-	self.security_config.setup_node(node)
+        self.security_config.setup_node(node)
 
         # Create and upload config file
         producer_prop_file = self.prop_file(node)


### PR DESCRIPTION
Switched console_consumer, verifiable_consumer and verifiable_producer to use new sasl.jaas_config property instead of static JAAS configuration file when used with SASL_PLAINTEXT.