### PR TITLE
MINOR: fix javadoc comment

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Transformer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Transformer.java
@@ -96,7 +96,7 @@ public interface Transformer<K, V, R> {
      * and not based on wall-clock time.
      *
      * @param timestamp the stream time when {@code punctuate} is being called
-     * @return must return {@code null}&mdash;otherwise, a {@link StreamsException exception} will be thrown
+     * @return new {@link KeyValue} pair to be forwarded to down stream&mdash;if {@code null} will not be forwarded
      */
     R punctuate(final long timestamp);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Transformer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Transformer.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TimestampExtractor;


### PR DESCRIPTION
Here's where it's called:
https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransform.java#L64-L67