### PR TITLE
Cluster file generator should produce valid json

### DIFF
--- a/tests/cluster_file_generator.sh
+++ b/tests/cluster_file_generator.sh
@@ -37,7 +37,7 @@ EOF
 
 for K in $(seq -w 02 ${KAFKA_NUM_CONTAINERS}); do
   KNODE="knode${K}"
-  if [ $K -eq 12 ]; then
+  if [ $K -eq ${KAFKA_NUM_CONTAINERS} ]; then
     SUFFIX=""
   else
     SUFFIX=","


### PR DESCRIPTION
This way, if the ${KAFKA_NUM_CONTAINERS} is changed in docker/run_tests.sh, the json is still valid