### PR TITLE
MINOR: Fixed 3 inner classes without instance reference to be static

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPassThrough.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPassThrough.java
@@ -25,10 +25,10 @@ class KStreamPassThrough<K, V> implements ProcessorSupplier<K, V> {
 
     @Override
     public Processor<K, V> get() {
-        return new KStreamPassThroughProcessor<K, V>();
+        return new KStreamPassThroughProcessor<>();
     }
 
-    public class KStreamPassThroughProcessor<K, V> extends AbstractProcessor<K, V> {
+    private static final class KStreamPassThroughProcessor<K, V> extends AbstractProcessor<K, V> {
         @Override
         public void process(K key, V value) {
             context().forward(key, value);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinMerger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinMerger.java
@@ -46,7 +46,8 @@ class KTableKTableJoinMerger<K, V> implements KTableProcessorSupplier<K, V, V> {
         parent2.enableSendingOldValues();
     }
 
-    private class KTableKTableJoinMergeProcessor<K, V> extends AbstractProcessor<K, Change<V>> {
+    private static final class KTableKTableJoinMergeProcessor<K, V>
+        extends AbstractProcessor<K, Change<V>> {
         @Override
         public void process(K key, Change<V> value) {
             context().forward(key, value);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorNode.java
@@ -110,7 +110,7 @@ public class ProcessorNode<K, V> {
     public void init(ProcessorContext context) {
         this.context = context;
         try {
-            nodeMetrics = new NodeMetrics(context.metrics(), name,  "task." + context.taskId());
+            nodeMetrics = new NodeMetrics(context.metrics(), name, "task." + context.taskId());
             nodeMetrics.metrics.measureLatencyNs(time, initDelegate, nodeMetrics.nodeCreationSensor);
         } catch (Exception e) {
             throw new StreamsException(String.format("failed to initialize processor %s", name), e);
@@ -164,7 +164,7 @@ public class ProcessorNode<K, V> {
         return sb.toString();
     }
 
-    protected class NodeMetrics  {
+    protected static final class NodeMetrics  {
         final StreamsMetricsImpl metrics;
         final String metricGrpName;
         final Map<String, String> metricTags;


### PR DESCRIPTION
* Turned 3 inner classes that weren't static but could be into `static` ones.
* Turned one `public` inner class that wasn't used publicly into a `private`.

Trivial but imo worthwhile to explicitly keep visibility and "staticness" correct in syntax (if only to be nice to the GC) :)