### PR TITLE
MINOR: add warning when offset topic is not replicated properly

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -777,7 +777,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val aliveBrokers = metadataCache.getAliveBrokers
     if (aliveBrokers.size < config.offsetsTopicReplicationFactor) {
       error(s"Number of alive brokers ${aliveBrokers.size} does not meet the replication requirement " +
-        s"${config.offsetsTopicReplicationFactor} for offsets topic. This error can be ignored if cluster is just starting up" +
+        s"${config.offsetsTopicReplicationFactor} for offsets topic. This error can be ignored if cluster is just starting up " +
         s"and not all brokers are up yet.");
       new MetadataResponse.TopicMetadata(Errors.GROUP_COORDINATOR_NOT_AVAILABLE, Topic.GroupMetadataTopicName, true,
         java.util.Collections.emptyList())

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -776,8 +776,9 @@ class KafkaApis(val requestChannel: RequestChannel,
   private def createGroupMetadataTopic(): MetadataResponse.TopicMetadata = {
     val aliveBrokers = metadataCache.getAliveBrokers
     if (aliveBrokers.size < config.offsetsTopicReplicationFactor) {
-      warn("Number of alive brokers %d does not meet the replication requirement %d for offsets topic "
-        .format(aliveBrokers.size, config.offsetsTopicReplicationFactor))
+      error(s"Number of alive brokers ${aliveBrokers.size} does not meet the replication requirement " +
+        s"${config.offsetsTopicReplicationFactor} for offsets topic. This error can be ignored if cluster is just starting up" +
+        s"and not all brokers are up yet.");
       new MetadataResponse.TopicMetadata(Errors.GROUP_COORDINATOR_NOT_AVAILABLE, Topic.GroupMetadataTopicName, true,
         java.util.Collections.emptyList())
     } else {

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -776,6 +776,8 @@ class KafkaApis(val requestChannel: RequestChannel,
   private def createGroupMetadataTopic(): MetadataResponse.TopicMetadata = {
     val aliveBrokers = metadataCache.getAliveBrokers
     if (aliveBrokers.size < config.offsetsTopicReplicationFactor) {
+      warn("Number of alive brokers %d does not meet the replication requirement %d for offsets topic "
+        .format(aliveBrokers.size, config.offsetsTopicReplicationFactor))
       new MetadataResponse.TopicMetadata(Errors.GROUP_COORDINATOR_NOT_AVAILABLE, Topic.GroupMetadataTopicName, true,
         java.util.Collections.emptyList())
     } else {

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -35,8 +35,7 @@ class StreamsSimpleBenchmarkTest(Test):
 
 
     @cluster(num_nodes=9)
-    #@matrix(test=["produce", "consume", "count", "processstream", "processstreamwithsink", "processstreamwithstatestore", "processstreamwithcachedstatestore", "kstreamktablejoin", "kstreamkstreamjoin", "ktablektablejoin"], scale=[1, 2, 3])
-    @matrix(test=["consume", "processstream"], scale=[1, 2, 3])
+    @matrix(test=["produce", "consume", "count", "processstream", "processstreamwithsink", "processstreamwithstatestore", "processstreamwithcachedstatestore", "kstreamktablejoin", "kstreamkstreamjoin", "ktablektablejoin"], scale=[1, 2, 3])
     def test_simple_benchmark(self, test, scale):
         """
         Run simple Kafka Streams benchmark

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -35,7 +35,8 @@ class StreamsSimpleBenchmarkTest(Test):
 
 
     @cluster(num_nodes=9)
-    @matrix(test=["produce", "consume", "count", "processstream", "processstreamwithsink", "processstreamwithstatestore", "processstreamwithcachedstatestore", "kstreamktablejoin", "kstreamkstreamjoin", "ktablektablejoin"], scale=[1, 2, 3])
+    #@matrix(test=["produce", "consume", "count", "processstream", "processstreamwithsink", "processstreamwithstatestore", "processstreamwithcachedstatestore", "kstreamktablejoin", "kstreamkstreamjoin", "ktablektablejoin"], scale=[1, 2, 3])
+    @matrix(test=["consume", "processstream"], scale=[1, 2, 3])
     def test_simple_benchmark(self, test, scale):
         """
         Run simple Kafka Streams benchmark


### PR DESCRIPTION
Added a warning, otherwise this problem is hard to debug if you haven't followed the latest KIP closely.