### PR TITLE
KAFKA-5055: Kafka Streams skipped-records-rate sensor bug

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -380,7 +380,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
      */
     @SuppressWarnings("unchecked")
     public int addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
-        final int oldQueueSize = partitionGroup.numBuffered();
+        final int oldQueueSize = partitionGroup.numBuffered(partition);
         final int newQueueSize = partitionGroup.addRawRecords(partition, records);
 
         log.trace("{} Added records into the buffered queue of partition {}, new queue size is {}", logPrefix, partition, newQueueSize);


### PR DESCRIPTION
Fix as described in the [KAFKA-5055 Jira comment](https://issues.apache.org/jira/browse/KAFKA-5055?focusedCommentId=15990086&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15990086).

@mjsax @guozhangwang take a look