### PR TITLE
KAFKA-5136: move coordinatorEpoch from WriteTxnMarkerRequest to TxnMarkerEntry

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -1358,13 +1358,13 @@ public class Protocol {
                     new ArrayOf(new Schema(
                             new Field("topic", STRING),
                             new Field("partitions", new ArrayOf(INT32)))),
-                    "The partitions to write markers for.")
+                    "The partitions to write markers for."),
+            new Field("coordinator_epoch",
+                      INT32,
+                      "Epoch associated with the transaction state partition hosted by this transaction coordinator")
     );
 
     public static final Schema WRITE_TXN_MARKERS_REQUEST_V0 = new Schema(
-            new Field("coordinator_epoch",
-                    INT32,
-                    "Epoch associated with the transaction state partition hosted by this transaction coordinator."),
             new Field("transaction_markers",
                     new ArrayOf(WRITE_TXN_MARKERS_ENTRY_V0),
                     "The transaction markers to be written.")

--- a/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/WriteTxnMarkersRequest.java
@@ -43,12 +43,18 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
     public static class TxnMarkerEntry {
         private final long producerId;
         private final short producerEpoch;
+        private final int coordinatorEpoch;
         private final TransactionResult result;
         private final List<TopicPartition> partitions;
 
-        public TxnMarkerEntry(long producerId, short producerEpoch, TransactionResult result, List<TopicPartition> partitions) {
+        public TxnMarkerEntry(long producerId,
+                              short producerEpoch,
+                              int coordinatorEpoch,
+                              TransactionResult result,
+                              List<TopicPartition> partitions) {
             this.producerId = producerId;
             this.producerEpoch = producerEpoch;
+            this.coordinatorEpoch = coordinatorEpoch;
             this.result = result;
             this.partitions = partitions;
         }
@@ -59,6 +65,10 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
 
         public short producerEpoch() {
             return producerEpoch;
+        }
+
+        public int coordinatorEpoch() {
+            return coordinatorEpoch;
         }
 
         public TransactionResult transactionResult() {
@@ -73,8 +83,9 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
         @Override
         public String toString() {
             return "TxnMarkerEntry{" +
-                    "pid=" + producerId +
-                    ", epoch=" + producerEpoch +
+                    "producerId=" + producerId +
+                    ", producerEpoch=" + producerEpoch +
+                    ", coordinatorEpoch=" + coordinatorEpoch +
                     ", result=" + result +
                     ", partitions=" + partitions +
                     '}';
@@ -87,47 +98,41 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
             final TxnMarkerEntry that = (TxnMarkerEntry) o;
             return producerId == that.producerId &&
                     producerEpoch == that.producerEpoch &&
+                    coordinatorEpoch == that.coordinatorEpoch &&
                     result == that.result &&
                     Objects.equals(partitions, that.partitions);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(producerId, producerEpoch, result, partitions);
+            return Objects.hash(producerId, producerEpoch, coordinatorEpoch, result, partitions);
         }
     }
 
     public static class Builder extends AbstractRequest.Builder<WriteTxnMarkersRequest> {
-        private final int coordinatorEpoch;
         private final List<TxnMarkerEntry> markers;
 
-        public Builder(int coordinatorEpoch, List<TxnMarkerEntry> markers) {
+        public Builder(List<TxnMarkerEntry> markers) {
             super(ApiKeys.WRITE_TXN_MARKERS);
-
             this.markers = markers;
-            this.coordinatorEpoch = coordinatorEpoch;
         }
 
         @Override
         public WriteTxnMarkersRequest build(short version) {
-            return new WriteTxnMarkersRequest(version, coordinatorEpoch, markers);
+            return new WriteTxnMarkersRequest(version, markers);
         }
     }
 
-    private final int coordinatorEpoch;
     private final List<TxnMarkerEntry> markers;
 
-    private WriteTxnMarkersRequest(short version, int coordinatorEpoch, List<TxnMarkerEntry> markers) {
+    private WriteTxnMarkersRequest(short version, List<TxnMarkerEntry> markers) {
         super(version);
 
         this.markers = markers;
-        this.coordinatorEpoch = coordinatorEpoch;
     }
 
     public WriteTxnMarkersRequest(Struct struct, short version) {
         super(version);
-        this.coordinatorEpoch = struct.getInt(COORDINATOR_EPOCH_KEY_NAME);
-
         List<TxnMarkerEntry> markers = new ArrayList<>();
         Object[] markersArray = struct.getArray(TXN_MARKER_ENTRY_KEY_NAME);
         for (Object markerObj : markersArray) {
@@ -135,6 +140,7 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
 
             long producerId = markerStruct.getLong(PID_KEY_NAME);
             short producerEpoch = markerStruct.getShort(EPOCH_KEY_NAME);
+            int coordinatorEpoch = markerStruct.getInt(COORDINATOR_EPOCH_KEY_NAME);
             TransactionResult result = TransactionResult.forId(markerStruct.getBoolean(TRANSACTION_RESULT_KEY_NAME));
 
             List<TopicPartition> partitions = new ArrayList<>();
@@ -147,15 +153,12 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
                 }
             }
 
-            markers.add(new TxnMarkerEntry(producerId, producerEpoch, result, partitions));
+            markers.add(new TxnMarkerEntry(producerId, producerEpoch, coordinatorEpoch, result, partitions));
         }
 
         this.markers = markers;
     }
 
-    public int coordinatorEpoch() {
-        return coordinatorEpoch;
-    }
 
     public List<TxnMarkerEntry> markers() {
         return markers;
@@ -164,7 +167,6 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
     @Override
     protected Struct toStruct() {
         Struct struct = new Struct(ApiKeys.WRITE_TXN_MARKERS.requestSchema(version()));
-        struct.set(COORDINATOR_EPOCH_KEY_NAME, coordinatorEpoch);
 
         Object[] markersArray = new Object[markers.size()];
         int i = 0;
@@ -172,6 +174,7 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
             Struct markerStruct = struct.instance(TXN_MARKER_ENTRY_KEY_NAME);
             markerStruct.set(PID_KEY_NAME, entry.producerId);
             markerStruct.set(EPOCH_KEY_NAME, entry.producerEpoch);
+            markerStruct.set(COORDINATOR_EPOCH_KEY_NAME, entry.coordinatorEpoch);
             markerStruct.set(TRANSACTION_RESULT_KEY_NAME, entry.result.id);
 
             Map<String, List<Integer>> mappedPartitions = CollectionUtils.groupDataByTopic(entry.partitions);
@@ -216,12 +219,11 @@ public class WriteTxnMarkersRequest extends AbstractRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final WriteTxnMarkersRequest that = (WriteTxnMarkersRequest) o;
-        return coordinatorEpoch == that.coordinatorEpoch &&
-                Objects.equals(markers, that.markers);
+        return Objects.equals(markers, that.markers);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(coordinatorEpoch, markers);
+        return Objects.hash(markers);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -891,9 +891,9 @@ public class RequestResponseTest {
     }
 
     private WriteTxnMarkersRequest createWriteTxnMarkersRequest() {
-        return new WriteTxnMarkersRequest.Builder(73,
-            Collections.singletonList(new WriteTxnMarkersRequest.TxnMarkerEntry(21L, (short) 42, TransactionResult.ABORT,
-                Collections.singletonList(new TopicPartition("topic", 73))))).build();
+        return new WriteTxnMarkersRequest.Builder(
+            Collections.singletonList(new WriteTxnMarkersRequest.TxnMarkerEntry(21L, (short) 42, 73, TransactionResult.ABORT,
+                                                                                Collections.singletonList(new TopicPartition("topic", 73))))).build();
     }
 
     private WriteTxnMarkersResponse createWriteTxnMarkersResponse() {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannel.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannel.scala
@@ -52,8 +52,7 @@ class TransactionMarkerChannel(interBrokerListenerName: ListenerName,
     }
 
     def maybeUpdateNode(node: Node): Unit = {
-      if (!destination.equals(node))
-        destination = node
+      destination = node
     }
 
     def addRequests(txnTopicPartition: Int, txnMarkerEntry: TxnMarkerEntry): Unit = {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannel.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannel.scala
@@ -62,14 +62,14 @@ class TransactionMarkerChannel(interBrokerListenerName: ListenerName,
     }
 
     def eachMetadataPartition[B](f:(Int, BlockingQueue[TxnMarkerEntry]) => B): mutable.Iterable[B] =
-      requestsPerMetadataPartition.filter{case(_, queue:BlockingQueue[TxnMarkerEntry]) => !queue.isEmpty}
+      requestsPerMetadataPartition.filter{ case(_, queue) => !queue.isEmpty}
         .map{case(partition:Int, queue:BlockingQueue[TxnMarkerEntry]) => f(partition, queue)}
 
 
     def node: Node = destination
 
     def totalQueuedRequests(): Int =
-      requestsPerMetadataPartition.map {case(_, queue:BlockingQueue[TxnMarkerEntry]) => queue.size()}
+      requestsPerMetadataPartition.map { case(_, queue) => queue.size()}
         .sum
 
   }
@@ -88,7 +88,7 @@ class TransactionMarkerChannel(interBrokerListenerName: ListenerName,
   private[transaction]
   def drainQueuedTransactionMarkers(txnMarkerPurgatory: DelayedOperationPurgatory[DelayedTxnMarker]): Iterable[RequestAndCompletionHandler] = {
     brokerStateMap.flatMap {case (brokerId: Int, brokerRequestQueue: BrokerRequestQueue) =>
-      brokerRequestQueue.eachMetadataPartition{ case(partitionId:Int, queue:BlockingQueue[TxnMarkerEntry]) =>
+      brokerRequestQueue.eachMetadataPartition{ case(partitionId, queue) =>
         val markersToSend: java.util.List[TxnMarkerEntry] = new util.ArrayList[TxnMarkerEntry]()
         queue.drainTo(markersToSend)
         val requestCompletionHandler = new TransactionMarkerRequestCompletionHandler(this, txnMarkerPurgatory, partitionId, markersToSend, brokerId)
@@ -173,7 +173,7 @@ class TransactionMarkerChannel(interBrokerListenerName: ListenerName,
   }
 
   def removeStateForPartition(partition: Int): mutable.Iterable[Long] = {
-    brokerStateMap.foreach {case(_, brokerQueue: BrokerRequestQueue) =>
+    brokerStateMap.foreach { case(_, brokerQueue) =>
       brokerQueue.removeRequestsForPartition(partition)
     }
     pendingTxnMap.filter { case (key: PendingTxnKey, _) => key.metadataPartition == partition }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -16,7 +16,6 @@
  */
 package kafka.coordinator.transaction
 
-import java.util
 
 import kafka.common.{InterBrokerSendThread, RequestAndCompletionHandler}
 import kafka.server.{DelayedOperationPurgatory, KafkaConfig, MetadataCache}
@@ -24,19 +23,13 @@ import kafka.utils.Logging
 import org.apache.kafka.clients._
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.network._
-import org.apache.kafka.common.requests.{TransactionResult, WriteTxnMarkersRequest}
+import org.apache.kafka.common.requests.TransactionResult
 import org.apache.kafka.common.security.JaasContext
 import org.apache.kafka.common.utils.Time
-import org.apache.kafka.common.Node
-
-import java.util.concurrent.BlockingQueue
 
 import org.apache.kafka.common.protocol.Errors
 
 import collection.JavaConverters._
-
-case class CoordinatorEpochAndMarkers(metadataPartition: Int, coordinatorEpoch: Int, txnMarkerEntries: util.List[WriteTxnMarkersRequest.TxnMarkerEntry])
-case class DestinationBrokerAndQueuedMarkers(destBrokerNode: Node, markersQueue: BlockingQueue[CoordinatorEpochAndMarkers])
 
 object TransactionMarkerChannelManager {
   def apply(config: KafkaConfig,

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -114,10 +114,10 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
   }
 
 
-  def addTxnMarkerRequest(coordinatorPartition: Int, metadata: TransactionMetadata, coordinatorEpoch: Int, completionCallback: WriteTxnMarkerCallback): Unit = {
+  def addTxnMarkerRequest(txnTopicPartition: Int, metadata: TransactionMetadata, coordinatorEpoch: Int, completionCallback: WriteTxnMarkerCallback): Unit = {
     val metadataToWrite = metadata synchronized metadata.copy()
 
-    if (!transactionMarkerChannel.maybeAddPendingRequest(coordinatorPartition, metadata))
+    if (!transactionMarkerChannel.maybeAddPendingRequest(txnTopicPartition, metadata))
       // TODO: Not sure this is the correct response here?
       completionCallback(Errors.INVALID_TXN_STATE)
     else {
@@ -129,7 +129,7 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
         case PrepareAbort => TransactionResult.ABORT
         case s => throw new IllegalStateException("Unexpected txn metadata state while writing markers: " + s)
       }
-      transactionMarkerChannel.addRequestToSend(coordinatorPartition,
+      transactionMarkerChannel.addRequestToSend(txnTopicPartition,
         metadataToWrite.pid,
         metadataToWrite.producerEpoch,
         result,
@@ -138,8 +138,8 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
     }
   }
 
-  def removeCompleted(metadataPartition: Int, pid: Long): Unit = {
-    transactionMarkerChannel.removeCompletedTxn(metadataPartition, pid)
+  def removeCompleted(txnTopicPartition: Int, pid: Long): Unit = {
+    transactionMarkerChannel.removeCompletedTxn(txnTopicPartition, pid)
   }
 
   def removeStateForPartition(transactionStateTopicPartitionId: Int): Unit = {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
@@ -30,20 +30,21 @@ import collection.JavaConversions._
 
 class TransactionMarkerRequestCompletionHandler(transactionMarkerChannel: TransactionMarkerChannel,
                                                 txnMarkerPurgatory: DelayedOperationPurgatory[DelayedTxnMarker],
-                                                epochAndMarkers: CoordinatorEpochAndMarkers,
+                                                metadataPartition: Int,
+                                                txnMarkerEntries: java.util.List[TxnMarkerEntry],
                                                 brokerId: Int) extends RequestCompletionHandler with Logging {
   override def onComplete(response: ClientResponse): Unit = {
     val correlationId = response.requestHeader.correlationId
     if (response.wasDisconnected) {
       trace(s"Cancelled request $response due to node ${response.destination} being disconnected")
       // re-enqueue the markers
-      for (txnMarker: TxnMarkerEntry <- epochAndMarkers.txnMarkerEntries) {
+      for (txnMarker: TxnMarkerEntry <- txnMarkerEntries) {
         transactionMarkerChannel.addRequestToSend(
-          epochAndMarkers.metadataPartition,
+          metadataPartition,
           txnMarker.producerId(),
           txnMarker.producerEpoch(),
           txnMarker.transactionResult(),
-          epochAndMarkers.coordinatorEpoch,
+          txnMarker.coordinatorEpoch(),
           txnMarker.partitions().toSet)
       }
     } else {
@@ -51,7 +52,7 @@ class TransactionMarkerRequestCompletionHandler(transactionMarkerChannel: Transa
 
       val writeTxnMarkerResponse = response.responseBody.asInstanceOf[WriteTxnMarkersResponse]
 
-      for (txnMarker: TxnMarkerEntry <- epochAndMarkers.txnMarkerEntries) {
+      for (txnMarker: TxnMarkerEntry <- txnMarkerEntries) {
         val errors = writeTxnMarkerResponse.errors(txnMarker.producerId())
 
         if (errors == null)
@@ -61,10 +62,10 @@ class TransactionMarkerRequestCompletionHandler(transactionMarkerChannel: Transa
         for ((topicPartition: TopicPartition, error: Errors) <- errors) {
           error match {
             case Errors.NONE =>
-              transactionMarkerChannel.pendingTxnMetadata(epochAndMarkers.metadataPartition, txnMarker.producerId()) match {
+              transactionMarkerChannel.pendingTxnMetadata(metadataPartition, txnMarker.producerId()) match {
                 case None =>
                   // TODO: probably need to respond with Errors.NOT_COORDINATOR
-                  throw new IllegalArgumentException(s"transaction metadata not found during write txn marker request. partition ${epochAndMarkers.metadataPartition} has likely emigrated")
+                  throw new IllegalArgumentException(s"transaction metadata not found during write txn marker request. partition ${metadataPartition} has likely emigrated")
                 case Some(metadata) =>
                   // do not synchronize on this metadata since it will only be accessed by the sender thread
                   metadata.topicPartitions -= topicPartition
@@ -79,11 +80,11 @@ class TransactionMarkerRequestCompletionHandler(transactionMarkerChannel: Transa
           if (retryPartitions.nonEmpty) {
             // re-enqueue with possible new leaders of the partitions
             transactionMarkerChannel.addRequestToSend(
-              epochAndMarkers.metadataPartition,
+              metadataPartition,
               txnMarker.producerId(),
               txnMarker.producerEpoch(),
               txnMarker.transactionResult,
-              epochAndMarkers.coordinatorEpoch,
+              txnMarker.coordinatorEpoch(),
               retryPartitions.toSet)
           }
           val completed = txnMarkerPurgatory.checkAndComplete(txnMarker.producerId())


### PR DESCRIPTION
Moving the coordinatorEpoch from WriteTxnMarkerRequest to TxnMarkerEntry will generate fewer broker send requests