### PR TITLE
KAFKA-5047: NullPointerException while using GlobalKTable in KafkaStreams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/GlobalKTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/GlobalKTable.java
@@ -55,7 +55,7 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
  * Note that in contrast to {@link KTable} a {@code GlobalKTable}'s state holds a full copy of the underlying topic,
  * thus all keys can be queried locally.
  * <p>
- * Records from the source topic that have null keys are dropped
+ * Records from the source topic that have null keys are dropped.
  *
  * @param <K> Type of primary keys
  * @param <V> Type of value changes

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/GlobalKTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/GlobalKTable.java
@@ -54,6 +54,8 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
  *}</pre>
  * Note that in contrast to {@link KTable} a {@code GlobalKTable}'s state holds a full copy of the underlying topic,
  * thus all keys can be queried locally.
+ * <p>
+ * Records from the source topic that have null keys are dropped
  *
  * @param <K> Type of primary keys
  * @param <V> Type of value changes

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -52,7 +52,7 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
  *     view.get(key);
  *}</pre>
  *<p>
- * Records from the source topic that have null keys are dropped
+ * Records from the source topic that have null keys are dropped.
  *
  * @param <K> Type of primary keys
  * @param <V> Type of value changes

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -51,6 +51,8 @@ import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
  *     ReadOnlyKeyValueStore view = streams.store(queryableStoreName, QueryableStoreTypes.keyValueStore());
  *     view.get(key);
  *}</pre>
+ *<p>
+ * Records from the source topic that have null keys are dropped
  *
  * @param <K> Type of primary keys
  * @param <V> Type of value changes

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -174,7 +174,11 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                 final ConsumerRecords<byte[], byte[]> records = consumer.poll(100);
                 for (ConsumerRecord<byte[], byte[]> record : records) {
                     offset = record.offset() + 1;
-                    stateRestoreCallback.restore(record.key(), record.value());
+                    if (record.key() == null) {
+                        log.warn("null key found at offset %d while restoring state from topic %s and partition %d. Skipping record", record.offset(), record.topic(), record.partition());
+                    } else {
+                        stateRestoreCallback.restore(record.key(), record.value());
+                    }
                 }
             }
             checkpointableOffsets.put(topicPartition, offset);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -174,9 +174,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
                 final ConsumerRecords<byte[], byte[]> records = consumer.poll(100);
                 for (ConsumerRecord<byte[], byte[]> record : records) {
                     offset = record.offset() + 1;
-                    if (record.key() == null) {
-                        log.warn("null key found at offset %d while restoring state from topic %s and partition %d. Skipping record", record.offset(), record.topic(), record.partition());
-                    } else {
+                    if (record.key() != null) {
                         stateRestoreCallback.restore(record.key(), record.value());
                     }
                 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -209,7 +209,9 @@ public class StoreChangelogReader implements ChangelogReader {
             if (restorer.hasCompleted(offset, endOffset)) {
                 return offset;
             }
-            restorer.restore(record.key(), record.value());
+            if (record.key() != null) {
+                restorer.restore(record.key(), record.value());
+            }
         }
         return consumer.position(restorer.partition());
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -51,6 +51,7 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -403,6 +404,31 @@ public class GlobalStateManagerImplTest {
         assertThat(updatedCheckpoint.get(t2), equalTo(initialCheckpoint.get(t2)));
         assertThat(updatedCheckpoint.get(t1), equalTo(101L));
     }
+
+    @Test
+    public void shouldSkipNullKeysWhenRestoring() throws Exception {
+        final HashMap<TopicPartition, Long> startOffsets = new HashMap<>();
+        startOffsets.put(t1, 1L);
+        final HashMap<TopicPartition, Long> endOffsets = new HashMap<>();
+        endOffsets.put(t1, 2L);
+        consumer.updatePartitions(t1.topic(), Collections.singletonList(new PartitionInfo(t1.topic(), t1.partition(), null, null, null)));
+        consumer.assign(Collections.singletonList(t1));
+        consumer.updateEndOffsets(endOffsets);
+        consumer.updateBeginningOffsets(startOffsets);
+        consumer.addRecord(new ConsumerRecord<>(t1.topic(), t1.partition(), 1, (byte[])null, "null".getBytes()));
+        final byte[] expectedKey = "key".getBytes();
+        final byte[] expectedValue = "value".getBytes();
+        consumer.addRecord(new ConsumerRecord<>(t1.topic(), t1.partition(), 2, expectedKey, expectedValue));
+
+        stateManager.initialize(context);
+        final TheStateRestoreCallback stateRestoreCallback = new TheStateRestoreCallback();
+        stateManager.register(store1, false, stateRestoreCallback);
+        assertEquals(1, stateRestoreCallback.restored.size());
+        final KeyValue<byte[], byte[]> restoredKv = stateRestoreCallback.restored.get(0);
+        assertArrayEquals(expectedKey, restoredKv.key);
+        assertArrayEquals(expectedValue, restoredKv.value);
+    }
+
 
     private Map<TopicPartition, Long> readOffsetsCheckpoint() throws IOException {
         final OffsetCheckpoint offsetCheckpoint = new OffsetCheckpoint(new File(stateManager.baseDir(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -51,7 +51,6 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -423,10 +422,8 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize(context);
         final TheStateRestoreCallback stateRestoreCallback = new TheStateRestoreCallback();
         stateManager.register(store1, false, stateRestoreCallback);
-        assertEquals(1, stateRestoreCallback.restored.size());
         final KeyValue<byte[], byte[]> restoredKv = stateRestoreCallback.restored.get(0);
-        assertArrayEquals(expectedKey, restoredKv.key);
-        assertArrayEquals(expectedValue, restoredKv.value);
+        assertThat(stateRestoreCallback.restored, equalTo(Collections.singletonList(KeyValue.pair(restoredKv.key, restoredKv.value))));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -415,7 +415,7 @@ public class GlobalStateManagerImplTest {
         consumer.assign(Collections.singletonList(t1));
         consumer.updateEndOffsets(endOffsets);
         consumer.updateBeginningOffsets(startOffsets);
-        consumer.addRecord(new ConsumerRecord<>(t1.topic(), t1.partition(), 1, (byte[])null, "null".getBytes()));
+        consumer.addRecord(new ConsumerRecord<>(t1.topic(), t1.partition(), 1, (byte[]) null, "null".getBytes()));
         final byte[] expectedKey = "key".getBytes();
         final byte[] expectedValue = "value".getBytes();
         consumer.addRecord(new ConsumerRecord<>(t1.topic(), t1.partition(), 2, expectedKey, expectedValue));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
@@ -33,7 +33,7 @@ public class StateRestorerTest {
     @Test
     public void shouldCallRestoreOnRestoreCallback() throws Exception {
         restorer.restore(new byte[0], new byte[0]);
-        assertThat(callback.restoreCount, equalTo(1));
+        assertThat(callback.restored.size(), equalTo(1));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -24,8 +24,11 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.test.MockRestoreCallback;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -34,7 +37,6 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.fail;
 
 public class StoreChangelogReaderTest {
@@ -248,9 +250,7 @@ public class StoreChangelogReaderTest {
         changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false));
         changelogReader.restore();
 
-        assertThat(callback.restored.size(), equalTo(2));
-        assertArrayEquals(callback.restored.get(0).key, bytes);
-        assertArrayEquals(callback.restored.get(1).key, bytes);
+        assertThat(callback.restored, CoreMatchers.equalTo(Utils.mkList(KeyValue.pair(bytes, bytes), KeyValue.pair(bytes, bytes))));
     }
 
     private void setupConsumer(final long messages, final TopicPartition topicPartition) {

--- a/streams/src/test/java/org/apache/kafka/test/MockRestoreCallback.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockRestoreCallback.java
@@ -16,13 +16,18 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MockRestoreCallback implements StateRestoreCallback {
-    public int restoreCount = 0;
+    public List<KeyValue<byte[], byte[]>> restored = new ArrayList<>();
+
 
     @Override
     public void restore(final byte[] key, final byte[] value) {
-        restoreCount++;
+        restored.add(KeyValue.pair(key, value));
     }
 }


### PR DESCRIPTION
Skip null keys when initializing GlobalKTables. This is inline with what happens during normal processing.