### PR TITLE
MINOR: ConfigDef `parseType` exception message updated.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -631,7 +631,7 @@ public class ConfigDef {
                     } else if (value instanceof String) {
                         return Short.parseShort(trimmed);
                     } else {
-                        throw new ConfigException(name, value, "Expected value to be a short / string, but it was a " + value.getClass().getName());
+                        throw new ConfigException(name, value, "Expected value to be a short, but it was a " + value.getClass().getName());
                     }
                 case LONG:
                     if (value instanceof Integer)

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -631,7 +631,7 @@ public class ConfigDef {
                     } else if (value instanceof String) {
                         return Short.parseShort(trimmed);
                     } else {
-                        throw new ConfigException(name, value, "Expected value to be a short, but it was a " + value.getClass().getName());
+                        throw new ConfigException(name, value, "Expected value to be a 16-bit integer (short), but it was a " + value.getClass().getName());
                     }
                 case LONG:
                     if (value instanceof Integer)

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -623,7 +623,7 @@ public class ConfigDef {
                     } else if (value instanceof String) {
                         return Integer.parseInt(trimmed);
                     } else {
-                        throw new ConfigException(name, value, "Expected value to be an number.");
+                        throw new ConfigException(name, value, "Expected value to be an integer, but it was a " + value.getClass().getName());
                     }
                 case SHORT:
                     if (value instanceof Short) {
@@ -631,7 +631,7 @@ public class ConfigDef {
                     } else if (value instanceof String) {
                         return Short.parseShort(trimmed);
                     } else {
-                        throw new ConfigException(name, value, "Expected value to be an number.");
+                        throw new ConfigException(name, value, "Expected value to be a short / string, but it was a " + value.getClass().getName());
                     }
                 case LONG:
                     if (value instanceof Integer)
@@ -641,14 +641,14 @@ public class ConfigDef {
                     else if (value instanceof String)
                         return Long.parseLong(trimmed);
                     else
-                        throw new ConfigException(name, value, "Expected value to be an number.");
+                        throw new ConfigException(name, value, "Expected value to be a long, but it was a " + value.getClass().getName());
                 case DOUBLE:
                     if (value instanceof Number)
                         return ((Number) value).doubleValue();
                     else if (value instanceof String)
                         return Double.parseDouble(trimmed);
                     else
-                        throw new ConfigException(name, value, "Expected value to be an number.");
+                        throw new ConfigException(name, value, "Expected value to be a double, but it was a " + value.getClass().getName());
                 case LIST:
                     if (value instanceof List)
                         return (List<?>) value;


### PR DESCRIPTION
 - When Kafka configurations are provided programmatically, for the below configuration incorrect error message gets printed.
        * configuration: kafkaProps.put("zookeeper.session.timeout.ms", 60_000L); - expects Integer value
        * Error Msg: "Invalid value 60000 for configuration zookeeper.session.timeout.ms : Expected value to be an number."
        * Long is also a number which misleads the error message.