### PR TITLE
KAFKA-4379 Followup: Avoid sending to changelog while restoring InMemoryLRUCache

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStore.java
@@ -55,7 +55,6 @@ public class InMemoryKeyValueLoggedStore<K, V> extends WrappedStateStore.Abstrac
 
         this.changeLogger = new StoreChangeLogger<>(inner.name(), context, serdes);
 
-
         // if the inner store is an LRU cache, add the eviction listener to log removed record
         if (inner instanceof MemoryLRUCache) {
             ((MemoryLRUCache<K, V>) inner).whenEldestRemoved(new MemoryNavigableLRUCache.EldestEntryRemovalListener<K, V>() {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreSupplier.java
@@ -37,7 +37,7 @@ public class InMemoryLRUCacheStoreSupplier<K, V> extends AbstractStoreSupplier<K
         this(name, capacity, keySerde, valueSerde, null, logged, logConfig);
     }
 
-    public InMemoryLRUCacheStoreSupplier(String name, int capacity, Serde<K> keySerde, Serde<V> valueSerde, Time time, boolean logged, Map<String, String> logConfig) {
+    private InMemoryLRUCacheStoreSupplier(String name, int capacity, Serde<K> keySerde, Serde<V> valueSerde, Time time, boolean logged, Map<String, String> logConfig) {
         super(name, keySerde, valueSerde, time, logged, logConfig);
         this.capacity = capacity;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -241,7 +241,22 @@ public class KeyValueStoreTestDriver<K, V> {
         props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, serdes.keySerde().getClass());
         props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, serdes.valueSerde().getClass());
 
-        context = new MockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, cache);
+        context = new MockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, cache) {
+            @Override
+            public StreamsMetrics metrics() {
+                return streamsMetrics;
+            }
+
+            @Override
+            public Map<String, Object> appConfigs() {
+                return new StreamsConfig(props).originals();
+            }
+
+            @Override
+            public Map<String, Object> appConfigsWithPrefix(final String prefix) {
+                return new StreamsConfig(props).originalsWithPrefix(prefix);
+            }
+        };
     }
 
     private void recordFlushed(final K key, final V value) {
@@ -262,7 +277,7 @@ public class KeyValueStoreTestDriver<K, V> {
      *
      * @return the restore entries; never null but possibly a null iterator
      */
-    public Iterable<KeyValue<K, V>> restoredEntries() {
+    public Iterable<KeyValue<byte[], byte[]>> restoredEntries() {
         return restorableEntries;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -158,6 +158,7 @@ public abstract class AbstractKeyValueStoreTest {
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
         store = createKeyValueStore(driver.context(), Integer.class, String.class, false);
+        context.restore(store.name(), driver.restoredEntries());
         // Verify that the store's contents were properly restored ...
         assertEquals(0, driver.checkForRestoredEntries(store));
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -153,7 +153,7 @@ public abstract class AbstractKeyValueStoreTest {
         driver.addEntryToRestoreLog(0, "zero");
         driver.addEntryToRestoreLog(1, "one");
         driver.addEntryToRestoreLog(2, "two");
-        driver.addEntryToRestoreLog(4, "four");
+        driver.addEntryToRestoreLog(3, "three");
 
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
@@ -173,7 +173,7 @@ public abstract class AbstractKeyValueStoreTest {
         driver.addEntryToRestoreLog(0, "zero");
         driver.addEntryToRestoreLog(1, "one");
         driver.addEntryToRestoreLog(2, "two");
-        driver.addEntryToRestoreLog(4, "four");
+        driver.addEntryToRestoreLog(3, "three");
 
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -53,6 +53,7 @@ public abstract class AbstractKeyValueStoreTest {
     public void after() {
         store.close();
         context.close();
+        driver.clear();
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -180,6 +180,7 @@ public abstract class AbstractKeyValueStoreTest {
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
         store = createKeyValueStore(driver.context(), Integer.class, String.class, true);
+        context.restore(store.name(), driver.restoredEntries());
         // Verify that the store's contents were properly restored ...
         assertEquals(0, driver.checkForRestoredEntries(store));
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -27,7 +27,8 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
     @Override
     protected <K, V> KeyValueStore<K, V> createKeyValueStore(
             ProcessorContext context,
-            Class<K> keyClass, Class<V> valueClass,
+            Class<K> keyClass,
+            Class<V> valueClass,
             boolean useContextSerdes) {
 
         StateStoreSupplier supplier;

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -39,6 +39,7 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
         KeyValueStore<K, V> store = (KeyValueStore<K, V>) supplier.get();
         store.init(context, store);
+        driver.restoreEntries();
         return store;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueStoreTest.java
@@ -39,7 +39,6 @@ public class InMemoryKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
         KeyValueStore<K, V> store = (KeyValueStore<K, V>) supplier.get();
         store.init(context, store);
-        driver.restoreEntries();
         return store;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
@@ -51,6 +51,7 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
 
         KeyValueStore<K, V> store = (KeyValueStore<K, V>) supplier.get();
         store.init(context, store);
+        driver.restoreEntries();
         return store;
     }
 
@@ -137,5 +138,32 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
         assertTrue(driver.flushedEntryRemoved(3));
         assertEquals(3, driver.numFlushedEntryRemoved());
     }
-    
+
+    @Test
+    public void testRestoreEvict() {
+        store.close();
+        // Add any entries that will be restored to any store
+        // that uses the driver's context ...
+        driver.addEntryToRestoreLog(0, "zero");
+        driver.addEntryToRestoreLog(1, "one");
+        driver.addEntryToRestoreLog(2, "two");
+        driver.addEntryToRestoreLog(3, "three");
+        driver.addEntryToRestoreLog(4, "four");
+        driver.addEntryToRestoreLog(5, "five");
+        driver.addEntryToRestoreLog(6, "fix");
+        driver.addEntryToRestoreLog(7, "seven");
+        driver.addEntryToRestoreLog(8, "eight");
+        driver.addEntryToRestoreLog(9, "nine");
+        driver.addEntryToRestoreLog(10, "ten");
+
+        // Create the store, which should register with the context and automatically
+        // receive the restore entries ...
+        store = createKeyValueStore(driver.context(), Integer.class, String.class, false);
+        // Verify that the store's changelog does not get more appends ...
+        assertEquals(0, driver.numFlushedEntryStored());
+        assertEquals(0, driver.numFlushedEntryRemoved());
+
+        // and there are no other entries ...
+        assertEquals(10, driver.sizeOf(store));
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
@@ -158,6 +158,7 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
         // Create the store, which should register with the context and automatically
         // receive the restore entries ...
         store = createKeyValueStore(driver.context(), Integer.class, String.class, false);
+        context.restore(store.name(), driver.restoredEntries());
         // Verify that the store's changelog does not get more appends ...
         assertEquals(0, driver.numFlushedEntryStored());
         assertEquals(0, driver.numFlushedEntryRemoved());

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryLRUCacheStoreTest.java
@@ -51,7 +51,6 @@ public class InMemoryLRUCacheStoreTest extends AbstractKeyValueStoreTest {
 
         KeyValueStore<K, V> store = (KeyValueStore<K, V>) supplier.get();
         store.init(context, store);
-        driver.restoreEntries();
         return store;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -38,6 +38,9 @@ import static org.junit.Assert.fail;
 
 public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
+    private final KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create(Integer.class, String.class);
+    private final MockProcessorContext context = (MockProcessorContext) driver.context();
+
     @SuppressWarnings("unchecked")
     @Override
     protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context,
@@ -62,7 +65,6 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
         final KeyValueStore<K, V> store = (KeyValueStore<K, V>) factory.build().get();
         store.init(context, store);
-        driver.restoreEntries();
         return store;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -16,16 +16,12 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.KeyValueStoreTestDriver;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.test.MockProcessorContext;
-import org.junit.After;
 import org.junit.Test;
 import org.rocksdb.Options;
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -38,9 +38,6 @@ import static org.junit.Assert.fail;
 
 public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
-    private final KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create(Integer.class, String.class);
-    private final MockProcessorContext context = (MockProcessorContext) driver.context();
-
     @SuppressWarnings("unchecked")
     @Override
     protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context,
@@ -65,6 +62,7 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
         final KeyValueStore<K, V> store = (KeyValueStore<K, V>) factory.build().get();
         store.init(context, store);
+        driver.restoreEntries();
         return store;
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreTest.java
@@ -38,9 +38,6 @@ import static org.junit.Assert.fail;
 
 public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
-    private final KeyValueStoreTestDriver<Integer, String> driver = KeyValueStoreTestDriver.create(Integer.class, String.class);
-    private final MockProcessorContext context = (MockProcessorContext) driver.context();
-
     @SuppressWarnings("unchecked")
     @Override
     protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context,
@@ -78,22 +75,13 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
         }
     }
 
-    @After
-    public void after() {
-        store.close();
-        context.close();
-    }
-
     @Test
     public void shouldUseCustomRocksDbConfigSetter() throws Exception {
-        driver.setConfig(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, TheRocksDbConfigSetter.class);
-        store = createKeyValueStore(driver.context(), Integer.class, String.class, false);
         assertTrue(TheRocksDbConfigSetter.called);
     }
 
     @Test
     public void shouldPerformRangeQueriesWithCachingDisabled() throws Exception {
-        store = createKeyValueStore(context, Integer.class, String.class, false);
         context.setTime(1L);
         store.put(1, "hi");
         store.put(2, "goodbye");
@@ -105,7 +93,6 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     @Test
     public void shouldPerformAllQueriesWithCachingDisabled() throws Exception {
-        store = createKeyValueStore(context, Integer.class, String.class, false);
         context.setTime(1L);
         store.put(1, "hi");
         store.put(2, "goodbye");
@@ -117,7 +104,6 @@ public class RocksDBKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     @Test
     public void shouldCloseOpenIteratorsWhenStoreClosedAndThrowInvalidStateStoreOnHasNextAndNext() throws Exception {
-        store = createKeyValueStore(context, Integer.class, String.class, false);
         context.setTime(1L);
         store.put(1, "hi");
         store.put(2, "goodbye");

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -257,12 +257,12 @@ public class MockProcessorContext implements InternalProcessorContext, RecordCol
 
     @Override
     public Map<String, Object> appConfigs() {
-        return new StreamsConfig(props).originals();
+        return Collections.emptyMap();
     }
 
     @Override
     public Map<String, Object> appConfigsWithPrefix(final String prefix) {
-        return new StreamsConfig(props).originalsWithPrefix(prefix);
+        return Collections.emptyMap();
     }
 
     @Override
@@ -299,5 +299,4 @@ public class MockProcessorContext implements InternalProcessorContext, RecordCol
     public void close() {
         metrics.close();
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
@@ -256,12 +257,12 @@ public class MockProcessorContext implements InternalProcessorContext, RecordCol
 
     @Override
     public Map<String, Object> appConfigs() {
-        return Collections.emptyMap();
+        return new StreamsConfig(props).originals();
     }
 
     @Override
     public Map<String, Object> appConfigsWithPrefix(final String prefix) {
-        return Collections.emptyMap();
+        return new StreamsConfig(props).originalsWithPrefix(prefix);
     }
 
     @Override
@@ -273,7 +274,7 @@ public class MockProcessorContext implements InternalProcessorContext, RecordCol
         return Collections.unmodifiableMap(storeMap);
     }
 
-    public void restore(final String storeName, final List<KeyValue<byte[], byte[]>> changeLog) {
+    public void restore(final String storeName, final Iterable<KeyValue<byte[], byte[]>> changeLog) {
         final StateRestoreCallback restoreCallback = restoreFuncs.get(storeName);
         for (final KeyValue<byte[], byte[]> entry : changeLog) {
             restoreCallback.restore(entry.key, entry.value);

--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;


### PR DESCRIPTION
1. Added a flag to indicate if it is restoring or not in the LRU Store; since we only have a restore callback we have to set it each time applying the change.
2. Fixed the corresponding unit test, plus some minor cleaning up.