### PR TITLE
KAFKA-5081: use gradle resolution strategy 'failOnVersionConflict' 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ buildscript {
   }
 }
 
+apply from: "$rootDir/gradle/dependencies.gradle"
+
 allprojects {
   apply plugin: 'idea'
   apply plugin: "jacoco"
@@ -65,6 +67,19 @@ allprojects {
     }
   }
 
+    configurations {
+        runtime {
+            resolutionStrategy {
+                failOnVersionConflict()
+                force "org.slf4j:slf4j-log4j12:$versions.slf4j"
+                force "org.slf4j:slf4j-api:$versions.slf4j"
+                force "org.apache.zookeeper:zookeeper:$versions.zookeeper"
+                force "log4j:log4j:$versions.log4j"
+                force "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson"
+                force "org.javassist:javassist:$versions.javassist"
+            }
+        }
+    }
 }
 
 ext {
@@ -91,7 +106,7 @@ ext {
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
 }
 
-apply from: "$rootDir/gradle/dependencies.gradle"
+
 apply from: file('wrapper.gradle')
 
 if (new File('.git').exists()) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -29,8 +29,10 @@ versions += [
   bcpkix: "1.56",
   easymock: "3.4",
   jackson: "2.8.5",
+  javassist: "3.21.0-GA",
   jetty: "9.2.15.v20160210",
   jersey: "2.24",
+  jfreechart: "1.0.0",
   log4j: "1.2.17",
   jopt: "5.0.3",
   junit: "4.12",
@@ -46,7 +48,6 @@ versions += [
   snappy: "1.1.2.6",
   zkclient: "0.10",
   zookeeper: "3.4.10",
-  jfreechart: "1.0.0",
 ]
 
 // Add Scala version


### PR DESCRIPTION
(in order to prevent redundant jars from being bundled into kafka distribution)