### PR TITLE
KAFKA-5357: StackOverFlow error in transaction coordinator

### DIFF
--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -45,7 +45,6 @@ class InterBrokerSendThread(name: String,
     for (request: RequestAndCompletionHandler <- requestsToSend) {
       val destination = Integer.toString(request.destination.id())
       val completionHandler = request.handler
-      // TODO: Need to check inter broker protocol and error if new request is not supported
       val clientRequest = networkClient.newClientRequest(destination,
         request.request,
         now,

--- a/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
+++ b/core/src/main/scala/kafka/common/InterBrokerSendThread.scala
@@ -72,6 +72,10 @@ class InterBrokerSendThread(name: String,
       case e: FatalExitError => throw e
       case t: Throwable =>
         error(s"unhandled exception caught in InterBrokerSendThread", t)
+        // rethrow any unhandled exceptions as FatalExitError so the JVM will be terminated
+        // as we will be in an unknown state with potentially some requests dropped and not
+        // being able to make progress. Known and expected Errors should have been appropriately
+        // dealt with already.
         throw new FatalExitError()
     }
   }

--- a/core/src/main/scala/kafka/coordinator/transaction/DelayedTxnMarker.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/DelayedTxnMarker.scala
@@ -28,16 +28,11 @@ private[transaction] class DelayedTxnMarker(txnMetadata: TransactionMetadata,
                                            completionCallback: Errors => Unit)
   extends DelayedOperation(TimeUnit.DAYS.toMillis(100 * 365)) {
 
-  // overridden since tryComplete already synchronizes on the existing txn metadata. This makes it safe to
-  // call purgatory operations while holding the group lock.
-  override def safeTryComplete(): Boolean = tryComplete()
-
   override def tryComplete(): Boolean = {
-    txnMetadata synchronized {
       if (txnMetadata.topicPartitions.isEmpty)
         forceComplete()
       else false
-    }
+
   }
 
   override def onExpiration(): Unit = {

--- a/core/src/main/scala/kafka/coordinator/transaction/DelayedTxnMarker.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/DelayedTxnMarker.scala
@@ -28,11 +28,16 @@ private[transaction] class DelayedTxnMarker(txnMetadata: TransactionMetadata,
                                            completionCallback: Errors => Unit)
   extends DelayedOperation(TimeUnit.DAYS.toMillis(100 * 365)) {
 
+  // overridden since tryComplete already synchronizes on the existing txn metadata. This makes it safe to
+  // call purgatory operations while holding the group lock.
+  override def safeTryComplete(): Boolean = tryComplete()
+
   override def tryComplete(): Boolean = {
+    txnMetadata synchronized {
       if (txnMetadata.topicPartitions.isEmpty)
         forceComplete()
       else false
-
+    }
   }
 
   override def onExpiration(): Unit = {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -20,6 +20,7 @@ import kafka.server.{DelayedOperationPurgatory, KafkaConfig, MetadataCache}
 import kafka.utils.timer.MockTimer
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.NetworkClient
+import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.requests.{TransactionResult, WriteTxnMarkersRequest}
 import org.apache.kafka.common.utils.{MockTime, Utils}
 import org.apache.kafka.common.{Node, TopicPartition}
@@ -59,13 +60,15 @@ class TransactionMarkerChannelManagerTest {
     reaperEnabled = false)
   private val time = new MockTime
 
+  private val metrics = new Metrics()
   private val channelManager = new TransactionMarkerChannelManager(
     KafkaConfig.fromProps(TestUtils.createBrokerConfig(1, "localhost:2181")),
     metadataCache,
     networkClient,
     txnStateManager,
     txnMarkerPurgatory,
-    time)
+    time,
+    metrics)
 
   private val senderThread = channelManager.senderThread
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.utils.{MockTime, Utils}
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.easymock.EasyMock
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{After, Test}
 
 import scala.collection.mutable
 
@@ -71,6 +71,11 @@ class TransactionMarkerChannelManagerTest {
     metrics)
 
   private val senderThread = channelManager.senderThread
+
+  @After
+  def after(): Unit = {
+    metrics.close()
+  }
 
   private def mockCache(): Unit = {
     EasyMock.expect(txnStateManager.partitionFor(transactionalId1))

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -20,11 +20,10 @@ import kafka.server.{DelayedOperationPurgatory, KafkaConfig, MetadataCache}
 import kafka.utils.timer.MockTimer
 import kafka.utils.TestUtils
 import org.apache.kafka.clients.NetworkClient
-import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.{TransactionResult, WriteTxnMarkersRequest}
 import org.apache.kafka.common.utils.{MockTime, Utils}
 import org.apache.kafka.common.{Node, TopicPartition}
-import org.easymock.{Capture, EasyMock, IAnswer}
+import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.Test
 
@@ -83,6 +82,8 @@ class TransactionMarkerChannelManagerTest {
     EasyMock.expect(txnStateManager.getAndMaybeAddTransactionState(EasyMock.eq(transactionalId2), EasyMock.anyObject[Option[TransactionMetadata]]()))
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata2))))
       .anyTimes()
+
+    EasyMock.replay(txnStateManager)
   }
 
   @Test
@@ -105,7 +106,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    EasyMock.replay(metadataCache, txnStateManager)
+    EasyMock.replay(metadataCache)
 
     channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
     channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
@@ -147,17 +148,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    val capturedCallback: Capture[Errors => Unit] = EasyMock.newCapture()
-    EasyMock.expect(txnStateManager.appendTransactionToLog(
-      EasyMock.eq(transactionalId2),
-      EasyMock.anyObject(),
-      EasyMock.anyObject(),
-      EasyMock.capture(capturedCallback)
-    )).andAnswer(new IAnswer[Unit] {
-      override def answer(): Unit = capturedCallback.getValue.apply(Errors.NONE)
-    })
-
-    EasyMock.replay(metadataCache, txnStateManager)
+    EasyMock.replay(metadataCache)
 
     channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
     channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
@@ -189,7 +180,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    EasyMock.replay(metadataCache, txnStateManager)
+    EasyMock.replay(metadataCache)
 
     channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
     channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))
@@ -237,7 +228,7 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.anyObject())
     ).andReturn(Some(broker2)).anyTimes()
 
-    EasyMock.replay(metadataCache, txnStateManager)
+    EasyMock.replay(metadataCache)
 
     channelManager.addTxnMarkersToSend(transactionalId1, coordinatorEpoch, txnResult, txnMetadata1, txnMetadata1.prepareComplete(time.milliseconds()))
     channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnMetadata2.prepareComplete(time.milliseconds()))


### PR DESCRIPTION
Replace recursion in `TransactionMarkerChannelManager#appendToLogCallback` with retryQueue. Retry the enqueued log appends each time the InterBrokerSendThread runs