### PR TITLE
Adjustments to docs to make them work with latest template

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -195,7 +195,9 @@
     <!--#include virtual="connect.html" -->
 
     <h2><a id="streams" href="#streams">9. Kafka Streams</a></h2>
-    <!--#include virtual="streams.html" -->
+    <p>Kafka Streams is a client library for processing and analyzing data stored in Kafka and either write the resulting data back to Kafka or send the final output to an external system. It builds upon important stream processing concepts such as properly distinguishing between event time and processing time, windowing support, and simple yet efficient management of application state.</p> 
+    <p>Kafka Streams has a <b>low barrier to entry</b>: You can quickly write and run a small-scale proof-of-concept on a single machine; and you only need to run additional instances of your application on multiple machines to scale up to high-volume production workloads. Kafka Streams transparently handles the load balancing of multiple instances of the same application by leveraging Kafka's parallelism model.</p>
+    <p><a href="/documentation/streams">Learn more about streams</a></p>
 
-<!--#include virtual="../includes/footer.html" -->
+<!--#include virtual="../includes/_footer.htm" -->
 <!--#include virtual="../includes/_docs_footer.htm" -->

--- a/docs/introduction.html
+++ b/docs/introduction.html
@@ -203,17 +203,4 @@
   </p>
 </script>
 
-<!--#include virtual="../includes/_header.htm" -->
-<!--#include virtual="../includes/_top.htm" -->
-<div class="content documentation documentation--current">
-	<!--#include virtual="../includes/_nav.htm" -->
-	<div class="right">
-    <div class="p-introduction"></div>
-  </div>
-</div>
-<!--#include virtual="../includes/_footer.htm" -->
-
-<script>
-// Show selected style on nav item
-$(function() { $('.b-nav__intro').addClass('selected'); });
-</script>
+<div class="p-introduction"></div>


### PR DESCRIPTION
- Change introduction.html to be a partial like all the other doc content sections
- Fix typo with include statement for the footer of docs
- Stop embedding the full Streams documentation inside of documentation.html now that we're treating it as a separate section.