### PR TITLE
KAFKA-4788: Revert "KAFKA-4092: retention.bytes should not be allowed to be less than segment.bytes"

### DIFF
--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -324,22 +324,11 @@ object LogConfig {
   }
 
   /**
-    * Check that the property values are valid relative to each other
-    */
-  def validateValues(props: Properties) {
-    val segmentBytes = if (props.getProperty(SegmentBytesProp) == null) Defaults.SegmentSize else props.getProperty(SegmentBytesProp).toLong
-    val retentionBytes = if (props.getProperty(RetentionBytesProp) == null) Defaults.RetentionSize else props.getProperty(RetentionBytesProp).toLong
-    if (segmentBytes > retentionBytes && retentionBytes != -1)
-      throw new InvalidConfigurationException(s"segment.bytes ${segmentBytes} is not less than or equal to retention.bytes ${retentionBytes}")
-  }
-
-  /**
    * Check that the given properties contain only valid log config names and that all values can be parsed and are valid
    */
   def validate(props: Properties) {
     validateNames(props)
     configDef.parse(props)
-    validateValues(props)
   }
 
 }

--- a/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogConfigTest.scala
@@ -111,16 +111,6 @@ class LogConfigTest {
       case _: ConfigException => false
     }
   }
-  def testValueValidator() {
-    val p = new Properties()
-    p.setProperty(LogConfig.SegmentBytesProp, "100")
-    p.setProperty(LogConfig.RetentionBytesProp, "100")
-    LogConfig.validate(p)
-    p.setProperty(LogConfig.RetentionBytesProp, "90")
-    intercept[IllegalArgumentException] {
-      LogConfig.validate(p)
-    }
-  }
 
   private def assertPropertyInvalid(name: String, values: AnyRef*) {
     values.foreach((value) => {


### PR DESCRIPTION
The intent is good, but it needs to take into account broker configs as well.
See KAFKA-4788 for more details.

This reverts commit 4ca5abe8ee7578f602fb7653cb8a09640607ea85.