### PR TITLE
KAFKA-5072[WIP]: Kafka topics should allow custom metadata configs within some config namespace

### DIFF
--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -100,6 +100,8 @@ object LogConfig {
     println(configDef.toHtmlTable)
   }
 
+  val MetadataNameSpace = "metadata."
+
   val Delete = "delete"
   val Compact = "compact"
 
@@ -320,7 +322,7 @@ object LogConfig {
   def validateNames(props: Properties) {
     val names = configNames
     for(name <- props.asScala.keys)
-      if (!names.contains(name))
+      if (!names.contains(name) && !name.startsWith(MetadataNameSpace))
         throw new InvalidConfigurationException(s"Unknown Log configuration $name.")
   }
 


### PR DESCRIPTION
@benstopford @ijuma @granthenke @junrao 

This change allows one to define any topic property within the namespace "metadata.*" - for e.g. metadata.description, metadata.project, metadata.contact.info, etc (More details on the JIRA)

Raising a PR with [WIP] tag since I am not sure how to add this to the documentation given that the list of topic properties is auto-generated for the documentation.

This contribution is my original work and I license the work to the Kafka project under the project's open source license