### PR TITLE
KAFKA-4966：Producer throw a NullPointerException under a network environment where packet loss and error packets exist.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -275,8 +275,10 @@ public class Sender implements Runnable {
                 for (Map.Entry<TopicPartition, ProduceResponse.PartitionResponse> entry : produceResponse.responses().entrySet()) {
                     TopicPartition tp = entry.getKey();
                     ProduceResponse.PartitionResponse partResp = entry.getValue();
-                    ProducerBatch batch = batches.get(tp);
-                    completeBatch(batch, partResp, correlationId, now);
+                    if (tp != null && partResp != null) {
+                        ProducerBatch batch = batches.get(tp);
+                        completeBatch(batch, partResp, correlationId, now);
+                    }
                 }
                 this.sensors.recordLatency(response.destination(), response.requestLatencyMs());
                 this.sensors.recordThrottleTime(produceResponse.getThrottleTime());


### PR DESCRIPTION
fix KAFKA-4966 NPE in sender complete batch