### PR TITLE
KAFKA-4596: Throttled Replica Reassignment Error

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -367,7 +367,7 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   }
 
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
-    def moving(before: Seq[Int], after: Seq[Int]) = before.toSet != after.toSet
+    def moving(before: Seq[Int], after: Seq[Int]) = (after.toSet -- before.toSet).nonEmpty
     //For any moving partition, throttle all the original (pre move) replicas (as any one might be a leader)
     existing.filter { case (tp, preMoveReplicas) =>
       proposed.contains(tp) && moving(preMoveReplicas, proposed(tp))

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -359,20 +359,22 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
     }
   }
 
+
   private def postRebalanceReplicasThatMoved(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     //For each partition in the proposed list, filter out any replicas that exist now (i.e. are in the proposed list and hence are not moving)
-    existing
-      .filter{ case (tp, current) => proposed.contains(tp)}
-      .map { case (tp, current) =>
-      tp -> (proposed(tp).toSet -- current).toSeq
+    proposed.map { case (tp, proposedReplicas) =>
+      tp -> (proposedReplicas.toSet -- existing(tp)).toSeq
     }
   }
 
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
-    //Throttle all existing replicas (as any one might be a leader). So just filter out those which aren't moving
-    existing.filter { case (tp, current) =>
-      proposed.contains(tp) &&
-      (proposed(tp).toSet -- current).nonEmpty
+    //For any moving partition, throttle all the original (pre move) replicas (as any one might be a leader)
+
+    def moving(postMoveReplicas: Seq[Int], preMoveReplicas: Seq[Int]) =
+      (postMoveReplicas.toSet -- preMoveReplicas.toSet).nonEmpty
+
+    existing.filter { case (tp, preMoveReplicas) =>
+      proposed.contains(tp) && moving(preMoveReplicas, proposed(tp))
     }
   }
 

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -360,14 +360,14 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   }
 
   private def postRebalanceReplicasThatMoved(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
-    //For each partition in the proposed list, filter out any replicas that exist now (i.e. are in the proposed list and hence are not moving)
+    //For each partition in the proposed list, filter out any replicas that exist now, and hence aren't being moved.
     proposed.map { case (tp, proposedReplicas) =>
       tp -> (proposedReplicas.toSet -- existing(tp)).toSeq
     }
   }
 
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
-    def moving(before: Seq[Int], after: Seq[Int]) = (before.toSet -- after.toSet).nonEmpty
+    def moving(before: Seq[Int], after: Seq[Int]) = before.toSet != after.toSet
     //For any moving partition, throttle all the original (pre move) replicas (as any one might be a leader)
     existing.filter { case (tp, preMoveReplicas) =>
       proposed.contains(tp) && moving(preMoveReplicas, proposed(tp))

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -359,7 +359,6 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
     }
   }
 
-
   private def postRebalanceReplicasThatMoved(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     //For each partition in the proposed list, filter out any replicas that exist now (i.e. are in the proposed list and hence are not moving)
     proposed.map { case (tp, proposedReplicas) =>
@@ -369,7 +368,6 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
 
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     def moving(before: Seq[Int], after: Seq[Int]) = (before.toSet -- after.toSet).nonEmpty
-
     //For any moving partition, throttle all the original (pre move) replicas (as any one might be a leader)
     existing.filter { case (tp, preMoveReplicas) =>
       proposed.contains(tp) && moving(preMoveReplicas, proposed(tp))

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -361,7 +361,9 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
 
   private def postRebalanceReplicasThatMoved(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     //For each partition in the proposed list, filter out any replicas that exist now (i.e. are in the proposed list and hence are not moving)
-    existing.map { case (tp, current) =>
+    existing
+      .filter{ case (tp, current) => proposed.contains(tp)}
+      .map { case (tp, current) =>
       tp -> (proposed(tp).toSet -- current).toSeq
     }
   }
@@ -369,6 +371,7 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
     //Throttle all existing replicas (as any one might be a leader). So just filter out those which aren't moving
     existing.filter { case (tp, current) =>
+      proposed.contains(tp) &&
       (proposed(tp).toSet -- current).nonEmpty
     }
   }

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -368,11 +368,9 @@ class ReassignPartitionsCommand(zkUtils: ZkUtils, proposedAssignment: Map[TopicA
   }
 
   private def preRebalanceReplicaForMovingPartitions(existing: Map[TopicAndPartition, Seq[Int]], proposed: Map[TopicAndPartition, Seq[Int]]): Map[TopicAndPartition, Seq[Int]] = {
+    def moving(before: Seq[Int], after: Seq[Int]) = (before.toSet -- after.toSet).nonEmpty
+
     //For any moving partition, throttle all the original (pre move) replicas (as any one might be a leader)
-
-    def moving(postMoveReplicas: Seq[Int], preMoveReplicas: Seq[Int]) =
-      (postMoveReplicas.toSet -- preMoveReplicas.toSet).nonEmpty
-
     existing.filter { case (tp, preMoveReplicas) =>
       proposed.contains(tp) && moving(preMoveReplicas, proposed(tp))
     }

--- a/core/src/test/scala/unit/kafka/admin/AdminTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AdminTest.scala
@@ -36,7 +36,7 @@ import java.util
 import kafka.utils.TestUtils._
 import kafka.admin.AdminUtils._
 
-import scala.collection.{Map, Seq, immutable}
+import scala.collection.{Map, immutable}
 import kafka.utils.CoreUtils._
 import org.apache.kafka.common.TopicPartition
 

--- a/core/src/test/scala/unit/kafka/admin/AdminTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AdminTest.scala
@@ -167,7 +167,7 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
 
   @Test
   def testPartitionReassignmentWithLeaderInNewReplicas() {
-    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2))
+    val expectedReplicaAssignment = Map(0  -> List(0, 1, 2), 1  -> List(0, 1, 2))
     val topic = "test"
     // create brokers
     val servers = TestUtils.createBrokerConfigs(4, zkConnect, false).map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))
@@ -178,7 +178,7 @@ class AdminTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
     val partitionToBeReassigned = 0
     val topicAndPartition = TopicAndPartition(topic, partitionToBeReassigned)
     val reassignPartitionsCommand = new ReassignPartitionsCommand(zkUtils, Map(topicAndPartition -> newReplicas))
-    assertTrue("Partition reassignment attempt failed for [test, 0]", reassignPartitionsCommand.reassignPartitions())
+    assertTrue("Partition reassignment attempt failed for [test, 0]", reassignPartitionsCommand.reassignPartitions(1000L))
     // wait until reassignment is completed
     TestUtils.waitUntilTrue(() => {
         val partitionsBeingReassigned = zkUtils.getPartitionsBeingReassigned().mapValues(_.newReplicas)

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -73,6 +73,7 @@ class ReassignPartitionsCommandTest extends Logging {
       override def changeTopicConfig(zkUtils: ZkUtils, topic: String, configChange: Properties): Unit = {
         assertEquals("0:102", configChange.get(FollowerReplicationThrottledReplicasProp))
         assertEquals("0:100,0:101", configChange.get(LeaderReplicationThrottledReplicasProp))
+        assertEquals("topic1", topic)
         calls += 1
       }
     }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -58,14 +58,14 @@ class ReassignPartitionsCommandTest extends Logging {
   }
 
   @Test
-  def shouldSupportProposedAsSubsetOfExisting() {
+  def shouldFindMovingReplicasWhenProposedIsSubsetOfExisting() {
     val assigner = new ReassignPartitionsCommand(null, null)
 
     //Given we have more existing partitions than we are proposing
     val existingSuperset = Map(
       TopicAndPartition("topic1", 0) -> Seq(100, 101),
       TopicAndPartition("topic1", 1) -> Seq(100, 102),
-      TopicAndPartition("foo", 0) -> Seq(100, 102)
+      TopicAndPartition("topic2", 0) -> Seq(100, 101, 102)
     )
     val proposedSubset = Map(TopicAndPartition("topic1", 0) -> Seq(101, 102))
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -69,7 +69,6 @@ class ReassignPartitionsCommandTest extends Logging {
     )
     val proposedSubset = Map(TopicAndPartition("topic1", 0) -> Seq(101, 102))
 
-
     val mock = new TestAdminUtils {
       override def changeTopicConfig(zkUtils: ZkUtils, topic: String, configChange: Properties): Unit = {
         assertEquals("0:102", configChange.get(FollowerReplicationThrottledReplicasProp))
@@ -78,6 +77,7 @@ class ReassignPartitionsCommandTest extends Logging {
       }
     }
 
+    //Then replicas should assign correctly (based on the proposed map)
     assigner.assignThrottledReplicas(existingSuperset, proposedSubset, mock)
     assertEquals(1, calls)
   }


### PR DESCRIPTION
Fixes a logic error in the Reassignment process which throws an exception if you don't rebalance all partitions. 