### PR TITLE
KAFKA-5046: Support file rotation in FileStreamSource Connector

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceTask.java
@@ -246,8 +246,16 @@ public class FileStreamSourceTask extends SourceTask {
         BasicFileAttributes attrs = Files.readAttributes(file.toPath(), BasicFileAttributes.class);
         Map<String, Object> fileAttrs = new TreeMap<>();
         fileAttrs.put(FILENAME_FIELD, file.getPath());
-        fileAttrs.put(FILE_CREATE_TIME_FIELD, attrs.creationTime().toMillis());
         fileAttrs.put(FILE_KEY_HASH_FIELD, Objects.hashCode(attrs.fileKey()));
+        if (attrs.fileKey() != null) {
+            // Several Linux filesystems do not support creation timestamps and return modified
+            // timestamp instead. Thus, if ``fileKey`` is available we'll use just that.
+            fileAttrs.put(FILE_CREATE_TIME_FIELD, 0);
+        } else {
+            // If ``fileKey`` is not available, we'll try and use creation timestamp
+            // (supported in Windows)
+            fileAttrs.put(FILE_CREATE_TIME_FIELD, attrs.creationTime().toMillis());
+        }
         return fileAttrs;
     }
 

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -91,7 +91,7 @@ public class FileStreamSourceTaskTest {
         assertEquals(1, records.size());
         assertEquals(TOPIC, records.get(0).topic());
         assertEquals("partial line finished", records.get(0).value());
-        assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(0).sourcePartition());
+        assertEquals(FileStreamSourceTask.getFileAttributes(tempFile), records.get(0).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 22L), records.get(0).sourceOffset());
         assertEquals(null, task.poll());
 
@@ -102,16 +102,16 @@ public class FileStreamSourceTaskTest {
         records = task.poll();
         assertEquals(4, records.size());
         assertEquals("line1", records.get(0).value());
-        assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(0).sourcePartition());
+        assertEquals(FileStreamSourceTask.getFileAttributes(tempFile), records.get(0).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 28L), records.get(0).sourceOffset());
         assertEquals("line2", records.get(1).value());
-        assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(1).sourcePartition());
+        assertEquals(FileStreamSourceTask.getFileAttributes(tempFile), records.get(1).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 35L), records.get(1).sourceOffset());
         assertEquals("line3", records.get(2).value());
-        assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(2).sourcePartition());
+        assertEquals(FileStreamSourceTask.getFileAttributes(tempFile), records.get(2).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 41L), records.get(2).sourceOffset());
         assertEquals("line4", records.get(3).value());
-        assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(3).sourcePartition());
+        assertEquals(FileStreamSourceTask.getFileAttributes(tempFile), records.get(3).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 47L), records.get(3).sourceOffset());
 
         os.write("subsequent text".getBytes());
@@ -119,7 +119,7 @@ public class FileStreamSourceTaskTest {
         records = task.poll();
         assertEquals(1, records.size());
         assertEquals("", records.get(0).value());
-        assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(0).sourcePartition());
+        assertEquals(FileStreamSourceTask.getFileAttributes(tempFile), records.get(0).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 48L), records.get(0).sourceOffset());
 
         task.stop();


### PR DESCRIPTION
- Detect file rotation/removal in FileStreamSource task.
- Extend offset key to include creation time and fileKey attributes.