### PR TITLE
Removed obsolete parameter form example config in docs.

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -560,7 +560,6 @@
   replica.lag.time.max.ms=10000
 
   controller.socket.timeout.ms=30000
-  controller.message.queue.size=10
 
   # Log configuration
   num.partitions=8


### PR DESCRIPTION
Parameter controller.message.queue.size was removed in 0.9 (KAFKA-2122) but is still listed in an example broker configuration in the documentation.