### PR TITLE
HOTFIX: ChangeLoggingKeyValueStore.name() returns null

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueStore.java
@@ -48,12 +48,7 @@ class ChangeLoggingKeyValueStore<K, V> extends WrappedStateStore.AbstractWrapped
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
     }
-
-    @Override
-    public String name() {
-        return null;
-    }
-
+    
     @SuppressWarnings("unchecked")
     @Override
     public void init(final ProcessorContext context, final StateStore root) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueStoreTest.java
@@ -200,6 +200,11 @@ public class ChangeLoggingKeyValueStoreTest {
         assertThat(store.get(hello), is(nullValue()));
     }
 
+    @Test
+    public void shouldReturnInnerStoreName() throws Exception {
+        assertThat(store.name(), equalTo("kv"));
+    }
+
     private String deserializedValueFromInner(final String key) {
         return valueSerde.deserializer().deserialize("blah", inner.get(Bytes.wrap(key.getBytes())));
     }


### PR DESCRIPTION
This class doesn't need to override this method as it is handled appropriately by the super class