### PR TITLE
MINOR: Improvements on log4j

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -344,13 +344,14 @@ public class KafkaStreams {
 
 
         if (globalTaskTopology != null) {
+            final String globalThreadId = clientId + "-GlobalStreamThread";
             globalStreamThread = new GlobalStreamThread(globalTaskTopology,
                                                         config,
                                                         clientSupplier.getRestoreConsumer(config.getRestoreConsumerConfigs(clientId + "-global")),
-                                                        new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time),
+                                                        new StateDirectory(applicationId, globalThreadId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time),
                                                         metrics,
                                                         time,
-                                                        clientId);
+                                                        globalThreadId);
         }
 
         for (int i = 0; i < threads.length; i++) {
@@ -568,7 +569,7 @@ public class KafkaStreams {
             localApplicationDir,
             appId);
 
-        final StateDirectory stateDirectory = new StateDirectory(appId, stateDir, Time.SYSTEM);
+        final StateDirectory stateDirectory = new StateDirectory(appId, "cleanup", stateDir, Time.SYSTEM);
         stateDirectory.cleanRemovedTasks(0);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStreamThread.java
@@ -41,6 +41,7 @@ import java.util.Map;
 public class GlobalStreamThread extends Thread {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalStreamThread.class);
+
     private final StreamsConfig config;
     private final Consumer<byte[], byte[]> consumer;
     private final StateDirectory stateDirectory;
@@ -57,17 +58,15 @@ public class GlobalStreamThread extends Thread {
                               final StateDirectory stateDirectory,
                               final Metrics metrics,
                               final Time time,
-                              final String clientId
-    ) {
-        super("GlobalStreamThread");
-        this.topology = topology;
+                              final String threadClientId) {
+        super(threadClientId);
+        this.time = time;
         this.config = config;
+        this.topology = topology;
         this.consumer = globalConsumer;
         this.stateDirectory = stateDirectory;
-        this.time = time;
         long cacheSizeBytes = Math.max(0, config.getLong(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG) /
                 (config.getInt(StreamsConfig.NUM_STREAM_THREADS_CONFIG) + 1));
-        final String threadClientId = clientId + "-" + getName();
         this.streamsMetrics = new StreamsMetricsImpl(metrics, threadClientId, Collections.singletonMap("client-id", threadClientId));
         this.cache = new ThreadCache(threadClientId, cacheSizeBytes, streamsMetrics);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -100,6 +100,8 @@ public class ProcessorStateManager implements StateManager {
         // load the checkpoint information
         checkpoint = new OffsetCheckpoint(new File(this.baseDir, CHECKPOINT_FILE_NAME));
         this.checkpointedOffsets = new HashMap<>(checkpoint.read());
+
+        log.info("{} Created state store manager for task {} with the acquired state dir lock", logPrefix, taskId);
     }
 
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -21,12 +21,15 @@ import org.apache.kafka.streams.processor.StateRestoreCallback;
 
 public class StateRestorer {
     static final int NO_CHECKPOINT = -1;
-    private final TopicPartition partition;
-    private final StateRestoreCallback stateRestoreCallback;
+
     private final Long checkpoint;
     private final long offsetLimit;
     private final boolean persistent;
+    private final TopicPartition partition;
+    private final StateRestoreCallback stateRestoreCallback;
+
     private long restoredOffset;
+    private long startingOffset;
 
     StateRestorer(final TopicPartition partition,
                   final StateRestoreCallback stateRestoreCallback,
@@ -44,20 +47,28 @@ public class StateRestorer {
         return partition;
     }
 
-    public long checkpoint() {
+    long checkpoint() {
         return checkpoint == null ? NO_CHECKPOINT : checkpoint;
     }
 
-    public void restore(final byte[] key, final byte[] value) {
+    void restore(final byte[] key, final byte[] value) {
         stateRestoreCallback.restore(key, value);
     }
 
-    public boolean isPersistent() {
+    boolean isPersistent() {
         return persistent;
     }
 
     void setRestoredOffset(final long restoredOffset) {
         this.restoredOffset = Math.min(offsetLimit, restoredOffset);
+    }
+
+    void setStartingOffset(final long startingOffset) {
+        this.startingOffset = Math.min(offsetLimit, startingOffset);
+    }
+
+    long startingOffset() {
+        return startingOffset;
     }
 
     boolean hasCompleted(final long recordOffset, final long endOffset) {
@@ -66,6 +77,10 @@ public class StateRestorer {
 
     Long restoredOffset() {
         return restoredOffset;
+    }
+
+    long restoredNumRecords() {
+        return restoredOffset - startingOffset;
     }
 
     long offsetLimit() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -39,18 +39,23 @@ public class StoreChangelogReader implements ChangelogReader {
     private static final Logger log = LoggerFactory.getLogger(StoreChangelogReader.class);
 
     private final Consumer<byte[], byte[]> consumer;
+    private final String logPrefix;
     private final Time time;
     private final long partitionValidationTimeoutMs;
     private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
     private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
 
-
-    public StoreChangelogReader(final Consumer<byte[], byte[]> consumer, final Time time, final long partitionValidationTimeoutMs) {
-        this.consumer = consumer;
+    public StoreChangelogReader(final String threadId, final Consumer<byte[], byte[]> consumer, final Time time, final long partitionValidationTimeoutMs) {
         this.time = time;
+        this.consumer = consumer;
         this.partitionValidationTimeoutMs = partitionValidationTimeoutMs;
+
+        this.logPrefix = String.format("stream-thread [%s]", threadId);
     }
 
+    public StoreChangelogReader(final Consumer<byte[], byte[]> consumer, final Time time, final long partitionValidationTimeoutMs) {
+        this("", consumer, time, partitionValidationTimeoutMs);
+    }
 
     @Override
     public void validatePartitionExists(final TopicPartition topicPartition, final String storeName) {
@@ -60,7 +65,7 @@ public class StoreChangelogReader implements ChangelogReader {
             try {
                 partitionInfo.putAll(consumer.listTopics());
             } catch (final TimeoutException e) {
-                log.warn("Could not list topics so will fall back to partition by partition fetching");
+                log.warn("{} Could not list topics so will fall back to partition by partition fetching", logPrefix);
             }
         }
 
@@ -81,7 +86,7 @@ public class StoreChangelogReader implements ChangelogReader {
             throw new StreamsException(String.format("Store %s's change log (%s) does not contain partition %s",
                                                      storeName, topicPartition.topic(), topicPartition.partition()));
         }
-        log.debug("Took {} ms to validate that partition {} exists", time.milliseconds() - start, topicPartition);
+        log.debug("{} Took {} ms to validate that partition {} exists", logPrefix, time.milliseconds() - start, topicPartition);
     }
 
     @Override
@@ -112,7 +117,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 }
             }
 
-            log.info("Starting restoring state stores from changelog topics {}", needsRestoring.keySet());
+            log.info("{} Starting restoring state stores from changelog topics {}", logPrefix, needsRestoring.keySet());
 
             consumer.assign(needsRestoring.keySet());
 
@@ -128,6 +133,11 @@ public class StoreChangelogReader implements ChangelogReader {
                                       consumer.position(restorer.partition()),
                                       endOffsets.get(restorer.partition()));
                 }
+                // TODO: each consumer.position() call after seekToBeginning will cause
+                // a blocking round trip to reset the position for that partition; we should
+                // batch them into a single round trip to reset for all necessary partitions
+
+                restorer.setStartingOffset(consumer.position(restorer.partition()));
             }
 
             final Set<TopicPartition> partitions = new HashSet<>(needsRestoring.keySet());
@@ -140,12 +150,13 @@ public class StoreChangelogReader implements ChangelogReader {
             }
         } finally {
             consumer.assign(Collections.<TopicPartition>emptyList());
-            log.debug("Took {} ms to restore active state", time.milliseconds() - start);
+            log.debug("{} Took {} ms to restore all active states", logPrefix, time.milliseconds() - start);
         }
     }
 
     private void logRestoreOffsets(final TopicPartition partition, final long checkpoint, final Long aLong) {
-        log.debug("restoring partition {} from offset {} to endOffset {}",
+        log.debug("{} Restoring partition {} from offset {} to endOffset {}",
+                  logPrefix,
                   partition,
                   checkpoint,
                   aLong);
@@ -178,7 +189,16 @@ public class StoreChangelogReader implements ChangelogReader {
                                       endOffset,
                                       pos));
             }
+
             restorer.setRestoredOffset(pos);
+
+            log.debug("{} Completed restoring state from changelog {} with {} records ranging from offset {} to {}",
+                    logPrefix,
+                    topicPartition,
+                    restorer.restoredNumRecords(),
+                    restorer.startingOffset(),
+                    restorer.restoredOffset());
+
             partitionIterator.remove();
         }
     }
@@ -210,6 +230,4 @@ public class StoreChangelogReader implements ChangelogReader {
         return false;
 
     }
-
-
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -99,7 +99,6 @@ public class StoreChangelogReader implements ChangelogReader {
             }
             final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(stateRestorers.keySet());
 
-
             // remove any partitions where we already have all of the data
             final Map<TopicPartition, StateRestorer> needsRestoring = new HashMap<>();
             for (final Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
@@ -112,6 +111,8 @@ public class StoreChangelogReader implements ChangelogReader {
                     needsRestoring.put(topicPartition, restorer);
                 }
             }
+
+            log.info("Starting restoring state stores from changelog topics {}", needsRestoring.keySet());
 
             consumer.assign(needsRestoring.keySet());
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -68,7 +68,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
     private Runnable commitDelegate = new Runnable() {
         @Override
         public void run() {
-            log.debug("{} Committing its state", logPrefix);
             // 1) flush local state
             stateMgr.flush(processorContext);
 
@@ -89,7 +88,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
      * @param partitions            the collection of assigned {@link TopicPartition}
      * @param topology              the instance of {@link ProcessorTopology}
      * @param consumer              the instance of {@link Consumer}
-     * @param restoreConsumer       the instance of {@link Consumer} used when restoring state
+     * @param changelogReader       the instance of {@link ChangelogReader} used for restoring state
      * @param config                the {@link StreamsConfig} specified by the user
      * @param metrics               the {@link StreamsMetrics} created by the thread
      * @param stateDirectory        the {@link StateDirectory} created by the thread

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -125,7 +125,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
         this.logPrefix = String.format("task [%s]", id);
 
-
         this.partitionGroup = new PartitionGroup(partitionQueues, timestampExtractor);
 
         // initialize the consumed offset cache

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -259,7 +259,6 @@ public class StreamThread extends Thread {
         }
         this.cache = new ThreadCache(threadClientId, cacheSizeBytes, this.streamsMetrics);
 
-
         this.logPrefix = String.format("stream-thread [%s]", threadClientId);
 
         // set the producer and consumer clients
@@ -292,7 +291,7 @@ public class StreamThread extends Thread {
         // standby ktables
         this.standbyRecords = new HashMap<>();
 
-        this.stateDirectory = new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time);
+        this.stateDirectory = new StateDirectory(applicationId, threadClientId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time);
         final Object maxPollInterval = consumerConfigs.get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
         this.rebalanceTimeoutMs =  (Integer) ConfigDef.parseType(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollInterval, Type.INT);
         this.pollTimeMs = config.getLong(StreamsConfig.POLL_MS_CONFIG);
@@ -1014,7 +1013,7 @@ public class StreamThread extends Thread {
         return performOnAllTasks(new AbstractTaskAction() {
             @Override
             public void apply(final AbstractTask task) {
-                log.info("{} Closing a task {}", StreamThread.this.logPrefix, task.id());
+                log.info("{} Closing task {}", StreamThread.this.logPrefix, task.id());
                 task.close();
                 streamsMetrics.tasksClosedSensor.record();
             }
@@ -1025,7 +1024,7 @@ public class StreamThread extends Thread {
         return performOnAllTasks(new AbstractTaskAction() {
             @Override
             public void apply(final AbstractTask task) {
-                log.info("{} Closing a task's topology {}", StreamThread.this.logPrefix, task.id());
+                log.info("{} Closing task's topology {}", StreamThread.this.logPrefix, task.id());
                 task.closeTopology();
                 streamsMetrics.tasksClosedSensor.record();
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1221,7 +1221,7 @@ public class StreamThread extends Thread {
 
             final long start = time.milliseconds();
             try {
-                storeChangelogReader = new StoreChangelogReader(restoreConsumer, time, requestTimeOut);
+                storeChangelogReader = new StoreChangelogReader(getName(), restoreConsumer, time, requestTimeOut);
                 setStateWhenNotInPendingShutdown(State.ASSIGNING_PARTITIONS);
                 // do this first as we may have suspended standby tasks that
                 // will become active or vice versa
@@ -1237,7 +1237,7 @@ public class StreamThread extends Thread {
                 rebalanceException = t;
                 throw t;
             } finally {
-                log.debug("{} partition assignment took {} ms.\n" +
+                log.info("{} partition assignment took {} ms.\n" +
                         "\tcurrent active tasks: {}\n" +
                         "\tcurrent standby tasks: {}",
                         logPrefix, time.milliseconds() - start,
@@ -1267,7 +1267,7 @@ public class StreamThread extends Thread {
                 removeStreamTasks();
                 removeStandbyTasks();
 
-                log.debug("{} partition revocation took {} ms.\n" +
+                log.info("{} partition revocation took {} ms.\n" +
                                 "\tsuspended active tasks: {}\n" +
                                 "\tsuspended standby tasks: {}\n" +
                                 "\tprevious active tasks: {}\n",

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -96,7 +96,7 @@ public class ThreadCache {
         }
         cache.flush();
 
-        log.debug("Thread {} cache stats on flush: #puts={}, #gets={}, #evicts={}, #flushes={}",
+        log.trace("Thread {} cache stats on flush: #puts={}, #gets={}, #evicts={}, #flushes={}",
                   name, puts(), gets(), evicts(), flushes());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadTest.java
@@ -62,7 +62,7 @@ public class GlobalStreamThreadTest {
                                                     new StateDirectory("appId", TestUtils.tempDirectory().getPath(), time),
                                                     new Metrics(),
                                                     new MockTime(),
-                                                    "client");
+                                                    "clientId");
     }
 
     @Test
@@ -93,7 +93,7 @@ public class GlobalStreamThreadTest {
                                                     new StateDirectory("appId", TestUtils.tempDirectory().getPath(), time),
                                                     new Metrics(),
                                                     new MockTime(),
-                                                    "client");
+                                                    "clientId");
 
         try {
             globalStreamThread.start();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
@@ -65,5 +65,20 @@ public class StateRestorerTest {
         assertThat(restorer.restoredOffset(), equalTo(OFFSET_LIMIT));
     }
 
+    @Test
+    public void shouldSetStartingOffsetToMinOfLimitAndOffset() throws Exception {
+        restorer.setStartingOffset(20);
+        assertThat(restorer.startingOffset(), equalTo(20L));
+        restorer.setRestoredOffset(100);
+        assertThat(restorer.restoredOffset(), equalTo(OFFSET_LIMIT));
+    }
 
+    @Test
+    public void shouldReturnCorrectNumRestoredRecords() throws Exception {
+        restorer.setStartingOffset(20);
+        restorer.setRestoredOffset(40);
+        assertThat(restorer.restoredNumRecords(), equalTo(20L));
+        restorer.setRestoredOffset(100);
+        assertThat(restorer.restoredNumRecords(), equalTo(OFFSET_LIMIT - 20));
+    }
 }


### PR DESCRIPTION
1. add thread id as prefix in state directory classes; also added logs for lock activities.
2. add logging for task creation / suspension.
3. add more information in rebalance listener logging.
4. add restored number of records into changlog reader.