### PR TITLE
[KAFKA-5338]There is a Misspell in ResetIntegrationTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -159,7 +159,7 @@ public class ResetIntegrationTest {
         TestUtils.waitForCondition(consumerGroupInactive, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT,
             "Streams Application consumer group did not time out after " + (TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT) + " ms.");
 
-        // insert bad record to maks sure intermediate user topic gets seekToEnd()
+        // insert bad record to make sure intermediate user topic gets seekToEnd()
         mockTime.sleep(1);
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
                 INTERMEDIATE_USER_TOPIC,


### PR DESCRIPTION
There is a Misspell in Annotations of ResetIntegrationTest.