### PR TITLE
MINOR: Move `Os` class to utils package and rename it to OperatingSystem

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/OperatingSystem.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/OperatingSystem.java
@@ -18,9 +18,9 @@ package org.apache.kafka.common.utils;
 
 import java.util.Locale;
 
-public final class Os {
+public final class OperatingSystem {
 
-    private Os() {
+    private OperatingSystem() {
     }
     
     public static final String NAME;

--- a/clients/src/main/java/org/apache/kafka/common/utils/Os.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Os.java
@@ -14,11 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.common;
+package org.apache.kafka.common.utils;
 
 import java.util.Locale;
 
 public final class Os {
+
+    private Os() {
+    }
+    
     public static final String NAME;
 
     public static final boolean IS_WINDOWS;

--- a/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
@@ -29,14 +29,14 @@ public class ShellTest {
 
     @Test
     public void testEchoHello() throws Exception {
-        assumeTrue(!Os.IS_WINDOWS);
+        assumeTrue(!OperatingSystem.IS_WINDOWS);
         String output = Shell.execCommand("echo", "hello");
         assertEquals("hello\n", output);
     }
 
     @Test
     public void testHeadDevZero() throws Exception {
-        assumeTrue(!Os.IS_WINDOWS);
+        assumeTrue(!OperatingSystem.IS_WINDOWS);
         final int length = 100000;
         String output = Shell.execCommand("head", "-c", Integer.toString(length), "/dev/zero");
         assertEquals(length, output.length());

--- a/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.utils;
 
-import org.apache.kafka.common.Os;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -25,8 +25,7 @@ import java.util.concurrent.locks.{Lock, ReentrantLock}
 import kafka.log.IndexSearchType.IndexSearchEntity
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.{CoreUtils, Logging}
-import org.apache.kafka.common.Os
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{Os, Utils}
 import sun.nio.ch.DirectBuffer
 
 import scala.math.ceil

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.{Lock, ReentrantLock}
 import kafka.log.IndexSearchType.IndexSearchEntity
 import kafka.utils.CoreUtils.inLock
 import kafka.utils.{CoreUtils, Logging}
-import org.apache.kafka.common.utils.{Os, Utils}
+import org.apache.kafka.common.utils.{OperatingSystem, Utils}
 import sun.nio.ch.DirectBuffer
 
 import scala.math.ceil
@@ -104,7 +104,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
       val position = mmap.position
 
       /* Windows won't let us modify the file length while the file is mmapped :-( */
-      if(Os.IS_WINDOWS)
+      if (OperatingSystem.IS_WINDOWS)
         forceUnmap(mmap);
       try {
         raf.setLength(roundedNewSize)
@@ -216,12 +216,11 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
    * and this requires synchronizing reads.
    */
   protected def maybeLock[T](lock: Lock)(fun: => T): T = {
-    if(Os.IS_WINDOWS)
+    if (OperatingSystem.IS_WINDOWS)
       lock.lock()
-    try {
-      fun
-    } finally {
-      if(Os.IS_WINDOWS)
+    try fun
+    finally {
+      if (OperatingSystem.IS_WINDOWS)
         lock.unlock()
     }
   }


### PR DESCRIPTION
The `common` package is public and this class is
internal.