### PR TITLE
KAFKA-5394. KafkaAdminClient#timeoutCallsInFlight does not work as ex…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -86,7 +86,17 @@ public interface KafkaClient extends Closeable {
     List<ClientResponse> poll(long timeout, long now);
 
     /**
+     * Diconnects the connection to a particular node, if there is one.
+     * Any pending ClientRequests for this connection will receive disconnections.
+     *
+     * @param nodeId The id of the node
+     */
+    void disconnect(String nodeId);
+
+    /**
      * Closes the connection to a particular node (if there is one).
+     * All requests on the connection will be cleared.  ClientRequest callbacks will not be invoked
+     * for the cleared requests, nor will they be returned from poll().
      *
      * @param nodeId The id of the node
      */

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -227,7 +227,37 @@ public class NetworkClient implements KafkaClient {
     }
 
     /**
+     * Diconnects the connection to a particular node, if there is one.
+     * Any pending ClientRequests for this connection will receive disconnections.
+     *
+     * @param nodeId The id of the node
+     */
+    @Override
+    public void disconnect(String nodeId) {
+        selector.close(nodeId);
+        List<ApiKeys> requestTypes = new ArrayList<>();
+        long now = time.milliseconds();
+        for (InFlightRequest request : inFlightRequests.clearAll(nodeId)) {
+            if (request.isInternalRequest && request.header.apiKey() == ApiKeys.METADATA.id)
+                metadataUpdater.handleDisconnection(request.destination);
+            else {
+                requestTypes.add(ApiKeys.forId(request.header.apiKey()));
+                abortedSends.add(new ClientResponse(request.header,
+                        request.callback, request.destination, request.createdTimeMs, now,
+                        true, null, null));
+            }
+        }
+        connectionStates.remove(nodeId);
+        if (log.isDebugEnabled()) {
+            log.debug("Manually disconnected from {}.  Removed requests: {}.", nodeId,
+                Utils.join(requestTypes, ", "));
+        }
+    }
+
+    /**
      * Closes the connection to a particular node (if there is one).
+     * All requests on the connection will be cleared.  ClientRequest callbacks will not be invoked
+     * for the cleared requests, nor will they be returned from poll().
      *
      * @param nodeId The id of the node
      */

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -227,7 +227,7 @@ public class NetworkClient implements KafkaClient {
     }
 
     /**
-     * Diconnects the connection to a particular node, if there is one.
+     * Disconnects the connection to a particular node, if there is one.
      * Any pending ClientRequests for this connection will receive disconnections.
      *
      * @param nodeId The id of the node

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -44,7 +44,7 @@ public abstract class AdminClient implements AutoCloseable {
      * @return The new KafkaAdminClient.
      */
     public static AdminClient create(Properties props) {
-        return KafkaAdminClient.createInternal(new AdminClientConfig(props));
+        return KafkaAdminClient.createInternal(new AdminClientConfig(props), null);
     }
 
     /**
@@ -54,7 +54,7 @@ public abstract class AdminClient implements AutoCloseable {
      * @return The new KafkaAdminClient.
      */
     public static AdminClient create(Map<String, Object> conf) {
-        return KafkaAdminClient.createInternal(new AdminClientConfig(conf));
+        return KafkaAdminClient.createInternal(new AdminClientConfig(conf), null);
     }
 
     /**
@@ -106,7 +106,7 @@ public abstract class AdminClient implements AutoCloseable {
                                                     CreateTopicsOptions options);
 
     /**
-     * Similar to #{@link AdminClient#deleteTopics(Collection<String>, DeleteTopicsOptions),
+     * Similar to #{@link AdminClient#deleteTopics(Collection<String>, DeleteTopicsOptions)},
      * but uses the default options.
      *
      * @param topics            The topic names to delete.
@@ -213,7 +213,7 @@ public abstract class AdminClient implements AutoCloseable {
     public abstract ApiVersionsResult apiVersions(Collection<Node> nodes, ApiVersionsOptions options);
 
     /**
-     * Similar to #{@link AdminClient#describeAcls(AclBindingFilter, DescribeAclsOptions),
+     * Similar to #{@link AdminClient#describeAcls(AclBindingFilter, DescribeAclsOptions)},
      * but uses the default options.
      *
      * @param filter            The filter to use.
@@ -236,7 +236,7 @@ public abstract class AdminClient implements AutoCloseable {
     public abstract DescribeAclsResult describeAcls(AclBindingFilter filter, DescribeAclsOptions options);
 
     /**
-     * Similar to #{@link AdminClient#createAcls(Collection<AclBinding>, CreateAclsOptions),
+     * Similar to #{@link AdminClient#createAcls(Collection<AclBinding>, CreateAclsOptions)},
      * but uses the default options.
      *
      * @param acls              The ACLs to create
@@ -259,7 +259,7 @@ public abstract class AdminClient implements AutoCloseable {
     public abstract CreateAclsResult createAcls(Collection<AclBinding> acls, CreateAclsOptions options);
 
     /**
-     * Similar to #{@link AdminClient#deleteAcls(Collection<AclBinding>, DeleteAclsOptions),
+     * Similar to #{@link AdminClient#deleteAcls(Collection<AclBinding>, DeleteAclsOptions)},
      * but uses the default options.
      *
      * @param filters           The filters to use.
@@ -334,5 +334,4 @@ public abstract class AdminClient implements AutoCloseable {
      * @return                The AlterConfigsResult
      */
     public abstract AlterConfigsResult alterConfigs(Map<ConfigResource, Config> configs, AlterConfigsOptions options);
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -165,7 +165,7 @@ public class AdminClientConfig extends AbstractConfig {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
     }
 
-    AdminClientConfig(Map<?, ?> props) {
+    public AdminClientConfig(Map<?, ?> props) {
         super(CONFIG, props);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -180,6 +180,11 @@ public class KafkaAdminClient extends AdminClient {
     private final AtomicLong hardShutdownTimeMs = new AtomicLong(INVALID_SHUTDOWN_TIME);
 
     /**
+     * A factory which creates TimeoutProcessors for the RPC thread.
+     */
+    private final TimeoutProcessorFactory timeoutProcessorFactory;
+
+    /**
      * Get or create a list value from a map.
      *
      * @param map   The map to get or create the element from.
@@ -270,7 +275,7 @@ public class KafkaAdminClient extends AdminClient {
         return throwable.getClass().getSimpleName();
     }
 
-    static KafkaAdminClient createInternal(AdminClientConfig config) {
+    static KafkaAdminClient createInternal(AdminClientConfig config, TimeoutProcessorFactory timeoutProcessorFactory) {
         Metadata metadata = null;
         Metrics metrics = null;
         NetworkClient networkClient = null;
@@ -312,7 +317,8 @@ public class KafkaAdminClient extends AdminClient {
                 true,
                 apiVersions);
             channelBuilder = null;
-            return new KafkaAdminClient(config, clientId, time, metadata, metrics, networkClient);
+            return new KafkaAdminClient(config, clientId, time, metadata, metrics, networkClient,
+                timeoutProcessorFactory);
         } catch (Throwable exc) {
             closeQuietly(metrics, "Metrics");
             closeQuietly(networkClient, "NetworkClient");
@@ -329,7 +335,7 @@ public class KafkaAdminClient extends AdminClient {
 
         try {
             metrics = new Metrics(new MetricConfig(), new LinkedList<MetricsReporter>(), time);
-            return new KafkaAdminClient(config, clientId, time, metadata, metrics, client);
+            return new KafkaAdminClient(config, clientId, time, metadata, metrics, client, null);
         } catch (Throwable exc) {
             closeQuietly(metrics, "Metrics");
             throw new KafkaException("Failed create new KafkaAdminClient", exc);
@@ -337,7 +343,7 @@ public class KafkaAdminClient extends AdminClient {
     }
 
     private KafkaAdminClient(AdminClientConfig config, String clientId, Time time, Metadata metadata,
-                     Metrics metrics, KafkaClient client) {
+                     Metrics metrics, KafkaClient client, TimeoutProcessorFactory timeoutProcessorFactory) {
         this.defaultTimeoutMs = config.getInt(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.clientId = clientId;
         this.time = time;
@@ -350,6 +356,8 @@ public class KafkaAdminClient extends AdminClient {
         this.runnable = new AdminClientRunnable();
         String threadName = "kafka-admin-client-thread" + (clientId.length() > 0 ? " | " + clientId : "");
         this.thread = new KafkaThread(threadName, runnable, false);
+        this.timeoutProcessorFactory = (timeoutProcessorFactory == null) ?
+            new TimeoutProcessorFactory() : timeoutProcessorFactory;
         config.logUnused();
         log.debug("Created Kafka admin client {}", this.clientId);
         thread.start();
@@ -449,7 +457,7 @@ public class KafkaAdminClient extends AdminClient {
         }
     }
 
-    private abstract class Call {
+    abstract class Call {
         private final String callName;
         private final long deadlineMs;
         private final NodeProvider nodeProvider;
@@ -557,6 +565,79 @@ public class KafkaAdminClient extends AdminClient {
         }
     }
 
+    static class TimeoutProcessorFactory {
+        TimeoutProcessor create(long now) {
+            return new TimeoutProcessor(now);
+        }
+    }
+
+    static class TimeoutProcessor {
+        /**
+         * The current time in milliseconds.
+         */
+        private final long now;
+
+        /**
+         * The number of milliseconds until the next timeout.
+         */
+        private int nextTimeoutMs;
+
+        /**
+         * Create a new timeout processor.
+         *
+         * @param now           The current time in milliseconds since the epoch.
+         */
+        TimeoutProcessor(long now) {
+            this.now = now;
+            this.nextTimeoutMs = Integer.MAX_VALUE;
+        }
+
+        /**
+         * Check for calls which have timed out.
+         * Timed out calls will be removed and failed.
+         * The remaining milliseconds until the next timeout will be updated.
+         *
+         * @param calls         The collection of calls.
+         *
+         * @return              The number of calls which were timed out.
+         */
+        int handleTimeouts(Collection<Call> calls, String msg) {
+            int numTimedOut = 0;
+            for (Iterator<Call> iter = calls.iterator(); iter.hasNext(); ) {
+                Call call = iter.next();
+                int remainingMs = calcTimeoutMsRemainingAsInt(now, call.deadlineMs);
+                if (remainingMs < 0) {
+                    call.fail(now, new TimeoutException(msg));
+                    iter.remove();
+                    numTimedOut++;
+                } else {
+                    nextTimeoutMs = Math.min(nextTimeoutMs, remainingMs);
+                }
+            }
+            return numTimedOut;
+        }
+
+        /**
+         * Check whether a call should be timed out.
+         * The remaining milliseconds until the next timeout will be updated.
+         *
+         * @param call      The call.
+         *
+         * @return          True if the call should be timed out.
+         */
+        boolean callHasExpired(Call call) {
+            int remainingMs = calcTimeoutMsRemainingAsInt(now, call.deadlineMs);
+            if (remainingMs < 0)
+                return true;
+            nextTimeoutMs = Math.min(nextTimeoutMs, remainingMs);
+            return false;
+        }
+
+        int nextTimeoutMs() {
+            return nextTimeoutMs;
+        }
+    }
+
     private final class AdminClientRunnable implements Runnable {
         /**
          * Pending calls.  Protected by the object monitor.
@@ -590,73 +671,6 @@ public class KafkaAdminClient extends AdminClient {
                 log.trace("{}: metadata is now ready.", clientId);
             }
             return null;
-        }
-
-        private class TimeoutProcessor {
-            /**
-             * The current time in milliseconds.
-             */
-            private final long now;
-
-            /**
-             * The number of milliseconds until the next timeout.
-             */
-            private int nextTimeoutMs;
-
-            /**
-             * Create a new timeout processor.
-             *
-             * @param now           The current time in milliseconds since the epoch.
-             */
-            TimeoutProcessor(long now) {
-                this.now = now;
-                this.nextTimeoutMs = Integer.MAX_VALUE;
-            }
-
-            /**
-             * Check for calls which have timed out.
-             * Timed out calls will be removed and failed.
-             * The remaining milliseconds until the next timeout will be updated.
-             *
-             * @param calls         The collection of calls.
-             *
-             * @return              The number of calls which were timed out.
-             */
-            int handleTimeouts(Collection<Call> calls, String msg) {
-                int numTimedOut = 0;
-                for (Iterator<Call> iter = calls.iterator(); iter.hasNext(); ) {
-                    Call call = iter.next();
-                    int remainingMs = calcTimeoutMsRemainingAsInt(now, call.deadlineMs);
-                    if (remainingMs < 0) {
-                        call.fail(now, new TimeoutException(msg));
-                        iter.remove();
-                        numTimedOut++;
-                    } else {
-                        nextTimeoutMs = Math.min(nextTimeoutMs, remainingMs);
-                    }
-                }
-                return numTimedOut;
-            }
-
-            /**
-             * Check whether a call should be timed out.
-             * The remaining milliseconds until the next timeout will be updated.
-             *
-             * @param call      The call.
-             *
-             * @return          True if the call should be timed out.
-             */
-            boolean callHasExpired(Call call) {
-                int remainingMs = calcTimeoutMsRemainingAsInt(now, call.deadlineMs);
-                if (remainingMs < 0)
-                    return true;
-                nextTimeoutMs = Math.min(nextTimeoutMs, remainingMs);
-                return false;
-            }
-
-            int nextTimeoutMs() {
-                return nextTimeoutMs;
-            }
         }
 
         /**
@@ -800,7 +814,7 @@ public class KafkaAdminClient extends AdminClient {
                 Call call = contexts.get(0);
                 if (processor.callHasExpired(call)) {
                     log.debug("{}: Closing connection to {} to time out {}", clientId, nodeId, call);
-                    client.close(nodeId);
+                    client.disconnect(nodeId);
                     numTimedOut++;
                     // We don't remove anything from the callsInFlight data structure.  Because the connection
                     // has been closed, the calls should be returned by the next client#poll(),
@@ -830,7 +844,7 @@ public class KafkaAdminClient extends AdminClient {
                     // an internal server error has occurred.  Close the connection and log an error message.
                     log.error("Internal server error on {}: server returned information about unknown " +
                         "correlation ID {}", response.destination(), correlationId);
-                    client.close(response.destination());
+                    client.disconnect(response.destination());
                     continue;
                 }
 
@@ -908,7 +922,7 @@ public class KafkaAdminClient extends AdminClient {
                     break;
 
                 // Handle timeouts.
-                TimeoutProcessor timeoutProcessor = new TimeoutProcessor(now);
+                TimeoutProcessor timeoutProcessor = timeoutProcessorFactory.create(now);
                 timeoutNewCalls(timeoutProcessor);
                 timeoutCallsToSend(timeoutProcessor, callsToSend);
                 timeoutCallsInFlight(timeoutProcessor, callsInFlight);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -843,7 +843,8 @@ public class KafkaAdminClient extends AdminClient {
                     // If the server returns information about a correlation ID we didn't use yet,
                     // an internal server error has occurred.  Close the connection and log an error message.
                     log.error("Internal server error on {}: server returned information about unknown " +
-                        "correlation ID {}", response.destination(), correlationId);
+                        "correlation ID {}.  requestHeader = {}", response.destination(), correlationId,
+                        response.requestHeader());
                     client.disconnect(response.destination());
                     continue;
                 }

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -126,6 +126,7 @@ public class MockClient implements KafkaClient {
         return isBlackedOut(node);
     }
 
+    @Override
     public void disconnect(String node) {
         long now = time.milliseconds();
         Iterator<ClientRequest> iter = requests.iterator();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -59,7 +59,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -363,7 +362,7 @@ public class KafkaAdminClientTest {
 
         synchronized boolean shouldInjectFailure() {
             numTries++;
-            return (numTries == 3);
+            return numTries == 3;
         }
 
         private int numTries = 0;


### PR DESCRIPTION
…pected

* Rename KafkaClient#close to KafkaClient#forget to emphasize that it forgets the requests on a given connection.
* Create KafkaClient#disconnect to tear down a connection and deliver disconnects to all the requests on it.
* AdminClient.java: fix mismatched braces in JavaDoc.
* Make the AdminClientConfig constructor visible for testing.
* KafkaAdminClient: add TimeoutProcessorFactory to make the TimeoutProcessor swappable for testing.
* Make TimeoutProcessor a static class rather than an inner class.