### PR TITLE
MINOR: remove misleading scala setter in ControllerContext

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -60,13 +60,11 @@ class ControllerContext(val zkUtils: ZkUtils) {
   private var liveBrokersUnderlying: Set[Broker] = Set.empty
   private var liveBrokerIdsUnderlying: Set[Int] = Set.empty
 
-  // setter
-  def liveBrokers_=(brokers: Set[Broker]) {
+  def updateLiveBrokers(brokers: Set[Broker]) {
     liveBrokersUnderlying = brokers
     liveBrokerIdsUnderlying = liveBrokersUnderlying.map(_.id)
   }
 
-  // getter
   def liveBrokers = liveBrokersUnderlying.filter(broker => !shuttingDownBrokerIds.contains(broker.id))
   def liveBrokerIds = liveBrokerIdsUnderlying -- shuttingDownBrokerIds
 
@@ -737,7 +735,7 @@ class KafkaController(val config: KafkaConfig, zkUtils: ZkUtils, val brokerState
 
   private def initializeControllerContext() {
     // update controller cache with delete topic information
-    controllerContext.liveBrokers = zkUtils.getAllBrokersInCluster().toSet
+    controllerContext.updateLiveBrokers(zkUtils.getAllBrokersInCluster().toSet)
     controllerContext.allTopics = zkUtils.getAllTopics().toSet
     controllerContext.partitionReplicaAssignment = zkUtils.getReplicaAssignmentForTopics(controllerContext.allTopics.toSeq)
     controllerContext.partitionLeadershipInfo = new mutable.HashMap[TopicAndPartition, LeaderIsrAndControllerEpoch]

--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -362,7 +362,7 @@ class ReplicaStateMachine(controller: KafkaController) extends Logging {
               val newBrokerIds = curBrokerIds -- liveOrShuttingDownBrokerIds
               val deadBrokerIds = liveOrShuttingDownBrokerIds -- curBrokerIds
               val newBrokers = curBrokers.filter(broker => newBrokerIds(broker.id))
-              controllerContext.liveBrokers = curBrokers
+              controllerContext.updateLiveBrokers(curBrokers)
               val newBrokerIdsSorted = newBrokerIds.toSeq.sorted
               val deadBrokerIdsSorted = deadBrokerIds.toSeq.sorted
               val liveBrokerIdsSorted = curBrokerIds.toSeq.sorted

--- a/core/src/test/scala/unit/kafka/server/ControlledShutdownLeaderSelectorTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ControlledShutdownLeaderSelectorTest.scala
@@ -40,7 +40,7 @@ class ControlledShutdownLeaderSelectorTest {
 
     val zkUtils = EasyMock.mock(classOf[ZkUtils])
     val controllerContext = new ControllerContext(zkUtils)
-    controllerContext.liveBrokers = assignment.map(Broker(_, Seq.empty, None)).toSet
+    controllerContext.updateLiveBrokers(assignment.map(Broker(_, Seq.empty, None)).toSet)
     controllerContext.shuttingDownBrokerIds = mutable.Set(2, 3)
     controllerContext.partitionReplicaAssignment = mutable.Map(topicPartition -> assignment)
 
@@ -57,7 +57,7 @@ class ControlledShutdownLeaderSelectorTest {
     controllerContext.shuttingDownBrokerIds += preferredReplicaId
 
     val deadBrokerId = 2
-    controllerContext.liveBrokers = controllerContext.liveOrShuttingDownBrokers.filter(_.id != deadBrokerId)
+    controllerContext.updateLiveBrokers(controllerContext.liveOrShuttingDownBrokers.filter(_.id != deadBrokerId))
     controllerContext.shuttingDownBrokerIds -= deadBrokerId
 
     val (thirdLeaderAndIsr, thirdReplicas) = leaderSelector.selectLeader(topicPartition, secondLeaderAndIsr)

--- a/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LeaderElectionTest.scala
@@ -136,7 +136,7 @@ class LeaderElectionTest extends ZooKeeperTestHarness {
     val nodes = brokers.map(_.getNode(listenerName))
 
     val controllerContext = new ControllerContext(zkUtils)
-    controllerContext.liveBrokers = brokers.toSet
+    controllerContext.updateLiveBrokers(brokers.toSet)
     val metrics = new Metrics
     val controllerChannelManager = new ControllerChannelManager(controllerContext, controllerConfig, Time.SYSTEM, metrics)
     controllerChannelManager.startup()


### PR DESCRIPTION
Using a scala setter `liveBrokers_` to update both `liveBrokersUnderlying` and `liveBrokerIdsUnderlying` in the ControllerContext was making the code hard to read.