### PR TITLE
KAFKA-4859: Raised Timeout

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamKTableJoinIntegrationTest.java
@@ -295,7 +295,7 @@ public class KStreamKTableJoinIntegrationTest {
         consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
 
         final List<KeyValue<String, Long>> actualClicksPerRegion = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig,
-            outputTopic, expectedClicksPerRegion.size());
+            outputTopic, expectedClicksPerRegion.size(), 2 * IntegrationTestUtils.DEFAULT_TIMEOUT);
 
         assertThat(actualClicksPerRegion, equalTo(expectedClicksPerRegion));
     }


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/KAFKA-4859 for me over hundreds of iterations while I could easily reproduce it with less than ~30-40 iterations without the increased timeout.

Also raising the timeout (at least on my setup) looks like a valid approach looking at test runtimes being consistently slightly above those 30s default timeout coming from `org.apache.kafka.streams.integration.utils.IntegrationTestUtils#DEFAULT_TIMEOUT`.

![byregion](https://cloud.githubusercontent.com/assets/6490959/23878174/1eac8154-0846-11e7-82a7-9e04f235630f.png)
