### PR TITLE
KAFKA-5273: Make KafkaConsumer.committed query the server for all partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.clients.consumer;
 
+import org.apache.kafka.common.requests.OffsetFetchResponse;
+
 import java.io.Serializable;
 
 /**
@@ -62,8 +64,14 @@ public class OffsetAndMetadata implements Serializable {
         OffsetAndMetadata that = (OffsetAndMetadata) o;
 
         if (offset != that.offset) return false;
-        return metadata == null ? that.metadata == null : metadata.equals(that.metadata);
 
+        // An empty metadata gets serialized  and stored as an empty string. Depending on where this call is made, we
+        // may be comparing a purely client side object -- where the value is actually null -- with a version fetched
+        // from the server, where the empty value will be an empty string. So we need to account for both.
+        if (metadata == null || metadata.equals(OffsetFetchResponse.NO_METADATA))
+            return that.metadata == null || that.metadata.equals(OffsetFetchResponse.NO_METADATA);
+
+        return metadata.equals(that.metadata);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
@@ -36,7 +36,12 @@ public class OffsetAndMetadata implements Serializable {
      */
     public OffsetAndMetadata(long offset, String metadata) {
         this.offset = offset;
-        this.metadata = metadata;
+        // The server converts null metadata to an empty string. So we store it as an empty string as well on the client
+        // to be consistent.
+        if (metadata == null)
+            this.metadata = OffsetFetchResponse.NO_METADATA;
+        else
+            this.metadata = metadata;
     }
 
     /**
@@ -64,12 +69,6 @@ public class OffsetAndMetadata implements Serializable {
         OffsetAndMetadata that = (OffsetAndMetadata) o;
 
         if (offset != that.offset) return false;
-
-        // An empty metadata gets serialized  and stored as an empty string. Depending on where this call is made, we
-        // may be comparing a purely client side object -- where the value is actually null -- with a version fetched
-        // from the server, where the empty value will be an empty string. So we need to account for both.
-        if (metadata == null || metadata.equals(OffsetFetchResponse.NO_METADATA))
-            return that.metadata == null || that.metadata.equals(OffsetFetchResponse.NO_METADATA);
 
         return metadata.equals(that.metadata);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
@@ -69,8 +69,7 @@ public class OffsetAndMetadata implements Serializable {
         OffsetAndMetadata that = (OffsetAndMetadata) o;
 
         if (offset != that.offset) return false;
-
-        return metadata.equals(that.metadata);
+        return metadata == null ? that.metadata == null : metadata.equals(that.metadata);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/OffsetAndMetadata.java
@@ -69,13 +69,13 @@ public class OffsetAndMetadata implements Serializable {
         OffsetAndMetadata that = (OffsetAndMetadata) o;
 
         if (offset != that.offset) return false;
-        return metadata == null ? that.metadata == null : metadata.equals(that.metadata);
+        return metadata.equals(that.metadata);
     }
 
     @Override
     public int hashCode() {
         int result = (int) (offset ^ (offset >>> 32));
-        result = 31 * result + (metadata != null ? metadata.hashCode() : 0);
+        result = 31 * result + metadata.hashCode();
         return result;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -510,10 +510,12 @@ public class KafkaConsumerTest {
         // fetch offset for two topics
         Map<TopicPartition, Long> offsets = new HashMap<>();
         offsets.put(tp0, offset1);
+        client.prepareResponseFrom(offsetResponse(offsets, Errors.NONE), coordinator);
+        assertEquals(offset1, consumer.committed(tp0).offset());
+
+        offsets.remove(tp0);
         offsets.put(tp1, offset2);
         client.prepareResponseFrom(offsetResponse(offsets, Errors.NONE), coordinator);
-
-        assertEquals(offset1, consumer.committed(tp0).offset());
         assertEquals(offset2, consumer.committed(tp1).offset());
     }
 
@@ -1149,6 +1151,10 @@ public class KafkaConsumerTest {
 
         client.prepareResponseFrom(offsetResponse(offsets, Errors.NONE), coordinator);
         assertEquals(0, consumer.committed(tp0).offset());
+
+        offsets.remove(tp0);
+        offsets.put(tp1, 0L);
+        client.prepareResponseFrom(offsetResponse(offsets, Errors.NONE), coordinator);
         assertEquals(0, consumer.committed(tp1).offset());
 
         // fetch and verify consumer's position in the two partitions

--- a/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
@@ -83,7 +83,7 @@ class TransactionsBounceTest extends KafkaServerTestHarness {
 
     TestUtils.seedTopicWithNumberedRecords(inputTopic, numInputRecords, servers)
 
-    var consumer = createConsumerAndSubscribeToTopics(consumerGroup, List(inputTopic))
+    val consumer = createConsumerAndSubscribeToTopics(consumerGroup, List(inputTopic))
     val producer = TestUtils.createTransactionalProducer("my-test-producer-t.id", servers)
 
     val scheduler = new BounceScheduler
@@ -110,8 +110,7 @@ class TransactionsBounceTest extends KafkaServerTestHarness {
         if (shouldAbort) {
           trace(s"Committed offsets. Aborting transaction of ${records.size} messages.")
           producer.abortTransaction()
-          consumer.close()
-          consumer = createConsumerAndSubscribeToTopics(consumerGroup, List(inputTopic))
+          TestUtils.resetToCommittedPositions(consumer)
         } else {
           trace(s"Committed offsets. committing transaction of ${records.size} messages.")
           producer.commitTransaction()

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -116,7 +116,7 @@ class TransactionsTest extends KafkaServerTestHarness {
 
     val producer = TestUtils.createTransactionalProducer(transactionalId, servers)
 
-    var consumer = transactionalConsumer(consumerGroupId, maxPollRecords = numSeedMessages / 4)
+    val consumer = transactionalConsumer(consumerGroupId, maxPollRecords = numSeedMessages / 4)
     consumer.subscribe(List(topic1))
     producer.initTransactions()
 
@@ -145,10 +145,8 @@ class TransactionsTest extends KafkaServerTestHarness {
           producer.abortTransaction()
           debug(s"aborted transaction Last committed record: ${new String(records.last.value(), "UTF-8")}. Num " +
             s"records written to $topic2: $recordsProcessed")
-          consumer.close()
-          consumer = transactionalConsumer(consumerGroupId, maxPollRecords = numSeedMessages / 4)
-          consumer.subscribe(List(topic1))
-        }
+          TestUtils.resetToCommittedPositions(consumer)
+       }
       }
     } finally {
       producer.close()

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1413,6 +1413,16 @@ object TestUtils extends Logging {
     records
   }
 
+  def resetToCommittedPositions(consumer: KafkaConsumer[Array[Byte], Array[Byte]]) = {
+    consumer.assignment.foreach { case(topicPartition) =>
+      val offset = consumer.committed(topicPartition)
+      if (offset != null)
+        consumer.seek(topicPartition, offset.offset)
+      else
+        consumer.seekToBeginning(Collections.singletonList(topicPartition))
+    }
+  }
+
 }
 
 class IntEncoder(props: VerifiableProperties = null) extends Encoder[Int] {


### PR DESCRIPTION
Before this patch the consumer would return the cached offsets for partitions in its current assignment. This worked when all the offset commits went through the consumer. 

With KIP-98, offsets can be committed transactionally through the producer. This means that relying on cached positions in the consumer returns incorrect information: since commits go through the producer, the cache is never updated. 

Hence we need to update the `KafkaConsumer.committed` method to always lookup the server for the last committed offset to ensure it gets the correct information every time.