### PR TITLE
KAFKA-4557: Handle Producer.send correctly in expiry callbacks

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -262,7 +262,7 @@ public final class RecordAccumulator {
         if (!expiredBatches.isEmpty()) {
             log.trace("Expired {} batches in accumulator", count);
             for (RecordBatch batch : expiredBatches) {
-                batch.expired();
+                batch.expirationDone();
                 deallocate(batch);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -248,6 +248,7 @@ public final class RecordAccumulator {
                         if (batch.maybeMarkExpired(requestTimeout, retryBackoffMs, now, this.lingerMs, isFull)) {
                             expiredBatches.add(batch);
                             count++;
+                            batch.close();
                             batchIterator.remove();
                         } else {
                             // Stop at the first batch that has not expired.

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -160,7 +160,6 @@ public final class RecordBatch {
     void expire() {
         if (expiryErrorMessage == null)
             throw new IllegalStateException("Batch has not been marked for expiry");
-        close();
         this.done(-1L, Record.NO_TIMESTAMP,
                   new TimeoutException("Expiring " + recordCount + " record(s) for " + topicPartition + " due to " + expiryErrorMessage));
     }


### PR DESCRIPTION
When iterating deque for expiring record batches, delay the actual completion of the batch until iteration is complete since callbacks invoked during expiry may send more records, modifying the deque, resulting in ConcurrentModificationException in the iterator.