### PR TITLE
Fix ZKSec Migrate example

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -908,7 +908,7 @@
     </ol>
     Here is an example of how to run the migration tool:
     <pre>
-    ./bin/zookeeper-security-migration --zookeeper.acl=secure --zookeeper.connection=localhost:2181
+    ./bin/zookeeper-security-migration --zookeeper.acl=secure --zookeeper.connect=localhost:2181
     </pre>
     <p>Run this to see the full list of parameters:</p>
     <pre>


### PR DESCRIPTION
Incorrect option in example 

https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/admin/ZkSecurityMigrator.scala#L71