### PR TITLE
[KAFKA-4964]Delete the kafka to prefix the name of the keystore and truststore file will be more suitable

### DIFF
--- a/docs/security.html
+++ b/docs/security.html
@@ -137,10 +137,10 @@
 
             Following SSL configs are needed on the broker side
             <pre>
-            ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+            ssl.keystore.location=/var/private/ssl/server.keystore.jks
             ssl.keystore.password=test1234
             ssl.key.password=test1234
-            ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+            ssl.truststore.location=/var/private/ssl/server.truststore.jks
             ssl.truststore.password=test1234</pre>
 
             Note: ssl.truststore.password is technically optional but highly recommended. If a password is not set access to the truststore is still available, but integrity checking is disabled.
@@ -191,14 +191,14 @@
             If client authentication is not required in the broker, then the following is a minimal configuration example:
             <pre>
             security.protocol=SSL
-            ssl.truststore.location=/var/private/ssl/kafka.client.truststore.jks
+            ssl.truststore.location=/var/private/ssl/client.truststore.jks
             ssl.truststore.password=test1234</pre>
 
             Note: ssl.truststore.password is technically optional but highly recommended. If a password is not set access to the truststore is still available, but integrity checking is disabled.
 
             If client authentication is required, then a keystore must be created like in step 1 and the following must also be configured:
             <pre>
-            ssl.keystore.location=/var/private/ssl/kafka.client.keystore.jks
+            ssl.keystore.location=/var/private/ssl/client.keystore.jks
             ssl.keystore.password=test1234
             ssl.key.password=test1234</pre>
 

--- a/docs/security.html
+++ b/docs/security.html
@@ -201,7 +201,6 @@
             ssl.keystore.location=/var/private/ssl/client.keystore.jks
             ssl.keystore.password=test1234
             ssl.key.password=test1234</pre>
-
 			
             Other configuration settings that may also be needed depending on our requirements and the broker configuration:
                 <ol>

--- a/docs/security.html
+++ b/docs/security.html
@@ -202,6 +202,7 @@
             ssl.keystore.password=test1234
             ssl.key.password=test1234</pre>
 
+			
             Other configuration settings that may also be needed depending on our requirements and the broker configuration:
                 <ol>
                     <li>ssl.provider (Optional). The name of the security provider used for SSL connections. Default value is the default security provider of the JVM.</li>


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/KAFKA-4964](url)
Kafka to prefix the name of the keystore and truststore file,will possible to cause misdirection, because of according to the previous steps to generate the file name without that prefix. Delete the prefix may helpful to the kafka SSL beginners.