### PR TITLE
KAFKA-5380: Fix transient failure in KafkaConsumerTest, close consumers

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -903,8 +903,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             log.debug("Subscribed to pattern: {}", pattern);
             this.subscriptions.subscribe(pattern, listener);
             this.metadata.needMetadataForAllTopics(true);
-            this.metadata.requestUpdate();
             this.coordinator.updatePatternSubscription(metadata.fetch());
+            this.metadata.requestUpdate();
         } finally {
             release();
         }

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -18,7 +18,6 @@ package org.apache.kafka.clients;
 
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.utils.Time;
@@ -173,7 +172,7 @@ public class MockClient implements KafkaClient {
         if (metadata != null && metadata.updateRequested()) {
             MetadataUpdate metadataUpdate = metadataUpdates.poll();
             if (cluster != null)
-                metadata.update(cloneCluster(cluster), this.unavailableTopics, time.milliseconds());
+                metadata.update(cluster, this.unavailableTopics, time.milliseconds());
             if (metadataUpdate == null)
                 metadata.update(metadata.fetch(), this.unavailableTopics, time.milliseconds());
             else {
@@ -308,18 +307,7 @@ public class MockClient implements KafkaClient {
     }
 
     public void cluster(Cluster cluster) {
-        this.cluster = cloneCluster(cluster);
-    }
-
-    private Cluster cloneCluster(Cluster cluster) {
-        Set<PartitionInfo> partitions = new HashSet<>();
-        for (String topic : cluster.topics())
-            partitions.addAll(cluster.partitionsForTopic(topic));
-        return new Cluster(cluster.clusterResource().clusterId(),
-                new ArrayList<>(cluster.nodes()),
-                partitions,
-                new HashSet<>(cluster.unauthorizedTopics()),
-                new HashSet<>(cluster.internalTopics()));
+        this.cluster = cluster;
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -396,6 +396,7 @@ public class KafkaConsumerTest {
         consumer.poll(0);
 
         assertTrue(heartbeatReceived.get());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -437,6 +438,7 @@ public class KafkaConsumerTest {
         consumer.poll(0);
 
         assertTrue(heartbeatReceived.get());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -470,6 +472,7 @@ public class KafkaConsumerTest {
         ConsumerRecords<String, String> records = consumer.poll(0);
         assertEquals(5, records.count());
         assertEquals(55L, consumer.position(tp0));
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -520,6 +523,7 @@ public class KafkaConsumerTest {
         offsets.put(tp1, offset2);
         client.prepareResponseFrom(offsetResponse(offsets, Errors.NONE), coordinator);
         assertEquals(offset2, consumer.committed(tp1).offset());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -565,6 +569,7 @@ public class KafkaConsumerTest {
         consumer.poll(0);
 
         assertTrue(commitReceived.get());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -603,6 +608,7 @@ public class KafkaConsumerTest {
         consumer.poll(0);
         assertEquals(singleton(topic), consumer.subscription());
         assertEquals(singleton(tp0), consumer.assignment());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -622,7 +628,7 @@ public class KafkaConsumerTest {
         topicMetadata.put(topic, 1);
         topicMetadata.put(otherTopic, 1);
 
-        Cluster cluster = TestUtils.clusterWith(1, topicMetadata);
+        Cluster cluster = TestUtils.clusterWith(1, new HashMap<>(topicMetadata));
         Metadata metadata = createMetadata();
         Node node = cluster.nodes().get(0);
 
@@ -638,18 +644,22 @@ public class KafkaConsumerTest {
         consumer.subscribe(Pattern.compile(topic), getConsumerRebalanceListener(consumer));
 
         client.prepareMetadataUpdate(cluster, Collections.<String>emptySet());
+        metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
 
         consumer.poll(0);
         assertEquals(singleton(topic), consumer.subscription());
 
         consumer.subscribe(Pattern.compile(otherTopic), getConsumerRebalanceListener(consumer));
 
+        cluster = TestUtils.clusterWith(1, new HashMap<>(topicMetadata));
         client.prepareMetadataUpdate(cluster, Collections.<String>emptySet());
+        metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
 
         prepareRebalance(client, node, singleton(otherTopic), assignor, singletonList(otherTopicPartition), coordinator);
         consumer.poll(0);
 
         assertEquals(singleton(otherTopic), consumer.subscription());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -746,6 +756,7 @@ public class KafkaConsumerTest {
             // clear interrupted state again since this thread may be reused by JUnit
             Thread.interrupted();
         }
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -783,6 +794,7 @@ public class KafkaConsumerTest {
 
         ConsumerRecords<String, String> records = consumer.poll(0);
         assertEquals(0, records.count());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -1327,6 +1339,7 @@ public class KafkaConsumerTest {
         Thread.sleep(heartbeatIntervalMs);
         final ConsumerRecords<String, String> records = consumer.poll(0);
         assertFalse(records.isEmpty());
+        consumer.close(0, TimeUnit.MILLISECONDS);
     }
 
     private void consumerCloseTest(final long closeTimeoutMs,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -644,8 +644,6 @@ public class KafkaConsumerTest {
         Node coordinator = prepareRebalance(client, node, singleton(topic), assignor, singletonList(tp0), null);
         consumer.subscribe(Pattern.compile(topic), getConsumerRebalanceListener(consumer));
 
-        client.prepareMetadataUpdate(cluster, Collections.<String>emptySet());
-
         consumer.poll(0);
         assertEquals(singleton(topic), consumer.subscription());
 

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -628,12 +628,13 @@ public class KafkaConsumerTest {
         topicMetadata.put(topic, 1);
         topicMetadata.put(otherTopic, 1);
 
-        Cluster cluster = TestUtils.clusterWith(1, new HashMap<>(topicMetadata));
+        Cluster cluster = TestUtils.clusterWith(1, topicMetadata);
         Metadata metadata = createMetadata();
         Node node = cluster.nodes().get(0);
 
         MockClient client = new MockClient(time, metadata);
         client.setNode(node);
+        client.cluster(cluster);
 
         metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
 
@@ -644,16 +645,11 @@ public class KafkaConsumerTest {
         consumer.subscribe(Pattern.compile(topic), getConsumerRebalanceListener(consumer));
 
         client.prepareMetadataUpdate(cluster, Collections.<String>emptySet());
-        metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
 
         consumer.poll(0);
         assertEquals(singleton(topic), consumer.subscription());
 
         consumer.subscribe(Pattern.compile(otherTopic), getConsumerRebalanceListener(consumer));
-
-        cluster = TestUtils.clusterWith(1, new HashMap<>(topicMetadata));
-        client.prepareMetadataUpdate(cluster, Collections.<String>emptySet());
-        metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
 
         prepareRebalance(client, node, singleton(otherTopic), assignor, singletonList(otherTopicPartition), coordinator);
         consumer.poll(0);


### PR DESCRIPTION
1. Fix ordering of metadata update request for regex subscription to avoid timing issue when heartbeat thread updates metadata
2. Override metadata cluster in MockClient for `KafkaConsumer#testChangingRegexSubscription` to avoid timing issues during update
3. Close consumer in all KafkaConsumer tests since they leave behind heartbeat threads.