### PR TITLE
KAFKA-4699: Invoke producer callbacks before completing the future

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -245,13 +245,14 @@ public class MockProducer<K, V> implements Producer<K, V> {
         }
 
         public void complete(RuntimeException e) {
-            result.done(e == null ? offset : -1L, Record.NO_TIMESTAMP, e);
+            result.set(e == null ? offset : -1L, Record.NO_TIMESTAMP, e);
             if (callback != null) {
                 if (e == null)
                     callback.onCompletion(metadata, null);
                 else
                     callback.onCompletion(null, e);
             }
+            result.done();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProduceRequestResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProduceRequestResult.java
@@ -34,7 +34,7 @@ public final class ProduceRequestResult {
     private final CountDownLatch latch = new CountDownLatch(1);
     private final TopicPartition topicPartition;
 
-    private volatile long baseOffset = -1L;
+    private volatile Long baseOffset = null;
     private volatile long logAppendTime = Record.NO_TIMESTAMP;
     private volatile RuntimeException error;
 
@@ -48,16 +48,24 @@ public final class ProduceRequestResult {
     }
 
     /**
-     * Mark this request as complete and unblock any threads waiting on its completion.
+     * Set the result of the produce request.
      *
      * @param baseOffset The base offset assigned to the record
      * @param logAppendTime The log append time or -1 if CreateTime is being used
      * @param error The error that occurred if there was one, or null
      */
-    public void done(long baseOffset, long logAppendTime, RuntimeException error) {
+    public void set(long baseOffset, long logAppendTime, RuntimeException error) {
         this.baseOffset = baseOffset;
         this.logAppendTime = logAppendTime;
         this.error = error;
+    }
+
+    /**
+     * Mark this request as complete and unblock any threads waiting on its completion.
+     */
+    public void done() {
+        if (baseOffset == null)
+            throw new IllegalStateException("The method `set` must be invoked before this method.");
         this.latch.countDown();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -93,8 +93,8 @@ public final class RecordBatch {
         log.trace("Produced messages to topic-partition {} with base offset offset {} and error: {}.",
                   topicPartition, baseOffset, exception);
 
-        // Complete the future before invoking the callbacks as we rely on its state for the `onCompletion` call
-        produceFuture.done(baseOffset, logAppendTime, exception);
+        // Set the future before invoking the callbacks as we rely on its state for the `onCompletion` call
+        produceFuture.set(baseOffset, logAppendTime, exception);
 
         // execute callbacks
         for (Thunk thunk : thunks) {
@@ -110,6 +110,7 @@ public final class RecordBatch {
             }
         }
 
+        produceFuture.done();
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/RecordSendTest.java
@@ -54,7 +54,8 @@ public class RecordSendTest {
         } catch (TimeoutException e) { /* this is good */
         }
 
-        request.done(baseOffset, Record.NO_TIMESTAMP, null);
+        request.set(baseOffset, Record.NO_TIMESTAMP, null);
+        request.done();
         assertTrue(future.isDone());
         assertEquals(baseOffset + relOffset, future.get().offset());
     }
@@ -86,7 +87,8 @@ public class RecordSendTest {
             public void run() {
                 try {
                     sleep(timeout);
-                    request.done(baseOffset, Record.NO_TIMESTAMP, error);
+                    request.set(baseOffset, Record.NO_TIMESTAMP, error);
+                    request.done();
                 } catch (InterruptedException e) { }
             }
         };

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
@@ -165,7 +165,7 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
         EasyMock.expect(task.cancel(eq(false))).andReturn(false);
         EasyMock.expect(task.isDone()).andReturn(false);
         EasyMock.expect(task.get()).andThrow(new CancellationException());
-        mockLog.trace(EasyMock.anyString(), EasyMock.anyObject());
+        mockLog.trace(EasyMock.anyString(), EasyMock.<Object>anyObject());
         PowerMock.expectLastCall();
         PowerMock.replayAll();
 


### PR DESCRIPTION
This behaviour was changed in 8b3c6c0, but it caused interceptor
test failures (which rely on callbacks) and since we’re so close to
code freeze, it’s better to be conservative.