### PR TITLE
KAFKA-4818: Implement transactional producer

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -124,6 +124,7 @@
     </subpackage>
 
     <subpackage name="producer">
+      <allow pkg="org.apache.kafka.clients.consumer" />
       <allow pkg="org.apache.kafka.clients.producer" />
     </subpackage>
   </subpackage>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -223,6 +223,15 @@ public class ConsumerConfig extends AbstractConfig {
                                                             + "If set to <code>true</code> the only way to receive records from an internal topic is subscribing to it.";
     public static final boolean DEFAULT_EXCLUDE_INTERNAL_TOPICS = true;
 
+    /** <code>isolation.level</code> */
+    public static final String ISOLATION_LEVEL_CONFIG = "isolation.level";
+    public static final String ISOLATION_LEVEL_DOC = "Controls how to read messages written transactionally. If set to <code>READ_COMMITTED</code>, consumer.poll() will only return "
+                                                    + "transactional messages which have been committed. If set to <code>READ_UNCOMMITTED</code>' (the default), consumer.poll() will return all messages, even transactional messages "
+                                                    + "which have been aborted. Non-transactional messages will be returned unconditionally in either mode.</p> <p>Messages will be  always returned in offset order. Hence, in "
+                                                    + " <code>READ_COMMITTED</code> mode, consumer.poll() will only return messages upto the last resolved (committed or aborted) transaction. In particular any messages appearing after "
+                                                    + " messages belonging onging transactions will be withheld until the said transaction has been completed and its messages are delivered to the application. As a result, <code>READ_COMMITTED</code> "
+                                                    + " consumers will not be able to read upto the log end offset when there are inflight transactions.";
+
     /**
      * <code>internal.leave.group.on.close</code>
      * Whether or not the consumer should leave the group on close. If set to <code>false</code> then a rebalance

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.internals.ProducerInterceptors;
 import org.apache.kafka.clients.producer.internals.RecordAccumulator;
 import org.apache.kafka.clients.producer.internals.Sender;
@@ -32,6 +33,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -843,4 +845,21 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 this.userCallback.onCompletion(metadata, exception);
         }
     }
+
+    @Override
+    public void abortTransaction() throws ProducerFencedException {}
+
+    @Override
+    public void beginTransaction() throws ProducerFencedException {}
+
+    @Override
+    public void commitTransaction() throws ProducerFencedException {}
+
+    @Override
+    public void initTransactions() throws IllegalStateException {}
+
+    @Override
+    public void sendOffsetsToTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                         final String consumerGroupId) throws ProducerFencedException {}
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.producer;
 
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.clients.producer.internals.FutureRecordMetadata;
 import org.apache.kafka.clients.producer.internals.ProduceRequestResult;
@@ -24,6 +25,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -255,5 +257,21 @@ public class MockProducer<K, V> implements Producer<K, V> {
             result.done();
         }
     }
+
+    @Override
+    public void abortTransaction() throws ProducerFencedException {}
+
+    @Override
+    public void beginTransaction() throws ProducerFencedException {}
+
+    @Override
+    public void commitTransaction() throws ProducerFencedException {}
+
+    @Override
+    public void initTransactions() throws IllegalStateException {}
+
+    @Override
+    public void sendOffsetsToTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                         final String consumerGroupId) throws ProducerFencedException {}
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/Producer.java
@@ -16,62 +16,122 @@
  */
 package org.apache.kafka.clients.producer;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.MetricName;
-
-
 /**
- * The interface for the {@link KafkaProducer}
+ * The interface for the {@link KafkaProducer}.
+ *s
  * @see KafkaProducer
  * @see MockProducer
  */
 public interface Producer<K, V> extends Closeable {
 
     /**
-     * Send the given record asynchronously and return a future which will eventually contain the response information.
-     * 
-     * @param record The record to send
-     * @return A future which will eventually contain the response information
+     * Aborts the ongoing transaction.
+     *
+     * @throws ProducerFencedException if another producer is with the same
+     * {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG transactional.id} is active.
      */
-    public Future<RecordMetadata> send(ProducerRecord<K, V> record);
+    void abortTransaction() throws ProducerFencedException;
 
     /**
-     * Send a record and invoke the given callback when the record has been acknowledged by the server
+     * Should be called before the start of each new transaction.
+     *
+     * @throws ProducerFencedException if another producer is with the same
+     * {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG transactional.id} is active.
      */
-    public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback);
-    
-    /**
-     * Flush any accumulated records from the producer. Blocks until all sends are complete.
-     */
-    public void flush();
+    void beginTransaction() throws ProducerFencedException;
 
     /**
-     * Get a list of partitions for the given topic for custom partition assignment. The partition metadata will change
-     * over time so this list should not be cached.
+     * Close this producer.
      */
-    public List<PartitionInfo> partitionsFor(String topic);
-
-    /**
-     * Return a map of metrics maintained by the producer
-     */
-    public Map<MetricName, ? extends Metric> metrics();
-
-    /**
-     * Close this producer
-     */
-    public void close();
+    @Override
+    void close();
 
     /**
      * Tries to close the producer cleanly within the specified timeout. If the close does not complete within the
      * timeout, fail any pending send requests and force close the producer.
      */
-    public void close(long timeout, TimeUnit unit);
+    void close(final long timeout, final TimeUnit unit);
+
+    /**
+     * Commits the ongoing transaction.
+     *
+     * @throws ProducerFencedException if another producer is with the same
+     * {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG transactional.id} is active.
+     */
+    void commitTransaction() throws ProducerFencedException;
+
+    /**
+     * Flush any accumulated records from the producer. Blocks until all sends are complete.
+     */
+    void flush();
+
+    /**
+     * Needs to be called before any of the other transaction methods are used.
+     * Assumes that the {@link ProducerConfig#TRANSACTIONAL_ID_DOC transactional.id} is specified in the
+     * {@link ProducerConfig producer configuration}.
+     * <p>
+     * This method does the following:
+     * <ol>
+     *   <li>Ensures any transactions initiated by previous instances of the producer are completed.
+     *       If the previous instance had failed with a transaction in progress, it will be aborted.
+     *       If the last transaction had begun completion, but not yet finished, this method awaits its completion.</li>
+     *   <li>Gets the internal producer id and epoch, used in all future transactional messages issued by the producer.</li>
+     * </ol>
+     *
+     * @throws IllegalStateException if the TransactionalId for the producer is not set in the configuration
+     */
+    void initTransactions() throws IllegalStateException;
+
+    /**
+     * Return a map of metrics maintained by the producer.
+     */
+    Map<MetricName, ? extends Metric> metrics();
+
+    /**
+     * Get a list of partitions for the given topic for custom partition assignment. The partition metadata will change
+     * over time so this list should not be cached.
+     */
+    List<PartitionInfo> partitionsFor(final String topic);
+
+    /**
+     * Send the given record asynchronously and return a future which will eventually contain the response information.
+     *
+     * @param record The record to send
+     * @return A future which will eventually contain the response information.
+     */
+    Future<RecordMetadata> send(final ProducerRecord<K, V> record);
+
+    /**
+     * Send a record and invoke the given callback when the record has been acknowledged by the server.
+     */
+    Future<RecordMetadata> send(final ProducerRecord<K, V> record, final Callback callback);
+
+    /**
+     * Sends a list of consumed offsets and marks those offsets as part of the current transaction.
+     * These offsets will be considered consumed only if the transaction is committed successfully.
+     * <p>
+     * This method should be used when you need to batch consumed and produced messages together, typically in a
+     * consume-transform-produce pattern.
+     * If this method is used, it's not required to {@link Consumer#commitSync() commit offsets with the consumer}.
+     *
+     * @throws ProducerFencedException if another producer is with the same
+     * {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG transactional.id} is active.
+     */
+    void sendOffsetsToTransaction(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                                  final String consumerGroupId) throws ProducerFencedException;
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -224,6 +224,29 @@ public class ProducerConfig extends AbstractConfig {
                                                         + "Implementing the <code>ProducerInterceptor</code> interface allows you to intercept (and possibly mutate) the records "
                                                         + "received by the producer before they are published to the Kafka cluster. By default, there are no interceptors.";
 
+    /** <code>enable.idempotence</code> */
+    public static final String ENABLE_IDEMPOTENCE_CONFIG = "enable.idempotence";
+    public static final String ENABLE_IDEMPOTENCE_DOC = "When set to 'true', the producer will ensure that exactly one copy of each message is written in the stream."
+                                                       + " If 'false', producer retries due to broker failures, etc., may write duplicates of the retried message in the stream."
+                                                       + " This is set to 'false' by default."
+                                                       + " Note that enabling idempotence requires <code>" + MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION + "</code> to be set to 1 and <code>" + RETRIES_CONFIG + "</code> cannot be zero.";
+
+    /** <code>transaction.timeout.ms</code> */
+    public static final String TRANSACTION_TIMEOUT_MS_CONFIG = "transaction.timeout.ms";
+    public static final String TRANSACTION_TIMEOUT_MS_DOC = "The maximum amount of time in ms that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction."
+                                                           + " This config value will be sent when calling <code>initTransactions()</code>."
+                                                           + " If this value is larger than the <code>max.transaction.timeout.ms</code> setting in the broker, the request will fail with a `InvalidTransactionTimeout` error."
+                                                           + " Default is 60000."
+                                                           + " This makes a transaction to not block downstream consumption more than a minute, which is generally allowable in real-time apps.";
+
+    /** <code>transactional.id</code> */
+    public static final String TRANSACTIONAL_ID_CONFIG = "transactional.id";
+    public static final String TRANSACTIONAL_ID_DOC = "The transactional id to use for transactional delivery."
+                                                     + " This enables reliability semantics which span multiple producer sessions since it allows the client to guarantee that transactions using the same transactional id have been completed prior to starting any new transactions."
+                                                     + " If no transactional id is provided, then the producer is limited to idempotent delivery."
+                                                     + " Note that <code>" + ENABLE_IDEMPOTENCE_CONFIG + "</code> must be enabled if a transactional id is configured."
+                                                     + " The default is empty, which means transactions cannot be used.";
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Importance.HIGH, CommonClientConfigs.BOOTSTRAP_SERVERS_DOC)
                                 .define(BUFFER_MEMORY_CONFIG, Type.LONG, 32 * 1024 * 1024L, atLeast(0L), Importance.HIGH, BUFFER_MEMORY_DOC)

--- a/clients/src/main/java/org/apache/kafka/common/errors/ProducerFencedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ProducerFencedException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class ProducerFencedException extends ApiException {
+
+    public ProducerFencedException(final String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
add public API for transactions
 - add new Producer methods to interface
 - add new Producer and Consumer config parameters

We want to add the API early to break the dependency for Streams EoS implementation and allow for parallel development.