### PR TITLE
KAFKA-4882: Remove internal converter configuration from example property files

### DIFF
--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -30,13 +30,6 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 key.converter.schemas.enable=true
 value.converter.schemas.enable=true
 
-# The internal converter used for offsets and config data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset and config data is never visible outside of Kafka Connect in this format.
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 # Topic to use for storing offsets. This topic should have many partitions and be replicated.
 offset.storage.topic=connect-offsets
 

--- a/config/connect-standalone.properties
+++ b/config/connect-standalone.properties
@@ -25,13 +25,6 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 key.converter.schemas.enable=true
 value.converter.schemas.enable=true
 
-# The internal converter used for offsets and config data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset and config data is never visible outside of Kafka Connect in this format.
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 offset.storage.file.filename=/tmp/connect.offsets
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -62,6 +62,7 @@ public class WorkerConfig extends AbstractConfig {
                     " Examples of common formats include JSON and Avro." +
                     " This setting controls the format used for internal bookkeeping data used by the framework, such as" +
                     " configs and offsets, so users can typically use any functioning Converter implementation.";
+    public static final String INTERNAL_KEY_CONVERTER_CLASS_DEFAULT = "org.apache.kafka.connect.json.JsonConverter";
 
     public static final String INTERNAL_VALUE_CONVERTER_CLASS_CONFIG = "internal.value.converter";
     public static final String INTERNAL_VALUE_CONVERTER_CLASS_DOC =
@@ -71,6 +72,7 @@ public class WorkerConfig extends AbstractConfig {
                     " Examples of common formats include JSON and Avro." +
                     " This setting controls the format used for internal bookkeeping data used by the framework, such as" +
                     " configs and offsets, so users can typically use any functioning Converter implementation.";
+    public static final String INTERNAL_VALUE_CONVERTER_CLASS_DEFAULT = "org.apache.kafka.connect.json.JsonConverter";
 
     public static final String TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG
             = "task.shutdown.graceful.timeout.ms";
@@ -136,9 +138,11 @@ public class WorkerConfig extends AbstractConfig {
                 .define(VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS,
                         Importance.HIGH, VALUE_CONVERTER_CLASS_DOC)
                 .define(INTERNAL_KEY_CONVERTER_CLASS_CONFIG, Type.CLASS,
-                        Importance.LOW, INTERNAL_KEY_CONVERTER_CLASS_DOC)
+                        INTERNAL_KEY_CONVERTER_CLASS_DEFAULT, Importance.LOW,
+                        INTERNAL_KEY_CONVERTER_CLASS_DOC)
                 .define(INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS,
-                        Importance.LOW, INTERNAL_VALUE_CONVERTER_CLASS_DOC)
+                        INTERNAL_VALUE_CONVERTER_CLASS_DEFAULT, Importance.LOW,
+                        INTERNAL_VALUE_CONVERTER_CLASS_DOC)
                 .define(TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG, Type.LONG,
                         TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_DEFAULT, Importance.LOW,
                         TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_DOC)

--- a/tests/kafkatest/tests/connect/templates/connect-distributed.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-distributed.properties
@@ -29,11 +29,6 @@ key.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 value.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 {% endif %}
 
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 offset.storage.topic={{ OFFSETS_TOPIC }}
 config.storage.topic={{ CONFIG_TOPIC }}
 status.storage.topic={{ STATUS_TOPIC }}

--- a/tests/kafkatest/tests/connect/templates/connect-standalone.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-standalone.properties
@@ -26,9 +26,4 @@ key.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 value.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 {% endif %}
 
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 offset.storage.file.filename={{ OFFSETS_FILE }}


### PR DESCRIPTION
Connect works best with the default JSON converters, and exposing the internal converter config tempts users to change it (see [KAFKA-4882](https://issues.apache.org/jira/browse/KAFKA-4882) for more info).

Also, I don't really see how `internal.key.converter.schemas.enable` ever gets used. I see some tests specifying this value but don't see anything in `org.apache.kafka.connect.runtime.WorkerConfig` or anywhere else (maybe I'm just missing it?).

Anyways, this is my first commit, hope it's okay :)

This contribution is my original work and I license the work to the project under the project's open source license.

cc @gwenshap @ewencp 