### PR TITLE
KAFKA-5008: Provide OSGi metadata for Kafka-Clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ buildscript {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
     classpath 'org.scoverage:gradle-scoverage:2.1.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    // For Bnd-Gradle plugin which provides OSGi metadata
+    classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.3.0'
   }
 }
 
@@ -682,6 +684,8 @@ project(':examples') {
 }
 
 project(':clients') {
+  apply plugin: 'biz.aQute.bnd.builder'
+
   archivesBaseName = "kafka-clients"
 
   dependencies {
@@ -735,6 +739,9 @@ project(':clients') {
     dependsOn createVersionFile
     from("$buildDir") {
         include "kafka/$buildVersionFileName"
+    }
+    manifest {
+      attributes('-groupid': project.group.toString(), 'artifactId': archivesBaseName)
     }
   }
 

--- a/clients/bnd.bnd
+++ b/clients/bnd.bnd
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Bundle-SymbolicName: ${-groupid}.${artifactId}
+
+# Export all packages from this bundle
+Export-Package: org.apache.kafka.clients.*, org.apache.kafka.common.*, org.apache.kafka.server.policy


### PR DESCRIPTION
This change uses the bnd-gradle-plugin for the kafka-clients module in order to generate OSGi metadata.
The bnd.bnd file is used by the plugin for instructions. For now, all packages are exported.

Signed-off-by: Marc Schlegel <maschlegel@gmail.com>