### PR TITLE
kafka-5068: Optionally print out metrics after running the perf tests

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.clients.consumer.{ConsumerRebalanceListener, KafkaConsum
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
-import kafka.utils.CommandLineUtils
+import kafka.utils.{CommandLineUtils, ToolsUtils}
 import java.util.{Collections, Properties, Random}
 
 import kafka.consumer.Consumer
@@ -105,20 +105,7 @@ object ConsumerPerformance {
     }
 
     if (metrics != null) {
-      var maxLengthOfDisplayName = 0
-      metrics.foreach {
-        case (mName, _) =>
-          val key = Array(mName.group(), mName.name(), mName.tags()).mkString(":")
-          if (maxLengthOfDisplayName < key.length) {
-            maxLengthOfDisplayName = key.length
-          }
-      }
-      println(s"\n%-${maxLengthOfDisplayName}s   %s".format("Metric Name", "Value"))
-      metrics.foreach {
-        case (mName, metric) =>
-          val key = Array(mName.group(), mName.name(), mName.tags()).mkString(":")
-          println(s"%-${maxLengthOfDisplayName}s : %.3f".format(key, metric.value()))
-      }
+      ToolsUtils.printMetrics(metrics)
     }
 
   }

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -247,14 +247,14 @@ public class ProducerPerformance {
         int maxLengthOfDisplayName = 0;
         for (Metric metric : metrics.values()) {
             MetricName mName = metric.metricName();
-            String mergedName = mName.group() + ":" + mName.name();
+            String mergedName = mName.group() + ":" + mName.name() + ":" + mName.tags();
             maxLengthOfDisplayName = maxLengthOfDisplayName < mergedName.length() ? mergedName.length() : maxLengthOfDisplayName;
         }
         String outputFormat = "%-" + maxLengthOfDisplayName + "s : %.3f";
         System.out.println(String.format("\n%-" + maxLengthOfDisplayName + "s   %s", "Metric Name", "Value"));
         for (Metric metric : metrics.values()) {
-            System.out.println(String.format(outputFormat, metric.metricName().group() + ":" + metric.metricName().name(),
-                    metric.value()));
+            MetricName mName = metric.metricName();
+            System.out.println(String.format(outputFormat, mName.group() + ":" + mName.name() + ":" + mName.tags(), metric.value()));
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -23,13 +23,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
-import java.util.Map;
+import java.util.Arrays;
 
 import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import org.apache.kafka.clients.producer.Callback;
@@ -42,8 +40,6 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
-import org.apache.kafka.common.Metric;
-import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 
@@ -137,7 +133,7 @@ public class ProducerPerformance {
 
             /* print out metrics */
             if (shouldPrintMetrics) {
-                printMetrics(producer);
+                ToolsUtils.printMetrics(producer.metrics());
             }
             producer.close();
         } catch (ArgumentParserException e) {
@@ -232,7 +228,7 @@ public class ProducerPerformance {
                 .dest("producerConfigFile")
                 .help("producer config properties file.");
 
-        parser.addArgument("--print.metrics")
+        parser.addArgument("--print-metrics")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("PRINT-METRICS")
@@ -240,22 +236,6 @@ public class ProducerPerformance {
                 .help("print out metrics at the end of the test.");
 
         return parser;
-    }
-
-    private static void printMetrics(KafkaProducer producer) {
-        Map<MetricName, ? extends Metric> metrics = producer.metrics();
-        int maxLengthOfDisplayName = 0;
-        for (Metric metric : metrics.values()) {
-            MetricName mName = metric.metricName();
-            String mergedName = mName.group() + ":" + mName.name() + ":" + mName.tags();
-            maxLengthOfDisplayName = maxLengthOfDisplayName < mergedName.length() ? mergedName.length() : maxLengthOfDisplayName;
-        }
-        String outputFormat = "%-" + maxLengthOfDisplayName + "s : %.3f";
-        System.out.println(String.format("\n%-" + maxLengthOfDisplayName + "s   %s", "Metric Name", "Value"));
-        for (Metric metric : metrics.values()) {
-            MetricName mName = metric.metricName();
-            System.out.println(String.format(outputFormat, mName.group() + ":" + mName.name() + ":" + mName.tags(), metric.value()));
-        }
     }
 
     private static class Stats {

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.tools;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
+import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -28,6 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Map;
 
 import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import org.apache.kafka.clients.producer.Callback;
@@ -40,6 +42,8 @@ import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Utils;
 
@@ -59,6 +63,7 @@ public class ProducerPerformance {
             List<String> producerProps = res.getList("producerConfig");
             String producerConfig = res.getString("producerConfigFile");
             String payloadFilePath = res.getString("payloadFile");
+            boolean shouldPrintMetrics = res.getBoolean("printMetrics");
 
             // since default value gets printed with the help text, we are escaping \n there and replacing it with correct value here.
             String payloadDelimiter = res.getString("payloadDelimiter").equals("\\n") ? "\n" : res.getString("payloadDelimiter");
@@ -127,10 +132,14 @@ public class ProducerPerformance {
                     throttler.throttle();
                 }
             }
-
             /* print final results */
-            producer.close();
             stats.printTotal();
+
+            /* print out metrics */
+            if (shouldPrintMetrics) {
+                printMetrics(producer);
+            }
+            producer.close();
         } catch (ArgumentParserException e) {
             if (args.length == 0) {
                 parser.printHelp();
@@ -223,7 +232,30 @@ public class ProducerPerformance {
                 .dest("producerConfigFile")
                 .help("producer config properties file.");
 
+        parser.addArgument("--print.metrics")
+                .action(storeTrue())
+                .type(Boolean.class)
+                .metavar("PRINT-METRICS")
+                .dest("printMetrics")
+                .help("print out metrics at the end of the test.");
+
         return parser;
+    }
+
+    private static void printMetrics(KafkaProducer producer) {
+        Map<MetricName, ? extends Metric> metrics = producer.metrics();
+        int maxLengthOfDisplayName = 0;
+        for (Metric metric : metrics.values()) {
+            MetricName mName = metric.metricName();
+            String mergedName = mName.group() + ":" + mName.name();
+            maxLengthOfDisplayName = maxLengthOfDisplayName < mergedName.length() ? mergedName.length() : maxLengthOfDisplayName;
+        }
+        String outputFormat = "%-" + maxLengthOfDisplayName + "s : %.3f";
+        System.out.println(String.format("\n%-" + maxLengthOfDisplayName + "s   %s", "Metric Name", "Value"));
+        for (Metric metric : metrics.values()) {
+            System.out.println(String.format(outputFormat, metric.metricName().group() + ":" + metric.metricName().name(),
+                    metric.value()));
+        }
     }
 
     private static class Stats {

--- a/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
@@ -47,8 +47,8 @@ public class ToolsUtils {
             String outputFormat = "%-" + maxLengthOfDisplayName + "s : %.3f";
             System.out.println(String.format("\n%-" + maxLengthOfDisplayName + "s   %s", "Metric Name", "Value"));
 
-            for (String key : sortedMetrics.keySet()) {
-                System.out.println(String.format(outputFormat, key, sortedMetrics.get(key)));
+            for (Map.Entry<String, Double> entry : sortedMetrics.entrySet()) {
+                System.out.println(String.format(outputFormat, entry.getKey(), entry.getValue()));
             }
         }
     }

--- a/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
@@ -1,0 +1,39 @@
+package org.apache.kafka.tools;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class ToolsUtils {
+
+    /**
+     * print out the metrics in alphabetical order
+     * @param metrics   the metrics to be printed out
+     */
+    public static void printMetrics(Map<MetricName, ? extends Metric> metrics) {
+        if (metrics != null && !metrics.isEmpty()) {
+            int maxLengthOfDisplayName = 0;
+            TreeMap<String, Double> sortedMetrics = new TreeMap<>(new Comparator<String>() {
+                @Override
+                public int compare(String o1, String o2) {
+                    return o1.compareTo(o2);
+                }
+            });
+            for (Metric metric : metrics.values()) {
+                MetricName mName = metric.metricName();
+                String mergedName = mName.group() + ":" + mName.name() + ":" + mName.tags();
+                maxLengthOfDisplayName = maxLengthOfDisplayName < mergedName.length() ? mergedName.length() : maxLengthOfDisplayName;
+                sortedMetrics.put(mergedName, metric.value());
+            }
+            String outputFormat = "%-" + maxLengthOfDisplayName + "s : %.3f";
+            System.out.println(String.format("\n%-" + maxLengthOfDisplayName + "s   %s", "Metric Name", "Value"));
+
+            for (String key : sortedMetrics.keySet()) {
+                System.out.println(String.format(outputFormat, key, sortedMetrics.get(key)));
+            }
+        }
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ToolsUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.tools;
 
 import org.apache.kafka.common.Metric;


### PR DESCRIPTION
@junrao added a config `--print.metrics` to control whether ProducerPerformance prints out metrics at the end of the test. If its okay, will add the code counterpart for consumer.
