### PR TITLE
MINOR: Let MirrorMaker pick up client.id if specified in consumer.properties

### DIFF
--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -17,6 +17,8 @@
 
 package kafka.tools
 
+import java.util.Properties
+
 import kafka.consumer.BaseConsumerRecord
 import org.apache.kafka.common.record.{Record, TimestampType}
 import org.junit.Assert._
@@ -53,6 +55,21 @@ class MirrorMakerTest {
     assertNull(producerRecord.partition)
     assertEquals("key", new String(producerRecord.key))
     assertEquals("value", new String(producerRecord.value))
+  }
+
+  @Test
+  def testGetClientIdFromConsumerConfig() {
+    val properties = new Properties()
+    properties.setProperty("group.id", "consumer_group")
+    properties.setProperty("client.id", "custom_client_id")
+    assertEquals("custom_client_id", MirrorMaker.getClientId(properties))
+  }
+
+  @Test
+  def testGetClientIdDefaultToGroupId() {
+    val properties = new Properties()
+    properties.setProperty("group.id", "consumer_group")
+    assertEquals("consumer_group", MirrorMaker.getClientId(properties))
   }
 
 }


### PR DESCRIPTION
With this change, defining client.id in the consumer.properties used by mirror
maker will no longer be ignored.
If not specified, the default will still be the group id.

----

Hi!

For reasons I won't get into here, we needed to change the client.id of our mirror maker consumers. We quickly realized that the config was not picked up, and looking at the code it became obvious why: it defaults to the groupId without checking for a clientId.
Hence this small change.

PS: Ran unit tests successfully.