### PR TITLE
KAFKA-5385: ProducerBatch expiry should go through Sender.failBatch

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -275,7 +275,7 @@ public final class ProducerBatch {
 
         boolean expired = expiryErrorMessage != null;
         if (expired)
-            close();
+            abort();
         return expired;
     }
 
@@ -284,7 +284,7 @@ public final class ProducerBatch {
      * the exception returned by this method.
      * @return An exception indicating the batch expired.
      */
-    RuntimeException timeoutException() {
+    TimeoutException timeoutException() {
         if (expiryErrorMessage == null)
             throw new IllegalStateException("Batch has not expired");
         return new TimeoutException("Expiring " + recordCount + " record(s) for " + topicPartition + ": " + expiryErrorMessage);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerBatch.java
@@ -264,7 +264,6 @@ public final class ProducerBatch {
      *     <li> the batch is in retry AND request timeout has elapsed after the backoff period ended.
      * </ol>
      * This methods closes this batch and sets {@code expiryErrorMessage} if the batch has timed out.
-     * {@link #expirationDone()} must be invoked to complete the produce future and invoke callbacks.
      */
     boolean maybeExpire(int requestTimeoutMs, long retryBackoffMs, long now, long lingerMs, boolean isFull) {
         if (!this.inRetry() && isFull && requestTimeoutMs < (now - this.lastAppendTime))
@@ -281,15 +280,14 @@ public final class ProducerBatch {
     }
 
     /**
-     * Completes the produce future with timeout exception and invokes callbacks.
-     * This method should be invoked only if {@link #maybeExpire(int, long, long, long, boolean)}
-     * returned true.
+     * If {@link #maybeExpire(int, long, long, long, boolean)} returned true, the sender will fail the batch with
+     * the exception returned by this method.
+     * @return An exception indicating the batch expired.
      */
-    void expirationDone() {
+    RuntimeException timeoutException() {
         if (expiryErrorMessage == null)
             throw new IllegalStateException("Batch has not expired");
-        this.done(-1L, NO_TIMESTAMP,
-                  new TimeoutException("Expiring " + recordCount + " record(s) for " + topicPartition + ": " + expiryErrorMessage));
+        return new TimeoutException("Expiring " + recordCount + " record(s) for " + topicPartition + ": " + expiryErrorMessage);
     }
 
     int attempts() {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java
@@ -263,12 +263,10 @@ public final class RecordAccumulator {
     }
 
     /**
-     * Abort the batches that have been sitting in RecordAccumulator for more than the configured requestTimeout
-     * due to metadata being unavailable
+     * Get a list of batches which have been sitting in the accumulator too long and need to be expired.
      */
-    public List<ProducerBatch> abortExpiredBatches(int requestTimeout, long now) {
+    public List<ProducerBatch> expiredBatches(int requestTimeout, long now) {
         List<ProducerBatch> expiredBatches = new ArrayList<>();
-        int count = 0;
         for (Map.Entry<TopicPartition, Deque<ProducerBatch>> entry : this.batches.entrySet()) {
             Deque<ProducerBatch> dq = entry.getValue();
             TopicPartition tp = entry.getKey();
@@ -290,7 +288,6 @@ public final class RecordAccumulator {
                         // callbacks are invoked.
                         if (batch.maybeExpire(requestTimeout, retryBackoffMs, now, this.lingerMs, isFull)) {
                             expiredBatches.add(batch);
-                            count++;
                             batchIterator.remove();
                         } else {
                             // Stop at the first batch that has not expired.
@@ -300,14 +297,6 @@ public final class RecordAccumulator {
                 }
             }
         }
-        if (!expiredBatches.isEmpty()) {
-            log.trace("Expired {} batches in accumulator", count);
-            for (ProducerBatch batch : expiredBatches) {
-                batch.expirationDone();
-                deallocate(batch);
-            }
-        }
-
         return expiredBatches;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -265,6 +265,8 @@ public class Sender implements Runnable {
         // Reset the producer id if an expired batch has previously been sent to the broker. Also update the metrics
         // for expired batches. see the documentation of @TransactionState.resetProducerId to understand why
         // we need to reset the producer id here.
+        if (!expiredBatches.isEmpty())
+            log.trace("Expired {} batches in accumulator", expiredBatches.size());
         for (ProducerBatch expiredBatch : expiredBatches) {
             failBatch(expiredBatch, -1, NO_TIMESTAMP, expiredBatch.timeoutException());
             if (transactionManager != null && expiredBatch.inRetry()) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -66,6 +66,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
+
 /**
  * The background thread that handles the sending of produce requests to the Kafka cluster. This thread makes metadata
  * requests to renew its view of the cluster and then sends produce requests to the appropriate nodes.
@@ -257,13 +259,14 @@ public class Sender implements Runnable {
             }
         }
 
-        List<ProducerBatch> expiredBatches = this.accumulator.abortExpiredBatches(this.requestTimeout, now);
+        List<ProducerBatch> expiredBatches = this.accumulator.expiredBatches(this.requestTimeout, now);
 
         boolean needsTransactionStateReset = false;
         // Reset the producer id if an expired batch has previously been sent to the broker. Also update the metrics
         // for expired batches. see the documentation of @TransactionState.resetProducerId to understand why
         // we need to reset the producer id here.
         for (ProducerBatch expiredBatch : expiredBatches) {
+            failBatch(expiredBatch, -1, NO_TIMESTAMP, expiredBatch.timeoutException());
             if (transactionManager != null && expiredBatch.inRetry()) {
                 needsTransactionStateReset = true;
             }
@@ -573,13 +576,17 @@ public class Sender implements Runnable {
     }
 
     private void failBatch(ProducerBatch batch, ProduceResponse.PartitionResponse response, RuntimeException exception) {
+        failBatch(batch, response.baseOffset, response.logAppendTime, exception);
+    }
+
+    private void failBatch(ProducerBatch batch, long baseOffset, long logAppendTime, RuntimeException exception) {
         if (transactionManager != null) {
             if (exception instanceof OutOfOrderSequenceException
                     && !transactionManager.isTransactional()
                     && transactionManager.hasProducerId(batch.producerId())) {
                 log.error("The broker received an out of order sequence number for topic-partition " +
                                 "{} at offset {}. This indicates data loss on the broker, and should be investigated.",
-                        batch.topicPartition, response.baseOffset);
+                        batch.topicPartition, baseOffset);
 
                 // Reset the transaction state since we have hit an irrecoverable exception and cannot make any guarantees
                 // about the previously committed message. Note that this will discard the producer id and sequence
@@ -593,8 +600,7 @@ public class Sender implements Runnable {
                 transactionManager.transitionToAbortableError(exception);
             }
         }
-
-        batch.done(response.baseOffset, response.logAppendTime, exception);
+        batch.done(baseOffset, logAppendTime, exception);
         this.accumulator.deallocate(batch);
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -1005,5 +1005,4 @@ public class TransactionManager {
                 reenqueue();
         }
     }
-
 }

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -1404,11 +1404,11 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
-        assertFalse(transactionManager.sendToPartitionAllowed(tp0));
+        assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
         sender.run(time.milliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
-        assertTrue(transactionManager.sendToPartitionAllowed(tp0));
+        assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(responseFuture.isDone());
 
         // Sleep 10 seconds to make sure that the batches in the queue would be expired if they can't be drained.
@@ -1450,11 +1450,11 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxnResponse(Errors.NONE, tp0, epoch, pid);
 
         assertFalse(transactionManager.transactionContainsPartition(tp0));
-        assertFalse(transactionManager.sendToPartitionAllowed(tp0));
+        assertFalse(transactionManager.isSendToPartitionAllowed(tp0));
         sender.run(time.milliseconds());  // send addPartitions.
         // Check that only addPartitions was sent.
         assertTrue(transactionManager.transactionContainsPartition(tp0));
-        assertTrue(transactionManager.sendToPartitionAllowed(tp0));
+        assertTrue(transactionManager.isSendToPartitionAllowed(tp0));
         assertFalse(responseFuture.isDone());
 
         TransactionalRequestResult commitResult = transactionManager.beginCommittingTransaction();

--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -29,10 +29,12 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -180,6 +182,16 @@ public class TransactionalMessageCopier {
         return positions;
     }
 
+    private static void resetToLastCommittedPositions(KafkaConsumer<String, String> consumer) {
+        for (TopicPartition topicPartition : consumer.assignment()) {
+            OffsetAndMetadata offsetAndMetadata = consumer.committed(topicPartition);
+            if (offsetAndMetadata != null)
+                consumer.seek(topicPartition, offsetAndMetadata.offset());
+            else
+                consumer.seekToBeginning(Collections.singletonList(topicPartition));
+        }
+    }
+
     private static long messagesRemaining(KafkaConsumer<String, String> consumer, TopicPartition partition) {
         long currentPosition = consumer.position(partition);
         Map<TopicPartition, Long> endOffsets = consumer.endOffsets(Arrays.asList(partition));
@@ -235,11 +247,9 @@ public class TransactionalMessageCopier {
 
         producer.initTransactions();
 
-
         final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
         final AtomicLong remainingMessages = new AtomicLong(maxMessages);
         final AtomicLong numMessagesProcessed = new AtomicLong(0);
-        int exitCode = 0;
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
@@ -260,18 +270,22 @@ public class TransactionalMessageCopier {
                     break;
                 int messagesInCurrentTransaction = 0;
                 long numMessagesForNextTransaction = Math.min(numMessagesPerTransaction, remainingMessages.get());
-                producer.beginTransaction();
-
-                while (messagesInCurrentTransaction < numMessagesForNextTransaction) {
-                    ConsumerRecords<String, String> records = consumer.poll(200L);
-                    for (ConsumerRecord<String, String> record : records) {
-                        producer.send(producerRecordFromConsumerRecord(outputTopic, record));
-                        messagesInCurrentTransaction++;
+                try {
+                    producer.beginTransaction();
+                    while (messagesInCurrentTransaction < numMessagesForNextTransaction) {
+                        ConsumerRecords<String, String> records = consumer.poll(200L);
+                        for (ConsumerRecord<String, String> record : records) {
+                            producer.send(producerRecordFromConsumerRecord(outputTopic, record));
+                            messagesInCurrentTransaction++;
+                        }
                     }
+                    producer.sendOffsetsToTransaction(consumerPositions(consumer), consumerGroup);
+                    producer.commitTransaction();
+                    remainingMessages.set(maxMessages - numMessagesProcessed.addAndGet(messagesInCurrentTransaction));
+                } catch (KafkaException e) {
+                    producer.abortTransaction();
+                    resetToLastCommittedPositions(consumer);
                 }
-                producer.sendOffsetsToTransaction(consumerPositions(consumer), consumerGroup);
-                producer.commitTransaction();
-                remainingMessages.set(maxMessages - numMessagesProcessed.addAndGet(messagesInCurrentTransaction));
             }
         } finally {
             producer.close();
@@ -279,6 +293,6 @@ public class TransactionalMessageCopier {
                 consumer.close();
             }
         }
-        System.exit(exitCode);
+        System.exit(0);
     }
 }


### PR DESCRIPTION
Before this patch, we would call `producerBatch.done` directly from the accumulator when expiring batches. This meant that we would not transition to the `ABORTABLE_ERROR` state in the transaction manager, allowing other transactional requests (including Commits!) to go through, even though the produce failed. 

This patch modifies the logic so that we call `Sender.failBatch` on every expired batch, thus ensuring that the transaction state is accurate. 