### PR TITLE
KAFKA-3896: Fix KStream-KStream leftJoin in RepartitionIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -61,12 +61,13 @@ public class IntegrationTestUtils {
      *
      * @param topic          Kafka topic to read messages from
      * @param consumerConfig Kafka consumer configuration
+     * @param waitTime       Maximum wait time in milliseconds
      * @param maxMessages    Maximum number of messages to read via the consumer.
      * @return The values retrieved via the consumer.
      */
-    public static <V> List<V> readValues(final String topic, final Properties consumerConfig, final int maxMessages) {
+    public static <V> List<V> readValues(final String topic, final Properties consumerConfig, final long waitTime, final int maxMessages) {
         final List<V> returnList = new ArrayList<>();
-        final List<KeyValue<Object, V>> kvs = readKeyValues(topic, consumerConfig, maxMessages);
+        final List<KeyValue<Object, V>> kvs = readKeyValues(topic, consumerConfig, waitTime, maxMessages);
         for (final KeyValue<?, V> kv : kvs) {
             returnList.add(kv.value);
         }
@@ -79,10 +80,11 @@ public class IntegrationTestUtils {
      *
      * @param topic          Kafka topic to read messages from
      * @param consumerConfig Kafka consumer configuration
+     * @param waitTime       Maximum wait time in milliseconds
      * @return The KeyValue elements retrieved via the consumer.
      */
-    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic, final Properties consumerConfig) {
-        return readKeyValues(topic, consumerConfig, UNLIMITED_MESSAGES);
+    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic, final Properties consumerConfig, final long waitTime) {
+        return readKeyValues(topic, consumerConfig, waitTime, UNLIMITED_MESSAGES);
     }
 
     /**
@@ -91,17 +93,17 @@ public class IntegrationTestUtils {
      *
      * @param topic          Kafka topic to read messages from
      * @param consumerConfig Kafka consumer configuration
+     * @param waitTime       Maximum wait time in milliseconds
      * @param maxMessages    Maximum number of messages to read via the consumer
      * @return The KeyValue elements retrieved via the consumer
      */
-    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic, final Properties consumerConfig, final int maxMessages) {
+    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic, final Properties consumerConfig, final long waitTime, final int maxMessages) {
         final KafkaConsumer<K, V> consumer = new KafkaConsumer<>(consumerConfig);
         consumer.subscribe(Collections.singletonList(topic));
         final int pollIntervalMs = 100;
-        final int maxTotalPollTimeMs = 2000;
-        int totalPollTimeMs = 0;
         final List<KeyValue<K, V>> consumedValues = new ArrayList<>();
-        while (totalPollTimeMs < maxTotalPollTimeMs && continueConsuming(consumedValues.size(), maxMessages)) {
+        int totalPollTimeMs = 0;
+        while (totalPollTimeMs < waitTime && continueConsuming(consumedValues.size(), maxMessages)) {
             totalPollTimeMs += pollIntervalMs;
             final ConsumerRecords<K, V> records = consumer.poll(pollIntervalMs);
             for (final ConsumerRecord<K, V> record : records) {
@@ -208,7 +210,7 @@ public class IntegrationTestUtils {
         final TestCondition valuesRead = new TestCondition() {
             @Override
             public boolean conditionMet() {
-                final List<KeyValue<K, V>> readData = readKeyValues(topic, consumerConfig);
+                final List<KeyValue<K, V>> readData = readKeyValues(topic, consumerConfig, waitTime);
                 accumData.addAll(readData);
                 return accumData.size() >= expectedNumRecords;
             }
@@ -248,8 +250,9 @@ public class IntegrationTestUtils {
         final TestCondition valuesRead = new TestCondition() {
             @Override
             public boolean conditionMet() {
-                final List<V> readData = readValues(topic, consumerConfig, expectedNumRecords);
+                final List<V> readData = readValues(topic, consumerConfig, waitTime, expectedNumRecords);
                 accumData.addAll(readData);
+
                 return accumData.size() >= expectedNumRecords;
             }
         };


### PR DESCRIPTION
The issue of transiently having duplicates is due to the bad design of the left join itself: in order to ignore the partial joined results such as `A:null`, it lets the producer to potentially send twice to source stream one and rely on all the following conditions to be true in order to pass the test:

1. `receiveMessages` happen to have fetched all the produced results and have committed offsets.
2. streams app happen to have completed sending all result data.
3. consumer used in `receiveMessages` will complete getting all messages in a single poll().

If any of the above is not true, the test fails.

Fixed this test to add a filter right after left join to filter out partial joined results. Minor cleanup on integration test utils.