### PR TITLE
MINOR: Fix javadoc typos in KStream#process

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -706,7 +706,7 @@ public interface KStream<K, V> {
      * {@link org.apache.kafka.streams.processor.Processor Processor} (provided by the given {@link ProcessorSupplier}).
      * This is a stateful record-by-record operation (cf. {@link #foreach(ForeachAction)}).
      * Furthermore, via {@link org.apache.kafka.streams.processor.Processor#punctuate(long) Processor.punctuate(long)}
-     * the processing progress can be observed and additional periodic actions get be performed.
+     * the processing progress can be observed and additional periodic actions can be performed.
      * Note that this is a terminal operation that returns void.
      * <p>
      * In order to assign a state, the state must be created and registered beforehand:
@@ -739,7 +739,7 @@ public interface KStream<K, V> {
      *                 context.schedule(1000); // call #punctuate() each 1000ms
      *             }
      *
-     *             void transform(K key, V value) {
+     *             void process(K key, V value) {
      *                 // can access this.state
      *             }
      *


### PR DESCRIPTION
interface for `Processor` in comments incorrectly had `transform` rather than `process`.
