### PR TITLE
KAFKA-5322:  Add an `OPERATION_NOT_ATTEMPTED` error code

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -708,6 +708,8 @@ public class TransactionManager {
                     return;
                 } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
                     unauthorizedTopics.add(topicPartition.topic());
+                } else if (error == Errors.OPERATION_NOT_ATTEMPTED) {
+                    log.info("{}Did not attempt to add partition {} to transaction because other partitions in the batch had errors.", logPrefix, topicPartition);
                 } else {
                     log.error("{}Could not add partition {} due to unexpected error {}", logPrefix, topicPartition, error);
                     hasPartitionErrors = true;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -709,7 +709,8 @@ public class TransactionManager {
                 } else if (error == Errors.TOPIC_AUTHORIZATION_FAILED) {
                     unauthorizedTopics.add(topicPartition.topic());
                 } else if (error == Errors.OPERATION_NOT_ATTEMPTED) {
-                    log.info("{}Did not attempt to add partition {} to transaction because other partitions in the batch had errors.", logPrefix, topicPartition);
+                    log.debug("{}Did not attempt to add partition {} to transaction because other partitions in the batch had errors.", logPrefix, topicPartition);
+                    hasPartitionErrors = true;
                 } else {
                     log.error("{}Could not add partition {} due to unexpected error {}", logPrefix, topicPartition, error);
                     hasPartitionErrors = true;

--- a/clients/src/main/java/org/apache/kafka/common/errors/OperationNotAttemptedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OperationNotAttemptedException.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * Indicates that the broker did not attempt to execute this operation. This may happen for batched RPCs where some
+ * operations in the batch failed, causing the broker to respond without trying the rest.
+ */
 public class OperationNotAttemptedException extends ApiException {
     public OperationNotAttemptedException(final String message) {
         super(message);

--- a/clients/src/main/java/org/apache/kafka/common/errors/OperationNotAttemptedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/OperationNotAttemptedException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class OperationNotAttemptedException extends ApiException {
+    public OperationNotAttemptedException(final String message) {
+        super(message);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -490,13 +490,13 @@ public enum Errors {
     }),
     OPERATION_NOT_ATTEMPTED(55, "The broker did not attempt to execute this operation. This may happen for batched RPCs " +
             "where some operations in the batch failed, causing the broker to respond without trying the rest.",
-            new ApiExceptionBuilder() {
-                @Override
-                public ApiException build(String message) {
-                    return new OperationNotAttemptedException(message);
-                }
-            });
-             
+        new ApiExceptionBuilder() {
+            @Override
+            public ApiException build(String message) {
+                return new OperationNotAttemptedException(message);
+            }
+        });
+
     private interface ApiExceptionBuilder {
         ApiException build(String message);
     }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -53,6 +53,7 @@ import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.OffsetMetadataTooLarge;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
+import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -486,7 +487,15 @@ public enum Errors {
         public ApiException build(String message) {
             return new SecurityDisabledException(message);
         }
-    });
+    }),
+    OPERATION_NOT_ATTEMPTED(55, "The broker did not attempt to execute this operation. This may happen for batched RPCs " +
+            "where some operations in the batch failed, causing the broker to respond without trying the rest.",
+            new ApiExceptionBuilder() {
+                @Override
+                public ApiException build(String message) {
+                    return new OperationNotAttemptedException(message);
+                }
+            });
              
     private interface ApiExceptionBuilder {
         ApiException build(String message);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -920,9 +920,7 @@ public class TransactionManagerTest {
     }
 
     private void prepareAddPartitionsToTxn(final TopicPartition tp, final Errors error) {
-        Map<TopicPartition, Errors> errors = new HashMap<>();
-        errors.put(tp, error);
-        prepareAddPartitionsToTxn(errors);
+        prepareAddPartitionsToTxn(Collections.singletonMap(tp, error));
     }
 
     private void prepareFindCoordinatorResponse(Errors error, boolean shouldDisconnect,

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1611,7 +1611,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         // the authorization check to indicate that they were not added to the transaction.
         val partitionErrors = (unauthorizedForWriteRequestInfo.map(_ -> Errors.TOPIC_AUTHORIZATION_FAILED) ++
           nonExistingOrUnauthorizedForDescribeTopics.map(_ -> Errors.UNKNOWN_TOPIC_OR_PARTITION) ++
-          internalTopics.map(_ ->Errors.TOPIC_AUTHORIZATION_FAILED) ++
+          internalTopics.map(_ -> Errors.TOPIC_AUTHORIZATION_FAILED) ++
           authorizedPartitions.map(_ -> Errors.OPERATION_NOT_ATTEMPTED)).toMap
 
         sendResponseMaybeThrottle(request, requestThrottleMs =>

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1606,9 +1606,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         || unauthorizedForWriteRequestInfo.nonEmpty
         || internalTopics.nonEmpty) {
 
-        // Any failed partition check causes the entire request to fail. We only send back error responses
-        // for the partitions that failed to avoid needing to send an ambiguous error code for the partitions
-        // which succeeded.
+        // Any failed partition check causes the entire request to fail. We send the appropriate error codes for the
+        // partitions which failed, and an 'OPERATION_NOT_ATTEMPTED' error code for the partitions which succeeded
+        // the authorization check to indicate that they were not added to the transaction.
         val partitionErrors = (unauthorizedForWriteRequestInfo.map(_ -> Errors.TOPIC_AUTHORIZATION_FAILED) ++
           nonExistingOrUnauthorizedForDescribeTopics.map(_ -> Errors.UNKNOWN_TOPIC_OR_PARTITION) ++
           internalTopics.map(_ ->Errors.TOPIC_AUTHORIZATION_FAILED) ++

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
@@ -1,0 +1,82 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package unit.kafka.server
+
+import java.util.Properties
+
+import kafka.server.{BaseRequestTest, KafkaConfig}
+import kafka.utils.TestUtils
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{AddPartitionsToTxnRequest, AddPartitionsToTxnResponse}
+import org.junit.{Before, Test}
+import org.junit.Assert._
+
+import scala.collection.JavaConversions._
+
+class AddPartitionsToTxnRequestTest extends BaseRequestTest {
+
+  private val topic1 = "foobartopic"
+  val numPartitions = 3
+
+
+  override def propertyOverrides(properties: Properties): Unit =
+    properties.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
+
+  @Before
+  override def setUp(): Unit = {
+    super.setUp()
+
+    TestUtils.createTopic(zkUtils, topic1, numPartitions, servers.size, servers, new Properties())
+  }
+
+  @Test
+  def shouldReceiveOperationNotAttemptedWhenOtherPartitionHasError(): Unit = {
+    // The basic idea is that we have one unknown topic and one created topic. We should get the 'UKNOWN_TOPIC_OR_PARTITION'
+    // error for the unknown topic and the 'OPERATION_NOT_ATTEMPTED' error for the known and authorized topic.
+    val nonExistentTopic = new TopicPartition("unknownTopic", 0)
+    val createdTopicPartition = new TopicPartition(topic1, 0)
+
+    val request = createRequest(List(createdTopicPartition, nonExistentTopic))
+    val leaderId = servers.head.config.brokerId
+    val response = sendAddPartitionsRequest(leaderId, request)
+
+    assertTrue(response.errors().containsKey(createdTopicPartition))
+    assertEquals(Errors.OPERATION_NOT_ATTEMPTED, response.errors().get(createdTopicPartition))
+
+    assertTrue(response.errors().containsKey(nonExistentTopic))
+    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, response.errors().get(nonExistentTopic))
+  }
+
+
+  private def sendAddPartitionsRequest(leaderId: Int, request: AddPartitionsToTxnRequest) : AddPartitionsToTxnResponse = {
+    val response = connectAndSend(request, ApiKeys.ADD_PARTITIONS_TO_TXN, destination = brokerSocketServer(leaderId))
+    AddPartitionsToTxnResponse.parse(response, request.version)
+  }
+
+  private def createRequest(partitions: List[TopicPartition]): AddPartitionsToTxnRequest = {
+
+    val transactionalId = "foobar"
+    val producerId = 1000L
+    val producerEpoch: Short = 0
+    val builder = new AddPartitionsToTxnRequest.Builder(transactionalId, producerId, producerEpoch, partitions)
+    builder.build()
+
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
@@ -60,7 +60,6 @@ class AddPartitionsToTxnRequestTest extends BaseRequestTest {
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, response.errors().get(nonExistentTopic))
   }
 
-
   private def sendAddPartitionsRequest(leaderId: Int, request: AddPartitionsToTxnRequest) : AddPartitionsToTxnResponse = {
     val response = connectAndSend(request, ApiKeys.ADD_PARTITIONS_TO_TXN, destination = brokerSocketServer(leaderId))
     AddPartitionsToTxnResponse.parse(response, request.version)
@@ -73,5 +72,4 @@ class AddPartitionsToTxnRequestTest extends BaseRequestTest {
     val builder = new AddPartitionsToTxnRequest.Builder(transactionalId, producerId, producerEpoch, partitions)
     builder.build()
   }
-
 }

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
@@ -15,11 +15,10 @@
   * limitations under the License.
   */
 
-package unit.kafka.server
+package kafka.server
 
 import java.util.Properties
 
-import kafka.server.{BaseRequestTest, KafkaConfig}
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}

--- a/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AddPartitionsToTxnRequestTest.scala
@@ -30,10 +30,8 @@ import org.junit.Assert._
 import scala.collection.JavaConversions._
 
 class AddPartitionsToTxnRequestTest extends BaseRequestTest {
-
   private val topic1 = "foobartopic"
   val numPartitions = 3
-
 
   override def propertyOverrides(properties: Properties): Unit =
     properties.put(KafkaConfig.AutoCreateTopicsEnableProp, false.toString)
@@ -41,7 +39,6 @@ class AddPartitionsToTxnRequestTest extends BaseRequestTest {
   @Before
   override def setUp(): Unit = {
     super.setUp()
-
     TestUtils.createTopic(zkUtils, topic1, numPartitions, servers.size, servers, new Properties())
   }
 
@@ -70,13 +67,11 @@ class AddPartitionsToTxnRequestTest extends BaseRequestTest {
   }
 
   private def createRequest(partitions: List[TopicPartition]): AddPartitionsToTxnRequest = {
-
     val transactionalId = "foobar"
     val producerId = 1000L
     val producerEpoch: Short = 0
     val builder = new AddPartitionsToTxnRequest.Builder(transactionalId, producerId, producerEpoch, partitions)
     builder.build()
-
   }
 
 }


### PR DESCRIPTION
In the `AddPartitionsToTxn` request handling, if even one partition fails authorization checks, the entire request is essentially failed. However, the `AddPartitionsToTxnResponse` today will only contain the error codes for the topics which failed authorization. It will have no error code for the topics which succeeded, making it inconsistent with other APIs.

This patch adds a new error code `OPERATION_NOT_ATTEMPTED` which is returned for the successful partitions to indicate that they were not added to the transaction.