### PR TITLE
KAFKA-5182: Close txn coordinator threads during broker shutdown

### DIFF
--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -30,7 +30,7 @@ class InterBrokerSendThread(name: String,
                             networkClient: NetworkClient,
                             requestGenerator: () => Iterable[RequestAndCompletionHandler],
                             time: Time)
-  extends ShutdownableThread(name, isInterruptible = false) {
+  extends ShutdownableThread(name, isInterruptible = true) {
 
   override def doWork() {
     val now = time.milliseconds()

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -29,8 +29,9 @@ import org.apache.kafka.common.utils.Time
 class InterBrokerSendThread(name: String,
                             networkClient: NetworkClient,
                             requestGenerator: () => Iterable[RequestAndCompletionHandler],
-                            time: Time)
-  extends ShutdownableThread(name, isInterruptible = true) {
+                            time: Time,
+                            isInterruptible: Boolean = true)
+  extends ShutdownableThread(name, isInterruptible) {
 
   override def doWork() {
     val now = time.milliseconds()

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -406,6 +406,7 @@ class TransactionCoordinator(brokerId: Int,
     pidManager.shutdown()
     txnManager.shutdown()
     txnMarkerChannelManager.shutdown()
+    txnMarkerPurgatory.shutdown()
     info("Shutdown complete.")
   }
 }

--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -393,7 +393,7 @@ final class DelayedOperationPurgatory[T <: DelayedOperation](purgatoryName: Stri
    * A background reaper to expire delayed operations that have timed out
    */
   private class ExpiredOperationReaper extends ShutdownableThread(
-    "ExpirationReaper-%d".format(brokerId),
+    "ExpirationReaper-%d-%s".format(brokerId, purgatoryName),
     false) {
 
     override def doWork() {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -611,6 +611,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           CoreUtils.swallow(zkUtils.close())
         if (metrics != null)
           CoreUtils.swallow(metrics.close())
+        if (transactionCoordinator != null)
+          CoreUtils.swallow(transactionCoordinator.shutdown())
 
         brokerState.newState(NotRunning)
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1096,6 +1096,7 @@ class ReplicaManager(val config: KafkaConfig,
     replicaFetcherManager.shutdown()
     delayedFetchPurgatory.shutdown()
     delayedProducePurgatory.shutdown()
+    delayedDeleteRecordsPurgatory.shutdown()
     if (checkpointHW)
       checkpointHighWatermarks()
     info("Shut down completely")


### PR DESCRIPTION
Shutdown delayed delete purgatory thread, transaction marker purgatory thread and send thread in `TransactionMarkerChannelManager` during broker shutdown. Made `InterBrokerSendThread` interruptible so that it is shutdown.