### PR TITLE
MINOR: set group initial rebalance delay to 0 in server.properties

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -132,7 +132,8 @@ zookeeper.connection.timeout.ms=6000
 ############################# Group Coordinator Settings #############################
 
 # The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
-# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of <code>max.poll.interval.ms</code>.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
 # The default value for this is 3 seconds.
-# During development and testing it might be desirable to set this to 0 inorder to not delay test execution time.
+# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
 group.initial.rebalance.delay.ms=0

--- a/config/server.properties
+++ b/config/server.properties
@@ -129,3 +129,10 @@ zookeeper.connect=localhost:2181
 zookeeper.connection.timeout.ms=6000
 
 
+############################# Group Coordinator Settings #############################
+
+# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of <code>max.poll.interval.ms</code>.
+# The default value for this is 3 seconds.
+# During development and testing it might be desirable to set this to 0 inorder to not delay test execution time.
+group.initial.rebalance.delay.ms=0


### PR DESCRIPTION
override the setting of `group.initial.rebalance.delay` in server.properties