### PR TITLE
KAFKA-5366: Add concurrent reads to transactions system test

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -356,6 +356,8 @@ public class Sender implements Runnable {
             } catch (IOException e) {
                 log.debug("{}Disconnect from {} while trying to send request {}. Going " +
                         "to back off and retry", transactionManager.logPrefix, targetNode, requestBuilder);
+                if (nextRequestHandler.needsCoordinator())
+                    transactionManager.lookupCoordinator(nextRequestHandler);
             }
 
             time.sleep(retryBackoffMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -356,8 +356,11 @@ public class Sender implements Runnable {
             } catch (IOException e) {
                 log.debug("{}Disconnect from {} while trying to send request {}. Going " +
                         "to back off and retry", transactionManager.logPrefix, targetNode, requestBuilder);
-                if (nextRequestHandler.needsCoordinator())
+                if (nextRequestHandler.needsCoordinator()) {
+                    // We break here so that we pick up the FindCoordinator request immediately.
                     transactionManager.lookupCoordinator(nextRequestHandler);
+                    break;
+                }
             }
 
             time.sleep(retryBackoffMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -610,6 +610,8 @@ public class TransactionManager {
                 clearInFlightRequestCorrelationId();
                 if (response.wasDisconnected()) {
                     log.trace("{}Disconnected from {}. Will retry.", logPrefix, response.destination());
+                    if (this.needsCoordinator())
+                        lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
                     reenqueue();
                 } else if (response.versionMismatch() != null) {
                     fatalError(response.versionMismatch());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -609,7 +609,7 @@ public class TransactionManager {
             } else {
                 clearInFlightRequestCorrelationId();
                 if (response.wasDisconnected()) {
-                    log.trace("{}Disconnected from {}. Will retry.", logPrefix, response.destination());
+                    log.debug("{}Disconnected from {}. Will retry.", logPrefix, response.destination());
                     if (this.needsCoordinator())
                         lookupCoordinator(this.coordinatorType(), this.coordinatorKey());
                     reenqueue();

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -397,7 +397,6 @@ public class TransactionManager {
             nextRequestHandler = pendingRequests.poll();
         }
 
-
         if (nextRequestHandler != null)
             log.trace("{}Request {} dequeued for sending", logPrefix, nextRequestHandler.requestBuilder());
 

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -45,8 +45,8 @@ class TransactionsTest(Test):
         # Test parameters
         self.num_input_partitions = 2
         self.num_output_partitions = 3
-        self.num_seed_messages = 20000
-        self.transaction_size = 500
+        self.num_seed_messages = 100000
+        self.transaction_size = 750
         self.first_transactional_id = "my-first-transactional-id"
         self.second_transactional_id = "my-second-transactional-id"
         self.consumer_group = "transactions-test-consumer-group"
@@ -158,18 +158,18 @@ class TransactionsTest(Test):
                                    new_consumer=True,
                                    message_validator=is_int,
                                    from_beginning=True,
-                                   consumer_timeout_ms=5000,
+                                   consumer_timeout_ms=15000,
                                    isolation_level="read_committed")
         consumer.start()
         # ensure that the consumer is up.
-        wait_until(lambda: consumer.alive(consumer.nodes[0]) == True,
+        wait_until(lambda: (len(consumer.messages_consumed[1]) > 0) == True,
                    timeout_sec=60,
-                   err_msg="Consumer failed to start for %ds" %\
+                   err_msg="Consumer failed to consume any messages for for %ds" %\
                    60)
         return consumer
 
     def drain_consumer(self, consumer):
-        # wait until the consumer closes, which will be 5 seconds after
+        # wait until the consumer closes, which will be 15 seconds after
         # receiving the last message.
         wait_until(lambda: consumer.alive(consumer.nodes[0]) == False,
                    timeout_sec=60,

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -214,6 +214,8 @@ class TransactionsTest(Test):
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol
         self.kafka.interbroker_security_protocol = security_protocol
+        self.kafka.logs["kafka_data"]["collect_default"] = True
+        self.kafka.logs["kafka_operational_logs_debug"]["collect_default"] = True
         self.kafka.start()
         input_messages = self.seed_messages()
         concurrently_consumed_messages = self.copy_messages_transactionally(failure_mode, bounce_target)

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -176,9 +176,9 @@ class TransactionsTest(Test):
         #  2. If we never reach 'num_seed_messages', then this will cause the
         #     test to fail.
         wait_until(lambda: len(consumer.messages_consumed[1]) >= self.num_seed_messages,
-                   timeout_sec=60,
+                   timeout_sec=90,
                    err_msg="Consumer consumed only %d out of %d messages in %ds" %\
-                   (len(consumer.messages_consumed[1]), self.num_seed_messages, 60))
+                   (len(consumer.messages_consumed[1]), self.num_seed_messages, 90))
         consumer.stop()
         return consumer.messages_consumed[1]
 

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -209,7 +209,7 @@ class TransactionsTest(Test):
 
     @cluster(num_nodes=9)
     @matrix(failure_mode=["clean_bounce", "hard_bounce"],
-            bounce_target=["clients"])
+            bounce_target=["clients", "brokers"])
     def test_transactions(self, failure_mode, bounce_target):
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -163,13 +163,18 @@ class TransactionsTest(Test):
         # ensure that the consumer is up.
         wait_until(lambda: (len(consumer.messages_consumed[1]) > 0) == True,
                    timeout_sec=60,
-                   err_msg="Consumer failed to consume any messages for for %ds" %\
+                   err_msg="Consumer failed to consume any messages for %ds" %\
                    60)
         return consumer
 
     def drain_consumer(self, consumer):
-        # wait until the consumer closes, which will be 15 seconds after
-        # receiving the last message.
+        # wait until we read at least the expected number of messages.
+        # This is a safe check because both failure modes will be caught:
+        #  1. If we have 'num_seed_messages' but there are duplicates, then
+        #     this is checked for later.
+        #
+        #  2. If we never reach 'num_seed_messages', then this will cause the
+        #     test to fail.
         wait_until(lambda: len(consumer.messages_consumed[1]) >= self.num_seed_messages,
                    timeout_sec=60,
                    err_msg="Consumer consumed only %d out of %d messages in %ds" %\

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -84,7 +84,6 @@ class TransactionsTest(Test):
                                            message_validator=is_int,
                                            max_messages=self.num_seed_messages,
                                            enable_idempotence=True)
-
         seed_producer.start()
         wait_until(lambda: seed_producer.num_acked >= self.num_seed_messages,
                    timeout_sec=seed_timeout_sec,
@@ -93,28 +92,8 @@ class TransactionsTest(Test):
         return seed_producer.acked
 
     def get_messages_from_output_topic(self):
-        consumer = ConsoleConsumer(context=self.test_context,
-                                   num_nodes=1,
-                                   kafka=self.kafka,
-                                   topic=self.output_topic,
-                                   new_consumer=True,
-                                   message_validator=is_int,
-                                   from_beginning=True,
-                                   consumer_timeout_ms=5000,
-                                   isolation_level="read_committed")
-        consumer.start()
-        # ensure that the consumer is up.
-        wait_until(lambda: consumer.alive(consumer.nodes[0]) == True,
-                   timeout_sec=60,
-                   err_msg="Consumer failed to start for %ds" %\
-                   60)
-        # wait until the consumer closes, which will be 5 seconds after
-        # receiving the last message.
-        wait_until(lambda: consumer.alive(consumer.nodes[0]) == False,
-                   timeout_sec=60,
-                   err_msg="Consumer failed to consume %d messages in %ds" %\
-                   (self.num_seed_messages, 60))
-        return consumer.messages_consumed[1]
+        consumer = self.start_consumer(self.output_topic, group_id="verifying_consumer")
+        return self.drain_consumer(consumer)
 
     def bounce_brokers(self, clean_shutdown):
        for node in self.kafka.nodes:
@@ -170,8 +149,47 @@ class TransactionsTest(Test):
         ))
         return copiers
 
+    def start_consumer(self, topic_to_read, group_id):
+        consumer = ConsoleConsumer(context=self.test_context,
+                                   num_nodes=1,
+                                   kafka=self.kafka,
+                                   topic=topic_to_read,
+                                   group_id=group_id,
+                                   new_consumer=True,
+                                   message_validator=is_int,
+                                   from_beginning=True,
+                                   consumer_timeout_ms=5000,
+                                   isolation_level="read_committed")
+        consumer.start()
+        # ensure that the consumer is up.
+        wait_until(lambda: consumer.alive(consumer.nodes[0]) == True,
+                   timeout_sec=60,
+                   err_msg="Consumer failed to start for %ds" %\
+                   60)
+        return consumer
+
+    def drain_consumer(self, consumer):
+        # wait until the consumer closes, which will be 5 seconds after
+        # receiving the last message.
+        wait_until(lambda: consumer.alive(consumer.nodes[0]) == False,
+                   timeout_sec=60,
+                   err_msg="Consumer failed to consume %d messages in %ds" %\
+                   (self.num_seed_messages, 60))
+        return consumer.messages_consumed[1]
+
     def copy_messages_transactionally(self, failure_mode, bounce_target):
+        """Copies messages transactionally from the seeded input topic to the
+        output topic, either bouncing brokers or clients in a hard and soft
+        way as it goes.
+
+        This method also consumes messages in read_committed mode from the
+        output topic while the bounces and copy is going on.
+
+        It returns the concurrently consumed messages.
+        """
         copiers = self.create_and_start_copiers()
+        concurrent_consumer = self.start_consumer(self.output_topic,
+                                                  group_id="concurrent_consumer")
         clean_shutdown = False
         if failure_mode == "clean_bounce":
             clean_shutdown = True
@@ -187,21 +205,32 @@ class TransactionsTest(Test):
                        err_msg="%s - Failed to copy all messages in  %ds." %\
                        (copier.transactional_id, 60))
         self.logger.info("finished copying messages")
+        return self.drain_consumer(concurrent_consumer)
 
-    @cluster(num_nodes=8)
+    @cluster(num_nodes=9)
     @matrix(failure_mode=["clean_bounce", "hard_bounce"],
-            bounce_target=["brokers", "clients"])
+            bounce_target=["clients"])
     def test_transactions(self, failure_mode, bounce_target):
         security_protocol = 'PLAINTEXT'
         self.kafka.security_protocol = security_protocol
         self.kafka.interbroker_security_protocol = security_protocol
         self.kafka.start()
         input_messages = self.seed_messages()
-        self.copy_messages_transactionally(failure_mode, bounce_target)
+        concurrently_consumed_messages = self.copy_messages_transactionally(failure_mode, bounce_target)
         output_messages = self.get_messages_from_output_topic()
+
+        concurrently_consumed_message_set = set(concurrently_consumed_messages)
         output_message_set = set(output_messages)
         input_message_set = set(input_messages)
+
         num_dups = abs(len(output_messages) - len(output_message_set))
+        num_dups_in_concurrent_consumer = abs(len(concurrently_consumed_messages)
+                                              - len(concurrently_consumed_message_set))
         assert num_dups == 0, "Detected %d duplicates in the output stream" % num_dups
         assert input_message_set == output_message_set, "Input and output message sets are not equal. Num input messages %d. Num output messages %d" %\
             (len(input_message_set), len(output_message_set))
+
+        assert num_dups_in_concurrent_consumer == 0, "Detected %d dups in concurrently consumed messages" % num_dups_in_concurrent_consumer
+        assert input_message_set == concurrently_consumed_message_set, \
+            "Input and concurrently consumed output message sets are not equal. Num input messages: %d. Num concurrently_consumed_messages: %d" %\
+            (len(input_message_set), len(concurrently_consumed_message_set))

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -255,10 +255,7 @@ public class TransactionalMessageCopier {
 
         try {
             while (0 < remainingMessages.get()) {
-                if ((((double) numMessagesProcessed.get() / maxMessages) * 100) % 10 == 0) {
-                    // print status for every 10% we progress.
-                    System.out.println(statusAsJson(numMessagesProcessed.get(), remainingMessages.get(), transactionalId));
-                }
+                System.out.println(statusAsJson(numMessagesProcessed.get(), remainingMessages.get(), transactionalId));
                 if (isShuttingDown.get())
                     break;
                 int messagesInCurrentTransaction = 0;


### PR DESCRIPTION
This currently fails in multiple ways. One of which is most likely KAFKA-5355, where the concurrent consumer reads duplicates.

During broker bounces, the concurrent consumer misses messages completely. This is another bug.