### PR TITLE
MINOR: Add subtree .gitignore files themselves to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ patch-process/*
 .idea
 .svn
 .classpath
+/*/**/.gitignore
 /.metadata
 /.recommenders
 *~


### PR DESCRIPTION
This seems like a silly rule, but for example the Eclipse Gradle integration
will 'helpfully' generate .gitignore files in every project that then
show as dirty.  For example, if you take a vanilla Eclipse install and import
Kafka, this is the status you get:

```
??	clients/.gitignore
??	connect/api/.gitignore
??	connect/file/.gitignore
??	connect/json/.gitignore
??	connect/runtime/.gitignore
??	connect/transforms/.gitignore
??	examples/bin/.gitignore
??	log4j-appender/.gitignore
??	streams/.gitignore
??	streams/examples/.gitignore
??	tools/.gitignore
```

Since Kafka only uses the top level `/.gitignore` we can just ignore all the rest.