### PR TITLE
KAFKA-5203: Metrics: fix resetting of histogram sample

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/stats/Percentiles.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/stats/Percentiles.java
@@ -115,6 +115,12 @@ public class Percentiles extends SampledStat implements CompoundStat {
             super(0.0, now);
             this.histogram = new Histogram(scheme);
         }
+
+        @Override
+        public void reset(long now) {
+            super.reset(now);
+            this.histogram.clear();
+        }
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/metrics/MetricsTest.java
@@ -424,6 +424,14 @@ public class MetricsTest {
         assertEquals(0.0, p25.value(), 1.0);
         assertEquals(0.0, p50.value(), 1.0);
         assertEquals(0.0, p75.value(), 1.0);
+
+        // record two more windows worth of sequential values
+        for (int i = 0; i < buckets; i++)
+            sensor.record(i);
+
+        assertEquals(25, p25.value(), 1.0);
+        assertEquals(50, p50.value(), 1.0);
+        assertEquals(75, p75.value(), 1.0);
     }
 
     @Test


### PR DESCRIPTION
Without the histogram cleanup, the percentiles are calculated
incorrectly after purging of one or more samples: event counts
go out of sync with counts in histogram buckets, and bucket
with lower value gets chosen for the given quantile.

This change adds the necessary histogram cleanup.