### PR TITLE
MINOR: Update dependencies for 0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ buildscript {
 
   dependencies {
     // For Apache Rat plugin to ignore non-Git files
-    classpath "org.ajoberstar:grgit:1.7.0"
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
+    classpath "org.ajoberstar:grgit:1.9.2"
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
     classpath 'org.scoverage:gradle-scoverage:2.1.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
   }
@@ -68,7 +68,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "3.2.1"
+  gradleVersion = "3.5"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []
@@ -881,9 +881,9 @@ project(':jmh-benchmarks') {
   dependencies {
       compile project(':clients')
       compile project(':streams')
-      compile 'org.openjdk.jmh:jmh-core:1.17.5'
-      compile 'org.openjdk.jmh:jmh-generator-annprocess:1.17.5'
-      compile 'org.openjdk.jmh:jmh-core-benchmarks:1.17.5'
+      compile 'org.openjdk.jmh:jmh-core:1.18'
+      compile 'org.openjdk.jmh:jmh-generator-annprocess:1.18'
+      compile 'org.openjdk.jmh:jmh-core-benchmarks:1.18'
   }
 
   jar {
@@ -1052,10 +1052,7 @@ project(':connect:runtime') {
     compile libs.jettyServer
     compile libs.jettyServlet
     compile libs.jettyServlets
-    compile(libs.reflections) {
-      // Exclude because of LGPL license
-      exclude group: 'com.google.code.findbugs', module: 'annotations'
-    }
+    compile(libs.reflections)
 
     testCompile project(':clients').sourceSets.test.output
     testCompile libs.easymock

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ versions += [
   apacheda: "1.0.0-M33",
   apacheds: "2.0.0-M21",
   argparse4j: "0.7.0",
-  bcpkix: "1.55",
+  bcpkix: "1.56",
   easymock: "3.4",
   jackson: "2.8.5",
   jetty: "9.2.15.v20160210",
@@ -37,22 +37,22 @@ versions += [
   lz4: "1.3.0",
   metrics: "2.2.0",
   powermock: "1.6.4",
-  reflections: "0.9.10",
+  reflections: "0.9.11",
   rocksDB: "5.0.1",
-  scalaTest: "3.0.1",
+  scalaTest: "3.0.2",
   scalaParserCombinators: "1.0.4",
   scoverage: "1.3.0",
-  slf4j: "1.7.21",
+  slf4j: "1.7.25",
   snappy: "1.1.2.6",
   zkclient: "0.10",
-  zookeeper: "3.4.9",
+  zookeeper: "3.4.10",
   jfreechart: "1.0.0",
 ]
 
 // Add Scala version
 def defaultScala210Version = '2.10.6'
-def defaultScala211Version = '2.11.8'
-def defaultScala212Version = '2.12.1'
+def defaultScala211Version = '2.11.11'
+def defaultScala212Version = '2.12.2'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.10') {
     versions["scala"] = defaultScala210Version


### PR DESCRIPTION
Worth special mention:

1. Update Scala to 2.11.11 and 2.12.2
2. Update Gradle to 3.5
3. Update ZooKeeper to 3.4.10
4. Update reflections to 0.9.11, which:
    * Switches to jsr305 annotations with a provided scope
    * Updates Guava from 18 to 20
    * Updates javaassist from 3.18 to 3.21

There’s a separate PR for updating RocksDb, so
I didn’t include that here.