### PR TITLE
change language level from java 7 to 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ subprojects {
   apply plugin: 'checkstyle'
   apply plugin: 'findbugs'
 
-  sourceCompatibility = 1.7
+  sourceCompatibility = 1.8
 
   compileJava {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
now that KIP-118 has passed, and there are no major releases coming before 0.11 ....

Signed-off-by: radai-rosenblatt <radai.rosenblatt@gmail.com>