### PR TITLE
KAFKA-5147: Add missing synchronization to TransactionManager

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -515,10 +515,12 @@ public class TransactionManager {
             result.done();
         }
 
-        synchronized void reenqueue() {
-            this.isRetry = true;
-            pendingRequests.add(this);
-        }
+        void reenqueue() {
+            synchronized (TransactionManager.this) {
+                this.isRetry = true;
+                pendingRequests.add(this);
+            }
+       }
 
         @Override
         @SuppressWarnings("unchecked")

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -874,7 +874,7 @@ public class TransactionManager {
         }
 
         @Override
-        public void handleResponse(AbstractResponse response) {
+        public synchronized void handleResponse(AbstractResponse response) {
             TxnOffsetCommitResponse txnOffsetCommitResponse = (TxnOffsetCommitResponse) response;
             boolean coordinatorReloaded = false;
             boolean hadFailure = false;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -333,7 +333,7 @@ public class TransactionManager {
     }
 
     synchronized TxnRequestHandler nextRequestHandler() {
-       if (!newPartitionsToBeAddedToTransaction.isEmpty())
+        if (!newPartitionsToBeAddedToTransaction.isEmpty())
             pendingRequests.add(addPartitionsToTransactionHandler());
 
         TxnRequestHandler nextRequestHandler = pendingRequests.poll();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -333,7 +333,7 @@ public class TransactionManager {
     }
 
     synchronized TxnRequestHandler nextRequestHandler() {
-        if (!newPartitionsToBeAddedToTransaction.isEmpty())
+       if (!newPartitionsToBeAddedToTransaction.isEmpty())
             pendingRequests.add(addPartitionsToTransactionHandler());
 
         TxnRequestHandler nextRequestHandler = pendingRequests.poll();
@@ -383,7 +383,7 @@ public class TransactionManager {
     }
 
     // visible for testing
-    boolean transactionContainsPartition(TopicPartition topicPartition) {
+    synchronized boolean transactionContainsPartition(TopicPartition topicPartition) {
         return isInTransaction() && partitionsInTransaction.contains(topicPartition);
     }
 
@@ -443,7 +443,7 @@ public class TransactionManager {
         return false;
     }
 
-    private void lookupCoordinator(FindCoordinatorRequest.CoordinatorType type, String coordinatorKey) {
+    private synchronized void lookupCoordinator(FindCoordinatorRequest.CoordinatorType type, String coordinatorKey) {
         switch (type) {
             case GROUP:
                 consumerGroupCoordinator = null;
@@ -459,7 +459,7 @@ public class TransactionManager {
         pendingRequests.add(new FindCoordinatorHandler(builder));
     }
 
-    private void completeTransaction() {
+    private synchronized void completeTransaction() {
         transitionTo(State.READY);
         lastError = null;
         partitionsInTransaction.clear();
@@ -515,7 +515,7 @@ public class TransactionManager {
             result.done();
         }
 
-        void reenqueue() {
+        synchronized void reenqueue() {
             this.isRetry = true;
             pendingRequests.add(this);
         }
@@ -634,7 +634,7 @@ public class TransactionManager {
         }
 
         @Override
-        public void handleResponse(AbstractResponse response) {
+        public synchronized void handleResponse(AbstractResponse response) {
             AddPartitionsToTxnResponse addPartitionsToTxnResponse = (AddPartitionsToTxnResponse) response;
             Map<TopicPartition, Errors> errors = addPartitionsToTxnResponse.errors();
             boolean hasPartitionErrors = false;
@@ -817,7 +817,7 @@ public class TransactionManager {
         }
 
         @Override
-        public void handleResponse(AbstractResponse response) {
+        public synchronized void handleResponse(AbstractResponse response) {
             AddOffsetsToTxnResponse addOffsetsToTxnResponse = (AddOffsetsToTxnResponse) response;
             Errors error = addOffsetsToTxnResponse.error();
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -534,7 +534,9 @@ public class TransactionManager {
                     fatalError(response.versionMismatch());
                 } else if (response.hasResponse()) {
                     log.trace("Got transactional response for request:" + requestBuilder());
-                    handleResponse(response.responseBody());
+                    synchronized (TransactionManager.this) {
+                        handleResponse(response.responseBody());
+                    }
                 } else {
                     fatalError(new KafkaException("Could not execute transactional request for unknown reasons"));
                 }
@@ -590,7 +592,7 @@ public class TransactionManager {
         }
 
         @Override
-        public synchronized void handleResponse(AbstractResponse response) {
+        public void handleResponse(AbstractResponse response) {
             InitProducerIdResponse initProducerIdResponse = (InitProducerIdResponse) response;
             Errors error = initProducerIdResponse.error();
 
@@ -634,7 +636,7 @@ public class TransactionManager {
         }
 
         @Override
-        public synchronized void handleResponse(AbstractResponse response) {
+        public void handleResponse(AbstractResponse response) {
             AddPartitionsToTxnResponse addPartitionsToTxnResponse = (AddPartitionsToTxnResponse) response;
             Map<TopicPartition, Errors> errors = addPartitionsToTxnResponse.errors();
             boolean hasPartitionErrors = false;
@@ -715,7 +717,7 @@ public class TransactionManager {
         }
 
         @Override
-        public synchronized void handleResponse(AbstractResponse response) {
+        public void handleResponse(AbstractResponse response) {
             FindCoordinatorResponse findCoordinatorResponse = (FindCoordinatorResponse) response;
             Errors error = findCoordinatorResponse.error();
 
@@ -769,7 +771,7 @@ public class TransactionManager {
         }
 
         @Override
-        public synchronized void handleResponse(AbstractResponse response) {
+        public void handleResponse(AbstractResponse response) {
             EndTxnResponse endTxnResponse = (EndTxnResponse) response;
             Errors error = endTxnResponse.error();
 
@@ -817,7 +819,7 @@ public class TransactionManager {
         }
 
         @Override
-        public synchronized void handleResponse(AbstractResponse response) {
+        public void handleResponse(AbstractResponse response) {
             AddOffsetsToTxnResponse addOffsetsToTxnResponse = (AddOffsetsToTxnResponse) response;
             Errors error = addOffsetsToTxnResponse.error();
 
@@ -874,7 +876,7 @@ public class TransactionManager {
         }
 
         @Override
-        public synchronized void handleResponse(AbstractResponse response) {
+        public void handleResponse(AbstractResponse response) {
             TxnOffsetCommitResponse txnOffsetCommitResponse = (TxnOffsetCommitResponse) response;
             boolean coordinatorReloaded = false;
             boolean hadFailure = false;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionalRequestResult.java
@@ -24,7 +24,7 @@ public final class TransactionalRequestResult {
     static final TransactionalRequestResult COMPLETE = new TransactionalRequestResult(new CountDownLatch(0));
 
     private final CountDownLatch latch;
-    private RuntimeException error = null;
+    private volatile RuntimeException error = null;
 
     public TransactionalRequestResult() {
         this(new CountDownLatch(1));


### PR DESCRIPTION
The basic idea is that exactly three collections, ie. `pendingRequests`, `newPartitionsToBeAddedToTransaction`, and `partitionsInTransaction` are accessed from the context of application threads. The first two are modified from the application threads, and the last is read from those threads. 

So to make the `TransactionManager` truly thread safe, we have to ensure that all accesses to these three members are done in a synchronized block. I inspected the code, and I believe this patch puts the synchronization in all the correct places.