### PR TITLE
KAFKA-2857: Retry querying the consumer group while initializing

### DIFF
--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -16,10 +16,10 @@ import java.nio.ByteBuffer
 import java.util.{Collections, Properties}
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.apache.kafka.common.requests.ApiVersionsResponse.ApiVersion
 import kafka.common.KafkaException
 import kafka.coordinator.GroupOverview
 import kafka.utils.Logging
+
 import org.apache.kafka.clients._
 import org.apache.kafka.clients.consumer.internals.{ConsumerNetworkClient, ConsumerProtocol, RequestFuture}
 import org.apache.kafka.common.config.ConfigDef.{Importance, Type}
@@ -28,6 +28,8 @@ import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network.Selector
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests._
+import org.apache.kafka.common.requests.ApiVersionsResponse.ApiVersion
+import org.apache.kafka.common.requests.DescribeGroupsResponse.GroupMetadata
 import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.apache.kafka.common.utils.{Time, Utils}
 import org.apache.kafka.common.{Cluster, Node, TopicPartition}
@@ -66,9 +68,17 @@ class AdminClient(val time: Time,
     throw new RuntimeException(s"Request $api failed on brokers $bootstrapBrokers")
   }
 
-  def findCoordinator(groupId: String): Node = {
+  var timerMs: Long = 0
+
+  def findCoordinator(groupId: String, timeoutMs: Long = 0): Node = {
     val requestBuilder = new GroupCoordinatorRequest.Builder(groupId)
-    val response = sendAnyNode(ApiKeys.GROUP_COORDINATOR, requestBuilder).asInstanceOf[GroupCoordinatorResponse]
+    var response = sendAnyNode(ApiKeys.GROUP_COORDINATOR, requestBuilder).asInstanceOf[GroupCoordinatorResponse]
+
+    while (response.error == Errors.GROUP_COORDINATOR_NOT_AVAILABLE && time.milliseconds - timerMs < timeoutMs) {
+      Thread.sleep(AdminClient.DefaultGroupQueryRetryIntervalMs)
+      response = sendAnyNode(ApiKeys.GROUP_COORDINATOR, requestBuilder).asInstanceOf[GroupCoordinatorResponse]
+    }
+
     response.error.maybeThrow()
     response.node
   }
@@ -165,14 +175,31 @@ class AdminClient(val time: Time,
                                   consumers: Option[List[ConsumerSummary]],
                                   coordinator: Node)
 
-  def describeConsumerGroup(groupId: String): ConsumerGroupSummary = {
-    val coordinator = findCoordinator(groupId)
+  def describeConsumerGroupHandler(coordinator: Node, groupId: String): GroupMetadata = {
     val responseBody = send(coordinator, ApiKeys.DESCRIBE_GROUPS,
         new DescribeGroupsRequest.Builder(Collections.singletonList(groupId)))
     val response = responseBody.asInstanceOf[DescribeGroupsResponse]
     val metadata = response.groups.get(groupId)
     if (metadata == null)
       throw new KafkaException(s"Response from broker contained no metadata for group $groupId")
+    metadata
+  }
+
+  def describeConsumerGroup(groupId: String): ConsumerGroupSummary = describeConsumerGroup(groupId, 0)
+
+  def describeConsumerGroup(groupId: String, timeoutMs: Long): ConsumerGroupSummary = {
+    timerMs = time.milliseconds
+
+    val coordinator = findCoordinator(groupId, timeoutMs)
+    var metadata = describeConsumerGroupHandler(coordinator, groupId)
+
+    while (metadata.state != "Dead" && metadata.state != "Empty" &&
+           metadata.protocolType != ConsumerProtocol.PROTOCOL_TYPE &&
+           time.milliseconds - timerMs < timeoutMs) {
+      Thread.sleep(AdminClient.DefaultGroupQueryRetryIntervalMs)
+      metadata = describeConsumerGroupHandler(coordinator, groupId)
+    }
+
     if (metadata.state != "Dead" && metadata.state != "Empty" && metadata.protocolType != ConsumerProtocol.PROTOCOL_TYPE)
       throw new IllegalArgumentException(s"Consumer Group $groupId with protocol type '${metadata.protocolType}' is not a valid consumer group")
 
@@ -204,6 +231,8 @@ object AdminClient {
   val DefaultSendBufferBytes = 128 * 1024
   val DefaultReceiveBufferBytes = 32 * 1024
   val DefaultRetryBackoffMs = 100
+  val DefaultGroupQueryRetryIntervalMs: Long = 100
+
   val AdminClientIdSequence = new AtomicInteger(1)
   val AdminConfigDef = {
     val config = new ConfigDef()

--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -81,7 +81,7 @@ class AdminClient(val time: Time,
       response = sendAnyNode(ApiKeys.GROUP_COORDINATOR, requestBuilder).asInstanceOf[GroupCoordinatorResponse]
     }
 
-    if (timeoutMs > 0 && time.milliseconds - startTime > timeoutMs)
+    if (response.error == Errors.GROUP_COORDINATOR_NOT_AVAILABLE)
       throw new TimeoutException("The consumer group command timed out while waiting for group to initialize: ", response.error.exception)
 
     response.error.maybeThrow()
@@ -200,7 +200,7 @@ class AdminClient(val time: Time,
     var metadata = describeConsumerGroupHandler(coordinator, groupId)
 
     while (!isValidConsumerGroupResponse(metadata) && time.milliseconds - startTime < timeoutMs) {
-      debug(s"The consumer group response for group '$groupId' is invalid. Retrying the request as the group may be initializing.")
+      debug(s"The consumer group response for group '$groupId' is invalid. Retrying the request as the group is initializing ...")
       Thread.sleep(AdminClient.DefaultGroupQueryRetryIntervalMs)
       metadata = describeConsumerGroupHandler(coordinator, groupId)
     }

--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -208,7 +208,6 @@ class AdminClient(val time: Time,
     if (!isValidConsumerGroupResponse(metadata))
       throw new TimeoutException("The consumer group command timed out while waiting for group to initialize")
 
-    metadata.error.maybeThrow()
     val consumers = metadata.members.asScala.map { consumer =>
       ConsumerSummary(consumer.memberId, consumer.clientId, consumer.clientHost, metadata.state match {
         case "Stable" =>

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -547,7 +547,7 @@ object ConsumerGroupCommand extends Logging {
     def checkArgs() {
       // check required args
       if (options.has(timeoutMsOpt) && (!describeOptPresent || useOldConsumer))
-        warn(s"Option '$timeoutMsOpt' is valid only when both '$bootstrapServerOpt' and '$describeOpt' are used.")
+        debug(s"Option '$timeoutMsOpt' is applicable only when both '$bootstrapServerOpt' and '$describeOpt' are used.")
 
       if (useOldConsumer) {
         if (options.has(bootstrapServerOpt))

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -532,7 +532,7 @@ object ConsumerGroupCommand extends Logging {
                              .withRequiredArg
                              .describedAs("timeout (ms)")
                              .ofType(classOf[Long])
-                             .defaultsTo(1000)
+                             .defaultsTo(5000)
     val commandConfigOpt = parser.accepts("command-config", CommandConfigDoc)
                                   .withRequiredArg
                                   .describedAs("command config property file")

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -91,7 +91,7 @@ public class StreamsResetter {
 
             adminClient = AdminClient.createSimplePlaintext(options.valueOf(bootstrapServerOption));
             final String groupId = options.valueOf(applicationIdOption);
-            if (!adminClient.describeConsumerGroup(groupId).consumers().get().isEmpty()) {
+            if (!adminClient.describeConsumerGroup(groupId, 0).consumers().get().isEmpty()) {
                 throw new IllegalStateException("Consumer group '" + groupId + "' is still active. " +
                     "Make sure to stop all running application instances before running the reset tool.");
             }

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -23,6 +23,7 @@ import java.util.Collections
 import java.util.Properties
 
 import org.easymock.EasyMock
+import org.junit.Assert._
 import org.junit.Before
 import org.junit.Test
 
@@ -35,10 +36,10 @@ import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
 
+import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.GroupCoordinatorNotAvailableException
 import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.apache.kafka.clients.consumer.KafkaConsumer
 
 
 class DescribeConsumerGroupTest extends KafkaServerTestHarness {
@@ -179,21 +180,8 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
 
-    TestUtils.waitUntilTrue(() => {
-        try {
-          val (state, assignments) = consumerGroupCommand.describeGroup()
-          println(state == Some("Dead") && assignments == Some(List()))
-          state == Some("Dead") && assignments == Some(List())
-        } catch {
-          case _: GroupCoordinatorNotAvailableException | _: IllegalArgumentException =>
-            // Do nothing while the group initializes
-            false
-          case e: Throwable =>
-            e.printStackTrace()
-            throw e
-        }
-      }, "Expected the state to be 'Dead' with no members in the group.")
-
+    val (state, assignments) = consumerGroupCommand.describeGroup()
+    assertTrue("Expected the state to be 'Dead' with no members in the group.", state == Some("Dead") && assignments == Some(List()))
     consumerGroupCommand.close()
   }
 
@@ -207,21 +195,13 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
 
     TestUtils.waitUntilTrue(() => {
-        try {
-          val (state, assignments) = consumerGroupCommand.describeGroup()
-          state == Some("Stable") &&
-          assignments.isDefined &&
-          assignments.get.count(_.group == group) == 1 &&
-          assignments.get.filter(_.group == group).head.consumerId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
-          assignments.get.filter(_.group == group).head.clientId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
-          assignments.get.filter(_.group == group).head.host.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE)
-        } catch {
-          case _: GroupCoordinatorNotAvailableException | _: IllegalArgumentException =>
-            // Do nothing while the group initializes
-            false
-          case e: Throwable =>
-            throw e
-        }
+        val (state, assignments) = consumerGroupCommand.describeGroup()
+        state == Some("Stable") &&
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 1 &&
+        assignments.get.filter(_.group == group).head.consumerId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
+        assignments.get.filter(_.group == group).head.clientId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
+        assignments.get.filter(_.group == group).head.host.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE)
       }, "Expected a 'Stable' group status, rows and valid values for consumer id / client id / host columns in describe group results.")
 
     consumerGroupCommand.close()
@@ -237,40 +217,24 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
 
     TestUtils.waitUntilTrue(() => {
-        try {
-          val (state, _) = consumerGroupCommand.describeGroup()
-          state == Some("Stable")
-        } catch {
-          case _: GroupCoordinatorNotAvailableException | _: IllegalArgumentException =>
-            // Do nothing while the group initializes
-            false
-          case e: Throwable =>
-            throw e
-        }
+        val (state, _) = consumerGroupCommand.describeGroup()
+        state == Some("Stable")
       }, "Expected the group to initially become stable.")
 
     // stop the consumer so the group has no active member anymore
     executor.shutdown()
 
     TestUtils.waitUntilTrue(() => {
-        try {
-          val (state, assignments) = consumerGroupCommand.describeGroup()
-          state == Some("Empty") &&
-          assignments.isDefined &&
-          assignments.get.count(_.group == group) == 1 &&
-          assignments.get.filter(_.group == group).head.consumerId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) && // the member should be gone
-          assignments.get.filter(_.group == group).head.clientId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
-          assignments.get.filter(_.group == group).head.host.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE)
-        } catch {
-          case _: GroupCoordinatorNotAvailableException | _: IllegalArgumentException =>
-            // Do nothing while the group initializes
-            false
-          case e: Throwable =>
-            throw e
-        } finally {
-          consumerGroupCommand.close()
-        }
+        val (state, assignments) = consumerGroupCommand.describeGroup()
+        state == Some("Empty") &&
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 1 &&
+        assignments.get.filter(_.group == group).head.consumerId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) && // the member should be gone
+        assignments.get.filter(_.group == group).head.clientId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
+        assignments.get.filter(_.group == group).head.host.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE)
       }, "Expected no active member in describe group results.")
+
+    consumerGroupCommand.close()
   }
 
   @Test
@@ -283,20 +247,12 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
 
     TestUtils.waitUntilTrue(() => {
-        try {
-          val (state, assignments) = consumerGroupCommand.describeGroup()
-          state == Some("Stable") &&
-          assignments.isDefined &&
-          assignments.get.count(_.group == group) == 2 &&
-          assignments.get.count{ x => x.group == group && x.partition.isDefined} == 1 &&
-          assignments.get.count{ x => x.group == group && !x.partition.isDefined} == 1
-        } catch {
-          case _: GroupCoordinatorNotAvailableException | _: IllegalArgumentException =>
-            // Do nothing while the group initializes
-            false
-          case e: Throwable =>
-            throw e
-        }
+        val (state, assignments) = consumerGroupCommand.describeGroup()
+        state == Some("Stable") &&
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 2 &&
+        assignments.get.count{ x => x.group == group && x.partition.isDefined} == 1 &&
+        assignments.get.count{ x => x.group == group && !x.partition.isDefined} == 1
       }, "Expected rows for consumers with no assigned partitions in describe group results.")
 
     consumerGroupCommand.close()
@@ -315,23 +271,39 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
 
     TestUtils.waitUntilTrue(() => {
-        try {
           val (state, assignments) = consumerGroupCommand.describeGroup()
           state == Some("Stable") &&
           assignments.isDefined &&
           assignments.get.count(_.group == group) == 2 &&
           assignments.get.count{ x => x.group == group && x.partition.isDefined} == 2 &&
           assignments.get.count{ x => x.group == group && !x.partition.isDefined} == 0
-        } catch {
-          case _: GroupCoordinatorNotAvailableException | _: IllegalArgumentException =>
-            // Do nothing while the group initializes
-            false
-          case e: Throwable =>
-            throw e
-        }
       }, "Expected two rows (one row per consumer) in describe group results.")
 
     consumerGroupCommand.close()
+  }
+
+  @Test
+  def testDescribeGroupWithNewConsumerWithShortInitializationTimeout() {
+    // run one consumer in the group consuming from a single-partition topic
+    val executor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
+
+    // set the group initialization timeout too low for the group to stabilize
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "group", "--group-init-timeout", "10")
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val consumerGroupCommand = new KafkaConsumerGroupService(opts)
+
+    try {
+      val (state, assignments) = consumerGroupCommand.describeGroup()
+      fail("The consumer group command should fail due to low initialization timeout")
+    } catch {
+      case e @ (_: GroupCoordinatorNotAvailableException | _: IllegalArgumentException) =>
+        // OK
+      case e: Throwable =>
+        fail("An unexpected exception occurred")
+        throw e
+    } finally {
+      consumerGroupCommand.close()
+    }
   }
 }
 

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -38,6 +38,7 @@ import kafka.utils.TestUtils
 
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.GroupCoordinatorNotAvailableException
+import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.StringDeserializer
 
@@ -296,10 +297,10 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
       val (state, assignments) = consumerGroupCommand.describeGroup()
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
-      case e @ (_: GroupCoordinatorNotAvailableException | _: IllegalArgumentException) =>
+      case e: TimeoutException =>
         // OK
       case e: Throwable =>
-        fail("An unexpected exception occurred")
+        fail("An unexpected exception occurred: " + e.getMessage)
         throw e
     } finally {
       consumerGroupCommand.close()

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -288,7 +288,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     val executor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
 
     // set the group initialization timeout too low for the group to stabilize
-    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "group", "--group-init-timeout", "10")
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "group", "--timeout", "10")
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -422,7 +422,7 @@ public class ResetIntegrationTest {
     private class WaitUntilConsumerGroupGotClosed implements TestCondition {
         @Override
         public boolean conditionMet() {
-            return adminClient.describeConsumerGroup(APP_ID + testNo).consumers().get().isEmpty();
+            return adminClient.describeConsumerGroup(APP_ID + testNo, 0).consumers().get().isEmpty();
         }
     }
 


### PR DESCRIPTION
This applies to new-consumer based groups and would avoid scenarios in which user issues a `--describe` query while the group is initializing.
Example: The following could occur for a newly created group.
```
kafka@kafka:~/workspace/kafka$ bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --group g
Note: This will only show information about consumers that use the Java consumer API (non-ZooKeeper-based consumers).

Error: Executing consumer group command failed due to The group coordinator is not available.
```

With this PR the group is queried repeatedly at specific intervals within a preset (and configurable) timeout `group-init-timeout` to circumvent unfortunate situations like above.