### PR TITLE
KIP-154 KAFKA-4667 Connect uses AdminClient to create internal topics when needed

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
@@ -56,6 +56,14 @@ public class NewTopic {
         return name;
     }
 
+    public int partitions() {
+        return numPartitions;
+    }
+
+    public short replicationFactor() {
+        return replicationFactor;
+    }
+
     /**
      * Set the configuration to use on the new topic.
      *
@@ -81,5 +89,17 @@ public class NewTopic {
                 return new TopicDetails(numPartitions, replicationFactor);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder bld = new StringBuilder();
+        bld.append("(name=").append(name).
+                append(", numPartitions=").append(numPartitions).
+                append(", replicationFactor=").append(replicationFactor).
+                append(", replicasAssignments=").append(replicasAssignments).
+                append(", configs=").append(configs).
+                append(")");
+        return bld.toString();
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.clients.admin;
 
-import org.apache.kafka.clients.Metadata;
-import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.admin.DeleteAclsResults.FilterResults;
 import org.apache.kafka.common.Cluster;
@@ -35,7 +33,9 @@ import org.apache.kafka.common.requests.DeleteAclsResponse;
 import org.apache.kafka.common.requests.DeleteAclsResponse.AclDeletionResult;
 import org.apache.kafka.common.requests.DeleteAclsResponse.AclFilterResponse;
 import org.apache.kafka.common.requests.DescribeAclsResponse;
-import org.apache.kafka.common.utils.Time;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,14 +48,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 
 /**
  * A unit test for KafkaAdminClient.
@@ -95,7 +93,7 @@ public class KafkaAdminClientTest {
         assertEquals("Null exception.", KafkaAdminClient.prettyPrintException(null));
         assertEquals("TimeoutException", KafkaAdminClient.prettyPrintException(new TimeoutException()));
         assertEquals("TimeoutException: The foobar timed out.",
-            KafkaAdminClient.prettyPrintException(new TimeoutException("The foobar timed out.")));
+                KafkaAdminClient.prettyPrintException(new TimeoutException("The foobar timed out.")));
     }
 
     private static Map<String, Object> newStrMap(String... vals) {
@@ -124,54 +122,36 @@ public class KafkaAdminClientTest {
             ids.add(id);
         }
         assertEquals("myCustomId",
-            KafkaAdminClient.generateClientId(newConfMap(AdminClientConfig.CLIENT_ID_CONFIG, "myCustomId")));
+                KafkaAdminClient.generateClientId(newConfMap(AdminClientConfig.CLIENT_ID_CONFIG, "myCustomId")));
     }
 
-    private static class MockKafkaAdminClientContext implements AutoCloseable {
-        final static String CLUSTER_ID = "mockClusterId";
-        final AdminClientConfig adminClientConfig;
-        final Metadata metadata;
-        final HashMap<Integer, Node> nodes;
-        final MockClient mockClient;
-        final AdminClient client;
-        Cluster cluster;
-
-        MockKafkaAdminClientContext(Map<String, Object> config) {
-            this.adminClientConfig = new AdminClientConfig(config);
-            this.metadata = new Metadata(adminClientConfig.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG),
-                adminClientConfig.getLong(AdminClientConfig.METADATA_MAX_AGE_CONFIG));
-            this.nodes = new HashMap<Integer, Node>();
-            this.nodes.put(0, new Node(0, "localhost", 8121));
-            this.nodes.put(1, new Node(1, "localhost", 8122));
-            this.nodes.put(2, new Node(2, "localhost", 8123));
-            this.mockClient = new MockClient(Time.SYSTEM, this.metadata);
-            this.client = KafkaAdminClient.create(adminClientConfig, mockClient, metadata);
-            this.cluster = new Cluster(CLUSTER_ID,  nodes.values(),
+    private static MockKafkaAdminClientEnv mockClientEnv(String... configVals) {
+        HashMap<Integer, Node> nodes = new HashMap<>();
+        nodes.put(0, new Node(0, "localhost", 8121));
+        nodes.put(1, new Node(1, "localhost", 8122));
+        nodes.put(2, new Node(2, "localhost", 8123));
+        Cluster cluster = new Cluster("mockClusterId", nodes.values(),
                 Collections.<PartitionInfo>emptySet(), Collections.<String>emptySet(),
                 Collections.<String>emptySet(), nodes.get(0));
-        }
-
-        @Override
-        public void close() {
-            this.client.close();
-        }
+        return new MockKafkaAdminClientEnv(cluster, configVals);
     }
 
     @Test
     public void testCloseAdminClient() throws Exception {
-        new MockKafkaAdminClientContext(newStrMap()).close();
+        try (MockKafkaAdminClientEnv env = mockClientEnv()) {
+        }
     }
 
     private static void assertFutureError(Future<?> future, Class<? extends Throwable> exceptionClass)
-        throws InterruptedException {
+            throws InterruptedException {
         try {
             future.get();
             fail("Expected a " + exceptionClass.getSimpleName() + " exception, but got success.");
         } catch (ExecutionException ee) {
             Throwable cause = ee.getCause();
             assertEquals("Expected a " + exceptionClass.getSimpleName() + " exception, but got " +
-                cause.getClass().getSimpleName(),
-                exceptionClass, cause.getClass());
+                            cause.getClass().getSimpleName(),
+                    exceptionClass, cause.getClass());
         }
     }
 
@@ -180,34 +160,27 @@ public class KafkaAdminClientTest {
      */
     @Test
     public void testTimeoutWithoutMetadata() throws Exception {
-        try (MockKafkaAdminClientContext ctx = new MockKafkaAdminClientContext(newStrMap(
-            AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10"))) {
-            ctx.mockClient.setNodeApiVersions(NodeApiVersions.create());
-            ctx.mockClient.setNode(new Node(0, "localhost", 8121));
-            ctx.mockClient.prepareResponse(new CreateTopicsResponse(new HashMap<String, ApiError>() {{
-                    put("myTopic", new ApiError(Errors.NONE, ""));
-                }}));
-            KafkaFuture<Void> future = ctx.client.
-                createTopics(Collections.singleton(new NewTopic("myTopic", new HashMap<Integer, List<Integer>>() {{
-                        put(0, Arrays.asList(new Integer[]{0, 1, 2}));
-                    }})), new CreateTopicsOptions().timeoutMs(1000)).all();
+        try (MockKafkaAdminClientEnv env = mockClientEnv(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "10")) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().setNode(new Node(0, "localhost", 8121));
+            env.kafkaClient().prepareResponse(new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
+            KafkaFuture<Void> future = env.adminClient().createTopics(
+                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(Integer.valueOf(0), Arrays.asList(new Integer[]{0, 1, 2})))),
+                    new CreateTopicsOptions().timeoutMs(1000)).all();
             assertFutureError(future, TimeoutException.class);
         }
     }
 
     @Test
     public void testCreateTopics() throws Exception {
-        try (MockKafkaAdminClientContext ctx = new MockKafkaAdminClientContext(newStrMap())) {
-            ctx.mockClient.setNodeApiVersions(NodeApiVersions.create());
-            ctx.mockClient.prepareMetadataUpdate(ctx.cluster, Collections.<String>emptySet());
-            ctx.mockClient.setNode(ctx.nodes.get(0));
-            ctx.mockClient.prepareResponse(new CreateTopicsResponse(new HashMap<String, ApiError>() {{
-                    put("myTopic", new ApiError(Errors.NONE, ""));
-                }}));
-            KafkaFuture<Void> future = ctx.client.
-                createTopics(Collections.singleton(new NewTopic("myTopic", new HashMap<Integer, List<Integer>>() {{
-                        put(0, Arrays.asList(new Integer[]{0, 1, 2}));
-                    }})), new CreateTopicsOptions().timeoutMs(10000)).all();
+        try (MockKafkaAdminClientEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(env.cluster().controller());
+            env.kafkaClient().prepareResponse(new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
+            KafkaFuture<Void> future = env.adminClient().createTopics(
+                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(Integer.valueOf(0), Arrays.asList(new Integer[]{0, 1, 2})))),
+                    new CreateTopicsOptions().timeoutMs(10000)).all();
             future.get();
         }
     }
@@ -223,45 +196,45 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testDescribeAcls() throws Exception {
-        try (MockKafkaAdminClientContext ctx = new MockKafkaAdminClientContext(newStrMap())) {
-            ctx.mockClient.setNodeApiVersions(NodeApiVersions.create());
-            ctx.mockClient.prepareMetadataUpdate(ctx.cluster, Collections.<String>emptySet());
-            ctx.mockClient.setNode(ctx.nodes.get(0));
+        try (MockKafkaAdminClientEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(env.cluster().controller());
 
             // Test a call where we get back ACL1 and ACL2.
-            ctx.mockClient.prepareResponse(new DescribeAclsResponse(0, null,
+            env.kafkaClient().prepareResponse(new DescribeAclsResponse(0, null,
                 new ArrayList<AclBinding>() {{
                         add(ACL1);
                         add(ACL2);
                     }}));
-            assertCollectionIs(ctx.client.describeAcls(FILTER1).all().get(), ACL1, ACL2);
+            assertCollectionIs(env.adminClient().describeAcls(FILTER1).all().get(), ACL1, ACL2);
 
             // Test a call where we get back no results.
-            ctx.mockClient.prepareResponse(new DescribeAclsResponse(0, null,
+            env.kafkaClient().prepareResponse(new DescribeAclsResponse(0, null,
                 Collections.<AclBinding>emptySet()));
-            assertTrue(ctx.client.describeAcls(FILTER2).all().get().isEmpty());
+            assertTrue(env.adminClient().describeAcls(FILTER2).all().get().isEmpty());
 
             // Test a call where we get back an error.
-            ctx.mockClient.prepareResponse(new DescribeAclsResponse(0,
+            env.kafkaClient().prepareResponse(new DescribeAclsResponse(0,
                 new SecurityDisabledException("Security is disabled"), Collections.<AclBinding>emptySet()));
-            assertFutureError(ctx.client.describeAcls(FILTER2).all(), SecurityDisabledException.class);
+            assertFutureError(env.adminClient().describeAcls(FILTER2).all(), SecurityDisabledException.class);
         }
     }
 
     @Test
     public void testCreateAcls() throws Exception {
-        try (MockKafkaAdminClientContext ctx = new MockKafkaAdminClientContext(newStrMap())) {
-            ctx.mockClient.setNodeApiVersions(NodeApiVersions.create());
-            ctx.mockClient.prepareMetadataUpdate(ctx.cluster, Collections.<String>emptySet());
-            ctx.mockClient.setNode(ctx.nodes.get(0));
+        try (MockKafkaAdminClientEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(env.cluster().controller());
 
             // Test a call where we successfully create two ACLs.
-            ctx.mockClient.prepareResponse(new CreateAclsResponse(0,
+            env.kafkaClient().prepareResponse(new CreateAclsResponse(0,
                 new ArrayList<AclCreationResponse>() {{
                         add(new AclCreationResponse(null));
                         add(new AclCreationResponse(null));
                     }}));
-            CreateAclsResults results = ctx.client.createAcls(new ArrayList<AclBinding>() {{
+            CreateAclsResults results = env.adminClient().createAcls(new ArrayList<AclBinding>() {{
                         add(ACL1);
                         add(ACL2);
                     }});
@@ -272,12 +245,12 @@ public class KafkaAdminClientTest {
             results.all().get();
 
             // Test a call where we fail to create one ACL.
-            ctx.mockClient.prepareResponse(new CreateAclsResponse(0,
+            env.kafkaClient().prepareResponse(new CreateAclsResponse(0,
                     new ArrayList<AclCreationResponse>() {{
                         add(new AclCreationResponse(new SecurityDisabledException("Security is disabled")));
                         add(new AclCreationResponse(null));
                     }}));
-            results = ctx.client.createAcls(new ArrayList<AclBinding>() {{
+            results = env.adminClient().createAcls(new ArrayList<AclBinding>() {{
                     add(ACL1);
                     add(ACL2);
                 }});
@@ -290,13 +263,13 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testDeleteAcls() throws Exception {
-        try (MockKafkaAdminClientContext ctx = new MockKafkaAdminClientContext(newStrMap())) {
-            ctx.mockClient.setNodeApiVersions(NodeApiVersions.create());
-            ctx.mockClient.prepareMetadataUpdate(ctx.cluster, Collections.<String>emptySet());
-            ctx.mockClient.setNode(ctx.nodes.get(0));
+        try (MockKafkaAdminClientEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(env.cluster().controller());
 
             // Test a call where one filter has an error.
-            ctx.mockClient.prepareResponse(new DeleteAclsResponse(0, new ArrayList<AclFilterResponse>() {{
+            env.kafkaClient().prepareResponse(new DeleteAclsResponse(0, new ArrayList<AclFilterResponse>() {{
                     add(new AclFilterResponse(null,
                             new ArrayList<AclDeletionResult>() {{
                                 add(new AclDeletionResult(null, ACL1));
@@ -305,7 +278,7 @@ public class KafkaAdminClientTest {
                     add(new AclFilterResponse(new SecurityDisabledException("No security"),
                         Collections.<AclDeletionResult>emptySet()));
                 }}));
-            DeleteAclsResults results = ctx.client.deleteAcls(new ArrayList<AclBindingFilter>() {{
+            DeleteAclsResults results = env.adminClient().deleteAcls(new ArrayList<AclBindingFilter>() {{
                         add(FILTER1);
                         add(FILTER2);
                     }});
@@ -320,7 +293,7 @@ public class KafkaAdminClientTest {
             assertFutureError(results.all(), SecurityDisabledException.class);
 
             // Test a call where one deletion result has an error.
-            ctx.mockClient.prepareResponse(new DeleteAclsResponse(0, new ArrayList<AclFilterResponse>() {{
+            env.kafkaClient().prepareResponse(new DeleteAclsResponse(0, new ArrayList<AclFilterResponse>() {{
                     add(new AclFilterResponse(null,
                         new ArrayList<AclDeletionResult>() {{
                                 add(new AclDeletionResult(null, ACL1));
@@ -328,7 +301,7 @@ public class KafkaAdminClientTest {
                             }}));
                     add(new AclFilterResponse(null, Collections.<AclDeletionResult>emptySet()));
                 }}));
-            results = ctx.client.deleteAcls(
+            results = env.adminClient().deleteAcls(
                     new ArrayList<AclBindingFilter>() {{
                             add(FILTER1);
                             add(FILTER2);
@@ -337,7 +310,7 @@ public class KafkaAdminClientTest {
             assertFutureError(results.all(), SecurityDisabledException.class);
 
             // Test a call where there are no errors.
-            ctx.mockClient.prepareResponse(new DeleteAclsResponse(0, new ArrayList<AclFilterResponse>() {{
+            env.kafkaClient().prepareResponse(new DeleteAclsResponse(0, new ArrayList<AclFilterResponse>() {{
                     add(new AclFilterResponse(null,
                         new ArrayList<AclDeletionResult>() {{
                                 add(new AclDeletionResult(null, ACL1));
@@ -347,7 +320,7 @@ public class KafkaAdminClientTest {
                                 add(new AclDeletionResult(null, ACL2));
                             }}));
                 }}));
-            results = ctx.client.deleteAcls(
+            results = env.adminClient().deleteAcls(
                     new ArrayList<AclBindingFilter>() {{
                         add(FILTER1);
                         add(FILTER2);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockKafkaAdminClientEnv.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockKafkaAdminClientEnv.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.MockClient;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.utils.Time;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple utility for setting up a mock {@link KafkaAdminClient} that uses a {@link MockClient} for a supplied
+ * {@link Cluster}. Create a {@link Cluster} manually or use {@link org.apache.kafka.test.TestUtils} methods to
+ * easily create a simple cluster.
+ * <p>
+ * To use in a test, create an instance and prepare its {@link #kafkaClient() MockClient} with the expected responses
+ * for the {@link AdminClient}. Then, use the {@link #adminClient() AdminClient} in the test, which will then use the MockClient
+ * and receive the responses you provided.
+ * <p>
+ * When finished, be sure to {@link #close() close} the environment object.
+ */
+public class MockKafkaAdminClientEnv implements AutoCloseable {
+    private final AdminClientConfig adminClientConfig;
+    private final Metadata metadata;
+    private final MockClient mockClient;
+    private final KafkaAdminClient client;
+    private final Cluster cluster;
+
+    public MockKafkaAdminClientEnv(Cluster cluster, String...vals) {
+        this(cluster, newStrMap(vals));
+    }
+
+    public MockKafkaAdminClientEnv(Cluster cluster, Map<String, Object> config) {
+        this.adminClientConfig = new AdminClientConfig(config);
+        this.cluster = cluster;
+        this.metadata = new Metadata(adminClientConfig.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG),
+                adminClientConfig.getLong(AdminClientConfig.METADATA_MAX_AGE_CONFIG));
+        this.mockClient = new MockClient(Time.SYSTEM, this.metadata);
+        this.client = KafkaAdminClient.create(adminClientConfig, mockClient, metadata);
+    }
+
+    public Cluster cluster() {
+        return cluster;
+    }
+
+    public AdminClient adminClient() {
+        return client;
+    }
+
+    public MockClient kafkaClient() {
+        return mockClient;
+    }
+
+    @Override
+    public void close() {
+        this.client.close();
+    }
+
+    private static Map<String, Object> newStrMap(String... vals) {
+        Map<String, Object> map = new HashMap<>();
+        map.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:8121");
+        map.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "1000");
+        if (vals.length % 2 != 0) {
+            throw new IllegalStateException();
+        }
+        for (int i = 0; i < vals.length; i += 2) {
+            map.put(vals[i], vals[i + 1]);
+        }
+        return map;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -69,12 +70,20 @@ public class TestUtils {
     public static final Random RANDOM = new Random();
     public static final long DEFAULT_MAX_WAIT_MS = 15000;
 
+    public static Cluster singletonCluster() {
+        return clusterWith(1);
+    }
+
     public static Cluster singletonCluster(final Map<String, Integer> topicPartitionCounts) {
         return clusterWith(1, topicPartitionCounts);
     }
 
     public static Cluster singletonCluster(final String topic, final int partitions) {
         return clusterWith(1, topic, partitions);
+    }
+
+    public static Cluster clusterWith(int nodes) {
+        return clusterWith(nodes, new HashMap<String, Integer>());
     }
 
     public static Cluster clusterWith(final int nodes, final Map<String, Integer> topicPartitionCounts) {

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -15,7 +15,11 @@
 # limitations under the License.
 ##
 
-# These are defaults. This file just demonstrates how to override some settings.
+# This file contains some of the configurations for the Kafka Connect distributed worker. This file is intended
+# to be used with the examples, and some settings may differ from those used in a production system, especially
+# the `bootstrap.servers` and those specifying replication factors.
+
+# A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
 bootstrap.servers=localhost:9092
 
 # unique name for the cluster, used in forming the Connect cluster group. Note that this must not conflict with consumer group IDs
@@ -30,8 +34,8 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 key.converter.schemas.enable=true
 value.converter.schemas.enable=true
 
-# The internal converter used for offsets and config data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset and config data is never visible outside of Kafka Connect in this format.
+# The internal converter used for offsets, config, and status data is configurable and must be specified, but most users will
+# always want to use the built-in default. Offset, config, and status data is never visible outside of Kafka Connect in this format.
 internal.key.converter=org.apache.kafka.connect.json.JsonConverter
 internal.value.converter=org.apache.kafka.connect.json.JsonConverter
 internal.key.converter.schemas.enable=false

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -37,15 +37,34 @@ internal.value.converter=org.apache.kafka.connect.json.JsonConverter
 internal.key.converter.schemas.enable=false
 internal.value.converter.schemas.enable=false
 
-# Topic to use for storing offsets. This topic should have many partitions and be replicated.
+# Topic to use for storing offsets. This topic should have many partitions and be replicated and compacted.
+# Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+# the topic before starting Kafka Connect if a specific topic configuration is needed.
+# Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+# Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+# to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
 offset.storage.topic=connect-offsets
+offset.storage.replication.factor=1
+#offset.storage.partitions=25
 
-# Topic to use for storing connector and task configurations; note that this should be a single partition, highly replicated topic.
-# You may need to manually create the topic to ensure single partition for the config topic as auto created topics may have multiple partitions.
+# Topic to use for storing connector and task configurations; note that this should be a single partition, highly replicated,
+# and compacted topic. Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+# the topic before starting Kafka Connect if a specific topic configuration is needed.
+# Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+# Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+# to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
 config.storage.topic=connect-configs
+config.storage.replication.factor=1
 
-# Topic to use for storing statuses. This topic can have multiple partitions and should be replicated.
+# Topic to use for storing statuses. This topic can have multiple partitions and should be replicated and compacted.
+# Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
+# the topic before starting Kafka Connect if a specific topic configuration is needed.
+# Most users will want to use the built-in default replication factor of 3 or in some cases even specify a larger value.
+# Since this means there must be at least as many brokers as the maximum replication factor used, we'd like to be able
+# to run this example on a single-broker cluster and so here we instead set the replication factor to 1.
 status.storage.topic=connect-status
+status.storage.replication.factor=1
+#status.storage.partitions=5
 
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -88,19 +88,49 @@ public class DistributedConfig extends WorkerConfig {
      * <code>offset.storage.topic</code>
      */
     public static final String OFFSET_STORAGE_TOPIC_CONFIG = "offset.storage.topic";
-    private static final String OFFSET_STORAGE_TOPIC_CONFIG_DOC = "kafka topic to store connector offsets in";
+    private static final String OFFSET_STORAGE_TOPIC_CONFIG_DOC = "The name of the Kafka topic where connector offsets are stored";
+
+    /**
+     * <code>offset.storage.partitions</code>
+     */
+    public static final String OFFSET_STORAGE_PARTITIONS_CONFIG = "offset.storage.partitions";
+    private static final String OFFSET_STORAGE_PARTITIONS_CONFIG_DOC = "The number of partitions used when creating the offset storage topic";
+
+    /**
+     * <code>offset.storage.replication.factor</code>
+     */
+    public static final String OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG = "offset.storage.replication.factor";
+    private static final String OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG_DOC = "Replication factor used when creating the offset storage topic";
 
     /**
      * <code>config.storage.topic</code>
      */
     public static final String CONFIG_TOPIC_CONFIG = "config.storage.topic";
-    private static final String CONFIG_TOPIC_CONFIG_DOC = "kafka topic to store configs";
+    private static final String CONFIG_TOPIC_CONFIG_DOC = "The name of the Kafka topic where connector configurations are stored";
+
+    /**
+     * <code>config.storage.replication.factor</code>
+     */
+    public static final String CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG = "config.storage.replication.factor";
+    private static final String CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG_DOC = "Replication factor used when creating the configuration storage topic";
 
     /**
      * <code>status.storage.topic</code>
      */
     public static final String STATUS_STORAGE_TOPIC_CONFIG = "status.storage.topic";
-    public static final String STATUS_STORAGE_TOPIC_CONFIG_DOC = "kafka topic to track connector and task status";
+    public static final String STATUS_STORAGE_TOPIC_CONFIG_DOC = "The name of the Kafka topic where connector and task status are stored";
+
+    /**
+     * <code>status.storage.partitions</code>
+     */
+    public static final String STATUS_STORAGE_PARTITIONS_CONFIG = "status.storage.partitions";
+    private static final String STATUS_STORAGE_PARTITIONS_CONFIG_DOC = "The number of partitions used when creating the status storage topic";
+
+    /**
+     * <code>status.storage.replication.factor</code>
+     */
+    public static final String STATUS_STORAGE_REPLICATION_FACTOR_CONFIG = "status.storage.replication.factor";
+    private static final String STATUS_STORAGE_REPLICATION_FACTOR_CONFIG_DOC = "Replication factor used when creating the status storage topic";
 
     static {
         CONFIG = baseConfigDef()
@@ -209,14 +239,39 @@ public class DistributedConfig extends WorkerConfig {
                         ConfigDef.Type.STRING,
                         ConfigDef.Importance.HIGH,
                         OFFSET_STORAGE_TOPIC_CONFIG_DOC)
+                .define(OFFSET_STORAGE_PARTITIONS_CONFIG,
+                        ConfigDef.Type.INT,
+                        25,
+                        ConfigDef.Importance.LOW,
+                        OFFSET_STORAGE_PARTITIONS_CONFIG_DOC)
+                .define(OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG,
+                        ConfigDef.Type.INT,
+                        3,
+                        ConfigDef.Importance.LOW,
+                        OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG_DOC)
                 .define(CONFIG_TOPIC_CONFIG,
                         ConfigDef.Type.STRING,
                         ConfigDef.Importance.HIGH,
                         CONFIG_TOPIC_CONFIG_DOC)
+                .define(CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG,
+                        ConfigDef.Type.INT,
+                        3,
+                        ConfigDef.Importance.LOW,
+                        CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG_DOC)
                 .define(STATUS_STORAGE_TOPIC_CONFIG,
                         ConfigDef.Type.STRING,
                         ConfigDef.Importance.HIGH,
-                        STATUS_STORAGE_TOPIC_CONFIG_DOC);
+                        STATUS_STORAGE_TOPIC_CONFIG_DOC)
+                .define(STATUS_STORAGE_PARTITIONS_CONFIG,
+                        ConfigDef.Type.INT,
+                        5,
+                        ConfigDef.Importance.LOW,
+                        STATUS_STORAGE_PARTITIONS_CONFIG_DOC)
+                .define(STATUS_STORAGE_REPLICATION_FACTOR_CONFIG,
+                        ConfigDef.Type.INT,
+                        3,
+                        ConfigDef.Importance.LOW,
+                        STATUS_STORAGE_REPLICATION_FACTOR_CONFIG_DOC);
     }
 
     public DistributedConfig(Map<String, String> props) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -242,11 +242,13 @@ public class DistributedConfig extends WorkerConfig {
                 .define(OFFSET_STORAGE_PARTITIONS_CONFIG,
                         ConfigDef.Type.INT,
                         25,
+                        atLeast(1),
                         ConfigDef.Importance.LOW,
                         OFFSET_STORAGE_PARTITIONS_CONFIG_DOC)
                 .define(OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG,
-                        ConfigDef.Type.INT,
+                        ConfigDef.Type.SHORT,
                         3,
+                        atLeast(1),
                         ConfigDef.Importance.LOW,
                         OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG_DOC)
                 .define(CONFIG_TOPIC_CONFIG,
@@ -254,8 +256,9 @@ public class DistributedConfig extends WorkerConfig {
                         ConfigDef.Importance.HIGH,
                         CONFIG_TOPIC_CONFIG_DOC)
                 .define(CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG,
-                        ConfigDef.Type.INT,
+                        ConfigDef.Type.SHORT,
                         3,
+                        atLeast(1),
                         ConfigDef.Importance.LOW,
                         CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG_DOC)
                 .define(STATUS_STORAGE_TOPIC_CONFIG,
@@ -265,11 +268,13 @@ public class DistributedConfig extends WorkerConfig {
                 .define(STATUS_STORAGE_PARTITIONS_CONFIG,
                         ConfigDef.Type.INT,
                         5,
+                        atLeast(1),
                         ConfigDef.Importance.LOW,
                         STATUS_STORAGE_PARTITIONS_CONFIG_DOC)
                 .define(STATUS_STORAGE_REPLICATION_FACTOR_CONFIG,
-                        ConfigDef.Type.INT,
+                        ConfigDef.Type.SHORT,
                         3,
+                        atLeast(1),
                         ConfigDef.Importance.LOW,
                         STATUS_STORAGE_REPLICATION_FACTOR_CONFIG_DOC);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -247,7 +247,7 @@ public class DistributedConfig extends WorkerConfig {
                         OFFSET_STORAGE_PARTITIONS_CONFIG_DOC)
                 .define(OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG,
                         ConfigDef.Type.SHORT,
-                        3,
+                        (short) 3,
                         atLeast(1),
                         ConfigDef.Importance.LOW,
                         OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG_DOC)
@@ -257,7 +257,7 @@ public class DistributedConfig extends WorkerConfig {
                         CONFIG_TOPIC_CONFIG_DOC)
                 .define(CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG,
                         ConfigDef.Type.SHORT,
-                        3,
+                        (short) 3,
                         atLeast(1),
                         ConfigDef.Importance.LOW,
                         CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG_DOC)
@@ -273,7 +273,7 @@ public class DistributedConfig extends WorkerConfig {
                         STATUS_STORAGE_PARTITIONS_CONFIG_DOC)
                 .define(STATUS_STORAGE_REPLICATION_FACTOR_CONFIG,
                         ConfigDef.Type.SHORT,
-                        3,
+                        (short) 3,
                         atLeast(1),
                         ConfigDef.Importance.LOW,
                         STATUS_STORAGE_REPLICATION_FACTOR_CONFIG_DOC);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -423,7 +423,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         final NewTopic topicDescription = TopicAdmin.defineTopic(topic).
                 compacted().
                 partitions(1).
-                replicationFactor(config.getInt(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG)).
+                replicationFactor(config.getShort(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG)).
                 build();
         TopicSupplier topicSupplier = new TopicSupplier() {
             @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -41,7 +40,6 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
-import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.apache.kafka.connect.util.TopicAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -407,7 +405,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
     }
 
     // package private for testing
-    KafkaBasedLog<String, byte[]> setupAndCreateKafkaBasedLog(String topic, WorkerConfig config) {
+    KafkaBasedLog<String, byte[]> setupAndCreateKafkaBasedLog(String topic, final WorkerConfig config) {
         Map<String, Object> producerProps = new HashMap<>();
         producerProps.putAll(config.originals());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
@@ -419,28 +417,29 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
 
-        final Map<String, Object> adminProps = new HashMap<>(config.originals());
-        final NewTopic topicDescription = TopicAdmin.defineTopic(topic).
+        Map<String, Object> adminProps = new HashMap<>(config.originals());
+        NewTopic topicDescription = TopicAdmin.defineTopic(topic).
                 compacted().
                 partitions(1).
                 replicationFactor(config.getShort(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG)).
                 build();
-        TopicSupplier topicSupplier = new TopicSupplier() {
-            @Override
-            public TopicDescription getOrCreateTopic(String topicName) {
-                try (TopicAdmin topicMaker = new TopicAdmin(adminProps)) {
-                    return topicMaker.createTopicIfMissing(topicDescription);
-                }
-            }
-        };
-        return createKafkaBasedLog(topic, producerProps, consumerProps, new ConsumeCallback(), topicSupplier);
+
+        return createKafkaBasedLog(topic, producerProps, consumerProps, new ConsumeCallback(), topicDescription, adminProps);
     }
 
     private KafkaBasedLog<String, byte[]> createKafkaBasedLog(String topic, Map<String, Object> producerProps,
                                                               Map<String, Object> consumerProps,
                                                               Callback<ConsumerRecord<String, byte[]>> consumedCallback,
-                                                              TopicSupplier topicSupplier) {
-        return new KafkaBasedLog<>(topic, producerProps, consumerProps, consumedCallback, Time.SYSTEM, topicSupplier);
+                                                              final NewTopic topicDescription, final Map<String, Object> adminProps) {
+        Runnable createTopics = new Runnable() {
+            @Override
+            public void run() {
+                try (TopicAdmin admin = new TopicAdmin(adminProps)) {
+                    admin.createTopics(topicDescription);
+                }
+            }
+        };
+        return new KafkaBasedLog<>(topic, producerProps, consumerProps, consumedCallback, Time.SYSTEM, createTopics);
     }
 
     @SuppressWarnings("unchecked")

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -84,7 +84,7 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         final NewTopic topicDescription = TopicAdmin.defineTopic(topic).
                 compacted().
                 partitions(config.getInt(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG)).
-                replicationFactor(config.getInt(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG)).
+                replicationFactor(config.getShort(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG)).
                 build();
         TopicSupplier topicSupplier = new TopicSupplier() {
             @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -40,7 +42,9 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
+import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.apache.kafka.connect.util.Table;
+import org.apache.kafka.connect.util.TopicAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,13 +137,35 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
 
+        final Map<String, Object> adminProps = new HashMap<>(config.originals());
+        final NewTopic topicDescription = TopicAdmin.defineTopic(topic).
+                compacted().
+                partitions(config.getInt(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG)).
+                replicationFactor(config.getInt(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG)).
+                build();
+        TopicSupplier topicSupplier = new TopicSupplier() {
+            @Override
+            public TopicDescription getOrCreateTopic(String topicName) {
+                try (TopicAdmin topicMaker = new TopicAdmin(adminProps)) {
+                    return topicMaker.createTopicIfMissing(topicDescription);
+                }
+            }
+        };
+
         Callback<ConsumerRecord<String, byte[]>> readCallback = new Callback<ConsumerRecord<String, byte[]>>() {
             @Override
             public void onCompletion(Throwable error, ConsumerRecord<String, byte[]> record) {
                 read(record);
             }
         };
-        this.kafkaLog = new KafkaBasedLog<>(topic, producerProps, consumerProps, readCallback, time);
+        this.kafkaLog = createKafkaBasedLog(topic, producerProps, consumerProps, readCallback, topicSupplier);
+    }
+
+    private KafkaBasedLog<String, byte[]> createKafkaBasedLog(String topic, Map<String, Object> producerProps,
+                                                              Map<String, Object> consumerProps,
+                                                              Callback<ConsumerRecord<String, byte[]>> consumedCallback,
+                                                              TopicSupplier topicSupplier) {
+        return new KafkaBasedLog<>(topic, producerProps, consumerProps, consumedCallback, time, topicSupplier);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -141,7 +141,7 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         final NewTopic topicDescription = TopicAdmin.defineTopic(topic).
                 compacted().
                 partitions(config.getInt(DistributedConfig.STATUS_STORAGE_PARTITIONS_CONFIG)).
-                replicationFactor(config.getInt(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG)).
+                replicationFactor(config.getShort(DistributedConfig.STATUS_STORAGE_REPLICATION_FACTOR_CONFIG)).
                 build();
         TopicSupplier topicSupplier = new TopicSupplier() {
             @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -16,8 +16,6 @@
  */
 package org.apache.kafka.connect.util;
 
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.admin.TopicPartitionInfo;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -69,19 +67,6 @@ import java.util.concurrent.Future;
  * </p>
  */
 public class KafkaBasedLog<K, V> {
-
-    /**
-     * A functional interface to obtain the description of a topic with a given name, creating the topic if necessary.
-     */
-    public interface TopicSupplier {
-        /**
-         * Get the description of the topic with the given name, optionally creating the topic if it does not yet exist.
-         * @param topicName the name of the topic
-         * @return the description for the newly-created or existing topic; null if it could not be obtained
-         */
-        TopicDescription getOrCreateTopic(String topicName);
-    }
-
     private static final Logger log = LoggerFactory.getLogger(KafkaBasedLog.class);
     private static final long CREATE_TOPIC_TIMEOUT_MS = 30000;
 
@@ -90,13 +75,13 @@ public class KafkaBasedLog<K, V> {
     private final Map<String, Object> producerConfigs;
     private final Map<String, Object> consumerConfigs;
     private final Callback<ConsumerRecord<K, V>> consumedCallback;
-    private final TopicSupplier topicSupplier;
     private Consumer<K, V> consumer;
     private Producer<K, V> producer;
 
     private Thread thread;
     private boolean stopRequested;
     private Queue<Callback<Void>> readLogEndOffsetCallbacks;
+    private Runnable initializer;
 
     /**
      * Create a new KafkaBasedLog object. This does not start reading the log and writing is not permitted until
@@ -113,14 +98,14 @@ public class KafkaBasedLog<K, V> {
      *                        behavior of this class.
      * @param consumedCallback callback to invoke for each {@link ConsumerRecord} consumed when tailing the log
      * @param time Time interface
-     * @param topicSupplier the function to get the description of a topic that exists or should be created; may be null
+     * @param initializer the component that should be run when this log is {@link #start() started}; may be null
      */
     public KafkaBasedLog(String topic,
                          Map<String, Object> producerConfigs,
                          Map<String, Object> consumerConfigs,
                          Callback<ConsumerRecord<K, V>> consumedCallback,
                          Time time,
-                         TopicSupplier topicSupplier) {
+                         Runnable initializer) {
         this.topic = topic;
         this.producerConfigs = producerConfigs;
         this.consumerConfigs = consumerConfigs;
@@ -128,10 +113,9 @@ public class KafkaBasedLog<K, V> {
         this.stopRequested = false;
         this.readLogEndOffsetCallbacks = new ArrayDeque<>();
         this.time = time;
-        this.topicSupplier = topicSupplier != null ? topicSupplier : new TopicSupplier() {
+        this.initializer = initializer != null ? initializer : new Runnable() {
             @Override
-            public TopicDescription getOrCreateTopic(String topicName) {
-                return null;
+            public void run() {
             }
         };
     }
@@ -139,31 +123,26 @@ public class KafkaBasedLog<K, V> {
     public void start() {
         log.info("Starting KafkaBasedLog with topic " + topic);
 
+        initializer.run();
         producer = createProducer();
         consumer = createConsumer();
 
         List<TopicPartition> partitions = new ArrayList<>();
-        TopicDescription topicDesc = topicSupplier.getOrCreateTopic(topic);
-        if (topicDesc != null) {
-            for (Map.Entry<Integer, TopicPartitionInfo> entry : topicDesc.partitions().entrySet()) {
-                partitions.add(new TopicPartition(topic, entry.getValue().partition()));
-            }
-        } else {
-            log.info("Unable to find or create topic '{}', so falling back to auto-creation.", topic);
-            List<PartitionInfo> partitionInfos = null;
-            long started = time.milliseconds();
-            while (partitionInfos == null && time.milliseconds() - started < CREATE_TOPIC_TIMEOUT_MS) {
-                partitionInfos = consumer.partitionsFor(topic);
-                Utils.sleep(Math.min(time.milliseconds() - started, 1000));
-                for (PartitionInfo partition : partitionInfos)
-                    partitions.add(new TopicPartition(partition.topic(), partition.partition()));
-            }
-            if (partitionInfos == null)
-                throw new ConnectException("Could not look up partition metadata for offset backing store topic in" +
-                        " allotted period. This could indicate a connectivity issue, unavailable topic partitions, or if" +
-                        " this is your first use of the topic it may have taken too long to auto-create.");
 
+        // We expect that the topics will have been created either manually by the user or automatically by the herder
+        List<PartitionInfo> partitionInfos = null;
+        long started = time.milliseconds();
+        while (partitionInfos == null && time.milliseconds() - started < CREATE_TOPIC_TIMEOUT_MS) {
+            partitionInfos = consumer.partitionsFor(topic);
+            Utils.sleep(Math.min(time.milliseconds() - started, 1000));
         }
+        if (partitionInfos == null)
+            throw new ConnectException("Could not look up partition metadata for offset backing store topic in" +
+                    " allotted period. This could indicate a connectivity issue, unavailable topic partitions, or if" +
+                    " this is your first use of the topic it may have taken too long to create.");
+
+        for (PartitionInfo partition : partitionInfos)
+            partitions.add(new TopicPartition(partition.topic(), partition.partition()));
         consumer.assign(partitions);
 
         readToLogEnd();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/KafkaBasedLog.java
@@ -149,7 +149,7 @@ public class KafkaBasedLog<K, V> {
                 partitions.add(new TopicPartition(topic, entry.getValue().partition()));
             }
         } else {
-            log.debug("Unable to find or create topic '{}', so falling back to auto-creation.", topic);
+            log.info("Unable to find or create topic '{}', so falling back to auto-creation.", topic);
             List<PartitionInfo> partitionInfos = null;
             long started = time.milliseconds();
             while (partitionInfos == null && time.milliseconds() - started < CREATE_TOPIC_TIMEOUT_MS) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -44,6 +44,13 @@ import java.util.concurrent.ExecutionException;
  */
 public class TopicAdmin implements AutoCloseable {
 
+    private static final String CLEANUP_POLICY_CONFIG = "cleanup.policy";
+    private static final String CLEANUP_POLICY_COMPACT = "compact";
+
+    private static final String MIN_INSYNC_REPLICAS_CONFIG = "min.insync.replicas";
+
+    private static final String UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG = "unclean.leader.election.enable";
+
     /**
      * A builder of {@link NewTopic} instances.
      */
@@ -74,8 +81,8 @@ public class TopicAdmin implements AutoCloseable {
          * @param replicationFactor the desired replication factor; must be positive
          * @return this builder to allow methods to be chained; never null
          */
-        public NewTopicBuilder replicationFactor(int replicationFactor) {
-            this.replicationFactor = (short) replicationFactor;
+        public NewTopicBuilder replicationFactor(short replicationFactor) {
+            this.replicationFactor = replicationFactor;
             return this;
         }
 
@@ -85,7 +92,7 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder compacted() {
-            this.configs.put("cleanup.policy", "compact");
+            this.configs.put(CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT);
             return this;
         }
 
@@ -96,7 +103,7 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder minInSyncReplicas(short minInSyncReplicas) {
-            this.configs.put("min.insync.replicas", Short.toString(minInSyncReplicas));
+            this.configs.put(MIN_INSYNC_REPLICAS_CONFIG, Short.toString(minInSyncReplicas));
             return this;
         }
 
@@ -108,7 +115,7 @@ public class TopicAdmin implements AutoCloseable {
          * @return this builder to allow methods to be chained; never null
          */
         public NewTopicBuilder uncleanLeaderElection(boolean allow) {
-            this.configs.put("unclean.leader.election.enable", Boolean.toString(allow));
+            this.configs.put(UNCLEAN_LEADER_ELECTION_ENABLE_CONFIG, Boolean.toString(allow));
             return this;
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Utility to simplify creating and managing topics via the {@link org.apache.kafka.clients.admin.AdminClient}.
+ */
+public class TopicAdmin implements AutoCloseable {
+
+    /**
+     * A builder of {@link NewTopic} instances.
+     */
+    public static class NewTopicBuilder {
+        private String name;
+        private int numPartitions;
+        private short replicationFactor;
+        private Map<String, String> configs = new HashMap<>();
+
+        NewTopicBuilder(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Specify the desired number of partitions for the topic.
+         *
+         * @param numPartitions the desired number of partitions; must be positive
+         * @return this builder to allow methods to be chained; never null
+         */
+        public NewTopicBuilder partitions(int numPartitions) {
+            this.numPartitions = numPartitions;
+            return this;
+        }
+
+        /**
+         * Specify the desired replication factor for the topic.
+         *
+         * @param replicationFactor the desired replication factor; must be positive
+         * @return this builder to allow methods to be chained; never null
+         */
+        public NewTopicBuilder replicationFactor(int replicationFactor) {
+            this.replicationFactor = (short) replicationFactor;
+            return this;
+        }
+
+        /**
+         * Specify that the topic should be compacted.
+         *
+         * @return this builder to allow methods to be chained; never null
+         */
+        public NewTopicBuilder compacted() {
+            this.configs.put("cleanup.policy", "compact");
+            return this;
+        }
+
+        /**
+         * Specify the minimum number of in-sync replicas required for this topic.
+         *
+         * @param minInSyncReplicas the minimum number of in-sync replicas allowed for the topic; must be positive
+         * @return this builder to allow methods to be chained; never null
+         */
+        public NewTopicBuilder minInSyncReplicas(short minInSyncReplicas) {
+            this.configs.put("min.insync.replicas", Short.toString(minInSyncReplicas));
+            return this;
+        }
+
+        /**
+         * Specify whether the broker is allowed to elect a leader that was not an in-sync replica when no ISRs
+         * are available.
+         *
+         * @param allow true if unclean leaders can be elected, or false if they are not allowed
+         * @return this builder to allow methods to be chained; never null
+         */
+        public NewTopicBuilder uncleanLeaderElection(boolean allow) {
+            this.configs.put("unclean.leader.election.enable", Boolean.toString(allow));
+            return this;
+        }
+
+        /**
+         * Specify the configuration properties for the topic, overwriting any previously-set properties.
+         *
+         * @param configs the desired topic configuration properties, or null if all existing properties should be cleared
+         * @return this builder to allow methods to be chained; never null
+         */
+        public NewTopicBuilder config(Map<String, Object> configs) {
+            if (configs != null) {
+                for (Map.Entry<String, Object> entry : configs.entrySet()) {
+                    Object value = entry.getValue();
+                    this.configs.put(entry.getKey(), value != null ? value.toString() : null);
+                }
+            } else {
+                this.configs.clear();
+            }
+            return this;
+        }
+
+        /**
+         * Build the {@link NewTopic} representation.
+         *
+         * @return the topic description; never null
+         */
+        public NewTopic build() {
+            return new NewTopic(name, numPartitions, replicationFactor).configs(configs);
+        }
+    }
+
+    /**
+     * Obtain a {@link NewTopicBuilder builder} to define a {@link NewTopic}.
+     * @param topicName the name of the topic
+     * @return the {@link NewTopic} description of the topic; never null
+     */
+    public static NewTopicBuilder defineTopic(String topicName) {
+        return new NewTopicBuilder(topicName);
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(TopicAdmin.class);
+    private final Map<String, Object> adminConfig;
+    private final AdminClient admin;
+
+    /**
+     * Create a new topic admin component with the given configuration.
+     *
+     * @param adminConfig the configuration for the {@link AdminClient}
+     */
+    public TopicAdmin(Map<String, Object> adminConfig) {
+        this(adminConfig, AdminClient.create(adminConfig));
+    }
+
+    // visible for testing
+    TopicAdmin(Map<String, Object> adminConfig, AdminClient adminClient) {
+        this.admin = adminClient;
+        this.adminConfig = adminConfig != null ? adminConfig : Collections.<String, Object>emptyMap();
+    }
+
+    /**
+     * Get a description of one or more topics.
+     *
+     * @param topicNames the names of the topics
+     * @return the mutable map of existing topic descriptions keyed by topic names; null only if the broker cannot perform this operation
+     * @throws ExecutionException   if an exception occurred during this operation
+     * @throws InterruptedException if this thread was interrupted while waiting for the description
+     */
+    private Map<String, TopicDescription> describeTopics(Collection<String> topicNames) throws ExecutionException, InterruptedException {
+        if (topicNames == null || topicNames.isEmpty()) return Collections.emptyMap();
+        Map<String, KafkaFuture<TopicDescription>> results = admin.describeTopics(topicNames).results();
+        Map<String, TopicDescription> descriptions = new HashMap<>();
+        for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : results.entrySet()) {
+            String topic = entry.getKey();
+            try {
+                descriptions.put(topic, entry.getValue().get());
+            } catch (InterruptedException e) {
+                throw e;
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof UnsupportedVersionException) {
+                    // Broker is too old
+                    return null;
+                }
+                if (cause instanceof UnknownTopicOrPartitionException || cause instanceof InvalidTopicException) {
+                    continue;
+                }
+                throw e;
+            }
+        }
+        return descriptions;
+    }
+
+    /**
+     * Given the topic definition, check whether the topic exists and if not then attempt to create the
+     * missing topic. The brokers will use its default topic options for anything not specified in the supplied definition.
+     * This method returns the topic details for the newly-created or previously-existing topic.
+     * <p>
+     * This operation requires the broker to support clients performing several administrative operations. If the broker
+     * does not support this capability, this method returns null.
+     *
+     * @param topic the specifications of the topic
+     * @return the topic description of the newly-created or existing topic; null only
+     * if the broker is too old to perform this operation
+     * @throws ConnectException if an error occurs, the operation takes too long, or the thread is interrupted while
+     *                          attempting to perform this operation
+     */
+    public TopicDescription createTopicIfMissing(NewTopic topic) {
+        Map<String, TopicDescription> result = createTopicsIfMissing(topic);
+        return result != null ? result.get(topic.name()) : null;
+    }
+
+    /**
+     * Given the topic definitions, check whether the topics exists and for all those that do not attempt to create the
+     * missing topics. The brokers will use its default topic options for anything not specified in the supplied definitions.
+     * This method returns the topic details for all of the topic included in the supplied descriptions.
+     * <p>
+     * This operation requires the broker to support clients performing several administrative operations. If the broker
+     * does not support this capability, this method returns null.
+     *
+     * @param topics the specifications of the topics
+     * @return the topic description of the newly-created or existing topics, keyed by the topic names; null only
+     * if the broker is too old to perform this operation
+     * @throws ConnectException if an error occurs, the operation takes too long, or the thread is interrupted while
+     *                          attempting to perform this operation
+     */
+    public Map<String, TopicDescription> createTopicsIfMissing(NewTopic... topics) {
+        if (topics == null || topics.length == 0) return Collections.emptyMap();
+
+        Map<String, NewTopic> topicsByName = new HashMap<>();
+        for (NewTopic topic : topics) {
+            if (topic != null) topicsByName.put(topic.name(), topic);
+        }
+        Set<String> requestedTopicNames = new HashSet<>(topicsByName.keySet());
+
+        try {
+            // Check for existing topics
+            Map<String, TopicDescription> descriptions = describeTopics(requestedTopicNames);
+            if (descriptions == null) {
+                // The broker is too old to do this work, so return immediately
+                log.debug("Unable to use Kafka admin client to read topic descriptions using the brokers at {}", this);
+                return null;
+            }
+
+            for (String existingTopicName : descriptions.keySet()) {
+                log.debug("Found existing topic '{}' on the brokers at {}", existingTopicName, this);
+                topicsByName.remove(existingTopicName);
+            }
+            if (topicsByName.isEmpty()) {
+                return descriptions;
+            }
+
+            // Attempt to create any missing topics
+            CreateTopicsOptions args = new CreateTopicsOptions().validateOnly(false);
+            Map<String, KafkaFuture<Void>> newResults = admin.createTopics(topicsByName.values(), args).results();
+
+            // Iterate over each one so that we can handle individual failures like when some topics already exist
+            for (Map.Entry<String, KafkaFuture<Void>> entry : newResults.entrySet()) {
+                String topic = entry.getKey();
+                try {
+                    entry.getValue().get();
+                    log.info("Created topic {} on brokers at {}", topicsByName.get(topic), this);
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof UnsupportedVersionException) {
+                        // Broker is too old
+                        log.info("Unable to use Kafka admin client to create topics using the brokers at {}", this);
+                        return null;
+                    }
+                    if (e.getCause() instanceof TopicExistsException) {
+                        // Must have been created by another client, so keep going
+                        log.debug("Found existing topic '{}' on the brokers at {}", topic, this);
+                        continue;
+                    }
+                    throw e;
+                }
+            }
+            // Get descriptions for the topics we just tried to create, including any that did in fact exist
+            Map<String, TopicDescription> newDescriptions = describeTopics(topicsByName.keySet());
+            // And combine with the descriptions for the already-existing topics
+            descriptions.putAll(newDescriptions);
+            return descriptions;
+        } catch (InterruptedException e) {
+            Thread.interrupted();
+            throw new ConnectException("Interrupted while attempting to create/find topic(s) '" + requestedTopicNames + "'", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof UnsupportedVersionException) {
+                // Broker is too old
+                log.debug("Unable to use Kafka admin client to create topic descriptions using the brokers at {}", this);
+                return null;
+            }
+            if (cause instanceof TimeoutException) {
+                // Timed out waiting for the operation to complete
+                throw new ConnectException("Timed out while checking for or creating topic(s) '" + requestedTopicNames + "'." +
+                        " This could indicate a connectivity issue, unavailable topic partitions, or if" +
+                        " this is your first use of the topic it may have taken too long to create.", cause);
+            }
+            throw new ConnectException("Error while attempting to create/find topics '" + requestedTopicNames + "'", cause);
+        }
+    }
+
+    @Override
+    public void close() {
+        admin.close();
+    }
+
+    @Override
+    public String toString() {
+        Object servers = adminConfig.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG);
+        return servers != null ? servers.toString() : "<unknown>";
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -19,22 +19,16 @@ package org.apache.kafka.connect.util;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
-import org.apache.kafka.clients.admin.ListTopicsOptions;
-import org.apache.kafka.clients.admin.ListTopicsResults;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -179,181 +173,82 @@ public class TopicAdmin implements AutoCloseable {
         this.adminConfig = adminConfig != null ? adminConfig : Collections.<String, Object>emptyMap();
     }
 
-    /**
-     * Filter the supplied list of topics to determine which of them already exist.
+   /**
+     * Attempt to create the topic described by the given definition, returning true if the topic was created or false
+     * if the topic already existed.
      *
-     * @param topicNames the names of the topics
-     * @return the set of names that refer to already-existing topics; null only if the broker cannot perform this operation
-     * @throws ExecutionException
-     * @throws InterruptedException
+     * @param topic the specification of the topic
+     * @return true if the topic was created or false if the topic already existed.
+     * @throws ConnectException            if an error occurs, the operation takes too long, or the thread is interrupted while
+     *                                     attempting to perform this operation
+     * @throws UnsupportedVersionException if the broker does not support the necessary APIs to perform this request
      */
-    private Set<String> existingTopics(Collection<String> topicNames) throws ExecutionException, InterruptedException {
-        if (topicNames == null || topicNames.isEmpty()) return Collections.emptySet();
-
-        Set<String> existingTopicNames = new HashSet<>();
-        try {
-            ListTopicsResults listingResults = admin.listTopics(new ListTopicsOptions().listInternal(true));
-            Map<String, TopicListing> topicListingsByName = listingResults.namesToDescriptions().get();
-            for (String topicName : topicNames) {
-                TopicListing listing = topicListingsByName.get(topicName);
-                if (listing != null) {
-                    existingTopicNames.add(listing.name());
-                }
-            }
-        } catch (InterruptedException e) {
-            throw e;
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof UnsupportedVersionException) {
-                // Broker is too old
-                return null;
-            }
-            throw e;
-        }
-        return existingTopicNames;
+    public boolean createTopic(NewTopic topic) {
+        if (topic == null) return false;
+        Set<String> newTopicNames = createTopics(topic);
+        return newTopicNames.contains(topic.name());
     }
 
     /**
-     * Get a description of one or more topics.
-     *
-     * @param topicNames the names of the topics
-     * @return the mutable map of existing topic descriptions keyed by topic names; null only if the broker cannot perform this operation
-     * @throws ExecutionException   if an exception occurred during this operation
-     * @throws InterruptedException if this thread was interrupted while waiting for the description
-     */
-    private Map<String, TopicDescription> describeTopics(Collection<String> topicNames) throws ExecutionException, InterruptedException {
-        if (topicNames == null || topicNames.isEmpty()) return Collections.emptyMap();
-
-        // Now get the descriptions for those topics that already exist ...
-        Map<String, KafkaFuture<TopicDescription>> results = admin.describeTopics(topicNames).results();
-        Map<String, TopicDescription> descriptions = new HashMap<>();
-        for (Map.Entry<String, KafkaFuture<TopicDescription>> entry : results.entrySet()) {
-            String topic = entry.getKey();
-            try {
-                descriptions.put(topic, entry.getValue().get());
-            } catch (InterruptedException e) {
-                throw e;
-            } catch (ExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof UnsupportedVersionException) {
-                    // Broker is too old
-                    return null;
-                }
-                if (cause instanceof UnknownTopicOrPartitionException || cause instanceof InvalidTopicException) {
-                    continue;
-                }
-                throw e;
-            }
-        }
-        return descriptions;
-    }
-
-    /**
-     * Given the topic definition, check whether the topic exists and if not then attempt to create the
-     * missing topic. The brokers will use its default topic options for anything not specified in the supplied definition.
-     * This method returns the topic details for the newly-created or previously-existing topic.
+     * Attempt to create the topics described by the given definitions, returning all of the names of those topics that
+     * were created by this request. Any existing topics with the same name are unchanged, and the names of such topics
+     * are excluded from the result.
      * <p>
-     * This operation requires the broker to support clients performing several administrative operations. If the broker
-     * does not support this capability, this method returns null.
-     *
-     * @param topic the specifications of the topic
-     * @return the topic description of the newly-created or existing topic; null only
-     * if the broker is too old to perform this operation
-     * @throws ConnectException if an error occurs, the operation takes too long, or the thread is interrupted while
-     *                          attempting to perform this operation
-     */
-    public TopicDescription createTopicIfMissing(NewTopic topic) {
-        Map<String, TopicDescription> result = createTopicsIfMissing(topic);
-        return result != null ? result.get(topic.name()) : null;
-    }
-
-    /**
-     * Given the topic definitions, check whether the topics exists and for all those that do not attempt to create the
-     * missing topics. The brokers will use its default topic options for anything not specified in the supplied definitions.
-     * This method returns the topic details for all of the topic included in the supplied descriptions.
-     * <p>
-     * This operation requires the broker to support clients performing several administrative operations. If the broker
-     * does not support this capability, this method returns null.
+     * If multiple topic definitions have the same topic name, the last one with that name will be used.
+     * </p>
      *
      * @param topics the specifications of the topics
-     * @return the topic description of the newly-created or existing topics, keyed by the topic names; null only
-     * if the broker is too old to perform this operation
-     * @throws ConnectException if an error occurs, the operation takes too long, or the thread is interrupted while
-     *                          attempting to perform this operation
+     * @return the names of the topics that were created by this operation; never null but possibly empty
+     * @throws ConnectException            if an error occurs, the operation takes too long, or the thread is interrupted while
+     *                                     attempting to perform this operation
+     * @throws UnsupportedVersionException if the broker does not support the necessary APIs to perform this request
      */
-    public Map<String, TopicDescription> createTopicsIfMissing(NewTopic... topics) {
-        if (topics == null || topics.length == 0) return Collections.emptyMap();
-
+    public Set<String> createTopics(NewTopic... topics) {
         Map<String, NewTopic> topicsByName = new HashMap<>();
-        for (NewTopic topic : topics) {
-            if (topic != null) topicsByName.put(topic.name(), topic);
+        if (topics != null) {
+            for (NewTopic topic : topics) {
+                if (topic != null) topicsByName.put(topic.name(), topic);
+            }
         }
-        Set<String> allRequestedTopicNames = new HashSet<>(topicsByName.keySet());
+        if (topicsByName.isEmpty()) return Collections.emptySet();
         String bootstrapServers = bootstrapServers();
+        String topicNameList = Utils.join(topicsByName.keySet(), "', '");
 
-        try {
-            // Getting topic descriptions for non-existant topics may auto-create them, so first see which of
-            // our topics do already exist
-            Set<String> existingTopicNames = existingTopics(topicsByName.keySet());
-            if (existingTopicNames == null) {
-                // The broker is too old to do this work, so return immediately
-                log.debug("Unable to use Kafka admin client to list existing topics using the brokers at {}", bootstrapServers);
-                return null;
-            }
+        // Attempt to create any missing topics
+        CreateTopicsOptions args = new CreateTopicsOptions().validateOnly(false);
+        Map<String, KafkaFuture<Void>> newResults = admin.createTopics(topicsByName.values(), args).results();
 
-            // Remove the topics that already exist
-            for (String existingTopicName : existingTopicNames) {
-                log.debug("Found existing topic '{}' on the brokers at {}", existingTopicName, bootstrapServers);
-                topicsByName.remove(existingTopicName);
-            }
-
-            if (!topicsByName.isEmpty()) {
-                // Attempt to create any missing topics
-                CreateTopicsOptions args = new CreateTopicsOptions().validateOnly(false);
-                Map<String, KafkaFuture<Void>> newResults = admin.createTopics(topicsByName.values(), args).results();
-
-                // Iterate over each one so that we can handle individual failures like when some topics already exist
-                for (Map.Entry<String, KafkaFuture<Void>> entry : newResults.entrySet()) {
-                    String topic = entry.getKey();
-                    try {
-                        entry.getValue().get();
-                        log.info("Created topic {} on brokers at {}", topicsByName.get(topic), bootstrapServers);
-                    } catch (ExecutionException e) {
-                        Throwable cause = e.getCause();
-                        if (cause instanceof UnsupportedVersionException) {
-                            // Broker is too old
-                            log.info("Unable to use Kafka admin client to create topics using the brokers at {}", bootstrapServers);
-                            return null;
-                        }
-                        if (e.getCause() instanceof TopicExistsException) {
-                            // Must have been created by another client, so keep going
-                            log.debug("Found existing topic '{}' on the brokers at {}", topic, bootstrapServers);
-                            continue;
-                        }
-                        throw e;
-                    }
+        // Iterate over each future so that we can handle individual failures like when some topics already exist
+        Set<String> newlyCreatedTopicNames = new HashSet<>();
+        for (Map.Entry<String, KafkaFuture<Void>> entry : newResults.entrySet()) {
+            String topic = entry.getKey();
+            try {
+                entry.getValue().get();
+                log.info("Created topic {} on brokers at {}", topicsByName.get(topic), bootstrapServers);
+                newlyCreatedTopicNames.add(topic);
+            } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                if (e.getCause() instanceof TopicExistsException) {
+                    log.debug("Found existing topic '{}' on the brokers at {}", topic, bootstrapServers);
+                    continue;
                 }
+                if (cause instanceof UnsupportedVersionException) {
+                    log.error("Unable to use Kafka admin client to create topic descriptions for '{}' using the brokers at {}", topicNameList, bootstrapServers);
+                    throw (UnsupportedVersionException) cause;
+                }
+                if (cause instanceof TimeoutException) {
+                    // Timed out waiting for the operation to complete
+                    throw new ConnectException("Timed out while checking for or creating topic(s) '" + topicNameList + "'." +
+                            " This could indicate a connectivity issue, unavailable topic partitions, or if" +
+                            " this is your first use of the topic it may have taken too long to create.", cause);
+                }
+                throw new ConnectException("Error while attempting to create/find topic(s) '" + topicNameList + "'", e);
+            } catch (InterruptedException e) {
+                Thread.interrupted();
+                throw new ConnectException("Interrupted while attempting to create/find topic(s) '" + topicNameList + "'", e);
             }
-            // Get descriptions for all the topics we're interested in, including those that we just may have created
-            return describeTopics(allRequestedTopicNames);
-        } catch (InterruptedException e) {
-            Thread.interrupted();
-            throw new ConnectException("Interrupted while attempting to create/find topic(s) '" + allRequestedTopicNames + "'", e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof UnsupportedVersionException) {
-                // Broker is too old
-                log.info("Unable to use Kafka admin client to create topic descriptions using the brokers at {}", bootstrapServers);
-                return null;
-            }
-            if (cause instanceof TimeoutException) {
-                // Timed out waiting for the operation to complete
-                throw new ConnectException("Timed out while checking for or creating topic(s) '" + allRequestedTopicNames + "'." +
-                        " This could indicate a connectivity issue, unavailable topic partitions, or if" +
-                        " this is your first use of the topic it may have taken too long to create.", cause);
-            }
-            throw new ConnectException("Error while attempting to create/find topics '" + allRequestedTopicNames + "'", cause);
         }
+        return newlyCreatedTopicNames;
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -31,7 +32,6 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
-import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.apache.kafka.connect.util.TestFuture;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -66,12 +66,14 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("unchecked")
 public class KafkaConfigBackingStoreTest {
     private static final String TOPIC = "connect-configs";
+    private static final short TOPIC_REPLICATION_FACTOR = 5;
     private static final Map<String, String> DEFAULT_CONFIG_STORAGE_PROPS = new HashMap<>();
     private static final DistributedConfig DEFAULT_DISTRIBUTED_CONFIG;
 
     static {
         DEFAULT_CONFIG_STORAGE_PROPS.put(DistributedConfig.CONFIG_TOPIC_CONFIG, TOPIC);
         DEFAULT_CONFIG_STORAGE_PROPS.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "connect-offsets");
+        DEFAULT_CONFIG_STORAGE_PROPS.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, Short.toString(TOPIC_REPLICATION_FACTOR));
         DEFAULT_CONFIG_STORAGE_PROPS.put(DistributedConfig.GROUP_ID_CONFIG, "connect");
         DEFAULT_CONFIG_STORAGE_PROPS.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "status-topic");
         DEFAULT_CONFIG_STORAGE_PROPS.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "broker1:9092,broker2:9093");
@@ -137,8 +139,9 @@ public class KafkaConfigBackingStoreTest {
     private Capture<String> capturedTopic = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedProducerProps = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedConsumerProps = EasyMock.newCapture();
+    private Capture<Map<String, Object>> capturedAdminProps = EasyMock.newCapture();
+    private Capture<NewTopic> capturedNewTopic = EasyMock.newCapture();
     private Capture<Callback<ConsumerRecord<String, byte[]>>> capturedConsumedCallback = EasyMock.newCapture();
-    private Capture<TopicSupplier> capturedTopicSupplier = EasyMock.newCapture();
 
     private long logOffset = 0;
 
@@ -165,6 +168,9 @@ public class KafkaConfigBackingStoreTest {
         assertEquals("org.apache.kafka.common.serialization.StringDeserializer", capturedConsumerProps.getValue().get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
         assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", capturedConsumerProps.getValue().get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
 
+        assertEquals(TOPIC, capturedNewTopic.getValue().name());
+        assertEquals(1, capturedNewTopic.getValue().partitions());
+        assertEquals(TOPIC_REPLICATION_FACTOR, capturedNewTopic.getValue().replicationFactor());
         configStorage.start();
         configStorage.stop();
 
@@ -750,7 +756,7 @@ public class KafkaConfigBackingStoreTest {
         PowerMock.expectPrivate(configStorage, "createKafkaBasedLog",
                 EasyMock.capture(capturedTopic), EasyMock.capture(capturedProducerProps),
                 EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback),
-                EasyMock.capture(capturedTopicSupplier))
+                EasyMock.capture(capturedNewTopic), EasyMock.capture(capturedAdminProps))
                 .andReturn(storeLog);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
+import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.apache.kafka.connect.util.TestFuture;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
@@ -137,6 +138,7 @@ public class KafkaConfigBackingStoreTest {
     private Capture<Map<String, Object>> capturedProducerProps = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedConsumerProps = EasyMock.newCapture();
     private Capture<Callback<ConsumerRecord<String, byte[]>>> capturedConsumedCallback = EasyMock.newCapture();
+    private Capture<TopicSupplier> capturedTopicSupplier = EasyMock.newCapture();
 
     private long logOffset = 0;
 
@@ -747,7 +749,8 @@ public class KafkaConfigBackingStoreTest {
     private void expectConfigure() throws Exception {
         PowerMock.expectPrivate(configStorage, "createKafkaBasedLog",
                 EasyMock.capture(capturedTopic), EasyMock.capture(capturedProducerProps),
-                EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback))
+                EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback),
+                EasyMock.capture(capturedTopicSupplier))
                 .andReturn(storeLog);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.KafkaBasedLog;
+import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -101,6 +102,7 @@ public class KafkaOffsetBackingStoreTest {
     private Capture<Map<String, Object>> capturedProducerProps = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedConsumerProps = EasyMock.newCapture();
     private Capture<Callback<ConsumerRecord<byte[], byte[]>>> capturedConsumedCallback = EasyMock.newCapture();
+    private Capture<TopicSupplier> capturedTopicSupplier = EasyMock.newCapture();
 
     @Before
     public void setUp() throws Exception {
@@ -402,7 +404,7 @@ public class KafkaOffsetBackingStoreTest {
 
     private void expectConfigure() throws Exception {
         PowerMock.expectPrivate(store, "createKafkaBasedLog", EasyMock.capture(capturedTopic), EasyMock.capture(capturedProducerProps),
-                EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback))
+                EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback), EasyMock.capture(capturedTopicSupplier))
                 .andReturn(storeLog);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -25,7 +26,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
 import org.apache.kafka.connect.util.KafkaBasedLog;
-import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -63,13 +63,17 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("unchecked")
 public class KafkaOffsetBackingStoreTest {
     private static final String TOPIC = "connect-offsets";
+    private static final short TOPIC_PARTITIONS = 2;
+    private static final short TOPIC_REPLICATION_FACTOR = 5;
     private static final Map<String, String> DEFAULT_PROPS = new HashMap<>();
     private static final DistributedConfig DEFAULT_DISTRIBUTED_CONFIG;
     static {
         DEFAULT_PROPS.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "broker1:9092,broker2:9093");
         DEFAULT_PROPS.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, TOPIC);
+        DEFAULT_PROPS.put(DistributedConfig.OFFSET_STORAGE_REPLICATION_FACTOR_CONFIG, Short.toString(TOPIC_REPLICATION_FACTOR));
+        DEFAULT_PROPS.put(DistributedConfig.OFFSET_STORAGE_PARTITIONS_CONFIG, Integer.toString(TOPIC_PARTITIONS));
         DEFAULT_PROPS.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "connect-configs");
-        DEFAULT_PROPS.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "connect-offsets");
+        DEFAULT_PROPS.put(DistributedConfig.CONFIG_STORAGE_REPLICATION_FACTOR_CONFIG, Short.toString(TOPIC_REPLICATION_FACTOR));
         DEFAULT_PROPS.put(DistributedConfig.GROUP_ID_CONFIG, "connect");
         DEFAULT_PROPS.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "status-topic");
         DEFAULT_PROPS.put(DistributedConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
@@ -101,8 +105,9 @@ public class KafkaOffsetBackingStoreTest {
     private Capture<String> capturedTopic = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedProducerProps = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedConsumerProps = EasyMock.newCapture();
+    private Capture<Map<String, Object>> capturedAdminProps = EasyMock.newCapture();
+    private Capture<NewTopic> capturedNewTopic = EasyMock.newCapture();
     private Capture<Callback<ConsumerRecord<byte[], byte[]>>> capturedConsumedCallback = EasyMock.newCapture();
-    private Capture<TopicSupplier> capturedTopicSupplier = EasyMock.newCapture();
 
     @Before
     public void setUp() throws Exception {
@@ -123,6 +128,10 @@ public class KafkaOffsetBackingStoreTest {
         assertEquals("org.apache.kafka.common.serialization.ByteArraySerializer", capturedProducerProps.getValue().get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG));
         assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", capturedConsumerProps.getValue().get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
         assertEquals("org.apache.kafka.common.serialization.ByteArrayDeserializer", capturedConsumerProps.getValue().get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+
+        assertEquals(TOPIC, capturedNewTopic.getValue().name());
+        assertEquals(TOPIC_PARTITIONS, capturedNewTopic.getValue().partitions());
+        assertEquals(TOPIC_REPLICATION_FACTOR, capturedNewTopic.getValue().replicationFactor());
 
         store.start();
         store.stop();
@@ -404,7 +413,8 @@ public class KafkaOffsetBackingStoreTest {
 
     private void expectConfigure() throws Exception {
         PowerMock.expectPrivate(store, "createKafkaBasedLog", EasyMock.capture(capturedTopic), EasyMock.capture(capturedProducerProps),
-                EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback), EasyMock.capture(capturedTopicSupplier))
+                EasyMock.capture(capturedConsumerProps), EasyMock.capture(capturedConsumedCallback),
+                EasyMock.capture(capturedNewTopic), EasyMock.capture(capturedAdminProps))
                 .andReturn(storeLog);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -17,8 +17,6 @@
 package org.apache.kafka.connect.util;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.clients.admin.TopicPartitionInfo;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -36,7 +34,6 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -56,9 +53,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -105,19 +100,6 @@ public class KafkaBasedLogTest {
     private static final PartitionInfo TPINFO0 = new PartitionInfo(TOPIC, 0, LEADER, new Node[]{REPLICA}, new Node[]{REPLICA});
     private static final PartitionInfo TPINFO1 = new PartitionInfo(TOPIC, 1, LEADER, new Node[]{REPLICA}, new Node[]{REPLICA});
 
-    private static final TopicDescription TOPIC_DESCRIPTION = createTopicDescription(TOPIC, TPINFO0, TPINFO1);
-
-    private static TopicDescription createTopicDescription(String topicName, PartitionInfo...partitionInfos) {
-        NavigableMap<Integer, TopicPartitionInfo> partitions = new TreeMap<>();
-        for (PartitionInfo info : partitionInfos) {
-            List<Node> replicas = Arrays.asList(info.replicas());
-            List<Node> isrs = Arrays.asList(info.inSyncReplicas());
-            TopicPartitionInfo tpInfo = new TopicPartitionInfo(info.partition(), info.leader(), replicas, isrs);
-            partitions.put(tpInfo.partition(), tpInfo);
-        }
-        return new TopicDescription(topicName, false, partitions);
-    }
-
     private static final String TP0_KEY = "TP0KEY";
     private static final String TP1_KEY = "TP1KEY";
     private static final String TP0_VALUE = "VAL0";
@@ -129,10 +111,10 @@ public class KafkaBasedLogTest {
     private KafkaBasedLog<String, String> store;
 
     @Mock
+    private Runnable initializer;
+    @Mock
     private KafkaProducer<String, String> producer;
     private MockConsumer<String, String> consumer;
-    @Mock
-    private TopicSupplier topicSupplier;
 
     private Map<TopicPartition, List<ConsumerRecord<String, String>>> consumedRecords = new HashMap<>();
     private Callback<ConsumerRecord<String, String>> consumedCallback = new Callback<ConsumerRecord<String, String>>() {
@@ -151,7 +133,7 @@ public class KafkaBasedLogTest {
     @Before
     public void setUp() throws Exception {
         store = PowerMock.createPartialMock(KafkaBasedLog.class, new String[]{"createConsumer", "createProducer"},
-                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, time, topicSupplier);
+                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, time, initializer);
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
         consumer.updatePartitions(TOPIC, Arrays.asList(TPINFO0, TPINFO1));
         Map<TopicPartition, Long> beginningOffsets = new HashMap<>();
@@ -482,7 +464,9 @@ public class KafkaBasedLogTest {
 
 
     private void expectStart() throws Exception {
-        EasyMock.expect(topicSupplier.getOrCreateTopic(EasyMock.eq(TOPIC))).andReturn(TOPIC_DESCRIPTION);
+        initializer.run();
+        EasyMock.expectLastCall().times(1);
+
         PowerMock.expectPrivate(store, "createProducer")
                 .andReturn(producer);
         PowerMock.expectPrivate(store, "createConsumer")

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.util.KafkaBasedLog.TopicSupplier;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -89,6 +90,7 @@ public class KafkaBasedLogTest {
 
     private static final Set<TopicPartition> CONSUMER_ASSIGNMENT = new HashSet<>(Arrays.asList(TP0, TP1));
     private static final Map<String, String> FIRST_SET = new HashMap<>();
+    private static final TopicSupplier TOPIC_SUPPLIER = null;
     static {
         FIRST_SET.put("key", "value");
         FIRST_SET.put(null, null);
@@ -131,7 +133,7 @@ public class KafkaBasedLogTest {
     @Before
     public void setUp() throws Exception {
         store = PowerMock.createPartialMock(KafkaBasedLog.class, new String[]{"createConsumer", "createProducer"},
-                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, time);
+                TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, time, TOPIC_SUPPLIER);
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
         consumer.updatePartitions(TOPIC, Arrays.asList(TPINFO0, TPINFO1));
         Map<TopicPartition, Long> beginningOffsets = new HashMap<>();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.clients.admin.MockKafkaAdminClientEnv;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.requests.CreateTopicsResponse;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
+import org.apache.kafka.common.requests.MetadataResponse.TopicMetadata;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+public class TopicAdminTest {
+
+    /**
+     * 0.10.x clients can't talk with 0.9.x brokers, and 0.10.0.0 introduced the new protocol with API versions.
+     * That means we can simulate an API version mismatch.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void returnNullWithApiVersionMismatch() throws Exception {
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        boolean internal = false;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
+            env.kafkaClient().prepareResponse(createTopicResponseWithUnsupportedVersion(newTopic));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicDescription desc = admin.createTopicIfMissing(newTopic);
+            assertNull(desc);
+        }
+    }
+
+    @Test
+    public void returnTopicDescriptionForExistingTopic() throws Exception {
+        NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        boolean internal = false;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicDescription desc = admin.createTopicIfMissing(newTopic);
+            assertNotNull(desc);
+            assertEquals(desc.name(), newTopic.name());
+            assertEquals(desc.internal(), internal);
+        }
+    }
+
+    @Test
+    public void returnTopicDescriptionForExistingInternalTopic() throws Exception {
+        NewTopic newTopic = TopicAdmin.defineTopic("_myTopic").partitions(1).compacted().build();
+        boolean internal = true;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicDescription desc = admin.createTopicIfMissing(newTopic);
+            assertNotNull(desc);
+            assertEquals(desc.name(), newTopic.name());
+            assertEquals(desc.internal(), internal);
+        }
+    }
+
+    @Test
+    public void returnTopicDescriptionForNewTopic() throws Exception {
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        boolean internal = false;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            // Three calls are made ...
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
+            env.kafkaClient().prepareResponse(createTopicResponse(newTopic));
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            TopicDescription desc = admin.createTopicIfMissing(newTopic);
+            assertNotNull(desc);
+            assertEquals(desc.name(), newTopic.name());
+            assertEquals(desc.internal(), internal);
+        }
+    }
+
+    @Test
+    public void returnTopicDescriptionsForMultipleNewTopics() throws Exception {
+        final NewTopic newTopic1 = TopicAdmin.defineTopic("myTopic1").partitions(1).compacted().build();
+        final NewTopic newTopic2 = TopicAdmin.defineTopic("myTopic2").partitions(1).compacted().build();
+        boolean internal = false;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            // Three calls are made ...
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
+            env.kafkaClient().prepareResponse(createTopicResponse(newTopic1, newTopic2));
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
+                    withTopic(newTopic1.name(), newTopic1.partitions(), internal).
+                    withTopic(newTopic2.name(), newTopic2.partitions(), internal).
+                    response());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, TopicDescription> desc = admin.createTopicsIfMissing(newTopic1, newTopic2);
+            assertNotNull(desc);
+            assertEquals(desc.size(), 2);
+            TopicDescription desc1 = desc.get(newTopic1.name());
+            TopicDescription desc2 = desc.get(newTopic2.name());
+            assertEquals(desc1.name(), newTopic1.name());
+            assertEquals(desc1.internal(), internal);
+            assertEquals(desc2.name(), newTopic2.name());
+            assertEquals(desc2.internal(), internal);
+        }
+    }
+
+    @Test
+    public void returnTopicDescriptionsForNewAndExistingTopics() throws Exception {
+        final NewTopic existingTopic = TopicAdmin.defineTopic("myTopic1").partitions(1).compacted().build();
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic2").partitions(1).compacted().build();
+        boolean internal = false;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            // First expect to find existing topic ...
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(existingTopic.name(), existingTopic.partitions(), internal).response());
+            // Then expect to create the new topic ...
+            env.kafkaClient().prepareResponse(createTopicResponse(newTopic));
+            // Finally return information for only new topic ...
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
+                    withTopic(newTopic.name(), newTopic.partitions(), internal).
+                    response());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, TopicDescription> desc = admin.createTopicsIfMissing(existingTopic, newTopic);
+            assertNotNull(desc);
+            assertEquals(desc.size(), 2);
+            TopicDescription desc1 = desc.get(existingTopic.name());
+            TopicDescription desc2 = desc.get(newTopic.name());
+            assertEquals(desc1.name(), existingTopic.name());
+            assertEquals(desc1.internal(), internal);
+            assertEquals(desc2.name(), newTopic.name());
+            assertEquals(desc2.internal(), internal);
+        }
+    }
+
+    @Test
+    public void returnTopicDescriptionsForMultipleTopicsCreatedByConcurrentClient() throws Exception {
+        final NewTopic existingTopic = TopicAdmin.defineTopic("myTopic1").partitions(1).compacted().build();
+        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic2").partitions(1).compacted().build();
+        boolean internal = false;
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            // First expect to find only the existing topic ...
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(existingTopic.name(), existingTopic.partitions(), internal).response());
+            // Then expect to create the new topic, except error because another client just created it ...
+            env.kafkaClient().prepareResponse(createTopicResponseWithAlreadyExists(newTopic));
+            // Finally return information for only new topic ...
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
+                    withTopic(newTopic.name(), newTopic.partitions(), internal).
+                    response());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Map<String, TopicDescription> desc = admin.createTopicsIfMissing(existingTopic, newTopic);
+            assertNotNull(desc);
+            assertEquals(desc.size(), 2);
+            TopicDescription desc1 = desc.get(existingTopic.name());
+            TopicDescription desc2 = desc.get(newTopic.name());
+            assertEquals(desc1.name(), existingTopic.name());
+            assertEquals(desc1.internal(), internal);
+            assertEquals(desc2.name(), newTopic.name());
+            assertEquals(desc2.internal(), internal);
+        }
+    }
+
+    private static class MetadataResponseBuilder {
+        private final Cluster cluster;
+        private final List<TopicMetadata> topicMetadata = new ArrayList<>();
+
+        private MetadataResponseBuilder(Cluster cluster) {
+            this.cluster = cluster;
+        }
+
+        public MetadataResponseBuilder withTopic(String topicName) {
+            return withTopic(topicName, 1);
+        }
+
+        public MetadataResponseBuilder withTopic(String topicName, int numPartitions) {
+            return withTopic(topicName, numPartitions, false);
+        }
+
+        public MetadataResponseBuilder withInternalTopic(String topicName) {
+            return withInternalTopic(topicName, 1);
+        }
+
+        public MetadataResponseBuilder withInternalTopic(String topicName, int numPartitions) {
+            return withTopic(topicName, numPartitions, true);
+        }
+
+        public MetadataResponseBuilder withTopic(String topicName, int numPartitions, boolean internalTopic) {
+            List<PartitionMetadata> partitionMetadataList = new ArrayList<>();
+            for (int i = 0; i != numPartitions; ++i) {
+                PartitionMetadata pm = new PartitionMetadata(Errors.NONE, i + 1, cluster.nodeById(i), cluster.nodes(), cluster.nodes());
+                partitionMetadataList.add(pm);
+            }
+            topicMetadata.add(new TopicMetadata(Errors.NONE, topicName, internalTopic, partitionMetadataList));
+            return this;
+        }
+
+        public MetadataResponse response() {
+            return new MetadataResponse(cluster.nodes(), cluster.clusterResource().clusterId(), cluster.controller().id(), topicMetadata);
+        }
+    }
+
+    private Cluster createCluster(int numNodes) {
+        HashMap<Integer, Node> nodes = new HashMap<>();
+        for (int i = 0; i != numNodes; ++i) {
+            nodes.put(i, new Node(i, "localhost", 8121 + i));
+        }
+        Cluster cluster = new Cluster("mockClusterId", nodes.values(),
+                Collections.<PartitionInfo>emptySet(), Collections.<String>emptySet(),
+                Collections.<String>emptySet(), nodes.get(0));
+        return cluster;
+    }
+
+    private MetadataResponseBuilder metadataResponseFor(Cluster cluster) {
+        return new MetadataResponseBuilder(cluster);
+    }
+
+    private CreateTopicsResponse createTopicResponse(NewTopic... topics) {
+        return createTopicResponse(new ApiError(Errors.NONE, ""), topics);
+    }
+
+    private CreateTopicsResponse createTopicResponseWithAlreadyExists(NewTopic... topics) {
+        return createTopicResponse(new ApiError(Errors.TOPIC_ALREADY_EXISTS, "Topic already exists"), topics);
+    }
+
+    private CreateTopicsResponse createTopicResponseWithUnsupportedVersion(NewTopic... topics) {
+        return createTopicResponse(new ApiError(Errors.UNSUPPORTED_VERSION, "This version of the API is not supported"), topics);
+    }
+
+    private CreateTopicsResponse createTopicResponse(ApiError error, NewTopic... topics) {
+        if (error == null) error = new ApiError(Errors.NONE, "");
+        Map<String, ApiError> topicResults = new HashMap<>();
+        for (NewTopic topic : topics) {
+            topicResults.put(topic.name(), error);
+        }
+        return new CreateTopicsResponse(topicResults);
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -41,23 +41,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 public class TopicAdminTest {
 
     /**

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -19,27 +19,24 @@ package org.apache.kafka.connect.util;
 import org.apache.kafka.clients.NodeApiVersions;
 import org.apache.kafka.clients.admin.MockKafkaAdminClientEnv;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
-import org.apache.kafka.common.requests.MetadataResponse;
-import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
-import org.apache.kafka.common.requests.MetadataResponse.TopicMetadata;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TopicAdminTest {
 
@@ -50,7 +47,7 @@ public class TopicAdminTest {
      * @throws Exception
      */
     @Test
-    public void returnNullWithApiVersionMismatch() throws Exception {
+    public void returnNullWithApiVersionMismatch() {
         final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
         boolean internal = false;
         Cluster cluster = createCluster(1);
@@ -58,203 +55,72 @@ public class TopicAdminTest {
             env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
             env.kafkaClient().prepareResponse(createTopicResponseWithUnsupportedVersion(newTopic));
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            TopicDescription desc = admin.createTopicIfMissing(newTopic);
-            assertNull(desc);
+            admin.createTopic(newTopic);
+            fail();
+        } catch (UnsupportedVersionException e) {
+            // expected
         }
     }
 
     @Test
-    public void returnTopicDescriptionForExistingTopic() throws Exception {
+    public void shouldNotCreateTopicWhenItAlreadyExists() {
         NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
-        boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
             env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            TopicDescription desc = admin.createTopicIfMissing(newTopic);
-            assertNotNull(desc);
-            assertEquals(desc.name(), newTopic.name());
-            assertEquals(desc.internal(), internal);
-        }
-    }
-
-    @Test
-    public void returnTopicDescriptionForExistingInternalTopic() throws Exception {
-        NewTopic newTopic = TopicAdmin.defineTopic("_myTopic").partitions(1).compacted().build();
-        boolean internal = true;
-        Cluster cluster = createCluster(1);
-        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
-            env.kafkaClient().setNode(cluster.controller());
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            TopicDescription desc = admin.createTopicIfMissing(newTopic);
-            assertNotNull(desc);
-            assertEquals(desc.name(), newTopic.name());
-            assertEquals(desc.internal(), internal);
-        }
-    }
-
-    @Test
-    public void returnTopicDescriptionForNewTopic() throws Exception {
-        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
-        boolean internal = false;
-        Cluster cluster = createCluster(1);
-        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
-            env.kafkaClient().setNode(cluster.controller());
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            // Three calls are made ...
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
-            env.kafkaClient().prepareResponse(createTopicResponse(newTopic));
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            TopicDescription desc = admin.createTopicIfMissing(newTopic);
-            assertNotNull(desc);
-            assertEquals(desc.name(), newTopic.name());
-            assertEquals(desc.internal(), internal);
-        }
-    }
-
-    @Test
-    public void returnTopicDescriptionsForMultipleNewTopics() throws Exception {
-        final NewTopic newTopic1 = TopicAdmin.defineTopic("myTopic1").partitions(1).compacted().build();
-        final NewTopic newTopic2 = TopicAdmin.defineTopic("myTopic2").partitions(1).compacted().build();
-        boolean internal = false;
-        Cluster cluster = createCluster(1);
-        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
-            env.kafkaClient().setNode(cluster.controller());
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            // Three calls are made ...
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
-            env.kafkaClient().prepareResponse(createTopicResponse(newTopic1, newTopic2));
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
-                    withTopic(newTopic1.name(), newTopic1.partitions(), internal).
-                    withTopic(newTopic2.name(), newTopic2.partitions(), internal).
-                    response());
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            Map<String, TopicDescription> desc = admin.createTopicsIfMissing(newTopic1, newTopic2);
-            assertNotNull(desc);
-            assertEquals(desc.size(), 2);
-            TopicDescription desc1 = desc.get(newTopic1.name());
-            TopicDescription desc2 = desc.get(newTopic2.name());
-            assertEquals(desc1.name(), newTopic1.name());
-            assertEquals(desc1.internal(), internal);
-            assertEquals(desc2.name(), newTopic2.name());
-            assertEquals(desc2.internal(), internal);
-        }
-    }
-
-    @Test
-    public void returnTopicDescriptionsForNewAndExistingTopics() throws Exception {
-        final NewTopic existingTopic = TopicAdmin.defineTopic("myTopic1").partitions(1).compacted().build();
-        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic2").partitions(1).compacted().build();
-        boolean internal = false;
-        Cluster cluster = createCluster(1);
-        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
-            env.kafkaClient().setNode(cluster.controller());
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            // First expect to find existing topic ...
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(existingTopic.name(), existingTopic.partitions(), internal).response());
-            // Then expect to create the new topic ...
-            env.kafkaClient().prepareResponse(createTopicResponse(newTopic));
-            // Finally return information for new and existing topics ...
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
-                    withTopic(newTopic.name(), newTopic.partitions(), internal).
-                    withTopic(existingTopic.name(), existingTopic.partitions(), internal).
-                    response());
-            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            Map<String, TopicDescription> desc = admin.createTopicsIfMissing(existingTopic, newTopic);
-            assertNotNull(desc);
-            assertEquals(desc.size(), 2);
-            TopicDescription desc1 = desc.get(existingTopic.name());
-            TopicDescription desc2 = desc.get(newTopic.name());
-            assertEquals(desc1.name(), existingTopic.name());
-            assertEquals(desc1.internal(), internal);
-            assertEquals(desc2.name(), newTopic.name());
-            assertEquals(desc2.internal(), internal);
-        }
-    }
-
-    @Test
-    public void returnTopicDescriptionsForMultipleTopicsCreatedByConcurrentClient() throws Exception {
-        final NewTopic existingTopic = TopicAdmin.defineTopic("myTopic1").partitions(1).compacted().build();
-        final NewTopic newTopic = TopicAdmin.defineTopic("myTopic2").partitions(1).compacted().build();
-        boolean internal = false;
-        Cluster cluster = createCluster(1);
-        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
-            env.kafkaClient().setNode(cluster.controller());
-            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
-            // First expect to find only the existing topic ...
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(existingTopic.name(), existingTopic.partitions(), internal).response());
-            // Then expect to create the new topic, except error because another client just created it ...
             env.kafkaClient().prepareResponse(createTopicResponseWithAlreadyExists(newTopic));
-            // Finally return information for new and existing topics ...
-            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
-                    withTopic(newTopic.name(), newTopic.partitions(), internal).
-                    withTopic(existingTopic.name(), existingTopic.partitions(), internal).
-                    response());
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
-            Map<String, TopicDescription> desc = admin.createTopicsIfMissing(existingTopic, newTopic);
-            assertNotNull(desc);
-            assertEquals(desc.size(), 2);
-            TopicDescription desc1 = desc.get(existingTopic.name());
-            TopicDescription desc2 = desc.get(newTopic.name());
-            assertEquals(desc1.name(), existingTopic.name());
-            assertEquals(desc1.internal(), internal);
-            assertEquals(desc2.name(), newTopic.name());
-            assertEquals(desc2.internal(), internal);
+            boolean created = admin.createTopic(newTopic);
+            assertFalse(created);
         }
     }
 
-    private static class MetadataResponseBuilder {
-        private final Cluster cluster;
-        private final List<TopicMetadata> topicMetadata = new ArrayList<>();
-
-        private MetadataResponseBuilder(Cluster cluster) {
-            this.cluster = cluster;
+    @Test
+    public void shouldCreateTopicWhenItDoesNotExist() {
+        NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(createTopicResponse(newTopic));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            boolean created = admin.createTopic(newTopic);
+            assertTrue(created);
         }
+    }
 
-        public MetadataResponseBuilder withTopic(String topicName) {
-            return withTopic(topicName, 1);
+    @Test
+    public void shouldCreateOneTopicWhenProvidedMultipleDefinitionsWithSameTopicName() {
+        NewTopic newTopic1 = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        NewTopic newTopic2 = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(createTopicResponse(newTopic1));
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            Set<String> newTopicNames = admin.createTopics(newTopic1, newTopic2);
+            assertEquals(1, newTopicNames.size());
+            assertEquals(newTopic2.name(), newTopicNames.iterator().next());
         }
+    }
 
-        public MetadataResponseBuilder withTopic(String topicName, int numPartitions) {
-            return withTopic(topicName, numPartitions, false);
-        }
-
-        public MetadataResponseBuilder withInternalTopic(String topicName) {
-            return withInternalTopic(topicName, 1);
-        }
-
-        public MetadataResponseBuilder withInternalTopic(String topicName, int numPartitions) {
-            return withTopic(topicName, numPartitions, true);
-        }
-
-        public MetadataResponseBuilder withTopic(String topicName, int numPartitions, boolean internalTopic) {
-            List<PartitionMetadata> partitionMetadataList = new ArrayList<>();
-            for (int i = 0; i != numPartitions; ++i) {
-                PartitionMetadata pm = new PartitionMetadata(Errors.NONE, i + 1, cluster.nodeById(i), cluster.nodes(), cluster.nodes());
-                partitionMetadataList.add(pm);
-            }
-            topicMetadata.add(new TopicMetadata(Errors.NONE, topicName, internalTopic, partitionMetadataList));
-            return this;
-        }
-
-        public MetadataResponse response() {
-            return new MetadataResponse(cluster.nodes(), cluster.clusterResource().clusterId(), cluster.controller().id(), topicMetadata);
+    @Test
+    public void shouldReturnFalseWhenSuppliedNullTopicDescription() {
+        Cluster cluster = createCluster(1);
+        try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            TopicAdmin admin = new TopicAdmin(null, env.adminClient());
+            boolean created = admin.createTopic(null);
+            assertFalse(created);
         }
     }
 
@@ -267,10 +133,6 @@ public class TopicAdminTest {
                 Collections.<PartitionInfo>emptySet(), Collections.<String>emptySet(),
                 Collections.<String>emptySet(), nodes.get(0));
         return cluster;
-    }
-
-    private MetadataResponseBuilder metadataResponseFor(Cluster cluster) {
-        return new MetadataResponseBuilder(cluster);
     }
 
     private CreateTopicsResponse createTopicResponse(NewTopic... topics) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -55,6 +55,7 @@ public class TopicAdminTest {
         boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).response());
@@ -71,8 +72,10 @@ public class TopicAdminTest {
         boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
             TopicDescription desc = admin.createTopicIfMissing(newTopic);
@@ -88,8 +91,10 @@ public class TopicAdminTest {
         boolean internal = true;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(newTopic.name(), newTopic.partitions(), internal).response());
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
             TopicDescription desc = admin.createTopicIfMissing(newTopic);
@@ -105,6 +110,7 @@ public class TopicAdminTest {
         boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
             // Three calls are made ...
@@ -126,6 +132,7 @@ public class TopicAdminTest {
         boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
             // Three calls are made ...
@@ -155,15 +162,17 @@ public class TopicAdminTest {
         boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
             // First expect to find existing topic ...
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(existingTopic.name(), existingTopic.partitions(), internal).response());
             // Then expect to create the new topic ...
             env.kafkaClient().prepareResponse(createTopicResponse(newTopic));
-            // Finally return information for only new topic ...
+            // Finally return information for new and existing topics ...
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
                     withTopic(newTopic.name(), newTopic.partitions(), internal).
+                    withTopic(existingTopic.name(), existingTopic.partitions(), internal).
                     response());
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
             Map<String, TopicDescription> desc = admin.createTopicsIfMissing(existingTopic, newTopic);
@@ -185,15 +194,17 @@ public class TopicAdminTest {
         boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
+            env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
             // First expect to find only the existing topic ...
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).withTopic(existingTopic.name(), existingTopic.partitions(), internal).response());
             // Then expect to create the new topic, except error because another client just created it ...
             env.kafkaClient().prepareResponse(createTopicResponseWithAlreadyExists(newTopic));
-            // Finally return information for only new topic ...
+            // Finally return information for new and existing topics ...
             env.kafkaClient().prepareResponse(metadataResponseFor(cluster).
                     withTopic(newTopic.name(), newTopic.partitions(), internal).
+                    withTopic(existingTopic.name(), existingTopic.partitions(), internal).
                     response());
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
             Map<String, TopicDescription> desc = admin.createTopicsIfMissing(existingTopic, newTopic);

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -45,8 +45,13 @@ class ConnectDistributedTest(Test):
 
     TOPIC = "test"
     OFFSETS_TOPIC = "connect-offsets"
+    OFFSETS_REPLICATION_FACTOR = "1"
+    OFFSETS_PARTITIONS = "1"
     CONFIG_TOPIC = "connect-configs"
+    CONFIG_REPLICATION_FACTOR = "1"
     STATUS_TOPIC = "connect-status"
+    STATUS_REPLICATION_FACTOR = "1"
+    STATUS_PARTITIONS = "1"
 
     # Since tasks can be assigned to any node and we're testing with files, we need to make sure the content is the same
     # across all nodes.

--- a/tests/kafkatest/tests/connect/connect_distributed_test.py
+++ b/tests/kafkatest/tests/connect/connect_distributed_test.py
@@ -75,11 +75,12 @@ class ConnectDistributedTest(Test):
         self.key_converter = "org.apache.kafka.connect.json.JsonConverter"
         self.value_converter = "org.apache.kafka.connect.json.JsonConverter"
         self.schemas = True
+        self.broker_config_overrides = [["auto.create.topics.enable","false"]]
 
     def setup_services(self, security_protocol=SecurityConfig.PLAINTEXT, timestamp_type=None):
         self.kafka = KafkaService(self.test_context, self.num_brokers, self.zk,
                                   security_protocol=security_protocol, interbroker_security_protocol=security_protocol,
-                                  topics=self.topics)
+                                  topics=self.topics, server_prop_overides=self.broker_config_overrides)
         if timestamp_type is not None:
             for node in self.kafka.nodes:
                 node.config[config_property.MESSAGE_TIMESTAMP_TYPE] = timestamp_type

--- a/tests/kafkatest/tests/connect/connect_rest_test.py
+++ b/tests/kafkatest/tests/connect/connect_rest_test.py
@@ -40,8 +40,13 @@ class ConnectRestApiTest(KafkaTest):
 
     TOPIC = "test"
     OFFSETS_TOPIC = "connect-offsets"
+    OFFSETS_REPLICATION_FACTOR = "1"
+    OFFSETS_PARTITIONS = "1"
     CONFIG_TOPIC = "connect-configs"
+    CONFIG_REPLICATION_FACTOR = "1"
     STATUS_TOPIC = "connect-status"
+    STATUS_REPLICATION_FACTOR = "1"
+    STATUS_PARTITIONS = "1"
 
     # Since tasks can be assigned to any node and we're testing with files, we need to make sure the content is the same
     # across all nodes.

--- a/tests/kafkatest/tests/connect/templates/connect-distributed.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-distributed.properties
@@ -35,8 +35,13 @@ internal.key.converter.schemas.enable=false
 internal.value.converter.schemas.enable=false
 
 offset.storage.topic={{ OFFSETS_TOPIC }}
+offset.storage.replication.factor={{ OFFSETS_REPLICATION_FACTOR }}
+offset.storage.partitions={{ OFFSETS_PARTITIONS }}
 config.storage.topic={{ CONFIG_TOPIC }}
+config.storage.replication.factor={{ CONFIG_REPLICATION_FACTOR }}
 status.storage.topic={{ STATUS_TOPIC }}
+status.storage.replication.factor={{ STATUS_REPLICATION_FACTOR }}
+status.storage.partitions={{ STATUS_PARTITIONS }}
 
 # Make sure data gets flushed frequently so tests don't have to wait to ensure they see data in output systems
 offset.flush.interval.ms=5000


### PR DESCRIPTION
The backing store for offsets, status, and configs now attempts to use the new AdminClient to look up the internal topics and create them if they don’t yet exist. If the necessary APIs are not available in the connected broker, the stores fall back to the old behavior of relying upon auto-created topics. Kafka Connect requires a minimum of Apache Kafka 0.10.0.1-cp1, and the AdminClient can work with all versions since 0.10.0.0.

All three of Connect’s internal topics are created as compacted topics, and new distributed worker configuration properties control the replication factor for all three topics and the number of partitions for the offsets and status topics; the config topic requires a single partition and does not allow it to be set via configuration. All of these new configuration properties have sensible defaults, meaning users can upgrade without having to change any of the existing configurations. In most situations, existing Connect deployments will have already created the storage topics prior to upgrading.

The replication factor defaults to 3, so anyone running Kafka clusters with fewer nodes than 3 will receive an error unless they explicitly set the replication factor for the three internal topics. This is actually desired behavior, since it signals the users that they should be aware they are not using sufficient replication for production use.

The integration tests use a cluster with a single broker, so they were changed to explicitly specify a replication factor of 1 and a single partition.

The `KafkaAdminClientTest` was refactored to extract a utility for setting up a `KafkaAdminClient` with a `MockClient` for unit tests.