### PR TITLE
MINOR: FetchRequest.Builder maxBytes for version <3

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -131,7 +131,7 @@ public class FetchRequest extends AbstractRequest {
         @Override
         public FetchRequest build(short version) {
             if (version < 3) {
-                maxBytes = -1;
+                maxBytes = DEFAULT_RESPONSE_MAX_BYTES;
             }
 
             return new FetchRequest(version, replicaId, maxWait, minBytes, maxBytes, fetchData);

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -313,7 +313,7 @@ public class RequestResponseTest {
         final short version = 1;
         FetchRequest fr = createFetchRequest(version);
         FetchRequest fr2 = new FetchRequest(fr.toStruct(), version);
-        assertEquals(fr2.maxBytes(),fr.maxBytes());
+        assertEquals(fr2.maxBytes(), fr.maxBytes());
     }
     
     private RequestHeader createRequestHeader() {

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -308,6 +308,14 @@ public class RequestResponseTest {
         createCreateTopicRequest(0, true);
     }
 
+    @Test
+    public void testFetchRequestMaxBytesOldVersions() throws Exception {
+        final short version = 1;
+        FetchRequest fr = createFetchRequest(version);
+        FetchRequest fr2 = new FetchRequest(fr.toStruct(), version);
+        assertEquals(fr2.maxBytes(),fr.maxBytes());
+    }
+    
     private RequestHeader createRequestHeader() {
         return new RequestHeader((short) 10, (short) 1, "", 10);
     }


### PR DESCRIPTION
The maxBytes field should be set to DEFAULT_RESPONSE_MAX_BYTES,
the same way as the constructor using the Struct does.

codeveloped with @mimaison