### PR TITLE
KAFKA-4745 -Optimize close to remove unnecessary flush

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/KafkaLZ4BlockOutputStream.java
@@ -259,10 +259,10 @@ public final class KafkaLZ4BlockOutputStream extends FilterOutputStream {
     @Override
     public void close() throws IOException {
         if (!finished) {
+            // basicallly flush the buffer writing the last block
             writeBlock();
+            // write the end block and finish the stream
             writeEndMark();
-            flush();
-            finished = true;
         }
         if (out != null) {
             out.close();


### PR DESCRIPTION
-Remove unnecessary 'flush', the underlying stream should handle it on close, also most apps flush before close.