### PR TITLE
Kafka 4198: Fix Race Condition in KafkaServer Shutdown

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1495,7 +1495,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * If auto-commit is enabled, this will commit the current offsets if possible within the default
      * timeout. See {@link #close(long, TimeUnit)} for details. Note that {@link #wakeup()}
      * cannot be used to interrupt close.
-     * 
+     *
      * @throws org.apache.kafka.common.errors.InterruptException if the calling thread is interrupted
      * before or while this function is called
      */

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -611,6 +611,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         AppInfoParser.unregisterAppInfo(jmxPrefix, config.brokerId.toString)
         shutdownLatch.countDown()
         info("shut down completed")
+      } else {
+        isShuttingDown.set(false)
       }
     }
     catch {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -577,8 +577,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
       if (isStartingUp.get)
         throw new IllegalStateException("Kafka server is still starting up, cannot shut down!")
 
-      val canShutdown = isShuttingDown.compareAndSet(false, true)
-      if (canShutdown && shutdownLatch.getCount > 0) {
+      if (shutdownLatch.getCount > 0 && isShuttingDown.compareAndSet(false, true)) {
         CoreUtils.swallow(controlledShutdown())
         brokerState.newState(BrokerShuttingDown)
         if(socketServer != null)
@@ -604,15 +603,13 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         if (metrics != null)
           CoreUtils.swallow(metrics.close())
 
+        CoreUtils.swallow(AppInfoParser.unregisterAppInfo(jmxPrefix, config.brokerId.toString))
         brokerState.newState(NotRunning)
 
         startupComplete.set(false)
         isShuttingDown.set(false)
-        AppInfoParser.unregisterAppInfo(jmxPrefix, config.brokerId.toString)
         shutdownLatch.countDown()
         info("shut down completed")
-      } else {
-        isShuttingDown.set(false)
       }
     }
     catch {

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -13,8 +13,8 @@
 
 package kafka.api
 
+import java.util.concurrent._
 import java.util.{Collection, Collections}
-import java.util.concurrent.{Callable, Executors, ExecutorService, Future, Semaphore, TimeUnit}
 
 import kafka.admin.AdminClient
 import kafka.server.KafkaConfig
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.junit.Assert._
-import org.junit.{Before, After, Test}
+import org.junit.{After, Before, Test}
 
 import scala.collection.JavaConverters._
 

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -5,7 +5,7 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -102,7 +102,7 @@ trait KafkaServerTestHarness extends ZooKeeperTestHarness {
     }
     super.tearDown
   }
-  
+
   /**
    * Pick a broker at random and kill it if it isn't already dead
    * Return the id of the broker killed
@@ -120,7 +120,7 @@ trait KafkaServerTestHarness extends ZooKeeperTestHarness {
       alive(index) = false
     }
   }
-  
+
   /**
    * Restart any dead brokers
    */


### PR DESCRIPTION
Fixes the initially reported issue in https://issues.apache.org/jira/browse/KAFKA-4198.

The relevant part (the other changes are just dead whitespaces that IDEA removed and one dead import fixed automatically by IDEA) in fixing the initial issue here is the change to `kafka.server.KafkaServer#shutdown`.

It contained this step:

```java
      val canShutdown = isShuttingDown.compareAndSet(false, true)
      if (canShutdown && shutdownLatch.getCount > 0) {
```

without any fallback for the case of `shutdownLatch.getCount == 0`. So in the case of `shutdownLatch.getCount == 0`  (when a previous call to the shutdown method was right about to finish) you would set `isShuttingDown` to true again without any possibility of ever getting the server started (since `startup` will check `isShuttingDown` before setting up a new latch with count 1).

Long story short: concurrent calls to shutdown can get the server locked in a broken state.

This fixes the reported error:

```sh
java.lang.IllegalStateException: Kafka server is still shutting down, cannot re-start!
	at kafka.server.KafkaServer.startup(KafkaServer.scala:184)
	at kafka.integration.KafkaServerTestHarness$$anonfun$restartDeadBrokers$2.apply$mcVI$sp(KafkaServerTestHarness.scala:117)
	at kafka.integration.KafkaServerTestHarness$$anonfun$restartDeadBrokers$2.apply(KafkaServerTestHarness.scala:116)
	at kafka.integration.KafkaServerTestHarness$$anonfun$restartDeadBrokers$2.apply(KafkaServerTestHarness.scala:116)
	at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	at scala.collection.immutable.Range.foreach(Range.scala:160)
	at scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	at kafka.integration.KafkaServerTestHarness$class.restartDeadBrokers(KafkaServerTestHarness.scala:116)
	at kafka.api.ConsumerBounceTest.restartDeadBrokers(ConsumerBounceTest.scala:34)
	at kafka.api.ConsumerBounceTest$BounceBrokerScheduler.doWork(ConsumerBounceTest.scala:158)
```

That said this error (reported in a comment to the JIRA)  is still left even with this fix:

```sh
kafka.api.ConsumerBounceTest > testConsumptionWithBrokerFailures FAILED
    java.lang.IllegalArgumentException: You can only check the position for partitions assigned to this consumer.
        at org.apache.kafka.clients.consumer.KafkaConsumer.position(KafkaConsumer.java:1271)
        at kafka.api.ConsumerBounceTest.consumeWithBrokerFailures(ConsumerBounceTest.scala:96)
        at kafka.api.ConsumerBounceTest.testConsumptionWithBrokerFailures(ConsumerBounceTest.scala:69)
```

... I think this one should get a separate JIRA though. It seems to me that the behaviour of the call to `partition` when a Broker just died is a separate issue from the one initially reported.