### PR TITLE
MINOR. Fix tests/docker/Dockerfile

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -23,9 +23,9 @@ ADD ssh /root/.ssh
 RUN chmod 600 /root/.ssh/id_rsa
 RUN apt update && apt install -y unzip wget curl jq coreutils openssh-server net-tools vim openjdk-8-jdk python-pip python-dev libffi-dev libssl-dev
 RUN pip install -U pip && pip install --upgrade cffi ducktape==0.6.0
-RUN mkdir -p "/opt/kafka_2.10-0.8.2.2" && curl "${MIRROR}kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka_2.10-0.8.2.2"
-RUN mkdir -p "/opt/kafka_2.10-0.9.0.1" && curl "${MIRROR}kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka_2.10-0.9.0.1"
-RUN mkdir -p "/opt/kafka_2.10-0.10.0.1" && curl "${MIRROR}kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka_2.10-0.10.0.1"
-RUN mkdir -p "/opt/kafka_2.10-0.10.1.1" && curl "${MIRROR}kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka_2.10-0.10.1.1"
+RUN mkdir -p "/opt/kafka-0.8.2.2" && curl -s "${MIRROR}kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.8.2.2"
+RUN mkdir -p "/opt/kafka-0.9.0.1" && curl -s "${MIRROR}kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.9.0.1"
+RUN mkdir -p "/opt/kafka-0.10.0.1" && curl -s "${MIRROR}kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.10.0.1"
+RUN mkdir -p "/opt/kafka-0.10.1.1" && curl -s "${MIRROR}kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-0.10.1.1"
 
 CMD service ssh start && tail -f /dev/null

--- a/tests/docker/run_tests.sh
+++ b/tests/docker/run_tests.sh
@@ -18,6 +18,11 @@
 #   TC_PATHS="tests/kafkatest/tests/streams tests/kafkatest/tests/tools" bash tests/docker/run_tests.sh
 set -x
 
+die() {
+    echo $@
+    exit 1
+}
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TESTS_DIR=`dirname ${SCRIPT_DIR}`
 KAFKA_SRC=`dirname ${TESTS_DIR}`
@@ -40,7 +45,8 @@ docker run --rm -it ${KAFKA_IMAGE} "true"
 if [[ $? != 0 || ${KAFKA_IMAGE_REBUILD} != "" ]]; then
     echo "kafka image ${KAFKA_IMAGE} does not exist. Building it from scratch."
     COMMIT_INFO=$(git describe HEAD)
-    docker build -t ${KAFKA_IMAGE} --label=commit_info=${COMMIT_INFO} ${SCRIPT_DIR}
+    docker build -t ${KAFKA_IMAGE} --label=commit_info=${COMMIT_INFO} ${SCRIPT_DIR} \
+        || die "docker build failed"
 fi
 
 echo "Using kafka image: ${KAFKA_IMAGE}"


### PR DESCRIPTION
Fix tests/docker/Dockerfile to put the old Kafka distributions in the
correct spot for tests.  Also, run_tests.sh should exit with an error
code if image rebuilding fails, rather than silently falling back to an
older image.