### PR TITLE
MINOR: Set log level for producer internals to trace for transactions test

### DIFF
--- a/tests/kafkatest/services/templates/tools_log4j.properties
+++ b/tests/kafkatest/services/templates/tools_log4j.properties
@@ -18,7 +18,7 @@ log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
 
 # The TransactionsTest set the transactional client code to log in TRACE 
 # level always. The rest will retain the default INFO level.
-log4j.logger.org.apache.kafka.clients.producer.internals={{ transactional_producer_log_level|default("INFO") }}
+log4j.logger.org.apache.kafka.clients.producer.internals={{ producer_internals_log_level|default("INFO") }}
 
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File={{ log_file }}

--- a/tests/kafkatest/services/templates/tools_log4j.properties
+++ b/tests/kafkatest/services/templates/tools_log4j.properties
@@ -16,6 +16,10 @@
 # Define the root logger with appender file
 log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
 
+# The TransactionsTest set the transactional client code to log in TRACE 
+# level always. The rest will retain the default INFO level.
+log4j.logger.org.apache.kafka.clients.producer.internals={{ transactional_producer_log_level|default("INFO") }}
+
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File={{ log_file }}
 log4j.appender.FILE.ImmediateFlush=true

--- a/tests/kafkatest/services/templates/tools_log4j.properties
+++ b/tests/kafkatest/services/templates/tools_log4j.properties
@@ -16,9 +16,11 @@
 # Define the root logger with appender file
 log4j.rootLogger = {{ log_level|default("INFO") }}, FILE
 
-# The TransactionsTest set the transactional client code to log in TRACE 
-# level always. The rest will retain the default INFO level.
-log4j.logger.org.apache.kafka.clients.producer.internals={{ producer_internals_log_level|default("INFO") }}
+{% if loggers is defined %}
+{% for logger, log_level in loggers.iteritems() %}
+log4j.logger.{{ logger }}={{ log_level }}
+{% endfor %}
+{% endif %}
 
 log4j.appender.FILE=org.apache.log4j.FileAppender
 log4j.appender.FILE.File={{ log_file }}

--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -61,7 +61,9 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
         self.consumed = -1
         self.remaining = -1
         self.stop_timeout_sec = 60
-        self.producer_internals_log_level = "TRACE"
+        self.loggers = {
+            "org.apache.kafka.clients.producer.internals": "TRACE"
+        }
 
     def _worker(self, idx, node):
         node.account.ssh("mkdir -p %s" % TransactionalMessageCopier.PERSISTENT_ROOT,

--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -47,9 +47,8 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
 
     def __init__(self, context, num_nodes, kafka, transactional_id, consumer_group,
                  input_topic, input_partition, output_topic, max_messages = -1,
-                 transaction_size = 1000, log_level="INFO"):
+                 transaction_size = 1000):
         super(TransactionalMessageCopier, self).__init__(context, num_nodes)
-        self.log_level = log_level
         self.kafka = kafka
         self.transactional_id = transactional_id
         self.consumer_group = consumer_group
@@ -62,6 +61,7 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
         self.consumed = -1
         self.remaining = -1
         self.stop_timeout_sec = 60
+        self.transactional_producer_log_level = "TRACE"
 
     def _worker(self, idx, node):
         node.account.ssh("mkdir -p %s" % TransactionalMessageCopier.PERSISTENT_ROOT,

--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -61,7 +61,7 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
         self.consumed = -1
         self.remaining = -1
         self.stop_timeout_sec = 60
-        self.transactional_producer_log_level = "TRACE"
+        self.producer_internals_log_level = "TRACE"
 
     def _worker(self, idx, node):
         node.account.ssh("mkdir -p %s" % TransactionalMessageCopier.PERSISTENT_ROOT,


### PR DESCRIPTION
We need this to debug most issues with the transactions system test.