### PR TITLE
KAFKA-4567 - Connect Producer and Consumer ignore ssl parameters…

### DIFF
--- a/docs/connect.html
+++ b/docs/connect.html
@@ -56,6 +56,8 @@
         <li><code>offset.storage.file.filename</code> - File to store offset data in</li>
     </ul>
 
+    The parameters that are configured here are intended for producers and consumers used by Kafka Connect to access the configuration, offset and status topics. For configuration of Kafka source and Kafka sink tasks, the same parameters can be used but need to be prefixed with <code>consumer.</code> and <code>producer.</code> respectively. The only parameter that is inherited from the worker configuration is <code>bootstrap.servers</code>, which in most cases will be sufficient, since the same cluster is often used for all purposes. A notable exeption is a secured cluster, which requires extra parameters to allow connections. These parameters will need to be set up to three times in the worker configuration, once for management access, once for Kafka sinks and once for Kafka sources.
+
     The remaining parameters are connector configuration files. You may include as many as you want, but all will execute within the same process (on different threads).
 
     Distributed mode handles automatic balancing of work, allows you to scale up (or down) dynamically, and offers fault tolerance both in the active tasks and for configuration and offset commit data. Execution is very similar to standalone mode:


### PR DESCRIPTION
KAFKA-4567 - Connect Producer and Consumer ignore ssl parameters configured for worker

Added brief explanation to the docs about parameter inheritance of Kafka consumers and producers from the worker config.