### PR TITLE
MINOR: Fixed Non-Final Close Method + its Duplication

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -648,7 +648,7 @@ public abstract class AbstractCoordinator implements Closeable {
      * Close the coordinator, waiting if needed to send LeaveGroup.
      */
     @Override
-    public final synchronized void close() {
+    public final void close() {
         close(0);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -648,7 +648,7 @@ public abstract class AbstractCoordinator implements Closeable {
      * Close the coordinator, waiting if needed to send LeaveGroup.
      */
     @Override
-    public synchronized void close() {
+    public final synchronized void close() {
         close(0);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -289,11 +289,6 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
         return JoinGroupRequest.UNKNOWN_MEMBER_ID;
     }
 
-    @Override
-    public void close() {
-        super.close();
-    }
-
     private boolean isLeader() {
         return assignmentSnapshot != null && memberId().equals(assignmentSnapshot.leader());
     }


### PR DESCRIPTION
Trivial but in my opinion it's well worth it making the `close` method `final` here and also deleting that duplication (especially since it's hiding the fact that the `close` is synchronized here).