### PR TITLE
KAFKA-4591: Create Topic Policy follow-up

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/errors/PolicyViolationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PolicyViolationException.java
@@ -17,6 +17,9 @@
 
 package org.apache.kafka.common.errors;
 
+/**
+ * Exception thrown if a create topics request does not satisfy the configured policy for a topic.
+ */
 public class PolicyViolationException extends ApiException {
 
     public PolicyViolationException(String message) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -166,7 +166,7 @@ public enum Errors {
             " the message was sent to an incompatible broker. See the broker logs for more details.")),
     UNSUPPORTED_FOR_MESSAGE_FORMAT(43,
         new UnsupportedForMessageFormatException("The message format version on the broker does not support the request.")),
-    POLICY_VIOLATION(44, new PolicyViolationException("Request parameters do not satisfy the system policy."));
+    POLICY_VIOLATION(44, new PolicyViolationException("Request parameters do not satisfy the configured policy."));
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
@@ -13,14 +13,28 @@
 
 package org.apache.kafka.server.policy;
 
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.errors.PolicyViolationException;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public interface CreateTopicPolicy {
+/**
+ * An interface for enforcing a policy on create topics requests.
+ *
+ * Common use cases are requiring that the replication factor, min.insync.replicas and/or retention settings for a
+ * topic are within an allowable range.
+ *
+ * If <code>create.topic.policy.class.name</code> is defined, Kafka will create an instance of the specified class
+ * using the default constructor and will then pass the broker configs to its <code>configure()</code> method. During
+ * broker shutdown, the <code>close()</code> method will be invoked so that resources can be released (if necessary).
+ */
+public interface CreateTopicPolicy extends Configurable, AutoCloseable {
 
+    /**
+     * Class containing the create request parameters.
+     */
     class RequestMetadata {
         private final String topic;
         private final int numPartitions;
@@ -28,8 +42,21 @@ public interface CreateTopicPolicy {
         private final Map<Integer, List<Integer>> replicasAssignments;
         private final Map<String, String> configs;
 
-        public RequestMetadata(String topic, int numPartitions, short replicationFactor,
-                               Map<Integer, List<Integer>> replicasAssignments, Map<String, String> configs) {
+        /**
+         * Create an instance of this class with the provided parameters.
+         *
+         * This constructor is public to make testing of <code>CreateTopicPolicy</code> implementations easier.
+         *
+         * @param topic the name of the topic to created.
+         * @param numPartitions the number of partitions to create or null if replicasAssignments is set.
+         * @param replicationFactor the replication factor for the topic or null if replicaAssignments is set.
+         * @param replicasAssignments replica assignments or null if numPartitions and replicationFactor is set. The
+         *                            assignment is a map from partition id to replica (broker) ids.
+         * @param configs topic configs for the topic to be created, not including broker defaults. Broker configs are
+         *                passed via the {@code configure()} method of the policy implementation.
+         */
+        public RequestMetadata(String topic, Integer numPartitions, Short replicationFactor,
+                        Map<Integer, List<Integer>> replicasAssignments, Map<String, String> configs) {
             this.topic = topic;
             this.numPartitions = numPartitions;
             this.replicationFactor = replicationFactor;
@@ -37,18 +64,38 @@ public interface CreateTopicPolicy {
             this.configs = Collections.unmodifiableMap(configs);
         }
 
+        /**
+         * Return the name of the topic to create.
+         */
         public String topic() {
             return topic;
         }
 
-        public int numPartitions() {
+        /**
+         * Return the number of partitions to create or null if replicaAssignments is not null.
+         */
+        public Integer numPartitions() {
             return numPartitions;
         }
 
+        /**
+         * Return the number of replicas to create or null if replicaAssignments is not null.
+         */
+        public Short replicationFactor() {
+            return replicationFactor;
+        }
+
+        /**
+         * Return a map from partition id to replica (broker) ids.
+         */
         public Map<Integer, List<Integer>> replicasAssignments() {
             return replicasAssignments;
         }
 
+        /**
+         * Return topic configs in the request, not including broker defaults. Broker configs are passed via
+         * the {@code configure()} method of the policy implementation.
+         */
         public Map<String, String> configs() {
             return configs;
         }
@@ -63,5 +110,15 @@ public interface CreateTopicPolicy {
         }
     }
 
+    /**
+     * Validate the request parameters and throw a <code>PolicyViolationException</code> with a suitable error
+     * message if the create request parameters for the provided topic do not satisfy this policy.
+     *
+     * Clients will receive the POLICY_VIOLATION error code along with the exception's message. Note that validation
+     * failure only affects the relevant topic, other topics in the request will still be processed.
+     *
+     * @param requestMetadata the create request parameters for the provided topic.
+     * @throws PolicyViolationException if the request parameters do not satisfy this policy.
+     */
     void validate(RequestMetadata requestMetadata) throws PolicyViolationException;
 }

--- a/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
+++ b/clients/src/main/java/org/apache/kafka/server/policy/CreateTopicPolicy.java
@@ -37,8 +37,8 @@ public interface CreateTopicPolicy extends Configurable, AutoCloseable {
      */
     class RequestMetadata {
         private final String topic;
-        private final int numPartitions;
-        private final short replicationFactor;
+        private final Integer numPartitions;
+        private final Short replicationFactor;
         private final Map<Integer, List<Integer>> replicasAssignments;
         private final Map<String, String> configs;
 
@@ -60,7 +60,7 @@ public interface CreateTopicPolicy extends Configurable, AutoCloseable {
             this.topic = topic;
             this.numPartitions = numPartitions;
             this.replicationFactor = replicationFactor;
-            this.replicasAssignments = Collections.unmodifiableMap(replicasAssignments);
+            this.replicasAssignments = replicasAssignments == null ? null : Collections.unmodifiableMap(replicasAssignments);
             this.configs = Collections.unmodifiableMap(configs);
         }
 
@@ -86,7 +86,8 @@ public interface CreateTopicPolicy extends Configurable, AutoCloseable {
         }
 
         /**
-         * Return a map from partition id to replica (broker) ids.
+         * Return a map from partition id to replica (broker) ids or null if numPartitions and replicationFactor are
+         * set instead.
          */
         public Map<Integer, List<Integer>> replicasAssignments() {
             return replicasAssignments;

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -117,7 +117,7 @@ class AdminManager(val config: KafkaConfig,
         CreateTopicMetadata(topic, assignments, new CreateTopicsResponse.Error(Errors.NONE, null))
       } catch {
         case e: Throwable =>
-          error(s"Error processing create topic request for topic $topic with arguments $arguments", e)
+          info(s"Error processing create topic request for topic $topic with arguments $arguments", e)
           CreateTopicMetadata(topic, Map(), new CreateTopicsResponse.Error(Errors.forException(e), e.getMessage))
       }
     }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -81,7 +81,7 @@ class AdminManager(val config: KafkaConfig,
             throw new InvalidRequestException("Both numPartitions or replicationFactor and replicasAssignments were set. " +
               "Both cannot be used at the same time.")
           else if (!arguments.replicasAssignments.isEmpty) {
-            // Note: we don't check that replicaAssignment doesn't contain unknown brokers - unlike in add-partitions case,
+            // Note: we don't check that replicaAssignment contains unknown brokers - unlike in add-partitions case,
             // this follows the existing logic in TopicCommand
             arguments.replicasAssignments.asScala.map { case (partitionId, replicas) =>
               (partitionId.intValue, replicas.asScala.map(_.intValue))

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -281,7 +281,7 @@ object KafkaConfig {
   val NumRecoveryThreadsPerDataDirProp = "num.recovery.threads.per.data.dir"
   val AutoCreateTopicsEnableProp = "auto.create.topics.enable"
   val MinInSyncReplicasProp = "min.insync.replicas"
-  val CreateTopicsPolicyClassNameProp = "create.topics.policy.class.name"
+  val CreateTopicPolicyClassNameProp = "create.topic.policy.class.name"
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsProp = "controller.socket.timeout.ms"
   val DefaultReplicationFactorProp = "default.replication.factor"
@@ -491,7 +491,7 @@ object KafkaConfig {
     "produce with acks of \"all\". This will ensure that the producer raises an exception " +
     "if a majority of replicas do not receive a write."
 
-  val CreateTopicsPolicyClassNameDoc = "The create topics policy class that should be used for validation. The class should " +
+  val CreateTopicPolicyClassNameDoc = "The create topics policy class that should be used for validation. The class should " +
     "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface."
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsDoc = "The socket timeout for controller-to-broker channels"
@@ -693,7 +693,7 @@ object KafkaConfig {
       .define(LogMessageFormatVersionProp, STRING, Defaults.LogMessageFormatVersion, MEDIUM, LogMessageFormatVersionDoc)
       .define(LogMessageTimestampTypeProp, STRING, Defaults.LogMessageTimestampType, in("CreateTime", "LogAppendTime"), MEDIUM, LogMessageTimestampTypeDoc)
       .define(LogMessageTimestampDifferenceMaxMsProp, LONG, Defaults.LogMessageTimestampDifferenceMaxMs, atLeast(0), MEDIUM, LogMessageTimestampDifferenceMaxMsDoc)
-      .define(CreateTopicsPolicyClassNameProp, CLASS, null, LOW, CreateTopicsPolicyClassNameDoc)
+      .define(CreateTopicPolicyClassNameProp, CLASS, null, LOW, CreateTopicPolicyClassNameDoc)
 
       /** ********* Replication configuration ***********/
       .define(ControllerSocketTimeoutMsProp, INT, Defaults.ControllerSocketTimeoutMs, MEDIUM, ControllerSocketTimeoutMsDoc)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -491,7 +491,7 @@ object KafkaConfig {
     "produce with acks of \"all\". This will ensure that the producer raises an exception " +
     "if a majority of replicas do not receive a write."
 
-  val CreateTopicPolicyClassNameDoc = "The create topics policy class that should be used for validation. The class should " +
+  val CreateTopicPolicyClassNameDoc = "The create topic policy class that should be used for validation. The class should " +
     "implement the <code>org.apache.kafka.server.policy.CreateTopicPolicy</code> interface."
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsDoc = "The socket timeout for controller-to-broker channels"

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -130,7 +130,7 @@ class AbstractCreateTopicsRequestTest extends BaseRequestTest {
   }
 
   protected def replicaAssignmentToJava(assignments: Map[Int, List[Int]]) = {
-    assignments.map { case (k, v) => (k:Integer, v.map { i => i:Integer }.asJava) }.asJava
+    assignments.map { case (k, v) => (k: Integer, v.map { i => i: Integer }.asJava) }.asJava
   }
 
   protected def sendCreateTopicRequest(request: CreateTopicsRequest, socketServer: SocketServer = controllerSocketServer): CreateTopicsResponse = {

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.server
 
+import java.util
 import java.util.Properties
 
 import kafka.utils.TestUtils
@@ -34,7 +35,7 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
 
   override def propertyOverrides(properties: Properties): Unit = {
     super.propertyOverrides(properties)
-    properties.put(KafkaConfig.CreateTopicsPolicyClassNameProp, classOf[Policy].getName)
+    properties.put(KafkaConfig.CreateTopicPolicyClassNameProp, classOf[Policy].getName)
   }
 
   @Test
@@ -73,9 +74,14 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
 }
 
 object CreateTopicsRequestWithPolicyTest {
+
   class Policy extends CreateTopicPolicy {
+    def configure(configs: util.Map[String, _]): Unit = ()
+
     def validate(requestMetadata: RequestMetadata): Unit =
       if (requestMetadata.numPartitions < 5)
         throw new PolicyViolationException(s"Topics should have at least 5 partitions, received ${requestMetadata.numPartitions}")
+
+    def close(): Unit = ()
   }
 }

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
@@ -41,10 +41,16 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
   @Test
   def testValidCreateTopicsRequests() {
     val timeout = 10000
+
     validateValidCreateTopicsRequests(new CreateTopicsRequest.Builder(
       Map("topic1" -> new CreateTopicsRequest.TopicDetails(5, 1.toShort)).asJava, timeout).build())
+
     validateValidCreateTopicsRequests(new CreateTopicsRequest.Builder(
       Map("topic2" -> new CreateTopicsRequest.TopicDetails(5, 3.toShort)).asJava, timeout, true).build())
+
+    val assignments = replicaAssignmentToJava(Map(0 -> List(1, 0), 1 -> List(0, 1)))
+    validateValidCreateTopicsRequests(new CreateTopicsRequest.Builder(
+      Map("topic3" -> new CreateTopicsRequest.TopicDetails(assignments)).asJava, timeout).build())
   }
 
   @Test
@@ -55,20 +61,32 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
 
     // Policy violations
     validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
-      Map("topic3" -> new CreateTopicsRequest.TopicDetails(4, 1.toShort)).asJava, timeout).build(),
-      Map("topic3" -> error(Errors.POLICY_VIOLATION, Some("Topics should have at least 5 partitions, received 4"))))
+      Map("policy-topic1" -> new CreateTopicsRequest.TopicDetails(4, 1.toShort)).asJava, timeout).build(),
+      Map("policy-topic1" -> error(Errors.POLICY_VIOLATION, Some("Topics should have at least 5 partitions, received 4"))))
 
     validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
-      Map("topic4" -> new CreateTopicsRequest.TopicDetails(4, 1.toShort)).asJava, timeout, true).build(),
-      Map("topic4" -> error(Errors.POLICY_VIOLATION, Some("Topics should have at least 5 partitions, received 4"))))
+      Map("policy-topic2" -> new CreateTopicsRequest.TopicDetails(4, 1.toShort)).asJava, timeout, true).build(),
+      Map("policy-topic2" -> error(Errors.POLICY_VIOLATION, Some("Topics should have at least 5 partitions, received 4"))))
+
+    val assignments = replicaAssignmentToJava(Map(0 -> List(1), 1 -> List(0)))
+    validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
+      Map("policy-topic3" -> new CreateTopicsRequest.TopicDetails(assignments)).asJava, timeout).build(),
+      Map("policy-topic3" -> error(Errors.POLICY_VIOLATION,
+        Some("""Topic partitions should have at least 2 partitions, received 1 for partition 0"""))), checkErrorMessage = true)
 
     // Check that basic errors still work
     validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
       Map(existingTopic -> new CreateTopicsRequest.TopicDetails(5, 1.toShort)).asJava, timeout).build(),
       Map(existingTopic -> error(Errors.TOPIC_ALREADY_EXISTS, Some("""Topic "existing-topic" already exists."""))))
+
     validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
       Map("error-replication" -> new CreateTopicsRequest.TopicDetails(10, (numBrokers + 1).toShort)).asJava, timeout, true).build(),
-      Map("error-replication" -> error(Errors.INVALID_REPLICATION_FACTOR, Some("replication factor: 4 larger than available brokers: 3"))))
+      Map("error-replication" -> error(Errors.INVALID_REPLICATION_FACTOR,
+        Some("replication factor: 4 larger than available brokers: 3"))))
+
+    validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
+      Map("error-replication2" -> new CreateTopicsRequest.TopicDetails(10, -1: Short)).asJava, timeout, true).build(),
+      Map("error-replication2" -> error(Errors.INVALID_REPLICATION_FACTOR, Some("replication factor must be larger than 0"))))
   }
 
 }
@@ -78,9 +96,26 @@ object CreateTopicsRequestWithPolicyTest {
   class Policy extends CreateTopicPolicy {
     def configure(configs: util.Map[String, _]): Unit = ()
 
-    def validate(requestMetadata: RequestMetadata): Unit =
-      if (requestMetadata.numPartitions < 5)
-        throw new PolicyViolationException(s"Topics should have at least 5 partitions, received ${requestMetadata.numPartitions}")
+    def validate(requestMetadata: RequestMetadata): Unit = {
+      import requestMetadata._
+      require(configs.isEmpty, s"Topic configs should be empty, but it is $configs")
+      if (numPartitions != null || replicationFactor != null) {
+        require(numPartitions != null, s"numPartitions should not be null, but it is $numPartitions")
+        require(replicationFactor != null, s"replicationFactor should not be null, but it is $replicationFactor")
+        require(replicasAssignments == null, s"replicaAssigments should be null, but it is $replicasAssignments")
+        if (numPartitions < 5)
+          throw new PolicyViolationException(s"Topics should have at least 5 partitions, received $numPartitions")
+      } else {
+        require(numPartitions == null, s"numPartitions should be null, but it is $numPartitions")
+        require(replicationFactor == null, s"replicationFactor should be null, but it is $replicationFactor")
+        require(replicasAssignments != null, s"replicaAssigments should not be null, but it is $replicasAssignments")
+        replicasAssignments.asScala.foreach { case (partitionId, assignment) =>
+          if (assignment.size < 2)
+            throw new PolicyViolationException("Topic partitions should have at least 2 partitions, received " +
+              s"${assignment.size} for partition $partitionId")
+        }
+      }
+    }
 
     def close(): Unit = ()
   }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -547,7 +547,7 @@ class KafkaConfigTest {
         case KafkaConfig.RequestTimeoutMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
 
         case KafkaConfig.AuthorizerClassNameProp => //ignore string
-        case KafkaConfig.CreateTopicsPolicyClassNameProp => //ignore string
+        case KafkaConfig.CreateTopicPolicyClassNameProp => //ignore string
 
         case KafkaConfig.PortProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.HostNameProp => // ignore string


### PR DESCRIPTION
1. Added javadoc to public classes
2. Removed `s` from config name for consistency with interface name
3. The policy interface now implements Configurable and AutoCloseable as per the KIP
4. Use `null` instead of `-1` in `RequestMetadata`
5. Perform all broker validation before invoking the policy
6. Add tests