### PR TITLE
KAFKA-4937: Batch offset fetches in the Consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1269,6 +1269,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 throw new IllegalArgumentException("You can only check the position for partitions assigned to this consumer.");
             Long offset = this.subscriptions.position(partition);
             if (offset == null) {
+                // batch update fetch positions for any partitions without a valid position
                 updateFetchPositions(subscriptions.assignedPartitions());
                 offset = this.subscriptions.position(partition);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1269,7 +1269,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 throw new IllegalArgumentException("You can only check the position for partitions assigned to this consumer.");
             Long offset = this.subscriptions.position(partition);
             if (offset == null) {
-                updateFetchPositions(Collections.singleton(partition));
+                updateFetchPositions(subscriptions.assignedPartitions());
                 offset = this.subscriptions.position(partition);
             }
             return offset;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1151,8 +1151,10 @@ public class KafkaConsumerTest {
         assertEquals(0, consumer.committed(tp1).offset());
 
         // fetch and verify consumer's position in the two partitions
-        client.prepareResponse(listOffsetsResponse(Collections.singletonMap(tp0, 3L), Errors.NONE));
-        client.prepareResponse(listOffsetsResponse(Collections.singletonMap(tp1, 3L), Errors.NONE));
+        final Map<TopicPartition, Long> offsetResponse = new HashMap<>();
+        offsetResponse.put(tp0, 3L);
+        offsetResponse.put(tp1, 3L);
+        client.prepareResponse(listOffsetsResponse(offsetResponse, Errors.NONE));
         assertEquals(3L, consumer.position(tp0));
         assertEquals(3L, consumer.position(tp1));
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -120,24 +121,26 @@ public class StoreChangelogReader implements ChangelogReader {
             log.info("{} Starting restoring state stores from changelog topics {}", logPrefix, needsRestoring.keySet());
 
             consumer.assign(needsRestoring.keySet());
-
+            final List<StateRestorer> needsPositionUpdate = new ArrayList<>();
             for (final StateRestorer restorer : needsRestoring.values()) {
                 if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
                     consumer.seek(restorer.partition(), restorer.checkpoint());
                     logRestoreOffsets(restorer.partition(),
                                       restorer.checkpoint(),
                                       endOffsets.get(restorer.partition()));
+                    restorer.setStartingOffset(consumer.position(restorer.partition()));
                 } else {
                     consumer.seekToBeginning(Collections.singletonList(restorer.partition()));
-                    logRestoreOffsets(restorer.partition(),
-                                      consumer.position(restorer.partition()),
-                                      endOffsets.get(restorer.partition()));
+                    needsPositionUpdate.add(restorer);
                 }
-                // TODO: each consumer.position() call after seekToBeginning will cause
-                // a blocking round trip to reset the position for that partition; we should
-                // batch them into a single round trip to reset for all necessary partitions
+            }
 
-                restorer.setStartingOffset(consumer.position(restorer.partition()));
+            for (final StateRestorer restorer : needsPositionUpdate) {
+                final long position = consumer.position(restorer.partition());
+                restorer.setStartingOffset(position);
+                logRestoreOffsets(restorer.partition(),
+                                  position,
+                                  endOffsets.get(restorer.partition()));
             }
 
             final Set<TopicPartition> partitions = new HashSet<>(needsRestoring.keySet());
@@ -154,12 +157,12 @@ public class StoreChangelogReader implements ChangelogReader {
         }
     }
 
-    private void logRestoreOffsets(final TopicPartition partition, final long checkpoint, final Long aLong) {
+    private void logRestoreOffsets(final TopicPartition partition, final long startingOffset, final Long endOffset) {
         log.debug("{} Restoring partition {} from offset {} to endOffset {}",
                   logPrefix,
                   partition,
-                  checkpoint,
-                  aLong);
+                  startingOffset,
+                  endOffset);
     }
 
     @Override


### PR DESCRIPTION
change `consumer.position` so that it always updates any partitions that need an update. Keep track of partitions that `seekToBeginning` in `StoreChangeLogReader` and do the `consumer.position` call after all `seekToBeginning` calls.