### PR TITLE
KAFKA-4772: [WIP] Use KStreamPeek to replace KeyValuePrinter

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -192,7 +192,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
     public void print(Serde<K> keySerde, Serde<V> valSerde, String streamName) {
         String name = topology.newName(PRINTING_NAME);
         streamName = (streamName == null) ? this.name : streamName;
-        topology.addProcessor(name, new KeyValuePrinter<>(keySerde, valSerde, streamName), this.name);
+        topology.addProcessor(name, new KeyValuePrinter<>(System.out, keySerde, valSerde, streamName), this.name);
     }
 
 


### PR DESCRIPTION
**Alternative to: https://github.com/apache/kafka/pull/2703 and serves as a reference for discussion.**
Tackles [KAFKA-4772](https://issues.apache.org/jira/browse/KAFKA-4772) and was previously discussed in https://github.com/apache/kafka/pull/2669

This PR contains only a slight improvement over the current `KeyValuePrinter`. The main functionaliy of the printer was refactored such that ForeachAction can be used. This would allow to further refactor KeyValuePrinter as soon as ForeachAction accepts a ProcessorContext as an argument, which is required to retrieve the topic name.