### PR TITLE
KAFKA-5237 - change logging of termination message to use stderr instead of stdout

### DIFF
--- a/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
@@ -211,7 +211,7 @@ object SimpleConsumerShell extends Logging {
             val fetchResponse = simpleConsumer.fetch(fetchRequest)
             val messageSet = fetchResponse.messageSet(topic, partitionId)
             if (messageSet.validBytes <= 0 && noWaitAtEndOfLog) {
-              println("Terminating. Reached the end of partition (%s, %d) at offset %d".format(topic, partitionId, offset))
+              System.err.println("Terminating. Reached the end of partition (%s, %d) at offset %d".format(topic, partitionId, offset))
               return
             }
             debug("multi fetched " + messageSet.sizeInBytes + " bytes from offset " + offset)


### PR DESCRIPTION
[KAFKA-5237](https://issues.apache.org/jira/browse/KAFKA-5237) - change logging of termination message to use stderr instead of stdout