### PR TITLE
KAFKA-5171 : TC should not accept empty string transactional id

### DIFF
--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -84,14 +84,14 @@ class TransactionCoordinatorTest {
 
 
   @Test
-  def shouldAcceptInitPidAndReturnNextPidWhenTransactionalIdIsEmpty(): Unit = {
+  def shouldReturnInvalidRequestWhenTransactionalIdIsEmpty(): Unit = {
     mockPidManager()
     EasyMock.replay(pidManager)
 
     coordinator.handleInitPid("", txnTimeoutMs, initPidMockCallback)
-    assertEquals(InitPidResult(0L, 0, Errors.NONE), result)
+    assertEquals(InitPidResult(-1L, -1, Errors.INVALID_REQUEST), result)
     coordinator.handleInitPid("", txnTimeoutMs, initPidMockCallback)
-    assertEquals(InitPidResult(1L, 0, Errors.NONE), result)
+    assertEquals(InitPidResult(-1L, -1, Errors.INVALID_REQUEST), result)
   }
 
   @Test


### PR DESCRIPTION
This is an initial PR. Changed the unit tests accordingly as per the expectation from TC.