### PR TITLE
KAFKA-4710: Interpolate log4j's logging source interpretation to correct location info of logs written through trait methods

### DIFF
--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -17,104 +17,172 @@
 
 package kafka.utils
 
-import org.apache.log4j.Logger
+import org.apache.log4j.spi.{LocationInfo, LoggerFactory, LoggingEvent}
+import org.apache.log4j.{Logger, Priority}
 
 trait Logging {
-  val loggerName = this.getClass.getName
-  lazy val logger = Logger.getLogger(loggerName)
+  protected val loggerName: String = this.getClass.getName
+  protected lazy val logger: Logger =
+    Logger.getLogger(loggerName, new TraitAwareLocationInfoProvidingLoggerFactory)
+  private[this] val traitImplFqcn = classOf[Logging].getName + "$class"
 
-  protected var logIdent: String = null
+  protected var logIdent: String = _
 
   // Force initialization to register Log4jControllerMBean
   private val log4jController = Log4jController
 
-  private def msgWithLogIdent(msg: String) = 
+  /**
+    * A [[LoggerFactory]] to create a [[Logger]] which does little tricky interpolation to correct
+    * logging location of logging which happens through calling [[Logging]] trait method.
+    *
+    * When a class extends Logging trait, Scala crates dedicated methods of those in [[Logging]] trait in
+    * each implementation classes, in order to implement mixin on java which inhibit multiple-inheritance.
+    * Hence, if an instance of class invokes [[Logging#warn]] method, the call stack would look like:
+    * {{{
+    * at org.apache.log4j.Category.log(Category.java:856)
+    * at kafka.utils.Logging$class.warn(Logging.scala:154) <-- an exact method defined in trait
+    * at kafka.utils.LoggingTest$TestLogger.warn(LoggingTest.scala:42) <-- a method grown in concrete class by mixin
+    * at kafka.utils.LoggingTest$TestLogger.logWarnByTraitMethod(LoggingTest.scala:44) <-- this is the practical logging location
+    * }}}
+    * In order to find a exact location of which the logging performed, we need to dig into call stack and find
+    * the first location where the method of [[Logging]] trait called so we can find the practical position
+    * of the logging by finding +2 more lower stack element.
+    */
+  private[this] class TraitAwareLocationInfoProvidingLoggerFactory extends LoggerFactory {
+    override def makeNewLoggerInstance(name: String): Logger = new Logger(name) {
+      override def forcedLog(fqcn: String, level: Priority, message: Any, t: Throwable): Unit = {
+        callAppenders(new LoggingEvent(fqcn, this, level, message, t) {
+          private[this] var locationInfoCache: LocationInfo = _
+
+          private[this] def isInvokedThroughTraitMethod(traitElem: StackTraceElement,
+                                                        implElem: StackTraceElement): Boolean = {
+            try {
+              // Scala trait mixin creates a dedicated method in concrete class which implements a trait.
+              // If implElem points a method which had defined through processing trait mixin, the class must be
+              // an implementation of Logging trait(interface in byte code level) and the method name should
+              // corresponds to the one's in Logging trait.
+              classOf[Logging].isAssignableFrom(Class.forName(implElem.getClassName)) &&
+                traitElem.getMethodName == implElem.getMethodName
+            } catch {
+              case _: Throwable => false
+            }
+          }
+
+          private[this] def findPracticalLoggingLocation(): LocationInfo = {
+            val callStack = (new Throwable).getStackTrace
+            callStack.view.dropWhile { elem =>
+              elem.getClassName != traitImplFqcn
+            }.take(3).toList match {
+              // If this logging invoked through trait method, the call stack should have exactly the expected
+              // pattern. See isInvokedThroughTraitMethod for the detail.
+              case traitElem :: implElem :: callerElem :: Nil
+                if isInvokedThroughTraitMethod(traitElem, implElem) =>
+                new LocationInfo(callerElem.getFileName, callerElem.getClassName, callerElem.getMethodName,
+                  String.valueOf(callerElem.getLineNumber))
+              // Otherwise this logging might be invoked through directly calling logger fields method.
+              // just fallback to the original implementation.
+              case _ => super.getLocationInformation
+            }
+          }
+
+          override def getLocationInformation: LocationInfo = {
+            if (locationInfoCache == null) {
+              locationInfoCache = findPracticalLoggingLocation()
+            }
+            locationInfoCache
+          }
+        })
+      }
+    }
+  }
+
+  private def msgWithLogIdent(msg: String) =
     if(logIdent == null) msg else logIdent + msg
 
-  def trace(msg: => String): Unit = {
+  final def trace(msg: => String): Unit = {
     if (logger.isTraceEnabled())
       logger.trace(msgWithLogIdent(msg))
   }
-  def trace(e: => Throwable): Any = {
+  final def trace(e: => Throwable): Any = {
     if (logger.isTraceEnabled())
       logger.trace(logIdent,e)
   }
-  def trace(msg: => String, e: => Throwable) = {
+  final def trace(msg: => String, e: => Throwable): Unit = {
     if (logger.isTraceEnabled())
       logger.trace(msgWithLogIdent(msg),e)
   }
-  def swallowTrace(action: => Unit) {
+  final def swallowTrace(action: => Unit) {
     CoreUtils.swallow(logger.trace, action)
   }
 
   def isDebugEnabled: Boolean = logger.isDebugEnabled
 
-  def debug(msg: => String): Unit = {
+  final def debug(msg: => String): Unit = {
     if (logger.isDebugEnabled())
       logger.debug(msgWithLogIdent(msg))
   }
-  def debug(e: => Throwable): Any = {
+  final def debug(e: => Throwable): Any = {
     if (logger.isDebugEnabled())
       logger.debug(logIdent,e)
   }
-  def debug(msg: => String, e: => Throwable) = {
+  final def debug(msg: => String, e: => Throwable): Unit = {
     if (logger.isDebugEnabled())
       logger.debug(msgWithLogIdent(msg),e)
   }
-  def swallowDebug(action: => Unit) {
+  final def swallowDebug(action: => Unit) {
     CoreUtils.swallow(logger.debug, action)
   }
 
-  def info(msg: => String): Unit = {
+  final def info(msg: => String): Unit = {
     if (logger.isInfoEnabled())
       logger.info(msgWithLogIdent(msg))
   }
-  def info(e: => Throwable): Any = {
+  final def info(e: => Throwable): Any = {
     if (logger.isInfoEnabled())
       logger.info(logIdent,e)
   }
-  def info(msg: => String,e: => Throwable) = {
+  final def info(msg: => String,e: => Throwable): Unit = {
     if (logger.isInfoEnabled())
       logger.info(msgWithLogIdent(msg),e)
   }
-  def swallowInfo(action: => Unit) {
+  final def swallowInfo(action: => Unit) {
     CoreUtils.swallow(logger.info, action)
   }
 
-  def warn(msg: => String): Unit = {
+  final def warn(msg: => String): Unit = {
     logger.warn(msgWithLogIdent(msg))
   }
-  def warn(e: => Throwable): Any = {
+  final def warn(e: => Throwable): Any = {
     logger.warn(logIdent,e)
   }
-  def warn(msg: => String, e: => Throwable) = {
+  final def warn(msg: => String, e: => Throwable): Unit = {
     logger.warn(msgWithLogIdent(msg),e)
   }
-  def swallowWarn(action: => Unit) {
+  final def swallowWarn(action: => Unit) {
     CoreUtils.swallow(logger.warn, action)
   }
-  def swallow(action: => Unit) = swallowWarn(action)
+  final def swallow(action: => Unit): Unit = swallowWarn(action)
 
-  def error(msg: => String): Unit = {
+  final def error(msg: => String): Unit = {
     logger.error(msgWithLogIdent(msg))
-  }		
-  def error(e: => Throwable): Any = {
+  }
+  final def error(e: => Throwable): Any = {
     logger.error(logIdent,e)
   }
-  def error(msg: => String, e: => Throwable) = {
+  final def error(msg: => String, e: => Throwable): Unit = {
     logger.error(msgWithLogIdent(msg),e)
   }
-  def swallowError(action: => Unit) {
+  final def swallowError(action: => Unit) {
     CoreUtils.swallow(logger.error, action)
   }
 
-  def fatal(msg: => String): Unit = {
+  final def fatal(msg: => String): Unit = {
     logger.fatal(msgWithLogIdent(msg))
   }
-  def fatal(e: => Throwable): Any = {
+  final def fatal(e: => Throwable): Any = {
     logger.fatal(logIdent,e)
-  }	
-  def fatal(msg: => String, e: => Throwable) = {
+  }
+  final def fatal(msg: => String, e: => Throwable): Unit = {
     logger.fatal(msgWithLogIdent(msg),e)
   }
 }

--- a/core/src/main/scala/kafka/utils/Logging.scala
+++ b/core/src/main/scala/kafka/utils/Logging.scala
@@ -100,16 +100,16 @@ trait Logging {
     if(logIdent == null) msg else logIdent + msg
 
   final def trace(msg: => String): Unit = {
-    if (logger.isTraceEnabled())
+    if (logger.isTraceEnabled)
       logger.trace(msgWithLogIdent(msg))
   }
   final def trace(e: => Throwable): Any = {
-    if (logger.isTraceEnabled())
-      logger.trace(logIdent,e)
+    if (logger.isTraceEnabled)
+      logger.trace(logIdent, e)
   }
   final def trace(msg: => String, e: => Throwable): Unit = {
-    if (logger.isTraceEnabled())
-      logger.trace(msgWithLogIdent(msg),e)
+    if (logger.isTraceEnabled)
+      logger.trace(msgWithLogIdent(msg), e)
   }
   final def swallowTrace(action: => Unit) {
     CoreUtils.swallow(logger.trace, action)
@@ -118,32 +118,32 @@ trait Logging {
   def isDebugEnabled: Boolean = logger.isDebugEnabled
 
   final def debug(msg: => String): Unit = {
-    if (logger.isDebugEnabled())
+    if (logger.isDebugEnabled)
       logger.debug(msgWithLogIdent(msg))
   }
   final def debug(e: => Throwable): Any = {
-    if (logger.isDebugEnabled())
-      logger.debug(logIdent,e)
+    if (logger.isDebugEnabled)
+      logger.debug(logIdent, e)
   }
   final def debug(msg: => String, e: => Throwable): Unit = {
-    if (logger.isDebugEnabled())
-      logger.debug(msgWithLogIdent(msg),e)
+    if (logger.isDebugEnabled)
+      logger.debug(msgWithLogIdent(msg), e)
   }
   final def swallowDebug(action: => Unit) {
     CoreUtils.swallow(logger.debug, action)
   }
 
   final def info(msg: => String): Unit = {
-    if (logger.isInfoEnabled())
+    if (logger.isInfoEnabled)
       logger.info(msgWithLogIdent(msg))
   }
   final def info(e: => Throwable): Any = {
-    if (logger.isInfoEnabled())
-      logger.info(logIdent,e)
+    if (logger.isInfoEnabled)
+      logger.info(logIdent, e)
   }
-  final def info(msg: => String,e: => Throwable): Unit = {
-    if (logger.isInfoEnabled())
-      logger.info(msgWithLogIdent(msg),e)
+  final def info(msg: => String, e: => Throwable): Unit = {
+    if (logger.isInfoEnabled)
+      logger.info(msgWithLogIdent(msg), e)
   }
   final def swallowInfo(action: => Unit) {
     CoreUtils.swallow(logger.info, action)
@@ -153,10 +153,10 @@ trait Logging {
     logger.warn(msgWithLogIdent(msg))
   }
   final def warn(e: => Throwable): Any = {
-    logger.warn(logIdent,e)
+    logger.warn(logIdent, e)
   }
   final def warn(msg: => String, e: => Throwable): Unit = {
-    logger.warn(msgWithLogIdent(msg),e)
+    logger.warn(msgWithLogIdent(msg), e)
   }
   final def swallowWarn(action: => Unit) {
     CoreUtils.swallow(logger.warn, action)
@@ -167,10 +167,10 @@ trait Logging {
     logger.error(msgWithLogIdent(msg))
   }
   final def error(e: => Throwable): Any = {
-    logger.error(logIdent,e)
+    logger.error(logIdent, e)
   }
   final def error(msg: => String, e: => Throwable): Unit = {
-    logger.error(msgWithLogIdent(msg),e)
+    logger.error(msgWithLogIdent(msg), e)
   }
   final def swallowError(action: => Unit) {
     CoreUtils.swallow(logger.error, action)
@@ -180,9 +180,9 @@ trait Logging {
     logger.fatal(msgWithLogIdent(msg))
   }
   final def fatal(e: => Throwable): Any = {
-    logger.fatal(logIdent,e)
+    logger.fatal(logIdent, e)
   }
   final def fatal(msg: => String, e: => Throwable): Unit = {
-    logger.fatal(msgWithLogIdent(msg),e)
+    logger.fatal(msgWithLogIdent(msg), e)
   }
 }

--- a/core/src/test/scala/kafka/utils/LoggingTest.scala
+++ b/core/src/test/scala/kafka/utils/LoggingTest.scala
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.utils
+
+import org.apache.log4j._
+import org.apache.log4j.spi._
+import org.junit.Assert._
+import org.junit.{Before, Test}
+
+import scala.collection.mutable.ListBuffer
+
+class LoggingTest {
+
+  private[this] class MockAppender extends AppenderSkeleton {
+    val eventLocations = new ListBuffer[LocationInfo]()
+
+    override def append(event: LoggingEvent): Unit = {
+      eventLocations += event.getLocationInformation
+    }
+
+    override def requiresLayout(): Boolean = false
+
+    override def close(): Unit = {}
+  }
+
+  private[this] class TestLogger extends Logging {
+    logger.isTraceEnabled // Instantiate lazy-val logger
+
+    def logWarnByTraitMethod(): Throwable = {
+      warn("warn through trait method"); new Throwable // intentionally placing on the same line to get exactly same line number
+    }
+
+    def logWarnBySwallowingLogMethod(): Throwable = {
+      swallowWarn(throw new RuntimeException("exception to be swallowed")); new Throwable // intentionally placing on the same line to get exactly same line number
+    }
+
+    def logWarnThroughLogger(): Throwable = {
+      logger.warn("warn through logger"); new Throwable // intentionally placing on the same line to get exactly same line number
+    }
+  }
+
+  private[this] class TestLoggerSubclass extends TestLogger {
+    def logWarnThroughSubclass(): Throwable = {
+      warn("warn by subclass"); new Throwable // intentionally placing on the same line to get exactly same line number
+    }
+  }
+
+
+  private[this] val appender = new MockAppender
+  private[this] val testLogger = new TestLogger
+
+  @Before
+  def setUp(): Unit = {
+    val logger = Logger.getLogger(classOf[TestLogger])
+    logger.setLevel(Level.WARN)
+    logger.addAppender(appender)
+  }
+
+  private[this] def callerInfo(throwable: Throwable): LocationInfo = {
+    val firstElem = throwable.getStackTrace.view.head
+    new LocationInfo(firstElem.getFileName, firstElem.getClassName, firstElem.getMethodName,
+      String.valueOf(firstElem.getLineNumber))
+  }
+
+  private[this] def verifyLocationInfo(actual: LocationInfo, got: LocationInfo): Unit = {
+    assertNotEquals(actual.getFileName, LocationInfo.NA)
+    assertEquals(actual.getFileName, got.getFileName)
+    assertNotEquals(actual.getClassName, LocationInfo.NA)
+    assertEquals(actual.getClassName, got.getClassName)
+    assertNotEquals(actual.getMethodName, LocationInfo.NA)
+    assertEquals(actual.getMethodName, got.getMethodName)
+    assertNotEquals(actual.getLineNumber, LocationInfo.NA)
+    assertEquals(actual.getLineNumber, got.getLineNumber)
+  }
+
+  @Test
+  def testLocationInfoWithTraitMethod(): Unit = {
+    val caller = callerInfo(testLogger.logWarnByTraitMethod())
+
+    assertEquals(1, appender.eventLocations.size)
+    verifyLocationInfo(caller, appender.eventLocations.head)
+  }
+
+  @Test
+  def testLocationInfoWithSwallowingLogMethod(): Unit = {
+    val caller = callerInfo(testLogger.logWarnBySwallowingLogMethod())
+
+    assertEquals(1, appender.eventLocations.size)
+    verifyLocationInfo(caller, appender.eventLocations.head)
+  }
+
+  @Test
+  def testLocationInfoWithDirectLoggerAccess(): Unit = {
+    val caller = callerInfo(testLogger.logWarnThroughLogger())
+
+    assertEquals(1, appender.eventLocations.size)
+    verifyLocationInfo(caller, appender.eventLocations.head)
+  }
+
+  @Test
+  def testLocationInfoWithTraitMethodBySubclass(): Unit = {
+    val subclassLogger = new TestLoggerSubclass
+    val logger = Logger.getLogger(classOf[TestLoggerSubclass])
+    logger.setLevel(Level.WARN)
+    logger.addAppender(appender)
+
+    val caller = callerInfo(subclassLogger.logWarnThroughSubclass())
+
+    assertEquals(1, appender.eventLocations.size)
+    verifyLocationInfo(caller, appender.eventLocations.head)
+  }
+
+  @Test
+  def testLocationInfoWithTraitMethodByExternal(): Unit = {
+    testLogger.warn("warn from external"); val caller = callerInfo(new Throwable) // intentionally placing on the same line to get exactly same line number
+
+    assertEquals(1, appender.eventLocations.size)
+    verifyLocationInfo(caller, appender.eventLocations.head)
+  }
+}


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/KAFKA-4710

This PR fixes location information of log4j `LoggingEvent` which is currently given wrongly due to indirect logger method invocation through Logging trait method.
By introducing custom `LoggingEvent` which manually traverses stack trace to find a correct location where the logs are originally written, an appender can now obtain the correct location instead of somewhere inside the `Logging.scala`.