### PR TITLE
KAFKA-5209 : Transient failure: kafka.server.MetadataRequestTest.testControllerId

### DIFF
--- a/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
@@ -107,6 +107,7 @@ abstract class BaseRequestTest extends KafkaServerTestHarness {
                      apiVersion: Option[Short] = None,
                      protocol: SecurityProtocol = SecurityProtocol.PLAINTEXT): ByteBuffer = {
     val socket = connect(destination, protocol)
+    Thread.sleep(7000)
     try send(request, apiKey, socket, apiVersion)
     finally socket.close()
   }


### PR DESCRIPTION
Added sleep after creating the socket so that socket can be spawned properly and ready to send the request.  @guozhangwang may I request you to review it. 