### PR TITLE
MINOR: clarify partition option behavior for console consumer

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -218,8 +218,8 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("blacklist")
       .ofType(classOf[String])
-    val partitionIdOpt = parser.accepts("partition", "The partition to consume from. Without the " +
-      "'--offset' option, consumption starts from the end of the partition.")
+    val partitionIdOpt = parser.accepts("partition", "The partition to consume from. Consumption " +
+      "starts from the end of the partition unless '--offset' is specified.")
       .withRequiredArg
       .describedAs("partition")
       .ofType(classOf[java.lang.Integer])

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -218,7 +218,8 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("blacklist")
       .ofType(classOf[String])
-    val partitionIdOpt = parser.accepts("partition", "The partition to consume from.")
+    val partitionIdOpt = parser.accepts("partition", "The partition to consume from. Without the " +
+      "'--offset' option, consumption starts from the end of the partition.")
       .withRequiredArg
       .describedAs("partition")
       .ofType(classOf[java.lang.Integer])


### PR DESCRIPTION
Console Consumer help doesn't say that ``--partition`` option needs ``--offset`` otherwise will consume from the end of the partition. This minor fix makes that happen.