### PR TITLE
KAFKA-5395: Remove synchronization from AbstractCoordinator.close, remove duplication

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -664,7 +664,7 @@ public abstract class AbstractCoordinator implements Closeable {
      * Close the coordinator, waiting if needed to send LeaveGroup.
      */
     @Override
-    public synchronized void close() {
+    public final void close() {
         close(0);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -290,11 +290,6 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
         return JoinGroupRequest.UNKNOWN_MEMBER_ID;
     }
 
-    @Override
-    public void close() {
-        super.close();
-    }
-
     private boolean isLeader() {
         return assignmentSnapshot != null && memberId().equals(assignmentSnapshot.leader());
     }


### PR DESCRIPTION
Cherry-picked from trunk.