### PR TITLE
KAFKA-3155: Avoid Long Overflow in org.apache.kafka.clients.producer.internals.RecordBatch#maybeExpire

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -81,7 +81,7 @@ public final class RecordAccumulator {
 
     /**
      * Create a new record accumulator
-     * 
+     *
      * @param batchSize The size to use when allocating {@link MemoryRecords} instances
      * @param totalSize The maximum memory the record accumulator can use.
      * @param compression The compression codec for the records
@@ -205,7 +205,7 @@ public final class RecordAccumulator {
 
                 // Don't deallocate this buffer in the finally block as it's being used in the record batch
                 buffer = null;
-                
+
                 return new RecordAppendResult(future, dq.size() > 1 || batch.isFull(), true);
             }
         } finally {
@@ -332,7 +332,7 @@ public final class RecordAccumulator {
                     RecordBatch batch = deque.peekFirst();
                     if (batch != null) {
                         long waitedTimeMs = batch.waitedTimeMs(nowMs);
-                        boolean backingOff = batch.attempts() > 0 && waitedTimeMs > retryBackoffMs;
+                        boolean backingOff = batch.attempts() > 0 && waitedTimeMs < retryBackoffMs;
                         long timeToWaitMs = backingOff ? retryBackoffMs : lingerMs;
                         boolean full = deque.size() > 1 || batch.isFull();
                         boolean expired = waitedTimeMs >= timeToWaitMs;
@@ -371,7 +371,7 @@ public final class RecordAccumulator {
     /**
      * Drain all the data for the given nodes and collate them into a list of batches that will fit within the specified
      * size on a per-node basis. This method attempts to avoid choosing the same topic-node over and over.
-     * 
+     *
      * @param cluster The current cluster metadata
      * @param nodes The list of node to drain
      * @param maxSize The maximum number of bytes to drain
@@ -402,7 +402,7 @@ public final class RecordAccumulator {
                         synchronized (deque) {
                             RecordBatch first = deque.peekFirst();
                             if (first != null) {
-                                boolean backoff = first.attempts() > 0 && first.waitedTimeMs(now) > retryBackoffMs;
+                                boolean backoff = first.attempts() > 0 && first.waitedTimeMs(now) < retryBackoffMs;
                                 // Only drain the batch if it is not during backoff period.
                                 if (!backoff) {
                                     if (size + first.sizeInBytes() > maxSize && !ready.isEmpty()) {
@@ -455,7 +455,7 @@ public final class RecordAccumulator {
         incomplete.remove(batch);
         free.deallocate(batch.buffer(), batch.initialCapacity());
     }
-    
+
     /**
      * Are there any threads currently waiting on a flush?
      *
@@ -469,7 +469,7 @@ public final class RecordAccumulator {
     Map<TopicPartition, Deque<RecordBatch>> batches() {
         return Collections.unmodifiableMap(batches);
     }
-    
+
     /**
      * Initiate the flushing of data from the accumulator...this makes all requests immediately ready
      */
@@ -575,7 +575,7 @@ public final class RecordAccumulator {
             this.unknownLeaderTopics = unknownLeaderTopics;
         }
     }
-    
+
     /*
      * A threadsafe helper class to hold RecordBatches that haven't been ack'd yet
      */
@@ -585,13 +585,13 @@ public final class RecordAccumulator {
         public IncompleteRecordBatches() {
             this.incomplete = new HashSet<RecordBatch>();
         }
-        
+
         public void add(RecordBatch batch) {
             synchronized (incomplete) {
                 this.incomplete.add(batch);
             }
         }
-        
+
         public void remove(RecordBatch batch) {
             synchronized (incomplete) {
                 boolean removed = this.incomplete.remove(batch);
@@ -599,7 +599,7 @@ public final class RecordAccumulator {
                     throw new IllegalStateException("Remove from the incomplete set failed. This should be impossible.");
             }
         }
-        
+
         public Iterable<RecordBatch> all() {
             synchronized (incomplete) {
                 return new ArrayList<>(this.incomplete);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -154,10 +154,10 @@ public final class RecordBatch {
     public boolean maybeExpire(int requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
         if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
             expiryErrorMessage = (now - this.lastAppendTime) + " ms has passed since last append";
-        else if (!this.inRetry() && requestTimeoutMs < (Math.max(0, now - this.createdMs) - lingerMs))
-            expiryErrorMessage = (Math.max(0, now - this.createdMs) - lingerMs) + " ms has passed since batch creation plus linger time";
-        else if (this.inRetry() && requestTimeoutMs < (now - this.lastAttemptMs - retryBackoffMs))
-            expiryErrorMessage = (now - this.lastAttemptMs - retryBackoffMs) + " ms has passed since last attempt plus backoff time";
+        else if (!this.inRetry() && requestTimeoutMs < (createdTimeMs(now) - lingerMs))
+            expiryErrorMessage = (createdTimeMs(now) - lingerMs) + " ms has passed since batch creation plus linger time";
+        else if (this.inRetry() && requestTimeoutMs < (waitedTimeMs(now) - retryBackoffMs))
+            expiryErrorMessage = (waitedTimeMs(now) - retryBackoffMs) + " ms has passed since last attempt plus backoff time";
 
         boolean expired = expiryErrorMessage != null;
         if (expired)
@@ -190,6 +190,10 @@ public final class RecordBatch {
 
     long queueTimeMs() {
         return drainedMs - createdMs;
+    }
+
+    long createdTimeMs(long nowMs) {
+        return Math.max(0, nowMs - createdMs);
     }
 
     long waitedTimeMs(long nowMs) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -152,13 +152,12 @@ public final class RecordBatch {
      * {@link #expirationDone()} must be invoked to complete the produce future and invoke callbacks.
      */
     public boolean maybeExpire(int requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
-
         if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
             expiryErrorMessage = (now - this.lastAppendTime) + " ms has passed since last append";
-        else if (!this.inRetry() && requestTimeoutMs < (now - Math.max(this.createdMs + lingerMs, lingerMs)))
-            expiryErrorMessage = (now - (this.createdMs + lingerMs)) + " ms has passed since batch creation plus linger time";
-        else if (this.inRetry() && requestTimeoutMs < (now - (this.lastAttemptMs + retryBackoffMs)))
-            expiryErrorMessage = (now - (this.lastAttemptMs + retryBackoffMs)) + " ms has passed since last attempt plus backoff time";
+        else if (!this.inRetry() && requestTimeoutMs < (now - this.createdMs - lingerMs))
+            expiryErrorMessage = (now - this.createdMs - lingerMs) + " ms has passed since batch creation plus linger time";
+        else if (this.inRetry() && requestTimeoutMs < (now - this.lastAttemptMs - retryBackoffMs))
+            expiryErrorMessage = (now - this.lastAttemptMs - retryBackoffMs) + " ms has passed since last attempt plus backoff time";
 
         boolean expired = expiryErrorMessage != null;
         if (expired)

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -154,8 +154,8 @@ public final class RecordBatch {
     public boolean maybeExpire(int requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
         if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
             expiryErrorMessage = (now - this.lastAppendTime) + " ms has passed since last append";
-        else if (!this.inRetry() && requestTimeoutMs < (now - this.createdMs - lingerMs))
-            expiryErrorMessage = (now - this.createdMs - lingerMs) + " ms has passed since batch creation plus linger time";
+        else if (!this.inRetry() && requestTimeoutMs < (Math.max(0, now - this.createdMs) - lingerMs))
+            expiryErrorMessage = (Math.max(0, now - this.createdMs) - lingerMs) + " ms has passed since batch creation plus linger time";
         else if (this.inRetry() && requestTimeoutMs < (now - this.lastAttemptMs - retryBackoffMs))
             expiryErrorMessage = (now - this.lastAttemptMs - retryBackoffMs) + " ms has passed since last attempt plus backoff time";
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordBatch.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A batch of records that is or will be sent.
- * 
+ *
  * This class is not thread safe and external synchronization must be used when modifying it
  */
 public final class RecordBatch {
@@ -69,7 +69,7 @@ public final class RecordBatch {
 
     /**
      * Append the record to the current record set and return the relative offset within that record set
-     * 
+     *
      * @return The RecordSend corresponding to this record or null if there isn't sufficient room.
      */
     public FutureRecordMetadata tryAppend(long timestamp, byte[] key, byte[] value, Callback callback, long now) {
@@ -92,7 +92,7 @@ public final class RecordBatch {
 
     /**
      * Complete the request.
-     * 
+     *
      * @param baseOffset The base offset of the messages assigned by the server
      * @param logAppendTime The log append time or -1 if CreateTime is being used
      * @param exception The exception that occurred (or null if the request was successful)
@@ -155,7 +155,7 @@ public final class RecordBatch {
 
         if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
             expiryErrorMessage = (now - this.lastAppendTime) + " ms has passed since last append";
-        else if (!this.inRetry() && requestTimeoutMs < (now - (this.createdMs + lingerMs)))
+        else if (!this.inRetry() && requestTimeoutMs < (now - Math.max(this.createdMs + lingerMs, lingerMs)))
             expiryErrorMessage = (now - (this.createdMs + lingerMs)) + " ms has passed since batch creation plus linger time";
         else if (this.inRetry() && requestTimeoutMs < (now - (this.lastAttemptMs + retryBackoffMs)))
             expiryErrorMessage = (now - (this.lastAttemptMs + retryBackoffMs)) + " ms has passed since last attempt plus backoff time";

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -300,7 +300,7 @@ public class Sender implements Runnable {
             log.warn("Got error produce response with correlation id {} on topic-partition {}, retrying ({} attempts left). Error: {}",
                      correlationId,
                      batch.topicPartition,
-                     this.retries - batch.attempts - 1,
+                     this.retries - batch.attempts() - 1,
                      error);
             this.accumulator.reenqueue(batch, now);
             this.sensors.recordRetries(batch.topicPartition.topic(), batch.recordCount);
@@ -332,7 +332,7 @@ public class Sender implements Runnable {
      * We can retry a send if the error is transient and the number of attempts taken is fewer than the maximum allowed
      */
     private boolean canRetry(RecordBatch batch, Errors error) {
-        return batch.attempts < this.retries && error.exception() instanceof RetriableException;
+        return batch.attempts() < this.retries && error.exception() instanceof RetriableException;
     }
 
     /**
@@ -519,7 +519,7 @@ public class Sender implements Runnable {
 
                     // global metrics
                     this.batchSizeSensor.record(batch.sizeInBytes(), now);
-                    this.queueTimeSensor.record(batch.drainedMs - batch.createdMs, now);
+                    this.queueTimeSensor.record(batch.queueTimeMs(), now);
                     this.compressionRateSensor.record(batch.compressionRate());
                     this.maxRecordSizeSensor.record(batch.maxRecordSize, now);
                     records += batch.recordCount;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordBatchTest.java
@@ -29,6 +29,22 @@ import static org.junit.Assert.assertFalse;
 public class RecordBatchTest {
 
     /**
+     * Arbitrary constant timestamp used as reproducible "now" reference.
+     */
+    private static final long REFERENCE_NOW = 1488748346917L;
+
+    /**
+     * Arbitrary constant MemoryRecordsBuilder for instantiating RecordBatch,
+     * when the specifics of its MemoryRecordsBuilder are not relevant.
+     */
+    private static final MemoryRecordsBuilder MEMORY_RECORDS_BUILDER =
+        new MemoryRecordsBuilder(
+            ByteBuffer.allocate(0), Record.CURRENT_MAGIC_VALUE,
+            CompressionType.NONE,
+            TimestampType.CREATE_TIME, 0L, Record.NO_TIMESTAMP, 0
+        );
+
+    /**
      * A RecordBatch configured using very large linger value, in combination
      * with a timestamp preceding the create time of a RecordBatch, is
      * interpreted correctly as not expired when the linger time is larger than
@@ -36,18 +52,48 @@ public class RecordBatchTest {
      */
     @Test
     public void testLargeLingerOldNowExpire() {
-        final long now = 1488748346917L;
+        final long now = REFERENCE_NOW;
         final RecordBatch batch = new RecordBatch(
-            new TopicPartition("topic", 1),
-            new MemoryRecordsBuilder(
-                ByteBuffer.allocate(0), Record.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
-                TimestampType.CREATE_TIME, 0L, Record.NO_TIMESTAMP, 0
-            ), now
+            new TopicPartition("topic", 1), MEMORY_RECORDS_BUILDER, now
         );
         // Use `now` 2ms before the create time.
         assertFalse(
             batch.maybeExpire(10240, 100L, now - 2L, Long.MAX_VALUE, false)
+        );
+    }
+
+    /**
+     * A RecordBatch configured using very large retryBackoff value, in combination
+     * with a timestamp preceding the create time of a RecordBatch, is
+     * interpreted correctly as not expired when the retryBackoff time is larger than
+     * the difference between now and create time by RecordBatch#maybeExpire.
+     */
+    @Test
+    public void testLargeRetryBackoffOldNowExpire() {
+        final long now = REFERENCE_NOW;
+        final RecordBatch batch = new RecordBatch(
+            new TopicPartition("topic", 1), MEMORY_RECORDS_BUILDER, now
+        );
+        // Use `now` 2ms before the create time.
+        assertFalse(
+            batch.maybeExpire(10240, Long.MAX_VALUE, now - 2L, 10240L, false)
+        );
+    }
+
+    /**
+     * A RecordBatch#maybeExpire call with a now value before the create time of
+     * the RecordBatch as correctly recognized as not expired when invoked with
+     * parameter {@code isFull} equal to {@code true}.
+     */
+    @Test
+    public void testLargeFullOldNowExpire() {
+        final long now = REFERENCE_NOW;
+        final RecordBatch batch = new RecordBatch(
+            new TopicPartition("topic", 1), MEMORY_RECORDS_BUILDER, now
+        );
+        // Use `now` 2ms before the create time.
+        assertFalse(
+            batch.maybeExpire(10240, 10240L, now - 2L, 10240L, true)
         );
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordBatchTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.clients.producer.internals;
 
 import java.nio.ByteBuffer;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordBatchTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/RecordBatchTest.java
@@ -1,0 +1,37 @@
+package org.apache.kafka.clients.producer.internals;
+
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class RecordBatchTest {
+
+    /**
+     * A RecordBatch configured using very large linger value, in combination
+     * with a timestamp preceding the create time of a RecordBatch, is
+     * interpreted correctly as not expired when the linger time is larger than
+     * the difference between now and create time by RecordBatch#maybeExpire.
+     */
+    @Test
+    public void testLargeLingerOldNowExpire() {
+        final long now = 1488748346917L;
+        final RecordBatch batch = new RecordBatch(
+            new TopicPartition("topic", 1),
+            new MemoryRecordsBuilder(
+                ByteBuffer.allocate(0), Record.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L, Record.NO_TIMESTAMP, 0
+            ), now
+        );
+        // Use `now` 2ms before the create time.
+        assertFalse(
+            batch.maybeExpire(10240, 100L, now - 2L, Long.MAX_VALUE, false)
+        );
+    }
+}

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -398,7 +398,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
    */
   @Test
   def testFlush() {
-    val producer = createProducer(brokerList, lingerMs = TimeUnit.HOURS.toMillis(1L))
+    val producer = createProducer(brokerList, lingerMs = Long.MaxValue)
     try {
       TestUtils.createTopic(zkUtils, topic, 2, 2, servers)
       val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, "value".getBytes)

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -398,7 +398,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
    */
   @Test
   def testFlush() {
-    val producer = createProducer(brokerList, lingerMs = Long.MaxValue)
+    val producer = createProducer(brokerList, lingerMs = TimeUnit.HOURS.toMillis(1L))
     try {
       TestUtils.createTopic(zkUtils, topic, 2, 2, servers)
       val record = new ProducerRecord[Array[Byte], Array[Byte]](topic, "value".getBytes)


### PR DESCRIPTION
This deals with https://issues.apache.org/jira/browse/KAFKA-3155

This is a really trivial one :) The problem is that `Long.MaxValue` for the linger overflows in `org.apache.kafka.clients.producer.internals.RecordBatch#maybeExpire` when added the current timestamp like so:

![longoverflow](https://cloud.githubusercontent.com/assets/6490959/23581016/f1852054-010c-11e7-9a7f-574937b5060f.png)

Then causing an error to be set for the batch by `Sender` like so (not happening every time since this depends on the timing of `Sender`):

![error](https://cloud.githubusercontent.com/assets/6490959/23581032/204725c2-010d-11e7-9553-0423e826e34c.png)

That error then causes a call to `org.apache.kafka.clients.producer.internals.ProduceRequestResult#done` on the batch, as can be seen in the second screenshot's stacktrace ... which then makes the check for "not done" fail.

~~Long story short ... trivial to fix by using 1h as linger instead of `Long.MaxValue` prevents the overflow and fixes the instability.~~
As requested fixed by saturated long addition :)