### PR TITLE
KAFKA-5065; AbstractCoordinator.ensureCoordinatorReady() stuck in loop if absent any bootstrap servers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -234,6 +234,14 @@ public class ConsumerConfig extends AbstractConfig {
      */
     static final String LEAVE_GROUP_ON_CLOSE_CONFIG = "internal.leave.group.on.close";
 
+
+    /**
+     * <code>max.block.ms</code>
+     */
+    public static final String MAX_BLOCK_MS_CONFIG = "max.block.ms";
+    private static final String MAX_BLOCK_MS_DOC = "The configuration controls how long <code>KafkaConsumer</code> will block for discovering <code>ConsumerCoordinator</code>.";
+    public static final long DEFAULT_MAX_BLOCK_MS = 60 * 1000;
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -405,6 +413,12 @@ public class ConsumerConfig extends AbstractConfig {
                                                 Type.BOOLEAN,
                                                 true,
                                                 Importance.LOW)
+                .define(MAX_BLOCK_MS_CONFIG,
+                        Type.LONG,
+                        DEFAULT_MAX_BLOCK_MS,
+                        atLeast(0),
+                        Importance.MEDIUM,
+                        MAX_BLOCK_MS_DOC)
                                 // security support
                                 .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -695,7 +695,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                                                        config.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG),
                                                        this.interceptors,
                                                        config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
-                                                       config.getBoolean(ConsumerConfig.LEAVE_GROUP_ON_CLOSE_CONFIG));
+                    config.getBoolean(ConsumerConfig.LEAVE_GROUP_ON_CLOSE_CONFIG),
+                    config.getLong(ConsumerConfig.MAX_BLOCK_MS_CONFIG));
             this.fetcher = new Fetcher<>(this.client,
                     config.getInt(ConsumerConfig.FETCH_MIN_BYTES_CONFIG),
                     config.getInt(ConsumerConfig.FETCH_MAX_BYTES_CONFIG),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RetriableException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -198,6 +199,11 @@ public abstract class AbstractCoordinator implements Closeable {
     public synchronized void ensureCoordinatorReady() {
         // Using zero as current time since timeout is effectively infinite
         ensureCoordinatorReady(0, Long.MAX_VALUE);
+    }
+
+    public synchronized void ensureCoordinatorReady(long timeoutMs) {
+        long now = time.milliseconds();
+        ensureCoordinatorReady(now, timeoutMs);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.errors.CoordinatorNotAvailableException;
 import org.apache.kafka.common.errors.IllegalGenerationException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RetriableException;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownMemberIdException;
 import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1501,6 +1501,7 @@ public class KafkaConsumerTest {
         int fetchSize = 1024 * 1024;
         int maxPollRecords = Integer.MAX_VALUE;
         boolean checkCrcs = true;
+        long maxBlockMs = 30 * 1000;
 
         Deserializer<String> keyDeserializer = new StringDeserializer();
         Deserializer<String> valueDeserializer = new StringDeserializer();
@@ -1529,7 +1530,8 @@ public class KafkaConsumerTest {
                 autoCommitIntervalMs,
                 interceptors,
                 excludeInternalTopics,
-                true);
+                true,
+                maxBlockMs);
 
         Fetcher<String, String> fetcher = new Fetcher<>(
                 consumerClient,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -96,6 +96,7 @@ public class ConsumerCoordinatorTest {
     private long retryBackoffMs = 100;
     private boolean autoCommitEnabled = false;
     private int autoCommitIntervalMs = 2000;
+    private long maxBlockMs = 10 * 1000;
     private MockPartitionAssignor partitionAssignor = new MockPartitionAssignor();
     private List<PartitionAssignor> assignors = Collections.<PartitionAssignor>singletonList(partitionAssignor);
     private MockTime time;
@@ -1605,7 +1606,8 @@ public class ConsumerCoordinatorTest {
                 autoCommitIntervalMs,
                 null,
                 excludeInternalTopics,
-                leaveGroup);
+                leaveGroup,
+                maxBlockMs);
     }
 
     private FindCoordinatorResponse groupCoordinatorResponse(Node node, Errors error) {


### PR DESCRIPTION
add a consumer config: "max.block.ms"
default to 60000 ms;
when specified, the ensureCoordinatorReady check default call will be limited by "max.block.ms"