### PR TITLE
KAFKA-4581: Fail early if multiple client login modules in sasl.jaas.config

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
@@ -55,8 +55,13 @@ public class JaasUtils {
         if (jaasConfigArgs != null) {
             if (loginType == LoginType.SERVER)
                 throw new IllegalArgumentException("JAAS config property not supported for server");
-            else
-                return new JaasConfig(loginType, jaasConfigArgs.value());
+            else {
+                JaasConfig jaasConfig = new JaasConfig(loginType, jaasConfigArgs.value());
+                AppConfigurationEntry[] clientModules = jaasConfig.getAppConfigurationEntry(LoginType.CLIENT.contextName());
+                if (clientModules != null && clientModules.length != 1)
+                    throw new IllegalArgumentException("JAAS config property for clients must specify only one login module");
+                return jaasConfig;
+            }
         } else
             return defaultJaasConfig(loginType);
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasUtils.java
@@ -58,8 +58,9 @@ public class JaasUtils {
             else {
                 JaasConfig jaasConfig = new JaasConfig(loginType, jaasConfigArgs.value());
                 AppConfigurationEntry[] clientModules = jaasConfig.getAppConfigurationEntry(LoginType.CLIENT.contextName());
-                if (clientModules != null && clientModules.length != 1)
-                    throw new IllegalArgumentException("JAAS config property for clients must specify only one login module");
+                int numModules = clientModules == null ? 0 : clientModules.length;
+                if (numModules != 1)
+                    throw new IllegalArgumentException("JAAS config property contains " + numModules + " login modules, should be one module");
                 return jaasConfig;
             }
         } else

--- a/clients/src/test/java/org/apache/kafka/common/security/JaasUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/JaasUtilsTest.java
@@ -129,9 +129,7 @@ public class JaasUtilsTest {
         }
         String jaasConfigProp = builder.toString();
 
-        Map<String, Object> configs = new HashMap<>();
-        configs.put(SaslConfigs.SASL_JAAS_CONFIG, new Password(jaasConfigProp));
-        Configuration configuration = JaasUtils.jaasConfig(LoginType.CLIENT, configs);
+        Configuration configuration = new JaasConfig(LoginType.CLIENT, jaasConfigProp);
         AppConfigurationEntry[] dynamicEntries = configuration.getAppConfigurationEntry(LoginType.CLIENT.contextName());
         assertEquals(moduleCount, dynamicEntries.length);
 


### PR DESCRIPTION
Validate and fail client connection if multiple login modules are specified in sasl.jaas.config to avoid harder-to-debug authentication failures later on.