### PR TITLE
MINOR: Fix transient failure of testCannotSendToInternalTopic

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -75,12 +75,7 @@ trait IntegrationTestHarness extends KafkaServerTestHarness {
       consumers += createNewConsumer
     }
 
-    // create the consumer offset topic
-    TestUtils.createTopic(zkUtils, Topic.GroupMetadataTopicName,
-      serverConfig.getProperty(KafkaConfig.OffsetsTopicPartitionsProp).toInt,
-      serverConfig.getProperty(KafkaConfig.OffsetsTopicReplicationFactorProp).toInt,
-      servers,
-      servers.head.groupCoordinator.offsetsTopicConfigs)
+    TestUtils.createOffsetsTopic(zkUtils, servers)
   }
 
   def createNewProducer: KafkaProducer[Array[Byte], Array[Byte]] = {

--- a/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerFailureHandlingTest.scala
@@ -123,7 +123,7 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
     val record = new ProducerRecord(topic10, null, "key".getBytes, new Array[Byte](maxMessageSize - 50))
     val recordMetadata = producer3.send(record).get
 
-    assertEquals(topic10, recordMetadata.topic())
+    assertEquals(topic10, recordMetadata.topic)
   }
 
   /** This should succeed as the replica fetcher thread can handle oversized messages since KIP-74 */
@@ -176,8 +176,8 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
   }
 
   /**
-    * Send with invalid partition id should throw KafkaException when partition is higher than the
-    * upper bound of partitions and IllegalArgumentException when partition is negative
+    * Send with invalid partition id should throw KafkaException when partition is higher than the upper bound of
+    * partitions.
     */
   @Test
   def testInvalidPartition() {
@@ -185,14 +185,14 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
     TestUtils.createTopic(zkUtils, topic1, 1, numServers, servers)
 
     // create a record with incorrect partition id (higher than the number of partitions), send should fail
-    val higherRecord = new ProducerRecord[Array[Byte], Array[Byte]](topic1, 1, "key".getBytes, "value".getBytes)
+    val higherRecord = new ProducerRecord(topic1, 1, "key".getBytes, "value".getBytes)
     intercept[KafkaException] {
       producer1.send(higherRecord)
     }
   }
 
   /**
-   * The send call after producer closed should throw KafkaException cased by IllegalStateException
+   * The send call after producer closed should throw IllegalStateException
    */
   @Test
   def testSendAfterClosed() {
@@ -218,14 +218,13 @@ class ProducerFailureHandlingTest extends KafkaServerTestHarness {
       producer3.close()
       producer3.send(record)
     }
-
-    // re-close producer is fine
   }
 
   @Test
   def testCannotSendToInternalTopic() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
     val thrown = intercept[ExecutionException] {
-      producer2.send(new ProducerRecord[Array[Byte],Array[Byte]](Topic.InternalTopics.head, "test".getBytes, "test".getBytes)).get
+      producer2.send(new ProducerRecord(Topic.GroupMetadataTopicName, "test".getBytes, "test".getBytes)).get
     }
     assertTrue("Unexpected exception while sending to an invalid topic " + thrown.getCause, thrown.getCause.isInstanceOf[InvalidTopicException])
   }


### PR DESCRIPTION
It’s a simple matter of creating the internal topic before trying to send
to it. Otherwise, we could get an `UnknownTopicOrPartitionException`
in some cases.

Without the change, I could reproduce a failure in less than
5 runs. With the change, 30 consecutive runs succeeded.