### PR TITLE
MINOR: additional refactoring around the use of Errors

### DIFF
--- a/core/src/main/scala/kafka/common/OffsetMetadataAndError.scala
+++ b/core/src/main/scala/kafka/common/OffsetMetadataAndError.scala
@@ -58,7 +58,7 @@ case class OffsetMetadataAndError(offsetMetadata: OffsetMetadata, error: Errors 
 
   def metadata = offsetMetadata.metadata
 
-  override def toString = "[%s,ErrorCode %d]".format(offsetMetadata, error)
+  override def toString = "[%s, Error='%s: %s']".format(offsetMetadata, error.exceptionName, error.message)
 }
 
 object OffsetMetadataAndError {

--- a/core/src/main/scala/kafka/common/OffsetMetadataAndError.scala
+++ b/core/src/main/scala/kafka/common/OffsetMetadataAndError.scala
@@ -58,7 +58,7 @@ case class OffsetMetadataAndError(offsetMetadata: OffsetMetadata, error: Errors 
 
   def metadata = offsetMetadata.metadata
 
-  override def toString = "[%s, Error='%s: %s']".format(offsetMetadata, error.exceptionName, error.message)
+  override def toString = "[%s, Error=%s]".format(offsetMetadata, error)
 }
 
 object OffsetMetadataAndError {

--- a/core/src/main/scala/kafka/coordinator/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/GroupCoordinator.scala
@@ -474,8 +474,8 @@ class GroupCoordinator(val brokerId: Int,
     if (!isActive.get) {
       (Errors.GROUP_COORDINATOR_NOT_AVAILABLE, List[GroupOverview]())
     } else {
-      val errorCode = if (groupManager.isLoading()) Errors.GROUP_LOAD_IN_PROGRESS else Errors.NONE
-      (errorCode, groupManager.currentGroups.map(_.overview).toList)
+      val error = if (groupManager.isLoading()) Errors.GROUP_LOAD_IN_PROGRESS else Errors.NONE
+      (error, groupManager.currentGroups.map(_.overview).toList)
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -278,7 +278,7 @@ class ReplicaFetcherThread(name: String,
           partitionData.offset
         else
           partitionData.offsets.get(0)
-      case errorCode => throw errorCode.exception
+      case error => throw error.exception
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -74,7 +74,8 @@ case class LogReadResult(info: FetchDataInfo,
   }
 
   override def toString =
-    s"Fetch Data: [$info], HW: [$hw], leaderLogEndOffset: [$leaderLogEndOffset], readSize: [$readSize], error: [${error.exceptionName}]"
+    s"Fetch Data: [$info], HW: [$hw], leaderLogEndOffset: [$leaderLogEndOffset], readSize: [$readSize], error: [$error]"
+
 }
 
 case class FetchPartitionData(error: Errors = Errors.NONE, hw: Long = -1L, records: Records)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -74,8 +74,7 @@ case class LogReadResult(info: FetchDataInfo,
   }
 
   override def toString =
-    s"Fetch Data: [$info], HW: [$hw], leaderLogEndOffset: [$leaderLogEndOffset], readSize: [$readSize], error: [$error]"
-
+    s"Fetch Data: [$info], HW: [$hw], leaderLogEndOffset: [$leaderLogEndOffset], readSize: [$readSize], error: [${error.exceptionName}]"
 }
 
 case class FetchPartitionData(error: Errors = Errors.NONE, hw: Long = -1L, records: Records)


### PR DESCRIPTION
A couple of updates were missed in the [PR](https://github.com/apache/kafka/pull/2475) that replaced the use of error codes with Errors objects.