### PR TITLE
AdminClient: add some more APIs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -37,8 +37,18 @@ public abstract class AdminClient implements AutoCloseable {
      * @param conf          The configuration.
      * @return              The new KafkaAdminClient.
      */
+    public static AdminClient create(AdminClientConfig conf) {
+        return KafkaAdminClient.createInternal(conf);
+    }
+
+    /**
+     * Create a new AdminClient with the given configuration.
+     *
+     * @param conf          The configuration.
+     * @return              The new KafkaAdminClient.
+     */
     public static AdminClient create(Map<String, Object> conf) {
-        return KafkaAdminClient.create(new AdminClientConfig(conf));
+        return KafkaAdminClient.createInternal(new AdminClientConfig(conf));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * The public interface for the {@link KafkaAdminClient}, which supports managing and inspecting topics,
@@ -34,11 +35,11 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Create a new AdminClient with the given configuration.
      *
-     * @param conf          The configuration.
+     * @param props         The configuration.
      * @return              The new KafkaAdminClient.
      */
-    public static AdminClient create(AdminClientConfig conf) {
-        return KafkaAdminClient.createInternal(conf);
+    public static AdminClient create(Properties props) {
+        return KafkaAdminClient.createInternal(new AdminClientConfig(props));
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -238,7 +238,7 @@ public class KafkaAdminClient extends AdminClient {
         return throwable.getClass().getSimpleName();
     }
 
-    static KafkaAdminClient create(AdminClientConfig config) {
+    static KafkaAdminClient createInternal(AdminClientConfig config) {
         Metadata metadata = null;
         Metrics metrics = null;
         NetworkClient networkClient = null;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
@@ -29,7 +29,7 @@ public class TopicDescription {
     private final boolean internal;
     private final NavigableMap<Integer, TopicPartitionInfo> partitions;
 
-    TopicDescription(String name, boolean internal,
+    public TopicDescription(String name, boolean internal,
                     NavigableMap<Integer, TopicPartitionInfo> partitions) {
         this.name = name;
         this.internal = internal;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicListing.java
@@ -24,7 +24,7 @@ public class TopicListing {
     private final String name;
     private final boolean internal;
 
-    TopicListing(String name, boolean internal) {
+    public TopicListing(String name, boolean internal) {
         this.name = name;
         this.internal = internal;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicPartitionInfo.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicPartitionInfo.java
@@ -28,7 +28,7 @@ public class TopicPartitionInfo {
     private final List<Node> replicas;
     private final List<Node> isr;
 
-    TopicPartitionInfo(int partition, Node leader, List<Node> replicas, List<Node> isr) {
+    public TopicPartitionInfo(int partition, Node leader, List<Node> replicas, List<Node> isr) {
         this.partition = partition;
         this.leader = leader;
         this.replicas = replicas;


### PR DESCRIPTION
Add a public create API that takes an AdminClientConf object.  Make the
constructors for TopicDescription, TopicListing, and TopicPartitionInfo
public to enable AdminClient users to write better tests.