### PR TITLE
KAFKA-4999: Add convenience overloads to seek* methods

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -106,9 +106,19 @@ public interface Consumer<K, V> extends Closeable {
     public void seek(TopicPartition partition, long offset);
 
     /**
+     * @see KafkaConsumer#seekToBeginning()
+     */
+    public void seekToBeginning();
+
+    /**
      * @see KafkaConsumer#seekToBeginning(Collection)
      */
     public void seekToBeginning(Collection<TopicPartition> partitions);
+
+    /**
+     * @see KafkaConsumer#seekToEnd()
+     */
+    public void seekToEnd();
 
     /**
      * @see KafkaConsumer#seekToEnd(Collection)

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1211,11 +1211,23 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         }
     }
 
+
+    /**
+     * Seek to the first offset for each for all of the currently assigned partitions. This function evaluates lazily,
+     * seeking to the first offset in all partitions only when {@link #poll(long)} or {@link #position(TopicPartition)}
+     * are called.
+     */
+    @Override
+    public void seekToBeginning() {
+        seekToBeginning(Collections.<TopicPartition>emptyList());
+    }
+
     /**
      * Seek to the first offset for each of the given partitions. This function evaluates lazily, seeking to the
      * first offset in all partitions only when {@link #poll(long)} or {@link #position(TopicPartition)} are called.
      * If no partition is provided, seek to the first offset for all of the currently assigned partitions.
      */
+    @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
         acquire();
         try {
@@ -1230,10 +1242,20 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     }
 
     /**
+     * Seek to the final offset for all of the currently assigned partitions. This function evaluates lazily, seeking to
+     * the final offset in all partitions only when {@link #poll(long)} or {@link #position(TopicPartition)} are called.
+     */
+    @Override
+    public void seekToEnd() {
+        seekToEnd(Collections.<TopicPartition>emptyList());
+    }
+
+    /**
      * Seek to the last offset for each of the given partitions. This function evaluates lazily, seeking to the
      * final offset in all partitions only when {@link #poll(long)} or {@link #position(TopicPartition)} are called.
      * If no partition is provided, seek to the final offset for all of the currently assigned partitions.
      */
+    @Override
     public void seekToEnd(Collection<TopicPartition> partitions) {
         acquire();
         try {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -254,6 +254,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
+    public void seekToBeginning() {
+        seekToBeginning(Collections.<TopicPartition>emptyList());
+    }
+
+    @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
         ensureNotClosed();
         for (TopicPartition tp : partitions)
@@ -262,6 +267,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
     public void updateBeginningOffsets(Map<TopicPartition, Long> newOffsets) {
         beginningOffsets.putAll(newOffsets);
+    }
+
+    @Override
+    public void seekToEnd() {
+        seekToEnd(Collections.<TopicPartition>emptyList());
     }
 
     @Override


### PR DESCRIPTION
This contribution is my original work and I license the work to the project under the project's open source license.