### PR TITLE
KAFKA-4994: Fix findbug warnings about OffsetStorageWriter

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
@@ -90,7 +90,7 @@ public class OffsetStorageWriter {
      * @param partition the partition to store an offset for
      * @param offset the offset
      */
-    public synchronized void offset(Map<String, ?> partition, Map<String, ?> offset) {
+    public void offset(Map<String, ?> partition, Map<String, ?> offset) {
         data.put((Map<String, Object>) partition, (Map<String, Object>) offset);
     }
 
@@ -104,7 +104,7 @@ public class OffsetStorageWriter {
      *
      * @return true if a flush was initiated, false if no data was available
      */
-    public synchronized boolean beginFlush() {
+    public boolean beginFlush() {
         if (flushing()) {
             log.error("Invalid call to OffsetStorageWriter flush() while already flushing, the "
                     + "framework should not allow this");
@@ -176,7 +176,7 @@ public class OffsetStorageWriter {
      * {@link #doFlush} has already been invoked. It should be used if an operation performed
      * between beginFlush and doFlush failed.
      */
-    public synchronized void cancelFlush() {
+    public void cancelFlush() {
         // Verify we're still flushing data to handle a race between cancelFlush() calls from up the
         // call stack and callbacks from the write request to underlying storage
         if (flushing()) {
@@ -192,7 +192,7 @@ public class OffsetStorageWriter {
      * Handle completion of a write. Returns true if this callback is for the current flush
      * operation, false if it's for an old operation that should now be ignored.
      */
-    private synchronized boolean handleFinishWrite(long flushId, Throwable error, Void result) {
+    private boolean handleFinishWrite(long flushId, Throwable error, Void result) {
         // Callbacks need to be handled carefully since the flush operation may have already timed
         // out and been cancelled.
         if (flushId != currentFlushId)


### PR DESCRIPTION
OffsetStorageWriter is not a thread-safe class and should be accessed
only from a Task's processing thread. The WorkerSourceTask class calls
the different methods (offset, beginFlush, cancelFlush, handleFinishWrite)
within a synchronized block. Hence the method definitions in
OffsetStorageWriter.java does not need to contain the keyword synchronized
again.

In the OffsetStorageWriter.java class, the doFlush() method is not explicitely
synchronized like the other methods in this class. Hence this can lead to
inconsistent synchronization of variables like currentFlushId and toFlush which
are set in the synchronized methods within this class.
- https://github.com/apache/kafka/blob/trunk/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageWriter.java
- https://github.com/apache/kafka/blob/trunk/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java#L295
