### PR TITLE
KAFKA-3741: add min.insync.replicas config to Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -266,7 +266,7 @@ public class StreamsConfig extends AbstractConfig {
     public static final String ZOOKEEPER_CONNECT_CONFIG = "zookeeper.connect";
     private static final String ZOOKEEPER_CONNECT_DOC = "Zookeeper connect string for Kafka topics management.";
 
-    /** {@code replication.factor} */
+    /** {@code min.insync.replicas} */
     public static final String MIN_IN_SYNC_REPLICAS_CONFIG = "min.insync.replicas";
     private static final String MIN_IN_SYNC_REPLICAS_DOC = "The minimum number of insync replicas for change log topics and repartition topics created by the stream processing application.";
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -229,6 +229,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         internalTopicManager = new InternalTopicManager(
                 new StreamsKafkaClient(this.streamThread.config),
                 configs.containsKey(StreamsConfig.REPLICATION_FACTOR_CONFIG) ? (Integer) configs.get(StreamsConfig.REPLICATION_FACTOR_CONFIG) : 1,
+                (Integer) configs.get(StreamsConfig.MIN_IN_SYNC_REPLICAS_CONFIG),
                 configs.containsKey(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG) ?
                         (Long) configs.get(StreamsConfig.WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG)
                         : WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsKafkaClient.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsKafkaClient.java
@@ -153,8 +153,11 @@ public class StreamsKafkaClient {
     /**
      * Create a set of new topics using batch request.
      */
-    public void createTopics(final Map<InternalTopicConfig, Integer> topicsMap, final int replicationFactor,
-                             final long windowChangeLogAdditionalRetention, final MetadataResponse metadata) {
+    public void createTopics(final Map<InternalTopicConfig, Integer> topicsMap,
+                             final int replicationFactor,
+                             final long windowChangeLogAdditionalRetention,
+                             final MetadataResponse metadata,
+                             final Integer minInsyncReplicas) {
 
         final Map<String, CreateTopicsRequest.TopicDetails> topicRequestDetails = new HashMap<>();
         for (Map.Entry<InternalTopicConfig, Integer> entry : topicsMap.entrySet()) {
@@ -162,6 +165,9 @@ public class StreamsKafkaClient {
             Integer partitions = entry.getValue();
             final Properties topicProperties = internalTopicConfig.toProperties(windowChangeLogAdditionalRetention);
             final Map<String, String> topicConfig = new HashMap<>();
+            if (minInsyncReplicas != null) {
+                topicConfig.put(StreamsConfig.MIN_IN_SYNC_REPLICAS_CONFIG, minInsyncReplicas.toString());
+            }
             for (String key : topicProperties.stringPropertyNames()) {
                 topicConfig.put(key, topicProperties.getProperty(key));
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -56,21 +56,21 @@ public class InternalTopicManagerTest {
 
     @Test
     public void shouldReturnCorrectPartitionCounts() throws Exception {
-        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1,
+        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1, 1,
             WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
         Assert.assertEquals(Collections.singletonMap(topic, 1), internalTopicManager.getNumPartitions(Collections.singleton(topic)));
     }
 
     @Test
     public void shouldCreateRequiredTopics() throws Exception {
-        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1,
+        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1, null,
             WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
         internalTopicManager.makeReady(Collections.singletonMap(new InternalTopicConfig(topic, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 1));
     }
 
     @Test
     public void shouldNotCreateTopicIfExistsWithDifferentPartitions() throws Exception {
-        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1,
+        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1, null,
             WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
         boolean exceptionWasThrown = false;
         try {
@@ -100,7 +100,7 @@ public class InternalTopicManagerTest {
 
         @Override
         public void createTopics(final Map<InternalTopicConfig, Integer> topicsMap, final int replicationFactor,
-                                 final long windowChangeLogAdditionalRetention, final MetadataResponse metadata) {
+                                 final long windowChangeLogAdditionalRetention, final MetadataResponse metadata, final Integer minInsyncReplicas) {
             // do nothing
         }
 

--- a/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockInternalTopicManager.java
@@ -38,7 +38,7 @@ public class MockInternalTopicManager extends InternalTopicManager {
     private MockConsumer<byte[], byte[]> restoreConsumer;
 
     public MockInternalTopicManager(StreamsConfig streamsConfig, MockConsumer<byte[], byte[]> restoreConsumer) {
-        super(new StreamsKafkaClient(streamsConfig), 0, 0, new MockTime());
+        super(new StreamsKafkaClient(streamsConfig), 0, null, 0, new MockTime());
 
         this.restoreConsumer = restoreConsumer;
     }


### PR DESCRIPTION
Allow users to specify `min.insync.replicas` via StreamsConfig. Default to `null` so that the server settting will be used. If `replication.factor` is lower than `min.insync.replicas` then set `min.insync.replicas` to `replication.factor`