### PR TITLE
KAFKA-5292. Fix authorization checks in AdminClient

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/acl/AclOperation.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclOperation.java
@@ -22,6 +22,24 @@ import java.util.Locale;
 
 /**
  * Represents an operation which an ACL grants or denies permission to perform.
+ *
+ * Some operations imply other operations.
+ *
+ * ALLOW ALL implies ALLOW everything
+ * DENY ALL implies DENY everything
+ *
+ * ALLOW READ implies ALLOW DESCRIBE
+ * ALLOW WRITE implies ALLOW DESCRIBE
+ * ALLOW DELETE implies ALLOW DESCRIBE
+ *
+ * ALLOW ALTER implies ALLOW DESCRIBE
+ * DENY DESCRIBE implies DENY ALTER
+ *
+ * ALLOW ALTER_CONFIGS implies ALLOW DESCRIBE_CONFIGS
+ * DENY DESCRIBE_CONFIGS implies DENY ALTER_CONFIGS
+ *
+ * ALLOW ALTER_CONFIGS on kafka-cluster implies ALLOW ALTER_CONFIGS on all topics.
+ * DENY DESCRIBE_CONFIGS on kafka-cluster implies DENY DESCRIBE_CONFIGS on all topics.
  */
 public enum AclOperation {
     /**

--- a/clients/src/main/java/org/apache/kafka/common/acl/AclOperation.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclOperation.java
@@ -33,13 +33,10 @@ import java.util.Locale;
  * ALLOW DELETE implies ALLOW DESCRIBE
  *
  * ALLOW ALTER implies ALLOW DESCRIBE
- * DENY DESCRIBE implies DENY ALTER
  *
  * ALLOW ALTER_CONFIGS implies ALLOW DESCRIBE_CONFIGS
- * DENY DESCRIBE_CONFIGS implies DENY ALTER_CONFIGS
  *
  * ALLOW ALTER_CONFIGS on kafka-cluster implies ALLOW ALTER_CONFIGS on all topics.
- * DENY DESCRIBE_CONFIGS on kafka-cluster implies DENY DESCRIBE_CONFIGS on all topics.
  */
 public enum AclOperation {
     /**

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -125,4 +125,7 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
         }
     }
 
+    public String toString(short version) {
+        return toStruct(version).toString();
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/resource/Resource.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/Resource.java
@@ -26,6 +26,16 @@ public class Resource {
     private final ResourceType resourceType;
     private final String name;
 
+    /**
+     * The name of the CLUSTER resource.
+     */
+    public final static String CLUSTER_NAME = "kafka-cluster";
+
+    /**
+     * A resource representing the whole cluster.
+     */
+    public final static Resource CLUSTER = new Resource(ResourceType.CLUSTER, CLUSTER_NAME);
+
     public Resource(ResourceType resourceType, String name) {
         Objects.requireNonNull(resourceType);
         this.resourceType = resourceType;

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
@@ -53,7 +53,12 @@ public enum ResourceType {
     /**
      * A broker.
      */
-    BROKER((byte) 5);
+    BROKER((byte) 5),
+
+    /**
+     * A transactional ID.
+     */
+    TRANSACTIONAL_ID((byte) 6);
 
     private final static HashMap<Byte, ResourceType> CODE_TO_VALUE = new HashMap<>();
 

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
@@ -51,14 +51,9 @@ public enum ResourceType {
     CLUSTER((byte) 4),
 
     /**
-     * A broker.
-     */
-    BROKER((byte) 5),
-
-    /**
      * A transactional ID.
      */
-    TRANSACTIONAL_ID((byte) 6);
+    TRANSACTIONAL_ID((byte) 5);
 
     private final static HashMap<Byte, ResourceType> CODE_TO_VALUE = new HashMap<>();
 

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclOperationTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclOperationTest.java
@@ -61,6 +61,7 @@ public class AclOperationTest {
 
     @Test
     public void testCode() throws Exception {
+        assertEquals(AclOperation.values().length, INFOS.length);
         for (AclOperationTestInfo info : INFOS) {
             assertEquals(info.operation + " was supposed to have code == " + info.code,
                 info.code, info.operation.code());

--- a/clients/src/test/java/org/apache/kafka/common/acl/AclPermissionTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/acl/AclPermissionTypeTest.java
@@ -53,6 +53,7 @@ public class AclPermissionTypeTest {
 
     @Test
     public void testCode() throws Exception {
+        assertEquals(AclPermissionType.values().length, INFOS.length);
         for (AclPermissionTypeTestInfo info : INFOS) {
             assertEquals(info.ty + " was supposed to have code == " + info.code,
                 info.code, info.ty.code());

--- a/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
@@ -41,7 +41,7 @@ public class ResourceTypeTest {
         new AclResourceTypeTestInfo(ResourceType.TOPIC, 2, "topic", false),
         new AclResourceTypeTestInfo(ResourceType.GROUP, 3, "group", false),
         new AclResourceTypeTestInfo(ResourceType.CLUSTER, 4, "cluster", false),
-        new AclResourceTypeTestInfo(ResourceType.TRANSACTIONAL_ID, 5, "transactionalId", false)
+        new AclResourceTypeTestInfo(ResourceType.TRANSACTIONAL_ID, 5, "transactional_id", false)
     };
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/resource/ResourceTypeTest.java
@@ -41,7 +41,7 @@ public class ResourceTypeTest {
         new AclResourceTypeTestInfo(ResourceType.TOPIC, 2, "topic", false),
         new AclResourceTypeTestInfo(ResourceType.GROUP, 3, "group", false),
         new AclResourceTypeTestInfo(ResourceType.CLUSTER, 4, "cluster", false),
-        new AclResourceTypeTestInfo(ResourceType.BROKER, 5, "broker", false)
+        new AclResourceTypeTestInfo(ResourceType.TRANSACTIONAL_ID, 5, "transactionalId", false)
     };
 
     @Test
@@ -54,6 +54,7 @@ public class ResourceTypeTest {
 
     @Test
     public void testCode() throws Exception {
+        assertEquals(ResourceType.values().length, INFOS.length);
         for (AclResourceTypeTestInfo info : INFOS) {
             assertEquals(info.resourceType + " was supposed to have code == " + info.code,
                 info.code, info.resourceType.code());

--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -33,7 +33,7 @@ object AclCommand {
   val ResourceTypeToValidOperations = Map[ResourceType, Set[Operation]] (
     Topic -> Set(Read, Write, Describe, Delete, DescribeConfigs, AlterConfigs, All),
     Group -> Set(Read, Describe, All),
-    Cluster -> Set(Create, ClusterAction, DescribeConfigs, AlterConfigs, IdempotentWrite, All),
+    Cluster -> Set(Create, ClusterAction, DescribeConfigs, AlterConfigs, IdempotentWrite, Alter, Describe, All),
     TransactionalId -> Set(Describe, Write, All)
   )
 

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -237,14 +237,15 @@ class RequestSendThread(val controllerId: Int,
         }
       }
       if (clientResponse != null) {
-        val api = ApiKeys.forId(clientResponse.requestHeader.apiKey)
+        val requestHeader = clientResponse.requestHeader
+        val api = ApiKeys.forId(requestHeader.apiKey)
         if (api != ApiKeys.LEADER_AND_ISR && api != ApiKeys.STOP_REPLICA && api != ApiKeys.UPDATE_METADATA_KEY)
           throw new KafkaException(s"Unexpected apiKey received: $apiKey")
 
         val response = clientResponse.responseBody
 
         stateChangeLogger.trace("Controller %d epoch %d received response %s for a request sent to broker %s"
-          .format(controllerId, controllerContext.epoch, response.toString(), brokerNode.toString))
+          .format(controllerId, controllerContext.epoch, response.toString(requestHeader.apiVersion), brokerNode.toString))
 
         if (callback != null) {
           callback(response)

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -244,7 +244,7 @@ class RequestSendThread(val controllerId: Int,
         val response = clientResponse.responseBody
 
         stateChangeLogger.trace("Controller %d epoch %d received response %s for a request sent to broker %s"
-          .format(controllerId, controllerContext.epoch, response.toString, brokerNode.toString))
+          .format(controllerId, controllerContext.epoch, response.toString(), brokerNode.toString))
 
         if (callback != null) {
           callback(response)

--- a/core/src/main/scala/kafka/security/auth/Operation.scala
+++ b/core/src/main/scala/kafka/security/auth/Operation.scala
@@ -81,13 +81,7 @@ object Operation {
     op.getOrElse(throw new KafkaException(operation + " not a valid operation name. The valid names are " + values.mkString(",")))
   }
 
-  def fromJava(operation: AclOperation): Try[Operation] = {
-    try {
-      Success(fromString(operation.toString))
-    } catch {
-      case throwable: Throwable => Failure(throwable)
-    }
-  }
+  def fromJava(operation: AclOperation): Operation = fromString(operation.toString.replaceAll("_", ""))
 
   def values: Seq[Operation] = List(Read, Write, Create, Delete, Alter, Describe, ClusterAction, AlterConfigs,
      DescribeConfigs, IdempotentWrite, All)

--- a/core/src/main/scala/kafka/security/auth/PermissionType.scala
+++ b/core/src/main/scala/kafka/security/auth/PermissionType.scala
@@ -46,13 +46,7 @@ object PermissionType {
     pType.getOrElse(throw new KafkaException(permissionType + " not a valid permissionType name. The valid names are " + values.mkString(",")))
   }
 
-  def fromJava(permissionType: AclPermissionType): Try[PermissionType] = {
-    try {
-      Success(fromString(permissionType.toString))
-    } catch {
-      case throwable: Throwable => Failure(throwable)
-    }
-  }
+  def fromJava(permissionType: AclPermissionType): PermissionType = fromString(permissionType.toString)
 
   def values: Seq[PermissionType] = List(Allow, Deny)
 }

--- a/core/src/main/scala/kafka/security/auth/ResourceType.scala
+++ b/core/src/main/scala/kafka/security/auth/ResourceType.scala
@@ -18,27 +18,41 @@ package kafka.security.auth
 
 import kafka.common.{BaseEnum, KafkaException}
 import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.resource.{ResourceType => JResourceType}
 
-sealed trait ResourceType extends BaseEnum { def error: Errors }
-
-case object Cluster extends ResourceType {
-  val name = "Cluster"
-  val error = Errors.CLUSTER_AUTHORIZATION_FAILED
+sealed trait ResourceType extends BaseEnum {
+  def error: Errors
+  def toJava: JResourceType
 }
 
 case object Topic extends ResourceType {
   val name = "Topic"
   val error = Errors.TOPIC_AUTHORIZATION_FAILED
+  val toJava = JResourceType.TOPIC
 }
 
 case object Group extends ResourceType {
   val name = "Group"
   val error = Errors.GROUP_AUTHORIZATION_FAILED
+  val toJava = JResourceType.GROUP
+}
+
+case object Cluster extends ResourceType {
+  val name = "Cluster"
+  val error = Errors.CLUSTER_AUTHORIZATION_FAILED
+  val toJava = JResourceType.CLUSTER
+}
+
+case object Broker extends ResourceType {
+  val name = "Broker"
+  val error = Errors.CLUSTER_AUTHORIZATION_FAILED // Same exception as Cluster, for now.
+  val toJava = JResourceType.BROKER
 }
 
 case object TransactionalId extends ResourceType {
   val name = "TransactionalId"
   val error = Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
+  val toJava = JResourceType.TRANSACTIONAL_ID
 }
 
 object ResourceType {
@@ -48,5 +62,7 @@ object ResourceType {
     rType.getOrElse(throw new KafkaException(resourceType + " not a valid resourceType name. The valid names are " + values.mkString(",")))
   }
 
-  def values: Seq[ResourceType] = List(Cluster, Topic, Group, TransactionalId)
+  def values: Seq[ResourceType] = List(Topic, Group, Cluster, Broker, TransactionalId)
+
+  def fromJava(operation: JResourceType): ResourceType = fromString(operation.toString.replaceAll("_", ""))
 }

--- a/core/src/main/scala/kafka/security/auth/ResourceType.scala
+++ b/core/src/main/scala/kafka/security/auth/ResourceType.scala
@@ -43,12 +43,6 @@ case object Cluster extends ResourceType {
   val toJava = JResourceType.CLUSTER
 }
 
-case object Broker extends ResourceType {
-  val name = "Broker"
-  val error = Errors.CLUSTER_AUTHORIZATION_FAILED // Same exception as Cluster, for now.
-  val toJava = JResourceType.BROKER
-}
-
 case object TransactionalId extends ResourceType {
   val name = "TransactionalId"
   val error = Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED
@@ -62,7 +56,7 @@ object ResourceType {
     rType.getOrElse(throw new KafkaException(resourceType + " not a valid resourceType name. The valid names are " + values.mkString(",")))
   }
 
-  def values: Seq[ResourceType] = List(Topic, Group, Cluster, Broker, TransactionalId)
+  def values: Seq[ResourceType] = List(Topic, Group, Cluster, TransactionalId)
 
   def fromJava(operation: JResourceType): ResourceType = fromString(operation.toString.replaceAll("_", ""))
 }

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -125,14 +125,7 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
     val acls = getAcls(resource) ++ getAcls(new Resource(resource.resourceType, Resource.WildCardResource))
 
     // Check if there is any Deny acl match that would disallow this operation.
-    // If Describe is forbidden, Alter is forbidden as well.
-    // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
-    val denyOps = operation match {
-      case Alter => Set[Operation](Alter, Describe)
-      case AlterConfigs => Set[Operation](AlterConfigs, DescribeConfigs)
-      case _ => Set[Operation](operation)
-    }
-    val denyMatch = denyOps.exists(operation => aclMatch(operation, resource, principal, host, Deny, acls))
+    val denyMatch = aclMatch(operation, resource, principal, host, Deny, acls)
 
     // Check if there are any Allow ACLs which would allow this operation.
     // Allowing read, write, delete, or alter implies allowing describe.

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2001,8 +2001,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case RResourceType.BROKER =>
           authorize(request.session, AlterConfigs, Resource.ClusterResource)
         case RResourceType.TOPIC =>
-          authorize(request.session, AlterConfigs, new Resource(Topic, resource.name)) ||
-            authorize(request.session, AlterConfigs, Resource.ClusterResource)
+          authorize(request.session, AlterConfigs, new Resource(Topic, resource.name))
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt")
       }
     }
@@ -2034,8 +2033,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       resource.`type` match {
         case RResourceType.BROKER => authorize(request.session, DescribeConfigs, Resource.ClusterResource)
         case RResourceType.TOPIC =>
-          authorize(request.session, DescribeConfigs, new Resource(Topic, resource.name)) ||
-            authorize(request.session, DescribeConfigs, Resource.ClusterResource)
+          authorize(request.session, DescribeConfigs, new Resource(Topic, resource.name))
         case rt => throw new InvalidRequestException(s"Unexpected resource type $rt for resource ${resource.name}")
       }
     }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1858,12 +1858,11 @@ class KafkaApis(val requestChannel: RequestChannel,
                 if (resource.name.isEmpty)
                   throw new InvalidRequestException("Invalid empty resource name")
                 auth.addAcls(immutable.Set(acl), resource)
-                if (logger.isDebugEnabled) {
-                  logger.debug("added acl " + acl + " to " + resource)
-                }
+                if (logger.isDebugEnabled)
+                  logger.debug(s"Added acl $acl to $resource")
               } catch {
                 case throwable : Throwable => if (logger.isDebugEnabled) {
-                    logger.debug("failed to add acl " + acl + " to " + resource, throwable)
+                    logger.debug(s"Failed to add acl $acl to $resource", throwable)
                   }
                   errors.put(i, throwable)
               }

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.clients.admin._
 import kafka.utils.{Logging, TestUtils, ZkUtils}
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.KafkaFuture
-import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
+import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{InvalidRequestException, SecurityDisabledException, TimeoutException, TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.protocol.ApiKeys

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -28,7 +28,7 @@ import org.apache.kafka.clients.admin._
 import kafka.utils.{Logging, TestUtils, ZkUtils}
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.KafkaFuture
-import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
+import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors.{InvalidRequestException, SecurityDisabledException, TimeoutException, TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.protocol.ApiKeys

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminClientIntegrationTest.scala
@@ -14,31 +14,67 @@ package kafka.api
 
 import java.io.File
 
-import kafka.security.auth.SimpleAclAuthorizer
+import kafka.admin.AclCommand
+import kafka.security.auth.{All, Allow, Alter, AlterConfigs, Authorizer, ClusterAction, Create, Delete, Deny, Describe, Operation, PermissionType, SimpleAclAuthorizer, Topic, Acl => AuthAcl, Resource => AuthResource}
 import org.apache.kafka.common.protocol.SecurityProtocol
 import kafka.server.KafkaConfig
-import kafka.utils.{JaasTestUtils, TestUtils}
-import org.apache.kafka.clients.admin.{AdminClient, CreateAclsOptions, DeleteAclsOptions}
+import kafka.utils.{CoreUtils, JaasTestUtils, TestUtils}
+import org.apache.kafka.clients.admin.{AdminClient, CreateAclsOptions, DeleteAclsOptions, KafkaAdminClient}
 import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
-import org.apache.kafka.common.errors.InvalidRequestException
+import org.apache.kafka.common.errors.{ClusterAuthorizationException, InvalidRequestException}
 import org.apache.kafka.common.resource.{Resource, ResourceFilter, ResourceType}
+import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.junit.Assert.assertEquals
 import org.junit.{After, Assert, Before, Test}
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
 
 class SaslSslAdminClientIntegrationTest extends AdminClientIntegrationTest with SaslSetup {
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "true")
   this.serverConfig.setProperty(KafkaConfig.AuthorizerClassNameProp, classOf[SimpleAclAuthorizer].getName())
-  this.serverConfig.setProperty(SimpleAclAuthorizer.AllowEveryoneIfNoAclIsFoundProp, "true")
 
   override protected def securityProtocol = SecurityProtocol.SASL_SSL
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
+
+  override def configureSecurityBeforeServersStart() {
+    val authorizer = CoreUtils.createObject[Authorizer](classOf[SimpleAclAuthorizer].getName())
+    authorizer.configure(this.configs.head.originals())
+    authorizer.addAcls(Set(new AuthAcl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*"), Allow,
+                            AuthAcl.WildCardHost, All)), new AuthResource(Topic, "*"))
+    authorizer.addAcls(Set(clusterAcl(Allow, Create),
+                           clusterAcl(Allow, Delete),
+                           clusterAcl(Allow, ClusterAction),
+                           clusterAcl(Allow, AlterConfigs),
+                           clusterAcl(Allow, Alter)),
+                       AuthResource.ClusterResource)
+  }
 
   @Before
   override def setUp(): Unit = {
     startSasl(jaasSections(Seq("GSSAPI"), Some("GSSAPI"), Both, JaasTestUtils.KafkaServerContextName))
     super.setUp()
+  }
+
+  private def clusterAcl(permissionType: PermissionType, operation: Operation): AuthAcl = {
+    new AuthAcl(new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "*"), permissionType,
+      AuthAcl.WildCardHost, operation)
+  }
+
+  private def addClusterAcl(permissionType: PermissionType, operation: Operation): Unit = {
+    val acls = Set(clusterAcl(permissionType, operation))
+    val authorizer = servers.head.apis.authorizer.get
+    val prevAcls = authorizer.getAcls(AuthResource.ClusterResource)
+    authorizer.addAcls(acls, AuthResource.ClusterResource)
+    TestUtils.waitAndVerifyAcls(prevAcls  ++ acls, authorizer, AuthResource.ClusterResource)
+  }
+
+  private def removeClusterAcl(permissionType: PermissionType, operation: Operation): Unit = {
+    val acls = Set(clusterAcl(permissionType, operation))
+    val authorizer = servers.head.apis.authorizer.get
+    val prevAcls = authorizer.getAcls(AuthResource.ClusterResource)
+    Assert.assertTrue(authorizer.removeAcls(acls, AuthResource.ClusterResource))
+    TestUtils.waitAndVerifyAcls(prevAcls -- acls, authorizer, AuthResource.ClusterResource)
   }
 
   @After
@@ -54,15 +90,10 @@ class SaslSslAdminClientIntegrationTest extends AdminClientIntegrationTest with 
   val ACL_UNKNOWN = new AclBinding(new Resource(ResourceType.TOPIC, "mytopic3"),
     new AccessControlEntry("User:ANONYMOUS", "*", AclOperation.UNKNOWN, AclPermissionType.ALLOW));
 
-  /**
-    * Test that ACL operations are not possible when the authorizer is disabled.
-    * Also see {@link kafka.api.KafkaAdminClientSecureIntegrationTest} for tests of ACL operations
-    * when the authorizer is enabled.
-    */
   @Test
   override def testAclOperations(): Unit = {
     client = AdminClient.create(createConfig())
-    assertEquals(0, client.describeAcls(AclBindingFilter.ANY).all().get().size())
+    assertEquals(6, client.describeAcls(AclBindingFilter.ANY).all().get().size())
     val results = client.createAcls(List(ACL2, ACL3).asJava)
     assertEquals(Set(ACL2, ACL3), results.results().keySet().asScala)
     results.results().values().asScala.foreach(value => value.get)
@@ -90,9 +121,9 @@ class SaslSslAdminClientIntegrationTest extends AdminClientIntegrationTest with 
     val results = client.createAcls(List(ACL2, ACL2).asJava)
     assertEquals(Set(ACL2, ACL2), results.results().keySet().asScala)
     results.all().get()
-    waitForDescribeAcls(client, AclBindingFilter.ANY, Set(ACL2))
+    waitForDescribeAcls(client, ACL2.toFilter, Set(ACL2))
 
-    val filterA = new AclBindingFilter(new ResourceFilter(ResourceType.CLUSTER, null), AccessControlEntryFilter.ANY)
+    val filterA = new AclBindingFilter(new ResourceFilter(ResourceType.GROUP, null), AccessControlEntryFilter.ANY)
     val filterB = new AclBindingFilter(new ResourceFilter(ResourceType.TOPIC, "mytopic2"), AccessControlEntryFilter.ANY)
 
     waitForDescribeAcls(client, filterA, Set())
@@ -118,5 +149,127 @@ class SaslSslAdminClientIntegrationTest extends AdminClientIntegrationTest with 
     assertEquals(Set(clusterAcl, emptyResourceNameAcl), results.results().keySet().asScala)
     assertFutureExceptionTypeEquals(results.results().get(clusterAcl), classOf[InvalidRequestException])
     assertFutureExceptionTypeEquals(results.results().get(emptyResourceNameAcl), classOf[InvalidRequestException])
+  }
+
+  val FOO_ACL = new AclBinding(new Resource(ResourceType.TOPIC, "foobar"),
+    new AccessControlEntry("User:ANONYMOUS", "*", AclOperation.READ, AclPermissionType.ALLOW))
+  val FOO_ACL_FILTER = FOO_ACL.toFilter
+
+  private def verifyCauseIsClusterAuth(e: Exception): Unit = {
+    if (!e.getCause.isInstanceOf[ClusterAuthorizationException]) {
+      throw e.getCause
+    }
+  }
+
+  private def testAclCreateGetDelete(expectAuth: Boolean): Unit = {
+    TestUtils.waitUntilTrue(() => {
+      val result = client.createAcls(List(FOO_ACL).asJava, new CreateAclsOptions())
+      if (expectAuth) {
+        Try(result.all().get) match {
+          case Failure(e: Exception) => {
+            verifyCauseIsClusterAuth(e)
+            false
+          }
+          case Success(_) => true
+        }
+      } else {
+        Try(result.all().get) match {
+          case Failure(e: Exception) => {
+            verifyCauseIsClusterAuth(e)
+            true
+          }
+          case Success(_) => false
+        }
+      }
+    }, "timed out waiting for createAcls to " + (if (expectAuth) "succeed" else "fail"))
+    if (expectAuth) {
+      waitForDescribeAcls(client, FOO_ACL_FILTER, Set(FOO_ACL))
+    }
+    TestUtils.waitUntilTrue(() => {
+      val result = client.deleteAcls(List(FOO_ACL.toFilter).asJava, new DeleteAclsOptions())
+      if (expectAuth) {
+        Try(result.all().get) match {
+          case Failure(e: Exception) => {
+            verifyCauseIsClusterAuth(e)
+            false
+          }
+          case Success(_) => true
+        }
+      } else {
+        Try(result.all().get) match {
+          case Failure(e: Exception) => {
+            verifyCauseIsClusterAuth(e)
+            true
+          }
+          case Success(removed) => {
+            assertEquals(Set(FOO_ACL), result.results.get(FOO_ACL_FILTER).get.acls.asScala.map(result => result.acl()).toSet)
+            true
+          }
+        }
+      }
+    }, "timed out waiting for deleteAcls to " + (if (expectAuth) "succeed" else "fail"))
+    if (expectAuth) {
+      waitForDescribeAcls(client, FOO_ACL_FILTER, Set())
+    }
+  }
+
+  private def testAclGet(expectAuth: Boolean): Unit = {
+    TestUtils.waitUntilTrue(() => {
+      val userAcl = new AclBinding(new Resource(ResourceType.TOPIC, "*"),
+        new AccessControlEntry("User:*", "*", AclOperation.ALL, AclPermissionType.ALLOW))
+      val results = client.describeAcls(userAcl.toFilter)
+      if (expectAuth) {
+        Try(results.all().get) match {
+          case Failure(e: Exception) => {
+            verifyCauseIsClusterAuth(e)
+            false
+          }
+          case Success(acls) => Set(userAcl).equals(acls.asScala.toSet)
+        }
+      } else {
+        Try(results.all().get) match {
+          case Failure(e: Exception) => {
+            verifyCauseIsClusterAuth(e)
+            true
+          }
+          case Success(_) => false
+        }
+      }
+    }, "timed out waiting for describeAcls to " + (if (expectAuth) "succeed" else "fail"))
+  }
+
+  @Test
+  def testAclAuthorizationDenied(): Unit = {
+    client = AdminClient.create(createConfig())
+
+    // Test that we cannot create or delete ACLs when Alter is denied.
+    addClusterAcl(Deny, Alter)
+    testAclGet(true)
+    testAclCreateGetDelete(false)
+
+    // Test that we cannot do anything with ACLs when Describe is denied.
+    removeClusterAcl(Deny, Alter)
+    addClusterAcl(Deny, Describe)
+    testAclGet(false)
+    testAclCreateGetDelete(false)
+
+    // Test that we can create, delete, and get ACLs with the default ACLs.
+    removeClusterAcl(Deny, Describe)
+    testAclGet(true)
+    testAclCreateGetDelete(true)
+
+    // Test that we can't do anything with ACLs without the Allow Alter ACL in place.
+    removeClusterAcl(Allow, Alter)
+    removeClusterAcl(Allow, Delete)
+    testAclGet(false)
+    testAclCreateGetDelete(false)
+
+    // Test that we can describe, but not alter ACLs, with only the Allow Describe ACL in place.
+    addClusterAcl(Allow, Describe)
+    testAclGet(true)
+    testAclCreateGetDelete(false)
+
+    removeClusterAcl(Allow, Describe)
+    addClusterAcl(Allow, Alter)
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslSslAdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslSslAdminClientIntegrationTest.scala
@@ -237,14 +237,16 @@ class SaslSslAdminClientIntegrationTest extends AdminClientIntegrationTest with 
     testAclGet(true)
     testAclCreateGetDelete(false)
 
-    // Test that we cannot do anything with ACLs when Describe is denied.
+    // Test that we cannot do anything with ACLs when Describe and Alter are denied.
     removeClusterAcl(Deny, Alter)
     addClusterAcl(Deny, Describe)
+    addClusterAcl(Deny, Alter)
     testAclGet(false)
     testAclCreateGetDelete(false)
 
     // Test that we can create, delete, and get ACLs with the default ACLs.
     removeClusterAcl(Deny, Describe)
+    removeClusterAcl(Deny, Alter)
     testAclGet(true)
     testAclCreateGetDelete(true)
 

--- a/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
@@ -14,25 +14,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package kafka.security.auth
 
-import kafka.common.{KafkaException}
-import org.junit.{Test, Assert}
+import org.apache.kafka.common.acl.AclOperation
+import org.junit.{Assert, Test}
 import org.scalatest.junit.JUnitSuite
 
 class OperationTest extends JUnitSuite {
-
+  /**
+    * Test round trip conversions between org.apache.kafka.common.acl.AclOperation and
+    * kafka.security.auth.Operation.
+    */
   @Test
-  def testFromString(): Unit = {
-    val op = Operation.fromString("READ")
-    Assert.assertEquals(Read, op)
-
-    try {
-      Operation.fromString("badName")
-      fail("Expected exception on invalid operation name.")
-    } catch {
-      case _: KafkaException => // expected
+  def testJavaConversions(): Unit = {
+    AclOperation.values().foreach {
+      aclOp => aclOp match {
+        case AclOperation.UNKNOWN => {}
+        case AclOperation.ANY => {}
+        case default => {
+          val op = Operation.fromJava(aclOp)
+          val aclOp2 = op.toJava
+          Assert.assertEquals(aclOp, aclOp2)
+        }
+      }
     }
   }
-
 }

--- a/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/OperationTest.scala
@@ -30,8 +30,7 @@ class OperationTest extends JUnitSuite {
   def testJavaConversions(): Unit = {
     AclOperation.values().foreach {
       aclOp => aclOp match {
-        case AclOperation.UNKNOWN => {}
-        case AclOperation.ANY => {}
+        case AclOperation.UNKNOWN | AclOperation.ANY =>
         case default => {
           val op = Operation.fromJava(aclOp)
           val aclOp2 = op.toJava

--- a/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/PermissionTypeTest.scala
@@ -17,7 +17,8 @@
 package kafka.security.auth
 
 import kafka.common.KafkaException
-import org.junit.{Test, Assert}
+import org.apache.kafka.common.acl.AclPermissionType
+import org.junit.{Assert, Test}
 import org.scalatest.junit.JUnitSuite
 
 class PermissionTypeTest extends JUnitSuite {
@@ -35,4 +36,22 @@ class PermissionTypeTest extends JUnitSuite {
     }
   }
 
+  /**
+    * Test round trip conversions between org.apache.kafka.common.acl.AclPermissionType and
+    * kafka.security.auth.PermissionType.
+    */
+  @Test
+  def testJavaConversions(): Unit = {
+    AclPermissionType.values().foreach {
+      aclPerm => aclPerm match {
+        case AclPermissionType.UNKNOWN => {}
+        case AclPermissionType.ANY => {}
+        case default => {
+          val perm = PermissionType.fromJava(aclPerm)
+          val aclPerm2 = perm.toJava
+          Assert.assertEquals(aclPerm, aclPerm2)
+        }
+      }
+    }
+  }
 }

--- a/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/ResourceTypeTest.scala
@@ -19,6 +19,7 @@ package kafka.security.auth
 import kafka.common.KafkaException
 import org.junit.{Test, Assert}
 import org.scalatest.junit.JUnitSuite
+import org.apache.kafka.common.resource.{ResourceType => JResourceType}
 
 class ResourceTypeTest extends JUnitSuite {
 
@@ -35,4 +36,22 @@ class ResourceTypeTest extends JUnitSuite {
     }
   }
 
+  /**
+    * Test round trip conversions between org.apache.kafka.common.acl.ResourceType and
+    * kafka.security.auth.ResourceType.
+    */
+  @Test
+  def testJavaConversions(): Unit = {
+    JResourceType.values().foreach {
+      jResourceType => jResourceType match {
+        case JResourceType.UNKNOWN => {}
+        case JResourceType.ANY => {}
+        case default => {
+          val resourceType = ResourceType.fromJava(jResourceType)
+          val jResourceType2 = resourceType.toJava
+          Assert.assertEquals(jResourceType, jResourceType2)
+        }
+      }
+    }
+  }
 }

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleAclAuthorizerTest.scala
@@ -364,9 +364,9 @@ class SimpleAclAuthorizerTest extends ZooKeeperTestHarness {
     testImplicationsOfAllow(Write, Set(Describe))
     testImplicationsOfAllow(Delete, Set(Describe))
     testImplicationsOfAllow(Alter, Set(Describe))
-    testImplicationsOfDeny(Describe, Set(Alter))
+    testImplicationsOfDeny(Describe, Set())
     testImplicationsOfAllow(AlterConfigs, Set(DescribeConfigs))
-    testImplicationsOfDeny(DescribeConfigs, Set(AlterConfigs))
+    testImplicationsOfDeny(DescribeConfigs, Set())
   }
 
   private def testImplicationsOfAllow(parentOp: Operation, allowedOps: Set[Operation]): Unit = {


### PR DESCRIPTION
* NetworkClient.java: when trace logging is enabled, show AbstractResponse Struct objects, rather than just a memory address of the AbstractResponse.
* AclOperation.java: add documentation of what ACLs imply other ACLs.
* Resource.java: add CLUSTER, CLUSTER_NAME constants.
* Reconcile the Java and Scala classes for ResourceType, OperationType, etc.  Add unit tests to ensure they can be converted to each other.
* AclCommand.scala: we should be able to apply ACLs containing Alter and Describe operations to Cluster resources.
* SimpleAclAuthorizer: update the authorizer to handle the ACL inheritance rules described in AclOperation.java.
* KafkaApis.scala: update createAcls and deleteAcls to use ALTER on CLUSTER, as described in the KIP.  describeAcls should use DESCRIBE on CLUSTER.  Use      fromJava methods instead of fromString methods to convert from Java objects to Scala ones.
* SaslSslAdminClientIntegrationTest.scala: do not use AllowEveryoneIfNoAclIsFound.  Add a configureSecurityBeforeServerStart hook which installs the ACLs     necessary for the tests.  Add a test of ACL authorization ALLOW and DENY functionality.
