### PR TITLE
KAFKA-5081: force version for 'jackson-annotations' in order to prevent redundant jars from being bundled into kafka distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ buildscript {
   }
 }
 
+apply from: "$rootDir/gradle/dependencies.gradle"
+
 allprojects {
   apply plugin: 'idea'
   apply plugin: "jacoco"
@@ -52,6 +54,13 @@ allprojects {
           if (rejected) {
             selection.reject('Release candidate')
           }
+        }
+      }
+    }
+    configurations {
+      runtime {
+        resolutionStrategy {
+          force "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson"
         }
       }
     }
@@ -91,7 +100,6 @@ ext {
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
 }
 
-apply from: "$rootDir/gradle/dependencies.gradle"
 apply from: file('wrapper.gradle')
 
 if (new File('.git').exists()) {


### PR DESCRIPTION
Long story short: prevent redundant jars from being bundled into kafka distribution.

(Inspired by this JIRA ticket: [KAFKA-5081](https://issues.apache.org/jira/browse/KAFKA-5081) **_two versions of jackson-annotations-xxx.jar in distribution tgz_**)