### PR TITLE
KAFKA-4942 fixed the commitTimeoutMs being set before the commit actually started

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -154,7 +154,6 @@ class WorkerSinkTask extends WorkerTask {
 
     protected void iteration() {
         final long offsetCommitIntervalMs = workerConfig.getLong(WorkerConfig.OFFSET_COMMIT_INTERVAL_MS_CONFIG);
-        final long commitTimeoutMs = commitStarted + workerConfig.getLong(WorkerConfig.OFFSET_COMMIT_TIMEOUT_MS_CONFIG);
 
         try {
             long now = time.milliseconds();
@@ -165,6 +164,8 @@ class WorkerSinkTask extends WorkerTask {
                 nextCommit += offsetCommitIntervalMs;
                 context.clearCommitRequest();
             }
+
+            final long commitTimeoutMs = commitStarted + workerConfig.getLong(WorkerConfig.OFFSET_COMMIT_TIMEOUT_MS_CONFIG);
 
             // Check for timed out commits
             if (committing && now >= commitTimeoutMs) {


### PR DESCRIPTION
this fixes KAFKA-4942