### PR TITLE
KAFKA-5229:Reflections logs excessive warnings when scanning classpaths

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -15,9 +15,11 @@
 
 log4j.rootLogger=INFO, stdout
 
+
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR
+log4j.logger.org.reflections=ERROR


### PR DESCRIPTION
changed the reflections log level to ERROR.
And tested it, now the warning logs are not shown up during the start of Kafka connect.
@ewencp could you please review the changes.