### PR TITLE
Use regex for including jars from libs folder instead of adding indiv…

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -125,12 +125,7 @@ do
 done
 
 # classpath addition for release
-for file in "$base_dir"/libs/*;
-do
-  if should_include_file "$file"; then
-    CLASSPATH="$CLASSPATH":"$file"
-  fi
-done
+CLASSPATH=$CLASSPATH:$base_dir/libs/*
 
 for file in "$base_dir"/core/build/libs/kafka_${SCALA_BINARY_VERSION}*.jar;
 do


### PR DESCRIPTION
…idual files

When we include individual files to classpath it may exceed the maximum
length of command line which is 4096 bytes.
This issue also breaks the stop script which will grep for
‘kafka.Kafka’ but when cmdline exceeds 4096 bytes, ‘kafka.Kafka’ text
won’t be present in the process cmdline and hence cannot be grepped.
Details here:
http://unix.stackexchange.com/questions/343353/grep-only-prints-up-to-4096-characters-of-any-process

Using `CLASSPATH=$CLASSPATH:$base_dir/libs/*` limits the length of
command line.