### PR TITLE
MINOR:  add file append to connect-log4j.properties

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -13,11 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=INFO, stdout, connectAppender
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.appender.connectAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.connectAppender.File=${kafka.logs.dir}/connect.log
+log4j.appender.connectAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.connectAppender.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.appender.connectAppender.MaxBackupIndex=10
+log4j.appender.connectAppender.MaxFileSize=100MB
+log4j.appender.connectAppender.Append=true
 
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -13,47 +13,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, stdout 
+log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-log4j.appender.kafkaAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.kafkaAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.kafkaAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.kafkaAppender.File=${kafka.logs.dir}/server.log
 log4j.appender.kafkaAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.kafkaAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.kafkaAppender.MaxBackupIndex=10
+log4j.appender.kafkaAppender.MaxFileSize=100MB
+log4j.appender.kafkaAppender.Append=true
 
-log4j.appender.stateChangeAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.stateChangeAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.stateChangeAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.stateChangeAppender.File=${kafka.logs.dir}/state-change.log
 log4j.appender.stateChangeAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.stateChangeAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.stateChangeAppender.MaxBackupIndex=10
+log4j.appender.stateChangeAppender.MaxFileSize=100MB
+log4j.appender.stateChangeAppender.Append=true
 
-log4j.appender.requestAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.requestAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.requestAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.requestAppender.File=${kafka.logs.dir}/kafka-request.log
 log4j.appender.requestAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.requestAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.requestAppender.MaxBackupIndex=10
+log4j.appender.requestAppender.MaxFileSize=100MB
+log4j.appender.requestAppender.Append=true
 
-log4j.appender.cleanerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.cleanerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.cleanerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.cleanerAppender.File=${kafka.logs.dir}/log-cleaner.log
 log4j.appender.cleanerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.cleanerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.cleanerAppender.MaxBackupIndex=10
+log4j.appender.cleanerAppender.MaxFileSize=100MB
+log4j.appender.cleanerAppender.Append=true
 
-log4j.appender.controllerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.controllerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.controllerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.controllerAppender.File=${kafka.logs.dir}/controller.log
 log4j.appender.controllerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.controllerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.controllerAppender.MaxBackupIndex=10
+log4j.appender.controllerAppender.MaxFileSize=100MB
+log4j.appender.controllerAppender.Append=true
 
-log4j.appender.authorizerAppender=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.authorizerAppender.DatePattern='.'yyyy-MM-dd-HH
+log4j.appender.authorizerAppender=org.apache.log4j.RollingFileAppender
 log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
+log4j.appender.authorizerAppender.MaxBackupIndex=10
+log4j.appender.authorizerAppender.MaxFileSize=100MB
+log4j.appender.authorizerAppender.Append=true
 
 # Turn on all our debugging info
 #log4j.logger.kafka.producer.async.DefaultEventHandler=DEBUG, kafkaAppender
@@ -84,4 +96,3 @@ log4j.additivity.state.change.logger=false
 #Change this to debug to get the actual audit log for authorizer.
 log4j.logger.kafka.authorizer.logger=WARN, authorizerAppender
 log4j.additivity.kafka.authorizer.logger=false
-


### PR DESCRIPTION
The default log4j for kafka connect should include a log to file.
(It would be nice)