### PR TITLE
HOTFIX: AddOffsetsToTxnResponse using incorrect schema in parse

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AddOffsetsToTxnResponse.java
@@ -65,6 +65,6 @@ public class AddOffsetsToTxnResponse extends AbstractResponse {
     }
 
     public static AddOffsetsToTxnResponse parse(ByteBuffer buffer, short version) {
-        return new AddOffsetsToTxnResponse(ApiKeys.ADD_PARTITIONS_TO_TXN.parseResponse(version, buffer));
+        return new AddOffsetsToTxnResponse(ApiKeys.ADD_OFFSETS_TO_TXN.parseResponse(version, buffer));
     }
 }


### PR DESCRIPTION
The parse method was incorrectly referring to `ApiKeys.ADD_PARTITIONS_TO_TXN`