### PR TITLE
KAFKA-4060 and KAFKA-4476 follow up

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.internals.StreamPartitionAssignor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +84,7 @@ public class DefaultPartitionGrouper implements PartitionGrouper {
 
             if (partitions == null) {
                 log.info("Skipping assigning topic {} to tasks since its metadata is not available yet", topic);
+                maxNumPartitions = StreamPartitionAssignor.NOT_AVAILABLE;
             } else {
                 int numPartitions = partitions.size();
                 if (numPartitions > maxNumPartitions)

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -59,8 +59,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
     private static final Logger log = LoggerFactory.getLogger(StreamPartitionAssignor.class);
 
-    final static int UNKNOWN = -1;
-    final static int NOT_AVAILABLE = -2;
+    private final static int UNKNOWN = -1;
+    public final static int NOT_AVAILABLE = -2;
 
     private static class AssignedPartition implements Comparable<AssignedPartition> {
         public final TaskId taskId;
@@ -369,7 +369,6 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         // create these topics if necessary
         prepareTopic(repartitionTopicMetadata);
 
-        metadataWithInternalTopics = metadata;
         metadataWithInternalTopics = metadata.withPartitions(allRepartitionTopicPartitions);
 
         log.debug("stream-thread [{}] Created repartition topics {} from the parsed topology.", streamThread.getName(), allRepartitionTopicPartitions.values());
@@ -591,12 +590,12 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
      *
      * @param topicPartitions Map that contains the topic names to be created with the number of partitions
      */
-    private void prepareTopic(Map<String, InternalTopicMetadata> topicPartitions) {
+    private void prepareTopic(final Map<String, InternalTopicMetadata> topicPartitions) {
         log.debug("stream-thread [{}] Starting to validate internal topics in partition assignor.", streamThread.getName());
 
-        for (Map.Entry<String, InternalTopicMetadata> entry : topicPartitions.entrySet()) {
-            InternalTopicConfig topic = entry.getValue().config;
-            Integer numPartitions = entry.getValue().numPartitions;
+        for (final Map.Entry<String, InternalTopicMetadata> entry : topicPartitions.entrySet()) {
+            final InternalTopicConfig topic = entry.getValue().config;
+            final Integer numPartitions = entry.getValue().numPartitions;
 
             if (numPartitions == NOT_AVAILABLE) {
                 continue;


### PR DESCRIPTION
ZK removed reveal a bug in `StreamPartitionAssigner` but did not fix it properly. This is a follow up bug fix.

Issue:
 - If topic metadata is missing, `StreamPartitionAssigner` should not create any affected tasks that consume topics with missing metadata.
 - Depending downstream tasks should not be create either.
 - For tasks that are not created, no store changelog topics (if any) should get created
 - For tasks that write output to not-yet existing internal repartitioning topics, those repartitioning topics should not get created