### PR TITLE
KAFKA-4891 kafka.request.logger TRACE regression

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -79,6 +79,11 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
 
     protected abstract Struct toStruct();
 
+    @Override
+    public String toString() {
+        return toStruct().toString();
+    }
+
     /**
      * Get an error response for a request
      */

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestHeader.java
@@ -85,4 +85,9 @@ public class RequestHeader extends AbstractRequestResponse {
     public static RequestHeader parse(ByteBuffer buffer) {
         return new RequestHeader(Protocol.REQUEST_HEADER.read(buffer));
     }
+
+    @Override
+    public String toString() {
+        return toStruct().toString();
+    }
 }


### PR DESCRIPTION
Both the headers and requests have regressed to just show object ids instead of their contents from their underlying structs. I'm guessing this regression came from commit [fc1cfe475e8ae8458d8ddf119ce18d0c64653a70](https://github.com/apache/kafka/commit/fc1cfe475e8ae8458d8ddf119ce18d0c64653a70)