### PR TITLE
KAFKA-5086; Update topic expiry time in Metadata every time the topic metadata is requested

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -623,6 +623,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         // is stale and the number of partitions for this topic has increased in the meantime.
         do {
             log.trace("Requesting metadata update for topic {}.", topic);
+            metadata.add(topic);
             int version = metadata.requestUpdate();
             sender.wakeup();
             try {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -329,11 +329,12 @@ public class KafkaProducerTest {
         Thread t = new Thread() {
             @Override
             public void run() {
-                for (int i = 0; i < 12; i++) {
+                long startTimeMs = System.currentTimeMillis();
+                for (int i = 0; i < 10; i++) {
+                    while (!metadata.updateRequested() && System.currentTimeMillis() - startTimeMs < 1000)
+                        yield();
                     metadata.update(Cluster.empty(), Collections.singleton(topic), time.milliseconds());
                     time.sleep(60 * 1000L);
-                    while (!metadata.updateRequested())
-                        yield();
                 }
             }
         };

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -23,9 +23,13 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.network.Selectable;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.MockProducerInterceptor;
 import org.apache.kafka.test.MockSerializer;
@@ -306,6 +310,44 @@ public class KafkaProducerTest {
         PowerMock.replay(metadata);
         producer.send(extendedRecord, null);
         PowerMock.verify(metadata);
+    }
+
+    @Test
+    public void testTopicRefreshInMetadata() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "600000");
+        KafkaProducer<String, String> producer = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
+        long refreshBackoffMs = 500L;
+        long metadataExpireMs = 60000L;
+        final Metadata metadata = new Metadata(refreshBackoffMs, metadataExpireMs, true, new ClusterResourceListeners());
+        final Time time = new MockTime();
+        MemberModifier.field(KafkaProducer.class, "metadata").set(producer, metadata);
+        MemberModifier.field(KafkaProducer.class, "time").set(producer, time);
+        String topic = "topic";
+
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for (int i = 0; i < 12; i++) {
+                    metadata.update(Cluster.empty(), Collections.<String>emptySet(), time.milliseconds());
+                    time.sleep(60 * 1000L);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        // skip
+                    }
+                }
+            }
+        });
+        t.start();
+        try {
+            producer.partitionsFor(topic);
+            fail("Expect TimeoutException");
+        } catch (TimeoutException e) {
+            // skip
+        }
+        Assert.assertTrue("Topic should still exist in metadata", metadata.containsTopic(topic));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -332,11 +332,8 @@ public class KafkaProducerTest {
                 for (int i = 0; i < 12; i++) {
                     metadata.update(Cluster.empty(), Collections.singleton(topic), time.milliseconds());
                     time.sleep(60 * 1000L);
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                        // skip
-                    }
+                    while (!metadata.updateRequested())
+                        yield();
                 }
             }
         };

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -324,13 +324,13 @@ public class KafkaProducerTest {
         final Time time = new MockTime();
         MemberModifier.field(KafkaProducer.class, "metadata").set(producer, metadata);
         MemberModifier.field(KafkaProducer.class, "time").set(producer, time);
-        String topic = "topic";
+        final String topic = "topic";
 
-        Thread t = new Thread(new Runnable() {
+        Thread t = new Thread() {
             @Override
             public void run() {
                 for (int i = 0; i < 12; i++) {
-                    metadata.update(Cluster.empty(), Collections.<String>emptySet(), time.milliseconds());
+                    metadata.update(Cluster.empty(), Collections.singleton(topic), time.milliseconds());
                     time.sleep(60 * 1000L);
                     try {
                         Thread.sleep(100);
@@ -339,7 +339,7 @@ public class KafkaProducerTest {
                     }
                 }
             }
-        });
+        };
         t.start();
         try {
             producer.partitionsFor(topic);


### PR DESCRIPTION
#As of current implementation, KafkaProducer.waitOnMetadata() will first reset topic expiry time of the topic before repeatedly sending TopicMetadataRequest and waiting for metadata response. However, if the metadata of the topic is not available within Metadata.TOPIC_EXPIRY_MS, which is set to 5 minutes, then the topic will be expired and removed from Metadata.topics. The TopicMetadataRequest will no longer include the topic and the KafkaProducer will never receive the metadata of this topic. It will enter an infinite loop of sending TopicMetadataRequest and waiting for metadata response.

This problem can be fixed by updating topic expiry time every time the topic metadata is requested.

Ping @becketqin for review.