### PR TITLE
KAFKA-4772: [WIP] Use peek to implement print

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -326,6 +326,25 @@ public interface KStream<K, V> {
                final String streamName);
 
     /**
+     * Print the records of this stream to {@code System.out}.
+     * <p>
+     * The provided serde will be used to deserialize the key or value in case the type is {@code byte[]} before calling
+     * {@code toString()} on the deserialized object.
+     * <p>
+     * Implementors will need to override {@code toString()} for keys and values that are not of type {@link String},
+     * {@link Integer} etc. to get meaningful information.
+     *
+     * @param keySerde   key serde used to deserialize key if type is {@code byte[]},
+     * @param valSerde   value serde used to deserialize value if type is {@code byte[]},
+     * @param streamName the name used to label the key/value pairs printed to the console
+     * @param mapper     mapper to allow customized output of key and value
+     */
+    void print(final Serde<K> keySerde,
+               final Serde<V> valSerde,
+               final String streamName,
+               final KeyValueMapper<K, V, String> mapper);
+
+    /**
      * Write the records of this stream to a file at the given path.
      * This function will use the generated name of the parent processor node to label the key/value pairs printed to
      * the file.


### PR DESCRIPTION
**PROPOSAL/DISCUSSION FOR KIP-132.**
Tackles [KAFKA-4772](https://issues.apache.org/jira/browse/KAFKA-4772) and [KAFKA-4830](https://issues.apache.org/jira/browse/KAFKA-4830).

The functionaliy of KeyValuePrinter is replaced with a printAction that
is being passed to KStreamPeek. We therefore can get rid of
KeyValuePrinter.

KStream.print was extended to handle KeyValueMapper in order to provide
users the option to change output of K and V. Therefore, constructors of
KeyValuePrinter as well as KeyValuePrinterProcessor have to be adapted. The default case
where no mapper will be passed, is still covered by the previous comma
separated out of K, V.