### PR TITLE
KAFKA-4913: creating a window store with one segment throws division by zero error

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -1190,9 +1190,8 @@ public class TopologyBuilder {
         }
 
         final WindowStoreSupplier windowStoreSupplier = (WindowStoreSupplier) supplier;
-        if (windowStoreSupplier.segments() > 1) {
-            cleanupPolicies.add(InternalTopicConfig.CleanupPolicy.delete);
-        }
+        cleanupPolicies.add(InternalTopicConfig.CleanupPolicy.delete);
+
         final InternalTopicConfig config = new InternalTopicConfig(name,
                                                                    cleanupPolicies,
                                                                    supplier.logConfig());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -1184,14 +1184,17 @@ public class TopologyBuilder {
     }
 
     private InternalTopicConfig createInternalTopicConfig(final StateStoreSupplier<?> supplier, final String name) {
+        final Set<InternalTopicConfig.CleanupPolicy> cleanupPolicies = Utils.mkSet(InternalTopicConfig.CleanupPolicy.compact);
         if (!(supplier instanceof WindowStoreSupplier)) {
-            return new InternalTopicConfig(name, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), supplier.logConfig());
+            return new InternalTopicConfig(name, cleanupPolicies, supplier.logConfig());
         }
 
         final WindowStoreSupplier windowStoreSupplier = (WindowStoreSupplier) supplier;
+        if (windowStoreSupplier.segments() > 1) {
+            cleanupPolicies.add(InternalTopicConfig.CleanupPolicy.delete);
+        }
         final InternalTopicConfig config = new InternalTopicConfig(name,
-                                                                   Utils.mkSet(InternalTopicConfig.CleanupPolicy.compact,
-                                                                               InternalTopicConfig.CleanupPolicy.delete),
+                                                                   cleanupPolicies,
                                                                    supplier.logConfig());
         config.setRetentionMs(windowStoreSupplier.retentionPeriod());
         return config;

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -111,6 +111,12 @@ public class Stores {
 
                                     @Override
                                     public PersistentKeyValueFactory<K, V> windowed(final long windowSize, final long retentionPeriod, final int numSegments, final boolean retainDuplicates) {
+                                        if (numSegments < 1) {
+                                            throw new IllegalArgumentException("numSegments must be positive");
+                                        }
+                                        if (retentionPeriod < 1) {
+                                            throw new IllegalArgumentException("retentionPeriod must be positive");
+                                        }
                                         this.windowSize = windowSize;
                                         this.numSegments = numSegments;
                                         this.retentionPeriod = retentionPeriod;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplier.java
@@ -89,4 +89,9 @@ public class RocksDBSessionStoreSupplier<K, V> extends AbstractStoreSupplier<K, 
     public long retentionPeriod() {
         return retentionPeriod;
     }
+
+    @Override
+    public int segments() {
+        return NUM_SEGMENTS;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplier.java
@@ -46,6 +46,12 @@ public class RocksDBWindowStoreSupplier<K, V> extends AbstractStoreSupplier<K, V
 
     public RocksDBWindowStoreSupplier(String name, long retentionPeriod, int numSegments, boolean retainDuplicates, Serde<K> keySerde, Serde<V> valueSerde, Time time, long windowSize, boolean logged, Map<String, String> logConfig, boolean enableCaching) {
         super(name, keySerde, valueSerde, time, logged, logConfig);
+        if (numSegments < 1) {
+            throw new IllegalArgumentException("numSegments must be positive");
+        }
+        if (retentionPeriod < 1) {
+            throw new IllegalArgumentException("retentionPeriod must be positive");
+        }
         this.retentionPeriod = retentionPeriod;
         this.retainDuplicates = retainDuplicates;
         this.numSegments = numSegments;
@@ -72,6 +78,11 @@ public class RocksDBWindowStoreSupplier<K, V> extends AbstractStoreSupplier<K, V
     @Override
     public long retentionPeriod() {
         return retentionPeriod;
+    }
+
+    @Override
+    public int segments() {
+        return numSegments;
     }
 
     private SegmentedBytesStore maybeWrapLogged(final SegmentedBytesStore inner) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
@@ -45,15 +45,24 @@ class Segments {
     private long maxSegmentId = -1L;
 
     Segments(final String name, final long retentionPeriod, final int numSegments) {
+        if (numSegments < 1) {
+            throw new IllegalArgumentException("numSegments must be positive");
+        }
+        if (retentionPeriod < 1) {
+            throw new IllegalArgumentException("retentionPeriod must be positive");
+        }
         this.name = name;
         this.numSegments = numSegments;
-        this.segmentInterval = Math.max(retentionPeriod / (numSegments - 1), MIN_SEGMENT_INTERVAL);
+        this.segmentInterval = numSegments == 1 ? Long.MAX_VALUE : Math.max(retentionPeriod / (numSegments - 1), MIN_SEGMENT_INTERVAL);
         // Create a date formatter. Formatted timestamps are used as segment name suffixes
         this.formatter = new SimpleDateFormat("yyyyMMddHHmm");
         this.formatter.setTimeZone(new SimpleTimeZone(0, "UTC"));
     }
 
     long segmentId(long timestamp) {
+        if (numSegments == 1) {
+            return 1;
+        }
         return timestamp / segmentInterval;
     }
 
@@ -154,7 +163,7 @@ class Segments {
     }
 
     private boolean isSegment(final Segment store, long segmentId) {
-        return store != null && store.id == segmentId;
+        return store != null && (numSegments == 1 || store.id == segmentId);
     }
 
     private void cleanup(final long segmentId) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreSupplier.java
@@ -28,4 +28,7 @@ public interface WindowStoreSupplier<T extends StateStore> extends StateStoreSup
 
     // window retention period in milli-second
     long retentionPeriod();
+
+    // number of segments in the store.
+    int segments();
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -49,8 +49,6 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.common.utils.Utils.mkList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -575,24 +573,6 @@ public class TopologyBuilderTest {
         assertEquals(2, policies.size());
         assertEquals("30000", properties.getProperty(InternalTopicManager.RETENTION_MS));
         assertEquals(2, properties.size());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldAddInternalTopicConfigWithCompactSetForWindowStoresWithOneSegment() throws Exception {
-        final TopologyBuilder builder = new TopologyBuilder();
-        builder.setApplicationId("appId");
-        builder.addSource("source", "topic");
-        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
-        builder.addStateStore(new RocksDBWindowStoreSupplier("store", 30000, 1, false, null, null, 10000, true, Collections.<String, String>emptyMap(), false), "processor");
-        final Map<Integer, TopicsInfo> topicGroups = builder.topicGroups();
-        final TopicsInfo topicsInfo = topicGroups.values().iterator().next();
-        final InternalTopicConfig topicConfig = topicsInfo.stateChangelogTopics.get("appId-store-changelog");
-        final Properties properties = topicConfig.toProperties(0);
-        final List<String> policies = Arrays.asList(properties.getProperty(InternalTopicManager.CLEANUP_POLICY_PROP).split(","));
-        assertEquals("appId-store-changelog", topicConfig.name());
-        assertThat(policies, equalTo(Collections.singletonList("compact")));
-        assertEquals(1, properties.size());
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -49,6 +49,8 @@ import java.util.regex.Pattern;
 
 import static org.apache.kafka.common.utils.Utils.mkList;
 import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -573,6 +575,24 @@ public class TopologyBuilderTest {
         assertEquals(2, policies.size());
         assertEquals("30000", properties.getProperty(InternalTopicManager.RETENTION_MS));
         assertEquals(2, properties.size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldAddInternalTopicConfigWithCompactSetForWindowStoresWithOneSegment() throws Exception {
+        final TopologyBuilder builder = new TopologyBuilder();
+        builder.setApplicationId("appId");
+        builder.addSource("source", "topic");
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addStateStore(new RocksDBWindowStoreSupplier("store", 30000, 1, false, null, null, 10000, true, Collections.<String, String>emptyMap(), false), "processor");
+        final Map<Integer, TopicsInfo> topicGroups = builder.topicGroups();
+        final TopicsInfo topicsInfo = topicGroups.values().iterator().next();
+        final InternalTopicConfig topicConfig = topicsInfo.stateChangelogTopics.get("appId-store-changelog");
+        final Properties properties = topicConfig.toProperties(0);
+        final List<String> policies = Arrays.asList(properties.getProperty(InternalTopicManager.CLEANUP_POLICY_PROP).split(","));
+        assertEquals("appId-store-changelog", topicConfig.name());
+        assertThat(policies, equalTo(Collections.singletonList("compact")));
+        assertEquals(1, properties.size());
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -854,7 +854,7 @@ public class StreamPartitionAssignorTest {
                         return null;
                     }
                 },
-                JoinWindows.of(0)
+                JoinWindows.of(1)
             );
 
         final UUID uuid = UUID.randomUUID();

--- a/streams/src/test/java/org/apache/kafka/streams/state/StoresTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StoresTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class StoresTest {
 
@@ -79,5 +80,36 @@ public class StoresTest {
                 .build();
 
         assertFalse(supplier.loggingEnabled());
+    }
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionIfCreatingWindowStoreWithLessThanOneSegment() throws Exception {
+        final Stores.PersistentKeyValueFactory<String, String> factory = Stores.create("store")
+                .withKeys(Serdes.String())
+                .withValues(Serdes.String())
+                .persistent();
+
+        try {
+            factory.windowed(10, 10, 0, false);
+            fail("Should have thrown illegal argument exception as numSegments is less than 1");
+        } catch (final IllegalArgumentException e) {
+            // pass
+        }
+    }
+
+
+    @Test
+    public void shouldThrowIllegalArgumentExceptionIfRetentionPeriodIsNotPositive() throws Exception {
+        final Stores.PersistentKeyValueFactory<String, String> factory = Stores.create("store")
+                .withKeys(Serdes.String())
+                .withValues(Serdes.String())
+                .persistent();
+
+        try {
+            factory.windowed(1, 0, 1, false);
+            fail("Should have thrown illegal argument exception as retention period is less than 1");
+        } catch (final IllegalArgumentException e) {
+            // pass
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
@@ -52,7 +52,9 @@ public class RocksDBWindowStoreSupplierTest {
 
     @After
     public void close() {
-        store.close();
+        if (store != null) {
+            store.close();
+        }
     }
 
     @Test
@@ -157,6 +159,18 @@ public class RocksDBWindowStoreSupplierTest {
         store.init(context, store);
         final StreamsMetrics metrics = context.metrics();
         assertFalse(metrics.metrics().isEmpty());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenNumSegmentsNotPositive() throws Exception {
+        new RocksDBWindowStoreSupplier("name", 1, 0, false, null, null, 1, true, Collections.<String, String>emptyMap(), false);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionWhenRetentionPerioudNotPositive() throws Exception {
+        new RocksDBWindowStoreSupplier("name", 0, 1, false, null, null, 1, true, Collections.<String, String>emptyMap(), false);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import java.io.File;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -181,6 +183,42 @@ public class SegmentsTest {
         verifyCorrectSegments(1, 5);
         segments.getOrCreateSegment(6, context);
         verifyCorrectSegments(2, 5);
+    }
+
+    @Test
+    public void shouldHaveSingleSegmentId() throws Exception {
+        segments = new Segments("name", 1, 1);
+        assertThat(segments.segmentId(0), equalTo(1L));
+        assertThat(segments.segmentId(Long.MAX_VALUE), equalTo(1L));
+    }
+
+    @Test
+    public void shouldOnlyCreateSingleSegmentWhenOnlyOneSegment() throws Exception {
+        segments = new Segments("name", 1, 1);
+        segments.getOrCreateSegment(1, context);
+        verifyCorrectSegments(1, 1);
+        segments.getOrCreateSegment(2, context);
+        verifyCorrectSegments(1, 1);
+        segments.getOrCreateSegment(10, context);
+        verifyCorrectSegments(1, 1);
+    }
+
+    @Test
+    public void shouldReturnSameSegmentForTimestampWhenOneSegment() throws Exception {
+        segments = new Segments("name", 1, 1);
+        segments.getOrCreateSegment(1, context);
+        final Segment segment = segments.getSegmentForTimestamp(1);
+        assertThat(segments.getSegmentForTimestamp(Long.MAX_VALUE), equalTo(segment));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfNumSegmentsNotPositive() throws Exception {
+        new Segments("name", 1, 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfRetentionPeriodNotPositive() throws Exception {
+        new Segments("name", 0, 1);
     }
 
     private void verifyCorrectSegments(final long first, final int numSegments) {


### PR DESCRIPTION
Allow a window store with a single segment. 