### PR TITLE
KAFKA-4914: Partition re-assignment tool should check types before pe…

### DIFF
--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -95,4 +95,13 @@ object Json {
    * a jackson-scala dependency).
    */
   def encodeAsBytes(obj: Any): Array[Byte] = mapper.writeValueAsBytes(obj)
+
+  /**
+    * Parse a JSON string into either a generic type T, or a Throwable in the case of exception.
+    */
+  def parseTo[T](input: String, klass: Class[T]): Either[Throwable, T] = {
+    try Right(mapper.readValue(input, klass))
+    catch { case e: Throwable => Left(e)}
+  }
+
 }

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -47,9 +47,10 @@ object Json {
     }
 
   /**
-   * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
+   * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of
+    * exception.
    */
-  def parseStringAs[T](input: String)(implicit tag: ClassTag[T]): Either[Throwable, T] = {
+  def parseStringAs[T](input: String)(implicit tag: ClassTag[T]): Either[JsonProcessingException, T] = {
     try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
     catch { case e: JsonProcessingException => Left(e) }
   }

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -47,8 +47,8 @@ object Json {
     }
 
   /**
-    * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
-    */
+   * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
+   */
   def parseStringAs[T](input: String)(implicit tag: ClassTag[T]): Either[Throwable, T] = {
     try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
     catch { case e: JsonProcessingException => Left(e) }
@@ -66,8 +66,8 @@ object Json {
     catch { case e: JsonProcessingException => Left(e) }
 
   /**
-    * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
-    */
+   * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
+   */
   def parseBytesAs[T](input: Array[Byte])(implicit tag: ClassTag[T]): Either[JsonProcessingException, T] = {
     try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
     catch { case e: JsonProcessingException => Left(e) }
@@ -100,16 +100,16 @@ object Json {
   }
 
   /**
-    * Encode an object into a JSON string. This method accepts any type supported by Jackson's ObjectMapper in
+   * Encode an object into a JSON string. This method accepts any type supported by Jackson's ObjectMapper in
    * the default configuration. That is, Java collections are supported, but Scala collections are not (to avoid
    * a jackson-scala dependency).
-    */
+   */
   def encodeAsString(obj: Any): String = mapper.writeValueAsString(obj)
 
   /**
-    * Encode an object into a JSON value in bytes. This method accepts any type supported by Jackson's ObjectMapper in
-    * the default configuration. That is, Java collections are supported, but Scala collections are not (to avoid
-    * a jackson-scala dependency).
-    */
+   * Encode an object into a JSON value in bytes. This method accepts any type supported by Jackson's ObjectMapper in
+   * the default configuration. That is, Java collections are supported, but Scala collections are not (to avoid
+   * a jackson-scala dependency).
+   */
   def encodeAsBytes(obj: Any): Array[Byte] = mapper.writeValueAsBytes(obj)
 }

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -47,6 +47,14 @@ object Json {
     }
 
   /**
+    * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
+    */
+  def parseStringAs[T](input: String)(implicit tag: ClassTag[T]): Either[Throwable, T] = {
+    try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
+    catch { case e: JsonProcessingException => Left(e) }
+  }
+
+  /**
    * Parse a JSON byte array into a JsonValue if possible. `None` is returned if `input` is not valid JSON.
    */
   def parseBytes(input: Array[Byte]): Option[JsonValue] =
@@ -56,6 +64,14 @@ object Json {
   def tryParseBytes(input: Array[Byte]): Either[JsonProcessingException, JsonValue] =
     try Right(mapper.readTree(input)).right.map(JsonValue(_))
     catch { case e: JsonProcessingException => Left(e) }
+
+  /**
+    * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
+    */
+  def parseBytesAs[T](input: Array[Byte])(implicit tag: ClassTag[T]): Either[JsonProcessingException, T] = {
+    try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
+    catch { case e: JsonProcessingException => Left(e) }
+  }
 
   /**
    * Encode an object into a JSON string. This method accepts any type T where
@@ -91,18 +107,9 @@ object Json {
   def encodeAsString(obj: Any): String = mapper.writeValueAsString(obj)
 
   /**
-   * Encode an object into a JSON value in bytes. This method accepts any type supported by Jackson's ObjectMapper in
-   * the default configuration. That is, Java collections are supported, but Scala collections are not (to avoid
-   * a jackson-scala dependency).
-   */
-  def encodeAsBytes(obj: Any): Array[Byte] = mapper.writeValueAsBytes(obj)
-
-  /**
-    * Parse a JSON string into either a generic type T, or a Throwable in the case of exception.
+    * Encode an object into a JSON value in bytes. This method accepts any type supported by Jackson's ObjectMapper in
+    * the default configuration. That is, Java collections are supported, but Scala collections are not (to avoid
+    * a jackson-scala dependency).
     */
-  def parseAs[T](input: String)(implicit tag: ClassTag[T]): Either[Throwable, T] = {
-    try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
-    catch { case e: Throwable => Left(e)}
-  }
-
+  def encodeAsBytes(obj: Any): Array[Byte] = mapper.writeValueAsBytes(obj)
 }

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import kafka.utils.json.JsonValue
 
 import scala.collection._
+import scala.reflect.ClassTag
 
 /**
  * Provides methods for parsing JSON with Jackson and encoding to JSON with a simple and naive custom implementation.
@@ -99,8 +100,8 @@ object Json {
   /**
     * Parse a JSON string into either a generic type T, or a Throwable in the case of exception.
     */
-  def parseTo[T](input: String, klass: Class[T]): Either[Throwable, T] = {
-    try Right(mapper.readValue(input, klass))
+  def parseAs[T](input: String)(implicit tag: ClassTag[T]): Either[Throwable, T] = {
+    try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
     catch { case e: Throwable => Left(e)}
   }
 

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -48,7 +48,7 @@ object Json {
 
   /**
    * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of
-    * exception.
+   * exception.
    */
   def parseStringAs[T](input: String)(implicit tag: ClassTag[T]): Either[JsonProcessingException, T] = {
     try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])
@@ -67,7 +67,7 @@ object Json {
     catch { case e: JsonProcessingException => Left(e) }
 
   /**
-   * Parse a JSON string into either a generic type T, or a JsonProcessingException in the case of exception.
+   * Parse a JSON byte array into either a generic type T, or a JsonProcessingException in the case of exception.
    */
   def parseBytesAs[T](input: Array[Byte])(implicit tag: ClassTag[T]): Either[JsonProcessingException, T] = {
     try Right(mapper.readValue(input, tag.runtimeClass).asInstanceOf[T])

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -144,7 +144,7 @@ object ZkUtils {
     DeleteTopicsPath + "/" + topic
 
   def parsePartitionReassignmentData(jsonData: String): Map[TopicAndPartition, Seq[Int]] = {
-    val parseResult = Json.parseAs[PartitionAssignment](jsonData)
+    val parseResult = Json.parseStringAs[PartitionAssignment](jsonData)
 
     val assignments = parseResult match {
       case Left(throwable) => throw new ConfigException(s"Invalid reassignment config: $throwable")

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -144,7 +144,7 @@ object ZkUtils {
     DeleteTopicsPath + "/" + topic
 
   def parsePartitionReassignmentData(jsonData: String): Map[TopicAndPartition, Seq[Int]] = {
-    val parseResult = Json.parseTo(jsonData, classOf[PartitionAssignment])
+    val parseResult = Json.parseAs[PartitionAssignment](jsonData)
 
     val assignments = parseResult match {
       case Left(throwable) => throw new ConfigException(s"Invalid reassignment config: $throwable")

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -143,7 +143,8 @@ object ZkUtils {
     DeleteTopicsPath + "/" + topic
 
   def parsePartitionReassignmentData(jsonData: String): Map[TopicAndPartition, Seq[Int]] = {
-    val assignments = ReassignPartitionsZNode.decode(jsonData.getBytes) match {
+    val utf8Bytes = jsonData.getBytes(StandardCharsets.UTF_8)
+    val assignments = ReassignPartitionsZNode.decode(utf8Bytes) match {
       case Left(e) => throw e
       case Right(result) => result
     }

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -20,7 +20,6 @@ package kafka.utils
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CountDownLatch
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import kafka.admin._
 import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, LeaderAndIsr}
 import kafka.cluster._
@@ -28,6 +27,7 @@ import kafka.common.{KafkaException, NoEpochForPartitionException, TopicAndParti
 import kafka.consumer.{ConsumerThreadId, TopicCount}
 import kafka.controller.{LeaderIsrAndControllerEpoch, ReassignedPartitionsContext}
 import kafka.zk.{BrokerIdZNode, ZkData}
+import kafka.zk.PartitionAssignment
 import org.I0Itec.zkclient.exception.{ZkBadVersionException, ZkException, ZkMarshallingError, ZkNoNodeException, ZkNodeExistsException}
 import org.I0Itec.zkclient.serialize.ZkSerializer
 import org.I0Itec.zkclient.{IZkChildListener, IZkDataListener, IZkStateListener, ZkClient, ZkConnection}
@@ -1206,25 +1206,3 @@ class ZKCheckedEphemeral(path: String,
     }
   }
 }
-
-// Case classes for JSON deserialization
-
-/**
-  * Deserialized representation of a partition assignment.
-  *
-  * An assignment consists of a `version` and a list of `partitions`, which represent the assignment
-  * of topic-partitions to brokers.
-  */
-case class PartitionAssignment(@JsonProperty("version") version: Int,
-                               @JsonProperty("partitions") partitions: java.util.List[ReplicaAssignment])
-
-/**
-  * Deserialized representation of a replica assignment for a `TopicPartition`, i.e. the assignment
-  * of brokers for a given `TopicPartition`.
-  *
-  * A replica assignment consists of a `topic`, `partition` and a list of `replicas`, which
-  * represent the broker ids that the `TopicPartition` is assigned to.
-  */
-case class ReplicaAssignment(@JsonProperty("topic") topic: String,
-                             @JsonProperty("partition") partitions: Int,
-                             @JsonProperty("replicas") replicas: java.util.List[Int])

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -146,12 +146,13 @@ object ZkUtils {
   def parsePartitionReassignmentData(jsonData: String): Map[TopicAndPartition, Seq[Int]] = {
     val parseResult = Json.parseTo(jsonData, classOf[PartitionAssignment])
 
-    if (parseResult.isLeft)
-      throw new ConfigException(s"Invalid reassignment config: ${parseResult.left}")
+    val assignments = parseResult match {
+      case Left(throwable) => throw new ConfigException(s"Invalid reassignment config: $throwable")
+      case Right(result) => result
+    }
 
-    val assignments = parseResult.right
     val seq = for {
-      assignment <- assignments.get.partitions.asScala
+      assignment <- assignments.partitions.asScala
     } yield {
       (TopicAndPartition(assignment.topic, assignment.partitions), assignment.replicas.asScala)
     }

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -19,6 +19,7 @@ package kafka.zk
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Properties
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import kafka.api.{ApiVersion, KAFKA_0_10_0_IV1, LeaderAndIsr}
 import kafka.cluster.{Broker, EndPoint}
 import kafka.common.KafkaException
@@ -566,3 +567,20 @@ object ZkData {
     } else ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala
   }
 }
+
+/**
+  * The assignment of brokers for a `TopicPartition`.
+  *
+  * A replica assignment consists of a `topic`, `partition` and a list of `replicas`, which
+  * represent the broker ids that the `TopicPartition` is assigned to.
+  */
+case class ReplicaAssignment(@JsonProperty("topic") topic: String,
+                             @JsonProperty("partition") partitions: Int,
+                             @JsonProperty("replicas") replicas: java.util.List[Int])
+
+/**
+  * An assignment consists of a `version` and a list of `partitions`, which represent the assignment
+  * of topic-partitions to brokers.
+  */
+case class PartitionAssignment(@JsonProperty("version") version: Int,
+                               @JsonProperty("partitions") partitions: java.util.List[ReplicaAssignment])

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -138,7 +138,7 @@ class JsonTest {
     val foo = "baz"
     val bar = 1
 
-    val result = Json.parseTo(s"""{"foo": "$foo", "bar": $bar}""", classOf[TestObject])
+    val result = Json.parseAs[TestObject](s"""{"foo": "$foo", "bar": $bar}""")
 
     assertTrue(result.isRight)
     assertEquals(TestObject(foo, bar), result.right.get)
@@ -146,7 +146,7 @@ class JsonTest {
 
   @Test
   def testParseTo_invalidJson() = {
-    val result = Json.parseTo("{invalid json}", classOf[TestObject])
+    val result = Json.parseAs[TestObject]("{invalid json}")
 
     assertTrue(result.isLeft)
     assertEquals(classOf[JsonParseException], result.left.get.getClass)

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -145,7 +145,7 @@ class JsonTest {
   }
 
   @Test
-  def testParseTo_invalidJson() = {
+  def testParseToWithInvalidJson() = {
     val result = Json.parseStringAs[TestObject]("{invalid json}")
 
     assertTrue(result.isLeft)

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -22,12 +22,17 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node._
+import kafka.utils.JsonTest.TestObject
 import kafka.utils.json.JsonValue
 import org.junit.Assert._
 import org.junit.Test
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
+
+object JsonTest {
+  case class TestObject(@JsonProperty("foo") foo: String, @JsonProperty("bar") bar: Int)
+}
 
 class JsonTest {
 
@@ -148,5 +153,3 @@ class JsonTest {
   }
 
 }
-
-case class TestObject(@JsonProperty("foo") foo: String, @JsonProperty("bar") bar: Int)

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -138,7 +138,7 @@ class JsonTest {
     val foo = "baz"
     val bar = 1
 
-    val result = Json.parseAs[TestObject](s"""{"foo": "$foo", "bar": $bar}""")
+    val result = Json.parseStringAs[TestObject](s"""{"foo": "$foo", "bar": $bar}""")
 
     assertTrue(result.isRight)
     assertEquals(TestObject(foo, bar), result.right.get)
@@ -146,7 +146,7 @@ class JsonTest {
 
   @Test
   def testParseTo_invalidJson() = {
-    val result = Json.parseAs[TestObject]("{invalid json}")
+    val result = Json.parseStringAs[TestObject]("{invalid json}")
 
     assertTrue(result.isLeft)
     assertEquals(classOf[JsonParseException], result.left.get.getClass)

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -151,5 +151,4 @@ class JsonTest {
     assertTrue(result.isLeft)
     assertEquals(classOf[JsonParseException], result.left.get.getClass)
   }
-
 }

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -18,11 +18,13 @@ package kafka.utils
 
 import java.nio.charset.StandardCharsets
 
-import org.junit.Assert._
-import org.junit.Test
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.JsonParseException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node._
 import kafka.utils.json.JsonValue
+import org.junit.Assert._
+import org.junit.Test
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
@@ -125,5 +127,26 @@ class JsonTest {
     assertEquals(""""str1\\,str2"""", new String(Json.encodeAsBytes("""str1\,str2"""), StandardCharsets.UTF_8))
     assertEquals(""""\"quoted\""""", new String(Json.encodeAsBytes(""""quoted""""), StandardCharsets.UTF_8))
   }
-  
+
+  @Test
+  def testParseTo() = {
+    val foo = "baz"
+    val bar = 1
+
+    val result = Json.parseTo(s"""{"foo": "$foo", "bar": $bar}""", classOf[TestObject])
+
+    assertTrue(result.isRight)
+    assertEquals(TestObject(foo, bar), result.right.get)
+  }
+
+  @Test
+  def testParseTo_invalidJson() = {
+    val result = Json.parseTo("{invalid json}", classOf[TestObject])
+
+    assertTrue(result.isLeft)
+    assertEquals(classOf[JsonParseException], result.left.get.getClass)
+  }
+
 }
+
+case class TestObject(@JsonProperty("foo") foo: String, @JsonProperty("bar") bar: Int)

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -168,5 +168,4 @@ class ZkUtilsTest extends ZooKeeperTestHarness {
     assertTrue(result.contains(TopicAndPartition(topic, partition1)))
     assertEquals(Seq(replica1, replica2), result(TopicAndPartition(topic, partition1)))
   }
-
 }

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -129,5 +129,4 @@ class ZkUtilsTest extends ZooKeeperTestHarness {
       assertEquals(seqid, zkUtils.getSequenceId(path))
     }
   }
-
 }

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -21,6 +21,7 @@ import kafka.api.LeaderAndIsr
 import kafka.common.TopicAndPartition
 import kafka.controller.LeaderIsrAndControllerEpoch
 import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.security.JaasUtils
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
@@ -42,6 +43,21 @@ class ZkUtilsTest extends ZooKeeperTestHarness {
      CoreUtils.swallow(zkUtils.close(), this)
     super.tearDown
   }
+
+  val topic = "foo"
+  val partition1 = 0
+  val replica1 = 1
+  val replica2 = 2
+  val reassignmentJson =
+    s"""
+      |{
+      |  "version":1,
+      |  "partitions": [
+      |    { "topic": "$topic", "partition":$partition1, "replicas":[$replica1, $replica2]},
+      |    { "topic": "$topic", "partition":$partition1, "replicas":[$replica1, $replica2]}
+      |  ]
+      |}
+    """.stripMargin
 
   @Test
   def testSuccessfulConditionalDeletePath() {
@@ -129,4 +145,28 @@ class ZkUtilsTest extends ZooKeeperTestHarness {
       assertEquals(seqid, zkUtils.getSequenceId(path))
     }
   }
+
+  @Test
+  def testParsePartitionReassignmentDataWithoutDedup_invalidJson() = {
+    val jsonStr = "{invalid json}"
+
+    try {
+      ZkUtils.parsePartitionReassignmentData(jsonStr)
+      fail("Should have thrown ConfigException");
+    } catch {
+      case e: ConfigException =>
+        assertTrue(e.getMessage.contains("Invalid reassignment config"))
+    }
+  }
+
+  @Test
+  def testParsePartitionReassignmentData() = {
+    val result = ZkUtils.parsePartitionReassignmentData(reassignmentJson)
+
+    // Duplicates are removed
+    assertEquals(1, result.size)
+    assertTrue(result.contains(TopicAndPartition(topic, partition1)))
+    assertEquals(Seq(replica1, replica2), result(TopicAndPartition(topic, partition1)))
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
@@ -14,38 +14,34 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
-package unit.kafka.zk
+package kafka.zk
+
+import java.nio.charset.StandardCharsets
 
 import com.fasterxml.jackson.core.JsonProcessingException
-import kafka.zk.ReassignPartitionsZNode
 import org.apache.kafka.common.TopicPartition
 import org.junit.Assert._
 import org.junit.Test
 
 class ReassignPartitionsZNodeTest {
 
-  val topic = "foo"
-  val partition1 = 0
-  val replica1 = 1
-  val replica2 = 2
+  private val topic = "foo"
+  private val partition1 = 0
+  private val replica1 = 1
+  private val replica2 = 2
 
-  private val reassignPartitionData = Map(
-    new TopicPartition(topic, partition1) -> Seq(replica1, replica2))
-  private val reassignmentJson = "{\"version\":1,\"partitions\":[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[1,2]}]}"
+  private val reassignPartitionData = Map(new TopicPartition(topic, partition1) -> Seq(replica1, replica2))
+  private val reassignmentJson = """{"version":1,"partitions":[{"topic":"foo","partition":0,"replicas":[1,2]}]}"""
 
   @Test
   def testEncode() {
-    val encodedJsonString = ReassignPartitionsZNode.encode(reassignPartitionData)
-      .map(_.toChar)
-      .mkString
-
+    val encodedJsonString = new String(ReassignPartitionsZNode.encode(reassignPartitionData), StandardCharsets.UTF_8)
     assertEquals(reassignmentJson, encodedJsonString)
   }
 
   @Test
   def testDecodeInvalidJson() {
     val result = ReassignPartitionsZNode.decode("invalid json".getBytes)
-
     assertTrue(result.isLeft)
     assertTrue(result.left.get.isInstanceOf[JsonProcessingException])
   }
@@ -53,7 +49,6 @@ class ReassignPartitionsZNodeTest {
   @Test
   def testDecodeValidJson() {
     val result = ReassignPartitionsZNode.decode(reassignmentJson.getBytes)
-
     assertTrue(result.isRight)
     val assignmentMap = result.right.get
     assertEquals(Seq(replica1, replica2), assignmentMap(new TopicPartition(topic, partition1)))

--- a/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
@@ -1,3 +1,19 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package unit.kafka.zk
 
 import com.fasterxml.jackson.core.JsonProcessingException

--- a/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ReassignPartitionsZNodeTest.scala
@@ -1,0 +1,45 @@
+package unit.kafka.zk
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import kafka.zk.ReassignPartitionsZNode
+import org.apache.kafka.common.TopicPartition
+import org.junit.Assert._
+import org.junit.Test
+
+class ReassignPartitionsZNodeTest {
+
+  val topic = "foo"
+  val partition1 = 0
+  val replica1 = 1
+  val replica2 = 2
+
+  private val reassignPartitionData = Map(
+    new TopicPartition(topic, partition1) -> Seq(replica1, replica2))
+  private val reassignmentJson = "{\"version\":1,\"partitions\":[{\"topic\":\"foo\",\"partition\":0,\"replicas\":[1,2]}]}"
+
+  @Test
+  def testEncode() {
+    val encodedJsonString = ReassignPartitionsZNode.encode(reassignPartitionData)
+      .map(_.toChar)
+      .mkString
+
+    assertEquals(reassignmentJson, encodedJsonString)
+  }
+
+  @Test
+  def testDecodeInvalidJson() {
+    val result = ReassignPartitionsZNode.decode("invalid json".getBytes)
+
+    assertTrue(result.isLeft)
+    assertTrue(result.left.get.isInstanceOf[JsonProcessingException])
+  }
+
+  @Test
+  def testDecodeValidJson() {
+    val result = ReassignPartitionsZNode.decode(reassignmentJson.getBytes)
+
+    assertTrue(result.isRight)
+    val assignmentMap = result.right.get
+    assertEquals(Seq(replica1, replica2), assignmentMap(new TopicPartition(topic, partition1)))
+  }
+}


### PR DESCRIPTION
…rsisting state in ZooKeeper

Prior to this, there have been instances where invalid data was allowed to be persisted in ZooKeeper, which causes ClassCastExceptions when a broker is restarted and reads this type-unsafe data.

Adds basic structural and type validation for the reassignment JSON via introduction of Scala case classes that map to the expected JSON structure.