### PR TITLE
KAFKA-5005: IntegrationTestUtils Consumers need to run from earliest offset

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -209,7 +209,6 @@ public class StreamThread extends Thread {
     final StateDirectory stateDirectory;
     private String originalReset;
     private StreamPartitionAssignor partitionAssignor;
-    private boolean cleanRun = false;
     private long timerStartedMs;
     private long lastCleanMs;
     private long lastCommitMs;
@@ -325,7 +324,6 @@ public class StreamThread extends Thread {
 
         try {
             runLoop();
-            cleanRun = true;
         } catch (final KafkaException e) {
             // just re-throw the exception as it should be logged already
             throw e;

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableJoinIntegrationTest.java
@@ -107,7 +107,6 @@ public class KTableKTableJoinIntegrationTest {
         IntegrationTestUtils.produceKeyValuesSynchronously(TABLE_1, table1, producerConfig, MOCK_TIME);
         IntegrationTestUtils.produceKeyValuesSynchronously(TABLE_2, table2, producerConfig, MOCK_TIME);
 
-
         CONSUMER_CONFIG.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         CONSUMER_CONFIG.put(ConsumerConfig.GROUP_ID_CONFIG, "ktable-ktable-consumer");
         CONSUMER_CONFIG.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableJoinIntegrationTest.java
@@ -112,7 +112,6 @@ public class KTableKTableJoinIntegrationTest {
         CONSUMER_CONFIG.put(ConsumerConfig.GROUP_ID_CONFIG, "ktable-ktable-consumer");
         CONSUMER_CONFIG.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         CONSUMER_CONFIG.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        CONSUMER_CONFIG.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     }
 
     @Before

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -21,6 +21,7 @@ import kafka.api.Request;
 import kafka.server.KafkaServer;
 import kafka.server.MetadataCache;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -57,62 +58,12 @@ public class IntegrationTestUtils {
     public static final String INTERNAL_LEAVE_GROUP_ON_CLOSE = "internal.leave.group.on.close";
 
     /**
-     * Returns up to `maxMessages` message-values from the topic.
-     *
-     * @param topic          Kafka topic to read messages from
-     * @param consumerConfig Kafka consumer configuration
-     * @param waitTime       Maximum wait time in milliseconds
-     * @param maxMessages    Maximum number of messages to read via the consumer.
-     * @return The values retrieved via the consumer.
-     */
-    public static <V> List<V> readValues(final String topic, final Properties consumerConfig, final long waitTime, final int maxMessages) {
-        final List<V> returnList = new ArrayList<>();
-        final List<KeyValue<Object, V>> kvs = readKeyValues(topic, consumerConfig, waitTime, maxMessages);
-        for (final KeyValue<?, V> kv : kvs) {
-            returnList.add(kv.value);
-        }
-        return returnList;
-    }
-
-    /**
-     * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from
-     * are already configured in the consumer).
-     *
-     * @param topic          Kafka topic to read messages from
-     * @param consumerConfig Kafka consumer configuration
-     * @param waitTime       Maximum wait time in milliseconds
-     * @param maxMessages    Maximum number of messages to read via the consumer
-     * @return The KeyValue elements retrieved via the consumer
-     */
-    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic, final Properties consumerConfig, final long waitTime, final int maxMessages) {
-        final List<KeyValue<K, V>> consumedValues;
-        try (Consumer<K, V> consumer = new KafkaConsumer<>(consumerConfig)) {
-            consumer.subscribe(Collections.singletonList(topic));
-            final int pollIntervalMs = 100;
-            consumedValues = new ArrayList<>();
-            int totalPollTimeMs = 0;
-            while (totalPollTimeMs < waitTime && continueConsuming(consumedValues.size(), maxMessages)) {
-                totalPollTimeMs += pollIntervalMs;
-                final ConsumerRecords<K, V> records = consumer.poll(pollIntervalMs);
-                for (final ConsumerRecord<K, V> record : records) {
-                    consumedValues.add(new KeyValue<>(record.key(), record.value()));
-                }
-            }
-        }
-
-        return consumedValues;
-    }
-
-    private static boolean continueConsuming(final int messagesConsumed, final int maxMessages) {
-        return maxMessages <= 0 || messagesConsumed < maxMessages;
-    }
-
-    /**
      * Removes local state stores.  Useful to reset state in-between integration test runs.
      *
      * @param streamsConfiguration Streams configuration settings
      */
-    public static void purgeLocalStreamsState(final Properties streamsConfiguration) throws IOException {
+    public static void purgeLocalStreamsState(final Properties streamsConfiguration) throws
+        IOException {
         final String tmpDir = TestUtils.IO_TMP_DIR.getPath();
         final String path = streamsConfiguration.getProperty(StreamsConfig.STATE_DIR_CONFIG);
         if (path != null) {
@@ -193,20 +144,21 @@ public class IntegrationTestUtils {
                                                                                   final int expectedNumRecords,
                                                                                   final long waitTime) throws InterruptedException {
         final List<KeyValue<K, V>> accumData = new ArrayList<>();
-
-        final TestCondition valuesRead = new TestCondition() {
-            @Override
-            public boolean conditionMet() {
-                final List<KeyValue<K, V>> readData = readKeyValues(topic, consumerConfig, waitTime, expectedNumRecords);
-                accumData.addAll(readData);
-                return accumData.size() >= expectedNumRecords;
-            }
-        };
-
-        final String conditionDetails = "Expecting " + expectedNumRecords + " records from topic " + topic + " while only received " + accumData.size() + ": " + accumData;
-
-        TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
-
+        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
+            final TestCondition valuesRead = new TestCondition() {
+                @Override
+                public boolean conditionMet() {
+                    final List<KeyValue<K, V>> readData =
+                        readKeyValues(topic, consumer, waitTime, expectedNumRecords);
+                    accumData.addAll(readData);
+                    return accumData.size() >= expectedNumRecords;
+                }
+            };
+            final String conditionDetails =
+                "Expecting " + expectedNumRecords + " records from topic " + topic +
+                    " while only received " + accumData.size() + ": " + accumData;
+            TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
+        }
         return accumData;
     }
 
@@ -233,21 +185,21 @@ public class IntegrationTestUtils {
                                                                 final int expectedNumRecords,
                                                                 final long waitTime) throws InterruptedException {
         final List<V> accumData = new ArrayList<>();
-
-        final TestCondition valuesRead = new TestCondition() {
-            @Override
-            public boolean conditionMet() {
-                final List<V> readData = readValues(topic, consumerConfig, waitTime, expectedNumRecords);
-                accumData.addAll(readData);
-
-                return accumData.size() >= expectedNumRecords;
-            }
-        };
-
-        final String conditionDetails = "Expecting " + expectedNumRecords + " records from topic " + topic + " while only received " + accumData.size() + ": " + accumData;
-
-        TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
-
+        try (final Consumer<Object, V> consumer = createConsumer(consumerConfig)) {
+            final TestCondition valuesRead = new TestCondition() {
+                @Override
+                public boolean conditionMet() {
+                    final List<V> readData =
+                        readValues(topic, consumer, waitTime, expectedNumRecords);
+                    accumData.addAll(readData);
+                    return accumData.size() >= expectedNumRecords;
+                }
+            };
+            final String conditionDetails =
+                "Expecting " + expectedNumRecords + " records from topic " + topic +
+                    " while only received " + accumData.size() + ": " + accumData;
+            TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
+        }
         return accumData;
     }
 
@@ -287,5 +239,61 @@ public class IntegrationTestUtils {
             }
         }, timeout, "metadata for topic=" + topic + " partition=" + partition + " not propagated to all brokers");
 
+    }
+
+    /**
+     * Returns up to `maxMessages` message-values from the topic.
+     *
+     * @param topic          Kafka topic to read messages from
+     * @param consumer       Kafka consumer
+     * @param waitTime       Maximum wait time in milliseconds
+     * @param maxMessages    Maximum number of messages to read via the consumer.
+     * @return The values retrieved via the consumer.
+     */
+    private static <V> List<V> readValues(final String topic, final Consumer<Object, V> consumer, final long waitTime, final int maxMessages) {
+        final List<V> returnList = new ArrayList<>();
+        final List<KeyValue<Object, V>> kvs = readKeyValues(topic, consumer, waitTime, maxMessages);
+        for (final KeyValue<?, V> kv : kvs) {
+            returnList.add(kv.value);
+        }
+        return returnList;
+    }
+
+    /**
+     * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from
+     * are already configured in the consumer).
+     *
+     * @param topic          Kafka topic to read messages from
+     * @param consumer       Kafka consumer
+     * @param waitTime       Maximum wait time in milliseconds
+     * @param maxMessages    Maximum number of messages to read via the consumer
+     * @return The KeyValue elements retrieved via the consumer
+     */
+    private static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic,
+        final Consumer<K, V> consumer, final long waitTime, final int maxMessages) {
+        final List<KeyValue<K, V>> consumedValues;
+        consumer.subscribe(Collections.singletonList(topic));
+        final int pollIntervalMs = 100;
+        consumedValues = new ArrayList<>();
+        int totalPollTimeMs = 0;
+        while (totalPollTimeMs < waitTime &&
+            continueConsuming(consumedValues.size(), maxMessages)) {
+            totalPollTimeMs += pollIntervalMs;
+            final ConsumerRecords<K, V> records = consumer.poll(pollIntervalMs);
+            for (final ConsumerRecord<K, V> record : records) {
+                consumedValues.add(new KeyValue<>(record.key(), record.value()));
+            }
+        }
+        return consumedValues;
+    }
+
+    private static boolean continueConsuming(final int messagesConsumed, final int maxMessages) {
+        return maxMessages <= 0 || messagesConsumed < maxMessages;
+    }
+
+    private static <K, V> KafkaConsumer<K, V> createConsumer(final Properties consumerConfig) {
+        final Properties filtered = new Properties(consumerConfig);
+        filtered.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        return new KafkaConsumer<>(filtered);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -291,9 +291,18 @@ public class IntegrationTestUtils {
         return maxMessages <= 0 || messagesConsumed < maxMessages;
     }
 
+    /**
+     * Sets up a {@link KafkaConsumer} from a copy of the given configuration that has
+     * {@link ConsumerConfig#AUTO_OFFSET_RESET_CONFIG} set to "earliest" and {@link ConsumerConfig#ENABLE_AUTO_COMMIT_CONFIG}
+     * set to "true" to prevent missing events as well as repeat consumption.
+     * @param consumerConfig Consumer configuration
+     * @return Consumer
+     */
     private static <K, V> KafkaConsumer<K, V> createConsumer(final Properties consumerConfig) {
-        final Properties filtered = new Properties(consumerConfig);
-        filtered.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        final Properties filtered = new Properties();
+        filtered.putAll(consumerConfig);
+        filtered.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        filtered.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
         return new KafkaConsumer<>(filtered);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -86,7 +86,7 @@ public class IntegrationTestUtils {
      */
     public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic, final Properties consumerConfig, final long waitTime, final int maxMessages) {
         final List<KeyValue<K, V>> consumedValues;
-        try (Consumer<K,V> consumer = new KafkaConsumer<>(consumerConfig)) {
+        try (Consumer<K, V> consumer = new KafkaConsumer<>(consumerConfig)) {
             consumer.subscribe(Collections.singletonList(topic));
             final int pollIntervalMs = 100;
             consumedValues = new ArrayList<>();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -245,6 +245,43 @@ public class IntegrationTestUtils {
      * Returns up to `maxMessages` message-values from the topic.
      *
      * @param topic          Kafka topic to read messages from
+     * @param consumerConfig Kafka consumer config
+     * @param waitTime       Maximum wait time in milliseconds
+     * @param maxMessages    Maximum number of messages to read via the consumer.
+     * @return The values retrieved via the consumer.
+     */
+    public static <V> List<V> readValues(final String topic, final Properties consumerConfig,
+        final long waitTime, final int maxMessages) {
+        final List<V> returnList;
+        try (final Consumer<Object, V> consumer = createConsumer(consumerConfig)) {
+            returnList = readValues(topic, consumer, waitTime, maxMessages);
+        }
+        return returnList;
+    }
+
+    /**
+     * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from
+     * are already configured in the consumer).
+     *
+     * @param topic          Kafka topic to read messages from
+     * @param consumerConfig Kafka consumer config
+     * @param waitTime       Maximum wait time in milliseconds
+     * @param maxMessages    Maximum number of messages to read via the consumer
+     * @return The KeyValue elements retrieved via the consumer
+     */
+    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic,
+        final Properties consumerConfig, final long waitTime, final int maxMessages) {
+        final List<KeyValue<K, V>> consumedValues;
+        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
+            consumedValues = readKeyValues(topic, consumer, waitTime, maxMessages);
+        }
+        return consumedValues;
+    }
+
+    /**
+     * Returns up to `maxMessages` message-values from the topic.
+     *
+     * @param topic          Kafka topic to read messages from
      * @param consumer       Kafka consumer
      * @param waitTime       Maximum wait time in milliseconds
      * @param maxMessages    Maximum number of messages to read via the consumer.


### PR DESCRIPTION
* Producer and Consumer `close` calls were not handled via `try-with-resources`
* `cleanRun` unused field removed
* Refactored handling of Consumer configuration in `IntegrationTestUtils` to ensure auto-committing of offsets and starting from `earliest`
  * As a result reverted https://github.com/apache/kafka/pull/2921 since it's redundant now