### PR TITLE
MINOR: Remove unused configuration setting

### DIFF
--- a/core/src/main/scala/kafka/consumer/ConsumerConfig.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerConfig.scala
@@ -40,6 +40,7 @@ object ConsumerConfig extends Config {
   val MinFetchBytes = 1
   val MaxFetchBytes = 50 * 1024 * 1024
   val MaxFetchWaitMs = 100
+  val RebalanceBackoffMs = 2000
   val MirrorTopicsWhitelist = ""
   val MirrorTopicsBlacklist = ""
   val MirrorConsumerNumThreads = 1
@@ -150,7 +151,7 @@ class ConsumerConfig private (val props: VerifiableProperties) extends ZKConfig(
     " to prevent unnecessary socket timeouts")
   
   /** backoff time between retries during rebalance */
-  val rebalanceBackoffMs = props.getInt("rebalance.backoff.ms", zkSyncTimeMs)
+  val rebalanceBackoffMs = props.getInt("rebalance.backoff.ms", RebalanceBackoffMs)
 
   /** backoff time to refresh the leader of a partition after it loses the current leader */
   val refreshLeaderBackoffMs = props.getInt("refresh.leader.backoff.ms", RefreshMetadataBackoffMs)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -225,7 +225,6 @@ object KafkaConfig {
   val ZkConnectProp = "zookeeper.connect"
   val ZkSessionTimeoutMsProp = "zookeeper.session.timeout.ms"
   val ZkConnectionTimeoutMsProp = "zookeeper.connection.timeout.ms"
-  val ZkSyncTimeMsProp = "zookeeper.sync.time.ms"
   val ZkEnableSecureAclsProp = "zookeeper.set.acl"
   /** ********* General Configuration ***********/
   val BrokerIdGenerationEnableProp = "broker.id.generation.enable"
@@ -669,7 +668,6 @@ object KafkaConfig {
       .define(ZkConnectProp, STRING, HIGH, ZkConnectDoc)
       .define(ZkSessionTimeoutMsProp, INT, Defaults.ZkSessionTimeoutMs, HIGH, ZkSessionTimeoutMsDoc)
       .define(ZkConnectionTimeoutMsProp, INT, null, HIGH, ZkConnectionTimeoutMsDoc)
-      .define(ZkSyncTimeMsProp, INT, Defaults.ZkSyncTimeMs, LOW, ZkSyncTimeMsDoc)
       .define(ZkEnableSecureAclsProp, BOOLEAN, Defaults.ZkEnableSecureAcls, HIGH, ZkEnableSecureAclsDoc)
 
       /** ********* General Configuration ***********/
@@ -885,7 +883,6 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean) extends Abstra
   val zkSessionTimeoutMs: Int = getInt(KafkaConfig.ZkSessionTimeoutMsProp)
   val zkConnectionTimeoutMs: Int =
     Option(getInt(KafkaConfig.ZkConnectionTimeoutMsProp)).map(_.toInt).getOrElse(getInt(KafkaConfig.ZkSessionTimeoutMsProp))
-  val zkSyncTimeMs: Int = getInt(KafkaConfig.ZkSyncTimeMsProp)
   val zkEnableSecureAcls: Boolean = getBoolean(KafkaConfig.ZkEnableSecureAclsProp)
 
   /** ********* General Configuration ***********/

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -975,7 +975,6 @@ object ZKConfig {
   val ZkConnectProp = "zookeeper.connect"
   val ZkSessionTimeoutMsProp = "zookeeper.session.timeout.ms"
   val ZkConnectionTimeoutMsProp = "zookeeper.connection.timeout.ms"
-  val ZkSyncTimeMsProp = "zookeeper.sync.time.ms"
 }
 
 class ZKConfig(props: VerifiableProperties) {
@@ -989,9 +988,6 @@ class ZKConfig(props: VerifiableProperties) {
 
   /** the max time that the client waits to establish a connection to zookeeper */
   val zkConnectionTimeoutMs = props.getInt(ZkConnectionTimeoutMsProp, zkSessionTimeoutMs)
-
-  /** how far a ZK follower can be behind a ZK leader */
-  val zkSyncTimeMs = props.getInt(ZkSyncTimeMsProp, 2000)
 }
 
 class ZkPath(client: ZkClient) {

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -537,7 +537,6 @@ class KafkaConfigTest {
         case KafkaConfig.ZkConnectProp => // ignore string
         case KafkaConfig.ZkSessionTimeoutMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.ZkConnectionTimeoutMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
-        case KafkaConfig.ZkSyncTimeMsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.ZkEnableSecureAclsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean")
 
         case KafkaConfig.BrokerIdProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -314,7 +314,6 @@ object TestUtils extends Logging {
     props.put("consumer.id", consumerId)
     props.put("consumer.timeout.ms", consumerTimeout.toString)
     props.put("zookeeper.session.timeout.ms", "6000")
-    props.put("zookeeper.sync.time.ms", "200")
     props.put("auto.commit.interval.ms", "1000")
     props.put("rebalance.max.retries", "4")
     props.put("auto.offset.reset", "smallest")

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -164,7 +164,7 @@
       <tr>
         <td>rebalance.backoff.ms</td>
         <td>2000</td>
-        <td>Backoff time between retries during rebalance. If not set explicitly, the value in zookeeper.sync.time.ms is used.
+        <td>Backoff time between retries during rebalance.
         </td>
       </tr>
       <tr>
@@ -203,11 +203,6 @@
         <td>zookeeper.connection.timeout.ms</td>
         <td colspan="1">6000</td>
         <td>The max time that the client waits while establishing a connection to zookeeper.</td>
-      </tr>
-      <tr>
-        <td>zookeeper.sync.time.ms </td>
-        <td colspan="1">2000</td>
-        <td>How far a ZK follower can be behind a ZK leader</td>
       </tr>
       <tr>
         <td>offsets.storage</td>


### PR DESCRIPTION
The configuration setting zookeeper.sync.time.ms was not used for anything.
Remove it to reduce confusion.

This changes rebalance.backoff.ms from defaulting to the value of zookeeper.sync.time.ms to default to 2000 (zookeeper.sync.time.ms's default). This means that if someone has not set rebalance.backoff.ms but has changed zookeeper.sync.time.ms from its default, then rebalance.backoff.ms will now instead be 2000ms. I'd be surprised if there were users who do this intentionally.