### PR TITLE
MINOR: Use API hyperlinks in 'Kafka Protocol Guide' to facilitate navigation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -89,7 +89,7 @@ public enum ApiKeys {
         for (ApiKeys key : ApiKeys.values()) {
             b.append("<tr>\n");
             b.append("<td>");
-            b.append(key.name);
+            b.append("<a href=\"#The_Messages_" + key.name + "\">" + key.name + "</a>");
             b.append("</td>");
             b.append("<td>");
             b.append(key.id);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -1176,10 +1176,11 @@ public class Protocol {
         for (ApiKeys key : ApiKeys.values()) {
             // Key
             b.append("<h5>");
+            b.append("<a name=\"The_Messages_" + key.name + "\">");
             b.append(key.name);
             b.append(" API (Key: ");
             b.append(key.id);
-            b.append("):</h5>\n\n");
+            b.append("):</a></h5>\n\n");
             // Requests
             b.append("<b>Requests:</b><br>\n");
             Schema[] requests = REQUESTS[key.id];


### PR DESCRIPTION
Finding the protocol associated with an API key can be a challenge in the lengthy [web page](http://kafka.apache.org/protocol.html#protocol_api_keys).
Adding hyperlinks would definitely help with that.

Co-authored with @imandhan.