### PR TITLE
KAFKA-5166: Add option "dry run" to Streams application reset tool

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -111,6 +111,9 @@ public class StreamsResetter {
                             "Make sure to stop all running application instances before running the reset tool.");
             }
 
+            if (dryRun) {
+                System.out.println("----Dry run displays the actions which will be performed when running Streams Reset Tool----");
+            }
             maybeResetInputAndInternalAndSeekToEndIntermediateTopicOffsets();
             maybeDeleteInternalTopics(zkUtils);
 
@@ -177,20 +180,18 @@ public class StreamsResetter {
 
         String groupId = options.valueOf(applicationIdOption);
 
+        if (inputTopics.size() == 0 && intermediateTopics.size() == 0) {
+            System.out.println("No input or intermediate topics specified. Skipping seek.");
+            return;
+        }
+
         if (!dryRun) {
-            if (inputTopics.size() == 0 && intermediateTopics.size() == 0) {
-                System.out.println("No input or intermediate topics specified. Skipping seek.");
-                return;
-            } else {
-                if (inputTopics.size() != 0) {
-                    System.out.println("Seek-to-beginning for input topics " + inputTopics + " and all internal topics.");
-                }
-                if (intermediateTopics.size() != 0) {
-                    System.out.println("Seek-to-end for intermediate topics " + intermediateTopics);
-                }
+            if (inputTopics.size() != 0) {
+                System.out.println("Seek-to-beginning for input topics " + inputTopics + " and all internal topics.");
             }
-        } else {
-            System.out.println("----Dry run displays the actions which will be performed when running Streams Reset Tool----");
+            if (intermediateTopics.size() != 0) {
+                System.out.println("Seek-to-end for intermediate topics " + intermediateTopics);
+            }
         }
 
         final Set<String> topicsToSubscribe = new HashSet<>(inputTopics.size() + intermediateTopics.size());
@@ -254,14 +255,14 @@ public class StreamsResetter {
 
             if (notFoundInputTopics.size() > 0) {
                 System.out.println("Following input topics are not found, skipping them");
-                for (String topic : notFoundInputTopics) {
+                for (final String topic : notFoundInputTopics) {
                     System.out.println("Topic: " + topic);
                 }
             }
 
             if (notFoundIntermediateTopics.size() > 0) {
                 System.out.println("Following intermediate topics are not found, skipping them");
-                for (String topic : notFoundIntermediateTopics) {
+                for (final String topic : notFoundIntermediateTopics) {
                     System.out.println("Topic:" + topic);
                 }
             }
@@ -270,10 +271,7 @@ public class StreamsResetter {
             System.err.println("ERROR: Resetting offsets failed.");
             throw e;
         }
-
-        if (!dryRun) {
-            System.out.println("Done.");
-        }
+        System.out.println("Done.");
     }
 
     private void maybeSeekToEnd(final KafkaConsumer<byte[], byte[]> client, final Set<TopicPartition> intermediateTopicPartitions) {
@@ -354,10 +352,7 @@ public class StreamsResetter {
                 }
             }
         }
-
-        if (!dryRun) {
-            System.out.println("Done.");
-        }
+        System.out.println("Done.");
     }
 
     private boolean isInternalTopic(final String topicName) {

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -188,8 +188,7 @@ public class StreamsResetter {
                     System.out.println("Seek-to-end for intermediate topics " + intermediateTopics);
                 }
             }
-        }
-        else {
+        } else {
             System.out.println("----Dry run displays the actions which will be performed when running Streams Reset Tool----");
         }
 
@@ -357,7 +356,7 @@ public class StreamsResetter {
             }
         }
 
-        if(!dryRun) {
+        if (!dryRun) {
             System.out.println("Done.");
         }
     }

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -134,6 +134,7 @@ public class StreamsResetter {
     private void dryRun() {
         final List<String> inputTopics = options.valuesOf(inputTopicsOption);
         final List<String> intermediateTopics = options.valuesOf(intermediateTopicsOption);
+        String groupId = options.valueOf(applicationIdOption);
 
         System.out.println("----Dry run displays the actions which will be performed when running Streams Reset Tool----");
 
@@ -142,7 +143,7 @@ public class StreamsResetter {
         List<String> internalTopics = new ArrayList<>();
 
         if (inputTopics.size() > 0) {
-            System.out.println("Following input topics offsets will be reset to beginning");
+            System.out.println("Following input topics offsets will be reset to beginning (for consumer group " + groupId + ")");
             for (final String topic : inputTopics) {
                 if (allTopics.contains(topic)) {
                     System.out.println("Topic - " + topic);
@@ -153,7 +154,7 @@ public class StreamsResetter {
         }
 
         if (intermediateTopics.size() > 0) {
-            System.out.println("Following intermediate topics offsets will be reset to end");
+            System.out.println("Following intermediate topics offsets will be reset to end (for consumer group " + groupId + ")");
             for (final String topic : intermediateTopics) {
                 if (!allTopics.contains(topic)) {
                     System.err.println("Topic - " + topic);
@@ -170,7 +171,7 @@ public class StreamsResetter {
         }
 
         if (internalTopics.size() > 0) {
-            System.out.println("Following internal topics offsets will be  reset to beginning");
+            System.out.println("Following internal topics offsets will be  reset to beginning (for consumer group " + groupId + ")");
             for (String topic : internalTopics) {
                 System.out.println("Topic - " + topic);
             }

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -16,21 +16,17 @@
  */
 package kafka.tools;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
+
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.OptionSpecBuilder;
+
 import kafka.admin.AdminClient;
 import kafka.admin.TopicCommand;
 import kafka.utils.ZkUtils;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
@@ -38,6 +34,14 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.utils.Exit;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * {@link StreamsResetter} resets the processing state of a Kafka Streams application so that, for example, you can reprocess its input from scratch.

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -329,11 +329,7 @@ public class StreamsResetter {
 
     private void maybeDeleteInternalTopics(final ZkUtils zkUtils) {
 
-        if (!dryRun) {
-            System.out.println("Deleting all internal/auto-created topics for application " + options.valueOf(applicationIdOption));
-        } else {
-            System.out.println("Following internal/auto-created topics will be Deleted for application " + options.valueOf(applicationIdOption));
-        }
+        System.out.println("Deleting all internal/auto-created topics for application " + options.valueOf(applicationIdOption));
 
         for (final String topic : allTopics) {
             if (isInternalTopic(topic)) {


### PR DESCRIPTION
Addressed the below review comment from #PR #2998 from @mjsax 

I am wondering if it would be better, to "embed" the dry-run into the actual code and branch on each place. Otherwise, if things get changed, we could easily introduce bugs (ie, dry run show something different than what the actual reset code does.

We could introduce methods like mabyeSeekToBeginning() that either does the seek or only prints to stdout. This would ensure that the main logic is used to "feed" into dry-run and we don't have code duplication.

WDYT?