### PR TITLE
KAFKA-5161: add code in reassign-partitions to check broker existence

### DIFF
--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -201,7 +201,7 @@ object ReassignPartitionsCommand extends Logging {
         .mkString(". ")
       throw new AdminCommandFailedException("Partition replica lists may not contain duplicate entries: %s".format(duplicatesMsg))
     }
-    //Check that all partitions in the proposed assignment exist in the cluster
+    // check that all partitions in the proposed assignment exist in the cluster
     val proposedTopics = partitionsToBeReassigned.map { case (tp, _) => tp.topic }.distinct
     val existingAssignment = zkUtils.getReplicaAssignmentForTopics(proposedTopics)
     val nonExistentPartitions = partitionsToBeReassigned.map { case (tp, _) => tp }.filterNot(existingAssignment.contains)
@@ -209,7 +209,7 @@ object ReassignPartitionsCommand extends Logging {
       throw new AdminCommandFailedException("The proposed assignment contains non-existent partitions: " +
         nonExistentPartitions)
 
-    //Check that all brokers in the proposed assignment exist in the cluster
+    // check that all brokers in the proposed assignment exist in the cluster
     val existingBrokerIDs = zkUtils.getSortedBrokerList()
     val nonExistingBrokerIDs = partitionsToBeReassigned.toMap.values.flatten.filterNot(existingBrokerIDs.contains).toSet
     if (nonExistingBrokerIDs.nonEmpty)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -213,7 +213,7 @@ object ReassignPartitionsCommand extends Logging {
     val existingBrokerIDs = zkUtils.getSortedBrokerList()
     val nonExistingBrokerIDs = partitionsToBeReassigned.toMap.values.flatten.filterNot(existingBrokerIDs.contains).toSet
     if (nonExistingBrokerIDs.nonEmpty)
-      throw new AdminCommandFailedException("The proposed assignment contains non-existent broker IDs: " + nonExistingBrokerIDs.mkString(","))
+      throw new AdminCommandFailedException("The proposed assignment contains non-existent brokerIDs: " + nonExistingBrokerIDs.mkString(","))
 
     partitionsToBeReassigned
   }

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -209,6 +209,12 @@ object ReassignPartitionsCommand extends Logging {
       throw new AdminCommandFailedException("The proposed assignment contains non-existent partitions: " +
         nonExistentPartitions)
 
+    //Check that all brokers in the proposed assignment exist in the cluster
+    val existingBrokerIDs = zkUtils.getSortedBrokerList()
+    val nonExistingBrokerIDs = partitionsToBeReassigned.toMap.values.flatten.filterNot(existingBrokerIDs.contains).toSet
+    if (nonExistingBrokerIDs.nonEmpty)
+      throw new AdminCommandFailedException("The proposed assignment contains non-existent broker IDs: " + nonExistingBrokerIDs.mkString(","))
+
     partitionsToBeReassigned
   }
 

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -307,7 +307,7 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     startBrokers(Seq(100, 101))
     createTopic(zkUtils, topicName, Map(0 -> Seq(100)), servers = servers)
 
-    //When we execute an assignment that specifies an invalid broker ID (102: invalid broker ID in this case)
+    //When we execute an assignment that specifies an invalid brokerID (102: invalid broker ID in this case)
     val topicJson = s"""{"version":1,"partitions":[{"topic":"$topicName","partition":0,"replicas":[101, 102]}]}"""
     ReassignPartitionsCommand.executeAssignment(zkUtils, topicJson, NoThrottle)
   }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -301,6 +301,17 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     ReassignPartitionsCommand.executeAssignment(zkUtils, topicJson, NoThrottle)
   }
 
+  @Test(expected = classOf[AdminCommandFailedException])
+  def shouldFailIfProposedHasInvalidBrokerID() {
+    //Given a single replica on server 100
+    startBrokers(Seq(100, 101))
+    createTopic(zkUtils, topicName, Map(0 -> Seq(100)), servers = servers)
+
+    //When we execute an assignment that specifies an invalid broker ID (102: invalid broker ID in this case)
+    val topicJson = s"""{"version":1,"partitions":[{"topic":"$topicName","partition":0,"replicas":[101, 102]}]}"""
+    ReassignPartitionsCommand.executeAssignment(zkUtils, topicJson, NoThrottle)
+  }
+
   @Test
   def shouldPerformThrottledReassignmentOverVariousTopics() {
     val throttle = Throttle(1000L)


### PR DESCRIPTION
Added code to check existence of the brokers in the proposed plan.