### PR TITLE
KAFKA-5185: Adding the RecordMetadata that is returned by the producer to the commitRecord method for SourceTask

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -18,6 +18,8 @@ package org.apache.kafka.connect.source;
 
 import org.apache.kafka.connect.connector.Task;
 
+import org.apache.kafka.clients.producer.RecordMetadata;
+
 import java.util.List;
 import java.util.Map;
 
@@ -88,9 +90,10 @@ public abstract class SourceTask implements Task {
      * </p>
      *
      * @param record {@link SourceRecord} that was successfully sent via the producer.
+     * @param recordMetaData {@link RecordMetaData} record metadata returned from the producer after it has been sent successfully. If a transformation, this will return null
      * @throws InterruptedException
      */
-    public void commitRecord(SourceRecord record) throws InterruptedException {
+    public void commitRecord(SourceRecord record, RecordMetadata recordMetadata) throws InterruptedException {
         // This space intentionally left blank.
     }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -87,11 +87,9 @@ public abstract class SourceTask implements Task {
      * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
      * automatically. This hook is provided for systems that also need to store offsets internally
      * in their own system.
-     * 
      * </p>
      *
      * @param record {@link SourceRecord} that was successfully sent via the producer.
-     * @param recordMetaData {@link RecordMetaData} record metadata returned from the producer after it has been sent successfully. If a transformation, this will return null
      * @throws InterruptedException
      */
     @Deprecated

--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -87,6 +87,26 @@ public abstract class SourceTask implements Task {
      * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
      * automatically. This hook is provided for systems that also need to store offsets internally
      * in their own system.
+     * 
+     * </p>
+     *
+     * @param record {@link SourceRecord} that was successfully sent via the producer.
+     * @param recordMetaData {@link RecordMetaData} record metadata returned from the producer after it has been sent successfully. If a transformation, this will return null
+     * @throws InterruptedException
+     */
+    @Deprecated
+    public void commitRecord(SourceRecord record) throws InterruptedException {
+        // This space intentionally left blank.
+    }
+    
+    /**
+     * <p>
+     * Commit an individual {@link SourceRecord} when the callback from the producer client is received, or if a record is filtered by a transformation.
+     * </p>
+     * <p>
+     * SourceTasks are not required to implement this functionality; Kafka Connect will record offsets
+     * automatically. This hook is provided for systems that also need to store offsets internally
+     * in their own system.
      * </p>
      *
      * @param record {@link SourceRecord} that was successfully sent via the producer.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -255,6 +255,7 @@ class WorkerSourceTask extends WorkerTask {
     private void commitTaskRecord(SourceRecord record, RecordMetadata recordMetadata) {
         try {
             task.commitRecord(record, recordMetadata);
+            task.commitRecord(record); //marked as depreciated and left for backwards compatibility
         } catch (InterruptedException e) {
             log.error("Exception thrown", e);
         } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -189,7 +189,7 @@ class WorkerSourceTask extends WorkerTask {
             final SourceRecord record = transformationChain.apply(preTransformRecord);
 
             if (record == null) {
-                commitTaskRecord(preTransformRecord);
+                commitTaskRecord(preTransformRecord, null);
                 continue;
             }
 
@@ -232,7 +232,7 @@ class WorkerSourceTask extends WorkerTask {
                                     log.trace("Wrote record successfully: topic {} partition {} offset {}",
                                             recordMetadata.topic(), recordMetadata.partition(),
                                             recordMetadata.offset());
-                                    commitTaskRecord(preTransformRecord);
+                                    commitTaskRecord(preTransformRecord, recordMetadata);
                                 }
                                 recordSent(producerRecord);
                             }
@@ -252,9 +252,9 @@ class WorkerSourceTask extends WorkerTask {
         return true;
     }
 
-    private void commitTaskRecord(SourceRecord record) {
+    private void commitTaskRecord(SourceRecord record, RecordMetadata recordMetadata) {
         try {
-            task.commitRecord(record);
+            task.commitRecord(record, recordMetadata);
         } catch (InterruptedException e) {
             log.error("Exception thrown", e);
         } catch (Throwable t) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/tools/VerifiableSourceTask.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,7 +122,7 @@ public class VerifiableSourceTask extends SourceTask {
     }
 
     @Override
-    public void commitRecord(SourceRecord record) throws InterruptedException {
+    public void commitRecord(SourceRecord record, RecordMetadata recordMetadata) throws InterruptedException {
         Map<String, Object> data = new HashMap<>();
         data.put("name", name);
         data.put("task", id);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -718,7 +718,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     }
 
     private void expectTaskCommitRecord(boolean anyTimes, boolean succeed) throws InterruptedException {
-        sourceTask.commitRecord(EasyMock.anyObject(SourceRecord.class));
+        sourceTask.commitRecord(EasyMock.anyObject(SourceRecord.class), EasyMock.anyObject(RecordMetadata.class));
         IExpectationSetters<Void> expect = EasyMock.expectLastCall();
         if (!succeed) {
             expect = expect.andThrow(new RuntimeException("Error committing record in source task"));


### PR DESCRIPTION
**Included:**
- Added the producers record metadata object to the commitRecord method on the SourceTask class so more data is provided from the producer and it allows anyone overriding and hooking into the commitRecord method to receive more information about where the record was produced to.

- If its a transformation, it will send in a null,  which is explained in the javadoc.