### PR TITLE
KAFKA-5225:StreamsResetter doesn't allow custom Consumer properties

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -231,7 +231,7 @@ public class StreamsResetter {
 
         final Properties config = new Properties();
         config.putAll(consumerConfig);
-        config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,options.valueOf(bootstrapServerOption));
+        config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOption));
         config.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         config.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
 

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -101,13 +101,14 @@ public class StreamsResetter {
 
             final String groupId = options.valueOf(applicationIdOption);
 
+            final Properties props = new Properties();
             if (options.has(commandConfigOption)) {
-                consumerConfig.putAll(Utils.loadProps(options.valueOf(commandConfigOption)));
+                props.putAll(Utils.loadProps(options.valueOf(commandConfigOption)));
             }
-            consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOption));
+            props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOption));
+            consumerConfig.putAll(props);
 
-            adminClient = AdminClient.create(consumerConfig);
-
+            adminClient = AdminClient.create(props);
 
             zkUtils = ZkUtils.apply(options.valueOf(zookeeperOption),
                 30000,
@@ -229,6 +230,7 @@ public class StreamsResetter {
 
         final Properties config = new Properties();
         config.putAll(consumerConfig);
+        config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,options.valueOf(bootstrapServerOption));
         config.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         config.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
 

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -106,6 +106,7 @@ public class StreamsResetter {
                 props.putAll(Utils.loadProps(options.valueOf(commandConfigOption)));
             }
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, options.valueOf(bootstrapServerOption));
+
             consumerConfig.putAll(props);
 
             adminClient = AdminClient.create(props);


### PR DESCRIPTION
Added command-config option, as the client configuration is required for AdminClient and Embedded Consumer.

@mjsax @guozhangwang please review the changes.

@msjax from previous PR couple of questions.
1. Tests for Secure cluster, do you mean to add Integration Test?
2. --dry-run option should print user configs or not? This is just a thought. (Not got what do you mean here?