### PR TITLE
KAFKA-4901: Make ProduceRequest thread-safe

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -79,9 +79,13 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
 
     protected abstract Struct toStruct();
 
-    @Override
-    public String toString() {
+    public String toString(boolean verbose) {
         return toStruct().toString();
+    }
+
+    @Override
+    public final String toString() {
+        return toString(true);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.Utils;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,13 +79,20 @@ public class ProduceRequest extends AbstractRequest {
 
     private final short acks;
     private final int timeout;
-    private final Map<TopicPartition, MemoryRecords> partitionRecords;
+
+    private final Collection<TopicPartition> partitions;
+
+    // This is set to null by `clearPartitionRecords` to prevent unnecessary memory retention when a produce request is
+    // put in the purgatory (due to client throttling, it can take a while before the response is sent).
+    // Care should be taken in methods that use this field.
+    private volatile Map<TopicPartition, MemoryRecords> partitionRecords;
 
     private ProduceRequest(short version, short acks, int timeout, Map<TopicPartition, MemoryRecords> partitionRecords) {
         super(version);
         this.acks = acks;
         this.timeout = timeout;
         this.partitionRecords = partitionRecords;
+        this.partitions = new ArrayList<>(partitionRecords.keySet());
     }
 
     public ProduceRequest(Struct struct, short version) {
@@ -100,6 +108,7 @@ public class ProduceRequest extends AbstractRequest {
                 partitionRecords.put(new TopicPartition(topic, partition), records);
             }
         }
+        partitions = new ArrayList<>(partitionRecords.keySet());
         acks = struct.getShort(ACKS_KEY_NAME);
         timeout = struct.getInt(TIMEOUT_KEY_NAME);
     }
@@ -109,6 +118,8 @@ public class ProduceRequest extends AbstractRequest {
      */
     @Override
     public Struct toStruct() {
+        // Store it in a local variable to protect against concurrent updates
+        Map<TopicPartition, MemoryRecords> partitionRecords = partitionRecordsOrFail();
         Struct struct = new Struct(ApiKeys.PRODUCE.requestSchema(version()));
         Map<String, Map<Integer, MemoryRecords>> recordsByTopic = CollectionUtils.groupDataByTopic(partitionRecords);
         struct.set(ACKS_KEY_NAME, acks);
@@ -133,6 +144,25 @@ public class ProduceRequest extends AbstractRequest {
     }
 
     @Override
+    public String toString() {
+        // Store it in a local variable to protect against concurrent updates
+        Map<TopicPartition, MemoryRecords> partitionRecords = this.partitionRecords;
+
+        StringBuilder bld = new StringBuilder();
+        bld.append("(type=ProduceRequest")
+                .append(", acks=").append(acks)
+                .append(", timeout=").append(timeout);
+
+        if (partitionRecords == null)
+            bld.append(", partitions=").append(Utils.mkString(partitions, ","));
+        else
+            bld.append(", partitionRecords=(").append(Utils.mkString(partitionRecords));
+
+        bld.append("))");
+        return bld.toString();
+    }
+
+    @Override
     public AbstractResponse getErrorResponse(Throwable e) {
         /* In case the producer doesn't actually want any response */
         if (acks == 0)
@@ -141,8 +171,8 @@ public class ProduceRequest extends AbstractRequest {
         Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new HashMap<>();
         ProduceResponse.PartitionResponse partitionResponse = new ProduceResponse.PartitionResponse(Errors.forException(e));
 
-        for (Map.Entry<TopicPartition, MemoryRecords> entry : partitionRecords.entrySet())
-            responseMap.put(entry.getKey(), partitionResponse);
+        for (TopicPartition tp : partitions)
+            responseMap.put(tp, partitionResponse);
 
         short versionId = version();
         switch (versionId) {
@@ -164,12 +194,20 @@ public class ProduceRequest extends AbstractRequest {
         return timeout;
     }
 
-    public Map<TopicPartition, MemoryRecords> partitionRecords() {
+    /**
+     * Returns the partition records or throws IllegalStateException if clearPartitionRecords() has been invoked.
+     */
+    public Map<TopicPartition, MemoryRecords> partitionRecordsOrFail() {
+        // Store it in a local variable to protect against concurrent updates
+        Map<TopicPartition, MemoryRecords> partitionRecords = this.partitionRecords;
+        if (partitionRecords == null)
+            throw new IllegalStateException("The partition records are no longer available because " +
+                    "clearPartitionRecords() has been invoked.");
         return partitionRecords;
     }
 
     public void clearPartitionRecords() {
-        partitionRecords.clear();
+        partitionRecords = null;
     }
 
     public static ProduceRequest parse(ByteBuffer buffer, short version) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -158,9 +158,9 @@ public class ProduceRequest extends AbstractRequest {
                 .append(",timeout=").append(timeout);
 
         if (verbose)
-            bld.append(",partitionSizes=").append(Utils.mkString(partitionSizes));
+            bld.append(",partitionSizes=").append(Utils.mkString(partitionSizes, "[", "]", "=", ","));
 
-        bld.append("])");
+        bld.append("}");
         return bld.toString();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -159,6 +159,8 @@ public class ProduceRequest extends AbstractRequest {
 
         if (verbose)
             bld.append(",partitionSizes=").append(Utils.mkString(partitionSizes, "[", "]", "=", ","));
+        else
+            bld.append(",numPartitions=").append(partitionSizes.size());
 
         bld.append("}");
         return bld.toString();

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -96,7 +96,7 @@ public class ProduceRequest extends AbstractRequest {
     }
 
     private static Map<TopicPartition, Integer> createPartitionSizes(Map<TopicPartition, MemoryRecords> partitionRecords) {
-        Map<TopicPartition, Integer> result = new HashMap<>();
+        Map<TopicPartition, Integer> result = new HashMap<>(partitionRecords.size());
         for (Map.Entry<TopicPartition, MemoryRecords> entry : partitionRecords.entrySet())
             result.put(entry.getKey(), entry.getValue().sizeInBytes());
         return result;

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -225,7 +225,9 @@ public class RequestResponseTest {
         ProduceRequest request = createProduceRequest();
         assertEquals(1, request.partitionRecordsOrFail().size());
         assertFalse(request.toString(false).contains("partitionSizes"));
+        assertTrue(request.toString(false).contains("numPartitions=1"));
         assertTrue(request.toString(true).contains("partitionSizes"));
+        assertFalse(request.toString(true).contains("numPartitions"));
 
         request.clearPartitionRecords();
         try {
@@ -234,8 +236,11 @@ public class RequestResponseTest {
         } catch (IllegalStateException e) {
             // OK
         }
+
         assertFalse(request.toString(false).contains("partitionSizes"));
+        assertTrue(request.toString(false).contains("numPartitions=1"));
         assertTrue(request.toString(true).contains("partitionSizes"));
+        assertFalse(request.toString(true).contains("numPartitions"));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -241,9 +241,10 @@ public class RequestResponseTest {
     @Test
     public void produceRequestGetErrorResponseTest() {
         ProduceRequest request = createProduceRequest();
+        Set<TopicPartition> partitions = new HashSet<>(request.partitionRecordsOrFail().keySet());
 
         ProduceResponse errorResponse = (ProduceResponse) request.getErrorResponse(new NotEnoughReplicasException());
-        assertEquals(1, errorResponse.responses().size());
+        assertEquals(partitions, errorResponse.responses().keySet());
         ProduceResponse.PartitionResponse partitionResponse = errorResponse.responses().values().iterator().next();
         assertEquals(Errors.NOT_ENOUGH_REPLICAS, partitionResponse.error);
         assertEquals(ProduceResponse.INVALID_OFFSET, partitionResponse.baseOffset);
@@ -253,7 +254,7 @@ public class RequestResponseTest {
 
         // `getErrorResponse` should behave the same after `clearPartitionRecords`
         errorResponse = (ProduceResponse) request.getErrorResponse(new NotEnoughReplicasException());
-        assertEquals(1, errorResponse.responses().size());
+        assertEquals(partitions, errorResponse.responses().keySet());
         partitionResponse = errorResponse.responses().values().iterator().next();
         assertEquals(Errors.NOT_ENOUGH_REPLICAS, partitionResponse.error);
         assertEquals(ProduceResponse.INVALID_OFFSET, partitionResponse.baseOffset);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -48,7 +48,9 @@ import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RequestResponseTest {
 
@@ -209,6 +211,31 @@ public class RequestResponseTest {
         struct.writeTo(buffer);
         buffer.rewind();
         return buffer;
+    }
+
+    @Test
+    public void produceRequestToStringTest() {
+        ProduceRequest request = createProduceRequest();
+        assertFalse(request.toString(false).contains("partitionSizes"));
+        assertTrue(request.toString(true).contains("partitionSizes"));
+    }
+
+    @Test
+    public void produceRequestClearPartitionsTest() {
+        ProduceRequest request = createProduceRequest();
+        assertEquals(1, request.partitionRecordsOrFail().size());
+        assertFalse(request.toString(false).contains("partitionSizes"));
+        assertTrue(request.toString(true).contains("partitionSizes"));
+
+        request.clearPartitionRecords();
+        try {
+            request.partitionRecordsOrFail();
+            fail("partitionRecordsOrFail should fail after clearPartitionRecords()");
+        } catch (IllegalStateException e) {
+            // OK
+        }
+        assertFalse(request.toString(false).contains("partitionSizes"));
+        assertTrue(request.toString(true).contains("partitionSizes"));
     }
 
     @Test

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -108,7 +108,7 @@ object RequestChannel extends Logging {
       if (requestObj != null)
         requestObj.describe(details)
       else
-        s"$header -- ${body[AbstractRequest]}"
+        s"$header -- ${body[AbstractRequest].toString(details)}"
     }
 
     def body[T <: AbstractRequest](implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {


### PR DESCRIPTION
If request logging is enabled, `ProduceRequest` can be accessed
and mutated concurrently from a network thread (which calls
`toString`) and a request handler thread (which calls
`clearPartitionRecords()`).

That can lead to a `ConcurrentModificationException` when iterating
the `partitionRecords` map.

The underlying thread-safety issue has existed since the server
started using the Java implementation of ProduceRequest in 0.10.0.
However, we were incorrectly not clearing the underlying struct until
0.10.2, so `toString` itself was thread-safe until that change. In 0.10.2,
`toString` is no longer thread-safe and we could potentially see a
`NullPointerException` given the right set of interleavings between
`toString` and `clearPartitionRecords` although we haven't seen that
happen yet.

In trunk, we changed the requests to have a `toStruct` method
instead of creating a struct in the constructor and `toString` was
no longer printing the contents of the `Struct`. This accidentally
fixed the race condition, but it meant that request logging was less
useful.

A couple of days ago, `AbstractRequest.toString` was changed to
print the contents of the request by calling `toStruct().toString()`
and reintroduced the race condition. The impact is more visible
because we iterate over a `HashMap`, which proactively
checks for concurrent modification (unlike arrays).

We will need a separate PR for 0.10.2.