### PR TITLE
MINOR: Add build_eclipse to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dist
 *classes
 target/
 build/
+build_eclipse/
 .gradle/
 lib_managed/
 src_managed/


### PR DESCRIPTION
build_eclipse is the configured output directory for eclipse when using
the gradle eclipse plugin and should be ignored