### PR TITLE
KAFKA-5039: Logging in BlockingChannel and SyncProducer connect

### DIFF
--- a/core/src/main/scala/kafka/network/BlockingChannel.scala
+++ b/core/src/main/scala/kafka/network/BlockingChannel.scala
@@ -82,7 +82,10 @@ class BlockingChannel( val host: String,
                          connectTimeoutMs))
 
       } catch {
-        case _: Throwable => disconnect()
+        case e: Throwable => {
+          debug("Error trying to connect, will disconnect.", e)
+          disconnect()
+        }
       }
     }
   }

--- a/core/src/main/scala/kafka/producer/SyncProducer.scala
+++ b/core/src/main/scala/kafka/producer/SyncProducer.scala
@@ -149,7 +149,9 @@ class SyncProducer(val config: SyncProducerConfig) extends Logging {
     if (!blockingChannel.isConnected && !shutdown) {
       try {
         blockingChannel.connect()
-        info("Connected to " + formatAddress(config.host, config.port) + " for producing")
+        if (blockingChannel.isConnected) {
+          info("Connected to " + formatAddress(config.host, config.port) + " for producing")
+        }
       } catch {
         case e: Exception => {
           disconnect()


### PR DESCRIPTION
When an exception is thrown in BlockingChannel::connect, the connection is disconnected but the actual exception is not logged. This later manifests as ClosedChannelException when trying to send. Also the SyncProducer wrongfully logs "Connected to host:port for producing" even in case of exceptions.

The proposed patch logs the exception in BlockingChannel::connect in debug level and logs the "Connected" message in SyncProducer only on successful connection.