### PR TITLE
Fixed path to log4j config file

### DIFF
--- a/bin/windows/zookeeper-server-start.bat
+++ b/bin/windows/zookeeper-server-start.bat
@@ -21,7 +21,7 @@ IF [%1] EQU [] (
 
 SetLocal
 IF ["%KAFKA_LOG4J_OPTS%"] EQU [""] (
-    set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:%~dp0../../config/log4j.properties
+    set KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:///%~dp0../../config/log4j.properties
 )
 IF ["%KAFKA_HEAP_OPTS%"] EQU [""] (
     set KAFKA_HEAP_OPTS=-Xmx512M -Xms512M


### PR DESCRIPTION
While running the quickstart tutorial, I came across this exception due to bad file URI:

D:\gdrive\workspace\Pulse\kafka_2.11-0.10.2.0>bin\windows\kafka-server-start.bat config\server.properties
log4j:ERROR Could not read configuration file from URL [file:D:/Userfiles/my_user_dir/Downloads/kafka_2.11-0.10.2.0/kafka_2.11-0.10.2.0/bin/windows/../../config/log4j.properties].
java.io.FileNotFoundException: D:\Userfiles\my_user_dir\Downloads\kafka_2.11-0.10.2.0\kafka_2.11-0.
10.2.0\bin\windows\..\..\config\log4j.properties (The system cannot find the path specified)
        at java.io.FileInputStream.open0(Native Method)