### PR TITLE
MINOR: Updated .gitignore for excluding out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ tests/venv
 docs/generated/
 
 .release-settings.json
+
+out


### PR DESCRIPTION
While building the project using IntelliJ IDEA, the "out" directory is generated but not excluded for commit by the .gitignore. Someone could accidentally commit it. This PR add the "out" directory into the .gitignore.