### PR TITLE
KAFKA-3896: Fix KStreamRepartitionJoinTest

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -205,6 +205,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             this.userEndPoint = userEndPoint;
         }
 
+        System.out.println("!!! constructing internal topic manager !!!");
+
         internalTopicManager = new InternalTopicManager(
                 new StreamsKafkaClient(this.streamThread.config),
                 configs.containsKey(StreamsConfig.REPLICATION_FACTOR_CONFIG) ? (Integer) configs.get(StreamsConfig.REPLICATION_FACTOR_CONFIG) : 1,
@@ -263,6 +265,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
      */
     @Override
     public Map<String, Assignment> assign(Cluster metadata, Map<String, Subscription> subscriptions) {
+
+        System.out.println("!!! starting to assign !!!");
 
         // construct the client metadata from the decoded subscription info
         Map<UUID, ClientMetadata> clientsMetadata = new HashMap<>();
@@ -533,6 +537,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                 i++;
             }
         }
+
+        System.out.println("!!! finished to assign !!!");
 
         return assignment;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamRepartitionJoinTest.java
@@ -160,7 +160,6 @@ public class KStreamRepartitionJoinTest {
         return new ExpectedOutputOnTopic(expectedStreamOneTwoJoin, "map-both-streams-and-join-" + testNo);
     }
 
-
     private ExpectedOutputOnTopic mapMapJoin() throws Exception {
         final KStream<Integer, Integer> mapMapStream = streamOne.map(
             new KeyValueMapper<Long, Integer, KeyValue<Long, Integer>>() {
@@ -178,8 +177,7 @@ public class KStreamRepartitionJoinTest {
         return new ExpectedOutputOnTopic(expectedStreamOneTwoJoin, outputTopic);
     }
 
-
-    public ExpectedOutputOnTopic selectKeyAndJoin() throws ExecutionException, InterruptedException {
+    private ExpectedOutputOnTopic selectKeyAndJoin() throws ExecutionException, InterruptedException {
 
         final KStream<Integer, Integer> keySelected =
             streamOne.selectKey(MockKeyValueMapper.<Long, Integer>SelectValueMapper());
@@ -188,7 +186,6 @@ public class KStreamRepartitionJoinTest {
         doJoin(keySelected, streamTwo, outputTopic);
         return new ExpectedOutputOnTopic(expectedStreamOneTwoJoin, outputTopic);
     }
-
 
     private ExpectedOutputOnTopic flatMapJoin() throws Exception {
         final KStream<Integer, Integer> flatMapped = streamOne.flatMap(
@@ -221,7 +218,7 @@ public class KStreamRepartitionJoinTest {
         return new ExpectedOutputOnTopic(Arrays.asList("A:1", "B:2", "C:3", "D:4", "E:5"), output);
     }
 
-    public ExpectedOutputOnTopic mapBothStreamsAndLeftJoin() throws Exception {
+    private ExpectedOutputOnTopic mapBothStreamsAndLeftJoin() throws Exception {
         final KStream<Integer, Integer> map1 = streamOne.map(keyMapper);
 
         final KStream<Integer, String> map2 = streamTwo.map(MockKeyValueMapper.<Integer, String>NoOpKeyValueMapper());
@@ -311,7 +308,6 @@ public class KStreamRepartitionJoinTest {
         produceStreamTwoInputTo(streamFourInput);
 
     }
-
 
     private void produceStreamTwoInputTo(final String streamTwoInput)
         throws ExecutionException, InterruptedException {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -214,7 +214,7 @@ public class IntegrationTestUtils {
             }
         };
 
-        final String conditionDetails = "Did not receive " + expectedNumRecords + " number of records";
+        final String conditionDetails = "Expecting " + expectedNumRecords + " records from topic " + topic + " while only received " + accumData.size() + ": " + accumData;
 
         TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
 
@@ -254,7 +254,7 @@ public class IntegrationTestUtils {
             }
         };
 
-        final String conditionDetails = "Did not receive " + expectedNumRecords + " number of records";
+        final String conditionDetails = "Expecting " + expectedNumRecords + " records from topic " + topic + " while only received " + accumData.size() + ": " + accumData;
 
         TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -23,47 +23,49 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.test.MockTimestampExtractor;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Arrays;
-import java.util.ArrayList;
 
 import static org.apache.kafka.streams.processor.internals.InternalTopicManager.WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT;
 
 public class InternalTopicManagerTest {
 
-    private String userEndPoint = "localhost:2171";
-    StreamsConfig config;
-    MockStreamKafkaClient streamsKafkaClient;
+    private final String topic = "test_topic";
+    private final String userEndPoint = "localhost:2171";
+    private MockStreamKafkaClient streamsKafkaClient;
 
     @Before
     public void init() {
-        config = new StreamsConfig(configProps());
+        final StreamsConfig config = new StreamsConfig(configProps());
         streamsKafkaClient = new MockStreamKafkaClient(config);
+    }
+
+    @After
+    public void shutdown() throws IOException {
+        streamsKafkaClient.close();
     }
 
     @Test
     public void shouldCreateRequiredTopics() throws Exception {
-
-        streamsKafkaClient.setReturnCorrectTopic(true);
         InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1, WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT);
-        internalTopicManager.makeReady(new InternalTopicConfig("test_topic", Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 1);
+        internalTopicManager.makeReady(Collections.singletonMap(new InternalTopicConfig(topic, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 1));
     }
 
     @Test
     public void shouldNotCreateTopicIfExistsWithDifferentPartitions() throws Exception {
-
-        streamsKafkaClient.setReturnCorrectTopic(true);
         InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1, WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT);
         boolean exceptionWasThrown = false;
         try {
-            internalTopicManager.makeReady(new InternalTopicConfig("test_topic", Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 2);
+            internalTopicManager.makeReady(Collections.singletonMap(new InternalTopicConfig(topic, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 2));
         } catch (StreamsException e) {
             exceptionWasThrown = true;
         }
@@ -82,43 +84,21 @@ public class InternalTopicManagerTest {
     }
 
     private class MockStreamKafkaClient extends StreamsKafkaClient {
-        public MockStreamKafkaClient(final StreamsConfig streamsConfig) {
+
+        MockStreamKafkaClient(final StreamsConfig streamsConfig) {
             super(streamsConfig);
         }
 
-        public boolean isReturnCorrectTopic() {
-            return returnCorrectTopic;
-        }
-
-        public void setReturnCorrectTopic(boolean returnCorrectTopic) {
-            this.returnCorrectTopic = returnCorrectTopic;
-        }
-
-        boolean returnCorrectTopic = false;
-
-
         @Override
         public void createTopics(final Map<InternalTopicConfig, Integer> topicsMap, final int replicationFactor, final long windowChangeLogAdditionalRetention) {
-
-        }
-
-        @Override
-        public MetadataResponse.TopicMetadata fetchTopicMetadata(final String topic) {
-
-            if (returnCorrectTopic) {
-                MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(Errors.NONE, 1, null, new ArrayList<Node>(), new ArrayList<Node>());
-                MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(Errors.NONE, topic, true, Arrays.asList(partitionMetadata));
-                return topicMetadata;
-            }
-            return null;
+            // do nothing
         }
 
         @Override
         public Collection<MetadataResponse.TopicMetadata> fetchTopicsMetadata() {
-            if (returnCorrectTopic) {
-                return Arrays.asList(fetchTopicMetadata("test_topic"));
-            }
-            return null;
+            MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(Errors.NONE, 1, null, new ArrayList<Node>(), new ArrayList<Node>());
+            MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(Errors.NONE, topic, true, Collections.singletonList(partitionMetadata));
+            return Collections.singleton(topicMetadata);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
@@ -33,7 +33,7 @@ import java.util.Set;
 public class MockInternalTopicManager extends InternalTopicManager {
 
     public Map<String, Integer> readyTopics = new HashMap<>();
-    public MockConsumer<byte[], byte[]> restoreConsumer;
+    private MockConsumer<byte[], byte[]> restoreConsumer;
 
     public MockInternalTopicManager(StreamsConfig streamsConfig, MockConsumer<byte[], byte[]> restoreConsumer) {
         super(new StreamsKafkaClient(streamsConfig), 0, 0);
@@ -46,7 +46,7 @@ public class MockInternalTopicManager extends InternalTopicManager {
         for (Map.Entry<InternalTopicConfig, Integer> entry : topics.entrySet()) {
             readyTopics.put(entry.getKey().name(), entry.getValue());
 
-            List<PartitionInfo> partitions = new ArrayList<>();
+            final List<PartitionInfo> partitions = new ArrayList<>();
             for (int i = 0; i < entry.getValue(); i++) {
                 partitions.add(new PartitionInfo(entry.getKey().name(), i, null, null, null));
             }
@@ -57,7 +57,7 @@ public class MockInternalTopicManager extends InternalTopicManager {
 
     @Override
     public Map<String, Integer> getNumPartitions(final Set<String> topics) {
-        Map<String, Integer> partitions = new HashMap<>();
+        final Map<String, Integer> partitions = new HashMap<>();
         for (String topic : topics) {
             partitions.put(topic, restoreConsumer.partitionsFor(topic) == null ?  null : restoreConsumer.partitionsFor(topic).size());
         }

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class MockInternalTopicManager extends InternalTopicManager {
 
@@ -41,15 +42,26 @@ public class MockInternalTopicManager extends InternalTopicManager {
     }
 
     @Override
-    public void makeReady(InternalTopicConfig topic, int numPartitions) {
-        readyTopics.put(topic.name(), numPartitions);
+    public void makeReady(final Map<InternalTopicConfig, Integer> topics) {
+        for (Map.Entry<InternalTopicConfig, Integer> entry : topics.entrySet()) {
+            readyTopics.put(entry.getKey().name(), entry.getValue());
 
-        List<PartitionInfo> partitions = new ArrayList<>();
-        for (int i = 0; i < numPartitions; i++) {
-            partitions.add(new PartitionInfo(topic.name(), i, null, null, null));
+            List<PartitionInfo> partitions = new ArrayList<>();
+            for (int i = 0; i < entry.getValue(); i++) {
+                partitions.add(new PartitionInfo(entry.getKey().name(), i, null, null, null));
+            }
+
+            restoreConsumer.updatePartitions(entry.getKey().name(), partitions);
         }
-
-        restoreConsumer.updatePartitions(topic.name(), partitions);
     }
 
+    @Override
+    public Map<String, Integer> getNumPartitions(final Set<String> topics) {
+        Map<String, Integer> partitions = new HashMap<>();
+        for (String topic : topics) {
+            partitions.put(topic, restoreConsumer.partitionsFor(topic) == null ?  null : restoreConsumer.partitionsFor(topic).size());
+        }
+
+        return partitions;
+    }
 }


### PR DESCRIPTION
The root cause of this issue is that in InternalTopicManager we are creating topics one-at-a-time, and for this test, there are 31 topics to be created, as a result it is possible that the consumer could time out during the assignment in rebalance, and the next leader has to do the same again because of "makeReady" calls are one-at-a-time.

This patch batches the topics into a single create request and also use the StreamsKafkaClient directly to fetch metadata for validating the created topics. Also optimized a bunch of inefficient code in InternalTopicManager and StreamsKafkaClient.

Minor cleanup: make the exception message more informative in integration tests.