### PR TITLE
KAFKA-4860: Allow spaces in paths on windows

### DIFF
--- a/bin/windows/connect-distributed.bat
+++ b/bin/windows/connect-distributed.bat
@@ -30,5 +30,5 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
 )
 
-%~dp0kafka-run-class.bat org.apache.kafka.connect.cli.ConnectDistributed %*
+"%~dp0kafka-run-class.bat" org.apache.kafka.connect.cli.ConnectDistributed %*
 EndLocal

--- a/bin/windows/connect-standalone.bat
+++ b/bin/windows/connect-standalone.bat
@@ -30,5 +30,5 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
 )
 
-%~dp0kafka-run-class.bat org.apache.kafka.connect.cli.ConnectStandalone %*
+"%~dp0kafka-run-class.bat" org.apache.kafka.connect.cli.ConnectStandalone %*
 EndLocal

--- a/bin/windows/kafka-acls.bat
+++ b/bin/windows/kafka-acls.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.admin.AclCommand %*
+"%~dp0kafka-run-class.bat" kafka.admin.AclCommand %*

--- a/bin/windows/kafka-configs.bat
+++ b/bin/windows/kafka-configs.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.admin.ConfigCommand %*
+"%~dp0kafka-run-class.bat" kafka.admin.ConfigCommand %*

--- a/bin/windows/kafka-console-consumer.bat
+++ b/bin/windows/kafka-console-consumer.bat
@@ -16,5 +16,5 @@ rem limitations under the License.
 
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M
-%~dp0kafka-run-class.bat kafka.tools.ConsoleConsumer %*
+"%~dp0kafka-run-class.bat" kafka.tools.ConsoleConsumer %*
 EndLocal

--- a/bin/windows/kafka-console-producer.bat
+++ b/bin/windows/kafka-console-producer.bat
@@ -16,5 +16,5 @@ rem limitations under the License.
 
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M
-%~dp0kafka-run-class.bat kafka.tools.ConsoleProducer %*
+"%~dp0kafka-run-class.bat" kafka.tools.ConsoleProducer %*
 EndLocal

--- a/bin/windows/kafka-consumer-groups.bat
+++ b/bin/windows/kafka-consumer-groups.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.admin.ConsumerGroupCommand %*
+"%~dp0kafka-run-class.bat" kafka.admin.ConsumerGroupCommand %*

--- a/bin/windows/kafka-consumer-offset-checker.bat
+++ b/bin/windows/kafka-consumer-offset-checker.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.tools.ConsumerOffsetChecker %*
+"%~dp0kafka-run-class.bat" kafka.tools.ConsumerOffsetChecker %*

--- a/bin/windows/kafka-consumer-perf-test.bat
+++ b/bin/windows/kafka-consumer-perf-test.bat
@@ -14,7 +14,11 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
+REM ***
+REM This is a modified version of script that works correctly with paths containing spaces.
+REM ***
+
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
-%~dp0kafka-run-class.bat kafka.tools.ConsumerPerformance %*
+"%~dp0kafka-run-class.bat" kafka.tools.ConsumerPerformance %*
 EndLocal

--- a/bin/windows/kafka-consumer-perf-test.bat
+++ b/bin/windows/kafka-consumer-perf-test.bat
@@ -14,10 +14,6 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-REM ***
-REM This is a modified version of script that works correctly with paths containing spaces.
-REM ***
-
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
 "%~dp0kafka-run-class.bat" kafka.tools.ConsumerPerformance %*

--- a/bin/windows/kafka-mirror-maker.bat
+++ b/bin/windows/kafka-mirror-maker.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.tools.MirrorMaker %*
+"%~dp0kafka-run-class.bat" kafka.tools.MirrorMaker %*

--- a/bin/windows/kafka-preferred-replica-election.bat
+++ b/bin/windows/kafka-preferred-replica-election.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.admin.PreferredReplicaLeaderElectionCommand %*
+"%~dp0kafka-run-class.bat" kafka.admin.PreferredReplicaLeaderElectionCommand %*

--- a/bin/windows/kafka-producer-perf-test.bat
+++ b/bin/windows/kafka-producer-perf-test.bat
@@ -16,5 +16,5 @@ rem limitations under the License.
 
 SetLocal
 set KAFKA_HEAP_OPTS=-Xmx512M
-%~dp0kafka-run-class.bat org.apache.kafka.tools.ProducerPerformance %*
+"%~dp0kafka-run-class.bat" org.apache.kafka.tools.ProducerPerformance %*
 EndLocal

--- a/bin/windows/kafka-reassign-partitions.bat
+++ b/bin/windows/kafka-reassign-partitions.bat
@@ -1,3 +1,4 @@
+@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.

--- a/bin/windows/kafka-reassign-partitions.bat
+++ b/bin/windows/kafka-reassign-partitions.bat
@@ -1,4 +1,3 @@
-@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.
@@ -14,4 +13,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.admin.ReassignPartitionsCommand %*
+"%~dp0kafka-run-class.bat" kafka.admin.ReassignPartitionsCommand %*

--- a/bin/windows/kafka-replay-log-producer.bat
+++ b/bin/windows/kafka-replay-log-producer.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.tools.ReplayLogProducer %*
+"%~dp0kafka-run-class.bat" kafka.tools.ReplayLogProducer %*

--- a/bin/windows/kafka-replica-verification.bat
+++ b/bin/windows/kafka-replica-verification.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.tools.ReplicaVerificationTool %*
+"%~dp0kafka-run-class.bat" kafka.tools.ReplicaVerificationTool %*

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -1,3 +1,4 @@
+@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.

--- a/bin/windows/kafka-run-class.bat
+++ b/bin/windows/kafka-run-class.bat
@@ -1,4 +1,3 @@
-@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.
@@ -43,60 +42,60 @@ IF ["%SCALA_BINARY_VERSION%"] EQU [""] (
 )
 
 rem Classpath addition for kafka-core dependencies
-for %%i in (%BASE_DIR%\core\build\dependant-libs-%SCALA_VERSION%\*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\core\build\dependant-libs-%SCALA_VERSION%\*.jar") do (
+	call :concat "%%i"
 )
 
 rem Classpath addition for kafka-examples
-for %%i in (%BASE_DIR%\examples\build\libs\kafka-examples*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\examples\build\libs\kafka-examples*.jar") do (
+	call :concat "%%i"
 )
 
 rem Classpath addition for kafka-clients
-for %%i in (%BASE_DIR%\clients\build\libs\kafka-clients*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\clients\build\libs\kafka-clients*.jar") do (
+	call :concat "%%i"
 )
 
 rem Classpath addition for kafka-streams
-for %%i in (%BASE_DIR%\streams\build\libs\kafka-streams*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\streams\build\libs\kafka-streams*.jar") do (
+	call :concat "%%i"
 )
 
 rem Classpath addition for kafka-streams-examples
-for %%i in (%BASE_DIR%\streams\examples\build\libs\kafka-streams-examples*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\streams\examples\build\libs\kafka-streams-examples*.jar") do (
+	call :concat "%%i"
 )
 
-for %%i in (%BASE_DIR%\streams\build\dependant-libs-%SCALA_VERSION%\rocksdb*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\streams\build\dependant-libs-%SCALA_VERSION%\rocksdb*.jar") do (
+	call :concat "%%i"
 )
 
 rem Classpath addition for kafka tools
-for %%i in (%BASE_DIR%\tools\build\libs\kafka-tools*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\tools\build\libs\kafka-tools*.jar") do (
+	call :concat "%%i"
 )
 
-for %%i in (%BASE_DIR%\tools\build\dependant-libs-%SCALA_VERSION%\*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\tools\build\dependant-libs-%SCALA_VERSION%\*.jar") do (
+	call :concat "%%i"
 )
 
 for %%p in (api runtime file json tools) do (
-	for %%i in (%BASE_DIR%\connect\%%p\build\libs\connect-%%p*.jar) do (
-		call :concat %%i
+	for %%i in ("%BASE_DIR%\connect\%%p\build\libs\connect-%%p*.jar") do (
+		call :concat "%%i"
 	)
 	if exist "%BASE_DIR%\connect\%%p\build\dependant-libs\*" (
-		call :concat %BASE_DIR%\connect\%%p\build\dependant-libs\*
+		call :concat "%BASE_DIR%\connect\%%p\build\dependant-libs\*"
 	)
 )
 
 rem Classpath addition for release
-for %%i in (%BASE_DIR%\libs\*) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\libs\*") do (
+	call :concat "%%i"
 )
 
 rem Classpath addition for core
-for %%i in (%BASE_DIR%\core\build\libs\kafka_%SCALA_BINARY_VERSION%*.jar) do (
-	call :concat %%i
+for %%i in ("%BASE_DIR%\core\build\libs\kafka_%SCALA_BINARY_VERSION%*.jar") do (
+	call :concat "%%i"
 )
 
 rem JMX settings
@@ -111,7 +110,7 @@ IF ["%JMX_PORT%"] NEQ [""] (
 
 rem Log directory to use
 IF ["%LOG_DIR%"] EQU [""] (
-    set LOG_DIR=%BASE_DIR%/logs
+    set LOG_DIR="%BASE_DIR~%/logs"
 )
 
 rem Log4j settings
@@ -119,12 +118,12 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 	set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%BASE_DIR%/config/tools-log4j.properties
 ) ELSE (
   rem create logs directory
-  IF not exist %LOG_DIR% (
-      mkdir %LOG_DIR%
+  IF not exist "%LOG_DIR%" (
+      mkdir "%LOG_DIR%"
   )
 )
 
-set KAFKA_LOG4J_OPTS=-Dkafka.logs.dir=%LOG_DIR% %KAFKA_LOG4J_OPTS%
+set KAFKA_LOG4J_OPTS=-Dkafka.logs.dir="%LOG_DIR%" "%KAFKA_LOG4J_OPTS%"
 
 rem Generic jvm settings you want to add
 IF ["%KAFKA_OPTS%"] EQU [""] (
@@ -171,22 +170,21 @@ IF ["%KAFKA_JVM_PERFORMANCE_OPTS%"] EQU [""] (
 	set KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+DisableExplicitGC -Djava.awt.headless=true
 )
 
-IF ["%CLASSPATH%"] EQU [""] (
+IF not defined CLASSPATH (
 	echo Classpath is empty. Please build the project first e.g. by running 'gradlew jarAll'
 	EXIT /B 2
 )
 
-set COMMAND=%JAVA% %KAFKA_HEAP_OPTS% %KAFKA_JVM_PERFORMANCE_OPTS% %KAFKA_JMX_OPTS% %KAFKA_LOG4J_OPTS% -cp "%CLASSPATH%" %KAFKA_OPTS% %*
+set COMMAND=%JAVA% %KAFKA_HEAP_OPTS% %KAFKA_JVM_PERFORMANCE_OPTS% %KAFKA_JMX_OPTS% %KAFKA_LOG4J_OPTS% -cp %CLASSPATH% %KAFKA_OPTS% %*
 rem echo.
 rem echo %COMMAND%
 rem echo.
-
 %COMMAND%
 
 goto :eof
 :concat
-IF ["%CLASSPATH%"] EQU [""] (
-  set "CLASSPATH=%1"
+IF not defined CLASSPATH (
+  set CLASSPATH="%~1"
 ) ELSE (
-  set "CLASSPATH=%CLASSPATH%;%1"
+  set CLASSPATH=%CLASSPATH%;"%~1"
 )

--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -1,4 +1,4 @@
-@echo off
+
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.
@@ -34,5 +34,5 @@ IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
         set KAFKA_HEAP_OPTS=-Xmx1G -Xms1G
     )
 )
-%~dp0kafka-run-class.bat kafka.Kafka %*
+"%~dp0kafka-run-class.bat" kafka.Kafka %*
 EndLocal

--- a/bin/windows/kafka-server-start.bat
+++ b/bin/windows/kafka-server-start.bat
@@ -1,4 +1,4 @@
-
+@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.

--- a/bin/windows/kafka-simple-consumer-shell.bat
+++ b/bin/windows/kafka-simple-consumer-shell.bat
@@ -14,4 +14,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.tools.SimpleConsumerShell %*
+"%~dp0kafka-run-class.bat" kafka.tools.SimpleConsumerShell %*

--- a/bin/windows/kafka-topics.bat
+++ b/bin/windows/kafka-topics.bat
@@ -1,3 +1,4 @@
+@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.

--- a/bin/windows/kafka-topics.bat
+++ b/bin/windows/kafka-topics.bat
@@ -1,4 +1,3 @@
-@echo off
 rem Licensed to the Apache Software Foundation (ASF) under one or more
 rem contributor license agreements.  See the NOTICE file distributed with
 rem this work for additional information regarding copyright ownership.
@@ -14,4 +13,4 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-%~dp0kafka-run-class.bat kafka.admin.TopicCommand %*
+"%~dp0kafka-run-class.bat" kafka.admin.TopicCommand %*

--- a/bin/windows/zookeeper-server-start.bat
+++ b/bin/windows/zookeeper-server-start.bat
@@ -26,5 +26,5 @@ IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
     set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M
 )
-%~dp0kafka-run-class.bat org.apache.zookeeper.server.quorum.QuorumPeerMain %*
+"%~dp0kafka-run-class.bat" org.apache.zookeeper.server.quorum.QuorumPeerMain %*
 EndLocal

--- a/bin/windows/zookeeper-shell.bat
+++ b/bin/windows/zookeeper-shell.bat
@@ -19,4 +19,4 @@ IF [%1] EQU [] (
 	EXIT /B 1
 )
 
-%~dp0kafka-run-class.bat org.apache.zookeeper.ZooKeeperMain -server %*
+"%~dp0kafka-run-class.bat" org.apache.zookeeper.ZooKeeperMain -server %*


### PR DESCRIPTION
When we install kafka on path with spaces, batch files were failing, this PR is trying to fix this issue.