### PR TITLE
MINOR: Fix docs; client no longer uses yammer metrics

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -686,7 +686,7 @@
 
   <h3><a id="monitoring" href="#monitoring">6.6 Monitoring</a></h3>
 
-  Kafka uses Yammer Metrics for metrics reporting in both the server and the client. This can be configured to report stats using pluggable stats reporters to hook up to your monitoring system.
+  Kafka uses Yammer Metrics for metrics reporting in the server and a custom metrics registry in the client. Both expose metrics via JMX and can be configured to report stats using pluggable stats reporters to hook up to your monitoring system.
   <p>
   The easiest way to see the available metrics is to fire up jconsole and point it at a running kafka client or server; this will allow browsing all metrics with JMX.
   <p>

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -686,7 +686,7 @@
 
   <h3><a id="monitoring" href="#monitoring">6.6 Monitoring</a></h3>
 
-  Kafka uses Yammer Metrics for metrics reporting in the server and a custom metrics registry in the client. Both expose metrics via JMX and can be configured to report stats using pluggable stats reporters to hook up to your monitoring system.
+  Kafka uses Yammer Metrics for metrics reporting in the server. The client library uses Kafka Metrics, a built-in metrics registry that minimizes transitive dependencies pulled into client applications. Both expose metrics via JMX and can be configured to report stats using pluggable stats reporters to hook up to your monitoring system.
   <p>
   The easiest way to see the available metrics is to fire up jconsole and point it at a running kafka client or server; this will allow browsing all metrics with JMX.
   <p>


### PR DESCRIPTION
Yammer metrics is no longer a dependency of the client, but the Monitoring section of the docs contradicts this. For quite some time, clients have been using an internal metrics system unrelated to Yammer/Dropwizard metrics.

This contribution is my original work and I license the work to the project under the project's open source license.