### PR TITLE
MINOR: Increase Throttle lower bound assertion in throttling_test

### DIFF
--- a/tests/kafkatest/tests/core/throttling_test.py
+++ b/tests/kafkatest/tests/core/throttling_test.py
@@ -133,7 +133,7 @@ class ThrottlingTest(ProduceConsumeValidateTest):
         self.logger.debug("Transfer took %d second. Estimated time : %ds",
                           time_taken,
                           estimated_throttled_time)
-        assert time_taken >= estimated_throttled_time, \
+        assert time_taken >= estimated_throttled_time * 0.9, \
             ("Expected rebalance to take at least %ds, but it took %ds" % (
                 estimated_throttled_time,
                 time_taken))


### PR DESCRIPTION
Improves the reliability of this test by decreasing the lower bound (this is to be expected as throttling  takes the first fetch to stabilise and will "over-fetch" for this first request)