### PR TITLE
KAFKA-4677: [Follow Up] add optimization to StickyTaskAssignor for rolling rebounce

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -150,4 +150,8 @@ public class ClientState<T> {
     int capacity() {
         return capacity;
     }
+
+    boolean hasUnfulfilledQuota(final int tasksPerThread) {
+        return activeTasks.size() < capacity * tasksPerThread;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -63,7 +63,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
                              numStandbyReplicas, taskId);
                     break;
                 }
-                assign(taskId, ids, false);
+                allocateTaskWithClientCandidates(taskId, ids, false);
             }
         }
     }
@@ -107,14 +107,14 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
 
         // assign any remaining unassigned tasks
         for (final TaskId taskId : unassigned) {
-            assign(taskId, clients.keySet(), true);
+            allocateTaskWithClientCandidates(taskId, clients.keySet(), true);
         }
 
     }
 
 
 
-    private void assign(final TaskId taskId, final Set<ID> clientsWithin, final boolean active) {
+    private void allocateTaskWithClientCandidates(final TaskId taskId, final Set<ID> clientsWithin, final boolean active) {
         final ClientState<TaskId> client = findClient(taskId, clientsWithin);
         taskPairs.addPairs(taskId, client.assignedTasks());
         client.assign(taskId, active);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -35,16 +36,12 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
     private final Map<TaskId, ID> previousActiveTaskAssignment = new HashMap<>();
     private final Map<TaskId, Set<ID>> previousStandbyTaskAssignment = new HashMap<>();
     private final TaskPairs taskPairs;
-    private final int availableCapacity;
-    private final boolean hasNewTasks;
 
     public StickyTaskAssignor(final Map<ID, ClientState<TaskId>> clients, final Set<TaskId> taskIds) {
         this.clients = clients;
         this.taskIds = taskIds;
-        this.availableCapacity = sumCapacity(clients.values());
         taskPairs = new TaskPairs(taskIds.size() * (taskIds.size() - 1) / 2);
         mapPreviousTaskAssignment(clients);
-        this.hasNewTasks = !previousActiveTaskAssignment.keySet().containsAll(taskIds);
     }
 
     @Override
@@ -72,27 +69,61 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
     }
 
     private void assignActive() {
-        final Set<TaskId> previouslyAssignedTaskIds = new HashSet<>(previousActiveTaskAssignment.keySet());
-        previouslyAssignedTaskIds.addAll(previousStandbyTaskAssignment.keySet());
-        previouslyAssignedTaskIds.retainAll(taskIds);
+        final int totalCapacity = sumCapacity(clients.values());
+        final int tasksPerThread = taskIds.size() / totalCapacity;
+        final Set<TaskId> assigned = new HashSet<>();
 
-        // assign previously assigned tasks first
-        for (final TaskId taskId : previouslyAssignedTaskIds) {
+        // first try and re-assign existing active tasks to clients that previously had
+        // the same active task
+        for (final Map.Entry<TaskId, ID> entry : previousActiveTaskAssignment.entrySet()) {
+            final TaskId taskId = entry.getKey();
+            if (taskIds.contains(taskId)) {
+                final ClientState<TaskId> client = clients.get(entry.getValue());
+                if (client.hasUnfulfilledQuota(tasksPerThread)) {
+                    assignTaskToClient(assigned, taskId, client);
+                }
+            }
+        }
+
+        final Set<TaskId> unassigned = new HashSet<>(taskIds);
+        unassigned.removeAll(assigned);
+
+        // try and assign any remaining unassigned tasks to clients that previously
+        // have seen the task.
+        for (final Iterator<TaskId> iterator = unassigned.iterator(); iterator.hasNext(); ) {
+            final TaskId taskId = iterator.next();
+            final Set<ID> clientIds = previousStandbyTaskAssignment.get(taskId);
+            if (clientIds != null) {
+                for (final ID clientId : clientIds) {
+                    final ClientState<TaskId> client = clients.get(clientId);
+                    if (client.hasUnfulfilledQuota(tasksPerThread)) {
+                        assignTaskToClient(assigned, taskId, client);
+                        iterator.remove();
+                        break;
+                    }
+                }
+            }
+        }
+
+        // assign any remaining unassigned tasks
+        for (final TaskId taskId : unassigned) {
             assign(taskId, clients.keySet(), true);
         }
 
-        final Set<TaskId> newTasks  = new HashSet<>(taskIds);
-        newTasks.removeAll(previouslyAssignedTaskIds);
-
-        for (final TaskId taskId : newTasks) {
-            assign(taskId, clients.keySet(), true);
-        }
     }
+
+
 
     private void assign(final TaskId taskId, final Set<ID> clientsWithin, final boolean active) {
         final ClientState<TaskId> client = findClient(taskId, clientsWithin);
         taskPairs.addPairs(taskId, client.assignedTasks());
         client.assign(taskId, active);
+    }
+
+    private void assignTaskToClient(final Set<TaskId> assigned, final TaskId taskId, final ClientState<TaskId> client) {
+        taskPairs.addPairs(taskId, client.assignedTasks());
+        client.assign(taskId, true);
+        assigned.add(taskId);
     }
 
     private Set<ID> findClientsWithoutAssignedTask(final TaskId taskId) {
@@ -131,9 +162,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
     }
 
     private boolean shouldBalanceLoad(final ClientState<TaskId> client) {
-        return !hasNewTasks
-                && client.reachedCapacity()
-                && hasClientsWithMoreAvailableCapacity(client);
+        return client.reachedCapacity() && hasClientsWithMoreAvailableCapacity(client);
     }
 
     private boolean hasClientsWithMoreAvailableCapacity(final ClientState<TaskId> client) {
@@ -208,6 +237,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
                 previousStandbyTaskAssignment.get(prevAssignedTask).add(clientState.getKey());
             }
         }
+
     }
 
     private int sumCapacity(final Collection<ClientState<TaskId>> values) {
@@ -217,7 +247,6 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
         }
         return capacity;
     }
-
 
     private static class TaskPairs {
         private final Set<Pair> pairs;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/ClientStateTest.java
@@ -146,5 +146,18 @@ public class ClientStateTest {
         c1.hasMoreAvailableCapacityThan(new ClientState<Integer>(0));
     }
 
+    @Test
+    public void shouldHaveUnfulfilledQuotaWhenActiveTaskSizeLessThanCapacityTimesTasksPerThread() throws Exception {
+        final ClientState<Integer> client = new ClientState<>(1);
+        client.assign(1, true);
+        assertTrue(client.hasUnfulfilledQuota(2));
+    }
+
+    @Test
+    public void shouldNotHaveUnfulfilledQuotaWhenActiveTaskSizeGreaterEqualThanCapacityTimesTasksPerThread() throws Exception {
+        final ClientState<Integer> client = new ClientState<>(1);
+        client.assign(1, true);
+        assertFalse(client.hasUnfulfilledQuota(1));
+    }
 
 }


### PR DESCRIPTION
Detect when a rebalance has happened due to one or more existing nodes bouncing. Keep assignment of previous active tasks the same and only assign the tasks that were not active to the new clients.