### PR TITLE
KAFKA-4948: Wait for offset commit in test to fix transient failure

### DIFF
--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -186,6 +186,13 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
       state == Some("Stable")
     }, "Expected the group to initially become stable.")
 
+    // Group assignments in describeGroup rely on finding committed consumer offsets.
+    // Wait for an offset commit before shutting down the group executor.
+    TestUtils.waitUntilTrue(() => {
+      val (_, assignments) = consumerGroupService.describeGroup()
+      !assignments.toSeq.flatMap(_.filter(_.group == group)).isEmpty
+    }, "Expected to find group in assignments after initial offset commit")
+
     // stop the consumer so the group has no active member anymore
     consumerGroupExecutor.shutdown()
 

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -190,7 +190,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     // Wait for an offset commit before shutting down the group executor.
     TestUtils.waitUntilTrue(() => {
       val (_, assignments) = consumerGroupService.describeGroup()
-      !assignments.toSeq.flatMap(_.filter(_.group == group)).isEmpty
+      assignments.exists(_.exists(_.group == group))
     }, "Expected to find group in assignments after initial offset commit")
 
     // stop the consumer so the group has no active member anymore


### PR DESCRIPTION
`DescribeConsumerGroupTest#testDescribeExistingGroupWithNoMembersWithNewConsumer` shuts down the consumer executor thread and then checks that the assignments returned by `describeGroup` contain the consume group with no members. But if the executor thread is shut down before any offsets are committed, the assignments returned by `describeGroup` doesn't contain the group at all. This PR waits for an offset commit by waiting for the group to appear in `describeGroup` assignments prior to shutting down the executor.