### PR TITLE
KAFKA-4276: Add REST configuration in connector properties

### DIFF
--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -49,3 +49,12 @@ status.storage.topic=connect-status
 
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000
+
+# These are provided to inform the user about the presence of the REST host and port configs 
+# Hostname & Port for the REST API to listen on. If this is set, it will bind to the interface used to listen to requests.
+#rest.host.name=
+#rest.port=8083
+
+# The Hostname & Port that will be given out to other workers to connect to i.e. URLs that are routable from other servers.
+#rest.advertised.host.name=
+#rest.advertised.port=


### PR DESCRIPTION
Addition of REST configuration in connect-distributed.properties config file
@gwenshap @ewencp - Please review.