### PR TITLE
Initial commit of partition assignment check in console consumer.

### DIFF
--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -18,7 +18,6 @@
  */
 package kafka.tools
 
-import java.io.IOException
 import java.util.Date
 import java.text.SimpleDateFormat
 import javax.management._
@@ -30,6 +29,12 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.math._
 import kafka.utils.{CommandLineUtils, Exit, Logging}
+
+
+/**
+  * A program for reading JMX metrics from a given endpoint. This tool only works reliably if the JmxServer is fully
+  * initialized prior to invoking the tool. See KAFKA-4620 for details.
+  */
 
 object JmxTool extends Logging {
 
@@ -84,8 +89,8 @@ object JmxTool extends Logging {
     val dateFormatExists = options.has(dateFormatOpt)
     val dateFormat = if(dateFormatExists) Some(new SimpleDateFormat(options.valueOf(dateFormatOpt))) else None
 
-    var jmxc : JMXConnector = null
-    var mbsc : MBeanServerConnection = null
+    var jmxc: JMXConnector = null
+    var mbsc: MBeanServerConnection = null
     var retries = 0
     val maxNumRetries = 20
     var connected = false
@@ -96,18 +101,18 @@ object JmxTool extends Logging {
         mbsc = jmxc.getMBeanServerConnection()
         connected = true
       } catch {
-        case e : Exception => {
-          System.err.println("Could not connect to JMX url: %s. Exception %s".format(url, e.getMessage))
+        case e : Exception =>
+          System.err.println(s"Could not connect to JMX url: ${url}. Exception ${e.getMessage}.")
+          e.printStackTrace()
           retries += 1
           Thread.sleep(500)
-        }
       }
     }
 
     if (!connected) {
       System.err.println("Could not connect to JMX url %s after %d retries".format(url, maxNumRetries))
       System.err.println("Exiting")
-      System.exit(1)
+      sys.exit(1)
     }
 
     val queries: Iterable[ObjectName] =

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -89,31 +89,8 @@ object JmxTool extends Logging {
     val dateFormatExists = options.has(dateFormatOpt)
     val dateFormat = if(dateFormatExists) Some(new SimpleDateFormat(options.valueOf(dateFormatOpt))) else None
 
-    var jmxc: JMXConnector = null
-    var mbsc: MBeanServerConnection = null
-    var retries = 0
-    val maxNumRetries = 10
-    var connected = false
-    while (retries < maxNumRetries && !connected) {
-      try {
-        System.err.println("Trying to connect to JMX url: %s".format(url))
-        jmxc = JMXConnectorFactory.connect(url, null)
-        mbsc = jmxc.getMBeanServerConnection()
-        connected = true
-      } catch {
-        case e : Exception =>
-          System.err.println(s"Could not connect to JMX url: ${url}. Exception ${e.getMessage}.")
-          e.printStackTrace()
-          retries += 1
-          Thread.sleep(500)
-      }
-    }
-
-    if (!connected) {
-      System.err.println("Could not connect to JMX url %s after %d retries".format(url, maxNumRetries))
-      System.err.println("Exiting")
-      sys.exit(1)
-    }
+    val jmxc = JMXConnectorFactory.connect(url, null)
+    val mbsc = jmxc.getMBeanServerConnection()
 
     val queries: Iterable[ObjectName] =
       if(options.has(objectNameOpt))

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -92,7 +92,7 @@ object JmxTool extends Logging {
     var jmxc: JMXConnector = null
     var mbsc: MBeanServerConnection = null
     var retries = 0
-    val maxNumRetries = 20
+    val maxNumRetries = 10
     var connected = false
     while (retries < maxNumRetries && !connected) {
       try {

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -89,8 +89,31 @@ object JmxTool extends Logging {
     val dateFormatExists = options.has(dateFormatOpt)
     val dateFormat = if(dateFormatExists) Some(new SimpleDateFormat(options.valueOf(dateFormatOpt))) else None
 
-    val jmxc = JMXConnectorFactory.connect(url, null)
-    val mbsc = jmxc.getMBeanServerConnection()
+    var jmxc: JMXConnector = null
+    var mbsc: MBeanServerConnection = null
+    var retries = 0
+    val maxNumRetries = 10
+    var connected = false
+    while (retries < maxNumRetries && !connected) {
+      try {
+        System.err.println("Trying to connect to JMX url: %s".format(url))
+        jmxc = JMXConnectorFactory.connect(url, null)
+        mbsc = jmxc.getMBeanServerConnection()
+        connected = true
+      } catch {
+        case e : Exception =>
+          System.err.println(s"Could not connect to JMX url: ${url}. Exception ${e.getMessage}.")
+          e.printStackTrace()
+          retries += 1
+          Thread.sleep(500)
+      }
+    }
+
+    if (!connected) {
+      System.err.println("Could not connect to JMX url %s after %d retries".format(url, maxNumRetries))
+      System.err.println("Exiting")
+      sys.exit(1)
+    }
 
     val queries: Iterable[ObjectName] =
       if(options.has(objectNameOpt))

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -150,9 +150,11 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
         if self.jmx_object_names is None:
            self.jmx_object_names = []
 
-        self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
-        self.jmx_attributes += ["assigned-partitions"]
-        self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id
+
+        if self.new_consumer is True:
+            self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
+            self.jmx_attributes += ["assigned-partitions"]
+            self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id
 
 
     def prop_file(self, node):
@@ -266,7 +268,6 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
 
             for line in itertools.chain([first_line], consumer_output):
                 msg = line.strip()
-
                 if msg == "shutdown_complete":
                     # Note that we can only rely on shutdown_complete message if running 0.10.0 or greater
                     if node in self.clean_shutdown_nodes:

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -88,11 +88,7 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
             "collect_default": True},
         "jmx_log": {
             "path" : JMX_TOOL_LOG,
-            "collect_default": True},
-        "jmx_err_log": {
-            "path": JMX_TOOL_ERROR_LOG,
-            "collect_default": True
-        }
+            "collect_default": True}
     }
 
     def __init__(self, context, num_nodes, kafka, topic, group_id="test-consumer-group", new_consumer=True,

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -143,13 +143,6 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
             assert version >= V_0_10_0_0
 
         self.print_timestamp = print_timestamp
-        if self.new_consumer is True:
-            if self.jmx_object_names is None:
-                self.jmx_object_names = []
-            self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
-            self.jmx_attributes += ["assigned-partitions"]
-            self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id
-
 
     def prop_file(self, node):
         """Return a string which can be used to create a configuration file appropriate for the given node."""
@@ -258,6 +251,13 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
 
         if first_line is not None:
             self.logger.debug("collecting following jmx objects: %s", self.jmx_object_names)
+            if self.new_consumer is True:
+                if self.jmx_object_names is None:
+                    self.jmx_object_names = []
+                self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
+                self.jmx_attributes += ["assigned-partitions"]
+                self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id
+
             self.start_jmx_tool(idx, node)
 
             for line in itertools.chain([first_line], consumer_output):
@@ -295,6 +295,8 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
         self.security_config.clean_node(node)
 
     def has_partitions_assigned(self, node):
+       if self.new_consumer is False:
+          return False
        idx = self.idx(node)
        self.start_jmx_tool(idx, node)
        self.read_jmx_output(idx, node)

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -147,11 +147,9 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
             assert version >= V_0_10_0_0
 
         self.print_timestamp = print_timestamp
-        if self.jmx_object_names is None:
-           self.jmx_object_names = []
-
-
         if self.new_consumer is True:
+            if self.jmx_object_names is None:
+                self.jmx_object_names = []
             self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
             self.jmx_attributes += ["assigned-partitions"]
             self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -88,7 +88,10 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
             "collect_default": True},
         "jmx_log": {
             "path" : JMX_TOOL_LOG,
-            "collect_default": True}
+            "collect_default": False},
+        "jmx_err_log": {
+            "path": JMX_TOOL_ERROR_LOG,
+            "collect_default": False}
     }
 
     def __init__(self, context, num_nodes, kafka, topic, group_id="test-consumer-group", new_consumer=True,

--- a/tests/kafkatest/services/console_consumer.py
+++ b/tests/kafkatest/services/console_consumer.py
@@ -254,13 +254,7 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
 
         if first_line is not None:
             self.logger.debug("collecting following jmx objects: %s", self.jmx_object_names)
-            if self.new_consumer is True:
-                if self.jmx_object_names is None:
-                    self.jmx_object_names = []
-                self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
-                self.jmx_attributes += ["assigned-partitions"]
-                self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id
-
+            self.init_jmx_attributes()
             self.start_jmx_tool(idx, node)
 
             for line in itertools.chain([first_line], consumer_output):
@@ -301,9 +295,19 @@ class ConsoleConsumer(KafkaPathResolverMixin, JmxMixin, BackgroundThreadService)
        if self.new_consumer is False:
           return False
        idx = self.idx(node)
+       self.init_jmx_attributes()
        self.start_jmx_tool(idx, node)
        self.read_jmx_output(idx, node)
        if not self.assigned_partitions_jmx_attr in self.maximum_jmx_value:
            return False
        self.logger.debug("Number of partitions assigned %f" % self.maximum_jmx_value[self.assigned_partitions_jmx_attr])
        return self.maximum_jmx_value[self.assigned_partitions_jmx_attr] > 0.0
+
+    def init_jmx_attributes(self):
+        if self.new_consumer is True:
+            if self.jmx_object_names is None:
+                self.jmx_object_names = []
+                self.jmx_object_names += ["kafka.consumer:type=consumer-coordinator-metrics,client-id=%s" % self.client_id]
+                self.jmx_attributes += ["assigned-partitions"]
+                self.assigned_partitions_jmx_attr = "kafka.consumer:type=consumer-coordinator-metrics,client-id=%s:assigned-partitions" % self.client_id
+

--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -35,6 +35,7 @@ class JmxMixin(object):
         self.average_jmx_value = {}  # map from object_attribute_name to average value observed over time
 
         self.jmx_tool_log = "/mnt/jmx_tool.log"
+        self.jmx_tool_err_log = "/mnt/jmx_tool.err.log"
 
     def clean_node(self, node):
         node.account.kill_process("jmx", clean_shutdown=False, allow_fail=True)
@@ -55,11 +56,12 @@ class JmxMixin(object):
             cmd += " --object-name %s" % jmx_object_name
         for jmx_attribute in self.jmx_attributes:
             cmd += " --attributes %s" % jmx_attribute
-        cmd += " >> %s &" % self.jmx_tool_log
+        cmd += " 1>> %s" % self.jmx_tool_log
+        cmd += " 2>> %s &" % self.jmx_tool_err_log
 
         self.logger.debug("%s: Start JmxTool %d command: %s" % (node.account, idx, cmd))
         node.account.ssh(cmd, allow_fail=False)
-        wait_until(lambda: self._jmx_has_output(node), timeout_sec=5, backoff_sec=.5, err_msg="%s: Jmx tool took too long to start" % node.account)
+        wait_until(lambda: self._jmx_has_output(node), timeout_sec=10, backoff_sec=.5, err_msg="%s: Jmx tool took too long to start" % node.account)
         self.started[idx-1] = True
 
     def _jmx_has_output(self, node):

--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -57,7 +57,7 @@ class JmxMixin(object):
         for jmx_attribute in self.jmx_attributes:
             cmd += " --attributes %s" % jmx_attribute
         cmd += " 1>> %s" % self.jmx_tool_log
-        cmd += " 2>> %s &" % self.jmx_tool_err_log
+        # cmd += " 2>> %s &" % self.jmx_tool_err_log
 
         self.logger.debug("%s: Start JmxTool %d command: %s" % (node.account, idx, cmd))
         node.account.ssh(cmd, allow_fail=False)

--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -56,7 +56,7 @@ class JmxMixin(object):
             cmd += " --object-name %s" % jmx_object_name
         for jmx_attribute in self.jmx_attributes:
             cmd += " --attributes %s" % jmx_attribute
-        cmd += " 1>> %s" % self.jmx_tool_log
+        cmd += " 1>> %s &" % self.jmx_tool_log
         # cmd += " 2>> %s &" % self.jmx_tool_err_log
 
         self.logger.debug("%s: Start JmxTool %d command: %s" % (node.account, idx, cmd))

--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -56,8 +56,8 @@ class JmxMixin(object):
             cmd += " --object-name %s" % jmx_object_name
         for jmx_attribute in self.jmx_attributes:
             cmd += " --attributes %s" % jmx_attribute
-        cmd += " 1>> %s &" % self.jmx_tool_log
-        # cmd += " 2>> %s &" % self.jmx_tool_err_log
+        cmd += " 1>> %s" % self.jmx_tool_log
+        cmd += " 2>> %s &" % self.jmx_tool_err_log
 
         self.logger.debug("%s: Start JmxTool %d command: %s" % (node.account, idx, cmd))
         node.account.ssh(cmd, allow_fail=False)

--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -15,7 +15,7 @@
 
 import time
 import math
-from ducktape.mark import parametrize,ignore
+from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
@@ -138,10 +138,9 @@ class ThrottlingTest(ProduceConsumeValidateTest):
                 estimated_throttled_time,
                 time_taken))
 
-    @ignore
     @cluster(num_nodes=10)
-    @parametrize(bounce_brokers=False)
     @parametrize(bounce_brokers=True)
+    @parametrize(bounce_brokers=False)
     def test_throttled_reassignment(self, bounce_brokers):
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -50,6 +50,14 @@ class ProduceConsumeValidateTest(Test):
         # Start background producer and consumer
         self.consumer.start()
         if (self.consumer_init_timeout_sec > 0):
+            self.logger.debug("Waiting %ds for the consumer to initialize.",
+                              self.consumer_init_timeout_sec)
+            start = int(time.time())
+            wait_until(lambda: self.consumer.alive(self.consumer.nodes[0]) is True,
+                       timeout_sec=self.consumer_init_timeout_sec,
+                       err_msg="Consumer process took more than %d s to fork" %\
+                       self.consumer_init_timeout_sec)
+            end = int(time.time())
             # TODO(apurva): This sleep is a hack. The problem is that the
             # the JmxTool is spawned before the consumer process is fully
             # initialized. Hence the connection fails. Retries on connection
@@ -62,14 +70,6 @@ class ProduceConsumeValidateTest(Test):
             #
             # This is covered in KAFKA-4620
             time.sleep(1)
-            self.logger.debug("Waiting %ds for the consumer to initialize.",
-                              self.consumer_init_timeout_sec)
-            start = int(time.time())
-            wait_until(lambda: self.consumer.alive(self.consumer.nodes[0]) is True,
-                       timeout_sec=self.consumer_init_timeout_sec,
-                       err_msg="Consumer process took more than %d s to fork" %\
-                       self.consumer_init_timeout_sec)
-            end = int(time.time())
             remaining_time = self.consumer_init_timeout_sec - (end - start)
             if remaining_time < 0 :
                 remaining_time = 0

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -15,7 +15,7 @@
 
 from ducktape.tests.test import Test
 from ducktape.utils.util import wait_until
-
+import time
 
 class ProduceConsumeValidateTest(Test):
     """This class provides a shared template for tests which follow the common pattern of:
@@ -50,12 +50,33 @@ class ProduceConsumeValidateTest(Test):
         # Start background producer and consumer
         self.consumer.start()
         if (self.consumer_init_timeout_sec > 0):
-            self.logger.debug("Waiting %ds for the consumer to fork.",
+            # TODO(apurva): This sleep is a hack. The problem is that the
+            # the JmxTool is spawned before the consumer process is fully
+            # initialized. Hence the connection fails. Retries on connection
+            # failures were added to the JmxTool, but unfortunately, it appears
+            # that the exception does not bubble to the top level, rendering
+            # the retry loop useless.
+            #
+            # We can remove this sleep once we figure out a way to do proper
+            # retries in JMXTool.
+            #
+            # This is covered in KAFKA-4620
+            time.sleep(1)
+            self.logger.debug("Waiting %ds for the consumer to initialize.",
                               self.consumer_init_timeout_sec)
+            start = int(time.time())
             wait_until(lambda: self.consumer.alive(self.consumer.nodes[0]) is True,
                        timeout_sec=self.consumer_init_timeout_sec,
                        err_msg="Consumer process took more than %d s to fork" %\
                        self.consumer_init_timeout_sec)
+            end = int(time.time())
+            remaining_time = self.consumer_init_timeout_sec - (end - start)
+            if remaining_time < 0 :
+                remaining_time = 0
+            wait_until(lambda: self.consumer.has_partitions_assigned(self.consumer.nodes[0]) is True,
+                       timeout_sec=remaining_time,
+                       err_msg="Consumer process took more than %d s to have partitions assigned" %\
+                       remaining_time)
 
         self.producer.start()
         wait_until(lambda: self.producer.num_acked > 5,

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -67,10 +67,11 @@ class ProduceConsumeValidateTest(Test):
             remaining_time = self.consumer_init_timeout_sec - (end - start)
             if remaining_time < 0 :
                 remaining_time = 0
-            wait_until(lambda: self.consumer.has_partitions_assigned(self.consumer.nodes[0]) is True,
-                       timeout_sec=remaining_time,
-                       err_msg="Consumer process took more than %d s to have partitions assigned" %\
-                       remaining_time)
+            if self.consumer.new_consumer is True:
+                wait_until(lambda: self.consumer.has_partitions_assigned(self.consumer.nodes[0]) is True,
+                           timeout_sec=remaining_time,
+                           err_msg="Consumer process took more than %d s to have partitions assigned" %\
+                           remaining_time)
 
         self.producer.start()
         wait_until(lambda: self.producer.num_acked > 5,

--- a/tests/kafkatest/tests/produce_consume_validate.py
+++ b/tests/kafkatest/tests/produce_consume_validate.py
@@ -58,17 +58,11 @@ class ProduceConsumeValidateTest(Test):
                        err_msg="Consumer process took more than %d s to fork" %\
                        self.consumer_init_timeout_sec)
             end = int(time.time())
-            # TODO(apurva): This sleep is a hack. The problem is that the
-            # the JmxTool is spawned before the consumer process is fully
-            # initialized. Hence the connection fails. Retries on connection
-            # failures were added to the JmxTool, but unfortunately, it appears
-            # that the exception does not bubble to the top level, rendering
-            # the retry loop useless.
-            #
-            # We can remove this sleep once we figure out a way to do proper
-            # retries in JMXTool.
-            #
-            # This is covered in KAFKA-4620
+            # If `JMXConnectFactory.connect` is invoked during the
+            # initialization of the JMX server, it may fail to throw the
+            # specified IOException back to the calling code. The sleep is a
+            # workaround that should allow initialization to complete before we
+            # try to connect. See KAFKA-4620 for more details.
             time.sleep(1)
             remaining_time = self.consumer_init_timeout_sec - (end - start)
             if remaining_time < 0 :


### PR DESCRIPTION
With this patch, the consumer will considered initialized in the ProduceConsumeValidate tests only if it has partitions assigned.