### PR TITLE
Added the producer record metadata to the SourceTask commitRecord

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -93,7 +93,7 @@ public abstract class SourceTask implements Task {
      * @param recordMetaData {@link RecordMetaData} record metadata returned from the producer after it has been sent successfully. If a transformation, this will return null
      * @throws InterruptedException
      */
-    public void commitRecord(SourceRecord record,RecordMetataData recordMetadata) throws InterruptedException {
+    public void commitRecord(SourceRecord record,RecordMetaData recordMetadata) throws InterruptedException {
         // This space intentionally left blank.
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -93,7 +93,7 @@ public abstract class SourceTask implements Task {
      * @param recordMetaData {@link RecordMetaData} record metadata returned from the producer after it has been sent successfully. If a transformation, this will return null
      * @throws InterruptedException
      */
-    public void commitRecord(SourceRecord record,RecordMetaData recordMetadata) throws InterruptedException {
+    public void commitRecord(SourceRecord record,RecordMetadata recordMetadata) throws InterruptedException {
         // This space intentionally left blank.
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -18,6 +18,8 @@ package org.apache.kafka.connect.source;
 
 import org.apache.kafka.connect.connector.Task;
 
+import org.apache.kafka.clients.producer.RecordMetadata;
+
 import java.util.List;
 import java.util.Map;
 
@@ -88,9 +90,10 @@ public abstract class SourceTask implements Task {
      * </p>
      *
      * @param record {@link SourceRecord} that was successfully sent via the producer.
+     * @param recordMetaData {@link RecordMetaData} record metadata returned from the producer after it has been sent successfully. If a transformation, this will return null
      * @throws InterruptedException
      */
-    public void commitRecord(SourceRecord record) throws InterruptedException {
+    public void commitRecord(SourceRecord record,RecordMetataData recordMetadata) throws InterruptedException {
         // This space intentionally left blank.
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -189,7 +189,7 @@ class WorkerSourceTask extends WorkerTask {
             final SourceRecord record = transformationChain.apply(preTransformRecord);
 
             if (record == null) {
-                commitTaskRecord(preTransformRecord);
+                commitTaskRecord(preTransformRecord,null);
                 continue;
             }
 
@@ -232,7 +232,7 @@ class WorkerSourceTask extends WorkerTask {
                                     log.trace("Wrote record successfully: topic {} partition {} offset {}",
                                             recordMetadata.topic(), recordMetadata.partition(),
                                             recordMetadata.offset());
-                                    commitTaskRecord(preTransformRecord);
+                                    commitTaskRecord(preTransformRecord,recordMetadata);
                                 }
                                 recordSent(producerRecord);
                             }
@@ -252,9 +252,9 @@ class WorkerSourceTask extends WorkerTask {
         return true;
     }
 
-    private void commitTaskRecord(SourceRecord record) {
+    private void commitTaskRecord(SourceRecord record, RecordMetadata recordMetadata) {
         try {
-            task.commitRecord(record);
+            task.commitRecord(record,recordMetadata);
         } catch (InterruptedException e) {
             log.error("Exception thrown", e);
         } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSourceTask.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +122,7 @@ public class VerifiableSourceTask extends SourceTask {
     }
 
     @Override
-    public void commitRecord(SourceRecord record) throws InterruptedException {
+    public void commitRecord(SourceRecord record, RecordMetadata recordMetadata) throws InterruptedException {
         Map<String, Object> data = new HashMap<>();
         data.put("name", name);
         data.put("task", id);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -718,7 +718,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     }
 
     private void expectTaskCommitRecord(boolean anyTimes, boolean succeed) throws InterruptedException {
-        sourceTask.commitRecord(EasyMock.anyObject(SourceRecord.class));
+        sourceTask.commitRecord(EasyMock.anyObject(SourceRecord.class),EasyMock.anyObject(RecordMetadata.class));
         IExpectationSetters<Void> expect = EasyMock.expectLastCall();
         if (!succeed) {
             expect = expect.andThrow(new RuntimeException("Error committing record in source task"));


### PR DESCRIPTION
- Added the Producers Record Metadata object to the commitRecord method on the SourceTask class so more data is provided to those who override and wish to hook into the recordCommit call from the producer. 
-If its a transformation, it will return null which is explained in the javadoc. 