### PR TITLE
MINOR: Fix some lgtm.com alerts, ensuring certain input/output resources are closed.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
@@ -383,8 +383,7 @@ public final class LegacyRecord {
                               ByteBuffer value,
                               CompressionType compressionType,
                               TimestampType timestampType) {
-        try {
-            DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer));
+        try (DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer))) {
             write(out, magic, timestamp, key, value, compressionType, timestampType);
         } catch (IOException e) {
             throw new KafkaException(e);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -69,8 +69,7 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
 
     @SuppressWarnings("unchecked")
     private void load() {
-        try {
-            ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
+        try (ObjectInputStream is = new ObjectInputStream(new FileInputStream(file))) {
             Object obj = is.readObject();
             if (!(obj instanceof HashMap))
                 throw new ConnectException("Expected HashMap but found " + obj.getClass());
@@ -81,7 +80,6 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
                 ByteBuffer value = (mapEntry.getValue() != null) ? ByteBuffer.wrap(mapEntry.getValue()) : null;
                 data.put(key, value);
             }
-            is.close();
         } catch (FileNotFoundException | EOFException e) {
             // FileNotFoundException: Ignore, may be new.
             // EOFException: Ignore, this means the file was missing or corrupt

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -89,8 +89,10 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
     }
 
     protected void save() {
-        try {
-            ObjectOutputStream os = new ObjectOutputStream(new FileOutputStream(file));
+        try (
+                FileOutputStream fos = new FileOutputStream(file);
+                ObjectOutputStream os = new ObjectOutputStream(fos)
+        ) {
             Map<byte[], byte[]> raw = new HashMap<>();
             for (Map.Entry<ByteBuffer, ByteBuffer> mapEntry : data.entrySet()) {
                 byte[] key = (mapEntry.getKey() != null) ? mapEntry.getKey().array() : null;
@@ -98,7 +100,6 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
                 raw.put(key, value);
             }
             os.writeObject(raw);
-            os.close();
         } catch (IOException e) {
             throw new ConnectException(e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -144,7 +144,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
                 new KeyValueMapper<K, V, KeyValue<K1, V>>() {
                     @Override
                     public KeyValue<K1, V> apply(K key, V value) {
-                        return new KeyValue<>(mapper.apply(key, value), value);
+                        return new KeyValue<K1, V>(mapper.apply(key, value), value);
                     }
                 }
             ),
@@ -224,9 +224,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         }
         String name = topology.newName(PRINTING_NAME);
         streamName = (streamName == null) ? this.name : streamName;
-        try {
-            PrintWriter printWriter = null;
-            printWriter = new PrintWriter(filePath, StandardCharsets.UTF_8.name());
+        try (PrintWriter printWriter = new PrintWriter(filePath, StandardCharsets.UTF_8.name())) {
             topology.addProcessor(name, new KeyValuePrinter<>(printWriter, keySerde, valSerde, streamName), this.name);
         } catch (FileNotFoundException | UnsupportedEncodingException e) {
             String message = "Unable to write stream to file at [" + filePath + "] " + e.getMessage();

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -170,8 +170,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
         }
         String name = topology.newName(PRINTING_NAME);
         streamName = (streamName == null) ? this.name : streamName;
-        try {
-            PrintWriter printWriter = new PrintWriter(filePath, StandardCharsets.UTF_8.name());
+        try (PrintWriter printWriter = new PrintWriter(filePath, StandardCharsets.UTF_8.name())) {
             topology.addProcessor(name, new KeyValuePrinter<>(printWriter, keySerde, valSerde, streamName), this.name);
         } catch (FileNotFoundException | UnsupportedEncodingException e) {
             String message = "Unable to write stream to file at [" + filePath + "] " + e.getMessage();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -120,9 +120,11 @@ public class AssignmentInfo {
     public static AssignmentInfo decode(ByteBuffer data) {
         // ensure we are at the beginning of the ByteBuffer
         data.rewind();
-        DataInputStream in = new DataInputStream(new ByteBufferInputStream(data));
-
-        try {
+        
+        try (
+            ByteBufferInputStream bbis = new ByteBufferInputStream(data);
+            DataInputStream in = new DataInputStream(bbis)
+        ) {
             // Decode version
             int version = in.readInt();
             if (version < 0 || version > CURRENT_VERSION) {


### PR DESCRIPTION
This PR uses the try-with-resources construct to ensure that certain input and output resources are always closed, preventing possible memory leaks.
This addresses some of the alerts found on lgtm.com: see the "Close input resource" and "Close output resource" rules at https://lgtm.com/projects/g/apache/kafka/alerts/.

Type arguments have been added in one unrelated place to get one of the modified files to compile.