### PR TITLE
KAFKA-4716: Send request to controller

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/perf/SimpleBenchmark.java
+++ b/streams/src/test/java/org/apache/kafka/streams/perf/SimpleBenchmark.java
@@ -65,6 +65,11 @@ import java.util.Random;
  * 3. Run the stream processing step second: SimpleBenchmark localhost:9092 /tmp/statedir numRecords false "all"
  * Note that what changed is the 4th parameter, from "true" indicating that is a load phase, to "false" indicating
  * that this is a real run.
+ *
+ * Note that "all" is a convenience option when running this test locally and will not work when running the test
+ * at scale (through tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py). That is due to exact syncronization
+ * needs for each test (e.g., you wouldn't want one instance to run "count" while another
+ * is still running "consume"
  */
 public class SimpleBenchmark {
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
@@ -96,15 +95,19 @@ public class InternalTopicManagerTest {
         }
 
         @Override
-        public void createTopics(final Map<InternalTopicConfig, Integer> topicsMap, final int replicationFactor, final long windowChangeLogAdditionalRetention) {
+        public void createTopics(final Map<InternalTopicConfig, Integer> topicsMap, final int replicationFactor,
+                                 final long windowChangeLogAdditionalRetention, final MetadataResponse metadata) {
             // do nothing
         }
 
         @Override
-        public Collection<MetadataResponse.TopicMetadata> fetchTopicsMetadata() {
-            MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(Errors.NONE, 1, null, new ArrayList<Node>(), new ArrayList<Node>());
+        public MetadataResponse fetchMetadata() {
+            Node node = new Node(1, "host1", 1001);
+            MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(Errors.NONE, 1, node, new ArrayList<Node>(), new ArrayList<Node>());
             MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(Errors.NONE, topic, true, Collections.singletonList(partitionMetadata));
-            return Collections.singleton(topicMetadata);
+            MetadataResponse response = new MetadataResponse(Collections.<Node>emptyList(), null, MetadataResponse.NO_CONTROLLER_ID,
+                Collections.singletonList(topicMetadata), 0);
+            return response;
         }
     }
 }

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -35,7 +35,7 @@ class StreamsSimpleBenchmarkTest(Test):
 
 
     @cluster(num_nodes=9)
-    @matrix(test=["all"], scale=[1, 2, 3])
+    @matrix(test=["produce", "consume", "count", "processstream", "processstreamwithsink", "processstreamwithstatestore", "processstreamwithcachedstatestore", "kstreamktablejoin", "kstreamkstreamjoin", "ktablektablejoin"], scale=[1, 2, 3])
     def test_simple_benchmark(self, test, scale):
         """
         Run simple Kafka Streams benchmark

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -35,7 +35,7 @@ class StreamsSimpleBenchmarkTest(Test):
 
 
     @cluster(num_nodes=9)
-    @matrix(test=["all"], scale=[1])
+    @matrix(test=["all"], scale=[1, 2, 3])
     def test_simple_benchmark(self, test, scale):
         """
         Run simple Kafka Streams benchmark

--- a/tests/kafkatest/tests/streams/streams_smoke_test.py
+++ b/tests/kafkatest/tests/streams/streams_smoke_test.py
@@ -27,7 +27,7 @@ class StreamsSmokeTest(KafkaTest):
     """
 
     def __init__(self, test_context):
-        super(StreamsSmokeTest, self).__init__(test_context, num_zk=1, num_brokers=2, topics={
+        super(StreamsSmokeTest, self).__init__(test_context, num_zk=1, num_brokers=3, topics={
             'echo' : { 'partitions': 5, 'replication-factor': 1 },
             'data' : { 'partitions': 5, 'replication-factor': 1 },
             'min' : { 'partitions': 5, 'replication-factor': 1 },
@@ -46,7 +46,7 @@ class StreamsSmokeTest(KafkaTest):
         self.processor3 = StreamsSmokeTestJobRunnerService(test_context, self.kafka)
         self.processor4 = StreamsSmokeTestJobRunnerService(test_context, self.kafka)
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=9)
     def test_streams(self):
         """
         Start a few smoke test clients, then repeat start a new one, stop (cleanly) running one a few times.


### PR DESCRIPTION
This PR fixes a blocker issue, where the streams client code cannot talk to the controller. It also enables a system test that was previously failing. 

This PR is for trunk only. A separate PR with just the fix (but not the tests) will be created for 0.10.2. 