### PR TITLE
KAFKA-4948: Failure in kafka.admin.DescribeConsumerGroupTest...

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -53,7 +53,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   // configure the servers and clients
   override def generateConfigs() = TestUtils.createBrokerConfigs(1, zkConnect, enableControlledShutdown = false).map { config =>
-    config.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "10")
+    config.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "5")
     KafkaConfig.fromProps(config, overridingProps)
   }
 

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -52,7 +52,10 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   val props = new Properties
 
   // configure the servers and clients
-  override def generateConfigs() = TestUtils.createBrokerConfigs(1, zkConnect, enableControlledShutdown = false).map(KafkaConfig.fromProps(_, overridingProps))
+  override def generateConfigs() = TestUtils.createBrokerConfigs(1, zkConnect, enableControlledShutdown = false).map { config =>
+    config.setProperty(KafkaConfig.OffsetsTopicPartitionsProp, "10")
+    KafkaConfig.fromProps(config, overridingProps)
+  }
 
   @Before
   override def setUp() {


### PR DESCRIPTION
This test fails regularly when run on OSX (on my machine anyway). The fix decreases the number of partitions in the consumer offsets topic allows it to complete within the timeout. 

As an aside I wondered why it was taking so long (regression??). This is why:
- It takes 6 seconds to create the offsets topic (on OSX)
- It takes ~200ms to create each log
- It takes ~ 100ms to create each index file (time index + offset index)
- This time is spent on the line [raf.setLength()](https://github.com/apache/kafka/blob/5fc530bc483db145e0cba3b63a57d6d6a7c547f2/core/src/main/scala/kafka/log/AbstractIndex.scala#L56)

This isn't an issue in practice, but at least we know this isn't a real regression. 