### PR TITLE
KAFKA-5294: PlainSaslServerFactory should allow a null Map in getMech…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServer.java
@@ -160,7 +160,8 @@ public class PlainSaslServer implements SaslServer {
 
         @Override
         public String[] getMechanismNames(Map<String, ?> props) {
-            String noPlainText = (props != null) ? (String) props.get(Sasl.POLICY_NOPLAINTEXT) : "false";
+            if (props == null) return new String[]{PLAIN_MECHANISM};
+            String noPlainText = (String) props.get(Sasl.POLICY_NOPLAINTEXT);
             if ("true".equals(noPlainText))
                 return new String[]{};
             else

--- a/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServer.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/plain/PlainSaslServer.java
@@ -160,7 +160,7 @@ public class PlainSaslServer implements SaslServer {
 
         @Override
         public String[] getMechanismNames(Map<String, ?> props) {
-            String noPlainText = (String) props.get(Sasl.POLICY_NOPLAINTEXT);
+            String noPlainText = (props != null) ? (String) props.get(Sasl.POLICY_NOPLAINTEXT) : "false";
             if ("true".equals(noPlainText))
                 return new String[]{};
             else


### PR DESCRIPTION
…anismNames

If props is null, use POLICY_NOPLAINTEXT default value: false

As far as I can tell, none of the other classes implementing SaslServerFactory use the properties Map