### PR TITLE
MINOR: Update possible errors in OffsetFetchResponse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetFetchResponse.java
@@ -57,13 +57,13 @@ public class OffsetFetchResponse extends AbstractResponse {
      *
      * - Group or coordinator errors:
      *   - GROUP_LOAD_IN_PROGRESS (14)
+     *   - GROUP_COORDINATOR_NOT_AVAILABLE (15)
      *   - NOT_COORDINATOR_FOR_GROUP (16)
      *   - GROUP_AUTHORIZATION_FAILED (30)
      */
 
     private static final List<Errors> PARTITION_ERRORS = Arrays.asList(
-            Errors.UNKNOWN_TOPIC_OR_PARTITION,
-            Errors.TOPIC_AUTHORIZATION_FAILED);
+            Errors.UNKNOWN_TOPIC_OR_PARTITION);
 
     private final Map<TopicPartition, PartitionData> responseData;
     private final Errors error;


### PR DESCRIPTION
Note: None of the use cases for offset fetch would lead to a `TOPIC_AUTHORIZATION_FAILED` error (fetching offset of an unauthorized partition would return an `UNKNOWN_TOPIC_OR_PARTITION` error). That is why it is being removed from the `PARTITION_ERRORS` list.