### PR TITLE
MINOR: Code Cleanup

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -302,7 +302,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 keySerializer, valueSerializer);
     }
 
-    @SuppressWarnings({"unchecked", "deprecation"})
+    @SuppressWarnings("unchecked")
     private KafkaProducer(ProducerConfig config, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         try {
             log.trace("Starting the Kafka producer");
@@ -339,7 +339,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 config.ignore(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG);
                 this.valueSerializer = ensureExtended(valueSerializer);
             }
-            
 
             // load interceptors and make sure they get clientId
             userProvidedConfigs.put(ProducerConfig.CLIENT_ID_CONFIG, clientId);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -628,7 +628,6 @@ public class TransactionManager {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public void onComplete(ClientResponse response) {
             if (response.requestHeader().correlationId() != inFlightRequestCorrelationId) {
                 fatalError(new RuntimeException("Detected more than one in-flight transactional request."));

--- a/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/OffsetsForLeaderEpochRequest.java
@@ -42,7 +42,7 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
     }
 
     public static class Builder extends AbstractRequest.Builder<OffsetsForLeaderEpochRequest> {
-        private Map<TopicPartition, Integer> epochsByPartition = new HashMap();
+        private Map<TopicPartition, Integer> epochsByPartition = new HashMap<>();
 
         public Builder() {
             super(ApiKeys.OFFSET_FOR_LEADER_EPOCH);
@@ -129,7 +129,7 @@ public class OffsetsForLeaderEpochRequest extends AbstractRequest {
     @Override
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         Errors error = Errors.forException(e);
-        Map<TopicPartition, EpochEndOffset> errorResponse = new HashMap();
+        Map<TopicPartition, EpochEndOffset> errorResponse = new HashMap<>();
         for (TopicPartition tp : epochsByPartition.keySet()) {
             errorResponse.put(tp, new EpochEndOffset(error, EpochEndOffset.UNDEFINED_EPOCH_OFFSET));
         }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -129,13 +129,12 @@ public class KafkaConsumerTest {
         final int oldCloseCount = MockMetricsReporter.CLOSE_COUNT.get();
         try {
             new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+            Assert.fail("should have caught an exception and returned");
         } catch (KafkaException e) {
             assertEquals(oldInitCount + 1, MockMetricsReporter.INIT_COUNT.get());
             assertEquals(oldCloseCount + 1, MockMetricsReporter.CLOSE_COUNT.get());
             assertEquals("Failed to construct kafka consumer", e.getMessage());
-            return;
         }
-        Assert.fail("should have caught an exception and returned");
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1190,23 +1190,17 @@ public class KafkaConsumerTest {
 
     @Test(expected = IllegalStateException.class)
     public void testPollWithEmptySubscription() {
-        KafkaConsumer<byte[], byte[]> consumer = newConsumer();
-        consumer.subscribe(Collections.<String>emptyList());
-        try {
+        try (KafkaConsumer<byte[], byte[]> consumer = newConsumer()) {
+            consumer.subscribe(Collections.<String>emptyList());
             consumer.poll(0);
-        } finally {
-            consumer.close();
         }
     }
 
     @Test(expected = IllegalStateException.class)
     public void testPollWithEmptyUserAssignment() {
-        KafkaConsumer<byte[], byte[]> consumer = newConsumer();
-        consumer.assign(Collections.<TopicPartition>emptySet());
-        try {
+        try (KafkaConsumer<byte[], byte[]> consumer = newConsumer()) {
+            consumer.assign(Collections.<TopicPartition>emptySet());
             consumer.poll(0);
-        } finally {
-            consumer.close();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -87,16 +87,12 @@ public class KafkaProducerTest {
 
         final int oldInitCount = MockMetricsReporter.INIT_COUNT.get();
         final int oldCloseCount = MockMetricsReporter.CLOSE_COUNT.get();
-        KafkaProducer<byte[], byte[]> producer = null;
-        try {
-            producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
+        try (KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer())) {
             fail("should have caught an exception and returned");
         } catch (KafkaException e) {
             assertEquals(oldInitCount + 1, MockMetricsReporter.INIT_COUNT.get());
             assertEquals(oldCloseCount + 1, MockMetricsReporter.CLOSE_COUNT.get());
             assertEquals("Failed to construct kafka producer", e.getMessage());
-        } finally {
-            if (producer != null) producer.close();
         }
     }
 
@@ -173,9 +169,7 @@ public class KafkaProducerTest {
         config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
         config.put(ProducerConfig.SEND_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
         config.put(ProducerConfig.RECEIVE_BUFFER_CONFIG, Selectable.USE_DEFAULT_BUFFER_SIZE);
-        KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(
-                config, new ByteArraySerializer(), new ByteArraySerializer());
-        producer.close();
+        new KafkaProducer<>(config, new ByteArraySerializer(), new ByteArraySerializer()).close();
     }
 
     @Test(expected = KafkaException.class)

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -356,7 +356,7 @@ public class KafkaProducerTest {
         }
         Assert.assertTrue("Topic should still exist in metadata", metadata.containsTopic(topic));
     }
-    
+
     @PrepareOnlyThisForTest(Metadata.class)
     @Test
     public void testHeaders() throws Exception {
@@ -370,8 +370,6 @@ public class KafkaProducerTest {
         MemberModifier.field(KafkaProducer.class, "metadata").set(producer, metadata);
 
         String topic = "topic";
-        Collection<Node> nodes = Collections.singletonList(new Node(0, "host1", 1000));
-
         final Cluster cluster = new Cluster(
                 "dummy",
                 Collections.singletonList(new Node(0, "host1", 1000)),
@@ -437,7 +435,7 @@ public class KafkaProducerTest {
             assertEquals(Sensor.RecordingLevel.DEBUG, producer.metrics.config().recordLevel());
         }
     }
-    
+
     @PrepareOnlyThisForTest(Metadata.class)
     @Test
     public void testInterceptorPartitionSetOnTooLargeRecord() throws Exception {
@@ -446,7 +444,7 @@ public class KafkaProducerTest {
         props.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1");
         String topic = "topic";
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, "value");
-        
+
         KafkaProducer<String, String> producer = new KafkaProducer<>(props, new StringSerializer(),
                 new StringSerializer());
         Metadata metadata = PowerMock.createNiceMock(Metadata.class);
@@ -458,20 +456,18 @@ public class KafkaProducerTest {
             Collections.<String>emptySet(),
             Collections.<String>emptySet());
         EasyMock.expect(metadata.fetch()).andReturn(cluster).once();
-        
+
         // Mock interceptors field
         ProducerInterceptors interceptors = PowerMock.createMock(ProducerInterceptors.class);
         EasyMock.expect(interceptors.onSend(record)).andReturn(record);
         interceptors.onSendError(EasyMock.eq(record), EasyMock.<TopicPartition>notNull(), EasyMock.<Exception>notNull());
         EasyMock.expectLastCall();
         MemberModifier.field(KafkaProducer.class, "interceptors").set(producer, interceptors);
-        
+
         PowerMock.replay(metadata);
         EasyMock.replay(interceptors);
         producer.send(record);
-        
-        EasyMock.verify(interceptors);
-        
-    }
 
+        EasyMock.verify(interceptors);
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -53,7 +53,6 @@ public class MockProducerTest {
 
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testAutoCompleteMock() throws Exception {
         Future<RecordMetadata> metadata = producer.send(record1);
         assertTrue("Send should be immediately complete", metadata.isDone());
@@ -77,6 +76,7 @@ public class MockProducerTest {
         assertEquals("Partition should be correct", 1, metadata.get().partition());
         producer.clear();
         assertEquals("Clear should erase our history", 0, producer.history().size());
+        producer.close();
     }
 
     @Test
@@ -98,12 +98,13 @@ public class MockProducerTest {
             assertEquals(e, err.getCause());
         }
         assertFalse("No more requests to complete", producer.completeNext());
-        
+
         Future<RecordMetadata> md3 = producer.send(record1);
         Future<RecordMetadata> md4 = producer.send(record2);
         assertTrue("Requests should not be completed.", !md3.isDone() && !md4.isDone());
         producer.flush();
         assertTrue("Requests should be completed.", md3.isDone() && md4.isDone());
+        producer.close();
     }
 
     @Test
@@ -327,6 +328,7 @@ public class MockProducerTest {
 
         assertTrue(md1.isDone());
         assertTrue(md2.isDone());
+        producer.close();
     }
 
     @Test
@@ -355,6 +357,7 @@ public class MockProducerTest {
 
         producer.abortTransaction();
         assertTrue(md1.isDone());
+        producer.close();
     }
 
     @Test
@@ -640,6 +643,7 @@ public class MockProducerTest {
         MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer());
         producer.send(record1);
         assertFalse(producer.flushed());
+        producer.close();
     }
 
     @Test
@@ -648,6 +652,7 @@ public class MockProducerTest {
         producer.send(record1);
         producer.flush();
         assertTrue(producer.flushed());
+        producer.close();
     }
 
     private boolean isError(Future<?> future) {

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.test.MockSerializer;
-import org.junit.After;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -48,25 +47,21 @@ import static org.junit.Assert.fail;
 public class MockProducerTest {
 
     private final String topic = "topic";
-    private final MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
     private final ProducerRecord<byte[], byte[]> record1 = new ProducerRecord<>(topic, "key1".getBytes(), "value1".getBytes());
     private final ProducerRecord<byte[], byte[]> record2 = new ProducerRecord<>(topic, "key2".getBytes(), "value2".getBytes());
-
-    @After
-    public void close() {
-        producer.close();
-    }
-
+    
     @Test
     public void testAutoCompleteMock() throws Exception {
-        Future<RecordMetadata> metadata = producer.send(record1);
-        assertTrue("Send should be immediately complete", metadata.isDone());
-        assertFalse("Send should be successful", isError(metadata));
-        assertEquals("Offset should be 0", 0L, metadata.get().offset());
-        assertEquals(topic, metadata.get().topic());
-        assertEquals("We should have the record in our history", singletonList(record1), producer.history());
-        producer.clear();
-        assertEquals("Clear should erase our history", 0, producer.history().size());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer())) {
+            Future<RecordMetadata> metadata = producer.send(record1);
+            assertTrue("Send should be immediately complete", metadata.isDone());
+            assertFalse("Send should be successful", isError(metadata));
+            assertEquals("Offset should be 0", 0L, metadata.get().offset());
+            assertEquals(topic, metadata.get().topic());
+            assertEquals("We should have the record in our history", singletonList(record1), producer.history());
+            producer.clear();
+            assertEquals("Clear should erase our history", 0, producer.history().size());
+        }
     }
 
     @Test
@@ -114,118 +109,146 @@ public class MockProducerTest {
 
     @Test
     public void shouldInitTransactions() {
-        producer.initTransactions();
-        assertTrue(producer.transactionInitialized());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            assertTrue(producer.transactionInitialized());
+        }
     }
 
     @Test
     public void shouldThrowOnInitTransactionIfProducerAlreadyInitializedForTransactions() {
-        producer.initTransactions();
-        try {
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
             producer.initTransactions();
-            fail("Should have thrown as producer is already initialized");
-        } catch (IllegalStateException e) { }
+            try {
+                producer.initTransactions();
+                fail("Should have thrown as producer is already initialized");
+            } catch (IllegalStateException e) { }
+        }
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowOnBeginTransactionIfTransactionsNotInitialized() {
-        producer.beginTransaction();
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.beginTransaction();
+        }
     }
 
     @Test
     public void shouldBeginTransactions() {
-        producer.initTransactions();
-        producer.beginTransaction();
-        assertTrue(producer.transactionInFlight());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            assertTrue(producer.transactionInFlight());
+        }
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowOnSendOffsetsToTransactionIfTransactionsNotInitialized() {
-        producer.sendOffsetsToTransaction(null, null);
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.sendOffsetsToTransaction(null, null);
+        }
     }
 
     @Test
     public void shouldThrowOnSendOffsetsToTransactionTransactionIfNoTransactionGotStarted() {
-        producer.initTransactions();
-        try {
-            producer.sendOffsetsToTransaction(null, null);
-            fail("Should have thrown as producer has no open transaction");
-        } catch (IllegalStateException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            try {
+                producer.sendOffsetsToTransaction(null, null);
+                fail("Should have thrown as producer has no open transaction");
+            } catch (IllegalStateException e) { }
+        }
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowOnCommitIfTransactionsNotInitialized() {
-        producer.commitTransaction();
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.commitTransaction();
+        }
     }
 
     @Test
     public void shouldThrowOnCommitTransactionIfNoTransactionGotStarted() {
-        producer.initTransactions();
-        try {
-            producer.commitTransaction();
-            fail("Should have thrown as producer has no open transaction");
-        } catch (IllegalStateException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            try {
+                producer.commitTransaction();
+                fail("Should have thrown as producer has no open transaction");
+            } catch (IllegalStateException e) { }
+        }
     }
 
     @Test
     public void shouldCommitEmptyTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
-        producer.commitTransaction();
-        assertFalse(producer.transactionInFlight());
-        assertTrue(producer.transactionCommitted());
-        assertFalse(producer.transactionAborted());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.commitTransaction();
+            assertFalse(producer.transactionInFlight());
+            assertTrue(producer.transactionCommitted());
+            assertFalse(producer.transactionAborted());
+        }
     }
 
     @Test
     public void shouldCountCommittedTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
 
-        assertThat(producer.commitCount(), equalTo(0L));
-        producer.commitTransaction();
-        assertThat(producer.commitCount(), equalTo(1L));
+            assertThat(producer.commitCount(), equalTo(0L));
+            producer.commitTransaction();
+            assertThat(producer.commitCount(), equalTo(1L));
+        }
     }
 
     @Test
     public void shouldNotCountAbortedTransaction() {
-        producer.initTransactions();
-
-        producer.beginTransaction();
-        producer.abortTransaction();
-
-        producer.beginTransaction();
-        producer.commitTransaction();
-        assertThat(producer.commitCount(), equalTo(1L));
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+    
+            producer.beginTransaction();
+            producer.abortTransaction();
+    
+            producer.beginTransaction();
+            producer.commitTransaction();
+            assertThat(producer.commitCount(), equalTo(1L));
+        }
     }
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowOnAbortIfTransactionsNotInitialized() {
-        producer.abortTransaction();
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.abortTransaction();
+        }
     }
 
     @Test
     public void shouldThrowOnAbortTransactionIfNoTransactionGotStarted() {
-        producer.initTransactions();
-        try {
-            producer.abortTransaction();
-            fail("Should have thrown as producer has no open transaction");
-        } catch (IllegalStateException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            try {
+                producer.abortTransaction();
+                fail("Should have thrown as producer has no open transaction");
+            } catch (IllegalStateException e) { }
+        }
     }
 
     @Test
     public void shouldAbortEmptyTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
-        producer.abortTransaction();
-        assertFalse(producer.transactionInFlight());
-        assertTrue(producer.transactionAborted());
-        assertFalse(producer.transactionCommitted());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.abortTransaction();
+            assertFalse(producer.transactionInFlight());
+            assertTrue(producer.transactionAborted());
+            assertFalse(producer.transactionCommitted());
+        }
     }
 
     @Test
     public void shouldAbortInFlightTransactionOnClose() {
-        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer());
         producer.initTransactions();
         producer.beginTransaction();
         producer.close();
@@ -236,86 +259,102 @@ public class MockProducerTest {
 
     @Test(expected = IllegalStateException.class)
     public void shouldThrowFenceProducerIfTransactionsNotInitialized() {
-        producer.fenceProducer();
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.fenceProducer();
+        }
     }
 
     @Test
     public void shouldThrowOnBeginTransactionsIfProducerGotFenced() {
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.beginTransaction();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.fenceProducer();
+            try {
+                producer.beginTransaction();
+                fail("Should have thrown as producer is fenced off");
+            } catch (ProducerFencedException e) { }
+        }
     }
 
     @Test
     public void shouldThrowOnSendIfProducerGotFenced() {
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.send(null);
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.fenceProducer();
+            try {
+                producer.send(null);
+                fail("Should have thrown as producer is fenced off");
+            } catch (ProducerFencedException e) { }
+        }
     }
 
     @Test
     public void shouldThrowOnFlushIfProducerGotFenced() {
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.flush();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.fenceProducer();
+            try {
+                producer.flush();
+                fail("Should have thrown as producer is fenced off");
+            } catch (ProducerFencedException e) { }
+        }
     }
 
     @Test
     public void shouldThrowOnSendOffsetsToTransactionIfProducerGotFenced() {
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.sendOffsetsToTransaction(null, null);
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.fenceProducer();
+            try {
+                producer.sendOffsetsToTransaction(null, null);
+                fail("Should have thrown as producer is fenced off");
+            } catch (ProducerFencedException e) { }
+        }
     }
 
     @Test
     public void shouldThrowOnCommitTransactionIfProducerGotFenced() {
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.commitTransaction();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.fenceProducer();
+            try {
+                producer.commitTransaction();
+                fail("Should have thrown as producer is fenced off");
+            } catch (ProducerFencedException e) { }
+        }
     }
 
     @Test
     public void shouldThrowOnAbortTransactionIfProducerGotFenced() {
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.abortTransaction();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.fenceProducer();
+            try {
+                producer.abortTransaction();
+                fail("Should have thrown as producer is fenced off");
+            } catch (ProducerFencedException e) { }
+        }
     }
 
     @Test
     public void shouldPublishMessagesOnlyAfterCommitIfTransactionsAreEnabled() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        producer.send(record1);
-        producer.send(record2);
-
-        assertTrue(producer.history().isEmpty());
-
-        producer.commitTransaction();
-
-        List<ProducerRecord<byte[], byte[]>> expectedResult = new ArrayList<>();
-        expectedResult.add(record1);
-        expectedResult.add(record2);
-
-        assertThat(producer.history(), equalTo(expectedResult));
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            producer.send(record1);
+            producer.send(record2);
+    
+            assertTrue(producer.history().isEmpty());
+    
+            producer.commitTransaction();
+    
+            List<ProducerRecord<byte[], byte[]>> expectedResult = new ArrayList<>();
+            expectedResult.add(record1);
+            expectedResult.add(record2);
+    
+            assertThat(producer.history(), equalTo(expectedResult));
+        }
     }
 
     @Test
@@ -339,17 +378,19 @@ public class MockProducerTest {
 
     @Test
     public void shouldDropMessagesOnAbortIfTransactionsAreEnabled() {
-        producer.initTransactions();
-
-        producer.beginTransaction();
-        producer.send(record1);
-        producer.send(record2);
-        producer.abortTransaction();
-        assertTrue(producer.history().isEmpty());
-
-        producer.beginTransaction();
-        producer.commitTransaction();
-        assertTrue(producer.history().isEmpty());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+    
+            producer.beginTransaction();
+            producer.send(record1);
+            producer.send(record2);
+            producer.abortTransaction();
+            assertTrue(producer.history().isEmpty());
+    
+            producer.beginTransaction();
+            producer.commitTransaction();
+            assertTrue(producer.history().isEmpty());
+        }
     }
 
     @Test
@@ -368,188 +409,206 @@ public class MockProducerTest {
 
     @Test
     public void shouldPreserveCommittedMessagesOnAbortIfTransactionsAreEnabled() {
-        producer.initTransactions();
-
-        producer.beginTransaction();
-        producer.send(record1);
-        producer.send(record2);
-        producer.commitTransaction();
-
-        producer.beginTransaction();
-        producer.abortTransaction();
-
-        List<ProducerRecord<byte[], byte[]>> expectedResult = new ArrayList<>();
-        expectedResult.add(record1);
-        expectedResult.add(record2);
-
-        assertThat(producer.history(), equalTo(expectedResult));
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+    
+            producer.beginTransaction();
+            producer.send(record1);
+            producer.send(record2);
+            producer.commitTransaction();
+    
+            producer.beginTransaction();
+            producer.abortTransaction();
+    
+            List<ProducerRecord<byte[], byte[]>> expectedResult = new ArrayList<>();
+            expectedResult.add(record1);
+            expectedResult.add(record2);
+    
+            assertThat(producer.history(), equalTo(expectedResult));
+        }
     }
 
     @Test
     public void shouldPublishConsumerGroupOffsetsOnlyAfterCommitIfTransactionsAreEnabled() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        String group1 = "g1";
-        Map<TopicPartition, OffsetAndMetadata> group1Commit = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
-            }
-        };
-        String group2 = "g2";
-        Map<TopicPartition, OffsetAndMetadata> group2Commit = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(101L, null));
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(21L, null));
-            }
-        };
-        producer.sendOffsetsToTransaction(group1Commit, group1);
-        producer.sendOffsetsToTransaction(group2Commit, group2);
-
-        assertTrue(producer.consumerGroupOffsetsHistory().isEmpty());
-
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();
-        expectedResult.put(group1, group1Commit);
-        expectedResult.put(group2, group2Commit);
-
-        producer.commitTransaction();
-        assertThat(producer.consumerGroupOffsetsHistory(), equalTo(Collections.singletonList(expectedResult)));
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            String group1 = "g1";
+            Map<TopicPartition, OffsetAndMetadata> group1Commit = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
+                }
+            };
+            String group2 = "g2";
+            Map<TopicPartition, OffsetAndMetadata> group2Commit = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(101L, null));
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(21L, null));
+                }
+            };
+            producer.sendOffsetsToTransaction(group1Commit, group1);
+            producer.sendOffsetsToTransaction(group2Commit, group2);
+    
+            assertTrue(producer.consumerGroupOffsetsHistory().isEmpty());
+    
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();
+            expectedResult.put(group1, group1Commit);
+            expectedResult.put(group2, group2Commit);
+    
+            producer.commitTransaction();
+            assertThat(producer.consumerGroupOffsetsHistory(), equalTo(Collections.singletonList(expectedResult)));
+        }
     }
 
     @Test
     public void shouldThrowOnNullConsumerGroupIdWhenSendOffsetsToTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        try {
-            producer.sendOffsetsToTransaction(Collections.<TopicPartition, OffsetAndMetadata>emptyMap(), null);
-            fail("Should have thrown NullPointerException");
-        } catch (NullPointerException e) { }
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            try {
+                producer.sendOffsetsToTransaction(Collections.<TopicPartition, OffsetAndMetadata>emptyMap(), null);
+                fail("Should have thrown NullPointerException");
+            } catch (NullPointerException e) { }
+        }
     }
 
     @Test
     public void shouldIgnoreEmptyOffsetsWhenSendOffsetsToTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
-        producer.sendOffsetsToTransaction(Collections.<TopicPartition, OffsetAndMetadata>emptyMap(), "groupId");
-        assertFalse(producer.sentOffsets());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+            producer.sendOffsetsToTransaction(Collections.<TopicPartition, OffsetAndMetadata>emptyMap(), "groupId");
+            assertFalse(producer.sentOffsets());
+        }
     }
 
     @Test
     public void shouldAddOffsetsWhenSendOffsetsToTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
 
-        assertFalse(producer.sentOffsets());
-
-        Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-            }
-        };
-        producer.sendOffsetsToTransaction(groupCommit, "groupId");
-        assertTrue(producer.sentOffsets());
+            assertFalse(producer.sentOffsets());
+    
+            Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                }
+            };
+            producer.sendOffsetsToTransaction(groupCommit, "groupId");
+            assertTrue(producer.sentOffsets());
+        }
     }
 
     @Test
     public void shouldResetSentOffsetsFlagOnlyWhenBeginningNewTransaction() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        assertFalse(producer.sentOffsets());
-
-        Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-            }
-        };
-        producer.sendOffsetsToTransaction(groupCommit, "groupId");
-        producer.commitTransaction(); // commit should not reset "sentOffsets" flag
-        assertTrue(producer.sentOffsets());
-
-        producer.beginTransaction();
-        assertFalse(producer.sentOffsets());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            assertFalse(producer.sentOffsets());
+    
+            Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                }
+            };
+            producer.sendOffsetsToTransaction(groupCommit, "groupId");
+            producer.commitTransaction(); // commit should not reset "sentOffsets" flag
+            assertTrue(producer.sentOffsets());
+    
+            producer.beginTransaction();
+            assertFalse(producer.sentOffsets());
+        }
     }
 
     @Test
     public void shouldPublishLatestAndCumulativeConsumerGroupOffsetsOnlyAfterCommitIfTransactionsAreEnabled() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        String group = "g";
-        Map<TopicPartition, OffsetAndMetadata> groupCommit1 = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
-            }
-        };
-        Map<TopicPartition, OffsetAndMetadata> groupCommit2 = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(101L, null));
-                put(new TopicPartition(topic, 2), new OffsetAndMetadata(21L, null));
-            }
-        };
-        producer.sendOffsetsToTransaction(groupCommit1, group);
-        producer.sendOffsetsToTransaction(groupCommit2, group);
-
-        assertTrue(producer.consumerGroupOffsetsHistory().isEmpty());
-
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();
-        expectedResult.put(group, new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(101L, null));
-                put(new TopicPartition(topic, 2), new OffsetAndMetadata(21L, null));
-            }
-        });
-
-        producer.commitTransaction();
-        assertThat(producer.consumerGroupOffsetsHistory(), equalTo(Collections.singletonList(expectedResult)));
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            String group = "g";
+            Map<TopicPartition, OffsetAndMetadata> groupCommit1 = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
+                }
+            };
+            Map<TopicPartition, OffsetAndMetadata> groupCommit2 = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(101L, null));
+                    put(new TopicPartition(topic, 2), new OffsetAndMetadata(21L, null));
+                }
+            };
+            producer.sendOffsetsToTransaction(groupCommit1, group);
+            producer.sendOffsetsToTransaction(groupCommit2, group);
+    
+            assertTrue(producer.consumerGroupOffsetsHistory().isEmpty());
+    
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();
+            expectedResult.put(group, new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(101L, null));
+                    put(new TopicPartition(topic, 2), new OffsetAndMetadata(21L, null));
+                }
+            });
+    
+            producer.commitTransaction();
+            assertThat(producer.consumerGroupOffsetsHistory(), equalTo(Collections.singletonList(expectedResult)));
+        }
     }
 
     @Test
     public void shouldDropConsumerGroupOffsetsOnAbortIfTransactionsAreEnabled() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        String group = "g";
-        Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
-            }
-        };
-        producer.sendOffsetsToTransaction(groupCommit, group);
-        producer.abortTransaction();
-
-        producer.beginTransaction();
-        producer.commitTransaction();
-        assertTrue(producer.consumerGroupOffsetsHistory().isEmpty());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            String group = "g";
+            Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
+                }
+            };
+            producer.sendOffsetsToTransaction(groupCommit, group);
+            producer.abortTransaction();
+    
+            producer.beginTransaction();
+            producer.commitTransaction();
+            assertTrue(producer.consumerGroupOffsetsHistory().isEmpty());
+        }
     }
 
     @Test
     public void shouldPreserveCommittedConsumerGroupsOffsetsOnAbortIfTransactionsAreEnabled() {
-        producer.initTransactions();
-        producer.beginTransaction();
-
-        String group = "g";
-        Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
-            {
-                put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
-                put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
-            }
-        };
-        producer.sendOffsetsToTransaction(groupCommit, group);
-        producer.commitTransaction();
-
-        producer.beginTransaction();
-        producer.abortTransaction();
-
-        Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();
-        expectedResult.put(group, groupCommit);
-
-        assertThat(producer.consumerGroupOffsetsHistory(), equalTo(Collections.singletonList(expectedResult)));
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            producer.initTransactions();
+            producer.beginTransaction();
+    
+            String group = "g";
+            Map<TopicPartition, OffsetAndMetadata> groupCommit = new HashMap<TopicPartition, OffsetAndMetadata>() {
+                {
+                    put(new TopicPartition(topic, 0), new OffsetAndMetadata(42L, null));
+                    put(new TopicPartition(topic, 1), new OffsetAndMetadata(73L, null));
+                }
+            };
+            producer.sendOffsetsToTransaction(groupCommit, group);
+            producer.commitTransaction();
+    
+            producer.beginTransaction();
+            producer.abortTransaction();
+    
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> expectedResult = new HashMap<>();
+            expectedResult.put(group, groupCommit);
+    
+            assertThat(producer.consumerGroupOffsetsHistory(), equalTo(Collections.singletonList(expectedResult)));
+        }
     }
 
     @Test
@@ -644,13 +703,17 @@ public class MockProducerTest {
 
     @Test
     public void shouldBeFlushedIfNoBufferedRecords() {
-        assertTrue(producer.flushed());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(false, new MockSerializer(), new MockSerializer())) {
+            assertTrue(producer.flushed());
+        }
     }
 
     @Test
     public void shouldBeFlushedWithAutoCompleteIfBufferedRecords() {
-        producer.send(record1);
-        assertTrue(producer.flushed());
+        try (MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer())) {
+            producer.send(record1);
+            assertTrue(producer.flushed());
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.test.MockSerializer;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -51,6 +52,10 @@ public class MockProducerTest {
     private final ProducerRecord<byte[], byte[]> record1 = new ProducerRecord<>(topic, "key1".getBytes(), "value1".getBytes());
     private final ProducerRecord<byte[], byte[]> record2 = new ProducerRecord<>(topic, "key2".getBytes(), "value2".getBytes());
 
+    @After
+    public void close() {
+        producer.close();
+    }
 
     @Test
     public void testAutoCompleteMock() throws Exception {
@@ -220,6 +225,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldAbortInFlightTransactionOnClose() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.initTransactions();
         producer.beginTransaction();
         producer.close();
@@ -548,6 +554,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnInitTransactionIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.initTransactions();
@@ -557,6 +564,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnSendIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.send(null);
@@ -566,6 +574,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnBeginTransactionIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.beginTransaction();
@@ -575,6 +584,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowSendOffsetsToTransactionIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.sendOffsetsToTransaction(null, null);
@@ -584,6 +594,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnCommitTransactionIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.commitTransaction();
@@ -593,6 +604,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnAbortTransactionIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.abortTransaction();
@@ -602,6 +614,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnCloseIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.close();
@@ -611,6 +624,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnFenceProducerIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.fenceProducer();
@@ -620,6 +634,7 @@ public class MockProducerTest {
 
     @Test
     public void shouldThrowOnFlushProducerIfProducerIsClosed() {
+        MockProducer<byte[], byte[]> producer = new MockProducer<>(true, new MockSerializer(), new MockSerializer());
         producer.close();
         try {
             producer.flush();

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -633,10 +633,9 @@ public class SenderTest {
         String topic = tp.topic();
         // Set a good compression ratio.
         CompressionRatioEstimator.setEstimation(topic, CompressionType.GZIP, 0.2f);
-        Metrics m = new Metrics();
-        accumulator = new RecordAccumulator(batchSize, 1024 * 1024, CompressionType.GZIP, 0L, 0L, m, time,
-                new ApiVersions(), txnManager);
-        try {
+        try (Metrics m = new Metrics()) {
+            accumulator = new RecordAccumulator(batchSize, 1024 * 1024, CompressionType.GZIP, 0L, 0L, m, time,
+                    new ApiVersions(), txnManager);
             Sender sender = new Sender(client, metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL, maxRetries,
                     m, time, REQUEST_TIMEOUT, 1000L, txnManager, new ApiVersions());
             // Create a two broker cluster, with partition 0 on broker 0 and partition 1 on broker 1
@@ -701,8 +700,6 @@ public class SenderTest {
 
             assertTrue("There should be a split",
                     m.metrics().get(m.metricName("batch-split-rate", "producer-metrics")).value() > 0);
-        } finally {
-            m.close();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferOutputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ByteBufferOutputStreamTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.common.utils;
 
 import org.junit.Test;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -49,6 +50,7 @@ public class ByteBufferOutputStreamTest {
         byte[] bytes = new byte[5];
         buffer.get(bytes);
         assertArrayEquals("hello".getBytes(), bytes);
+        output.close();
     }
 
     @Test
@@ -75,19 +77,20 @@ public class ByteBufferOutputStreamTest {
         byte[] bytes = new byte[5];
         buffer.get(bytes);
         assertArrayEquals("hello".getBytes(), bytes);
+        output.close();
     }
 
     @Test
-    public void testWriteByteBuffer() {
+    public void testWriteByteBuffer() throws IOException {
         testWriteByteBuffer(ByteBuffer.allocate(16));
     }
 
     @Test
-    public void testWriteDirectByteBuffer() {
+    public void testWriteDirectByteBuffer() throws IOException {
         testWriteByteBuffer(ByteBuffer.allocateDirect(16));
     }
 
-    private void testWriteByteBuffer(ByteBuffer input) {
+    private void testWriteByteBuffer(ByteBuffer input) throws IOException {
         long value = 234239230L;
         input.putLong(value);
         input.flip();
@@ -97,6 +100,7 @@ public class ByteBufferOutputStreamTest {
         assertEquals(8, input.position());
         assertEquals(8, output.position());
         assertEquals(value, output.buffer().getLong(0));
+        output.close();
     }
 
 }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -123,6 +123,7 @@ public class FileStreamSourceTaskTest {
         assertEquals(Collections.singletonMap(FileStreamSourceTask.FILENAME_FIELD, tempFile.getAbsolutePath()), records.get(0).sourcePartition());
         assertEquals(Collections.singletonMap(FileStreamSourceTask.POSITION_FIELD, 48L), records.get(0).sourceOffset());
 
+        os.close();
         task.stop();
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -137,7 +137,6 @@ public class Plugins {
         return delegatingLoader.transformations();
     }
 
-    @SuppressWarnings("unchecked")
     public Connector newConnector(String connectorClassOrAlias) {
         Class<? extends Connector> klass;
         try {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -72,8 +72,10 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
         try {
             ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
             Object obj = is.readObject();
-            if (!(obj instanceof HashMap))
+            if (!(obj instanceof HashMap)) {
+                is.close();
                 throw new ConnectException("Expected HashMap but found " + obj.getClass());
+            }
             Map<byte[], byte[]> raw = (Map<byte[], byte[]>) obj;
             data = new HashMap<>();
             for (Map.Entry<byte[], byte[]> mapEntry : raw.entrySet()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -69,8 +69,7 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
 
     @SuppressWarnings("unchecked")
     private void load() {
-        try {
-            ObjectInputStream is = new ObjectInputStream(new FileInputStream(file));
+        try (ObjectInputStream is = new ObjectInputStream(new FileInputStream(file))) {
             Object obj = is.readObject();
             if (!(obj instanceof HashMap)) {
                 is.close();
@@ -83,7 +82,6 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
                 ByteBuffer value = (mapEntry.getValue() != null) ? ByteBuffer.wrap(mapEntry.getValue()) : null;
                 data.put(key, value);
             }
-            is.close();
         } catch (FileNotFoundException | EOFException e) {
             // FileNotFoundException: Ignore, may be new.
             // EOFException: Ignore, this means the file was missing or corrupt

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -71,10 +71,8 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
     private void load() {
         try (ObjectInputStream is = new ObjectInputStream(new FileInputStream(file))) {
             Object obj = is.readObject();
-            if (!(obj instanceof HashMap)) {
-                is.close();
+            if (!(obj instanceof HashMap))
                 throw new ConnectException("Expected HashMap but found " + obj.getClass());
-            }
             Map<byte[], byte[]> raw = (Map<byte[], byte[]>) obj;
             data = new HashMap<>();
             for (Map.Entry<byte[], byte[]> mapEntry : raw.entrySet()) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -115,7 +115,6 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
     private long recordsReturned;
 
 
-    @SuppressWarnings("unchecked")
     @Override
     public void setup() {
         super.setup();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -135,7 +135,6 @@ public class KafkaConfigBackingStoreTest {
     KafkaBasedLog<String, byte[]> storeLog;
     private KafkaConfigBackingStore configStorage;
 
-    private String internalTopic;
     private Capture<String> capturedTopic = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedProducerProps = EasyMock.newCapture();
     private Capture<Map<String, Object>> capturedConsumerProps = EasyMock.newCapture();
@@ -363,7 +362,7 @@ public class KafkaConfigBackingStoreTest {
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(1), CONFIGS_SERIALIZED.get(2)),
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TARGET_STATE_KEYS.get(0), CONFIGS_SERIALIZED.get(3)),
                 new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(4)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -403,7 +402,7 @@ public class KafkaConfigBackingStoreTest {
                 new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(1)),
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(1), CONFIGS_SERIALIZED.get(2)),
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(3)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -445,7 +444,7 @@ public class KafkaConfigBackingStoreTest {
                 new ConsumerRecord<>(TOPIC, 0, 1, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(1)),
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(1), CONFIGS_SERIALIZED.get(2)),
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(3)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -494,7 +493,7 @@ public class KafkaConfigBackingStoreTest {
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(1), CONFIGS_SERIALIZED.get(2)),
                 new ConsumerRecord<>(TOPIC, 0, 3, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TARGET_STATE_KEYS.get(0), CONFIGS_SERIALIZED.get(3)),
                 new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(4)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -540,7 +539,7 @@ public class KafkaConfigBackingStoreTest {
                 // Connector after root update should make it through, task update shouldn't
                 new ConsumerRecord<>(TOPIC, 0, 5, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, CONNECTOR_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(5)),
                 new ConsumerRecord<>(TOPIC, 0, 6, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(6)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -594,7 +593,7 @@ public class KafkaConfigBackingStoreTest {
                 new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TARGET_STATE_KEYS.get(0), CONFIGS_SERIALIZED.get(4)),
                 new ConsumerRecord<>(TOPIC, 0, 5, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(5)));
 
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -640,7 +639,7 @@ public class KafkaConfigBackingStoreTest {
             new ConsumerRecord<>(TOPIC, 0, 5, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, CONNECTOR_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(5)),
             new ConsumerRecord<>(TOPIC, 0, 6, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(6)),
             new ConsumerRecord<>(TOPIC, 0, 7, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(7)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(1), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
@@ -691,7 +690,7 @@ public class KafkaConfigBackingStoreTest {
                 new ConsumerRecord<>(TOPIC, 0, 2, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(1), CONFIGS_SERIALIZED.get(2)),
                 new ConsumerRecord<>(TOPIC, 0, 4, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, COMMIT_TASKS_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(4)),
                 new ConsumerRecord<>(TOPIC, 0, 5, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, TASK_CONFIG_KEYS.get(0), CONFIGS_SERIALIZED.get(5)));
-        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap();
+        LinkedHashMap<byte[], Struct> deserialized = new LinkedHashMap<>();
         deserialized.put(CONFIGS_SERIALIZED.get(0), CONNECTOR_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(2), TASK_CONFIG_STRUCTS.get(0));
         deserialized.put(CONFIGS_SERIALIZED.get(4), TASKS_COMMIT_STRUCT_TWO_TASK_CONNECTOR);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -49,7 +49,6 @@ public class TopicAdminTest {
     @Test
     public void returnNullWithApiVersionMismatch() {
         final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
-        boolean internal = false;
         Cluster cluster = createCluster(1);
         try (MockKafkaAdminClientEnv env = new MockKafkaAdminClientEnv(cluster)) {
             env.kafkaClient().setNode(cluster.controller());

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -34,6 +35,14 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class CastTest {
+    private final Cast<SourceRecord> xformKey = new Cast.Key<>();
+    private final Cast<SourceRecord> xformValue = new Cast.Value<>();
+
+    @After
+    public void teardown() {
+        xformKey.close();
+        xformValue.close();
+    }
 
     @Test(expected = ConfigException.class)
     public void testConfigEmpty() {
@@ -72,256 +81,214 @@ public class CastTest {
 
     @Test
     public void castWholeRecordKeyWithSchema() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        SourceRecord transformed = xformKey.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42, Schema.STRING_SCHEMA, "bogus"));
 
         assertEquals(Schema.Type.INT8, transformed.keySchema().type());
         assertEquals((byte) 42, transformed.key());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaInt8() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.INT8, transformed.valueSchema().type());
         assertEquals((byte) 42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaInt16() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int16"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int16"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.INT16, transformed.valueSchema().type());
         assertEquals((short) 42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaInt32() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.INT32, transformed.valueSchema().type());
         assertEquals(42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaInt64() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int64"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int64"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.INT64, transformed.valueSchema().type());
         assertEquals((long) 42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaFloat32() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float32"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float32"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.FLOAT32, transformed.valueSchema().type());
         assertEquals(42.f, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaFloat64() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float64"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float64"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.FLOAT64, transformed.valueSchema().type());
         assertEquals(42., transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaBooleanTrue() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.BOOLEAN, transformed.valueSchema().type());
         assertEquals(true, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaBooleanFalse() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 0));
 
         assertEquals(Schema.Type.BOOLEAN, transformed.valueSchema().type());
         assertEquals(false, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueWithSchemaString() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 Schema.INT32_SCHEMA, 42));
 
         assertEquals(Schema.Type.STRING, transformed.valueSchema().type());
         assertEquals("42", transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordDefaultValue() {
         // Validate default value in schema is correctly converted
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 SchemaBuilder.float32().defaultValue(-42.125f).build(), 42.125f));
 
         assertEquals(Schema.Type.INT32, transformed.valueSchema().type());
         assertEquals(42, transformed.value());
         assertEquals(-42, transformed.valueSchema().defaultValue());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordKeySchemaless() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        SourceRecord transformed = xformKey.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42, Schema.STRING_SCHEMA, "bogus"));
 
         assertNull(transformed.keySchema());
         assertEquals((byte) 42, transformed.key());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessInt8() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals((byte) 42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessInt16() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int16"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int16"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals((short) 42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessInt32() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int32"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals(42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessInt64() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int64"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int64"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals((long) 42, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessFloat32() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float32"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float32"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals(42.f, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessFloat64() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float64"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "float64"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals(42., transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessBooleanTrue() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals(true, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessBooleanFalse() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "boolean"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 0));
 
         assertNull(transformed.valueSchema());
         assertEquals(false, transformed.value());
-        xform.close();
     }
 
     @Test
     public void castWholeRecordValueSchemalessString() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "string"));
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, 42));
 
         assertNull(transformed.valueSchema());
         assertEquals("42", transformed.value());
-        xform.close();
     }
 
     @Test(expected = DataException.class)
@@ -335,8 +302,7 @@ public class CastTest {
 
     @Test
     public void castFieldsWithSchema() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32,optional:int32"));
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32,optional:int32"));
 
         // Include an optional fields and fields with defaults to validate their values are passed through properly
         SchemaBuilder builder = SchemaBuilder.struct();
@@ -363,7 +329,7 @@ public class CastTest {
         recordValue.put("string", "42");
         // optional field intentionally omitted
 
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 supportedTypesSchema, recordValue));
 
         assertEquals((short) 8, ((Struct) transformed.value()).get("int8"));
@@ -378,14 +344,12 @@ public class CastTest {
         assertEquals((byte) 1, ((Struct) transformed.value()).get("boolean"));
         assertEquals(42, ((Struct) transformed.value()).get("string"));
         assertNull(((Struct) transformed.value()).get("optional"));
-        xform.close();
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void castFieldsSchemaless() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32"));
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8:int16,int16:int32,int32:int64,int64:boolean,float32:float64,float64:boolean,boolean:int8,string:int32"));
         Map<String, Object> recordValue = new HashMap<>();
         recordValue.put("int8", (byte) 8);
         recordValue.put("int16", (short) 16);
@@ -395,7 +359,7 @@ public class CastTest {
         recordValue.put("float64", -64.);
         recordValue.put("boolean", true);
         recordValue.put("string", "42");
-        SourceRecord transformed = xform.apply(new SourceRecord(null, null, "topic", 0,
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null, "topic", 0,
                 null, recordValue));
 
         assertNull(transformed.valueSchema());
@@ -407,7 +371,6 @@ public class CastTest {
         assertEquals(true, ((Map<String, Object>) transformed.value()).get("float64"));
         assertEquals((byte) 1, ((Map<String, Object>) transformed.value()).get("boolean"));
         assertEquals(42, ((Map<String, Object>) transformed.value()).get("string"));
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -37,37 +37,37 @@ public class CastTest {
 
     @Test(expected = ConfigException.class)
     public void testConfigEmpty() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
-        xform.close();
+        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
+            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidSchemaType() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
-        xform.close();
+        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
+            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidTargetType() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
-        xform.close();
+        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
+            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidMap() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
-        xform.close();
+        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
+            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigMixWholeAndFieldTransformation() {
-        final Cast<SourceRecord> xform = new Cast.Key<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
-        xform.close();
+        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
+            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
+        }
     }
 
     @Test
@@ -326,10 +326,10 @@ public class CastTest {
 
     @Test(expected = DataException.class)
     public void castWholeRecordValueSchemalessUnsupportedType() {
-        final Cast<SourceRecord> xform = new Cast.Value<>();
-        xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-        xform.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
-        xform.close();
+        try (final Cast<SourceRecord> xform = new Cast.Value<>()) {
+            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+            xform.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
+        }
     }
 
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -39,30 +39,35 @@ public class CastTest {
     public void testConfigEmpty() {
         final Cast<SourceRecord> xform = new Cast.Key<>();
         xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
+        xform.close();
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidSchemaType() {
         final Cast<SourceRecord> xform = new Cast.Key<>();
         xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
+        xform.close();
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidTargetType() {
         final Cast<SourceRecord> xform = new Cast.Key<>();
         xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
+        xform.close();
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidMap() {
         final Cast<SourceRecord> xform = new Cast.Key<>();
         xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
+        xform.close();
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigMixWholeAndFieldTransformation() {
         final Cast<SourceRecord> xform = new Cast.Key<>();
         xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
+        xform.close();
     }
 
     @Test
@@ -74,6 +79,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.INT8, transformed.keySchema().type());
         assertEquals((byte) 42, transformed.key());
+        xform.close();
     }
 
     @Test
@@ -85,6 +91,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.INT8, transformed.valueSchema().type());
         assertEquals((byte) 42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -96,6 +103,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.INT16, transformed.valueSchema().type());
         assertEquals((short) 42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -107,6 +115,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.INT32, transformed.valueSchema().type());
         assertEquals(42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -118,6 +127,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.INT64, transformed.valueSchema().type());
         assertEquals((long) 42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -129,6 +139,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.FLOAT32, transformed.valueSchema().type());
         assertEquals(42.f, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -140,6 +151,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.FLOAT64, transformed.valueSchema().type());
         assertEquals(42., transformed.value());
+        xform.close();
     }
 
     @Test
@@ -151,6 +163,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.BOOLEAN, transformed.valueSchema().type());
         assertEquals(true, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -162,6 +175,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.BOOLEAN, transformed.valueSchema().type());
         assertEquals(false, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -173,6 +187,7 @@ public class CastTest {
 
         assertEquals(Schema.Type.STRING, transformed.valueSchema().type());
         assertEquals("42", transformed.value());
+        xform.close();
     }
 
     @Test
@@ -186,6 +201,7 @@ public class CastTest {
         assertEquals(Schema.Type.INT32, transformed.valueSchema().type());
         assertEquals(42, transformed.value());
         assertEquals(-42, transformed.valueSchema().defaultValue());
+        xform.close();
     }
 
     @Test
@@ -197,6 +213,7 @@ public class CastTest {
 
         assertNull(transformed.keySchema());
         assertEquals((byte) 42, transformed.key());
+        xform.close();
     }
 
     @Test
@@ -208,6 +225,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals((byte) 42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -219,6 +237,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals((short) 42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -230,6 +249,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -241,6 +261,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals((long) 42, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -252,6 +273,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(42.f, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -263,6 +285,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(42., transformed.value());
+        xform.close();
     }
 
     @Test
@@ -274,6 +297,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(true, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -285,6 +309,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(false, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -296,6 +321,7 @@ public class CastTest {
 
         assertNull(transformed.valueSchema());
         assertEquals("42", transformed.value());
+        xform.close();
     }
 
     @Test(expected = DataException.class)
@@ -303,6 +329,7 @@ public class CastTest {
         final Cast<SourceRecord> xform = new Cast.Value<>();
         xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
         xform.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
+        xform.close();
     }
 
 
@@ -351,6 +378,7 @@ public class CastTest {
         assertEquals((byte) 1, ((Struct) transformed.value()).get("boolean"));
         assertEquals(42, ((Struct) transformed.value()).get("string"));
         assertNull(((Struct) transformed.value()).get("optional"));
+        xform.close();
     }
 
     @SuppressWarnings("unchecked")
@@ -379,6 +407,7 @@ public class CastTest {
         assertEquals(true, ((Map<String, Object>) transformed.value()).get("float64"));
         assertEquals((byte) 1, ((Map<String, Object>) transformed.value()).get("boolean"));
         assertEquals(42, ((Map<String, Object>) transformed.value()).get("string"));
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/CastTest.java
@@ -46,37 +46,27 @@ public class CastTest {
 
     @Test(expected = ConfigException.class)
     public void testConfigEmpty() {
-        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
-            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
-        }
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, ""));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidSchemaType() {
-        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
-            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
-        }
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:faketype"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidTargetType() {
-        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
-            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
-        }
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:array"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidMap() {
-        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
-            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
-        }
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8:extra"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigMixWholeAndFieldTransformation() {
-        try (final Cast<SourceRecord> xform = new Cast.Key<>()) {
-            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
-        }
+        xformKey.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "foo:int8,int32"));
     }
 
     @Test
@@ -293,10 +283,8 @@ public class CastTest {
 
     @Test(expected = DataException.class)
     public void castWholeRecordValueSchemalessUnsupportedType() {
-        try (final Cast<SourceRecord> xform = new Cast.Value<>()) {
-            xform.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
-            xform.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
-        }
+        xformValue.configure(Collections.singletonMap(Cast.SPEC_CONFIG, "int8"));
+        xformValue.apply(new SourceRecord(null, null, "topic", 0, null, Collections.singletonList("foo")));
     }
 
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -39,6 +39,7 @@ public class ExtractFieldTest {
 
         assertNull(transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
+        xform.close();
     }
 
     @Test
@@ -53,6 +54,7 @@ public class ExtractFieldTest {
 
         assertEquals(Schema.INT32_SCHEMA, transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ExtractFieldTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -28,10 +29,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class ExtractFieldTest {
+    private final ExtractField<SinkRecord> xform = new ExtractField.Key<>();
+
+    @After
+    public void teardown() {
+        xform.close();
+    }
 
     @Test
     public void schemaless() {
-        final ExtractField<SinkRecord> xform = new ExtractField.Key<>();
         xform.configure(Collections.singletonMap("field", "magic"));
 
         final SinkRecord record = new SinkRecord("test", 0, null, Collections.singletonMap("magic", 42), null, null, 0);
@@ -39,12 +45,10 @@ public class ExtractFieldTest {
 
         assertNull(transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
-        xform.close();
     }
 
     @Test
     public void withSchema() {
-        final ExtractField<SinkRecord> xform = new ExtractField.Key<>();
         xform.configure(Collections.singletonMap("field", "magic"));
 
         final Schema keySchema = SchemaBuilder.struct().field("magic", Schema.INT32_SCHEMA).build();
@@ -54,7 +58,6 @@ public class ExtractFieldTest {
 
         assertEquals(Schema.INT32_SCHEMA, transformedRecord.keySchema());
         assertEquals(42, transformedRecord.key());
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
@@ -39,18 +39,18 @@ public class FlattenTest {
 
     @Test(expected = DataException.class)
     public void topLevelStructRequired() {
-        final Flatten<SourceRecord> xform = new Flatten.Value<>();
-        xform.configure(Collections.<String, String>emptyMap());
-        xform.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
-        xform.close();
+        try (final Flatten<SourceRecord> xform = new Flatten.Value<>()) {
+            xform.configure(Collections.<String, String>emptyMap());
+            xform.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
+        }
     }
 
     @Test(expected = DataException.class)
     public void topLevelMapRequired() {
-        final Flatten<SourceRecord> xform = new Flatten.Value<>();
-        xform.configure(Collections.<String, String>emptyMap());
-        xform.apply(new SourceRecord(null, null, "topic", 0, null, 42));
-        xform.close();
+        try (final Flatten<SourceRecord> xform = new Flatten.Value<>()) {
+            xform.configure(Collections.<String, String>emptyMap());
+            xform.apply(new SourceRecord(null, null, "topic", 0, null, 42));
+        }
     }
 
     @Test
@@ -222,11 +222,11 @@ public class FlattenTest {
 
     @Test(expected = DataException.class)
     public void testUnsupportedTypeInMap() {
-        final Flatten<SourceRecord> xform = new Flatten.Value<>();
-        xform.configure(Collections.<String, String>emptyMap());
-        Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
-        xform.apply(new SourceRecord(null, null, "topic", 0, null, value));
-        xform.close();
+        try (final Flatten<SourceRecord> xform = new Flatten.Value<>()) {
+            xform.configure(Collections.<String, String>emptyMap());
+            Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
+            xform.apply(new SourceRecord(null, null, "topic", 0, null, value));
+        }
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
@@ -42,6 +42,7 @@ public class FlattenTest {
         final Flatten<SourceRecord> xform = new Flatten.Value<>();
         xform.configure(Collections.<String, String>emptyMap());
         xform.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
+        xform.close();
     }
 
     @Test(expected = DataException.class)
@@ -49,6 +50,7 @@ public class FlattenTest {
         final Flatten<SourceRecord> xform = new Flatten.Value<>();
         xform.configure(Collections.<String, String>emptyMap());
         xform.apply(new SourceRecord(null, null, "topic", 0, null, 42));
+        xform.close();
     }
 
     @Test
@@ -109,6 +111,7 @@ public class FlattenTest {
         assertEquals(true, transformedStruct.getBoolean("A.B.boolean"));
         assertEquals("stringy", transformedStruct.getString("A.B.string"));
         assertArrayEquals("bytes".getBytes(), transformedStruct.getBytes("A.B.bytes"));
+        xform.close();
     }
 
     @Test
@@ -147,6 +150,7 @@ public class FlattenTest {
         assertEquals(true, transformedMap.get("A#B#boolean"));
         assertEquals("stringy", transformedMap.get("A#B#string"));
         assertArrayEquals("bytes".getBytes(), (byte[]) transformedMap.get("A#B#bytes"));
+        xform.close();
     }
 
     @Test
@@ -175,6 +179,7 @@ public class FlattenTest {
         assertEquals(Schema.Type.STRUCT, transformed.valueSchema().type());
         Struct transformedStruct = (Struct) transformed.value();
         assertNull(transformedStruct.get("B.opt_int32"));
+        xform.close();
     }
 
     @Test
@@ -196,6 +201,7 @@ public class FlattenTest {
         Map<String, Object> transformedMap = (Map<String, Object>) transformed.value();
 
         assertNull(transformedMap.get("B.opt_int32"));
+        xform.close();
     }
 
     @Test
@@ -211,6 +217,7 @@ public class FlattenTest {
         assertTrue(transformed.key() instanceof Map);
         Map<String, Object> transformedMap = (Map<String, Object>) transformed.key();
         assertEquals(12, transformedMap.get("A.B"));
+        xform.close();
     }
 
     @Test(expected = DataException.class)
@@ -219,6 +226,7 @@ public class FlattenTest {
         xform.configure(Collections.<String, String>emptyMap());
         Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
         xform.apply(new SourceRecord(null, null, "topic", 0, null, value));
+        xform.close();
     }
 
     @Test
@@ -253,5 +261,6 @@ public class FlattenTest {
         // the parent didn't specify the default explicitly, we should still be using the field's normal default
         Schema transformedOptFieldSchema = SchemaBuilder.string().optional().defaultValue("child_default").build();
         assertEquals(transformedOptFieldSchema, transformedSchema.field("opt_field").schema());
+        xform.close();
     }
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/FlattenTest.java
@@ -48,18 +48,14 @@ public class FlattenTest {
 
     @Test(expected = DataException.class)
     public void topLevelStructRequired() {
-        try (final Flatten<SourceRecord> xform = new Flatten.Value<>()) {
-            xform.configure(Collections.<String, String>emptyMap());
-            xform.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
-        }
+        xformValue.configure(Collections.<String, String>emptyMap());
+        xformValue.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
     }
 
     @Test(expected = DataException.class)
     public void topLevelMapRequired() {
-        try (final Flatten<SourceRecord> xform = new Flatten.Value<>()) {
-            xform.configure(Collections.<String, String>emptyMap());
-            xform.apply(new SourceRecord(null, null, "topic", 0, null, 42));
-        }
+        xformValue.configure(Collections.<String, String>emptyMap());
+        xformValue.apply(new SourceRecord(null, null, "topic", 0, null, 42));
     }
 
     @Test
@@ -221,11 +217,9 @@ public class FlattenTest {
 
     @Test(expected = DataException.class)
     public void testUnsupportedTypeInMap() {
-        try (final Flatten<SourceRecord> xform = new Flatten.Value<>()) {
-            xform.configure(Collections.<String, String>emptyMap());
-            Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
-            xform.apply(new SourceRecord(null, null, "topic", 0, null, value));
-        }
+        xformValue.configure(Collections.<String, String>emptyMap());
+        Object value = Collections.singletonMap("foo", Arrays.asList("bar", "baz"));
+        xformValue.apply(new SourceRecord(null, null, "topic", 0, null, value));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
@@ -38,6 +38,7 @@ public class HoistFieldTest {
 
         assertNull(transformedRecord.keySchema());
         assertEquals(Collections.singletonMap("magic", 42), transformedRecord.key());
+        xform.close();
     }
 
     @Test
@@ -51,6 +52,7 @@ public class HoistFieldTest {
         assertEquals(Schema.Type.STRUCT, transformedRecord.keySchema().type());
         assertEquals(record.keySchema(),  transformedRecord.keySchema().field("magic").schema());
         assertEquals(42, ((Struct) transformedRecord.key()).get("magic"));
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/HoistFieldTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.transforms;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -27,10 +28,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class HoistFieldTest {
+    private final HoistField<SinkRecord> xform = new HoistField.Key<>();
+
+    @After
+    public void teardown() {
+        xform.close();
+    }
 
     @Test
     public void schemaless() {
-        final HoistField<SinkRecord> xform = new HoistField.Key<>();
         xform.configure(Collections.singletonMap("field", "magic"));
 
         final SinkRecord record = new SinkRecord("test", 0, null, 42, null, null, 0);
@@ -38,12 +44,10 @@ public class HoistFieldTest {
 
         assertNull(transformedRecord.keySchema());
         assertEquals(Collections.singletonMap("magic", 42), transformedRecord.key());
-        xform.close();
     }
 
     @Test
     public void withSchema() {
-        final HoistField<SinkRecord> xform = new HoistField.Key<>();
         xform.configure(Collections.singletonMap("field", "magic"));
 
         final SinkRecord record = new SinkRecord("test", 0, Schema.INT32_SCHEMA, 42, null, null, 0);
@@ -52,7 +56,6 @@ public class HoistFieldTest {
         assertEquals(Schema.Type.STRUCT, transformedRecord.keySchema().type());
         assertEquals(record.keySchema(),  transformedRecord.keySchema().field("magic").schema());
         assertEquals(42, ((Struct) transformedRecord.key()).get("magic"));
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -40,6 +40,7 @@ public class InsertFieldTest {
         xform.apply(new SourceRecord(null, null,
                 "", 0,
                 Schema.INT32_SCHEMA, 42));
+        xform.close();
     }
 
     @Test
@@ -83,6 +84,7 @@ public class InsertFieldTest {
         final SourceRecord transformedRecord2 = xform.apply(
                 new SourceRecord(null, null, "test", 1, simpleStructSchema, new Struct(simpleStructSchema)));
         assertSame(transformedRecord.valueSchema(), transformedRecord2.valueSchema());
+        xform.close();
     }
 
     @Test
@@ -107,6 +109,7 @@ public class InsertFieldTest {
         assertEquals(0, ((Map) transformedRecord.value()).get("partition_field"));
         assertEquals(null, ((Map) transformedRecord.value()).get("timestamp_field"));
         assertEquals("my-instance-id", ((Map) transformedRecord.value()).get("instance_id"));
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -42,10 +42,8 @@ public class InsertFieldTest {
 
     @Test(expected = DataException.class)
     public void topLevelStructRequired() {
-        try (final InsertField<SourceRecord> xform = new InsertField.Value<>()) {
-            xform.configure(Collections.singletonMap("topic.field", "topic_field"));
-            xform.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42));
-        }
+        xform.configure(Collections.singletonMap("topic.field", "topic_field"));
+        xform.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42));
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -32,6 +33,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 public class InsertFieldTest {
+    private InsertField<SourceRecord> xform = new InsertField.Value<>();
+
+    @After
+    public void teardown() {
+        xform.close();
+    }
 
     @Test(expected = DataException.class)
     public void topLevelStructRequired() {
@@ -50,7 +57,6 @@ public class InsertFieldTest {
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
 
-        final InsertField<SourceRecord> xform = new InsertField.Value<>();
         xform.configure(props);
 
         final Schema simpleStructSchema = SchemaBuilder.struct().name("name").version(1).doc("doc").field("magic", Schema.OPTIONAL_INT64_SCHEMA).build();
@@ -82,7 +88,6 @@ public class InsertFieldTest {
         final SourceRecord transformedRecord2 = xform.apply(
                 new SourceRecord(null, null, "test", 1, simpleStructSchema, new Struct(simpleStructSchema)));
         assertSame(transformedRecord.valueSchema(), transformedRecord2.valueSchema());
-        xform.close();
     }
 
     @Test
@@ -94,7 +99,6 @@ public class InsertFieldTest {
         props.put("static.field", "instance_id");
         props.put("static.value", "my-instance-id");
 
-        final InsertField<SourceRecord> xform = new InsertField.Value<>();
         xform.configure(props);
 
         final SourceRecord record = new SourceRecord(null, null, "test", 0,
@@ -107,7 +111,6 @@ public class InsertFieldTest {
         assertEquals(0, ((Map) transformedRecord.value()).get("partition_field"));
         assertEquals(null, ((Map) transformedRecord.value()).get("timestamp_field"));
         assertEquals("my-instance-id", ((Map) transformedRecord.value()).get("instance_id"));
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/InsertFieldTest.java
@@ -35,12 +35,10 @@ public class InsertFieldTest {
 
     @Test(expected = DataException.class)
     public void topLevelStructRequired() {
-        final InsertField<SourceRecord> xform = new InsertField.Value<>();
-        xform.configure(Collections.singletonMap("topic.field", "topic_field"));
-        xform.apply(new SourceRecord(null, null,
-                "", 0,
-                Schema.INT32_SCHEMA, 42));
-        xform.close();
+        try (final InsertField<SourceRecord> xform = new InsertField.Value<>()) {
+            xform.configure(Collections.singletonMap("topic.field", "topic_field"));
+            xform.apply(new SourceRecord(null, null, "", 0, Schema.INT32_SCHEMA, 42));
+        }
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/RegexRouterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/RegexRouterTest.java
@@ -32,8 +32,9 @@ public class RegexRouterTest {
         props.put("replacement", replacement);
         final RegexRouter<SinkRecord> router = new RegexRouter<>();
         router.configure(props);
-        return router.apply(new SinkRecord(topic, 0, null, null, null, null, 0))
-                .topic();
+        String sinkTopic = router.apply(new SinkRecord(topic, 0, null, null, null, null, 0)).topic();
+        router.close();
+        return sinkTopic;
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -28,11 +29,15 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 public class ReplaceFieldTest {
+    private ReplaceField<SinkRecord> xform = new ReplaceField.Value<>();
+
+    @After
+    public void teardown() {
+        xform.close();
+    }
 
     @Test
     public void schemaless() {
-        final ReplaceField<SinkRecord> xform = new ReplaceField.Value<>();
-
         final Map<String, String> props = new HashMap<>();
         props.put("blacklist", "dont");
         props.put("renames", "abc:xyz,foo:bar");
@@ -53,13 +58,10 @@ public class ReplaceFieldTest {
         assertEquals(42, updatedValue.get("xyz"));
         assertEquals(true, updatedValue.get("bar"));
         assertEquals("etc", updatedValue.get("etc"));
-        xform.close();
     }
 
     @Test
     public void withSchema() {
-        final ReplaceField<SinkRecord> xform = new ReplaceField.Value<>();
-
         final Map<String, String> props = new HashMap<>();
         props.put("whitelist", "abc,foo");
         props.put("renames", "abc:xyz,foo:bar");
@@ -87,7 +89,6 @@ public class ReplaceFieldTest {
         assertEquals(2, updatedValue.schema().fields().size());
         assertEquals(new Integer(42), updatedValue.getInt32("xyz"));
         assertEquals(true, updatedValue.getBoolean("bar"));
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ReplaceFieldTest.java
@@ -53,6 +53,7 @@ public class ReplaceFieldTest {
         assertEquals(42, updatedValue.get("xyz"));
         assertEquals(true, updatedValue.get("bar"));
         assertEquals("etc", updatedValue.get("etc"));
+        xform.close();
     }
 
     @Test
@@ -86,6 +87,7 @@ public class ReplaceFieldTest {
         assertEquals(2, updatedValue.schema().fields().size());
         assertEquals(new Integer(42), updatedValue.getInt32("xyz"));
         assertEquals(true, updatedValue.getBoolean("bar"));
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
@@ -39,6 +39,7 @@ public class SetSchemaMetadataTest {
         final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
         final SinkRecord updatedRecord = xform.apply(record);
         assertEquals("foo", updatedRecord.valueSchema().name());
+        xform.close();
     }
 
     @Test
@@ -48,6 +49,7 @@ public class SetSchemaMetadataTest {
         final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
         final SinkRecord updatedRecord = xform.apply(record);
         assertEquals(new Integer(42), updatedRecord.valueSchema().version());
+        xform.close();
     }
 
     @Test
@@ -65,6 +67,7 @@ public class SetSchemaMetadataTest {
 
         assertEquals("foo", updatedRecord.valueSchema().name());
         assertEquals(new Integer(42), updatedRecord.valueSchema().version());
+        xform.close();
     }
 
     @Test
@@ -95,6 +98,7 @@ public class SetSchemaMetadataTest {
 
         // Make sure the struct's schema and fields all point to the new schema
         assertMatchingSchema((Struct) updatedRecord.value(), updatedRecord.valueSchema());
+        xform.close();
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/SetSchemaMetadataTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -31,25 +32,27 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 public class SetSchemaMetadataTest {
+    private final SetSchemaMetadata<SinkRecord> xform = new SetSchemaMetadata.Value<>();
 
-    @Test
-    public void schemaNameUpdate() {
-        final SetSchemaMetadata<SinkRecord> xform = new SetSchemaMetadata.Value<>();
-        xform.configure(Collections.singletonMap("schema.name", "foo"));
-        final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
-        final SinkRecord updatedRecord = xform.apply(record);
-        assertEquals("foo", updatedRecord.valueSchema().name());
+    @After
+    public void teardown() {
         xform.close();
     }
 
     @Test
+    public void schemaNameUpdate() {
+        xform.configure(Collections.singletonMap("schema.name", "foo"));
+        final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
+        final SinkRecord updatedRecord = xform.apply(record);
+        assertEquals("foo", updatedRecord.valueSchema().name());
+    }
+
+    @Test
     public void schemaVersionUpdate() {
-        final SetSchemaMetadata<SinkRecord> xform = new SetSchemaMetadata.Value<>();
         xform.configure(Collections.singletonMap("schema.version", 42));
         final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
         final SinkRecord updatedRecord = xform.apply(record);
         assertEquals(new Integer(42), updatedRecord.valueSchema().version());
-        xform.close();
     }
 
     @Test
@@ -58,7 +61,6 @@ public class SetSchemaMetadataTest {
         props.put("schema.name", "foo");
         props.put("schema.version", "42");
 
-        final SetSchemaMetadata<SinkRecord> xform = new SetSchemaMetadata.Value<>();
         xform.configure(props);
 
         final SinkRecord record = new SinkRecord("", 0, null, null, SchemaBuilder.struct().build(), null, 0);
@@ -67,7 +69,6 @@ public class SetSchemaMetadataTest {
 
         assertEquals("foo", updatedRecord.valueSchema().name());
         assertEquals(new Integer(42), updatedRecord.valueSchema().version());
-        xform.close();
     }
 
     @Test
@@ -86,7 +87,6 @@ public class SetSchemaMetadataTest {
         final Map<String, String> props = new HashMap<>();
         props.put("schema.name", "foo");
         props.put("schema.version", "42");
-        final SetSchemaMetadata<SinkRecord> xform = new SetSchemaMetadata.Value<>();
         xform.configure(props);
 
         final SinkRecord record = new SinkRecord("", 0, null, null, schema, value, 0);
@@ -98,7 +98,6 @@ public class SetSchemaMetadataTest {
 
         // Make sure the struct's schema and fields all point to the new schema
         assertMatchingSchema((Struct) updatedRecord.value(), updatedRecord.valueSchema());
-        xform.close();
     }
 
     @Test

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -84,33 +84,25 @@ public class TimestampConverterTest {
 
     @Test(expected = ConfigException.class)
     public void testConfigNoTargetType() {
-        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
-            xform.configure(Collections.<String, String>emptyMap());
-        }
+        xformValue.configure(Collections.<String, String>emptyMap());
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidTargetType() {
-        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
-            xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "invalid"));
-        }
+        xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "invalid"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigMissingFormat() {
-        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
-            xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
-        }
+        xformValue.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidFormat() {
-        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
-            Map<String, String> config = new HashMap<>();
-            config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
-            config.put(TimestampConverter.FORMAT_CONFIG, "bad-format");
-            xform.configure(config);
-        }
+        Map<String, String> config = new HashMap<>();
+        config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
+        config.put(TimestampConverter.FORMAT_CONFIG, "bad-format");
+        xformValue.configure(config);
     }
 
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -75,32 +75,33 @@ public class TimestampConverterTest {
 
     @Test(expected = ConfigException.class)
     public void testConfigNoTargetType() {
-        TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>();
-        xform.configure(Collections.<String, String>emptyMap());
-        xform.close();
+        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
+            xform.configure(Collections.<String, String>emptyMap());
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidTargetType() {
-        TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>();
-        xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "invalid"));
+        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
+            xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "invalid"));
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigMissingFormat() {
-        TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>();
-        xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
-        xform.close();
+        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
+            xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
+        }
     }
 
     @Test(expected = ConfigException.class)
     public void testConfigInvalidFormat() {
-        TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>();
-        Map<String, String> config = new HashMap<>();
-        config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
-        config.put(TimestampConverter.FORMAT_CONFIG, "bad-format");
-        xform.configure(config);
-        xform.close();
+        try (TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>()) {
+            Map<String, String> config = new HashMap<>();
+            config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
+            config.put(TimestampConverter.FORMAT_CONFIG, "bad-format");
+            xform.configure(config);
+        }
     }
 
 

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampConverterTest.java
@@ -77,6 +77,7 @@ public class TimestampConverterTest {
     public void testConfigNoTargetType() {
         TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>();
         xform.configure(Collections.<String, String>emptyMap());
+        xform.close();
     }
 
     @Test(expected = ConfigException.class)
@@ -89,6 +90,7 @@ public class TimestampConverterTest {
     public void testConfigMissingFormat() {
         TimestampConverter<SourceRecord> xform = new TimestampConverter.Value<>();
         xform.configure(Collections.singletonMap(TimestampConverter.TARGET_TYPE_CONFIG, "string"));
+        xform.close();
     }
 
     @Test(expected = ConfigException.class)
@@ -98,6 +100,7 @@ public class TimestampConverterTest {
         config.put(TimestampConverter.TARGET_TYPE_CONFIG, "string");
         config.put(TimestampConverter.FORMAT_CONFIG, "bad-format");
         xform.configure(config);
+        xform.close();
     }
 
 
@@ -111,6 +114,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -121,6 +125,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -131,6 +136,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -141,6 +147,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME_UNIX, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -154,6 +161,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME_STRING, transformed.value());
+        xform.close();
     }
 
 
@@ -168,6 +176,7 @@ public class TimestampConverterTest {
         assertNull(transformed.valueSchema());
         // No change expected since the source type is coarser-grained
         assertEquals(DATE.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -179,6 +188,7 @@ public class TimestampConverterTest {
         assertNull(transformed.valueSchema());
         // No change expected since the source type is coarser-grained
         assertEquals(TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -189,6 +199,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -202,6 +213,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.value());
+        xform.close();
     }
 
 
@@ -215,6 +227,7 @@ public class TimestampConverterTest {
 
         assertEquals(Timestamp.SCHEMA, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -225,6 +238,7 @@ public class TimestampConverterTest {
 
         assertEquals(Date.SCHEMA, transformed.valueSchema());
         assertEquals(DATE.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -235,6 +249,7 @@ public class TimestampConverterTest {
 
         assertEquals(Time.SCHEMA, transformed.valueSchema());
         assertEquals(TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -245,6 +260,7 @@ public class TimestampConverterTest {
 
         assertEquals(Schema.INT64_SCHEMA, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME_UNIX, transformed.value());
+        xform.close();
     }
 
     @Test
@@ -258,6 +274,7 @@ public class TimestampConverterTest {
 
         assertEquals(Schema.STRING_SCHEMA, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME_STRING, transformed.value());
+        xform.close();
     }
 
 
@@ -272,6 +289,7 @@ public class TimestampConverterTest {
         assertEquals(Timestamp.SCHEMA, transformed.valueSchema());
         // No change expected since the source type is coarser-grained
         assertEquals(DATE.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -283,6 +301,7 @@ public class TimestampConverterTest {
         assertEquals(Timestamp.SCHEMA, transformed.valueSchema());
         // No change expected since the source type is coarser-grained
         assertEquals(TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -293,6 +312,7 @@ public class TimestampConverterTest {
 
         assertEquals(Timestamp.SCHEMA, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -306,6 +326,7 @@ public class TimestampConverterTest {
 
         assertEquals(Timestamp.SCHEMA, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.value());
+        xform.close();
     }
 
 
@@ -324,6 +345,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.valueSchema());
         assertEquals(Collections.singletonMap("ts", DATE.getTime()), transformed.value());
+        xform.close();
     }
 
     @Test
@@ -352,6 +374,7 @@ public class TimestampConverterTest {
         assertEquals(expectedSchema, transformed.valueSchema());
         assertEquals(DATE_PLUS_TIME.getTime(), ((Struct) transformed.value()).get("ts"));
         assertEquals("test", ((Struct) transformed.value()).get("other"));
+        xform.close();
     }
 
 
@@ -365,6 +388,7 @@ public class TimestampConverterTest {
 
         assertNull(transformed.keySchema());
         assertEquals(DATE_PLUS_TIME.getTime(), transformed.key());
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampRouterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampRouterTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.connect.transforms;
 
 import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -24,10 +25,15 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 
 public class TimestampRouterTest {
+    private final TimestampRouter<SourceRecord> xform = new TimestampRouter<>();
+
+    @After
+    public void teardown() {
+        xform.close();
+    }
 
     @Test
     public void defaultConfiguration() {
-        final TimestampRouter<SourceRecord> xform = new TimestampRouter<>();
         xform.configure(Collections.<String, Object>emptyMap()); // defaults
         final SourceRecord record = new SourceRecord(
                 null, null,
@@ -37,7 +43,6 @@ public class TimestampRouterTest {
                 1483425001864L
         );
         assertEquals("test-20170103", xform.apply(record).topic());
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampRouterTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/TimestampRouterTest.java
@@ -37,6 +37,7 @@ public class TimestampRouterTest {
                 1483425001864L
         );
         assertEquals("test-20170103", xform.apply(record).topic());
+        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ValueToKeyTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ValueToKeyTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -29,10 +30,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class ValueToKeyTest {
+    private final ValueToKey<SinkRecord> xform = new ValueToKey<>();
+
+    @After
+    public void teardown() {
+        xform.close();
+    }
 
     @Test
     public void schemaless() {
-        final ValueToKey<SinkRecord> xform = new ValueToKey<>();
         xform.configure(Collections.singletonMap("fields", "a,b"));
 
         final HashMap<String, Integer> value = new HashMap<>();
@@ -49,12 +55,10 @@ public class ValueToKeyTest {
 
         assertNull(transformedRecord.keySchema());
         assertEquals(expectedKey, transformedRecord.key());
-        xform.close();
     }
 
     @Test
     public void withSchema() {
-        final ValueToKey<SinkRecord> xform = new ValueToKey<>();
         xform.configure(Collections.singletonMap("fields", "a,b"));
 
         final Schema valueSchema = SchemaBuilder.struct()
@@ -82,7 +86,6 @@ public class ValueToKeyTest {
 
         assertEquals(expectedKeySchema, transformedRecord.keySchema());
         assertEquals(expectedKey, transformedRecord.key());
-        xform.close();
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ValueToKeyTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/ValueToKeyTest.java
@@ -49,6 +49,7 @@ public class ValueToKeyTest {
 
         assertNull(transformedRecord.keySchema());
         assertEquals(expectedKey, transformedRecord.key());
+        xform.close();
     }
 
     @Test
@@ -81,6 +82,7 @@ public class ValueToKeyTest {
 
         assertEquals(expectedKeySchema, transformedRecord.keySchema());
         assertEquals(expectedKey, transformedRecord.key());
+        xform.close();
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -53,7 +53,6 @@ import org.apache.kafka.streams.processor.TopologyBuilder;
  * @see KGroupedStream
  * @see KStreamBuilder#stream(String...)
  */
-@SuppressWarnings("unused")
 @InterfaceStability.Evolving
 public interface KStream<K, V> {
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStreamBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStreamBuilder.java
@@ -1039,7 +1039,6 @@ public class KStreamBuilder extends TopologyBuilder {
      * @param queryableStoreName the state store name; If {@code null} this is the equivalent of {@link KStreamBuilder#globalTable(Serde, Serde, String)} ()}
      * @return a {@link GlobalKTable} for the specified topic
      */
-    @SuppressWarnings("unchecked")
     public <K, V> GlobalKTable<K, V> globalTable(final Serde<K> keySerde,
                                                  final Serde<V> valSerde,
                                                  final TimestampExtractor timestampExtractor,
@@ -1083,14 +1082,13 @@ public class KStreamBuilder extends TopologyBuilder {
      * @param storeSupplier user defined state store supplier. Cannot be {@code null}.
      * @return a {@link GlobalKTable} for the specified topic
      */
-    @SuppressWarnings("unchecked")
     public <K, V> GlobalKTable<K, V> globalTable(final Serde<K> keySerde,
                                                  final Serde<V> valSerde,
                                                  final String topic,
                                                  final StateStoreSupplier<KeyValueStore> storeSupplier) {
         return doGlobalTable(keySerde, valSerde, null, topic, storeSupplier);
     }
-    
+
     /**
      * Create a {@link GlobalKTable} for the specified topic.
      * The default {@link TimestampExtractor} as specified in the {@link StreamsConfig config} is used.
@@ -1121,7 +1119,6 @@ public class KStreamBuilder extends TopologyBuilder {
      *                           {@link KStreamBuilder#globalTable(Serde, Serde, String)} ()}
      * @return a {@link GlobalKTable} for the specified topic
      */
-    @SuppressWarnings("unchecked")
     public <K, V> GlobalKTable<K, V> globalTable(final Serde<K> keySerde,
                                                  final Serde<V> valSerde,
                                                  final String topic,
@@ -1198,7 +1195,6 @@ public class KStreamBuilder extends TopologyBuilder {
      * @param topic     the topic name; cannot be {@code null}
      * @return a {@link GlobalKTable} for the specified topic
      */
-    @SuppressWarnings("unchecked")
     public <K, V> GlobalKTable<K, V> globalTable(final Serde<K> keySerde,
                                                  final Serde<V> valSerde,
                                                  final String topic) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -92,7 +92,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
     }
 
 
-    @SuppressWarnings("unchecked")
     @Override
     public <W extends Window> KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                                             final Windows<W> windows,
@@ -101,7 +100,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
         return reduce(reducer, windows, windowedStore(keySerde, valSerde, windows, getOrCreateName(queryableStoreName, REDUCE_NAME)));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <W extends Window> KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                                             final Windows<W> windows) {
@@ -152,7 +150,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
                 storeSupplier);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <W extends Window, T> KTable<Windowed<K>, T> aggregate(final Initializer<T> initializer,
                                                                   final Aggregator<? super K, ? super V, T> aggregator,
@@ -163,7 +160,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
         return aggregate(initializer, aggregator, windows, windowedStore(keySerde, aggValueSerde, windows, getOrCreateName(queryableStoreName, AGGREGATE_NAME)));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <W extends Window, T> KTable<Windowed<K>, T> aggregate(final Initializer<T> initializer,
                                                                   final Aggregator<? super K, ? super V, T> aggregator,
@@ -266,7 +262,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
 
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <T> KTable<Windowed<K>, T> aggregate(final Initializer<T> initializer,
                                                 final Aggregator<? super K, ? super V, T> aggregator,
@@ -309,7 +304,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
         return count(sessionWindows, (String) null);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public KTable<Windowed<K>, Long> count(final SessionWindows sessionWindows,
                                            final StateStoreSupplier<SessionStore> storeSupplier) {
@@ -350,7 +344,6 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
                               .sessionWindowed(sessionWindows.maintainMs()).build());
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                          final SessionWindows sessionWindows) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoin.java
@@ -67,7 +67,6 @@ class KTableKTableJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, 
             this.valueGetter = valueGetter;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public void init(ProcessorContext context) {
             super.init(context);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableLeftJoin.java
@@ -57,7 +57,6 @@ class KTableKTableLeftJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, 
             this.valueGetter = valueGetter;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public void init(ProcessorContext context) {
             super.init(context);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -56,7 +56,6 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
             this.valueGetter = valueGetter;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public void init(ProcessorContext context) {
             super.init(context);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -57,7 +57,6 @@ class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
             this.valueGetter = valueGetter;
         }
 
-        @SuppressWarnings("unchecked")
         @Override
         public void init(ProcessorContext context) {
             super.init(context);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -49,7 +49,6 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
         this.deserializationExceptionHandler = deserializationExceptionHandler;
     }
 
-    @SuppressWarnings("unchecked")
     public Map<TopicPartition, Long> initialize() {
         final Set<String> storeNames = stateMgr.initialize(processorContext);
         final Map<String, String> storeNameToTopic = topology.storeToChangelogTopic();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1135,7 +1135,6 @@ public class StreamThread extends Thread {
         streamsMetrics.removeAllSensors();
     }
 
-    @SuppressWarnings("ThrowableNotThrown")
     private void shutdownTasksAndState(final boolean cleanRun) {
         log.debug("{} Shutting down all active tasks {}, standby tasks {}, suspended tasks {}, and suspended standby tasks {}",
             logPrefix, activeTasks.keySet(), standbyTasks.keySet(),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -128,6 +128,7 @@ public class AssignmentInfo {
             if (version < 0 || version > CURRENT_VERSION) {
                 TaskAssignmentException ex = new TaskAssignmentException("Unknown assignment data version: " + version);
                 log.error(ex.getMessage(), ex);
+                in.close();
                 throw ex;
             }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/AssignmentInfo.java
@@ -120,15 +120,13 @@ public class AssignmentInfo {
     public static AssignmentInfo decode(ByteBuffer data) {
         // ensure we are at the beginning of the ByteBuffer
         data.rewind();
-        DataInputStream in = new DataInputStream(new ByteBufferInputStream(data));
 
-        try {
+        try (DataInputStream in = new DataInputStream(new ByteBufferInputStream(data))) {
             // Decode version
             int version = in.readInt();
             if (version < 0 || version > CURRENT_VERSION) {
                 TaskAssignmentException ex = new TaskAssignmentException("Unknown assignment data version: " + version);
                 log.error(ex.getMessage(), ex);
-                in.close();
                 throw ex;
             }
 
@@ -156,7 +154,6 @@ public class AssignmentInfo {
             }
 
             return new AssignmentInfo(activeTasks, standbyTasks, hostStateToTopicPartitions);
-
 
         } catch (IOException ex) {
             throw new TaskAssignmentException("Failed to decode AssignmentInfo", ex);

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -61,7 +61,6 @@ public final class StateSerdes<K, V> {
      * @param valueSerde    the serde for values; cannot be null
      * @throws IllegalArgumentException if key or value serde is null
      */
-    @SuppressWarnings("unchecked")
     public StateSerdes(final String topic,
                        final Serde<K> keySerde,
                        final Serde<V> valueSerde) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingKeyValueStore.java
@@ -53,7 +53,6 @@ class CachingKeyValueStore<K, V> extends WrappedStateStore.AbstractStateStore im
         this.valueSerde = valueSerde;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void init(final ProcessorContext context, final StateStore root) {
         underlying.init(context, root);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CachingWindowStore.java
@@ -63,7 +63,6 @@ class CachingWindowStore<K, V> extends WrappedStateStore.AbstractStateStore impl
         this.cacheFunction = new SegmentedCacheFunction(keySchema, segmentInterval);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void init(final ProcessorContext context, final StateStore root) {
         underlying.init(context, root);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ChangeLoggingSegmentedBytesStore.java
@@ -67,7 +67,6 @@ class ChangeLoggingSegmentedBytesStore extends WrappedStateStore.AbstractStateSt
 
 
     @Override
-    @SuppressWarnings("unchecked")
     public void init(final ProcessorContext context, final StateStore root) {
         bytesStore.init(context, root);
         changeLogger = new StoreChangeLogger<>(

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -239,7 +239,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public synchronized void put(K key, V value) {
         Objects.requireNonNull(key, "key cannot be null");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/KStreamBuilderTest.java
@@ -318,7 +318,7 @@ public class KStreamBuilderTest {
         final String topicName = "topic-1";
         
         builder.stream(TopologyBuilder.AutoOffsetReset.EARLIEST, topicName);
-        
+
         assertTrue(builder.earliestResetTopicsPattern().matcher(topicName).matches());
         assertFalse(builder.latestResetTopicsPattern().matcher(topicName).matches());
     }
@@ -373,7 +373,7 @@ public class KStreamBuilderTest {
         final String topic = "topic-5";
 
         builder.stream(topicPattern);
-        
+
         assertFalse(builder.latestResetTopicsPattern().matcher(topic).matches());
         assertFalse(builder.earliestResetTopicsPattern().matcher(topic).matches());
 
@@ -401,7 +401,6 @@ public class KStreamBuilderTest {
         assertFalse(builder.earliestResetTopicsPattern().matcher(topicTwo).matches());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void kStreamTimestampExtractorShouldBeNull() throws Exception {
         builder.stream("topic");
@@ -409,7 +408,6 @@ public class KStreamBuilderTest {
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorToStreamWithKeyValSerdePerSource() throws Exception {
         builder.stream(new MockTimestampExtractor(), null, null, "topic");
@@ -419,7 +417,6 @@ public class KStreamBuilderTest {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorToStreamWithOffsetResetPerSource() throws Exception {
         builder.stream(null, new MockTimestampExtractor(), null, null, "topic");
@@ -427,7 +424,6 @@ public class KStreamBuilderTest {
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorToTablePerSource() throws Exception {
         builder.table("topic", "store");
@@ -435,7 +431,6 @@ public class KStreamBuilderTest {
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void kTableTimestampExtractorShouldBeNull() throws Exception {
         builder.table("topic", "store");
@@ -443,7 +438,6 @@ public class KStreamBuilderTest {
         assertNull(processorTopology.source("topic").getTimestampExtractor());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorToTableWithKeyValSerdePerSource() throws Exception {
         builder.table(null, new MockTimestampExtractor(), null, null, "topic", "store");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -47,7 +47,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("unchecked")
 public class KStreamSessionWindowAggregateProcessorTest {
 
     private static final long GAP_MS = 5 * 60 * 1000L;
@@ -84,7 +83,6 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private MockProcessorContext context;
 
 
-    @SuppressWarnings("unchecked")
     @Before
     public void initializeStore() {
         final File stateDir = TestUtils.tempDirectory();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -89,6 +89,8 @@ public class WindowedStreamPartitionerTest {
                 assertEquals(expected, actual);
             }
         }
+
+        defaultPartitioner.close();
     }
 
     @Test
@@ -113,6 +115,8 @@ public class WindowedStreamPartitionerTest {
         Serializer<?> inner1 = windowedSerializer1.innerSerializer();
         assertNotNull("Inner serializer should be not null", inner1);
         assertTrue("Inner serializer type should be ByteArraySerializer", inner1 instanceof ByteArraySerializer);
+        windowedSerializer.close();
+        windowedSerializer1.close();
     }
 
     @Test
@@ -137,5 +141,7 @@ public class WindowedStreamPartitionerTest {
         Deserializer<?> inner1 = windowedDeserializer1.innerDeserializer();
         assertNotNull("Inner deserializer should be not null", inner1);
         assertTrue("Inner deserializer type should be ByteArrayDeserializer", inner1 instanceof ByteArrayDeserializer);
+        windowedDeserializer.close();
+        windowedDeserializer1.close();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyBuilderTest.java
@@ -78,7 +78,7 @@ public class TopologyBuilderTest {
     @Test
     public void shouldAddSourcePatternWithOffsetReset() {
         final TopologyBuilder builder = new TopologyBuilder();
-        
+
         final String earliestTopicPattern = "earliest.*Topic";
         final String latestTopicPattern = "latest.*Topic";
 
@@ -107,7 +107,7 @@ public class TopologyBuilderTest {
         final TopologyBuilder builder = new TopologyBuilder();
         final Serde<String> stringSerde = Serdes.String();
         final Pattern expectedPattern = Pattern.compile("test-.*");
-        
+
         builder.addSource("source", stringSerde.deserializer(), stringSerde.deserializer(), Pattern.compile("test-.*"));
 
         assertEquals(expectedPattern.pattern(), builder.sourceTopicPattern().pattern());
@@ -143,7 +143,7 @@ public class TopologyBuilderTest {
     }
 
 
-    
+
     @Test(expected = TopologyBuilderException.class)
     public void testAddSourceWithSameName() {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -579,7 +579,6 @@ public class TopologyBuilderTest {
         assertEquals(2, properties.size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddInternalTopicConfigWithCompactForNonWindowStores() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -596,7 +595,6 @@ public class TopologyBuilderTest {
         assertEquals(1, properties.size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddInternalTopicConfigWithCleanupPolicyDeleteForInternalTopics() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -702,7 +700,6 @@ public class TopologyBuilderTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorPerSource() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -711,7 +708,6 @@ public class TopologyBuilderTest {
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorWithOffsetResetPerSource() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -720,7 +716,6 @@ public class TopologyBuilderTest {
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorWithPatternPerSource() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -730,7 +725,6 @@ public class TopologyBuilderTest {
         assertThat(processorTopology.source(pattern.pattern()).getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorWithOffsetResetAndPatternPerSource() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -740,7 +734,6 @@ public class TopologyBuilderTest {
         assertThat(processorTopology.source(pattern.pattern()).getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorWithOffsetResetAndKeyValSerdesPerSource() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();
@@ -749,7 +742,6 @@ public class TopologyBuilderTest {
         assertThat(processorTopology.source("topic").getTimestampExtractor(), instanceOf(MockTimestampExtractor.class));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldAddTimestampExtractorWithOffsetResetAndKeyValSerdesAndPatternPerSource() throws Exception {
         final TopologyBuilder builder = new TopologyBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/QuickUnionTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/QuickUnionTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertNotEquals;
 
 public class QuickUnionTest {
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testUnite() {
         QuickUnion<Long> qu = new QuickUnion<>();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -177,7 +177,6 @@ public class StandbyTaskTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testUpdate() throws Exception {
         StreamsConfig config = createConfig(baseDir);
@@ -224,7 +223,6 @@ public class StandbyTaskTest {
 
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testUpdateKTable() throws Exception {
         consumer.assign(Utils.mkList(ktable));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -131,7 +131,6 @@ public class StreamPartitionAssignorTest {
         partitionAssignor.configure(configurationMap);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testSubscription() throws Exception {
         builder.addSource("source1", "topic1");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -724,7 +724,6 @@ public class StreamTaskTest {
         });
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldThrowExceptionIfAnyExceptionsRaisedDuringCloseButStillCloseAllProcessorNodesTopology() throws Exception {
         task.close(true);

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -185,7 +185,6 @@ public class KeyValueStoreTestDriver<K, V> {
         final Producer<byte[], byte[]> producer = new MockProducer<>(true, rawSerializer, rawSerializer);
 
         final RecordCollector recordCollector = new RecordCollectorImpl(producer, "KeyValueStoreTestDriver") {
-            @SuppressWarnings("unchecked")
             @Override
             public <K1, V1> void send(final String topic,
                                       final K1 key,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingSegmentedBytesStoreTest.java
@@ -61,7 +61,6 @@ public class ChangeLoggingSegmentedBytesStoreTest {
     private final ChangeLoggingSegmentedBytesStore store = new ChangeLoggingSegmentedBytesStore(bytesStore);
     private final Map sent = new HashMap<>();
 
-    @SuppressWarnings("unchecked")
     @Before
     public void setUp() throws Exception {
         context.setTime(0);
@@ -74,7 +73,6 @@ public class ChangeLoggingSegmentedBytesStoreTest {
         store.close();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldLogPuts() throws Exception {
         final byte[] value1 = {0};
@@ -88,7 +86,6 @@ public class ChangeLoggingSegmentedBytesStoreTest {
         assertArrayEquals(value2, (byte[]) sent.get(key2));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldLogRemoves() throws Exception {
         final Bytes key1 = Bytes.wrap(new byte[]{0});

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStoreTest.java
@@ -46,7 +46,6 @@ public class CompositeReadOnlyKeyValueStoreTest {
     private KeyValueStore<String, String>
         otherUnderlyingStore;
 
-    @SuppressWarnings("unchecked")
     @Before
     public void before() {
         final StateStoreProviderStub stubProviderOne = new StateStoreProviderStub(false);
@@ -141,8 +140,6 @@ public class CompositeReadOnlyKeyValueStoreTest {
         } catch (UnsupportedOperationException e) { }
     }
 
-
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldFindValueForKeyWhenMultiStores() throws Exception {
         final KeyValueStore<String, String> cache = newStoreInstance();
@@ -167,7 +164,6 @@ public class CompositeReadOnlyKeyValueStoreTest {
         assertEquals(2, results.size());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldSupportRangeAcrossMultipleKVStores() throws Exception {
         final KeyValueStore<String, String> cache = newStoreInstance();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/DelegatingPeekingKeyValueIteratorTest.java
@@ -43,6 +43,7 @@ public class DelegatingPeekingKeyValueIteratorTest {
         assertEquals("A", peekingIterator.peekNextKey());
         assertEquals("A", peekingIterator.peekNextKey());
         assertTrue(peekingIterator.hasNext());
+        peekingIterator.close();
     }
 
     @Test
@@ -52,6 +53,7 @@ public class DelegatingPeekingKeyValueIteratorTest {
         assertEquals(KeyValue.pair("A", "A"), peekingIterator.peekNext());
         assertEquals(KeyValue.pair("A", "A"), peekingIterator.peekNext());
         assertTrue(peekingIterator.hasNext());
+        peekingIterator.close();
     }
 
     @Test
@@ -71,18 +73,21 @@ public class DelegatingPeekingKeyValueIteratorTest {
             index++;
         }
         assertEquals(kvs.length, index);
+        peekingIterator.close();
     }
 
     @Test(expected = NoSuchElementException.class)
     public void shouldThrowNoSuchElementWhenNoMoreItemsLeftAndNextCalled() throws Exception {
         final DelegatingPeekingKeyValueIterator<String, String> peekingIterator = new DelegatingPeekingKeyValueIterator<>(name, store.all());
         peekingIterator.next();
+        peekingIterator.close();
     }
 
     @Test(expected = NoSuchElementException.class)
     public void shouldThrowNoSuchElementWhenNoMoreItemsLeftAndPeekNextCalled() throws Exception {
         final DelegatingPeekingKeyValueIterator<String, String> peekingIterator = new DelegatingPeekingKeyValueIterator<>(name, store.all());
         peekingIterator.peekNextKey();
+        peekingIterator.close();
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheKeyValueStoreIteratorTest.java
@@ -64,6 +64,7 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
             values[index++] = value;
             assertArrayEquals(bytes[bytesIndex++], value);
         }
+        iterator.close();
     }
 
 
@@ -171,6 +172,7 @@ public class MergedSortedCacheKeyValueStoreIteratorTest {
             assertArrayEquals(bytes[bytesIndex++], keys);
             iterator.next();
         }
+        iterator.close();
     }
 
     private MergedSortedCacheKeyValueStoreIterator<byte[], byte[]> createIterator() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MergedSortedCacheWrappedWindowStoreIteratorTest.java
@@ -80,6 +80,7 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
             assertArrayEquals(expected.value, next.value);
             assertEquals(expected.key, next.key);
         }
+        iterator.close();
     }
 
     @Test
@@ -98,6 +99,7 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
         assertThat(iterator.peekNextKey(), equalTo(0L));
         iterator.next();
         assertThat(iterator.peekNextKey(), equalTo(10L));
+        iterator.close();
     }
 
     @Test
@@ -112,5 +114,6 @@ public class MergedSortedCacheWrappedWindowStoreIteratorTest {
         assertThat(iterator.peekNextKey(), equalTo(0L));
         iterator.next();
         assertThat(iterator.peekNextKey(), equalTo(10L));
+        iterator.close();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredSegmentedBytesStoreTest.java
@@ -46,7 +46,6 @@ public class MeteredSegmentedBytesStoreTest {
     private final Set<String> latencyRecorded = new HashSet<>();
     private final Set<String> throughputRecorded = new HashSet<>();
 
-    @SuppressWarnings("unchecked")
     @Before
     public void setUp() throws Exception {
         final Metrics metrics = new Metrics();

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreSupplierTest.java
@@ -133,7 +133,6 @@ public class RocksDBKeyValueStoreSupplierTest {
         assertThat(store, is(instanceOf(MeteredKeyValueStore.class)));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenCached() throws Exception {
         store = createStore(false, true);
@@ -142,7 +141,6 @@ public class RocksDBKeyValueStoreSupplierTest {
         assertFalse(metrics.metrics().isEmpty());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenLogged() throws Exception {
         store = createStore(true, false);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplierTest.java
@@ -112,7 +112,6 @@ public class RocksDBSessionStoreSupplierTest {
         assertThat(store, is(instanceOf(RocksDBSessionStore.class)));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenCached() throws Exception {
         store = createStore(false, true);
@@ -121,7 +120,6 @@ public class RocksDBSessionStoreSupplierTest {
         assertFalse(metrics.metrics().isEmpty());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenLogged() throws Exception {
         store = createStore(true, false);
@@ -130,7 +128,6 @@ public class RocksDBSessionStoreSupplierTest {
         assertFalse(metrics.metrics().isEmpty());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenNotLoggedOrCached() throws Exception {
         store = createStore(false, false);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
@@ -135,7 +135,6 @@ public class RocksDBWindowStoreSupplierTest {
         assertThat(store, is(instanceOf(RocksDBWindowStore.class)));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenCached() throws Exception {
         store = createStore(false, true, 3);
@@ -144,7 +143,6 @@ public class RocksDBWindowStoreSupplierTest {
         assertFalse(metrics.metrics().isEmpty());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenLogged() throws Exception {
         store = createStore(true, false, 3);
@@ -153,7 +151,6 @@ public class RocksDBWindowStoreSupplierTest {
         assertFalse(metrics.metrics().isEmpty());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldHaveMeteredStoreWhenNotLoggedOrCached() throws Exception {
         store = createStore(false, false, 3);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreChangeLoggerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreChangeLoggerTest.java
@@ -39,7 +39,6 @@ public class StoreChangeLoggerTest {
 
     private final MockProcessorContext context = new MockProcessorContext(StateSerdes.withBuiltinTypes(topic, Integer.class, String.class),
             new RecordCollectorImpl(null, "StoreChangeLoggerTest") {
-                @SuppressWarnings("unchecked")
                 @Override
                 public <K1, V1> void send(final String topic,
                                           final K1 key,
@@ -71,7 +70,6 @@ public class StoreChangeLoggerTest {
         context.close();
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testAddRemove() throws Exception {
         context.setTime(1);

--- a/streams/src/test/java/org/apache/kafka/streams/tests/BrokerCompatibilityTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/BrokerCompatibilityTest.java
@@ -101,6 +101,7 @@ public class BrokerCompatibilityTest {
 
 
         System.out.println("close Kafka Streams");
+        producer.close();
         streams.close();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/SmokeTestDriver.java
@@ -77,7 +77,6 @@ public class SmokeTestDriver extends SmokeTestUtil {
     // This main() is not used by the system test. It is intended to be used for local debugging.
     public static void main(String[] args) throws Exception {
         final String kafka = "localhost:9092";
-        final String zookeeper = "localhost:2181";
         final File stateDir = TestUtils.tempDirectory();
 
         final int numKeys = 20;

--- a/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ClientCompatibilityTest.java
@@ -370,113 +370,109 @@ public class ClientCompatibilityTest {
         consumerProps.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, 512);
         ClientCompatibilityTestDeserializer deserializer =
             new ClientCompatibilityTestDeserializer(testConfig.expectClusterId);
-        final KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps, deserializer, deserializer);
-        final List<PartitionInfo> partitionInfos = consumer.partitionsFor(testConfig.topic);
-        if (partitionInfos.size() < 1) {
-            consumer.close();
-            throw new RuntimeException("Expected at least one partition for topic " + testConfig.topic);
-        }
-        final Map<TopicPartition, Long> timestampsToSearch = new HashMap<>();
-        final LinkedList<TopicPartition> topicPartitions = new LinkedList<>();
-        for (PartitionInfo partitionInfo : partitionInfos) {
-            TopicPartition topicPartition = new TopicPartition(partitionInfo.topic(), partitionInfo.partition());
-            timestampsToSearch.put(topicPartition, prodTimeMs);
-            topicPartitions.add(topicPartition);
-        }
-        final OffsetsForTime offsetsForTime = new OffsetsForTime();
-        tryFeature("offsetsForTimes", testConfig.offsetsForTimesSupported,
-                new Invoker() {
-                    @Override
-                    public void invoke() {
-                        offsetsForTime.result = consumer.offsetsForTimes(timestampsToSearch);
-                    }
-                },
-                new ResultTester() {
-                    @Override
-                    public void test() {
-                        log.info("offsetsForTime = {}", offsetsForTime.result);
-                    }
-                });
-        // Whether or not offsetsForTimes works, beginningOffsets and endOffsets
-        // should work.
-        consumer.beginningOffsets(timestampsToSearch.keySet());
-        consumer.endOffsets(timestampsToSearch.keySet());
+        try (final KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(consumerProps, deserializer, deserializer)) {
+            final List<PartitionInfo> partitionInfos = consumer.partitionsFor(testConfig.topic);
+            if (partitionInfos.size() < 1)
+                throw new RuntimeException("Expected at least one partition for topic " + testConfig.topic);
+            final Map<TopicPartition, Long> timestampsToSearch = new HashMap<>();
+            final LinkedList<TopicPartition> topicPartitions = new LinkedList<>();
+            for (PartitionInfo partitionInfo : partitionInfos) {
+                TopicPartition topicPartition = new TopicPartition(partitionInfo.topic(), partitionInfo.partition());
+                timestampsToSearch.put(topicPartition, prodTimeMs);
+                topicPartitions.add(topicPartition);
+            }
+            final OffsetsForTime offsetsForTime = new OffsetsForTime();
+            tryFeature("offsetsForTimes", testConfig.offsetsForTimesSupported,
+                    new Invoker() {
+                        @Override
+                        public void invoke() {
+                            offsetsForTime.result = consumer.offsetsForTimes(timestampsToSearch);
+                        }
+                    },
+                    new ResultTester() {
+                        @Override
+                        public void test() {
+                            log.info("offsetsForTime = {}", offsetsForTime.result);
+                        }
+                    });
+            // Whether or not offsetsForTimes works, beginningOffsets and endOffsets
+            // should work.
+            consumer.beginningOffsets(timestampsToSearch.keySet());
+            consumer.endOffsets(timestampsToSearch.keySet());
 
-        consumer.assign(topicPartitions);
-        consumer.seekToBeginning(topicPartitions);
-        final Iterator<byte[]> iter = new Iterator<byte[]>() {
-            private static final int TIMEOUT_MS = 10000;
-            private Iterator<ConsumerRecord<byte[], byte[]>> recordIter = null;
-            private byte[] next = null;
+            consumer.assign(topicPartitions);
+            consumer.seekToBeginning(topicPartitions);
+            final Iterator<byte[]> iter = new Iterator<byte[]>() {
+                private static final int TIMEOUT_MS = 10000;
+                private Iterator<ConsumerRecord<byte[], byte[]>> recordIter = null;
+                private byte[] next = null;
 
-            private byte[] fetchNext() {
-                while (true) {
-                    long curTime = Time.SYSTEM.milliseconds();
-                    if (curTime - prodTimeMs > TIMEOUT_MS)
-                        throw new RuntimeException("Timed out after " + TIMEOUT_MS + " ms.");
-                    if (recordIter == null) {
-                        ConsumerRecords<byte[], byte[]> records = consumer.poll(100);
-                        recordIter = records.iterator();
+                private byte[] fetchNext() {
+                    while (true) {
+                        long curTime = Time.SYSTEM.milliseconds();
+                        if (curTime - prodTimeMs > TIMEOUT_MS)
+                            throw new RuntimeException("Timed out after " + TIMEOUT_MS + " ms.");
+                        if (recordIter == null) {
+                            ConsumerRecords<byte[], byte[]> records = consumer.poll(100);
+                            recordIter = records.iterator();
+                        }
+                        if (recordIter.hasNext())
+                            return recordIter.next().value();
+                        recordIter = null;
                     }
-                    if (recordIter.hasNext())
-                        return recordIter.next().value();
-                    recordIter = null;
                 }
-            }
 
-            @Override
-            public boolean hasNext() {
-                if (next != null)
-                    return true;
-                next = fetchNext();
-                return next != null;
-            }
+                @Override
+                public boolean hasNext() {
+                    if (next != null)
+                        return true;
+                    next = fetchNext();
+                    return next != null;
+                }
 
-            @Override
-            public byte[] next() {
-                if (!hasNext())
-                    throw new NoSuchElementException();
-                byte[] cur = next;
-                next = null;
-                return cur;
-            }
+                @Override
+                public byte[] next() {
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    byte[] cur = next;
+                    next = null;
+                    return cur;
+                }
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        };
-        byte[] next = iter.next();
-        try {
-            compareArrays(message1, next);
-            log.debug("Found first message...");
-        } catch (RuntimeException e) {
-            consumer.close();
-            throw new RuntimeException("The first message in this topic was not ours. Please use a new topic when " +
-                    "running this program.");
-        }
-        try {
-            next = iter.next();
-            if (testConfig.expectRecordTooLargeException) {
-                consumer.close();
-                throw new RuntimeException("Expected to get a RecordTooLargeException when reading a record " +
-                        "bigger than " + ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG);
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
+            };
+            byte[] next = iter.next();
+            try {
+                compareArrays(message1, next);
+                log.debug("Found first message...");
+            } catch (RuntimeException e) {
+                throw new RuntimeException("The first message in this topic was not ours. Please use a new topic when " +
+                        "running this program.");
             }
             try {
-                compareArrays(message2, next);
-            } catch (RuntimeException e) {
-                System.out.println("The second message in this topic was not ours. Please use a new " +
-                    "topic when running this program.");
-                Exit.exit(1);
+                next = iter.next();
+                if (testConfig.expectRecordTooLargeException) {
+                    throw new RuntimeException("Expected to get a RecordTooLargeException when reading a record " +
+                            "bigger than " + ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG);
+                }
+                try {
+                    compareArrays(message2, next);
+                } catch (RuntimeException e) {
+                    System.out.println("The second message in this topic was not ours. Please use a new " +
+                        "topic when running this program.");
+                    Exit.exit(1);
+                }
+            } catch (RecordTooLargeException e) {
+                log.debug("Got RecordTooLargeException", e);
+                if (!testConfig.expectRecordTooLargeException)
+                    throw new RuntimeException("Got an unexpected RecordTooLargeException when reading a record " +
+                        "bigger than " + ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG);
             }
-        } catch (RecordTooLargeException e) {
-            log.debug("Got RecordTooLargeException", e);
-            if (!testConfig.expectRecordTooLargeException)
-                throw new RuntimeException("Got an unexpected RecordTooLargeException when reading a record " +
-                    "bigger than " + ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG);
+            log.debug("Closing consumer.");
         }
-        log.debug("Closing consumer.");
-        consumer.close();
         log.info("Closed consumer.");
     }
 


### PR DESCRIPTION
Clean up includes:

- Switching try-catch-finally blocks to try-with-resources when possible
- Removing some seemingly unnecessary `@SuppressWarnings` annotations
- Resolving some Java warnings
- Closing unclosed Closable objects
- Removing unused code