### PR TITLE
KAFKA-5351: Reset pending state when returning an error in appendTransactionToLog

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -187,7 +187,7 @@ class TransactionCoordinator(brokerId: Int,
     } else {
       // caller should have synchronized on txnMetadata already
       txnMetadata.state match {
-        case PrepareAbort | PrepareCommit  =>
+        case PrepareAbort | PrepareCommit =>
           // reply to client and let client backoff and retry
           Left(initTransactionError(Errors.CONCURRENT_TRANSACTIONS))
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -307,6 +307,13 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
             txnStartTimestamp = transitMetadata.txnStartTimestamp
             topicPartitions.clear()
           }
+        case Dead =>
+          // The transactionalId was being expired. The completion of the operation should result in removal of the
+          // the metadata from the cache, so we should never realistically transition to the dead state.
+          throw new IllegalStateException(s"TransactionalId : $transactionalId is trying to complete a transition to " +
+            s"$toState. This means that the transactionalId was being expierd, and the only acceptable completion of " +
+            s"this operation is to remove the transaction metadata from the cache, not to persist the $toState in the log.")
+
       }
 
       debug(s"TransactionalId $transactionalId complete transition from $state to $transitMetadata")

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -311,7 +311,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
           // The transactionalId was being expired. The completion of the operation should result in removal of the
           // the metadata from the cache, so we should never realistically transition to the dead state.
           throw new IllegalStateException(s"TransactionalId : $transactionalId is trying to complete a transition to " +
-            s"$toState. This means that the transactionalId was being expierd, and the only acceptable completion of " +
+            s"$toState. This means that the transactionalId was being expired, and the only acceptable completion of " +
             s"this operation is to remove the transaction metadata from the cache, not to persist the $toState in the log.")
 
       }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -547,13 +547,21 @@ class TransactionStateManager(brokerId: Int,
             val metadata = epochAndTxnMetadata.transactionMetadata
             metadata synchronized {
               if (epochAndTxnMetadata.coordinatorEpoch == coordinatorEpoch) {
-                debug(s"Transactional id ${metadata.transactionalId}, resetting pending state since we are returing error $responseError")
+                debug(s"TransactionalId ${metadata.transactionalId}, resetting pending state since we are returning error $responseError")
                 metadata.pendingState = None
+              } else {
+                info(s"TransactionalId ${metadata.transactionalId} coordinator epoch changed from " +
+                  s"${epochAndTxnMetadata.coordinatorEpoch} to $coordinatorEpoch after append to log returned $responseError")
               }
             }
-          case Left(_) =>
+          case Right(None) =>
             // Do nothing here, since we want to return the original append error to the user.
+            warn(s"Found no metadata TransactionalId $transactionalId after append to log returned error $responseError")
+          case Left(error) =>
+            // Do nothing here, since we want to return the original append error to the user.
+            warn(s"Retrieving metadata for transactionalId $transactionalId returned $error after append to the log returned error $responseError")
         }
+
       }
 
       responseCallback(responseError)

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -520,12 +520,6 @@ class TransactionStateManager(brokerId: Int,
                 // in this case directly return NOT_COORDINATOR to client and let it to re-discover the transaction coordinator
                 info(s"Updating $transactionalId's transaction state to $newMetadata with coordinator epoch $coordinatorEpoch for $transactionalId failed after the transaction message " +
                   s"has been appended to the log. The cached coordinator epoch has changed to ${epochAndMetadata.coordinatorEpoch}")
-                if (metadata.pendingState.isDefined)
-                  throw new IllegalStateException(s"TransactionalId ${metadata.transactionalId} has a pending state " +
-                    s"of ${metadata.pendingState.get} even though the coordinator epoch doesn't match. This should not " +
-                    s"happen since the pending state should be cleared on emmigration and immigration, which is the only " +
-                    s"event that can change the coordinatorEpoch.")
-
                 responseError = Errors.NOT_COORDINATOR
               } else {
                 metadata.completeTransitionTo(newMetadata)
@@ -556,10 +550,10 @@ class TransactionStateManager(brokerId: Int,
             }
           case Right(None) =>
             // Do nothing here, since we want to return the original append error to the user.
-            warn(s"Found no metadata TransactionalId $transactionalId after append to log returned error $responseError")
+            info(s"Found no metadata TransactionalId $transactionalId after append to log returned error $responseError")
           case Left(error) =>
             // Do nothing here, since we want to return the original append error to the user.
-            warn(s"Retrieving metadata for transactionalId $transactionalId returned $error after append to the log returned error $responseError")
+            info(s"Retrieving metadata for transactionalId $transactionalId returned $error after append to the log returned error $responseError")
         }
 
       }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -225,6 +225,7 @@ class TransactionStateManagerTest {
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch, newMetadata, assertCallback)
 
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
     // append to log again with expected failures
     txnMetadata1.pendingState = None
@@ -236,18 +237,22 @@ class TransactionStateManagerTest {
     prepareForTxnMessageAppend(Errors.UNKNOWN_TOPIC_OR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
     prepareForTxnMessageAppend(Errors.NOT_ENOUGH_REPLICAS)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
     prepareForTxnMessageAppend(Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
     prepareForTxnMessageAppend(Errors.REQUEST_TIMED_OUT)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
     // test NOT_COORDINATOR cases
     expectedError = Errors.NOT_COORDINATOR
@@ -255,17 +260,20 @@ class TransactionStateManagerTest {
     prepareForTxnMessageAppend(Errors.NOT_LEADER_FOR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    // test NOT_COORDINATOR cases
+    // test Unknown cases
     expectedError = Errors.UNKNOWN
 
     prepareForTxnMessageAppend(Errors.MESSAGE_TOO_LARGE)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
 
     prepareForTxnMessageAppend(Errors.RECORD_LIST_TOO_LARGE)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getAndMaybeAddTransactionState(transactionalId1))
+    assertTrue(txnMetadata1.pendingState.isEmpty)
   }
 
   @Test


### PR DESCRIPTION
Without this patch, future client retries would get the `CONCURRENT_TRANSACTIONS` error code indefinitely, since the pending state wouldn't be cleared when the append to the log failed.