### PR TITLE
KAFKA-4764: Improve diagnostics for SASL auth failures

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -56,7 +56,7 @@ final class ClusterConnectionStates {
         NodeConnectionState state = nodeState.get(id);
         if (state == null)
             return false;
-        else if (state.authFailed) // connections with authentication failures are blacked out forever
+        else if (state.authenticationFailed) // connections with authentication failures are blacked out forever
             return true;
         else
             return state.state == ConnectionState.DISCONNECTED && now - state.lastConnectAttemptMs < this.reconnectBackoffMs;
@@ -111,15 +111,15 @@ final class ClusterConnectionStates {
         nodeState.lastConnectAttemptMs = now;
     }
 
-    public void authFailed(String id, long now) {
+    public void authenticationFailed(String id, long now) {
         NodeConnectionState nodeState = nodeState(id);
-        nodeState.authFailed = true;
+        nodeState.authenticationFailed = true;
     }
 
-    public boolean authFailed() {
+    public boolean authenticationFailed() {
         boolean authFailed = !nodeState.isEmpty();
         for (NodeConnectionState state : nodeState.values()) {
-            if (!state.authFailed) {
+            if (!state.authenticationFailed) {
                 authFailed = false;
                 break;
             }
@@ -191,7 +191,7 @@ final class ClusterConnectionStates {
     private static class NodeConnectionState {
 
         ConnectionState state;
-        boolean authFailed;
+        boolean authenticationFailed;
         long lastConnectAttemptMs;
 
         public NodeConnectionState(ConnectionState state, long lastConnectAttempt) {

--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -68,6 +68,12 @@ public interface KafkaClient extends Closeable {
     boolean connectionFailed(Node node);
 
     /**
+     * Check if authentication failed to all available nodes
+     * @return true if connections to all available nodes failed with authentication errors
+     */
+    boolean authFailed();
+
+    /**
      * Queue up the given request for sending. Requests can only be sent on ready connections.
      * @param request The request
      * @param now The current timestamp

--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -71,7 +71,7 @@ public interface KafkaClient extends Closeable {
      * Check if authentication failed to all available nodes
      * @return true if connections to all available nodes failed with authentication errors
      */
-    boolean authFailed();
+    boolean authenticationFailed();
 
     /**
      * Queue up the given request for sending. Requests can only be sent on ready connections.

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -233,8 +233,8 @@ public class NetworkClient implements KafkaClient {
     }
 
     @Override
-    public boolean authFailed() {
-        return connectionStates.authFailed();
+    public boolean authenticationFailed() {
+        return connectionStates.authenticationFailed();
     }
 
     /**
@@ -581,9 +581,9 @@ public class NetworkClient implements KafkaClient {
             log.debug("Node {} disconnected.", node);
             processDisconnection(responses, node, now);
         }
-        for (String node : this.selector.authFailed()) {
+        for (String node : this.selector.authenticationFailed()) {
             log.debug("Node {} authentication failed.", node);
-            connectionStates.authFailed(node, now);
+            connectionStates.authenticationFailed(node, now);
         }
         // we got a disconnect so we should probably refresh our metadata and see if that broker is dead
         if (this.selector.disconnected().size() > 0)
@@ -688,7 +688,7 @@ public class NetworkClient implements KafkaClient {
                 return metadataTimeout;
             }
 
-            if (authFailed()) {
+            if (authenticationFailed()) {
                 log.debug("Give up sending metadata request since authentication failed to all nodes");
                 return requestTimeoutMs;
             } else {

--- a/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
@@ -95,7 +95,7 @@ public interface Selectable {
      * The list of connections that failed authentication on the last {@link #poll(long) poll()}
      * call.
      */
-    public List<String> authFailed();
+    public List<String> authenticationFailed();
 
     /**
      * Disable reads from the given connection

--- a/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
@@ -92,6 +92,12 @@ public interface Selectable {
     public List<String> connected();
 
     /**
+     * The list of connections that failed authentication on the last {@link #poll(long) poll()}
+     * call.
+     */
+    public List<String> authFailed();
+
+    /**
      * Disable reads from the given connection
      * @param id The id for the connection
      */

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -94,7 +94,7 @@ public class Selector implements Selectable {
     private final Map<String, KafkaChannel> closingChannels;
     private final List<String> disconnected;
     private final List<String> connected;
-    private final List<String> authFailed;
+    private final List<String> authenticationFailed;
     private final List<String> failedSends;
     private final Time time;
     private final SelectorMetrics sensors;
@@ -142,7 +142,7 @@ public class Selector implements Selectable {
         this.closingChannels = new HashMap<>();
         this.connected = new ArrayList<>();
         this.disconnected = new ArrayList<>();
-        this.authFailed = new ArrayList<>();
+        this.authenticationFailed = new ArrayList<>();
         this.failedSends = new ArrayList<>();
         this.sensors = new SelectorMetrics(metrics);
         this.channelBuilder = channelBuilder;
@@ -379,7 +379,7 @@ public class Selector implements Selectable {
             } catch (Exception e) {
                 String desc = channel.socketDescription();
                 if (e instanceof AuthenticationException) {
-                    authFailed.add(channel.id());
+                    authenticationFailed.add(channel.id());
                     log.warn("Authentication failed for connection with {}; closing connection", desc, e);
                 } else if (e instanceof IOException)
                     log.debug("Connection with {} disconnected", desc, e);
@@ -406,8 +406,8 @@ public class Selector implements Selectable {
     }
 
     @Override
-    public List<String> authFailed() {
-        return this.authFailed;
+    public List<String> authenticationFailed() {
+        return this.authenticationFailed;
     }
 
     @Override
@@ -472,7 +472,7 @@ public class Selector implements Selectable {
         this.completedReceives.clear();
         this.connected.clear();
         this.disconnected.clear();
-        this.authFailed.clear();
+        this.authenticationFailed.clear();
         // Remove closed channels after all their staged receives have been processed or if a send was requested
         for (Iterator<Map.Entry<String, KafkaChannel>> it = closingChannels.entrySet().iterator(); it.hasNext(); ) {
             KafkaChannel channel = it.next().getValue();

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.ControllerMovedException;
@@ -166,7 +167,8 @@ public enum Errors {
             " the message was sent to an incompatible broker. See the broker logs for more details.")),
     UNSUPPORTED_FOR_MESSAGE_FORMAT(43,
         new UnsupportedForMessageFormatException("The message format version on the broker does not support the request.")),
-    POLICY_VIOLATION(44, new PolicyViolationException("Request parameters do not satisfy the configured policy."));
+    POLICY_VIOLATION(44, new PolicyViolationException("Request parameters do not satisfy the configured policy.")),
+    AUTHENTICATION_FAILED(45, new AuthenticationException("Authentication of client using SASL failed."));
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -125,6 +125,11 @@ public class MockClient implements KafkaClient {
         return isBlackedOut(node);
     }
 
+    @Override
+    public boolean authFailed() {
+        return false;
+    }
+
     public void disconnect(String node) {
         long now = time.milliseconds();
         Iterator<ClientRequest> iter = requests.iterator();

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -126,7 +126,7 @@ public class MockClient implements KafkaClient {
     }
 
     @Override
-    public boolean authFailed() {
+    public boolean authenticationFailed() {
         return false;
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -78,14 +78,26 @@ public class NetworkTestUtils {
     }
 
     public static void waitForChannelClose(Selector selector, String node) throws IOException {
+        waitForChannelClose(selector, node, false);
+    }
+
+    public static void waitForAuthenticationFailureAndClose(Selector selector, String node) throws IOException {
+        waitForChannelClose(selector, node, true);
+    }
+
+    private static void waitForChannelClose(Selector selector, String node, boolean expectAuthFailure) throws IOException {
         boolean closed = false;
+        int authFailed = 0;
         for (int i = 0; i < 30; i++) {
             selector.poll(1000L);
+            authFailed += selector.authFailed().size();
             if (selector.channel(node) == null) {
                 closed = true;
                 break;
             }
         }
+        if (expectAuthFailure)
+            assertEquals(1, authFailed);
         assertTrue("Channel was not closed by timeout", closed);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -90,7 +90,7 @@ public class NetworkTestUtils {
         int authFailed = 0;
         for (int i = 0; i < 30; i++) {
             selector.poll(1000L);
-            authFailed += selector.authFailed().size();
+            authFailed += selector.authenticationFailed().size();
             if (selector.channel(node) == null) {
                 closed = true;
                 break;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -138,7 +138,7 @@ public class SaslAuthenticatorTest {
 
         server = createEchoServer(securityProtocol);
         createClientConnection(securityProtocol, node);
-        NetworkTestUtils.waitForChannelClose(selector, node);
+        NetworkTestUtils.waitForAuthenticationFailureAndClose(selector, node);
     }
 
     /**
@@ -153,7 +153,7 @@ public class SaslAuthenticatorTest {
 
         server = createEchoServer(securityProtocol);
         createClientConnection(securityProtocol, node);
-        NetworkTestUtils.waitForChannelClose(selector, node);
+        NetworkTestUtils.waitForAuthenticationFailureAndClose(selector, node);
     }
 
     /**
@@ -287,7 +287,7 @@ public class SaslAuthenticatorTest {
         server = createEchoServer(securityProtocol);
         updateScramCredentialCache(TestJaasConfig.USERNAME, TestJaasConfig.PASSWORD);
         createClientConnection(securityProtocol, node);
-        NetworkTestUtils.waitForChannelClose(selector, node);
+        NetworkTestUtils.waitForAuthenticationFailureAndClose(selector, node);
     }
 
     /**
@@ -306,7 +306,7 @@ public class SaslAuthenticatorTest {
         server = createEchoServer(securityProtocol);
         updateScramCredentialCache(TestJaasConfig.USERNAME, TestJaasConfig.PASSWORD);
         createClientConnection(securityProtocol, node);
-        NetworkTestUtils.waitForChannelClose(selector, node);
+        NetworkTestUtils.waitForAuthenticationFailureAndClose(selector, node);
     }
 
     /**
@@ -324,7 +324,7 @@ public class SaslAuthenticatorTest {
         String node = "1";
         saslClientConfigs.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-256");
         createClientConnection(securityProtocol, node);
-        NetworkTestUtils.waitForChannelClose(selector, node);
+        NetworkTestUtils.waitForAuthenticationFailureAndClose(selector, node);
 
         saslClientConfigs.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
         createAndCheckClientConnection(securityProtocol, "2");

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -39,7 +39,7 @@ public class MockSelector implements Selectable {
     private final List<NetworkReceive> completedReceives = new ArrayList<NetworkReceive>();
     private final List<String> disconnected = new ArrayList<String>();
     private final List<String> connected = new ArrayList<String>();
-    private final List<String> authFailed = new ArrayList<String>();
+    private final List<String> authenticationFailed = new ArrayList<String>();
     private final List<DelayedReceive> delayedReceives = new ArrayList<>();
 
     public MockSelector(Time time) {
@@ -134,8 +134,8 @@ public class MockSelector implements Selectable {
     }
 
     @Override
-    public List<String> authFailed() {
-        return authFailed;
+    public List<String> authenticationFailed() {
+        return authenticationFailed;
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -39,6 +39,7 @@ public class MockSelector implements Selectable {
     private final List<NetworkReceive> completedReceives = new ArrayList<NetworkReceive>();
     private final List<String> disconnected = new ArrayList<String>();
     private final List<String> connected = new ArrayList<String>();
+    private final List<String> authFailed = new ArrayList<String>();
     private final List<DelayedReceive> delayedReceives = new ArrayList<>();
 
     public MockSelector(Time time) {
@@ -130,6 +131,11 @@ public class MockSelector implements Selectable {
         List<String> currentConnected = new ArrayList<>(connected);
         connected.clear();
         return currentConnected;
+    }
+
+    @Override
+    public List<String> authFailed() {
+        return authFailed;
     }
 
     @Override

--- a/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SaslApiVersionsRequestTest.scala
@@ -16,11 +16,11 @@
   */
 package kafka.server
 
-import java.io.IOException
 import java.net.Socket
 import java.util.Collections
 
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, SecurityProtocol}
+import org.apache.kafka.common.protocol.types.SchemaException
 import org.apache.kafka.common.requests.{ApiVersionsRequest, ApiVersionsResponse}
 import org.apache.kafka.common.requests.SaslHandshakeRequest
 import org.apache.kafka.common.requests.SaslHandshakeResponse
@@ -58,7 +58,7 @@ class SaslApiVersionsRequestTest extends BaseRequestTest with SaslTestHarness {
         sendApiVersionsRequest(plaintextSocket, new ApiVersionsRequest.Builder().build(0))
         fail("Versions Request during Sasl handshake did not fail")
       } catch {
-        case _: IOException => // expected exception
+        case _: SchemaException => // expected exception
       }
     } finally {
       plaintextSocket.close()


### PR DESCRIPTION
First step towards improving handling of client SASL authentication failures.