### PR TITLE
KAFKA-4851: only search available segments during Segments.segments(from, to)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
@@ -42,7 +42,7 @@ class Segments {
     private final long segmentInterval;
     private final SimpleDateFormat formatter;
     private long minSegmentId = Long.MAX_VALUE;
-    private long currentSegmentId = -1L;
+    private long maxSegmentId = -1L;
 
     Segments(final String name, final long retentionPeriod, final int numSegments) {
         this.name = name;
@@ -66,7 +66,7 @@ class Segments {
     }
 
     Segment getOrCreateSegment(final long segmentId, final ProcessorContext context) {
-        if (segmentId > currentSegmentId - numSegments) {
+        if (segmentId > maxSegmentId - numSegments) {
             final long key = segmentId % numSegments;
             final Segment segment = segments.get(key);
             if (!isSegment(segment, segmentId)) {
@@ -76,9 +76,9 @@ class Segments {
                 Segment newSegment = new Segment(segmentName(segmentId), name, segmentId);
                 newSegment.openDB(context);
                 segments.put(key, newSegment);
-                currentSegmentId = segmentId > currentSegmentId ? segmentId : currentSegmentId;
+                maxSegmentId = segmentId > maxSegmentId ? segmentId : maxSegmentId;
                 if (minSegmentId == Long.MAX_VALUE) {
-                    minSegmentId = currentSegmentId;
+                    minSegmentId = maxSegmentId;
                 }
             }
             return segments.get(key);
@@ -117,7 +117,7 @@ class Segments {
 
     List<Segment> segments(final long timeFrom, final long timeTo) {
         final long segFrom = Math.max(minSegmentId, segmentId(Math.max(0L, timeFrom)));
-        final long segTo = Math.min(currentSegmentId, segmentId(Math.min(currentSegmentId * segmentInterval, Math.max(0, timeTo))));
+        final long segTo = Math.min(maxSegmentId, segmentId(Math.min(maxSegmentId * segmentInterval, Math.max(0, timeTo))));
 
         final List<Segment> segments = new ArrayList<>();
         for (long segmentId = segFrom; segmentId <= segTo; segmentId++) {
@@ -158,9 +158,9 @@ class Segments {
     }
 
     private void cleanup(final long segmentId) {
-        final long oldestSegmentId = currentSegmentId < segmentId
+        final long oldestSegmentId = maxSegmentId < segmentId
                 ? segmentId - numSegments
-                : currentSegmentId - numSegments;
+                : maxSegmentId - numSegments;
 
         for (Map.Entry<Long, Segment> segmentEntry : segments.entrySet()) {
             final Segment segment = segmentEntry.getValue();


### PR DESCRIPTION
restrict the locating of segments in `Segments#segments(..)` to only the segments that are currently available, i.e., rather than searching the hashmap for many segments that don't exist.