### PR TITLE
KAFKA-4668: Replicate mirrormaker topics from earliest

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -55,6 +55,7 @@ import scala.util.{Failure, Success, Try}
  *            max.block.ms=max long
  *            max.in.flight.requests.per.connection=1
  *       2. Consumer Settings
+ *            auto.offset.reset=earliest
  *            enable.auto.commit=false
  *       3. Mirror Maker Setting:
  *            abort.on.send.failure=true
@@ -99,6 +100,8 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
                       consumerConfigProps: Properties,
                       customRebalanceListener: Option[ConsumerRebalanceListener],
                       whitelist: Option[String]): Seq[ConsumerWrapper] = {
+    // Replicate from the beginning of the topic
+    maybeSetDefaultProperty(consumerConfigProps, "auto.offset.reset", "earliest")
     // Disable consumer auto offsets commit to prevent data loss.
     maybeSetDefaultProperty(consumerConfigProps, "enable.auto.commit", "false")
     // Hardcode the deserializer to ByteArrayDeserializer


### PR DESCRIPTION
MirrorMaker currently inherits the default value for `auto.offset.reset`, which is `latest`.

While for most consumers this is a sensible default, MirrorMakers are specifically designed for replication, so they should default to replicating topics from the beginning.

A specific scenario where this really matters is when a MirrorMaker is subscribed to a regex pattern. If auto-topic creation is enabled on the cluster, and you start producing to a non-existent topic that matches the regex, then there will be a period of time where the producer is producing before the new topic's partitions have been picked up by the MirrorMaker. Those messages will never be consumed by the MirrorMaker because it will start from latest, ignoring those just-produced messages.