### PR TITLE
MINOR: Reduce Fork Count in ITs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ subprojects {
   }
 
   task integrationTest(type: Test, dependsOn: compileJava) {
-    maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
+    maxParallelForks = userMaxForks ?: (Math.max(Runtime.runtime.availableProcessors(), 2) / 2)
 
     minHeapSize = "256m"
     maxHeapSize = "2048m"
@@ -368,8 +368,8 @@ def fineTuneEclipseClasspathFile(eclipse, project) {
       if (project.name.equals('core')) {
         cp.entries.findAll { it.kind == "src" && it.path.equals("src/test/scala") }*.excludes = ["integration/", "other/", "unit/"]
       }
-      /* 
-       * Set all eclipse build output to go to 'build_eclipse' directory. This is to ensure that gradle and eclipse use different 
+      /*
+       * Set all eclipse build output to go to 'build_eclipse' directory. This is to ensure that gradle and eclipse use different
        * build output directories, and also avoid using the eclpise default of 'bin' which clashes with some of our script directories.
        * https://discuss.gradle.org/t/eclipse-generated-files-should-be-put-in-the-same-place-as-the-gradle-generated-files/6986/2
        */


### PR DESCRIPTION
While looking into instabilities like https://issues.apache.org/jira/browse/KAFKA-4692 I noticed that we are running one JVM fork per core in the ITs.

This seems to me could be contributing to the instability of some ITs a lot. Turning down the number of forks to half the cores, the IT suits speed up measurably for me (example streams goes from ~4 minutes to 2.5 minutes).
Also, case in point this is what 4 forks look like on an i7 (that would get 8 forks in trunk):

![4forks](https://cloud.githubusercontent.com/assets/6490959/24557893/a7afa746-1639-11e7-94ff-6327695cf108.png)

Effectively there's still load on all 8 cores at 4 forks (which is expected looking at the fact that most ITs have 2 or more I/O threads).

=> imo it's a good idea to turn this down to half the cores. Let's see how Jenkins behaves with this in terms of the build times :)
