### PR TITLE
KAFKA-5111: Improve internal Task APIs

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -110,8 +110,6 @@ public abstract class AbstractTask {
         return cache;
     }
 
-    public abstract void init();
-    public abstract void resume();
     public abstract void commit();
     public abstract void suspend();
     public abstract void close();
@@ -190,7 +188,7 @@ public abstract class AbstractTask {
     /**
      * Flush all state stores owned by this task
      */
-    protected void flushState() {
+    void flushState() {
         stateMgr.flush();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -70,18 +70,18 @@ public abstract class AbstractTask {
         // create the processor state manager
         try {
             stateMgr = new ProcessorStateManager(id, partitions, isStandby, stateDirectory, topology.storeToChangelogTopic(), changelogReader);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new ProcessorStateException(String.format("task [%s] Error while creating the state manager", id), e);
         }
     }
 
-    protected void initializeStateStores() {
+    void initializeStateStores() {
         // set initial offset limits
         initializeOffsetLimits();
 
-        for (StateStore store : this.topology.stateStores()) {
+        for (final StateStore store : topology.stateStores()) {
             log.trace("task [{}] Initializing store {}", id(), store.name());
-            store.init(this.processorContext, store);
+            store.init(processorContext, store);
         }
 
     }
@@ -95,7 +95,7 @@ public abstract class AbstractTask {
     }
 
     public final Set<TopicPartition> partitions() {
-        return this.partitions;
+        return partitions;
     }
 
     public final ProcessorTopology topology() {
@@ -124,10 +124,10 @@ public abstract class AbstractTask {
      * @param writeCheckpoint boolean indicating if a checkpoint file should be written
      */
     void closeStateManager(final boolean writeCheckpoint) {
-        log.trace("task [{}] Closing", id());
+        log.trace("task [{}] Closing", id);
         try {
             stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             throw new ProcessorStateException("Error while closing the state manager", e);
         }
     }
@@ -137,15 +137,15 @@ public abstract class AbstractTask {
     }
 
     protected void initializeOffsetLimits() {
-        for (TopicPartition partition : partitions) {
+        for (final TopicPartition partition : partitions) {
             try {
-                OffsetAndMetadata metadata = consumer.committed(partition); // TODO: batch API?
+                final OffsetAndMetadata metadata = consumer.committed(partition); // TODO: batch API?
                 stateMgr.putOffsetLimit(partition, metadata != null ? metadata.offset() : 0L);
-            } catch (AuthorizationException e) {
+            } catch (final AuthorizationException e) {
                 throw new ProcessorStateException(String.format("task [%s] AuthorizationException when initializing offsets for %s", id, partition), e);
-            } catch (WakeupException e) {
+            } catch (final WakeupException e) {
                 throw e;
-            } catch (KafkaException e) {
+            } catch (final KafkaException e) {
                 throw new ProcessorStateException(String.format("task [%s] Failed to initialize offsets for %s", id, partition), e);
             }
         }
@@ -171,7 +171,7 @@ public abstract class AbstractTask {
      * @return A string representation of the StreamTask instance.
      */
     public String toString(final String indent) {
-        final StringBuilder sb = new StringBuilder(indent + "StreamsTask taskId: " + this.id() + "\n");
+        final StringBuilder sb = new StringBuilder(indent + "StreamsTask taskId: " + id + "\n");
 
         // print topology
         if (topology != null) {
@@ -181,7 +181,7 @@ public abstract class AbstractTask {
         // print assigned partitions
         if (partitions != null && !partitions.isEmpty()) {
             sb.append(indent).append("Partitions [");
-            for (TopicPartition topicPartition : partitions) {
+            for (final TopicPartition topicPartition : partitions) {
                 sb.append(topicPartition.toString()).append(", ");
             }
             sb.setLength(sb.length() - 2);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -110,14 +110,11 @@ public abstract class AbstractTask {
         return cache;
     }
 
+    public abstract void init();
+    public abstract void resume();
     public abstract void commit();
-
+    public abstract void suspend();
     public abstract void close();
-
-    public abstract void initTopology();
-    public abstract void closeTopology();
-
-    public abstract void commitOffsets();
 
     /**
      * @throws ProcessorStateException if there is an error while closing the state manager
@@ -193,7 +190,7 @@ public abstract class AbstractTask {
     /**
      * Flush all state stores owned by this task
      */
-    public void flushState() {
+    protected void flushState() {
         stateMgr.flush();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -46,20 +46,20 @@ public abstract class AbstractTask {
     protected final Consumer consumer;
     protected final ProcessorStateManager stateMgr;
     protected final Set<TopicPartition> partitions;
-    protected InternalProcessorContext processorContext;
+    InternalProcessorContext processorContext;
     protected final ThreadCache cache;
     /**
      * @throws ProcessorStateException if the state manager cannot be created
      */
-    protected AbstractTask(final TaskId id,
-                           final String applicationId,
-                           final Collection<TopicPartition> partitions,
-                           final ProcessorTopology topology,
-                           final Consumer<byte[], byte[]> consumer,
-                           final ChangelogReader changelogReader,
-                           final boolean isStandby,
-                           final StateDirectory stateDirectory,
-                           final ThreadCache cache) {
+    AbstractTask(final TaskId id,
+                 final String applicationId,
+                 final Collection<TopicPartition> partitions,
+                 final ProcessorTopology topology,
+                 final Consumer<byte[], byte[]> consumer,
+                 final ChangelogReader changelogReader,
+                 final boolean isStandby,
+                 final StateDirectory stateDirectory,
+                 final ThreadCache cache) {
         this.id = id;
         this.applicationId = applicationId;
         this.partitions = new HashSet<>(partitions);
@@ -110,6 +110,7 @@ public abstract class AbstractTask {
         return cache;
     }
 
+    public abstract void resume();
     public abstract void commit();
     public abstract void suspend();
     public abstract void close();
@@ -120,11 +121,7 @@ public abstract class AbstractTask {
      */
     void closeStateManager(final boolean writeCheckpoint) {
         log.trace("task [{}] Closing", id);
-        try {
-            stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
-        } catch (final IOException e) {
-            throw new ProcessorStateException("Error while closing the state manager", e);
-        }
+        stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
     }
 
     protected Map<TopicPartition, Long> recordCollectorOffsets() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -78,18 +78,18 @@ public class ProcessorStateManager implements StateManager {
         this.taskId = taskId;
         this.stateDirectory = stateDirectory;
         this.changelogReader = changelogReader;
-        this.logPrefix = String.format("task [%s]", taskId);
+        logPrefix = String.format("task [%s]", taskId);
 
-        this.partitionForTopic = new HashMap<>();
-        for (TopicPartition source : sources) {
-            this.partitionForTopic.put(source.topic(), source);
+        partitionForTopic = new HashMap<>();
+        for (final TopicPartition source : sources) {
+            partitionForTopic.put(source.topic(), source);
         }
-        this.stores = new LinkedHashMap<>();
-        this.globalStores = new HashMap<>();
-        this.offsetLimits = new HashMap<>();
-        this.restoredOffsets = new HashMap<>();
+        stores = new LinkedHashMap<>();
+        globalStores = new HashMap<>();
+        offsetLimits = new HashMap<>();
+        restoredOffsets = new HashMap<>();
         this.isStandby = isStandby;
-        this.restoreCallbacks = isStandby ? new HashMap<String, StateRestoreCallback>() : null;
+        restoreCallbacks = isStandby ? new HashMap<String, StateRestoreCallback>() : null;
         this.storeToChangelogTopic = storeToChangelogTopic;
 
         if (!stateDirectory.lock(taskId, 5)) {
@@ -100,26 +100,27 @@ public class ProcessorStateManager implements StateManager {
         // note that the parent directory could have been accidentally deleted here,
         // so catch that exception if that is the case
         try {
-            this.baseDir = stateDirectory.directoryForTask(taskId);
-        } catch (ProcessorStateException e) {
+            baseDir = stateDirectory.directoryForTask(taskId);
+        } catch (final ProcessorStateException e) {
             throw new LockException(String.format("%s Failed to get the directory for task %s. Exception %s",
                 logPrefix, taskId, e));
         }
 
         // load the checkpoint information
-        checkpoint = new OffsetCheckpoint(new File(this.baseDir, CHECKPOINT_FILE_NAME));
-        this.checkpointedOffsets = new HashMap<>(checkpoint.read());
+        checkpoint = new OffsetCheckpoint(new File(baseDir, CHECKPOINT_FILE_NAME));
+        checkpointedOffsets = new HashMap<>(checkpoint.read());
 
         log.info("{} Created state store manager for task {} with the acquired state dir lock", logPrefix, taskId);
     }
 
 
-    public static String storeChangelogTopic(String applicationId, String storeName) {
+    public static String storeChangelogTopic(final String applicationId, final String storeName) {
         return applicationId + "-" + storeName + STATE_CHANGELOG_TOPIC_SUFFIX;
     }
 
+    @Override
     public File baseDir() {
-        return this.baseDir;
+        return baseDir;
     }
 
     /**
@@ -130,21 +131,24 @@ public class ProcessorStateManager implements StateManager {
      *
      * @throws StreamsException if the store's change log does not contain the partition
      */
-    public void register(StateStore store, boolean loggingEnabled, StateRestoreCallback stateRestoreCallback) {
+    @Override
+    public void register(final StateStore store,
+                         final boolean loggingEnabled,
+                         final StateRestoreCallback stateRestoreCallback) {
         log.debug("{} Registering state store {} to its state manager", logPrefix, store.name());
 
         if (store.name().equals(CHECKPOINT_FILE_NAME)) {
             throw new IllegalArgumentException(String.format("%s Illegal store name: %s", logPrefix, CHECKPOINT_FILE_NAME));
         }
 
-        if (this.stores.containsKey(store.name())) {
+        if (stores.containsKey(store.name())) {
             throw new IllegalArgumentException(String.format("%s Store %s has already been registered.", logPrefix, store.name()));
         }
 
         // check that the underlying change log topic exist or not
-        String topic = storeToChangelogTopic.get(store.name());
+        final String topic = storeToChangelogTopic.get(store.name());
         if (topic == null) {
-            this.stores.put(store.name(), store);
+            stores.put(store.name(), store);
             return;
         }
 
@@ -167,17 +171,17 @@ public class ProcessorStateManager implements StateManager {
             changelogReader.register(restorer);
         }
 
-        this.stores.put(store.name(), store);
+        stores.put(store.name(), store);
     }
 
-
+    @Override
     public Map<TopicPartition, Long> checkpointed() {
-        Map<TopicPartition, Long> partitionsAndOffsets = new HashMap<>();
+        final Map<TopicPartition, Long> partitionsAndOffsets = new HashMap<>();
 
-        for (Map.Entry<String, StateRestoreCallback> entry : restoreCallbacks.entrySet()) {
-            String topicName = entry.getKey();
-            int partition = getPartition(topicName);
-            TopicPartition storePartition = new TopicPartition(topicName, partition);
+        for (final Map.Entry<String, StateRestoreCallback> entry : restoreCallbacks.entrySet()) {
+            final String topicName = entry.getKey();
+            final int partition = getPartition(topicName);
+            final TopicPartition storePartition = new TopicPartition(topicName, partition);
 
             if (checkpointedOffsets.containsKey(storePartition)) {
                 partitionsAndOffsets.put(storePartition, checkpointedOffsets.get(storePartition));
@@ -188,26 +192,28 @@ public class ProcessorStateManager implements StateManager {
         return partitionsAndOffsets;
     }
 
-    public List<ConsumerRecord<byte[], byte[]>> updateStandbyStates(TopicPartition storePartition, List<ConsumerRecord<byte[], byte[]>> records) {
-        long limit = offsetLimit(storePartition);
+    List<ConsumerRecord<byte[], byte[]>> updateStandbyStates(final TopicPartition storePartition,
+                                                             final List<ConsumerRecord<byte[], byte[]>> records) {
+        final long limit = offsetLimit(storePartition);
         List<ConsumerRecord<byte[], byte[]>> remainingRecords = null;
 
         // restore states from changelog records
-        StateRestoreCallback restoreCallback = restoreCallbacks.get(storePartition.topic());
+        final StateRestoreCallback restoreCallback = restoreCallbacks.get(storePartition.topic());
 
         long lastOffset = -1L;
         int count = 0;
-        for (ConsumerRecord<byte[], byte[]> record : records) {
+        for (final ConsumerRecord<byte[], byte[]> record : records) {
             if (record.offset() < limit) {
                 try {
                     restoreCallback.restore(record.key(), record.value());
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     throw new ProcessorStateException(String.format("%s exception caught while trying to restore state from %s", logPrefix, storePartition), e);
                 }
                 lastOffset = record.offset();
             } else {
-                if (remainingRecords == null)
+                if (remainingRecords == null) {
                     remainingRecords = new ArrayList<>(records.size() - count);
+                }
 
                 remainingRecords.add(record);
             }
@@ -220,28 +226,29 @@ public class ProcessorStateManager implements StateManager {
         return remainingRecords;
     }
 
-    public void putOffsetLimit(TopicPartition partition, long limit) {
+    void putOffsetLimit(final TopicPartition partition, final long limit) {
         offsetLimits.put(partition, limit);
     }
 
-    private long offsetLimit(TopicPartition partition) {
-        Long limit = offsetLimits.get(partition);
+    private long offsetLimit(final TopicPartition partition) {
+        final Long limit = offsetLimits.get(partition);
         return limit != null ? limit : Long.MAX_VALUE;
     }
 
-    public StateStore getStore(String name) {
+    @Override
+    public StateStore getStore(final String name) {
         return stores.get(name);
     }
 
     @Override
     public void flush() {
-        if (!this.stores.isEmpty()) {
+        if (!stores.isEmpty()) {
             log.debug("{} Flushing all stores registered in the state manager", logPrefix);
-            for (StateStore store : this.stores.values()) {
+            for (final StateStore store : stores.values()) {
                 try {
                     log.trace("{} Flushing store={}", logPrefix, store.name());
                     store.flush();
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     throw new ProcessorStateException(String.format("%s Failed to flush state store %s", logPrefix, store.name()), e);
                 }
             }
@@ -252,17 +259,17 @@ public class ProcessorStateManager implements StateManager {
      * @throws IOException if any error happens when closing the state stores
      */
     @Override
-    public void close(Map<TopicPartition, Long> ackedOffsets) throws IOException {
+    public void close(final Map<TopicPartition, Long> ackedOffsets) throws IOException {
         try {
             // attempting to close the stores, just in case they
             // are not closed by a ProcessorNode yet
             if (!stores.isEmpty()) {
                 log.debug("{} Closing its state manager and all the registered state stores", logPrefix);
-                for (Map.Entry<String, StateStore> entry : stores.entrySet()) {
+                for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
                     log.debug("{} Closing storage engine {}", logPrefix, entry.getKey());
                     try {
                         entry.getValue().close();
-                    } catch (Exception e) {
+                    } catch (final Exception e) {
                         throw new ProcessorStateException(String.format("%s Failed to close state store %s", logPrefix, entry.getKey()), e);
                     }
                 }
@@ -283,7 +290,7 @@ public class ProcessorStateManager implements StateManager {
     public void checkpoint(final Map<TopicPartition, Long> ackedOffsets) {
         checkpointedOffsets.putAll(changelogReader.restoredOffsets());
         for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
-            String storeName = entry.getKey();
+            final String storeName = entry.getKey();
             // only checkpoint the offset to the offsets file if
             // it is persistent AND changelog enabled
             if (entry.getValue().persistent() && storeToChangelogTopic.containsKey(storeName)) {
@@ -300,23 +307,24 @@ public class ProcessorStateManager implements StateManager {
         // write the checkpoint file before closing, to indicate clean shutdown
         try {
             checkpoint.write(checkpointedOffsets);
-        } catch (IOException e) {
+        } catch (final IOException e) {
             log.warn("Failed to write checkpoint file to {}", new File(baseDir, CHECKPOINT_FILE_NAME), e);
         }
     }
 
-    private int getPartition(String topic) {
-        TopicPartition partition = partitionForTopic.get(topic);
+    private int getPartition(final String topic) {
+        final TopicPartition partition = partitionForTopic.get(topic);
 
         return partition == null ? taskId.partition : partition.partition();
     }
 
     void registerGlobalStateStores(final List<StateStore> stateStores) {
-        for (StateStore stateStore : stateStores) {
+        for (final StateStore stateStore : stateStores) {
             globalStores.put(stateStore.name(), stateStore);
         }
     }
 
+    @Override
     public StateStore getGlobalStore(final String name) {
         return globalStores.get(name);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -288,7 +288,7 @@ public class ProcessorStateManager implements StateManager {
     // write the checkpoint
     @Override
     public void checkpoint(final Map<TopicPartition, Long> ackedOffsets) {
-        log.trace("{} Writing checkpoint", logPrefix);
+        log.trace("{} Writing checkpoint: {}", logPrefix, ackedOffsets);
         checkpointedOffsets.putAll(changelogReader.restoredOffsets());
         for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
             final String storeName = entry.getKey();
@@ -320,6 +320,7 @@ public class ProcessorStateManager implements StateManager {
     }
 
     void registerGlobalStateStores(final List<StateStore> stateStores) {
+        log.info("{} Register global stores", logPrefix);
         for (final StateStore stateStore : stateStores) {
             globalStores.put(stateStore.name(), stateStore);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -320,7 +320,7 @@ public class ProcessorStateManager implements StateManager {
     }
 
     void registerGlobalStateStores(final List<StateStore> stateStores) {
-        log.info("{} Register global stores", logPrefix);
+        log.info("{} Register global stores {}", logPrefix, stateStores);
         for (final StateStore stateStore : stateStores) {
             globalStores.put(stateStore.name(), stateStore);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -288,6 +288,7 @@ public class ProcessorStateManager implements StateManager {
     // write the checkpoint
     @Override
     public void checkpoint(final Map<TopicPartition, Long> ackedOffsets) {
+        log.trace("{} Writing checkpoint", logPrefix);
         checkpointedOffsets.putAll(changelogReader.restoredOffsets());
         for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
             final String storeName = entry.getKey();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -75,10 +75,6 @@ public class StandbyTask extends AbstractTask {
         return checkpointedOffsets;
     }
 
-    Collection<TopicPartition> changeLogPartitions() {
-        return checkpointedOffsets.keySet();
-    }
-
     /**
      * Updates a state store using records from one change log partition
      * @return a list of records not consumed
@@ -87,12 +83,6 @@ public class StandbyTask extends AbstractTask {
         log.debug("standby-task [{}] Updating standby replicas of its state store for partition [{}]", id(), partition);
         return stateMgr.updateStandbyStates(partition, records);
     }
-
-    @Override
-    public void init() {}
-
-    @Override
-    public void resume() {}
 
     @Override
     public void commit() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -49,33 +49,33 @@ public class StandbyTask extends AbstractTask {
      * @param metrics               the {@link StreamsMetrics} created by the thread
      * @param stateDirectory        the {@link StateDirectory} created by the thread
      */
-    public StandbyTask(final TaskId id,
-                       final String applicationId,
-                       final Collection<TopicPartition> partitions,
-                       final ProcessorTopology topology,
-                       final Consumer<byte[], byte[]> consumer,
-                       final ChangelogReader changelogReader,
-                       final StreamsConfig config,
-                       final StreamsMetrics metrics,
-                       final StateDirectory stateDirectory) {
+    StandbyTask(final TaskId id,
+                final String applicationId,
+                final Collection<TopicPartition> partitions,
+                final ProcessorTopology topology,
+                final Consumer<byte[], byte[]> consumer,
+                final ChangelogReader changelogReader,
+                final StreamsConfig config,
+                final StreamsMetrics metrics,
+                final StateDirectory stateDirectory) {
         super(id, applicationId, partitions, topology, consumer, changelogReader, true, stateDirectory, null);
 
         // initialize the topology with its own context
-        this.processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
+        processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
 
         log.info("standby-task [{}] Initializing state stores", id());
         initializeStateStores();
 
-        this.processorContext.initialized();
+        processorContext.initialized();
 
-        this.checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
+        checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
-    public Map<TopicPartition, Long> checkpointedOffsets() {
+    Map<TopicPartition, Long> checkpointedOffsets() {
         return checkpointedOffsets;
     }
 
-    public Collection<TopicPartition> changeLogPartitions() {
+    Collection<TopicPartition> changeLogPartitions() {
         return checkpointedOffsets.keySet();
     }
 
@@ -83,11 +83,12 @@ public class StandbyTask extends AbstractTask {
      * Updates a state store using records from one change log partition
      * @return a list of records not consumed
      */
-    public List<ConsumerRecord<byte[], byte[]>> update(TopicPartition partition, List<ConsumerRecord<byte[], byte[]>> records) {
+    public List<ConsumerRecord<byte[], byte[]>> update(final TopicPartition partition, final List<ConsumerRecord<byte[], byte[]>> records) {
         log.debug("standby-task [{}] Updating standby replicas of its state store for partition [{}]", id(), partition);
         return stateMgr.updateStandbyStates(partition, records);
     }
 
+    @Override
     public void commit() {
         log.debug("standby-task [{}] Committing its state", id());
         stateMgr.flush();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -89,6 +89,12 @@ public class StandbyTask extends AbstractTask {
     }
 
     @Override
+    public void init() {}
+
+    @Override
+    public void resume() {}
+
+    @Override
     public void commit() {
         log.debug("standby-task [{}] Committing its state", id());
         stateMgr.flush();
@@ -98,31 +104,19 @@ public class StandbyTask extends AbstractTask {
     }
 
     @Override
+    public void suspend() {
+        commit();
+    }
+
+    @Override
     public void close() {
-        //no-op
+        try {
+            commit();
+            closeStateManager(true);
+        } catch (final RuntimeException e) {
+            closeStateManager(false);
+            throw e;
+        }
     }
 
-    @Override
-    public void initTopology() {
-        //no-op
-    }
-
-    @Override
-    public void closeTopology() {
-        //no-op
-    }
-
-    @Override
-    public void commitOffsets() {
-        // no-op
-    }
-
-    /**
-     * Produces a string representation contain useful information about a StreamTask.
-     * This is useful in debugging scenarios.
-     * @return A string representation of the StreamTask instance.
-     */
-    public String toString() {
-        return super.toString();
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -206,7 +206,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         }
 
         streamThread = (StreamThread) o;
-        streamThread.partitionAssignor(this);
+        streamThread.setPartitionAssignor(this);
 
         String userEndPoint = (String) configs.get(StreamsConfig.APPLICATION_SERVER_CONFIG);
         if (userEndPoint != null && !userEndPoint.isEmpty()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -63,7 +63,6 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
     private boolean commitRequested = false;
     private boolean commitOffsetNeeded = false;
-    private boolean requiresPoll = true;
     private final Time time;
     private final TaskMetrics metrics;
     private final Runnable commitDelegate = new Runnable() {
@@ -155,7 +154,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
      * @return the number of added records
      */
     @SuppressWarnings("unchecked")
-    public int addRecords(TopicPartition partition, Iterable<ConsumerRecord<byte[], byte[]>> records) {
+    public int addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
         final int oldQueueSize = partitionGroup.numBuffered();
         final int newQueueSize = partitionGroup.addRawRecords(partition, records);
 
@@ -163,7 +162,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
         // if after adding these records, its partition queue's buffered size has been
         // increased beyond the threshold, we can then pause the consumption for this partition
-        if (newQueueSize > this.maxBufferedSize) {
+        if (newQueueSize > maxBufferedSize) {
             consumer.pause(singleton(partition));
         }
 
@@ -173,7 +172,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
     /**
      * @return The number of records left in the buffer of this task's partition group
      */
-    public int numBuffered() {
+    int numBuffered() {
         return partitionGroup.numBuffered();
     }
 
@@ -185,20 +184,17 @@ public class StreamTask extends AbstractTask implements Punctuator {
     @SuppressWarnings("unchecked")
     public boolean process() {
         // get the next record to process
-        StampedRecord record = partitionGroup.nextRecord(recordInfo);
+        final StampedRecord record = partitionGroup.nextRecord(recordInfo);
 
         // if there is no record to process, return immediately
         if (record == null) {
-            requiresPoll = true;
             return false;
         }
-
-        requiresPoll = false;
 
         try {
             // process the record by passing to the source node of the topology
             final ProcessorNode currNode = recordInfo.node();
-            TopicPartition partition = recordInfo.partition();
+            final TopicPartition partition = recordInfo.partition();
 
             log.trace("{} Start processing one record [{}]", logPrefix, record);
             final ProcessorRecordContext recordContext = createRecordContext(record);
@@ -213,22 +209,17 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
             // after processing this record, if its partition queue's buffered size has been
             // decreased to the threshold, we can then resume the consumption on this partition
-            if (recordInfo.queue().size() == this.maxBufferedSize) {
+            if (recordInfo.queue().size() == maxBufferedSize) {
                 consumer.resume(singleton(partition));
-                requiresPoll = true;
             }
-
-            if (partitionGroup.topQueueSize() <= this.maxBufferedSize) {
-                requiresPoll = true;
-            }
-        } catch (KafkaException ke) {
+        } catch (final KafkaException e) {
             throw new StreamsException(format("Exception caught in process. taskId=%s, processor=%s, topic=%s, partition=%d, offset=%d",
                                               id.toString(),
                                               processorContext.currentNode().name(),
                                               record.topic(),
                                               record.partition(),
                                               record.offset()
-                                              ), ke);
+                                              ), e);
         } finally {
             processorContext.setCurrentNode(null);
         }
@@ -240,33 +231,30 @@ public class StreamTask extends AbstractTask implements Punctuator {
         processorContext.setRecordContext(recordContext);
         processorContext.setCurrentNode(currNode);
     }
-
-    public boolean requiresPoll() {
-        return requiresPoll;
-    }
-
     /**
      * Possibly trigger registered punctuation functions if
      * current partition group timestamp has reached the defined stamp
      */
-    public boolean maybePunctuate() {
-        long timestamp = partitionGroup.timestamp();
+    boolean maybePunctuate() {
+        final long timestamp = partitionGroup.timestamp();
 
         // if the timestamp is not known yet, meaning there is not enough data accumulated
         // to reason stream partition time, then skip.
-        if (timestamp == TimestampTracker.NOT_KNOWN)
+        if (timestamp == TimestampTracker.NOT_KNOWN) {
             return false;
-        else
+        } else {
             return punctuationQueue.mayPunctuate(timestamp, this);
+        }
     }
 
     /**
      * @throws IllegalStateException if the current node is not null
      */
     @Override
-    public void punctuate(ProcessorNode node, long timestamp) {
-        if (processorContext.currentNode() != null)
+    public void punctuate(final ProcessorNode node, final long timestamp) {
+        if (processorContext.currentNode() != null) {
             throw new IllegalStateException(String.format("%s Current node is not null", logPrefix));
+        }
 
         final StampedRecord stampedRecord = new StampedRecord(DUMMY_RECORD, timestamp);
         updateProcessorContext(createRecordContext(stampedRecord), node);
@@ -275,8 +263,8 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
         try {
             node.punctuate(timestamp);
-        } catch (KafkaException ke) {
-            throw new StreamsException(String.format("Exception caught in punctuate. taskId=%s processor=%s", id,  node.name()), ke);
+        } catch (final KafkaException e) {
+            throw new StreamsException(String.format("Exception caught in punctuate. taskId=%s processor=%s", id,  node.name()), e);
         } finally {
             processorContext.setCurrentNode(null);
         }
@@ -285,6 +273,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
     /**
      * Commit the current task state
      */
+    @Override
     public void commit() {
         metrics.metrics.measureLatencyNs(time, commitDelegate, metrics.taskCommitTimeSensor);
     }
@@ -295,10 +284,10 @@ public class StreamTask extends AbstractTask implements Punctuator {
     @Override
     public void commitOffsets() {
         if (commitOffsetNeeded) {
-            Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
-            for (Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
-                TopicPartition partition = entry.getKey();
-                long offset = entry.getValue() + 1;
+            final Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
+            for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
+                final TopicPartition partition = entry.getKey();
+                final long offset = entry.getValue() + 1;
                 consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
                 stateMgr.putOffsetLimit(partition, offset);
             }
@@ -317,15 +306,15 @@ public class StreamTask extends AbstractTask implements Punctuator {
     /**
      * Whether or not a request has been made to commit the current state
      */
-    public boolean commitNeeded() {
-        return this.commitRequested;
+    boolean commitNeeded() {
+        return commitRequested;
     }
 
     /**
      * Request committing the current task's state
      */
-    public void needCommit() {
-        this.commitRequested = true;
+    void needCommit() {
+        commitRequested = true;
     }
 
     /**
@@ -334,9 +323,10 @@ public class StreamTask extends AbstractTask implements Punctuator {
      * @param interval  the interval in milliseconds
      * @throws IllegalStateException if the current node is not null
      */
-    public void schedule(long interval) {
-        if (processorContext.currentNode() == null)
+    public void schedule(final long interval) {
+        if (processorContext.currentNode() == null) {
             throw new IllegalStateException(String.format("%s Current node is null", logPrefix));
+        }
 
         punctuationQueue.schedule(new PunctuationSchedule(processorContext.currentNode(), interval));
     }
@@ -345,7 +335,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
     public void initTopology() {
         // initialize the task by initializing all its processor nodes in the topology
         log.info("{} Initializing processor nodes of the topology", logPrefix);
-        for (ProcessorNode node : this.topology.processors()) {
+        for (final ProcessorNode node : topology.processors()) {
             processorContext.setCurrentNode(node);
             try {
                 node.init(processorContext);
@@ -357,17 +347,16 @@ public class StreamTask extends AbstractTask implements Punctuator {
 
     @Override
     public void closeTopology() {
-
-        this.partitionGroup.clear();
+        partitionGroup.clear();
 
         // close the processors
         // make sure close() is called for each node even when there is a RuntimeException
         RuntimeException exception = null;
-        for (ProcessorNode node : this.topology.processors()) {
+        for (final ProcessorNode node : topology.processors()) {
             processorContext.setCurrentNode(node);
             try {
                 node.close();
-            } catch (RuntimeException e) {
+            } catch (final RuntimeException e) {
                 exception = e;
             } finally {
                 processorContext.setCurrentNode(null);
@@ -386,7 +375,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
     public void close() {
         log.debug("{} Closing processor topology", logPrefix);
 
-        this.partitionGroup.close();
+        partitionGroup.close();
         closeTopology();
         metrics.removeAllSensors();
     }
@@ -409,7 +398,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
     }
 
     @SuppressWarnings("unchecked")
-    private RecordQueue createRecordQueue(TopicPartition partition, SourceNode source, final TimestampExtractor timestampExtractor) {
+    private RecordQueue createRecordQueue(final TopicPartition partition, final SourceNode source, final TimestampExtractor timestampExtractor) {
         return new RecordQueue(partition, source, timestampExtractor);
     }
 
@@ -436,13 +425,13 @@ public class StreamTask extends AbstractTask implements Punctuator {
         final Sensor taskCommitTimeSensor;
 
 
-        public TaskMetrics(StreamsMetrics metrics) {
-            String name = id.toString();
+        public TaskMetrics(final StreamsMetrics metrics) {
+            final String name = id.toString();
             this.metrics = (StreamsMetricsImpl) metrics;
-            this.taskCommitTimeSensor = metrics.addLatencyAndThroughputSensor("task", name, "commit", Sensor.RecordingLevel.DEBUG, "streams-task-id", name);
+            taskCommitTimeSensor = metrics.addLatencyAndThroughputSensor("task", name, "commit", Sensor.RecordingLevel.DEBUG, "streams-task-id", name);
         }
 
-        public void removeAllSensors() {
+        void removeAllSensors() {
             metrics.removeSensor(taskCommitTimeSensor);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -947,7 +947,7 @@ public class StreamThread extends Thread {
                 try {
                     final StreamTask task = findMatchingSuspendedTask(taskId, partitions);
                     if (task != null) {
-                        log.debug("{} recycling old task {}", logPrefix, taskId);
+                        log.debug("{} resuming old task {}", logPrefix, taskId);
                         suspendedTasks.remove(taskId);
                         task.resume();
 
@@ -1011,9 +1011,8 @@ public class StreamThread extends Thread {
             final StandbyTask task = findMatchingSuspendedStandbyTask(taskId, partitions);
 
             if (task != null) {
-                log.debug("{} recycling old standby task {}", logPrefix, taskId);
+                log.debug("{} resuming old standby task {}", logPrefix, taskId);
                 suspendedStandbyTasks.remove(taskId);
-                task.init();
             } else {
                 newStandbyTasks.put(taskId, partitions);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1013,6 +1013,7 @@ public class StreamThread extends Thread {
             if (task != null) {
                 log.debug("{} resuming old standby task {}", logPrefix, taskId);
                 suspendedStandbyTasks.remove(taskId);
+                task.resume();
             } else {
                 newStandbyTasks.put(taskId, partitions);
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -76,6 +76,9 @@ public class AbstractTaskTest {
                                 new StateDirectory("app", TestUtils.tempDirectory().getPath(), time),
                                 new ThreadCache("testCache", 0, new MockStreamsMetrics(new Metrics()))) {
             @Override
+            public void resume() {}
+
+            @Override
             public void commit() {}
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -76,29 +76,19 @@ public class AbstractTaskTest {
                                 new StateDirectory("app", TestUtils.tempDirectory().getPath(), time),
                                 new ThreadCache("testCache", 0, new MockStreamsMetrics(new Metrics()))) {
             @Override
-            public void commit() {
-                // do nothing
-            }
+            public void init() {}
 
             @Override
-            public void close() {
-
-            }
+            public void resume() {}
 
             @Override
-            public void initTopology() {
-
-            }
+            public void commit() {}
 
             @Override
-            public void closeTopology() {
-
-            }
+            public void suspend() {}
 
             @Override
-            public void commitOffsets() {
-                // do nothing
-            }
+            public void close() {}
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -76,12 +76,6 @@ public class AbstractTaskTest {
                                 new StateDirectory("app", TestUtils.tempDirectory().getPath(), time),
                                 new ThreadCache("testCache", 0, new MockStreamsMetrics(new Metrics()))) {
             @Override
-            public void init() {}
-
-            @Override
-            public void resume() {}
-
-            @Override
             public void commit() {}
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -159,7 +159,7 @@ public class StandbyTaskTest {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
 
-        assertEquals(Utils.mkSet(partition2), new HashSet<>(task.changeLogPartitions()));
+        assertEquals(Utils.mkSet(partition2), new HashSet<>(task.checkpointedOffsets().keySet()));
 
     }
 
@@ -169,7 +169,7 @@ public class StandbyTaskTest {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
 
-        restoreStateConsumer.assign(new ArrayList<>(task.changeLogPartitions()));
+        restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         task.update(partition1,
                 records(new ConsumerRecord<>(partition1.topic(), partition1.partition(), 10, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue))
@@ -183,7 +183,7 @@ public class StandbyTaskTest {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
 
-        restoreStateConsumer.assign(new ArrayList<>(task.changeLogPartitions()));
+        restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
                 new ConsumerRecord<>(partition2.topic(), partition2.partition(), 10, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, 1, 100),
@@ -241,7 +241,7 @@ public class StandbyTaskTest {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, ktablePartitions, ktableTopology, consumer, changelogReader, config, null, stateDirectory);
 
-        restoreStateConsumer.assign(new ArrayList<>(task.changeLogPartitions()));
+        restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
                 new ConsumerRecord<>(ktable.topic(), ktable.partition(), 10, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, 1, 100),
@@ -362,7 +362,7 @@ public class StandbyTaskTest {
         );
 
 
-        restoreStateConsumer.assign(new ArrayList<>(task.changeLogPartitions()));
+        restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         final byte[] serializedValue = Serdes.Integer().serializer().serialize("", 1);
         task.update(ktable, Collections.singletonList(new ConsumerRecord<>(ktable.topic(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -527,7 +527,7 @@ public class StreamTaskTest {
         task.close();
         task = createTaskThatThrowsExceptionOnClose();
         try {
-            task.closeTopology();
+            task.close();
             fail("should have thrown runtime exception");
         } catch (final RuntimeException e) {
             // ok
@@ -548,11 +548,6 @@ public class StreamTaskTest {
         assertTrue(source2.closed);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void shouldThrowWhenClosingProducerForNonEoS() {
-        task.closeProducer();
-    }
-
     @SuppressWarnings("unchecked")
     @Test
     public void shouldCloseProducerWhenExactlyOneEnabled() {
@@ -565,7 +560,7 @@ public class StreamTaskTest {
         task = new StreamTask(taskId00, applicationId, partitions, topology, consumer,
             changelogReader, config, streamsMetrics, stateDirectory, null, time, new RecordCollectorImpl(producer, "taskId"));
 
-        task.closeProducer();
+        task.close();
 
         assertTrue(producer.closed);
     }
@@ -607,7 +602,9 @@ public class StreamTaskTest {
 
         @Override
         public void flush() {
-            flushed.set(true);
+            if (flushed != null) {
+                flushed.set(true);
+            }
         }
 
         @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -114,8 +114,8 @@ public class StreamTaskTest {
     private final MockTime time = new MockTime();
     private File baseDir;
     private StateDirectory stateDirectory;
-    private RecordCollectorImpl recordCollector = new RecordCollectorImpl(producer, "taskId");
-    private ThreadCache testCache =  new ThreadCache("testCache", 0, streamsMetrics);
+    private final RecordCollectorImpl recordCollector = new RecordCollectorImpl(producer, "taskId");
+    private final ThreadCache testCache =  new ThreadCache("testCache", 0, streamsMetrics);
     private StreamsConfig config;
     private StreamTask task;
 
@@ -151,7 +151,7 @@ public class StreamTaskTest {
         if (task != null) {
             try {
                 task.close();
-            } catch (Exception e) {
+            } catch (final Exception e) {
                 // ignore exceptions
             }
         }
@@ -206,17 +206,17 @@ public class StreamTaskTest {
 
     @Test
     public void testMetrics() throws Exception {
-        String name = task.id().toString();
-        String[] entities = {"all", name};
-        String operation = "commit";
+        final String name = task.id().toString();
+        final String[] entities = {"all", name};
+        final String operation = "commit";
 
-        String groupName = "stream-task-metrics";
-        Map<String, String> tags = Collections.singletonMap("streams-task-id", name);
+        final String groupName = "stream-task-metrics";
+        final Map<String, String> tags = Collections.singletonMap("streams-task-id", name);
 
         assertNotNull(metrics.getSensor(operation));
         assertNotNull(metrics.getSensor(name + "-" + operation));
 
-        for (String entity : entities) {
+        for (final String entity : entities) {
             assertNotNull(metrics.metrics().get(metrics.metricName(entity + "-" + operation + "-latency-avg", groupName,
                 "The average latency in milliseconds of " + entity + " " + operation + " operation.", tags)));
             assertNotNull(metrics.metrics().get(metrics.metricName(entity + "-" + operation + "-latency-max", groupName,
@@ -340,7 +340,6 @@ public class StreamTaskTest {
         assertFalse(task.maybePunctuate());
 
         processor.supplier.checkAndClearPunctuateResult(20L, 30L, 40L);
-
     }
 
     @SuppressWarnings("unchecked")
@@ -375,14 +374,13 @@ public class StreamTaskTest {
         try {
             task.process();
             fail("Should've thrown StreamsException");
-        } catch (StreamsException e) {
+        } catch (final StreamsException e) {
             final String message = e.getMessage();
             assertTrue("message=" + message + " should contain topic", message.contains("topic=" + topic1[0]));
             assertTrue("message=" + message + " should contain partition", message.contains("partition=" + partition1.partition()));
             assertTrue("message=" + message + " should contain offset", message.contains("offset=" + offset));
             assertTrue("message=" + message + " should contain processor", message.contains("processor=" + processorNode.name()));
         }
-
     }
 
     @SuppressWarnings("unchecked")
@@ -395,9 +393,7 @@ public class StreamTaskTest {
             }
 
             @Override
-            public void process(final Object key, final Object value) {
-                //
-            }
+            public void process(final Object key, final Object value) {}
 
             @Override
             public void punctuate(final long timestamp) {
@@ -409,12 +405,11 @@ public class StreamTaskTest {
         try {
             task.punctuate(punctuator, 1);
             fail("Should've thrown StreamsException");
-        } catch (StreamsException e) {
+        } catch (final StreamsException e) {
             final String message = e.getMessage();
             assertTrue("message=" + message + " should contain processor", message.contains("processor=test"));
             assertThat(((ProcessorContextImpl) task.processorContext()).currentNode(), nullValue());
         }
-
     }
 
     @Test
@@ -534,7 +529,7 @@ public class StreamTaskTest {
         try {
             task.closeTopology();
             fail("should have thrown runtime exception");
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             // ok
         }
     }
@@ -544,8 +539,8 @@ public class StreamTaskTest {
         task.close();
         task = createTaskThatThrowsExceptionOnClose();
         try {
-            task.closeTopology();
-        } catch (RuntimeException e) {
+            task.close();
+        } catch (final RuntimeException e) {
             // expected
         }
         assertTrue(processor.closed);
@@ -561,7 +556,7 @@ public class StreamTaskTest {
     @SuppressWarnings("unchecked")
     @Test
     public void shouldCloseProducerWhenExactlyOneEnabled() {
-        final Map properties = this.config.values();
+        final Map properties = config.values();
         properties.put(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, "exactly_once");
         final StreamsConfig config = new StreamsConfig(properties);
 
@@ -593,12 +588,11 @@ public class StreamTaskTest {
                                                                  Collections.<String, String>emptyMap(),
                                                                  Collections.<StateStore>emptyList());
 
-
         return new StreamTask(taskId00, applicationId, partitions,
                               topology, consumer, changelogReader, config, streamsMetrics, stateDirectory, testCache, time, recordCollector);
     }
 
-    private Iterable<ConsumerRecord<byte[], byte[]>> records(ConsumerRecord<byte[], byte[]>... recs) {
+    private Iterable<ConsumerRecord<byte[], byte[]>> records(final ConsumerRecord<byte[], byte[]>... recs) {
         return Arrays.asList(recs);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -173,12 +173,6 @@ public class StreamThreadTest {
         }
 
         @Override
-        public void commitOffsets() {
-            super.commitOffsets();
-            committed = true;
-        }
-
-        @Override
         protected void initializeOffsetLimits() {}
 
         @Override
@@ -364,8 +358,8 @@ public class StreamThreadTest {
         final Map<TaskId, Set<TopicPartition>> thread1Assignment = new HashMap<>(task0);
         final Map<TaskId, Set<TopicPartition>> thread2Assignment = new HashMap<>(task1);
 
-        thread1.partitionAssignor(new MockStreamsPartitionAssignor(thread1Assignment));
-        thread2.partitionAssignor(new MockStreamsPartitionAssignor(thread2Assignment));
+        thread1.setPartitionAssignor(new MockStreamsPartitionAssignor(thread1Assignment));
+        thread2.setPartitionAssignor(new MockStreamsPartitionAssignor(thread2Assignment));
 
         // revoke (to get threads in correct state)
         thread1.rebalanceListener.onPartitionsRevoked(EMPTY_SET);
@@ -529,7 +523,7 @@ public class StreamThreadTest {
             final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
             activeTasks.put(task1, Collections.singleton(t1p1));
             activeTasks.put(task2, Collections.singleton(t1p2));
-            thread.partitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
+            thread.setPartitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
 
             revokedPartitions = Collections.emptyList();
             assignedPartitions = Arrays.asList(t1p1, t1p2);
@@ -708,7 +702,7 @@ public class StreamThreadTest {
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
         assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
         assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(assignment));
 
         thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
 
@@ -744,7 +738,7 @@ public class StreamThreadTest {
         assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
         assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
         assignment.put(new TaskId(0, 2), Collections.singleton(new TopicPartition("someTopic", 2)));
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(assignment));
 
         final Set<TopicPartition> assignedPartitions = new HashSet<>();
         Collections.addAll(assignedPartitions, new TopicPartition("someTopic", 0), new TopicPartition("someTopic", 2));
@@ -794,7 +788,7 @@ public class StreamThreadTest {
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
         assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
         assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(assignment));
 
         thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
 
@@ -826,7 +820,7 @@ public class StreamThreadTest {
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
         assignment.put(new TaskId(0, 0), Collections.singleton(new TopicPartition("someTopic", 0)));
         assignment.put(new TaskId(0, 1), Collections.singleton(new TopicPartition("someTopic", 1)));
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(assignment));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(assignment));
 
         thread.rebalanceListener.onPartitionsAssigned(Collections.singleton(new TopicPartition("someTopic", 0)));
 
@@ -848,7 +842,7 @@ public class StreamThreadTest {
         final StreamThread thread = new StreamThread(builder, config, new MockClientSupplier(), applicationId,
                                                clientId, processId, new Metrics(), new MockTime(), new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0);
 
-        thread.partitionAssignor(new StreamPartitionAssignor() {
+        thread.setPartitionAssignor(new StreamPartitionAssignor() {
             @Override
             Map<TaskId, Set<TopicPartition>> standbyTasks() {
                 return Collections.singletonMap(new TaskId(0, 0), Utils.mkSet(new TopicPartition("topic", 0)));
@@ -889,7 +883,7 @@ public class StreamThreadTest {
         final TopicPartition t1 = new TopicPartition("t1", 0);
         standbyTasks.put(new TaskId(0, 0), Utils.mkSet(t1));
 
-        thread.partitionAssignor(new StreamPartitionAssignor() {
+        thread.setPartitionAssignor(new StreamPartitionAssignor() {
             @Override
             Map<TaskId, Set<TopicPartition>> standbyTasks() {
                 return standbyTasks;
@@ -950,7 +944,7 @@ public class StreamThreadTest {
         final TopicPartition t2 = new TopicPartition("t2", 0);
         activeTasks.put(new TaskId(1, 0), Utils.mkSet(t2));
 
-        thread.partitionAssignor(new StreamPartitionAssignor() {
+        thread.setPartitionAssignor(new StreamPartitionAssignor() {
             @Override
             Map<TaskId, Set<TopicPartition>> standbyTasks() {
                 return standbyTasks;
@@ -1004,7 +998,7 @@ public class StreamThreadTest {
         final TaskId taskId = new TaskId(0, 0);
         activeTasks.put(taskId, task00Partitions);
 
-        thread.partitionAssignor(new StreamPartitionAssignor() {
+        thread.setPartitionAssignor(new StreamPartitionAssignor() {
             @Override
             Map<TaskId, Set<TopicPartition>> activeTasks() {
                 return activeTasks;
@@ -1068,7 +1062,7 @@ public class StreamThreadTest {
         activeTasks.put(testStreamTask.id, testStreamTask.partitions);
 
 
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
 
         thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
         thread.rebalanceListener.onPartitionsAssigned(testStreamTask.partitions);
@@ -1119,7 +1113,7 @@ public class StreamThreadTest {
         activeTasks.put(testStreamTask.id, testStreamTask.partitions);
 
 
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
 
         thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
         thread.rebalanceListener.onPartitionsAssigned(testStreamTask.partitions);
@@ -1135,7 +1129,7 @@ public class StreamThreadTest {
     }
 
     @Test
-    public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringCloseTopologyWhenSuspendingState() throws Exception {
+    public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringSuspendWhenSuspendingState() throws Exception {
         final KStreamBuilder builder = new KStreamBuilder();
         builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey();
@@ -1152,7 +1146,7 @@ public class StreamThreadTest {
                                                                  new MockStreamsMetrics(new Metrics()),
                                                                  new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time)) {
             @Override
-            public void closeTopology() {
+            public void suspend() {
                 throw new RuntimeException("KABOOM!");
             }
         };
@@ -1172,7 +1166,7 @@ public class StreamThreadTest {
         activeTasks.put(testStreamTask.id, testStreamTask.partitions);
 
 
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
 
         thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
         thread.rebalanceListener.onPartitionsAssigned(testStreamTask.partitions);
@@ -1203,7 +1197,7 @@ public class StreamThreadTest {
                                                                  new MockStreamsMetrics(new Metrics()),
                                                                  new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), time)) {
             @Override
-            public void flushState() {
+            protected void flushState() {
                 throw new RuntimeException("KABOOM!");
             }
         };
@@ -1223,7 +1217,7 @@ public class StreamThreadTest {
         activeTasks.put(testStreamTask.id, testStreamTask.partitions);
 
 
-        thread.partitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
+        thread.setPartitionAssignor(new MockStreamsPartitionAssignor(activeTasks));
 
         thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
         thread.rebalanceListener.onPartitionsAssigned(testStreamTask.partitions);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -1129,7 +1129,7 @@ public class StreamThreadTest {
     }
 
     @Test
-    public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringSuspendWhenSuspendingState() throws Exception {
+    public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringTaskSuspension() throws Exception {
         final KStreamBuilder builder = new KStreamBuilder();
         builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -87,14 +87,14 @@ public class StreamThreadTest {
         processId = UUID.randomUUID();
     }
 
-    private TopicPartition t1p1 = new TopicPartition("topic1", 1);
-    private TopicPartition t1p2 = new TopicPartition("topic1", 2);
-    private TopicPartition t2p1 = new TopicPartition("topic2", 1);
-    private TopicPartition t2p2 = new TopicPartition("topic2", 2);
-    private TopicPartition t3p1 = new TopicPartition("topic3", 1);
-    private TopicPartition t3p2 = new TopicPartition("topic3", 2);
+    private final TopicPartition t1p1 = new TopicPartition("topic1", 1);
+    private final TopicPartition t1p2 = new TopicPartition("topic1", 2);
+    private final TopicPartition t2p1 = new TopicPartition("topic2", 1);
+    private final TopicPartition t2p2 = new TopicPartition("topic2", 2);
+    private final TopicPartition t3p1 = new TopicPartition("topic3", 1);
+    private final TopicPartition t3p2 = new TopicPartition("topic3", 2);
 
-    private List<PartitionInfo> infos = Arrays.asList(
+    private final List<PartitionInfo> infos = Arrays.asList(
         new PartitionInfo("topic1", 0, Node.noNode(), new Node[0], new Node[0]),
         new PartitionInfo("topic1", 1, Node.noNode(), new Node[0], new Node[0]),
         new PartitionInfo("topic1", 2, Node.noNode(), new Node[0], new Node[0]),
@@ -106,15 +106,15 @@ public class StreamThreadTest {
         new PartitionInfo("topic3", 2, Node.noNode(), new Node[0], new Node[0])
     );
 
-    private Cluster metadata = new Cluster("cluster", Collections.singleton(Node.noNode()), infos, Collections.<String>emptySet(),
+    private final Cluster metadata = new Cluster("cluster", Collections.singleton(Node.noNode()), infos, Collections.<String>emptySet(),
             Collections.<String>emptySet());
 
     private final PartitionAssignor.Subscription subscription =
         new PartitionAssignor.Subscription(Arrays.asList("topic1", "topic2", "topic3"), subscriptionUserData());
 
     private ByteBuffer subscriptionUserData() {
-        UUID uuid = UUID.randomUUID();
-        ByteBuffer buf = ByteBuffer.allocate(4 + 16 + 4 + 4);
+        final UUID uuid = UUID.randomUUID();
+        final ByteBuffer buf = ByteBuffer.allocate(4 + 16 + 4 + 4);
         // version
         buf.putInt(1);
         // encode client processId
@@ -152,16 +152,16 @@ public class StreamThreadTest {
         private boolean closed;
         private boolean closedStateManager;
 
-        TestStreamTask(TaskId id,
-                       String applicationId,
-                       Collection<TopicPartition> partitions,
-                       ProcessorTopology topology,
-                       Consumer<byte[], byte[]> consumer,
-                       Producer<byte[], byte[]> producer,
-                       Consumer<byte[], byte[]> restoreConsumer,
-                       StreamsConfig config,
-                       StreamsMetrics metrics,
-                       StateDirectory stateDirectory) {
+        TestStreamTask(final TaskId id,
+                       final String applicationId,
+                       final Collection<TopicPartition> partitions,
+                       final ProcessorTopology topology,
+                       final Consumer<byte[], byte[]> consumer,
+                       final Producer<byte[], byte[]> producer,
+                       final Consumer<byte[], byte[]> restoreConsumer,
+                       final StreamsConfig config,
+                       final StreamsMetrics metrics,
+                       final StateDirectory stateDirectory) {
             super(id, applicationId, partitions, topology, consumer, new StoreChangelogReader(restoreConsumer, Time.SYSTEM, 5000), config, metrics,
                   stateDirectory, null, new MockTime(), new RecordCollectorImpl(producer, id.toString()));
         }
@@ -179,20 +179,18 @@ public class StreamThreadTest {
         }
 
         @Override
-        protected void initializeOffsetLimits() {
-            // do nothing
-        }
+        protected void initializeOffsetLimits() {}
 
         @Override
         public void close() {
-            this.closed = true;
+            closed = true;
             super.close();
         }
 
         @Override
-        void closeStateManager(boolean writeCheckpoint) {
+        void closeStateManager(final boolean writeCheckpoint) {
             super.closeStateManager(writeCheckpoint);
-            this.closedStateManager = true;
+            closedStateManager = true;
         }
     }
 
@@ -200,11 +198,11 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testPartitionAssignmentChange() throws Exception {
-        StreamsConfig config = new StreamsConfig(configProps());
-        StateListenerStub stateListener = new StateListenerStub();
+        final StreamsConfig config = new StreamsConfig(configProps());
+        final StateListenerStub stateListener = new StateListenerStub();
 
 
-        TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+        final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
         builder.addSource("source1", "topic1");
         builder.addSource("source2", "topic2");
         builder.addSource("source3", "topic3");
@@ -212,12 +210,12 @@ public class StreamThreadTest {
 
 
         final MockClientSupplier mockClientSupplier = new MockClientSupplier();
-        StreamThread thread = new StreamThread(builder, config, mockClientSupplier, applicationId, clientId, processId, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0) {
+        final StreamThread thread = new StreamThread(builder, config, mockClientSupplier, applicationId, clientId, processId, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0) {
 
             @Override
-            protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
+            protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitionsForTask) {
 
-                ProcessorTopology topology = builder.build(id.topicGroupId);
+                final ProcessorTopology topology = builder.build(id.topicGroupId);
                 return new TestStreamTask(id, applicationId, partitionsForTask, topology, consumer,
                     mockClientSupplier.producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
             }
@@ -227,7 +225,7 @@ public class StreamThreadTest {
         assertEquals(thread.state(), StreamThread.State.RUNNING);
         initPartitionGrouper(config, thread, mockClientSupplier);
 
-        ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
+        final ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
 
         assertTrue(thread.tasks().isEmpty());
 
@@ -394,7 +392,7 @@ public class StreamThreadTest {
         thread2Assignment.clear();
         thread2Assignment.putAll(task0);
 
-        Thread runIt = new Thread(new Runnable() {
+        final Thread runIt = new Thread(new Runnable() {
             @Override
             public void run() {
                 thread1.rebalanceListener.onPartitionsAssigned(task1Assignment);
@@ -428,16 +426,16 @@ public class StreamThreadTest {
 
     @Test
     public void testMetrics() throws Exception {
-        TopologyBuilder builder = new TopologyBuilder().setApplicationId("MetricsApp");
-        StreamsConfig config = new StreamsConfig(configProps());
-        MockClientSupplier clientSupplier = new MockClientSupplier();
+        final TopologyBuilder builder = new TopologyBuilder().setApplicationId("MetricsApp");
+        final StreamsConfig config = new StreamsConfig(configProps());
+        final MockClientSupplier clientSupplier = new MockClientSupplier();
 
-        Metrics metrics = new Metrics();
-        StreamThread thread = new StreamThread(builder, config, clientSupplier, applicationId,
+        final Metrics metrics = new Metrics();
+        final StreamThread thread = new StreamThread(builder, config, clientSupplier, applicationId,
             clientId,  processId, metrics, new MockTime(), new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0);
-        String defaultGroupName = "stream-metrics";
-        String defaultPrefix = "thread." + thread.threadClientId();
-        Map<String, String> defaultTags = Collections.singletonMap("client-id", thread.threadClientId());
+        final String defaultGroupName = "stream-metrics";
+        final String defaultPrefix = "thread." + thread.threadClientId();
+        final Map<String, String> defaultTags = Collections.singletonMap("client-id", thread.threadClientId());
 
         assertNotNull(metrics.getSensor(defaultPrefix + ".commit-latency"));
         assertNotNull(metrics.getSensor(defaultPrefix + ".poll-latency"));
@@ -466,21 +464,21 @@ public class StreamThreadTest {
 
     @Test
     public void testMaybeClean() throws Exception {
-        File baseDir = Files.createTempDirectory("test").toFile();
+        final File baseDir = Files.createTempDirectory("test").toFile();
         try {
             final long cleanupDelay = 1000L;
-            Properties props = configProps();
+            final Properties props = configProps();
             props.setProperty(StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG, Long.toString(cleanupDelay));
             props.setProperty(StreamsConfig.STATE_DIR_CONFIG, baseDir.getCanonicalPath());
 
-            StreamsConfig config = new StreamsConfig(props);
+            final StreamsConfig config = new StreamsConfig(props);
 
-            File applicationDir = new File(baseDir, applicationId);
+            final File applicationDir = new File(baseDir, applicationId);
             applicationDir.mkdir();
-            File stateDir1 = new File(applicationDir, task1.toString());
-            File stateDir2 = new File(applicationDir, task2.toString());
-            File stateDir3 = new File(applicationDir, task3.toString());
-            File extraDir = new File(applicationDir, "X");
+            final File stateDir1 = new File(applicationDir, task1.toString());
+            final File stateDir2 = new File(applicationDir, task2.toString());
+            final File stateDir3 = new File(applicationDir, task3.toString());
+            final File extraDir = new File(applicationDir, "X");
             stateDir1.mkdir();
             stateDir2.mkdir();
             stateDir3.mkdir();
@@ -488,21 +486,21 @@ public class StreamThreadTest {
 
             final MockTime mockTime = new MockTime();
 
-            TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+            final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
             builder.addSource("source1", "topic1");
 
             final MockClientSupplier mockClientSupplier = new MockClientSupplier();
-            StreamThread thread = new StreamThread(builder, config, mockClientSupplier, applicationId, clientId, processId, new Metrics(), mockTime, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            final StreamThread thread = new StreamThread(builder, config, mockClientSupplier, applicationId, clientId, processId, new Metrics(), mockTime, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
                                                    0) {
 
                 @Override
-                public void maybeClean(long now) {
+                public void maybeClean(final long now) {
                     super.maybeClean(now);
                 }
 
                 @Override
-                protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
-                    ProcessorTopology topology = builder.build(id.topicGroupId);
+                protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitionsForTask) {
+                    final ProcessorTopology topology = builder.build(id.topicGroupId);
                     return new TestStreamTask(id, applicationId, partitionsForTask, topology, consumer,
                         mockClientSupplier.producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
                 }
@@ -510,7 +508,7 @@ public class StreamThreadTest {
 
             initPartitionGrouper(config, thread, mockClientSupplier);
 
-            ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
+            final ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
 
             assertTrue(thread.tasks().isEmpty());
             mockTime.sleep(cleanupDelay);
@@ -576,7 +574,7 @@ public class StreamThreadTest {
 
             // previous tasks should be committed
             assertEquals(2, prevTasks.size());
-            for (StreamTask task : prevTasks.values()) {
+            for (final StreamTask task : prevTasks.values()) {
                 assertTrue(((TestStreamTask) task).committed);
                 ((TestStreamTask) task).committed = false;
             }
@@ -607,32 +605,32 @@ public class StreamThreadTest {
 
     @Test
     public void testMaybeCommit() throws Exception {
-        File baseDir = Files.createTempDirectory("test").toFile();
+        final File baseDir = Files.createTempDirectory("test").toFile();
         try {
             final long commitInterval = 1000L;
-            Properties props = configProps();
+            final Properties props = configProps();
             props.setProperty(StreamsConfig.STATE_DIR_CONFIG, baseDir.getCanonicalPath());
             props.setProperty(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, Long.toString(commitInterval));
 
-            StreamsConfig config = new StreamsConfig(props);
+            final StreamsConfig config = new StreamsConfig(props);
 
             final MockTime mockTime = new MockTime();
 
-            TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
+            final TopologyBuilder builder = new TopologyBuilder().setApplicationId("X");
             builder.addSource("source1", "topic1");
 
             final MockClientSupplier mockClientSupplier = new MockClientSupplier();
-            StreamThread thread = new StreamThread(builder, config, mockClientSupplier, applicationId, clientId, processId, new Metrics(), mockTime, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            final StreamThread thread = new StreamThread(builder, config, mockClientSupplier, applicationId, clientId, processId, new Metrics(), mockTime, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
                                                    0) {
 
                 @Override
-                public void maybeCommit(long now) {
+                public void maybeCommit(final long now) {
                     super.maybeCommit(now);
                 }
 
                 @Override
-                protected StreamTask createStreamTask(TaskId id, Collection<TopicPartition> partitionsForTask) {
-                    ProcessorTopology topology = builder.build(id.topicGroupId);
+                protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitionsForTask) {
+                    final ProcessorTopology topology = builder.build(id.topicGroupId);
                     return new TestStreamTask(id, applicationId, partitionsForTask, topology, consumer,
                         mockClientSupplier.producer, restoreConsumer, config, new MockStreamsMetrics(new Metrics()), stateDirectory);
                 }
@@ -640,10 +638,10 @@ public class StreamThreadTest {
 
             initPartitionGrouper(config, thread, mockClientSupplier);
 
-            ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
+            final ConsumerRebalanceListener rebalanceListener = thread.rebalanceListener;
 
-            List<TopicPartition> revokedPartitions;
-            List<TopicPartition> assignedPartitions;
+            final List<TopicPartition> revokedPartitions;
+            final List<TopicPartition> assignedPartitions;
 
             //
             // Assign t1p1 and t1p2. This should create Task 1 & 2
@@ -659,14 +657,14 @@ public class StreamThreadTest {
             // no task is committed before the commit interval
             mockTime.sleep(commitInterval - 10L);
             thread.maybeCommit(mockTime.milliseconds());
-            for (StreamTask task : thread.tasks().values()) {
+            for (final StreamTask task : thread.tasks().values()) {
                 assertFalse(((TestStreamTask) task).committed);
             }
 
             // all tasks are committed after the commit interval
             mockTime.sleep(11L);
             thread.maybeCommit(mockTime.milliseconds());
-            for (StreamTask task : thread.tasks().values()) {
+            for (final StreamTask task : thread.tasks().values()) {
                 assertTrue(((TestStreamTask) task).committed);
                 ((TestStreamTask) task).committed = false;
             }
@@ -674,18 +672,17 @@ public class StreamThreadTest {
             // no task is committed before the commit interval, again
             mockTime.sleep(commitInterval - 10L);
             thread.maybeCommit(mockTime.milliseconds());
-            for (StreamTask task : thread.tasks().values()) {
+            for (final StreamTask task : thread.tasks().values()) {
                 assertFalse(((TestStreamTask) task).committed);
             }
 
             // all tasks are committed after the commit interval, again
             mockTime.sleep(11L);
             thread.maybeCommit(mockTime.milliseconds());
-            for (StreamTask task : thread.tasks().values()) {
+            for (final StreamTask task : thread.tasks().values()) {
                 assertTrue(((TestStreamTask) task).committed);
                 ((TestStreamTask) task).committed = false;
             }
-
         } finally {
             Utils.delete(baseDir);
         }
@@ -755,7 +752,7 @@ public class StreamThreadTest {
 
         assertNull(thread.threadProducer);
         assertEquals(thread.tasks().size(), clientSupplier.numberOfCreatedProducers);
-        Iterator it = clientSupplier.producers.iterator();
+        final Iterator it = clientSupplier.producers.iterator();
         for (final StreamTask task : thread.tasks().values()) {
             assertSame(it.next(), task.producer());
         }
@@ -767,7 +764,7 @@ public class StreamThreadTest {
         final List<Producer> producers = new LinkedList<>();
 
         @Override
-        public Producer<byte[], byte[]> getProducer(Map<String, Object> config) {
+        public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
             final Producer<byte[], byte[]> producer = new MockedProducer<>();
             producers.add(producer);
             ++numberOfCreatedProducers;
@@ -1182,7 +1179,7 @@ public class StreamThreadTest {
         try {
             thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
             fail("should have thrown exception");
-        } catch (Exception e) {
+        } catch (final Exception e) {
             // expected
         }
         assertFalse(testStreamTask.committed);
@@ -1233,7 +1230,7 @@ public class StreamThreadTest {
         try {
             thread.rebalanceListener.onPartitionsRevoked(Collections.<TopicPartition>emptyList());
             fail("should have thrown exception");
-        } catch (Exception e) {
+        } catch (final Exception e) {
             // expected
         }
         assertFalse(testStreamTask.committed);
@@ -1241,15 +1238,14 @@ public class StreamThreadTest {
     }
 
 
-    private void initPartitionGrouper(StreamsConfig config, StreamThread thread, MockClientSupplier clientSupplier) {
-
-        StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
+    private void initPartitionGrouper(final StreamsConfig config, final StreamThread thread, final MockClientSupplier clientSupplier) {
+        final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
 
         partitionAssignor.configure(config.getConsumerConfigs(thread, thread.applicationId, thread.clientId));
-        MockInternalTopicManager internalTopicManager = new MockInternalTopicManager(thread.config, clientSupplier.restoreConsumer);
+        final MockInternalTopicManager internalTopicManager = new MockInternalTopicManager(thread.config, clientSupplier.restoreConsumer);
         partitionAssignor.setInternalTopicManager(internalTopicManager);
 
-        Map<String, PartitionAssignor.Assignment> assignments =
+        final Map<String, PartitionAssignor.Assignment> assignments =
             partitionAssignor.assign(metadata, Collections.singletonMap("client", subscription));
 
         partitionAssignor.onAssignment(assignments.get("client"));
@@ -1262,7 +1258,7 @@ public class StreamThreadTest {
 
         @Override
         public void onChange(final StreamThread thread, final StreamThread.State newState, final StreamThread.State oldState) {
-            this.numChanges++;
+            ++numChanges;
             if (this.newState != null) {
                 if (this.newState != oldState) {
                     throw new RuntimeException("State mismatch " + oldState + " different from " + this.newState);


### PR DESCRIPTION
 Refactors Task with proper interface methods `init()`, `resume()`, `commit()`, `suspend()`, and `close()`. All other methods for task handling are internal now. This allows to simplify `StreamThread` code, avoid code duplication and allows for easier reasoning of control flow.