### PR TITLE
MINOR: Improve information in assert failure for testMetricCollectionAfterShutdown

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -404,14 +404,14 @@ class SocketServerTest extends JUnitSuite {
   def testMetricCollectionAfterShutdown(): Unit = {
     server.shutdown()
 
-    val sum = YammerMetrics
+    val nonZeroMetricNamesAndValues = YammerMetrics
       .defaultRegistry
       .allMetrics.asScala
       .filterKeys(k => k.getName.endsWith("IdlePercent") || k.getName.endsWith("NetworkProcessorAvgIdlePercent"))
-      .collect { case (_, metric: Gauge[_]) => metric.value.asInstanceOf[Double] }
-      .sum
+      .collect { case (k, metric: Gauge[_]) => (k, metric.value().asInstanceOf[Double]) }
+      .filter { case (_, value) => value != 0.0 }
 
-    assertEquals(0, sum, 0)
+    assertEquals(Map.empty, nonZeroMetricNamesAndValues)
   }
 
 }


### PR DESCRIPTION
This test is failing consistently in https://jenkins.confluent.io/job/kafka-trunk/,
but nowhere else. I ran this branch in a clone of that job several times and this
test didn't fail. I suggest we merge this PR, which improves the test, to help us
gather more information about the test failure.