### PR TITLE
MINOR: make flush no-op as we don't need to call flush on commit.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -355,7 +355,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public synchronized void flush() {
-        //NO-OP method since we don't flush on commits
+        // no-op method since we don't flush on commits
     }
     /**
      * @throws ProcessorStateException if flushing failed because of any internal store exceptions
@@ -374,6 +374,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             return;
         }
 
+        flushInternal();
         open = false;
         closeOpenIterators();
         options.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -374,7 +374,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             return;
         }
 
-        flushInternal();
         open = false;
         closeOpenIterators();
         options.close();

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -355,11 +355,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
 
     @Override
     public synchronized void flush() {
-        if (db == null) {
-            return;
-        }
-        // flush RocksDB
-        flushInternal();
+        //NO-OP method since we don't flush on commits
     }
     /**
      * @throws ProcessorStateException if flushing failed because of any internal store exceptions


### PR DESCRIPTION
In the event of a crash, we always restore the data from the backing changelog.  So it seems that we don't need to 
 persist all data to disk by calling flush when committing.  Frequent flushing leads to a large number of small files for compaction increasing
 compaction pressure.   This PR will perform benchmarks to see if there is any performance gain in not calling `flush()` each time we commit.