### PR TITLE
KAFKA-5168: Cleanup delayed produce purgatory during partition emmigration

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -284,8 +284,6 @@ class TransactionStateManager(brokerId: Int,
     def removeTransactions() {
       var numTxnsRemoved = 0
 
-
-
       inLock(stateLock) {
         for (transactionalId <- transactionMetadataCache.keys) {
           if (partitionFor(transactionalId) == partition) {
@@ -295,7 +293,7 @@ class TransactionStateManager(brokerId: Int,
             numTxnsRemoved += 1
           }
         }
-        
+
         replicaManager.forceCompleteDelayedProduce(
           new TopicPartitionOperationKey(topicPartition))
 

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -262,6 +262,11 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
     }
   }
 
+  /**
+    * Force complete any watched operations for the provided key
+    *
+    * @return the number of completed operations
+    */
   def forceComplete(key: Any): Int = {
     val watchers = inReadLock(removeWatchersLock) {watchersForKey.get(key)}
     if (watchers == null)

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -261,6 +261,14 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
         Nil
     }
   }
+
+  def forceComplete(key: Any): Int = {
+    val watchers = inReadLock(removeWatchersLock) {watchersForKey.get(key)}
+    if (watchers == null)
+      0
+    else
+      watchers.forceComplete()
+  }
   /*
    * Return all the current watcher lists,
    * note that the returned watchers may be removed from the list by other threads
@@ -369,6 +377,20 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
         removeKeyIfEmpty(key, this)
 
       purged
+    }
+
+    def forceComplete(): Int = {
+      var completed = 0
+      val iter = operations.iterator()
+      while(iter.hasNext) {
+        val current = iter.next()
+        if (!current.isCompleted) {
+          current.forceComplete()
+          iter.remove()
+          completed +=1
+        }
+      }
+      completed
     }
   }
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -130,6 +130,7 @@ class ReplicaManager(val config: KafkaConfig,
                      quotaManager: ReplicationQuotaManager,
                      val metadataCache: MetadataCache,
                      threadNamePrefix: Option[String] = None) extends Logging with KafkaMetricsGroup {
+
   /* epoch of the controller that last changed the leader */
   @volatile var controllerEpoch: Int = KafkaController.InitialControllerEpoch - 1
   private val localBrokerId = config.brokerId
@@ -241,6 +242,15 @@ class ReplicaManager(val config: KafkaConfig,
   def tryCompleteDelayedDeleteRecords(key: DelayedOperationKey) {
     val completed = delayedDeleteRecordsPurgatory.checkAndComplete(key)
     debug("Request key %s unblocked %d DeleteRecordsRequest.".format(key.keyLabel, completed))
+  }
+
+  /**
+    * Force complete any delayed produce requests with the request key. This can
+    * be triggered when a partition emmigrates
+    */
+  def forceCompleteDelayedProduce(key: DelayedOperationKey): Unit = {
+    val completed = delayedProducePurgatory.forceComplete(key)
+    debug(s"force completed $completed produce requests for key ${key.keyLabel}")
   }
 
   def startup() {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import kafka.common.Topic
 import kafka.common.Topic.TransactionStateTopicName
 import kafka.log.Log
-import kafka.server.{FetchDataInfo, LogOffsetMetadata, ReplicaManager}
+import kafka.server.{FetchDataInfo, LogOffsetMetadata, ReplicaManager, TopicPartitionOperationKey}
 import kafka.utils.{MockScheduler, ZkUtils}
 import kafka.utils.TestUtils.fail
 import org.apache.kafka.common.TopicPartition
@@ -311,6 +311,18 @@ class TransactionStateManagerTest {
   @Test
   def shouldWriteTxnMarkersForTransactionInPreparedAbortState(): Unit = {
     verifyWritesTxnMarkersInPrepareState(PrepareAbort)
+  }
+
+  @Test
+  def shouldRemoveDelayedProduceOperationsWhenPartitionRemoved(): Unit = {
+    EasyMock.expect(replicaManager.forceCompleteDelayedProduce(
+      new TopicPartitionOperationKey(new TopicPartition(Topic.TransactionStateTopicName, 0))))
+
+    EasyMock.replay(replicaManager)
+    transactionManager.removeTransactionsForPartition(0)
+    scheduler.tick()
+
+    EasyMock.verify(replicaManager)
   }
 
   private def verifyWritesTxnMarkersInPrepareState(state: TransactionState): Unit = {

--- a/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
@@ -117,6 +117,16 @@ class DelayedOperationTest {
     assertEquals(Nil, cancelledOperations)
   }
 
+  @Test
+  def shouldForceCompleteRequestForKey(): Unit = {
+    purgatory.tryCompleteElseWatch(new MockDelayedOperation(10000L), Seq("key"))
+    purgatory.tryCompleteElseWatch(new MockDelayedOperation(10000L), Seq("key"))
+    purgatory.tryCompleteElseWatch(new MockDelayedOperation(10000L), Seq("key2"))
+
+    assertEquals(2, purgatory.forceComplete("key"))
+    assertEquals(1, purgatory.watched)
+    assertEquals(1, purgatory.forceComplete("key2"))
+  }
 
 
   class MockDelayedOperation(delayMs: Long) extends DelayedOperation(delayMs) {


### PR DESCRIPTION
remove operations from the replica manager's producer purgatory on transaction emmigration