### PR TITLE
KAFKA-5099: Replica Deletion Regression from KIP-101

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -234,7 +234,6 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     brokerConfigs.head.setProperty("log.cleaner.enable","true")
     brokerConfigs.head.setProperty("log.cleanup.policy","compact")
     brokerConfigs.head.setProperty("log.segment.bytes","100")
-    brokerConfigs.head.setProperty("log.segment.delete.delay.ms","1000")
     brokerConfigs.head.setProperty("log.cleaner.dedupe.buffer.size","1048577")
 
     val servers = createTestTopicAndCluster(topic,brokerConfigs)

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -2035,7 +2035,7 @@ class LogTest {
     assertEquals(ListBuffer(EpochEntry(1, 0), EpochEntry(2, 1), EpochEntry(3, 3)), leaderEpochCache.epochEntries)
 
     // deliberately remove some of the epoch entries
-    leaderEpochCache.clearLatest(2)
+    leaderEpochCache.clearAndFlushLatest(2)
     assertNotEquals(ListBuffer(EpochEntry(1, 0), EpochEntry(2, 1), EpochEntry(3, 3)), leaderEpochCache.epochEntries)
     log.close()
 

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
@@ -401,7 +401,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When clear latest on epoch boundary
-    cache.clearLatest(offset = 8)
+    cache.clearAndFlushLatest(offset = 8)
 
     //Then should remove two latest epochs (remove is inclusive)
     assertEquals(ListBuffer(EpochEntry(2, 6)), cache.epochEntries)
@@ -418,7 +418,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset ON epoch boundary
-    cache.clearEarliest(offset = 8)
+    cache.clearAndFlushEarliest(offset = 8)
 
     //Then should preserve (3, 8)
     assertEquals(ListBuffer(EpochEntry(3, 8), EpochEntry(4, 11)), cache.epochEntries)
@@ -435,7 +435,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset BETWEEN epoch boundaries
-    cache.clearEarliest(offset = 9)
+    cache.clearAndFlushEarliest(offset = 9)
 
     //Then we should retain epoch 3, but update it's offset to 9 as 8 has been removed
     assertEquals(ListBuffer(EpochEntry(3, 9), EpochEntry(4, 11)), cache.epochEntries)
@@ -452,7 +452,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset before first epoch offset
-    cache.clearEarliest(offset = 1)
+    cache.clearAndFlushEarliest(offset = 1)
 
     //Then nothing should change
     assertEquals(ListBuffer(EpochEntry(2, 6),EpochEntry(3, 8), EpochEntry(4, 11)), cache.epochEntries)
@@ -469,7 +469,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset on earliest epoch boundary
-    cache.clearEarliest(offset = 6)
+    cache.clearAndFlushEarliest(offset = 6)
 
     //Then nothing should change
     assertEquals(ListBuffer(EpochEntry(2, 6),EpochEntry(3, 8), EpochEntry(4, 11)), cache.epochEntries)
@@ -486,7 +486,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When
-    cache.clearEarliest(offset = 11)
+    cache.clearAndFlushEarliest(offset = 11)
 
     //Then retain the last
     assertEquals(ListBuffer(EpochEntry(4, 11)), cache.epochEntries)
@@ -503,7 +503,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When we clear from a postition between offset 8 & offset 11
-    cache.clearEarliest(offset = 9)
+    cache.clearAndFlushEarliest(offset = 9)
 
     //Then we should update the middle epoch entry's offset
     assertEquals(ListBuffer(EpochEntry(3, 9), EpochEntry(4, 11)), cache.epochEntries)
@@ -520,7 +520,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 2, offset = 10)
 
     //When we clear from a postition between offset 0 & offset 7
-    cache.clearEarliest(offset = 5)
+    cache.clearAndFlushEarliest(offset = 5)
 
     //Then we should keeep epoch 0 but update the offset appropriately
     assertEquals(ListBuffer(EpochEntry(0,5), EpochEntry(1, 7), EpochEntry(2, 10)), cache.epochEntries)
@@ -537,7 +537,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset beyond last epoch
-    cache.clearEarliest(offset = 15)
+    cache.clearAndFlushEarliest(offset = 15)
 
     //Then update the last
     assertEquals(ListBuffer(EpochEntry(4, 15)), cache.epochEntries)
@@ -554,7 +554,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset BETWEEN epoch boundaries
-    cache.clearLatest(offset = 9)
+    cache.clearAndFlushLatest(offset = 9)
 
     //Then should keep the preceding epochs
     assertEquals(3, cache.latestEpoch())
@@ -572,7 +572,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When 
-    cache.clear()
+    cache.clearAndFlush()
 
     //Then 
     assertEquals(0, cache.epochEntries.size)
@@ -589,7 +589,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset on epoch boundary
-    cache.clearLatest(offset = UNDEFINED_EPOCH_OFFSET)
+    cache.clearAndFlushLatest(offset = UNDEFINED_EPOCH_OFFSET)
 
     //Then should do nothing
     assertEquals(3, cache.epochEntries.size)
@@ -606,7 +606,7 @@ class LeaderEpochFileCacheTest {
     cache.assign(epoch = 4, offset = 11)
 
     //When reset to offset on epoch boundary
-    cache.clearEarliest(offset = UNDEFINED_EPOCH_OFFSET)
+    cache.clearAndFlushEarliest(offset = UNDEFINED_EPOCH_OFFSET)
 
     //Then should do nothing
     assertEquals(3, cache.epochEntries.size)
@@ -645,7 +645,7 @@ class LeaderEpochFileCacheTest {
     val cache = new LeaderEpochFileCache(tp, () => leoFinder, checkpoint)
 
     //Then
-    cache.clearEarliest(7)
+    cache.clearAndFlushEarliest(7)
   }
 
   @Test
@@ -657,7 +657,7 @@ class LeaderEpochFileCacheTest {
     val cache = new LeaderEpochFileCache(tp, () => leoFinder, checkpoint)
 
     //Then
-    cache.clearLatest(7)
+    cache.clearAndFlushLatest(7)
   }
 
   @Before

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -217,6 +217,7 @@ object TestUtils extends Logging {
     props.put(KafkaConfig.ControllerSocketTimeoutMsProp, "1500")
     props.put(KafkaConfig.ControlledShutdownEnableProp, enableControlledShutdown.toString)
     props.put(KafkaConfig.DeleteTopicEnableProp, enableDeleteTopic.toString)
+    props.put(KafkaConfig.LogDeleteDelayMsProp, "1000")
     props.put(KafkaConfig.ControlledShutdownRetryBackoffMsProp, "100")
     props.put(KafkaConfig.LogCleanerDedupeBufferSizeProp, "2097152")
     props.put(KafkaConfig.LogMessageTimestampDifferenceMaxMsProp, Long.MaxValue.toString)
@@ -1122,7 +1123,7 @@ object TestUtils extends Logging {
           }
         }
       }
-    ), "Failed to hard-delete the delete directory", waitTime = 3 * 60 * 1000)
+    ), "Failed to hard-delete the delete directory")
   }
 
   /**


### PR DESCRIPTION
Replica deletion regressed from KIP-101. Replica deletion happens when a broker receives a StopReplicaRequest with delete=true. Ever since KAFKA-1911, replica deletion has been async, meaning the broker responds with a StopReplicaResponse simply after marking the replica directory as staged for deletion. This marking happens by moving a data log directory and its contents such as /tmp/kafka-logs1/t1-0 to a marked directory like /tmp/kafka-logs1/t1-0.8c9c4c0c61c44cc59ebeb00075a2a07f-delete, acting as a soft-delete. A scheduled thread later actually deletes the data. It appears that the regression occurs while the scheduled thread is actually trying to delete the data, which means the controller considers operations such as partition reassignment and topic deletion complete. But if you look at the log4j logs and data logs, you'll find that the soft-deleted data logs actually won't get deleted.

The bug is that upon log deletion, we attempt to flush the LeaderEpochFileCache to the original file location instead of the moved file location. Restarting the broker actually allows for the soft-deleted directories to get deleted.

This patch avoids the issue by simply not flushing the LeaderEpochFileCache upon log deletion.