### PR TITLE
KAFKA-3070: SASL unit tests dont work with IBM JDK

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.security.authenticator.LoginManager;
 import org.apache.kafka.common.security.authenticator.SaslClientAuthenticator;
 import org.apache.kafka.common.security.authenticator.SaslServerAuthenticator;
 import org.apache.kafka.common.security.ssl.SslFactory;
+import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.KafkaException;
 import org.slf4j.Logger;
@@ -143,7 +144,7 @@ public class SaslChannelBuilder implements ChannelBuilder {
         Class<?> classRef;
         Method getInstanceMethod;
         Method getDefaultRealmMethod;
-        if (System.getProperty("java.vendor").contains("IBM")) {
+        if (Java.isIBMJdk()) {
             classRef = Class.forName("com.ibm.security.krb5.internal.Config");
         } else {
             classRef = Class.forName("sun.security.krb5.Config");

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -45,4 +45,12 @@ public class JavaTest {
         assertTrue(Java.isIBMJdk());
     }
 
+    @Test
+    public void testLoadKerberosLoginModule() throws ClassNotFoundException {
+        String clazz = (Java.isIBMJdk()
+                ? "com.ibm.security.auth.module.Krb5LoginModule"
+                : "com.sun.security.auth.module.Krb5LoginModule");
+        Class.forName(clazz);
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -16,33 +16,33 @@
  */
 package org.apache.kafka.common.utils;
 
-import java.util.StringTokenizer;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public final class Java {
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-    private Java() {
+public class JavaTest {
+
+    private String javaVendor;
+
+    @Before
+    public void before() {
+        javaVendor = System.getProperty("java.vendor");
     }
 
-    public static final String JVM_SPEC_VERSION = System.getProperty("java.specification.version");
-
-    private static final int JVM_MAJOR_VERSION;
-    private static final int JVM_MINOR_VERSION;
-
-    static {
-        final StringTokenizer st = new StringTokenizer(JVM_SPEC_VERSION, ".");
-        JVM_MAJOR_VERSION = Integer.parseInt(st.nextToken());
-        if (st.hasMoreTokens()) {
-            JVM_MINOR_VERSION = Integer.parseInt(st.nextToken());
-        } else {
-            JVM_MINOR_VERSION = 0;
-        }
+    @After
+    public void after() {
+        System.setProperty("java.vendor", javaVendor);
     }
 
-    public static final boolean IS_JAVA9_COMPATIBLE = JVM_MAJOR_VERSION > 1 ||
-            (JVM_MAJOR_VERSION == 1 && JVM_MINOR_VERSION >= 9);
-
-    public static boolean isIBMJdk() {
-        return System.getProperty("java.vendor").contains("IBM");
+    @Test
+    public void testIsIBMJdk() {
+        System.setProperty("java.vendor", "Oracle Corporation");
+        assertFalse(Java.isIBMJdk());
+        System.setProperty("java.vendor", "IBM Corporation");
+        assertTrue(Java.isIBMJdk());
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -47,9 +47,9 @@ public class JavaTest {
 
     @Test
     public void testLoadKerberosLoginModule() throws ClassNotFoundException {
-        String clazz = (Java.isIBMJdk()
+        String clazz = Java.isIBMJdk()
                 ? "com.ibm.security.auth.module.Krb5LoginModule"
-                : "com.sun.security.auth.module.Krb5LoginModule");
+                : "com.sun.security.auth.module.Krb5LoginModule";
         Class.forName(clazz);
     }
 

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -50,7 +50,7 @@ import org.apache.directory.server.kerberos.shared.keytab.{Keytab, KeytabEntry}
 import org.apache.directory.server.protocol.shared.transport.{TcpTransport, UdpTransport}
 import org.apache.directory.server.xdbm.Index
 import org.apache.directory.shared.kerberos.KerberosTime
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{Java, Utils}
 
 /**
   * Mini KDC based on Apache Directory Server that can be embedded in tests or used from command line as a standalone
@@ -256,7 +256,7 @@ class MiniKdc(config: Properties, workDir: File) extends Logging {
 
   private def refreshJvmKerberosConfig(): Unit = {
     val klass =
-      if (System.getProperty("java.vendor").contains("IBM"))
+      if (Java.isIBMJdk)
         Class.forName("com.ibm.security.krb5.internal.Config")
       else
         Class.forName("sun.security.krb5.Config")

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -37,12 +37,12 @@ object JaasTestUtils {
         "com.sun.security.auth.module.Krb5LoginModule"
 
     def entries: Map[String, String] =
-      if (Java.isIBMJdk) 
+      if (Java.isIBMJdk)
         Map(
           "principal" -> principal,
           "credsType" -> "both"
         ) ++ (if (useKeyTab) Map("useKeytab" -> s"file:$keyTab") else Map.empty)
-      else 
+      else
         Map(
           "useKeyTab" -> useKeyTab.toString,
           "storeKey" -> storeKey.toString,

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -238,7 +238,7 @@ object TestUtils extends Logging {
       props.putAll(sslConfigs(Mode.SERVER, false, trustStoreFile, s"server$nodeId"))
 
     if (protocolAndPorts.exists { case (protocol, _) => usesSaslAuthentication(protocol) })
-      props.putAll(saslConfigs(saslProperties))
+      props.putAll(JaasTestUtils.saslConfigs(saslProperties))
 
     interBrokerSecurityProtocol.foreach { protocol =>
       props.put(KafkaConfig.InterBrokerSecurityProtocolProp, protocol.name)
@@ -502,8 +502,9 @@ object TestUtils extends Logging {
     val props = new Properties
     if (usesSslTransportLayer(securityProtocol))
       props.putAll(sslConfigs(mode, securityProtocol == SecurityProtocol.SSL, trustStoreFile, certAlias))
+
     if (usesSaslAuthentication(securityProtocol))
-      props.putAll(saslConfigs(saslProperties))
+      props.putAll(JaasTestUtils.saslConfigs(saslProperties))
     props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol.name)
     props
   }
@@ -1165,13 +1166,6 @@ object TestUtils extends Logging {
     val sslProps = new Properties()
     sslConfigs.asScala.foreach { case (k, v) => sslProps.put(k, v) }
     sslProps
-  }
-
-  def saslConfigs(saslProperties: Option[Properties]): Properties = {
-    saslProperties match {
-      case Some(properties) => properties
-      case None => new Properties
-    }
   }
 
   // a X509TrustManager to trust self-signed certs for unit tests.


### PR DESCRIPTION
Use IBM Kerberos module for SASL tests if running on IBM JDK

Developed with @edoardocomar
Based on https://github.com/apache/kafka/pull/738 by @rajinisivaram