### PR TITLE
KAFKA-3452: follow up - fix state store restoration for session and window stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -29,6 +29,7 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
     private final String name;
     private final Segments segments;
     private final KeySchema keySchema;
+    private final boolean logged;
     private ProcessorContext context;
     private volatile boolean open;
 
@@ -36,9 +37,11 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
     RocksDBSegmentedBytesStore(final String name,
                                final long retention,
                                final int numSegments,
-                               final KeySchema keySchema) {
+                               final KeySchema keySchema,
+                               final boolean logged) {
         this.name = name;
         this.keySchema = keySchema;
+        this.logged = logged;
         this.segments = new Segments(name, retention, numSegments);
     }
 
@@ -98,7 +101,7 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
         segments.openExisting(context);
 
         // register and possibly restore the state from the logs
-        context.register(root, false, new StateRestoreCallback() {
+        context.register(root, logged, new StateRestoreCallback() {
             @Override
             public void restore(byte[] key, byte[] value) {
                 put(Bytes.wrap(key), value);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplier.java
@@ -52,7 +52,7 @@ public class RocksDBSessionStoreSupplier<K, V> extends AbstractStoreSupplier<K, 
         final RocksDBSegmentedBytesStore bytesStore = new RocksDBSegmentedBytesStore(name,
                                                                                      retentionPeriod,
                                                                                      NUM_SEGMENTS,
-                                                                                     new SessionKeySchema());
+                                                                                     new SessionKeySchema(), logged);
         final MeteredSegmentedBytesStore metered = new MeteredSegmentedBytesStore(logged ? new ChangeLoggingSegmentedBytesStore(bytesStore)
                                                                                           : bytesStore, "rocksdb-session-store", time);
         if (enableCaching) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplier.java
@@ -58,7 +58,7 @@ public class RocksDBWindowStoreSupplier<K, V> extends AbstractStoreSupplier<K, V
     }
 
     public WindowStore get() {
-        final RocksDBSegmentedBytesStore bytesStore = new RocksDBSegmentedBytesStore(name, retentionPeriod, numSegments, new WindowStoreKeySchema());
+        final RocksDBSegmentedBytesStore bytesStore = new RocksDBSegmentedBytesStore(name, retentionPeriod, numSegments, new WindowStoreKeySchema(), logged);
         if (!enableCaching) {
             final RocksDBWindowStore<K, V> segmentedStore = new RocksDBWindowStore<>(name, retainDuplicates, keySerde, valueSerde,
                                                                                      logged ? new ChangeLoggingSegmentedBytesStore(bytesStore)

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -58,7 +58,7 @@ public class CachingSessionStoreTest {
 
     @Before
     public void setUp() throws Exception {
-        underlying = new RocksDBSegmentedBytesStore("test", 60000, 3, new SessionKeySchema());
+        underlying = new RocksDBSegmentedBytesStore("test", 60000, 3, new SessionKeySchema(), false);
         cachingStore = new CachingSessionStore<>(underlying,
                                                  Serdes.String(),
                                                  Serdes.Long());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -58,7 +58,7 @@ public class CachingWindowStoreTest {
     @Before
     public void setUp() throws Exception {
         keySchema = new WindowStoreKeySchema();
-        underlying = new RocksDBSegmentedBytesStore("test", 30000, 3, keySchema);
+        underlying = new RocksDBSegmentedBytesStore("test", 30000, 3, keySchema, false);
         cacheListener = new CachingKeyValueStoreTest.CacheFlushListenerStub<>();
         cachingStore = new CachingWindowStore<>(underlying,
                                                 Serdes.String(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
@@ -59,7 +59,8 @@ public class RocksDBSegmentedBytesStoreTest {
         bytesStore = new RocksDBSegmentedBytesStore(storeName,
                                                     retention,
                                                     numSegments,
-                                                    new SessionKeySchema());
+                                                    new SessionKeySchema(),
+                                                    false);
 
         stateDir = TestUtils.tempDirectory();
         final MockProcessorContext context = new MockProcessorContext(null,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplierTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.streams.state.SessionStore;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.NoOpRecordCollector;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RocksDBSessionStoreSupplierTest {
+
+    @Test
+    public void shouldRegisterWithLoggingEnabledWhenStoreLogged() throws Exception {
+        final SessionStore sessionStore = createStore(true, false);
+        sessionStore.init(new MockProcessorContext(new StateSerdes<>("", Serdes.String(), Serdes.String()), new NoOpRecordCollector()) {
+            @Override
+            public void register(final StateStore store, final boolean loggingEnabled, final StateRestoreCallback func) {
+                assertTrue("store should be registering as loggingEnabled", loggingEnabled);
+            }
+        }, sessionStore);
+    }
+
+    @Test
+    public void shouldRegisterWithLoggingEnabledWhenStoreLoggedAndCached() throws Exception {
+        final SessionStore sessionStore = createStore(true, true);
+        sessionStore.init(new MockProcessorContext(new StateSerdes<>("", Serdes.String(), Serdes.String()), new NoOpRecordCollector()) {
+            @Override
+            public void register(final StateStore store, final boolean loggingEnabled, final StateRestoreCallback func) {
+                assertTrue("store should be registering as loggingEnabled", loggingEnabled);
+            }
+
+            @Override
+            public ThreadCache getCache() {
+                return new ThreadCache("name", 0, new MockStreamsMetrics(new Metrics()));
+            }
+        }, sessionStore);
+    }
+
+    @Test
+    public void shouldRegisterWithLoggingDisabledWhenStoreNotLogged() throws Exception {
+        final SessionStore sessionStore = createStore(false, false);
+        sessionStore.init(new MockProcessorContext(new StateSerdes<>("", Serdes.String(), Serdes.String()), new NoOpRecordCollector()) {
+            @Override
+            public void register(final StateStore store, final boolean loggingEnabled, final StateRestoreCallback func) {
+                assertFalse("store should not be registering as loggingEnabled", loggingEnabled);
+            }
+        }, sessionStore);
+    }
+
+    private SessionStore createStore(final boolean logged, final boolean cached) {
+        return new RocksDBSessionStoreSupplier<>("name",
+                                                10L,
+                                                Serdes.String(),
+                                                Serdes.String(),
+                                                logged,
+                                                Collections.<String, String>emptyMap(),
+                                                cached).get();
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -47,7 +47,7 @@ public class RocksDBSessionStoreTest {
     @Before
     public void before() {
         final RocksDBSegmentedBytesStore bytesStore =
-                new RocksDBSegmentedBytesStore("session-store", 10000L, 3, new SessionKeySchema());
+                new RocksDBSegmentedBytesStore("session-store", 10000L, 3, new SessionKeySchema(), false);
 
         sessionStore = new RocksDBSessionStore<>(bytesStore,
                                                  Serdes.String(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
+import org.apache.kafka.streams.state.StateSerdes;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.NoOpRecordCollector;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RocksDBWindowStoreSupplierTest {
+
+    @Test
+    public void shouldRegisterWithLoggingEnabledWhenWindowStoreLogged() throws Exception {
+        final WindowStore windowStore = createStore(true, false);
+        windowStore.init(new MockProcessorContext(new StateSerdes<>("", Serdes.String(), Serdes.String()), new NoOpRecordCollector()) {
+            @Override
+            public void register(final StateStore store, final boolean loggingEnabled, final StateRestoreCallback func) {
+                assertTrue("store should be registering as loggingEnabled", loggingEnabled);
+            }
+        }, windowStore);
+    }
+
+    @Test
+    public void shouldRegisterWithLoggingEnabledWhenWindowStoreLoggedAndCached() throws Exception {
+        final WindowStore windowStore = createStore(true, true);
+        windowStore.init(new MockProcessorContext(new StateSerdes<>("", Serdes.String(), Serdes.String()), new NoOpRecordCollector()) {
+            @Override
+            public void register(final StateStore store, final boolean loggingEnabled, final StateRestoreCallback func) {
+                assertTrue("store should be registering as loggingEnabled", loggingEnabled);
+            }
+
+            @Override
+            public ThreadCache getCache() {
+                return new ThreadCache("name", 0, new MockStreamsMetrics(new Metrics()));
+            }
+        }, windowStore);
+    }
+
+    @Test
+    public void shouldRegisterWithLoggingDisabledWhenWindowStoreNotLogged() throws Exception {
+        final WindowStore windowStore = createStore(false, false);
+        windowStore.init(new MockProcessorContext(new StateSerdes<>("", Serdes.String(), Serdes.String()), new NoOpRecordCollector()) {
+            @Override
+            public void register(final StateStore store, final boolean loggingEnabled, final StateRestoreCallback func) {
+                assertFalse("store should not be registering as loggingEnabled", loggingEnabled);
+            }
+        }, windowStore);
+    }
+
+    private WindowStore createStore(final boolean logged, final boolean cached) {
+        return new RocksDBWindowStoreSupplier<>("name",
+                                                10,
+                                                3,
+                                                false,
+                                                Serdes.String(),
+                                                Serdes.String(),
+                                                10,
+                                                logged,
+                                                Collections.<String, String>emptyMap(),
+                                                cached).get();
+    }
+
+}


### PR DESCRIPTION
The refactoring of the stores in https://github.com/apache/kafka/pull/2166 introduced `ChangeLoggingSegmentedBytesStore`, thus removing the change logging from the `RocksDBWindowStore` etc. However, the inner most store still needs to know whether or not logging is enabled such that it can register correctly with `ProcessorContext` and enable StateStore restoration