### PR TITLE
KAFKA-5134 Replace zkClient.getChildren method with zkUtils.getChildren

### DIFF
--- a/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
+++ b/core/src/main/scala/kafka/common/ZkNodeChangeNotificationListener.scala
@@ -77,8 +77,8 @@ class ZkNodeChangeNotificationListener(private val zkUtils: ZkUtils,
    * Process all changes
    */
   def processAllNotifications() {
-    val changes = zkUtils.zkClient.getChildren(seqNodeRoot)
-    processNotifications(changes.asScala.sorted)
+    val changes = zkUtils.getChildren(seqNodeRoot)
+    processNotifications(changes.sorted)
   }
 
   /**

--- a/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
+++ b/core/src/main/scala/kafka/consumer/ZookeeperTopicEventWatcher.scala
@@ -65,7 +65,7 @@ class ZookeeperTopicEventWatcher(val zkUtils: ZkUtils,
       lock.synchronized {
         try {
           if (zkUtils != null) {
-            val latestTopics = zkUtils.zkClient.getChildren(ZkUtils.BrokerTopicsPath).asScala
+            val latestTopics = zkUtils.getChildren(ZkUtils.BrokerTopicsPath)
             debug("all topics: %s".format(latestTopics))
             eventHandler.handleTopicEvent(latestTopics)
           }

--- a/core/src/test/scala/unit/kafka/consumer/ZookeeperConsumerConnectorTest.scala
+++ b/core/src/test/scala/unit/kafka/consumer/ZookeeperConsumerConnectorTest.scala
@@ -416,13 +416,8 @@ class ZookeeperConsumerConnectorTest extends KafkaServerTestHarness with Logging
   }
 
   def getZKChildrenValues(path : String) : Seq[Tuple2[String,String]] = {
-    val children = zkUtils.zkClient.getChildren(path)
-    Collections.sort(children)
-    val childrenAsSeq : Seq[java.lang.String] = {
-      import scala.collection.JavaConversions._
-      children.toSeq
-    }
-    childrenAsSeq.map(partition =>
+    val children = zkUtils.getChildren(path).sorted
+    children.map(partition =>
       (partition, zkUtils.zkClient.readData(path + "/" + partition).asInstanceOf[String]))
   }
 


### PR DESCRIPTION
@ijuma plz review. I also created a version where I didn't refactor the  getPartitionAssignmentForTopics and the getConsumersPerTopic methods, but I thought maybe it is a good idea to do and move the logic (where there is no ZK connection) to the ZkUtils Object.
About the two new methods, I wanted to make them private and visible only for testing, but because the tests where I use them are not in the same package I couldn't do it. 