### PR TITLE
MINOR: Add logging when commitSync fails in StreamTask

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -297,13 +297,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
             try {
                 consumer.commitSync(consumedOffsetsAndMetadata);
             } catch (final CommitFailedException cfe) {
-                for (final Map.Entry<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataEntry : consumedOffsetsAndMetadata.entrySet()) {
-                    log.warn("FAILED COMMIT: topic={} partition={} offset={}",
-                            topicPartitionOffsetAndMetadataEntry.getKey().topic(),
-                            topicPartitionOffsetAndMetadataEntry.getKey().partition(),
-                            topicPartitionOffsetAndMetadataEntry.getValue().offset());
-                }
-
+                log.warn("FAILED COMMITS: {} ", consumedOffsetsAndMetadata);
                 throw cfe;
             }
             commitOffsetNeeded = false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -297,7 +297,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
             try {
                 consumer.commitSync(consumedOffsetsAndMetadata);
             } catch (final CommitFailedException cfe) {
-                for (Map.Entry<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataEntry : consumedOffsetsAndMetadata.entrySet()) {
+                for (final Map.Entry<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataEntry : consumedOffsetsAndMetadata.entrySet()) {
                     log.warn("FAILED COMMIT: topic={} partition={} offset={}",
                             topicPartitionOffsetAndMetadataEntry.getKey().topic(),
                             topicPartitionOffsetAndMetadataEntry.getKey().partition(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -296,9 +296,12 @@ public class StreamTask extends AbstractTask implements Punctuator {
             }
             try {
                 consumer.commitSync(consumedOffsetsAndMetadata);
-            } catch (CommitFailedException cfe) {
+            } catch (final CommitFailedException cfe) {
                 for (Map.Entry<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataEntry : consumedOffsetsAndMetadata.entrySet()) {
-                    logConsumerOffsets(topicPartitionOffsetAndMetadataEntry.getKey(), topicPartitionOffsetAndMetadataEntry.getValue());
+                    log.warn("FAILED COMMIT: topic={} partition={} offset={}",
+                            topicPartitionOffsetAndMetadataEntry.getKey().topic(),
+                            topicPartitionOffsetAndMetadataEntry.getKey().partition(),
+                            topicPartitionOffsetAndMetadataEntry.getValue().offset());
                 }
 
                 throw cfe;
@@ -307,20 +310,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
         }
 
         commitRequested = false;
-    }
-
-    /**
-     * Helper method to log the failed offsets from {@link #commitOffsets()}.
-     *
-     * @param topicPartition Holds topic and partition information.
-     * @param offsetAndMetadata Holds offset and metadata information.
-     *
-     * @see {@link TopicPartition}
-     * @see {@link OffsetAndMetadata}
-     */
-    private void logConsumerOffsets(TopicPartition topicPartition, OffsetAndMetadata offsetAndMetadata) {
-        log.warn("FAILED COMMIT: topic={} partition={} offset={}",
-                topicPartition.topic(), topicPartition.partition(), offsetAndMetadata.offset());
     }
 
     /**


### PR DESCRIPTION
When `consumer.commitSync` fails in `StreamTask`, the `CommitFailedException` bubbles up to [here](https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java#L780) and swallowed.  It'd be great if we knew which offsets failed to commit so that we may rewind our consumer.