### PR TITLE
KAFKA-4649: Improve test coverage GlobalStateManagerImpl

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -374,11 +374,6 @@ public class GlobalStateManagerImplTest {
         }
     }
 
-    @Test(expected = StreamsException.class)
-    public void shouldThrowStreamsExceptionIfFailedToReadCheckpoints() throws Exception {
-        writeCorruptCheckpoint();
-        stateManager.initialize(context);
-    }
 
     @Test(expected = LockException.class)
     public void shouldThrowLockExceptionIfIOExceptionCaughtWhenTryingToLockStateDir() throws Exception {
@@ -395,7 +390,7 @@ public class GlobalStateManagerImplTest {
     private void writeCorruptCheckpoint() throws IOException {
         final File checkpointFile = new File(stateManager.baseDir(), ProcessorStateManager.CHECKPOINT_FILE_NAME);
         try (final FileOutputStream stream = new FileOutputStream(checkpointFile)) {
-            stream.write("0\n1\nblah".getBytes());
+            stream.write("0\n1\nfoo".getBytes());
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -68,6 +68,7 @@ public class GlobalStateManagerImplTest {
     private MockConsumer<byte[], byte[]> consumer;
     private File checkpointFile;
     private final TheStateRestoreCallback stateRestoreCallback = new TheStateRestoreCallback();
+    private ProcessorTopology topology;
 
     @Before
     public void before() throws IOException {
@@ -80,12 +81,12 @@ public class GlobalStateManagerImplTest {
         storeToProcessorNode.put(store1, new MockProcessorNode(-1));
         store2 = new NoOpReadOnlyStore("t2-store");
         storeToProcessorNode.put(store2, new MockProcessorNode(-1));
-        final ProcessorTopology topology = new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
-                                                                 Collections.<String, SourceNode>emptyMap(),
-                                                                 Collections.<String, SinkNode>emptyMap(),
-                                                                 Collections.<StateStore>emptyList(),
-                                                                 storeToTopic,
-                                                                 Arrays.<StateStore>asList(store1, store2));
+        topology = new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
+                                         Collections.<String, SourceNode>emptyMap(),
+                                         Collections.<String, SinkNode>emptyMap(),
+                                         Collections.<StateStore>emptyList(),
+                                         storeToTopic,
+                                         Arrays.<StateStore>asList(store1, store2));
 
         context = new NoOpProcessorContext();
         stateDirPath = TestUtils.tempDirectory().getPath();
@@ -107,7 +108,7 @@ public class GlobalStateManagerImplTest {
     }
 
     @Test(expected = LockException.class)
-    public void shouldThrowStreamsExceptionIfCantGetLock() throws Exception {
+    public void shouldThrowLockExceptionIfCantGetLock() throws Exception {
         final StateDirectory stateDir = new StateDirectory("appId", stateDirPath);
         try {
             stateDir.lockGlobalState(1);
@@ -135,10 +136,7 @@ public class GlobalStateManagerImplTest {
 
     @Test(expected = StreamsException.class)
     public void shouldThrowStreamsExceptionIfFailedToReadCheckpointedOffsets() throws Exception {
-        final File checkpointFile = new File(stateManager.baseDir(), ProcessorStateManager.CHECKPOINT_FILE_NAME);
-        try (final FileOutputStream stream = new FileOutputStream(checkpointFile)) {
-            stream.write("0\n1\nblah".getBytes());
-        }
+        writeCorruptCheckpoint();
         stateManager.initialize(context);
     }
 
@@ -361,10 +359,7 @@ public class GlobalStateManagerImplTest {
 
     @Test
     public void shouldReleaseLockIfExceptionWhenLoadingCheckpoints() throws Exception {
-        final File checkpointFile = new File(stateManager.baseDir(), ProcessorStateManager.CHECKPOINT_FILE_NAME);
-        try (final FileOutputStream stream = new FileOutputStream(checkpointFile)) {
-            stream.write("0\n1\nblah".getBytes());
-        }
+        writeCorruptCheckpoint();
         try {
             stateManager.initialize(context);
         } catch (StreamsException e) {
@@ -376,6 +371,31 @@ public class GlobalStateManagerImplTest {
             assertTrue(stateDir.lockGlobalState(1));
         } finally {
             stateDir.unlockGlobalState();
+        }
+    }
+
+    @Test(expected = StreamsException.class)
+    public void shouldThrowStreamsExceptionIfFailedToReadCheckpoints() throws Exception {
+        writeCorruptCheckpoint();
+        stateManager.initialize(context);
+    }
+
+    @Test(expected = LockException.class)
+    public void shouldThrowLockExceptionIfIOExceptionCaughtWhenTryingToLockStateDir() throws Exception {
+        stateManager = new GlobalStateManagerImpl(topology, consumer, new StateDirectory("appId", stateDirPath) {
+            @Override
+            public boolean lockGlobalState(final int retry) throws IOException {
+                throw new IOException("KABOOM!");
+            }
+        });
+
+        stateManager.initialize(context);
+    }
+
+    private void writeCorruptCheckpoint() throws IOException {
+        final File checkpointFile = new File(stateManager.baseDir(), ProcessorStateManager.CHECKPOINT_FILE_NAME);
+        try (final FileOutputStream stream = new FileOutputStream(checkpointFile)) {
+            stream.write("0\n1\nblah".getBytes());
         }
     }
 


### PR DESCRIPTION
Add coverage for exception paths in `initialize()`