### PR TITLE
KAFKA-4493: Validate a plaintext client connection to a SSL broker

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/InvalidTransportLayerException.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/InvalidTransportLayerException.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import org.apache.kafka.common.KafkaException;
+
+public class InvalidTransportLayerException extends KafkaException {
+
+    public InvalidTransportLayerException(String message) {
+        super(message);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/NetworkReceive.java
@@ -106,11 +106,15 @@ public class NetworkReceive implements Receive {
                 this.buffer = ByteBuffer.allocate(receiveSize);
             }
         }
+
+        // Packet head is the same as a SSL handshake bytes but actually the packet is correct.
+        // Over read data must be inserted into the buffer.
         if (tempOverBuf != null) {
             buffer.put(tempOverBuf);
             read += 1024;
             tempOverBuf = null;
         }
+
         if (buffer != null) {
             int bytesRead = channel.read(buffer);
             if (bytesRead < 0)

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -369,6 +369,9 @@ public class Selector implements Selectable {
                 if (!key.isValid())
                     close(channel, true);
 
+            } catch (InvalidTransportLayerException e) {
+                close(channel, true);
+                throw e;
             } catch (Exception e) {
                 String desc = channel.socketDescription();
                 if (e instanceof IOException)

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -57,6 +57,8 @@ public class Utils {
 
     private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
+    private static final char[] HEX_TO_CHAR = "0123456789ABCDEF".toCharArray();
+
     /**
      * Get a sorted list representation of a collection.
      * @param collection The collection to sort
@@ -803,4 +805,17 @@ public class Utils {
         return Crc32.crc32(buffer.array(), buffer.arrayOffset() + start, size);
     }
 
+    /**
+     * Convert byte array into a string
+     * @param data Byte array to convert into a string
+     * @return A string
+     */
+    public static String hexToString(byte[] data) {
+        StringBuilder r = new StringBuilder(data.length * 2);
+        for (byte b : data) {
+            r.append(HEX_TO_CHAR[(b >> 4) & 0xF]);
+            r.append(HEX_TO_CHAR[b & 0xF]);
+        }
+        return r.toString();
+    }
 }


### PR DESCRIPTION
When a SSL Alert protocol is received from the broker by sending a request from a client, `InvalidTransportLayerException` is raised from `selector.poll`.