### PR TITLE
Replaced for with foreach and replace if ,else if, else  condition with match

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/ByteBufferReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ByteBufferReceive.java
@@ -33,8 +33,7 @@ public class ByteBufferReceive implements Receive {
         super();
         this.source = source;
         this.buffers = buffers;
-        for (int i = 0; i < buffers.length; i++)
-            remaining += buffers[i].remaining();
+        for (ByteBuffer buffer : buffers) remaining += buffer.remaining();
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/network/ByteBufferReceive.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ByteBufferReceive.java
@@ -33,7 +33,8 @@ public class ByteBufferReceive implements Receive {
         super();
         this.source = source;
         this.buffers = buffers;
-        for (ByteBuffer buffer : buffers) remaining += buffer.remaining();
+        for (ByteBuffer buffer : buffers)
+            remaining += buffer.remaining();
     }
 
     @Override

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -307,23 +307,22 @@ object ConsumerGroupCommand extends Logging {
 
       offsetFetchResponse.requestInfo.foreach { case (topicAndPartition, offsetAndMetadata) =>
         offsetAndMetadata match {
-          case OffsetMetadataAndError.NoOffset => {
-          val topicDirs = new ZKGroupTopicDirs(group, topicAndPartition.topic)
-          // this group may not have migrated off zookeeper for offsets storage (we don't expose the dual-commit option in this tool
-          // (meaning the lag may be off until all the consumers in the group have the same setting for offsets storage)
-          try {
-            val offset = zkUtils.readData(topicDirs.consumerOffsetDir + "/" + topicAndPartition.partition)._1.toLong
-            offsetMap.put(topicAndPartition, offset)
-          } catch {
-            case z: ZkNoNodeException =>
-              printError(s"Could not fetch offset from zookeeper for group '$group' partition '$topicAndPartition' due to missing offset data in zookeeper.", Some(z))
-          }
-        }
+          case OffsetMetadataAndError.NoOffset =>
+            val topicDirs = new ZKGroupTopicDirs(group, topicAndPartition.topic)
+            // this group may not have migrated off zookeeper for offsets storage (we don't expose the dual-commit option in this tool
+            // (meaning the lag may be off until all the consumers in the group have the same setting for offsets storage)
+            try {
+              val offset = zkUtils.readData(topicDirs.consumerOffsetDir + "/" + topicAndPartition.partition)._1.toLong
+              offsetMap.put(topicAndPartition, offset)
+            } catch {
+              case z: ZkNoNodeException =>
+                printError(s"Could not fetch offset from zookeeper for group '$group' partition '$topicAndPartition' due to missing offset data in zookeeper.", Some(z))
+            }
           case offsetAndMetaData if offsetAndMetaData.error == Errors.NONE.code =>
-          offsetMap.put(topicAndPartition, offsetAndMetadata.offset)
+            offsetMap.put(topicAndPartition, offsetAndMetadata.offset)
           case _ =>
-          printError(s"Could not fetch offset from kafka for group '$group' partition '$topicAndPartition' due to ${Errors.forCode(offsetAndMetadata.error).exception}.")
-      }
+            printError(s"Could not fetch offset from kafka for group '$group' partition '$topicAndPartition' due to ${Errors.forCode(offsetAndMetadata.error).exception}.")
+        }
       }
       channel.disconnect()
       offsetMap.toMap

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
@@ -119,8 +119,8 @@ public class KTableKTableJoinTest {
 
         // push all four items to the primary stream. this should produce two items.
 
-        for (int i = 0; i < expectedKeys.length; i++) {
-            driver.process(topic1, expectedKeys[i], "XX" + expectedKeys[i]);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
         }
         driver.flushState();
 
@@ -128,8 +128,8 @@ public class KTableKTableJoinTest {
         checkJoinedValues(getter, kv(0, "XX0+Y0"), kv(1, "XX1+Y1"));
 
         // push all items to the other stream. this should produce four items.
-        for (int i = 0; i < expectedKeys.length; i++) {
-            driver.process(topic2, expectedKeys[i], "YY" + expectedKeys[i]);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
         }
         driver.flushState();
 
@@ -138,8 +138,8 @@ public class KTableKTableJoinTest {
 
         // push all four items to the primary stream. this should produce four items.
 
-        for (int i = 0; i < expectedKeys.length; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        for (int expectedKey1 : expectedKeys) {
+            driver.process(topic1, expectedKey1, "X" + expectedKey1);
         }
         driver.flushState();
 
@@ -311,8 +311,8 @@ public class KTableKTableJoinTest {
 
         // push all four items to the primary stream. this should produce four items.
 
-        for (int i = 0; i < expectedKeys.length; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        for (int expectedKey1 : expectedKeys) {
+            driver.process(topic1, expectedKey1, "X" + expectedKey1);
         }
         driver.flushState();
         proc.checkAndClearProcessResult("0:(X0+YY0<-XX0+YY0)", "1:(X1+YY1<-XX1+YY1)", "2:(X2+YY2<-XX2+YY2)", "3:(X3+YY3<-XX3+YY3)");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
@@ -138,8 +138,8 @@ public class KTableKTableJoinTest {
 
         // push all four items to the primary stream. this should produce four items.
 
-        for (int expectedKey1 : expectedKeys) {
-            driver.process(topic1, expectedKey1, "X" + expectedKey1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
         }
         driver.flushState();
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinTest.java
@@ -311,8 +311,8 @@ public class KTableKTableJoinTest {
 
         // push all four items to the primary stream. this should produce four items.
 
-        for (int expectedKey1 : expectedKeys) {
-            driver.process(topic1, expectedKey1, "X" + expectedKey1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
         }
         driver.flushState();
         proc.checkAndClearProcessResult("0:(X0+YY0<-XX0+YY0)", "1:(X1+YY1<-XX1+YY1)", "2:(X2+YY2<-XX2+YY2)", "3:(X3+YY3<-XX3+YY3)");


### PR DESCRIPTION
In some Places for the loop was used but it can be replaced by the for each.
In One file if else if else was used so I replaced the same with match.