### PR TITLE
kafka-5118: Improve message for Kafka failed startup with non-Kafka data in data.dirs

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1362,13 +1362,16 @@ object Log {
 
     def exception(dir: File): KafkaException = {
       new KafkaException("Found directory " + dir.getCanonicalPath + ", " +
-        "'" + dir.getName + "' is not in the form of topic-partition\n" +
+        "'" + dir.getName + "' is not in the form of topic-partition or " +
+        "ongoing-deleting directory(topic-partition.uniqueId-delete)\n" +
         "If a directory does not contain Kafka topic data it should not exist in Kafka's log " +
         "directory")
     }
 
     val dirName = dir.getName
     if (dirName == null || dirName.isEmpty || !dirName.contains('-'))
+      throw exception(dir)
+    if (dirName.endsWith(DeleteDirSuffix) && !dirName.matches("^(\\S+)-(\\S+)\\.(\\S+)" + DeleteDirSuffix))
       throw exception(dir)
 
     val name: String =

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -23,6 +23,7 @@ import java.util.Properties
 
 import org.apache.kafka.common.errors._
 import kafka.api.ApiVersion
+import kafka.common.KafkaException
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 import kafka.utils._
@@ -1619,6 +1620,24 @@ class LogTest {
       fail("KafkaException should have been thrown for dir: " + dir.getCanonicalPath)
     } catch {
       case _: Exception => // its GOOD!
+    }
+  }
+
+  @Test
+  def testParseTopicPartitionNameForExistingInvalidDir() {
+    val dir1 = new File(logDir + "/non_kafka_dir")
+    try {
+      Log.parseTopicPartitionName(dir1)
+      fail("KafkaException should have been thrown for dir: " + dir1.getCanonicalPath)
+    } catch {
+      case _: KafkaException => // should only throw KafkaException
+    }
+    val dir2 = new File(logDir + "/non_kafka_dir-delete")
+    try {
+      Log.parseTopicPartitionName(dir2)
+      fail("KafkaException should have been thrown for dir: " + dir2.getCanonicalPath)
+    } catch {
+      case _: KafkaException => // should only throw KafkaException
     }
   }
 


### PR DESCRIPTION
Explicitly throwing clear exceptions when starting up a Kafka with some non-Kafka data in data.dirs.