### PR TITLE
KAFKA-4858: Broker should ignore long topic names

### DIFF
--- a/core/src/main/scala/kafka/common/Topic.scala
+++ b/core/src/main/scala/kafka/common/Topic.scala
@@ -35,7 +35,7 @@ object Topic {
       throw new org.apache.kafka.common.errors.InvalidTopicException("topic name is illegal, can't be empty")
     else if (topic.equals(".") || topic.equals(".."))
       throw new org.apache.kafka.common.errors.InvalidTopicException("topic name cannot be \".\" or \"..\"")
-    else if (topic.length > maxNameLength)
+    else if (!isNameValid(topic, false))
       throw new org.apache.kafka.common.errors.InvalidTopicException("topic name is illegal, can't be longer than " + maxNameLength + " characters")
 
     rgx.findFirstIn(topic) match {
@@ -70,4 +70,12 @@ object Topic {
   def isInternal(topic: String): Boolean =
     InternalTopics.contains(topic)
 
+  def isNameValid(topic: String, alreadyCreated: Boolean = true): Boolean = {
+    val validTopicName = topic.length <= maxNameLength
+    if (alreadyCreated && !validTopicName)
+      println(s"The name of the topic '$topic' exceeds the allowed length (${Topic.getMaxNameLength}); so it will be ignored.")
+    validTopicName
+  }
+
+  def getMaxNameLength = maxNameLength
 }

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -19,7 +19,7 @@ package kafka.controller
 import collection._
 import java.util.concurrent.atomic.AtomicBoolean
 import kafka.api.LeaderAndIsr
-import kafka.common.{LeaderElectionNotNeededException, TopicAndPartition, StateChangeFailedException, NoReplicaOnlineException}
+import kafka.common.{LeaderElectionNotNeededException, NoReplicaOnlineException, StateChangeFailedException, Topic, TopicAndPartition}
 import kafka.utils.{Logging, ReplicationUtils}
 import kafka.utils.ZkUtils._
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
@@ -414,7 +414,7 @@ class PartitionStateMachine(controller: KafkaController) extends Logging {
           try {
             val currentChildren = {
               debug("Topic change listener fired for path %s with children %s".format(parentPath, children.mkString(",")))
-              children.toSet
+              children.filter(Topic.isNameValid(_)).toSet
             }
             val newTopics = currentChildren -- controllerContext.allTopics
             val deletedTopics = controllerContext.allTopics -- currentChildren

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch
 import kafka.admin._
 import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, LeaderAndIsr}
 import kafka.cluster._
-import kafka.common.{KafkaException, NoEpochForPartitionException, TopicAndPartition}
+import kafka.common.{KafkaException, NoEpochForPartitionException, Topic, TopicAndPartition}
 import kafka.consumer.{ConsumerThreadId, TopicCount}
 import kafka.controller.{KafkaController, LeaderIsrAndControllerEpoch, ReassignedPartitionsContext}
 import kafka.server.ConfigType
@@ -830,7 +830,7 @@ class ZkUtils(val zkClient: ZkClient,
   }
 
   def getAllTopics(): Seq[String] = {
-    val topics = getChildrenParentMayNotExist(BrokerTopicsPath)
+    val topics = getChildrenParentMayNotExist(BrokerTopicsPath).filter(Topic.isNameValid(_))
     if(topics == null)
       Seq.empty[String]
     else


### PR DESCRIPTION
Starting from the 0.10.0.0 release topics names of over 249 characters are not allowed (`kafka-topics.sh` would disallow the creation). However, it is possible to use an older client version against the more recent brokers and attempt to create topics with longer names.
This causes problems with the broker when trying to bring the corresponding partitions online (as described in the [JIRA](https://issues.apache.org/jira/browse/KAFKA-4858)).
This PR makes the broker ignore those topics to avoid the reported failures.