### PR TITLE
MINOR: log4j template should accept log_level

### DIFF
--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -48,7 +48,6 @@ class StreamsSimpleBenchmarkTest(Test):
         # SETUP PHASE
         #############
         self.zk = ZookeeperService(self.test_context, num_nodes=1)
-        self.zk.log_level = "INFO"
         self.zk.start()
         self.kafka = KafkaService(self.test_context, num_nodes=scale, zk=self.zk, version=DEV_BRANCH, topics={
             'simpleBenchmarkSourceTopic' : { 'partitions': scale, 'replication-factor': self.replication },

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -61,7 +61,7 @@ class StreamsSimpleBenchmarkTest(Test):
             'joinSourceTopic1KTableKTable' : { 'partitions': scale, 'replication-factor': self.replication },
             'joinSourceTopic2KTableKTable' : { 'partitions': scale, 'replication-factor': self.replication }
         })
-        self.kafka.log_level = "DEBUG"
+        self.kafka.log_level = "INFO"
         self.kafka.start()
  
         ################

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -48,6 +48,7 @@ class StreamsSimpleBenchmarkTest(Test):
         # SETUP PHASE
         #############
         self.zk = ZookeeperService(self.test_context, num_nodes=1)
+        self.zk.log_level = "INFO"
         self.zk.start()
         self.kafka = KafkaService(self.test_context, num_nodes=scale, zk=self.zk, version=DEV_BRANCH, topics={
             'simpleBenchmarkSourceTopic' : { 'partitions': scale, 'replication-factor': self.replication },
@@ -60,6 +61,7 @@ class StreamsSimpleBenchmarkTest(Test):
             'joinSourceTopic1KTableKTable' : { 'partitions': scale, 'replication-factor': self.replication },
             'joinSourceTopic2KTableKTable' : { 'partitions': scale, 'replication-factor': self.replication }
         })
+        self.kafka.log_level = "DEBUG"
         self.kafka.start()
  
         ################

--- a/tests/kafkatest/services/kafka/templates/log4j.properties
+++ b/tests/kafkatest/services/kafka/templates/log4j.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=DEBUG, stdout
+log4j.rootLogger={{ log_level|default("DEBUG") }}, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -106,32 +106,32 @@ log4j.appender.authorizerDebugAppender.layout.ConversionPattern=[%d] %p %m (%c)%
 log4j.appender.authorizerDebugAppender.Threshold=DEBUG
 
 # Turn on all our debugging info
-log4j.logger.kafka.producer.async.DefaultEventHandler=DEBUG, kafkaInfoAppender, kafkaDebugAppender
-log4j.logger.kafka.client.ClientUtils=DEBUG, kafkaInfoAppender, kafkaDebugAppender
-log4j.logger.kafka.perf=DEBUG, kafkaInfoAppender, kafkaDebugAppender
-log4j.logger.kafka.perf.ProducerPerformance$ProducerThread=DEBUG, kafkaInfoAppender, kafkaDebugAppender
-log4j.logger.org.I0Itec.zkclient.ZkClient=DEBUG, kafkaInfoAppender, kafkaDebugAppender
+log4j.logger.kafka.producer.async.DefaultEventHandler={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
+log4j.logger.kafka.client.ClientUtils={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
+log4j.logger.kafka.perf={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
+log4j.logger.kafka.perf.ProducerPerformance$ProducerThread={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
+log4j.logger.org.I0Itec.zkclient.ZkClient={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
 log4j.logger.kafka={{ log_level|default("DEBUG") }}, kafkaInfoAppender, kafkaDebugAppender
 
-log4j.logger.kafka.network.RequestChannel$=DEBUG, requestInfoAppender, requestDebugAppender
+log4j.logger.kafka.network.RequestChannel$={{ log_level|default("DEBUG") }}, requestInfoAppender, requestDebugAppender
 log4j.additivity.kafka.network.RequestChannel$=false
 
-log4j.logger.kafka.network.Processor=DEBUG, requestInfoAppender, requestDebugAppender
-log4j.logger.kafka.server.KafkaApis=DEBUG, requestInfoAppender, requestDebugAppender
+log4j.logger.kafka.network.Processor={{ log_level|default("DEBUG") }}, requestInfoAppender, requestDebugAppender
+log4j.logger.kafka.server.KafkaApis={{ log_level|default("DEBUG") }}, requestInfoAppender, requestDebugAppender
 log4j.additivity.kafka.server.KafkaApis=false
-log4j.logger.kafka.request.logger=DEBUG, requestInfoAppender, requestDebugAppender
+log4j.logger.kafka.request.logger={{ log_level|default("DEBUG") }}, requestInfoAppender, requestDebugAppender
 log4j.additivity.kafka.request.logger=false
 
-log4j.logger.kafka.controller=DEBUG, controllerInfoAppender, controllerDebugAppender
+log4j.logger.kafka.controller={{ log_level|default("DEBUG") }}, controllerInfoAppender, controllerDebugAppender
 log4j.additivity.kafka.controller=false
 
-log4j.logger.kafka.log.LogCleaner=DEBUG, cleanerInfoAppender, cleanerDebugAppender
+log4j.logger.kafka.log.LogCleaner={{ log_level|default("DEBUG") }}, cleanerInfoAppender, cleanerDebugAppender
 log4j.additivity.kafka.log.LogCleaner=false
 
-log4j.logger.state.change.logger=DEBUG, stateChangeInfoAppender, stateChangeDebugAppender
+log4j.logger.state.change.logger={{ log_level|default("DEBUG") }}, stateChangeInfoAppender, stateChangeDebugAppender
 log4j.additivity.state.change.logger=false
 
 #Change this to debug to get the actual audit log for authorizer.
-log4j.logger.kafka.authorizer.logger=DEBUG, authorizerInfoAppender, authorizerDebugAppender
+log4j.logger.kafka.authorizer.logger={{ log_level|default("DEBUG") }}, authorizerInfoAppender, authorizerDebugAppender
 log4j.additivity.kafka.authorizer.logger=false
 


### PR DESCRIPTION
The log_level parameter is used in system tests in kafka.py. However the log4j template accepted that parameter in only one place. This led to a large number of DEBUG lines printed even when the intention was to capture only INFO lines. Led to huge log files. Thanks to @ijuma for noticing this.