### PR TITLE
(WIP) KAFKA-5142: Expose Record Headers in Kafka Connect (DO NOT MERGE)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/BooleanDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/BooleanDeserializer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+public class BooleanDeserializer implements Deserializer<Boolean> {
+
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
+
+    public Boolean deserialize(String topic, byte[] data) {
+        if (data == null)
+            return null;
+        if (data.length != 1) {
+            throw new SerializationException("Size of data received by IntegerDeserializer is " +
+                    "not 1");
+        }
+        return data[0] == 1;
+    }
+
+    public void close() {
+        // nothing to do
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/BooleanSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/BooleanSerializer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Map;
+
+public class BooleanSerializer implements Serializer<Boolean> {
+
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
+
+    public byte[] serialize(String topic, Boolean data) {
+        if (data == null)
+            return null;
+        
+        byte b = (byte)(data?1:0);
+        return new byte[] {b};
+    }
+
+    public void close() {
+        // nothing to do
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteDeserializer.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+public class ByteDeserializer implements Deserializer<Byte> {
+
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
+
+    public Byte deserialize(String topic, byte[] data) {
+        if (data == null)
+            return null;
+        if (data.length != 1) {
+            throw new SerializationException("Size of data received by IntegerDeserializer is " +
+                    "not 1");
+        }
+        return data[0];
+    }
+
+    public void close() {
+        // nothing to do
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteSerializer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Map;
+
+public class ByteSerializer implements Serializer<Byte> {
+
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
+
+    public byte[] serialize(String topic, Byte data) {
+        if (data == null)
+            return null;
+
+        return new byte[] {data};
+    }
+
+    public void close() {
+        // nothing to do
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ShortDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ShortDeserializer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+public class ShortDeserializer implements Deserializer<Short> {
+
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
+
+    public Short deserialize(String topic, byte[] data) {
+        if (data == null)
+            return null;
+        if (data.length != 2) {
+            throw new SerializationException("Size of data received by IntegerDeserializer is " +
+                    "not 2");
+        }
+
+        short value = 0;
+        for (byte b : data) {
+            value <<= 8;
+            value |= b & 0xFF;
+        }
+        return value;
+    }
+
+    public void close() {
+        // nothing to do
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ShortSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ShortSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.serialization;
+
+import java.util.Map;
+
+public class ShortSerializer implements Serializer<Short> {
+
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
+
+    public byte[] serialize(String topic, Short data) {
+        if (data == null)
+            return null;
+
+        return new byte[] {
+            (byte) (data >>> 8),
+            data.byteValue()
+        };
+    }
+
+    public void close() {
+        // nothing to do
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectHeader.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectHeader.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.connector;
+
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * <p>
+ * Class for headers containing data to be copied to/from Kafka. This corresponds closely to
+ * Kafka's Header classes, and holds the data that may be used by both
+ * sources and sinks (key, valueSchema, value).
+ * </p>
+ */
+public class ConnectHeader {
+    
+    private final String key;
+    private final Schema valueSchema;
+    private final Object value;
+
+    public ConnectHeader(String key, Schema valueSchema, Object value) {
+        this.key = key;
+        this.valueSchema = valueSchema;
+        this.value = value;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public Object value() {
+        return value;
+    }
+
+    public Schema valueSchema() {
+        return valueSchema;
+    }
+    
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkRecord.java
@@ -16,7 +16,10 @@
  */
 package org.apache.kafka.connect.sink;
 
+import java.util.List;
+
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.connector.ConnectHeader;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 
@@ -38,7 +41,12 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
 
     public SinkRecord(String topic, int partition, Schema keySchema, Object key, Schema valueSchema, Object value, long kafkaOffset,
                       Long timestamp, TimestampType timestampType) {
-        super(topic, partition, keySchema, key, valueSchema, value, timestamp);
+        this(topic, partition, keySchema, key, valueSchema, value, kafkaOffset, timestamp, timestampType, null);
+    }
+
+    public SinkRecord(String topic, int partition, Schema keySchema, Object key, Schema valueSchema, Object value, long kafkaOffset,
+                      Long timestamp, TimestampType timestampType, List<ConnectHeader> headers) {
+        super(topic, partition, keySchema, key, valueSchema, value, timestamp, headers);
         this.kafkaOffset = kafkaOffset;
         this.timestampType = timestampType;
     }
@@ -52,8 +60,8 @@ public class SinkRecord extends ConnectRecord<SinkRecord> {
     }
 
     @Override
-    public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value, Long timestamp) {
-        return new SinkRecord(topic, kafkaPartition, keySchema, key, valueSchema, value, kafkaOffset(), timestamp, timestampType);
+    public SinkRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value, Long timestamp, List<ConnectHeader> headers) {
+        return new SinkRecord(topic, kafkaPartition, keySchema, key, valueSchema, value, kafkaOffset(), timestamp, timestampType, headers);
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceRecord.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.connect.source;
 
+import org.apache.kafka.connect.connector.ConnectHeader;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -69,7 +71,15 @@ public class SourceRecord extends ConnectRecord<SourceRecord> {
                         Schema keySchema, Object key,
                         Schema valueSchema, Object value,
                         Long timestamp) {
-        super(topic, partition, keySchema, key, valueSchema, value, timestamp);
+        this(sourcePartition, sourceOffset, topic, partition, keySchema, key, valueSchema, value, timestamp, null);
+    }
+
+    public SourceRecord(Map<String, ?> sourcePartition, Map<String, ?> sourceOffset,
+                        String topic, Integer partition,
+                        Schema keySchema, Object key,
+                        Schema valueSchema, Object value,
+                        Long timestamp, List<ConnectHeader> headers) {
+        super(topic, partition, keySchema, key, valueSchema, value, timestamp, headers);
         this.sourcePartition = sourcePartition;
         this.sourceOffset = sourceOffset;
     }
@@ -83,8 +93,8 @@ public class SourceRecord extends ConnectRecord<SourceRecord> {
     }
 
     @Override
-    public SourceRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value, Long timestamp) {
-        return new SourceRecord(sourcePartition, sourceOffset, topic, kafkaPartition, keySchema, key, valueSchema, value, timestamp);
+    public SourceRecord newRecord(String topic, Integer kafkaPartition, Schema keySchema, Object key, Schema valueSchema, Object value, Long timestamp, List<ConnectHeader> headers) {
+        return new SourceRecord(sourcePartition, sourceOffset, topic, kafkaPartition, keySchema, key, valueSchema, value, timestamp, headers);
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/MemorySubjectSchemaRepo.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/MemorySubjectSchemaRepo.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+
+public class MemorySubjectSchemaRepo implements SubjectSchemaRepo {
+    
+    public Map<String, Schema> subjectSchemas = new HashMap<>();
+    
+    @Override
+    public void register(String key, Schema schema) {
+        subjectSchemas.put(key, schema);
+    }
+    
+    @Override
+    public Schema schema(String key){
+        return subjectSchemas.get(key);
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/PrimativeSubjectConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/PrimativeSubjectConverter.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.BooleanDeserializer;
+import org.apache.kafka.common.serialization.BooleanSerializer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.ShortDeserializer;
+import org.apache.kafka.common.serialization.ShortSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+public class PrimativeSubjectConverter implements SubjectConverter {
+ 
+    
+    private static Map<Schema, Serializer> schemaSerializerMap = new HashMap<>();
+    private static Map<Schema, Deserializer> schemaDeserializerMap = new HashMap<>();
+
+    static {
+        register(Schema.BYTES_SCHEMA, new ByteArraySerializer(), new ByteArrayDeserializer());
+        register(Schema.INT8_SCHEMA, new ShortSerializer(), new ShortDeserializer());
+        register(Schema.INT16_SCHEMA, new IntegerSerializer(), new IntegerDeserializer());
+        register(Schema.INT32_SCHEMA, new IntegerSerializer(), new IntegerDeserializer());
+        register(Schema.INT64_SCHEMA, new LongSerializer(), new LongDeserializer());
+        register(Schema.FLOAT32_SCHEMA, new FloatSerializer(), new FloatDeserializer());
+        register(Schema.FLOAT64_SCHEMA, new DoubleSerializer(), new DoubleDeserializer());
+        register(Schema.BOOLEAN_SCHEMA, new BooleanSerializer(), new BooleanDeserializer());
+        register(Schema.STRING_SCHEMA, new StringSerializer(), new StringDeserializer());
+    }
+    
+    private static void register(Schema schema, Serializer serializer, Deserializer deserializer){
+        schemaSerializerMap.put(schema, serializer);
+        schemaDeserializerMap.put(schema, deserializer);
+    }
+    
+    private SubjectSchemaRepo subjectSchemaRepo = new MemorySubjectSchemaRepo();
+    private Schema defaultSchema = Schema.BYTES_SCHEMA;
+    
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        for(String configKey : configs.keySet()) {
+            if (configKey.startsWith("converter.subject.")) {
+                String subject = configKey.substring("converter.subject.".length());
+                Schema.Type type = Schema.Type.valueOf(((String) configs.get(configKey)).toUpperCase());
+                if (type != null && type.isPrimitive()) {
+                    subjectSchemaRepo.register(subject, SchemaBuilder.type(type).build());
+                }
+            }
+        }
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, String subject, Schema schema, Object value) {
+        Schema registeredSchema = subjectSchemaRepo.schema(subject);
+        if (registeredSchema == null){
+            subjectSchemaRepo.register(subject, schema);
+        } else if (!schema.type().equals(registeredSchema.type())) {
+            throw new SerializationException("schema type for subject does not match registered schema type subject=" + subject);
+        } else if (!schema.type().isPrimitive()) {
+            throw new SerializationException("only primitive types are supported subject=" + subject);
+        }
+        return schemaSerializerMap.get(schema).serialize(topic, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, String subject, byte[] value) {
+        Schema schema = subjectSchemaRepo.schema(subject);
+        if (schema == null){
+            schema = defaultSchema;
+        }
+        Deserializer deserializer = schemaDeserializerMap.get(schema);
+        Object object = deserializer.deserialize(topic, value);
+        return new SchemaAndValue(schema, object);
+    }
+    
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/StringConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/StringConverter.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * this class can also be configured to use the same encoding for both encoding and decoding with the converter.encoding
  * setting.
  */
-public class StringConverter implements Converter {
+public class StringConverter implements Converter, SubjectConverter {
     private final StringSerializer serializer = new StringSerializer();
     private final StringDeserializer deserializer = new StringDeserializer();
 
@@ -58,6 +58,16 @@ public class StringConverter implements Converter {
 
         serializer.configure(serializerConfigs, isKey);
         deserializer.configure(deserializerConfigs, isKey);
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, String subject, Schema schema, Object value) {
+        return fromConnectData(topic, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, String subject, byte[] value) {
+        return toConnectData(topic, value);
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/SubjectConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/SubjectConverter.java
@@ -16,17 +16,17 @@
  */
 package org.apache.kafka.connect.storage;
 
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
-
-import java.util.Map;
 
 /**
  * The Converter interface provides support for translating between Kafka Connect's runtime data format
  * and byte[]. Internally, this likely includes an intermediate step to the format used by the serialization
  * layer (e.g. JsonNode, GenericRecord, Message).
  */
-public interface Converter {
+public interface SubjectConverter {
 
     /**
      * Configure this class.
@@ -42,7 +42,7 @@ public interface Converter {
      * @param value the value to convert
      * @return the serialized value
      */
-    byte[] fromConnectData(String topic, Schema schema, Object value);
+    byte[] fromConnectData(String topic, String subject, Schema schema, Object value);
 
     /**toConnectData
      * Convert a native object to a Kafka Connect data object.
@@ -50,5 +50,5 @@ public interface Converter {
      * @param value the value to convert
      * @return an object containing the {@link Schema} and the converted value
      */
-    SchemaAndValue toConnectData(String topic, byte[] value);
+    SchemaAndValue toConnectData(String topic, String subject, byte[] value);
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/SubjectSchemaRepo.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/SubjectSchemaRepo.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.connect.data.Schema;
+
+public interface SubjectSchemaRepo {
+    void register(String key, Schema schema);
+
+    Schema schema(String key);
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/PrimativeSubjectConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/PrimativeSubjectConverterTest.java
@@ -1,0 +1,96 @@
+package org.apache.kafka.connect.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by pearcem on 03/05/2017.
+ */
+public class PrimativeSubjectConverterTest {
+
+    private SubjectConverter converter;
+
+    @Before
+    public void setup(){
+        converter = new PrimativeSubjectConverter();
+        
+        Map<String, Object> configs = new HashMap<>();
+
+        configs.put("converter.subject.MyStringHeader", "String");
+        configs.put("converter.subject.MyIntegerHeader", "int32");
+        configs.put("converter.subject.MyShortHeader", "int16");
+        configs.put("converter.subject.MyBytesHeader", "bytes");
+
+        converter.configure(configs, false);
+    }
+    
+    @Test
+    public void testBytes() throws UnsupportedEncodingException {
+
+        byte[] fromKafka = "test".getBytes();
+        SchemaAndValue schemaAndValue = converter.toConnectData("topic", "MyBytesHeader", fromKafka);
+
+        assertEquals(Schema.BYTES_SCHEMA, schemaAndValue.schema());
+        assertTrue(Arrays.equals(fromKafka, (byte[]) schemaAndValue.value()));
+
+        byte[] toKafka = converter.fromConnectData("topic", "MyBytesHeader", schemaAndValue.schema(), schemaAndValue.value() );
+
+        assertTrue(Arrays.equals(fromKafka, toKafka));
+
+    }
+
+    @Test
+    public void testInteger() throws UnsupportedEncodingException {
+
+        Integer integer = 42;
+        IntegerSerializer integerSerializer = new IntegerSerializer();
+        byte[] fromKafka = integerSerializer.serialize("", integer);
+        
+        SchemaAndValue schemaAndValue = converter.toConnectData("topic", "MyIntegerHeader", fromKafka);
+
+        assertEquals(Schema.INT32_SCHEMA, schemaAndValue.schema());
+        assertEquals(integer, schemaAndValue.value());
+
+        byte[] toKafka = converter.fromConnectData("topic", "MyIntegerHeader", schemaAndValue.schema(), schemaAndValue.value() );
+
+        assertTrue(Arrays.equals(fromKafka, toKafka));
+
+    }
+
+    @Test
+    public void testString() throws UnsupportedEncodingException {
+
+        String string = "test";
+        StringSerializer stringSerializer = new StringSerializer();
+        byte[] fromKafka = stringSerializer.serialize("", string);
+        
+        
+        SchemaAndValue schemaAndValue = converter.toConnectData("topic", "MyStringHeader", fromKafka);
+
+        assertEquals(Schema.STRING_SCHEMA, schemaAndValue.schema());
+        assertEquals(string, schemaAndValue.value());
+        
+        
+        byte[] toKafka = converter.fromConnectData("topic", "MyStringHeader", schemaAndValue.schema(), schemaAndValue.value() );
+        
+        assertTrue(Arrays.equals(fromKafka, toKafka));
+
+        
+        
+    }
+
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/converters/ByteArrayConverter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/converters/ByteArrayConverter.java
@@ -21,16 +21,27 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.SubjectConverter;
 
 import java.util.Map;
 
 /**
  * Pass-through converter for raw byte data.
  */
-public class ByteArrayConverter implements Converter {
+public class ByteArrayConverter implements Converter, SubjectConverter {
 
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, String subject, Schema schema, Object value) {
+        return fromConnectData(topic, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, String subject, byte[] value) {
+        return toConnectData(topic, value);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -70,6 +70,11 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String VALUE_CONVERTER_CLASS_DOC = WorkerConfig.VALUE_CONVERTER_CLASS_DOC;
     public static final String VALUE_CONVERTER_CLASS_DISPLAY = "Value converter class";
 
+    public static final String HEADER_CONVERTER_CLASS_CONFIG = WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG;
+    public static final String HEADER_CONVERTER_CLASS_DOC = WorkerConfig.HEADER_CONVERTER_CLASS_DOC;
+    public static final String HEADER_CONVERTER_CLASS_DEFAULT = WorkerConfig.HEADER_CONVERTER_CLASS_DEFAULT;
+    public static final String HEADER_CONVERTER_CLASS_DISPLAY = "Header converter class";
+
     public static final String TASKS_MAX_CONFIG = "tasks.max";
     private static final String TASKS_MAX_DOC = "Maximum number of tasks to use for this connector.";
     public static final int TASKS_MAX_DEFAULT = 1;
@@ -88,6 +93,7 @@ public class ConnectorConfig extends AbstractConfig {
                 .define(TASKS_MAX_CONFIG, Type.INT, TASKS_MAX_DEFAULT, atLeast(TASKS_MIN_CONFIG), Importance.HIGH, TASKS_MAX_DOC, COMMON_GROUP, 3, Width.SHORT, TASK_MAX_DISPLAY)
                 .define(KEY_CONVERTER_CLASS_CONFIG, Type.CLASS, null, Importance.LOW, KEY_CONVERTER_CLASS_DOC, COMMON_GROUP, 4, Width.SHORT, KEY_CONVERTER_CLASS_DISPLAY)
                 .define(VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS, null, Importance.LOW, VALUE_CONVERTER_CLASS_DOC, COMMON_GROUP, 5, Width.SHORT, VALUE_CONVERTER_CLASS_DISPLAY)
+                .define(HEADER_CONVERTER_CLASS_CONFIG, Type.CLASS, HEADER_CONVERTER_CLASS_DEFAULT, Importance.LOW, HEADER_CONVERTER_CLASS_DEFAULT, COMMON_GROUP, 6, Width.SHORT, HEADER_CONVERTER_CLASS_DISPLAY)
                 .define(TRANSFORMS_CONFIG, Type.LIST, null, new ConfigDef.Validator() {
                     @Override
                     public void ensureValid(String name, Object value) {
@@ -97,7 +103,7 @@ public class ConnectorConfig extends AbstractConfig {
                             throw new ConfigException(name, value, "Duplicate alias provided.");
                         }
                     }
-                }, Importance.LOW, TRANSFORMS_DOC, TRANSFORMS_GROUP, 6, Width.LONG, TRANSFORMS_DISPLAY);
+                }, Importance.LOW, TRANSFORMS_DOC, TRANSFORMS_GROUP, 7, Width.LONG, TRANSFORMS_DISPLAY);
     }
 
     public ConnectorConfig() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -20,6 +20,9 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.storage.SubjectConverter;
 
 import java.util.Map;
 
@@ -53,6 +56,15 @@ public class WorkerConfig extends AbstractConfig {
                     " This controls the format of the values in messages written to or read from Kafka, and since this is" +
                     " independent of connectors it allows any connector to work with any serialization format." +
                     " Examples of common formats include JSON and Avro.";
+
+    public static final String HEADER_CONVERTER_CLASS_CONFIG = "header.converter";
+    public static final String HEADER_CONVERTER_CLASS_DOC =
+        "Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka." +
+        " This controls the format of the headers in messages written to or read from Kafka, and since this is" +
+        " independent of connectors it allows any connector to work with any serialization format." +
+        " Examples of common formats include JSON and Avro.";
+    public static final String HEADER_CONVERTER_CLASS_DEFAULT = "org.apache.kafka.connect.storage.StringConverter";
+
 
     public static final String INTERNAL_KEY_CONVERTER_CLASS_CONFIG = "internal.key.converter";
     public static final String INTERNAL_KEY_CONVERTER_CLASS_DOC =
@@ -135,6 +147,9 @@ public class WorkerConfig extends AbstractConfig {
                         Importance.HIGH, KEY_CONVERTER_CLASS_DOC)
                 .define(VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS,
                         Importance.HIGH, VALUE_CONVERTER_CLASS_DOC)
+                .define(HEADER_CONVERTER_CLASS_CONFIG, Type.CLASS, 
+                        HEADER_CONVERTER_CLASS_DEFAULT,
+                        Importance.MEDIUM, HEADER_CONVERTER_CLASS_DOC)
                 .define(INTERNAL_KEY_CONVERTER_CLASS_CONFIG, Type.CLASS,
                         Importance.LOW, INTERNAL_KEY_CONVERTER_CLASS_DOC)
                 .define(INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.SubjectConverter;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.MockTime;
 import org.easymock.Capture;
@@ -108,6 +109,8 @@ public class WorkerSinkTaskTest {
     @Mock
     private Converter valueConverter;
     @Mock
+    private SubjectConverter headerConverter;
+    @Mock
     private TransformationChain<SinkRecord> transformationChain;
     @Mock
     private TaskStatus.Listener statusListener;
@@ -123,6 +126,7 @@ public class WorkerSinkTaskTest {
         Map<String, String> workerProps = new HashMap<>();
         workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put("header.converter", "org.apache.kafka.connect.storage.StringConverter");
         workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.key.converter.schemas.enable", "false");
@@ -131,7 +135,7 @@ public class WorkerSinkTaskTest {
         workerConfig = new StandaloneConfig(workerProps);
         workerTask = PowerMock.createPartialMock(
                 WorkerSinkTask.class, new String[]{"createConsumer"},
-                taskId, sinkTask, statusListener, initialState, workerConfig, keyConverter, valueConverter, transformationChain, time);
+                taskId, sinkTask, statusListener, initialState, workerConfig, keyConverter, valueConverter, headerConverter, transformationChain, time);
 
         recordsReturned = 0;
     }
@@ -140,7 +144,7 @@ public class WorkerSinkTaskTest {
     public void testStartPaused() throws Exception {
         workerTask = PowerMock.createPartialMock(
                 WorkerSinkTask.class, new String[]{"createConsumer"},
-                taskId, sinkTask, statusListener, TargetState.PAUSED, workerConfig, keyConverter, valueConverter, transformationChain, time);
+                taskId, sinkTask, statusListener, TargetState.PAUSED, workerConfig, keyConverter, valueConverter, headerConverter, transformationChain, time);
 
         expectInitializeTask();
         expectPollInitialAssignment();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.sink.SinkConnector;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.SubjectConverter;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.MockTime;
 import org.apache.kafka.connect.util.ThreadedTest;
@@ -103,6 +104,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
     private WorkerConfig workerConfig;
     @Mock private Converter keyConverter;
     @Mock private Converter valueConverter;
+    @Mock private SubjectConverter subjectConverter;
     @Mock private TransformationChain transformationChain;
     private WorkerSinkTask workerTask;
     @Mock private KafkaConsumer<byte[], byte[]> consumer;
@@ -120,6 +122,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         Map<String, String> workerProps = new HashMap<>();
         workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put("header.converter", "org.apache.kafka.connect.storage.SubjectConverter");
         workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.key.converter.schemas.enable", "false");
@@ -128,7 +131,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         workerConfig = new StandaloneConfig(workerProps);
         workerTask = PowerMock.createPartialMock(
                 WorkerSinkTask.class, new String[]{"createConsumer"},
-                taskId, sinkTask, statusListener, initialState, workerConfig, keyConverter, valueConverter, TransformationChain.<SinkRecord>noOp(), time);
+                taskId, sinkTask, statusListener, initialState, workerConfig, keyConverter, valueConverter, subjectConverter, TransformationChain.<SinkRecord>noOp(), time);
 
         recordsReturned = 0;
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.source.SourceTaskContext;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.storage.SubjectConverter;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.ThreadedTest;
@@ -85,6 +86,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     @Mock private SourceTask sourceTask;
     @Mock private Converter keyConverter;
     @Mock private Converter valueConverter;
+    @Mock private SubjectConverter headerConverter;
     @Mock private TransformationChain<SourceRecord> transformationChain;
     @Mock private KafkaProducer<byte[], byte[]> producer;
     @Mock private OffsetStorageReader offsetReader;
@@ -111,6 +113,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         Map<String, String> workerProps = new HashMap<>();
         workerProps.put("key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
+        workerProps.put("header.converter", "org.apache.kafka.connect.storage.StringConverter");
         workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.key.converter.schemas.enable", "false");
@@ -125,7 +128,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     }
 
     private void createWorkerTask(TargetState initialState) {
-        workerTask = new WorkerSourceTask(taskId, sourceTask, statusListener, initialState, keyConverter, valueConverter, transformationChain,
+        workerTask = new WorkerSourceTask(taskId, sourceTask, statusListener, initialState, keyConverter, valueConverter, headerConverter, transformationChain,
                 producer, offsetReader, offsetWriter, config, Time.SYSTEM);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -34,6 +34,8 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.OffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.storage.SubjectConverter;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.MockTime;
 import org.apache.kafka.connect.util.ThreadedTest;
@@ -372,6 +374,7 @@ public class WorkerTest extends ThreadedTest {
                 EasyMock.eq(TargetState.STARTED),
                 EasyMock.anyObject(JsonConverter.class),
                 EasyMock.anyObject(JsonConverter.class),
+                EasyMock.anyObject(StringConverter.class),
                 EasyMock.eq(TransformationChain.<SourceRecord>noOp()),
                 EasyMock.anyObject(KafkaProducer.class),
                 EasyMock.anyObject(OffsetStorageReader.class),
@@ -446,6 +449,7 @@ public class WorkerTest extends ThreadedTest {
                 EasyMock.eq(TargetState.STARTED),
                 EasyMock.anyObject(JsonConverter.class),
                 EasyMock.anyObject(JsonConverter.class),
+                EasyMock.anyObject(StringConverter.class),
                 EasyMock.eq(TransformationChain.<SourceRecord>noOp()),
                 EasyMock.anyObject(KafkaProducer.class),
                 EasyMock.anyObject(OffsetStorageReader.class),
@@ -493,6 +497,7 @@ public class WorkerTest extends ThreadedTest {
 
         Capture<TestConverter> keyConverter = EasyMock.newCapture();
         Capture<TestConverter> valueConverter = EasyMock.newCapture();
+        Capture<TestConverter> headerConverter = EasyMock.newCapture();
 
         PowerMock.expectNew(
                 WorkerSourceTask.class, EasyMock.eq(TASK_ID),
@@ -501,6 +506,7 @@ public class WorkerTest extends ThreadedTest {
                 EasyMock.eq(TargetState.STARTED),
                 EasyMock.capture(keyConverter),
                 EasyMock.capture(valueConverter),
+                EasyMock.capture(headerConverter),
                 EasyMock.eq(TransformationChain.<SourceRecord>noOp()),
                 EasyMock.anyObject(KafkaProducer.class),
                 EasyMock.anyObject(OffsetStorageReader.class),
@@ -627,12 +633,22 @@ public class WorkerTest extends ThreadedTest {
         }
     }
 
-    public static class TestConverter implements Converter {
+    public static class TestConverter implements Converter, SubjectConverter {
         public Map<String, ?> configs;
 
         @Override
         public void configure(Map<String, ?> configs, boolean isKey) {
             this.configs = configs;
+        }
+
+        @Override
+        public byte[] fromConnectData(String topic, String subject, Schema schema, Object value) {
+            return new byte[0];
+        }
+
+        @Override
+        public SchemaAndValue toConnectData(String topic, String subject, byte[] value) {
+            return null;
         }
 
         @Override


### PR DESCRIPTION
as per KIP-145

Add constructors to Connect/Source/SinkRecord to take `Iterable<Header>`

add accessor method to ConnectRecord `Headers headers()`
Update WorkerSource/Sink to pass headers to/from Producer/ConsumerRecords