### PR TITLE
MINOR: Fix typo in WordCountProcessorDemo

### DIFF
--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorDemo.java
@@ -42,7 +42,7 @@ import java.util.Properties;
  * is an updated count of a single word.
  *
  * Before running this example you must create the source topic (e.g. via bin/kafka-topics.sh --create ...)
- * and write some data to it (e.g. via bin-kafka-console-producer.sh). Otherwise you won't see any data arriving in the output topic.
+ * and write some data to it (e.g. via bin/kafka-console-producer.sh). Otherwise you won't see any data arriving in the output topic.
  */
 public class WordCountProcessorDemo {
 


### PR DESCRIPTION
`bin-kafka-console-producer.sh` should be `bin/kafka-console-producer.sh`.