### PR TITLE
KAFKA-4921: AssignedPartition implements equals

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -74,6 +74,25 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         public int compareTo(final AssignedPartition that) {
             return PARTITION_COMPARATOR.compare(this.partition, that.partition);
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            AssignedPartition that = (AssignedPartition) o;
+
+            if (taskId != null ? !taskId.equals(that.taskId) : that.taskId != null) return false;
+            return partition != null ? partition.equals(that.partition) : that.partition == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = taskId != null ? taskId.hashCode() : 0;
+            result = 31 * result + (partition != null ? partition.hashCode() : 0);
+            return result;
+        }
     }
 
     private static class ClientMetadata {


### PR DESCRIPTION
Solves: [KAFKA-4921](https://issues.apache.org/jira/browse/KAFKA-4921)

Bug type EQ_COMPARETO_USE_OBJECT_EQUALS (click for details)
In class org.apache.kafka.streams.processor.internals.StreamPartitionAssignor$AssignedPartition
In method org.apache.kafka.streams.processor.internals.StreamPartitionAssignor$AssignedPartition.compareTo(StreamPartitionAssignor$AssignedPartition)
At StreamPartitionAssignor.java:[line 75]