### PR TITLE
KAFKA-5081: force version for 'jackson-annotations' in order to prevent redundant jars from being bundled into kafka distribution (and to align with other jackson libraries)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ buildscript {
   }
 }
 
+apply from: "$rootDir/gradle/dependencies.gradle"
+
 allprojects {
   apply plugin: 'idea'
   apply plugin: "jacoco"
@@ -52,6 +54,13 @@ allprojects {
           if (rejected) {
             selection.reject('Release candidate')
           }
+        }
+      }
+    }
+    configurations {
+      runtime {
+        resolutionStrategy {
+          force "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson"
         }
       }
     }
@@ -91,7 +100,6 @@ ext {
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
 }
 
-apply from: "$rootDir/gradle/dependencies.gradle"
 apply from: file('wrapper.gradle')
 
 if (new File('.git').exists()) {


### PR DESCRIPTION
**JIRA ticket:** [KAFKA-5081 two versions of jackson-annotations-xxx.jar in distribution tgz](https://issues.apache.org/jira/browse/KAFKA-5081)

**Solutions:**
1. accept this merge request **_OR_**
2. upgrade jackson libraries to version **_2.9.x_** (currently available as a pre-release only)

**Related jackson issue:** [Add explicit \`jackson-annotations\` dependency version for \`jackson-databind\`](https://github.com/FasterXML/jackson-databind/issues/1545)

**Note:** previous (equivalent) merge request #2900 ended up deep in the sand with swarm of messages due to flaky test, so I opted to close it and to open this one.

@ijuma: FYI