### PR TITLE
KAFKA-5031: validate count of records for DefaultRecordBatch in validateMessagesAndAssignOffsets

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecord.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Utils;
 import java.io.DataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.zip.Checksum;
@@ -315,41 +316,53 @@ public class DefaultRecord implements Record {
                                           long baseTimestamp,
                                           int baseSequence,
                                           Long logAppendTime) {
-        byte attributes = buffer.get();
-        long timestampDelta = ByteUtils.readVarlong(buffer);
-        long timestamp = baseTimestamp + timestampDelta;
-        if (logAppendTime != null)
-            timestamp = logAppendTime;
+        try {
+            int recordStart = buffer.position();
+            byte attributes = buffer.get();
+            long timestampDelta = ByteUtils.readVarlong(buffer);
+            long timestamp = baseTimestamp + timestampDelta;
+            if (logAppendTime != null)
+                timestamp = logAppendTime;
 
-        int offsetDelta = ByteUtils.readVarint(buffer);
-        long offset = baseOffset + offsetDelta;
-        int sequence = baseSequence >= 0 ?
-                DefaultRecordBatch.incrementSequence(baseSequence, offsetDelta) :
-                RecordBatch.NO_SEQUENCE;
+            int offsetDelta = ByteUtils.readVarint(buffer);
+            long offset = baseOffset + offsetDelta;
+            int sequence = baseSequence >= 0 ?
+                    DefaultRecordBatch.incrementSequence(baseSequence, offsetDelta) :
+                    RecordBatch.NO_SEQUENCE;
 
-        ByteBuffer key = null;
-        int keySize = ByteUtils.readVarint(buffer);
-        if (keySize >= 0) {
-            key = buffer.slice();
-            key.limit(keySize);
-            buffer.position(buffer.position() + keySize);
+            ByteBuffer key = null;
+            int keySize = ByteUtils.readVarint(buffer);
+            if (keySize >= 0) {
+                key = buffer.slice();
+                key.limit(keySize);
+                buffer.position(buffer.position() + keySize);
+            }
+
+            ByteBuffer value = null;
+            int valueSize = ByteUtils.readVarint(buffer);
+            if (valueSize >= 0) {
+                value = buffer.slice();
+                value.limit(valueSize);
+                buffer.position(buffer.position() + valueSize);
+            }
+
+            int numHeaders = ByteUtils.readVarint(buffer);
+            if (numHeaders < 0)
+                throw new InvalidRecordException("Found invalid number of record headers " + numHeaders);
+
+            if (numHeaders == 0)
+                return new DefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, key, value, Record.EMPTY_HEADERS);
+
+            Header[] headers = readHeaders(buffer, numHeaders, recordStart, sizeInBytes);
+
+            return new DefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, key, value, headers);
+        } catch (BufferUnderflowException | IllegalArgumentException e) {
+            throw new InvalidRecordException("Invalid header data or number of headers declared for the record, reason for failure was "
+                    + e.getMessage());
         }
+    }
 
-        ByteBuffer value = null;
-        int valueSize = ByteUtils.readVarint(buffer);
-        if (valueSize >= 0) {
-            value = buffer.slice();
-            value.limit(valueSize);
-            buffer.position(buffer.position() + valueSize);
-        }
-
-        int numHeaders = ByteUtils.readVarint(buffer);
-        if (numHeaders < 0)
-            throw new InvalidRecordException("Found invalid number of record headers " + numHeaders);
-
-        if (numHeaders == 0)
-            return new DefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, key, value, Record.EMPTY_HEADERS);
-
+    private static Header[] readHeaders(ByteBuffer buffer, int numHeaders, int recordStart, int sizeInBytes) {
         Header[] headers = new Header[numHeaders];
         for (int i = 0; i < numHeaders; i++) {
             int headerKeySize = ByteUtils.readVarint(buffer);
@@ -370,7 +383,10 @@ public class DefaultRecord implements Record {
             headers[i] = new RecordHeader(headerKey, headerValue);
         }
 
-        return new DefaultRecord(sizeInBytes, attributes, offset, timestamp, sequence, key, value, headers);
+        // validate whether we have read all header bytes in the current record
+        if (buffer.position() - recordStart != sizeInBytes - ByteUtils.sizeOfVarint(sizeInBytes))
+            throw new InvalidRecordException("Invalid header data or number of headers declared for the record");
+        return headers;
     }
 
     public static int sizeInBytes(int offsetDelta,

--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -24,7 +24,9 @@ import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.kafka.common.utils.Crc32C;
 
 import java.io.DataInputStream;
+import java.io.EOFException;
 import java.io.IOException;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
@@ -124,7 +126,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
     public void ensureValid() {
         if (sizeInBytes() < RECORD_BATCH_OVERHEAD)
             throw new InvalidRecordException("Record batch is corrupt (the size " + sizeInBytes() +
-                    "is smaller than the minimum allowed overhead " + RECORD_BATCH_OVERHEAD + ")");
+                    " is smaller than the minimum allowed overhead " + RECORD_BATCH_OVERHEAD + ")");
 
         if (!isValid())
             throw new InvalidRecordException("Record is corrupt (stored crc = " + checksum()
@@ -235,7 +237,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
     }
 
     private CloseableIterator<Record> compressedIterator(BufferSupplier bufferSupplier) {
-        ByteBuffer buffer = this.buffer.duplicate();
+        final ByteBuffer buffer = this.buffer.duplicate();
         buffer.position(RECORDS_OFFSET);
         final DataInputStream inputStream = new DataInputStream(compressionType().wrapForInput(buffer, magic(),
                 bufferSupplier));
@@ -245,8 +247,19 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
             protected Record readNext(long baseOffset, long baseTimestamp, int baseSequence, Long logAppendTime) {
                 try {
                     return DefaultRecord.readFrom(inputStream, baseOffset, baseTimestamp, baseSequence, logAppendTime);
+                } catch (EOFException e) {
+                    throw new InvalidRecordException("Incorrect declared batch size, premature EOF reached");
                 } catch (IOException e) {
                     throw new KafkaException("Failed to decompress record stream", e);
+                }
+            }
+
+            @Override
+            protected boolean ensureNoneRemaining() {
+                try {
+                    return inputStream.read() == -1;
+                } catch (IOException e) {
+                    return false;
                 }
             }
 
@@ -267,7 +280,15 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
         return new RecordIterator() {
             @Override
             protected Record readNext(long baseOffset, long baseTimestamp, int baseSequence, Long logAppendTime) {
-                return DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, logAppendTime);
+                try {
+                    return DefaultRecord.readFrom(buffer, baseOffset, baseTimestamp, baseSequence, logAppendTime);
+                } catch (BufferUnderflowException e) {
+                    throw new InvalidRecordException("Incorrect declared batch size, premature EOF reached");
+                }
+            }
+            @Override
+            protected boolean ensureNoneRemaining() {
+                return !buffer.hasRemaining();
             }
             @Override
             public void close() {}
@@ -500,10 +521,20 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
                 throw new NoSuchElementException();
 
             readRecords++;
-            return readNext(baseOffset, baseTimestamp, baseSequence, logAppendTime);
+            Record rec = readNext(baseOffset, baseTimestamp, baseSequence, logAppendTime);
+            if (readRecords == numRecords) {
+                // Validate that the actual size of the batch is equal to declared size
+                // by checking that after reading declared number of items, there no items left
+                // (overflow case, i.e. reading past buffer end is checked elsewhere).
+                if (!ensureNoneRemaining())
+                    throw new InvalidRecordException("Incorrect declared batch size, records still remaining in file");
+            }
+            return rec;
         }
 
         protected abstract Record readNext(long baseOffset, long baseTimestamp, int baseSequence, Long logAppendTime);
+
+        protected abstract boolean ensureNoneRemaining();
 
         @Override
         public void remove() {

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -35,6 +35,7 @@ private[kafka] object LogValidator extends Logging {
    * 2. When magic value >= 1, inner messages of a compressed message set must have monotonically increasing offsets
    *    starting from 0.
    * 3. When magic value >= 1, validate and maybe overwrite timestamps of messages.
+   * 4. Declared count of records in DefaultRecordBatch must match number of valid records contained therein.
    *
    * This method will convert messages as necessary to the topic's configured message format version. If no format
    * conversion or value overwriting is required for messages, this method will perform in-place operations to


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-5031

Implements additional check for `DefaultRecordBatch` that compares number of records declared in the header with actual number of records.