### PR TITLE
HOTFIX: ClassCastException in Request logging

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -117,7 +117,7 @@ class KafkaApis(val requestChannel: RequestChannel,
           else
             requestChannel.sendResponse(new Response(request, response))
 
-          error("Error when handling request %s".format(request.body), e)
+          error("Error when handling request %s".format(request.body[AbstractRequest]), e)
         }
     } finally
       request.apiLocalCompleteTimeMs = time.milliseconds


### PR DESCRIPTION
Comming from [here](https://github.com/apache/kafka/pull/2570#issuecomment-280859637)

Fixed ClassCastException resulting from missing type hint in request logging.