### PR TITLE
MINOR:  Running the ConsumerIteratorTest unit tests，TMP directory has not  been  deleted when an exception occurs

### DIFF
--- a/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
+++ b/core/src/test/scala/unit/kafka/zk/EmbeddedZookeeper.scala
@@ -48,7 +48,7 @@ class EmbeddedZookeeper() {
     }
 
     Iterator.continually(isDown()).exists(identity)
-
+    CoreUtils.swallow(zookeeper.getZKDatabase.close())
     Utils.delete(logDir)
     Utils.delete(snapshotDir)
   }


### PR DESCRIPTION
OS:Windows 7
After the running ConsumerIteratorTest unit tests,
the TMP directory '..\AppData\Local\Temp\kafka-6579284700084877567\version-2' has not been deleted

Exception information:
at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:86)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
	at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:102)
	at sun.nio.fs.WindowsFileSystemProvider.implDelete(WindowsFileSystemProvider.java:269)
	at sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:103)
	at java.nio.file.Files.delete(Files.java:1126)
	at org.apache.kafka.common.utils.Utils$2.visitFile(Utils.java:575)
	at org.apache.kafka.common.utils.Utils$2.visitFile(Utils.java:564)
	at java.nio.file.Files.walkFileTree(Files.java:2670)
	at java.nio.file.Files.walkFileTree(Files.java:2742)
	at org.apache.kafka.common.utils.Utils.delete(Utils.java:564)
	at org.apache.kafka.test.TestUtils$1.run(TestUtils.java:182)
[2017-06-05 11:03:32,552] ERROR Error deleting C:\Users\10110346\AppData\Local\Temp\kafka-5691323213778461274 (org.apache.kafka.test.TestUtils:184)
java.nio.file.FileSystemException: C:\Users\10110346\AppData\Local\Temp\kafka-5691323213778461274\version-2\log.1: 另一个程序正在使用此文件，进程无法访问。