### PR TITLE
KAFKA-4920: Stamped implements equals

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Stamped.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Stamped.java
@@ -34,4 +34,22 @@ public class Stamped<V> implements Comparable {
         else if (timestamp > otherTimestamp) return 1;
         return 0;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Stamped<?> stamped = (Stamped<?>) o;
+
+        if (timestamp != stamped.timestamp) return false;
+        return value != null ? value.equals(stamped.value) : stamped.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = 31 * result + (int) (timestamp ^ (timestamp >>> 32));
+        return result;
+    }
 }


### PR DESCRIPTION
Solves: [KAFKA-4920](https://issues.apache.org/jira/browse/KAFKA-4920)
Bug type EQ_COMPARETO_USE_OBJECT_EQUALS (click for details)
In class org.apache.kafka.streams.processor.internals.Stamped
In method org.apache.kafka.streams.processor.internals.Stamped.compareTo(Object)
At Stamped.java:[lines 31-35]