### PR TITLE
KAFKA-4819: Expose states for active tasks to public API

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -51,6 +51,7 @@ import org.apache.kafka.streams.processor.internals.ThreadStateTransitionValidat
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.StreamsMetadata;
+import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.state.internals.GlobalStateStoreProvider;
 import org.apache.kafka.streams.state.internals.QueryableStoreProvider;
 import org.apache.kafka.streams.state.internals.StateStoreProvider;
@@ -793,8 +794,11 @@ public class KafkaStreams {
      * {@link Topology} and {@link StreamsBuilder}).
      *
      * @return A string representation of the Kafka Streams instance.
+     *
+     * @deprecated Use {@link #localThreadsMetadata()} to retrieve runtime information.
      */
     @Override
+    @Deprecated
     public String toString() {
         return toString("");
     }
@@ -806,7 +810,10 @@ public class KafkaStreams {
      *
      * @param indent the top-level indent for each line
      * @return A string representation of the Kafka Streams instance.
+     *
+     * @deprecated Use {@link #localThreadsMetadata()} to retrieve runtime information.
      */
+    @Deprecated
     public String toString(final String indent) {
         final StringBuilder sb = new StringBuilder()
             .append(indent)
@@ -959,5 +966,19 @@ public class KafkaStreams {
     public <T> T store(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         validateIsRunning();
         return queryableStoreProvider.getStore(storeName, queryableStoreType);
+    }
+
+    /**
+     * Returns runtime information about the local threads of this {@link KafkaStreams} instance.
+     *
+     * @return the set of {@link ThreadMetadata}.
+     */
+    public Set<ThreadMetadata> localThreadsMetadata() {
+        validateIsRunning();
+        final Set<ThreadMetadata> threadMetadata = new HashSet<>();
+        for (StreamThread thread : threads) {
+            threadMetadata.add(thread.threadMetadata());
+        }
+        return threadMetadata;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TaskMetadata.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.KafkaStreams;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents the state of a single task running within a {@link KafkaStreams} application.
+ */
+public class TaskMetadata {
+
+    private final String taskId;
+
+    private final Set<TopicPartition> topicPartitions;
+
+    public TaskMetadata(final String taskId,
+                        final Set<TopicPartition> topicPartitions) {
+        this.taskId = taskId;
+        this.topicPartitions = Collections.unmodifiableSet(topicPartitions);
+    }
+
+    public String taskId() {
+        return taskId;
+    }
+
+    public Set<TopicPartition> topicPartitions() {
+        return topicPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TaskMetadata that = (TaskMetadata) o;
+        return Objects.equals(taskId, that.taskId) &&
+               Objects.equals(topicPartitions, that.topicPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(taskId, topicPartitions);
+    }
+
+    @Override
+    public String toString() {
+        return "TaskMetadata{" +
+                "taskId=" + taskId +
+                ", topicPartitions=" + topicPartitions +
+                '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ThreadMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ThreadMetadata.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor;
+
+import org.apache.kafka.streams.KafkaStreams;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Represents the state of a single thread running within a {@link KafkaStreams} application.
+ */
+public class ThreadMetadata {
+
+    private final String threadName;
+
+    private final String threadState;
+
+    private final Set<TaskMetadata> activeTasks;
+
+    private final Set<TaskMetadata> standbyTasks;
+
+    public ThreadMetadata(final String threadName,
+                          final String threadState,
+                          final Set<TaskMetadata> activeTasks,
+                          final Set<TaskMetadata> standbyTasks) {
+        this.threadName = threadName;
+        this.threadState = threadState;
+        this.activeTasks = Collections.unmodifiableSet(activeTasks);
+        this.standbyTasks = Collections.unmodifiableSet(standbyTasks);
+    }
+
+    public String threadState() {
+        return threadState;
+    }
+
+    public String threadName() {
+        return threadName;
+    }
+
+    public Set<TaskMetadata> activeTasks() {
+        return activeTasks;
+    }
+
+    public Set<TaskMetadata> standbyTasks() {
+        return standbyTasks;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ThreadMetadata that = (ThreadMetadata) o;
+        return Objects.equals(threadName, that.threadName) &&
+               Objects.equals(threadState, that.threadState) &&
+               Objects.equals(activeTasks, that.activeTasks) &&
+               Objects.equals(standbyTasks, that.standbyTasks);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(threadName, threadState, activeTasks, standbyTasks);
+    }
+
+    @Override
+    public String toString() {
+        return "ThreadMetadata{" +
+                "threadName=" + threadName +
+                ", threadState=" + threadState +
+                ", activeTasks=" + activeTasks +
+                ", standbyTasks=" + standbyTasks +
+                '}';
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -43,6 +43,8 @@ import org.apache.kafka.streams.errors.TaskIdFormatException;
 import org.apache.kafka.streams.processor.PartitionGrouper;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.TaskMetadata;
+import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -196,6 +198,11 @@ public class StreamThread extends Thread implements ThreadDataProvider {
             }
 
             state = newState;
+            if (newState == State.RUNNING) {
+                updateThreadMetadata(taskManager.activeTasks(), taskManager.standbyTasks());
+            } else {
+                updateThreadMetadata(null, null);
+            }
         }
 
         if (stateListener != null) {
@@ -560,6 +567,8 @@ public class StreamThread extends Thread implements ThreadDataProvider {
 
     public final String applicationId;
 
+    private volatile ThreadMetadata threadMetadata;
+
     private final static int UNLIMITED_RECORDS = -1;
 
     public StreamThread(final InternalTopologyBuilder builder,
@@ -603,6 +612,7 @@ public class StreamThread extends Thread implements ThreadDataProvider {
         }
         this.consumer = clientSupplier.getConsumer(consumerConfigs);
         taskManager.setConsumer(consumer);
+        updateThreadMetadata(null, null);
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -1170,5 +1180,30 @@ public class StreamThread extends Thread implements ThreadDataProvider {
 
     private void refreshMetadataState() {
         streamsMetadataState.onChange(metadataProvider.getPartitionsByHostState(), metadataProvider.clusterMetadata());
+    }
+
+    /**
+     * Return information about the current {@link StreamThread}.
+     *
+     * @return {@link ThreadMetadata}.
+     */
+    public final ThreadMetadata threadMetadata() {
+        return threadMetadata;
+    }
+
+    private void updateThreadMetadata(final Map<TaskId, Task> activeTasks, final Map<TaskId, Task> standbyTasks) {
+        final Set<TaskMetadata> activeTasksMetadata = new HashSet<>();
+        if (activeTasks != null) {
+            for (Map.Entry<TaskId, Task> task : activeTasks.entrySet()) {
+                activeTasksMetadata.add(new TaskMetadata(task.getKey().toString(), task.getValue().partitions()));
+            }
+        }
+        final Set<TaskMetadata> standbyTasksMetadata = new HashSet<>();
+        if (standbyTasks != null) {
+            for (Map.Entry<TaskId, Task> task : standbyTasks.entrySet()) {
+                standbyTasksMetadata.add(new TaskMetadata(task.getKey().toString(), task.getValue().partitions()));
+            }
+        }
+        threadMetadata = new ThreadMetadata(this.getName(), this.state().name(), activeTasksMetadata, standbyTasksMetadata);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -192,7 +192,7 @@ public class StreamsMetadataState {
     /**
      * Respond to changes to the HostInfo -> TopicPartition mapping. Will rebuild the
      * metadata
-     * @param currentState  the current mapping of {@link HostInfo} -> {@link TopicPartition}s
+     * @param currentState       the current mapping of {@link HostInfo} -> {@link TopicPartition}s
      * @param clusterMetadata    the current clusterMetadata {@link Cluster}
      */
     synchronized void onChange(final Map<HostInfo, Set<TopicPartition>> currentState, final Cluster clusterMetadata) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -239,6 +239,10 @@ class TaskManager {
         return active.runningTaskMap();
     }
 
+    Map<TaskId, Task> standbyTasks() {
+        return standby.runningTaskMap();
+    }
+
     void setConsumer(final Consumer<byte[], byte[]> consumer) {
         this.consumer = consumer;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -23,12 +23,14 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread;
 import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.MockStateRestoreListener;
@@ -45,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -53,6 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 
 @Category({IntegrationTest.class})
 public class KafkaStreamsTest {
@@ -396,6 +400,26 @@ public class KafkaStreamsTest {
             // stop the thread so we don't interfere with other tests etc
             keepRunning.set(false);
         }
+    }
+
+    @Test
+    public void shouldReturnThreadMetadata() {
+        final Properties props = new Properties();
+        props.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
+        props.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        props.setProperty(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, Sensor.RecordingLevel.INFO.toString());
+        props.setProperty(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "2");
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+        streams.start();
+        Set<ThreadMetadata> threadMetadata = streams.localThreadsMetadata();
+        assertNotNull(threadMetadata);
+        assertEquals(2, threadMetadata.size());
+        for (ThreadMetadata metadata : threadMetadata) {
+            assertTrue(Utils.mkList("RUNNING", "CREATED").contains(metadata.threadState()));
+            assertEquals(0, metadata.standbyTasks().size());
+            assertEquals(0, metadata.activeTasks().size());
+        }
+        streams.close();
     }
 
 


### PR DESCRIPTION
Simple implementation of the feature : [KAFKA-4819](https://issues.apache.org/jira/browse/KAFKA-4819)
 KAFKA-4819

This PR adds a new method `threadStates` to public API of `KafkaStreams` which returns all currently states of running threads and active tasks.

Below is a example for a simple topology consuming from topics; test-p2 and test-p4.

[{"name":"StreamThread-1","state":"RUNNING","activeTasks":[{"id":"0_0", "assignments":["test-p4-0","test-p2-0"], "consumedOffsetsByPartition":[{"topicPartition":"test-p2-0","offset":"test-p2-0"}]}, {"id":"0_2", "assignments":["test-p4-2"], "consumedOffsetsByPartition":[]}]}, {"name":"StreamThread-2","state":"RUNNING","activeTasks":[{"id":"0_1", "assignments":["test-p4-1","test-p2-1"], "consumedOffsetsByPartition":[{"topicPartition":"test-p2-1","offset":"test-p2-1"}]}, {"id":"0_3", "assignments":["test-p4-3"], "consumedOffsetsByPartition":[]}]}]