### PR TITLE
MINOR: fix flakiness in testDeleteAcls

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -288,7 +288,6 @@ public class KafkaAdminClientTest {
             assertEquals(ACL1, filter1Results.acls().get(0).acl());
             assertEquals(null, filter1Results.acls().get(1).exception());
             assertEquals(ACL2, filter1Results.acls().get(1).acl());
-            assertTrue(filterResults.get(FILTER2).isCompletedExceptionally());
             assertFutureError(filterResults.get(FILTER2), SecurityDisabledException.class);
             assertFutureError(results.all(), SecurityDisabledException.class);
 


### PR DESCRIPTION
This call to isCompletedExceptionally introduced a race condition
because the future might not have been completed.  assertFutureError
checks that the exception is present and of the correct type in any
case, so the call was not necessary.