### PR TITLE
MINOR: Remove redundant volatile write in RecordHeaders

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -216,6 +216,7 @@
     <allow pkg="org.openjdk.jmh.runner.options" />
     <allow pkg="org.openjdk.jmh.infra" />
     <allow pkg="org.apache.kafka.common" />
+    <allow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.streams" />
     <allow pkg="org.github.jamm" />
   </subpackage>

--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeaders.java
@@ -30,7 +30,7 @@ import org.apache.kafka.common.utils.AbstractIterator;
 public class RecordHeaders implements Headers {
     
     private final List<Header> headers;
-    private volatile boolean isReadOnly = false;
+    private volatile boolean isReadOnly;
 
     public RecordHeaders() {
         this((Iterable<Header>) null);

--- a/gradle/findbugs-exclude.xml
+++ b/gradle/findbugs-exclude.xml
@@ -165,6 +165,7 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Or>
             <Package name="org.apache.kafka.jmh.cache.generated"/>
             <Package name="org.apache.kafka.jmh.record.generated"/>
+            <Package name="org.apache.kafka.jmh.producer.generated"/>
         </Or>
     </Match>
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/producer/ProducerRecordBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/producer/ProducerRecordBenchmark.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.jmh.producer;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class ProducerRecordBenchmark {
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public ProducerRecord<String, String> constructorBenchmark() {
+        return new ProducerRecord("topic", "value");
+    }
+
+}


### PR DESCRIPTION
The JMH benchmark included shows that the redundant
volatile write causes the constructor of `ProducerRecord`
to take more than 50% longer:

ProducerRecordBenchmark.constructorBenchmark  avgt   15  24.136 ± 1.458  ns/op (before)
ProducerRecordBenchmark.constructorBenchmark  avgt   15  14.904 ± 0.231  ns/op (after)