### PR TITLE
MINOR: Use new-consumer config in MirrorMaker doc

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -58,7 +58,7 @@ import org.apache.kafka.clients.consumer.{ConsumerConfig => NewConsumerConfig}
  *            max.block.ms=max long
  *            max.in.flight.requests.per.connection=1
  *       2. Consumer Settings
- *            auto.commit.enable=false
+ *            enable.auto.commit=false
  *       3. Mirror Maker Setting:
  *            abort.on.send.failure=true
  */


### PR DESCRIPTION
Mirrormaker was updated to default to the new consumer in 3db752a565071c78e4b11eaafa739844fa785b04

Old consumer calls the param `auto.commit.enable`, new consumer calls it `enable.auto.commit`. So I updated the docstring to use the new consumer name for the param.