### PR TITLE
WIP: KAFKA-5403: Transaction system test consumer should dedup messages by offset

### DIFF
--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -90,7 +90,6 @@ class ConsumerEventHandler(object):
                 "Consumed from an unexpected offset (%d, %d) for partition %s" % \
                 (self.position[tp], min_offset, str(tp))
             self.position[tp] = max_offset + 1
-
         self.total_consumed += event["count"]
 
     def handle_partitions_revoked(self, event):
@@ -234,6 +233,7 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                         handler.handle_offsets_committed(event, node, self.logger)
                         self._update_global_committed(event)
                     elif name == "records_consumed":
+                        self.logger.debug("%s: got records consumed : %s" % (str(node.account), event))
                         handler.handle_records_consumed(event)
                         self._update_global_position(event, node)
                     elif name == "partitions_revoked":

--- a/tests/kafkatest/services/verifiable_consumer.py
+++ b/tests/kafkatest/services/verifiable_consumer.py
@@ -22,7 +22,7 @@ from ducktape.services.background_thread import BackgroundThreadService
 from kafkatest.directory_layout.kafka_path import KafkaPathResolverMixin
 from kafkatest.services.kafka import TopicPartition
 from kafkatest.services.verifiable_client import VerifiableClientMixin
-from kafkatest.version import DEV_BRANCH
+from kafkatest.version import DEV_BRANCH, V_0_11_0_0
 
 
 class ConsumerState:
@@ -42,6 +42,7 @@ class ConsumerEventHandler(object):
         self.assignment = []
         self.position = {}
         self.committed = {}
+        self.record_data = {}
         self.total_consumed = 0
 
     def handle_shutdown_complete(self):
@@ -69,7 +70,7 @@ class ConsumerEventHandler(object):
                 assert tp in self.position, "No previous position for %s: %s" % (str(tp), event)
                 assert self.position[tp] >= offset, \
                     "The committed offset %d was greater than the current position %d for partition %s" % \
-                    (offset, self.position[t], str(tp))
+                    (offset, self.position[tp], str(tp))
                 self.committed[tp] = offset
 
     def handle_records_consumed(self, event):
@@ -88,7 +89,7 @@ class ConsumerEventHandler(object):
             assert tp not in self.position or self.position[tp] == min_offset, \
                 "Consumed from an unexpected offset (%d, %d) for partition %s" % \
                 (self.position[tp], min_offset, str(tp))
-            self.position[tp] = max_offset + 1 
+            self.position[tp] = max_offset + 1
 
         self.total_consumed += event["count"]
 
@@ -113,6 +114,15 @@ class ConsumerEventHandler(object):
         if not clean_shutdown:
             self.handle_shutdown_complete()
 
+    def handle_record_data(self, record):
+        if not record['partition'] in self.record_data:
+            self.record_data[record['partition']] = {}
+        self.record_data[record['partition']].update({
+            record['offset'] : {
+                record['key'] : record['value']
+            }
+        })
+
     def current_assignment(self):
         return list(self.assignment)
 
@@ -131,10 +141,10 @@ class ConsumerEventHandler(object):
 
 class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, BackgroundThreadService):
     """This service wraps org.apache.kafka.tools.VerifiableConsumer for use in
-    system testing. 
-    
+    system testing.
+
     NOTE: this class should be treated as a PUBLIC API. Downstream users use
-    this service both directly and through class extension, so care must be 
+    this service both directly and through class extension, so care must be
     taken to ensure compatibility.
     """
 
@@ -161,10 +171,11 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
     def __init__(self, context, num_nodes, kafka, topic, group_id,
                  max_messages=-1, session_timeout_sec=30, enable_autocommit=False,
                  assignment_strategy="org.apache.kafka.clients.consumer.RangeAssignor",
-                 version=DEV_BRANCH, stop_timeout_sec=30, log_level="INFO"):
+                 version=DEV_BRANCH, stop_timeout_sec=30, log_level="INFO",
+                 collect_records=False, isolation_level="read_uncommitted"):
         super(VerifiableConsumer, self).__init__(context, num_nodes)
         self.log_level = log_level
-        
+
         self.kafka = kafka
         self.topic = topic
         self.group_id = group_id
@@ -174,6 +185,8 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         self.assignment_strategy = assignment_strategy
         self.prop_file = ""
         self.stop_timeout_sec = stop_timeout_sec
+        self.collect_records = collect_records
+        self.isolation_level = isolation_level
 
         self.event_handlers = {}
         self.global_position = {}
@@ -227,6 +240,8 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
                         handler.handle_partitions_revoked(event)
                     elif name == "partitions_assigned":
                         handler.handle_partitions_assigned(event)
+                    elif name == "record_data":
+                        handler.handle_record_data(event)
                     else:
                         self.logger.debug("%s: ignoring unknown event: %s" % (str(node.account), event))
 
@@ -266,9 +281,15 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         cmd += " --group-id %s --topic %s --broker-list %s --session-timeout %s --assignment-strategy %s %s" % \
                (self.group_id, self.topic, self.kafka.bootstrap_servers(self.security_config.security_protocol),
                self.session_timeout_sec*1000, self.assignment_strategy, "--enable-autocommit" if self.enable_autocommit else "")
-               
+
         if self.max_messages > 0:
             cmd += " --max-messages %s" % str(self.max_messages)
+
+        if self.collect_records:
+            cmd += " --verbose"
+
+        if node.version >= V_0_11_0_0:
+            cmd += " --isolation-level %s" % self.isolation_level
 
         cmd += " --consumer.config %s" % VerifiableConsumer.CONFIG_FILE
         cmd += " 2>> %s | tee -a %s &" % (VerifiableConsumer.STDOUT_CAPTURE, VerifiableConsumer.STDOUT_CAPTURE)
@@ -356,6 +377,15 @@ class VerifiableConsumer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         with self.lock:
             return [handler.node for handler in self.event_handlers.itervalues()
                     if handler.state == ConsumerState.Dead]
+
+    def records(self):
+        consumed_records = {}
+        with self.lock:
+            for handler in self.event_handlers.itervalues():
+                for partition in handler.record_data.keys():
+                    for offset in handler.record_data[partition]:
+                        consumed_records.update(offset)
+        return consumed_records
 
     def alive_nodes(self):
         with self.lock:

--- a/tests/kafkatest/tests/core/transactions_test.py
+++ b/tests/kafkatest/tests/core/transactions_test.py
@@ -156,7 +156,8 @@ class TransactionsTest(Test):
                                       topic=topic_to_read,
                                       group_id=group_id,
                                       isolation_level="read_committed",
-                                      collect_records=True)
+                                      collect_records=True,
+                                      log_level="DEBUG")
         consumer.start()
         # ensure that the consumer is up.
         wait_until(lambda: consumer.total_consumed() > 0 == True,

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -566,6 +566,14 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .metavar("CONFIG_FILE")
                 .help("Consumer config properties file (config options shared with command line parameters will be overridden).");
 
+        parser.addArgument("--isolation-level")
+                .action(store())
+                .required(false)
+                .type(String.class)
+                .setDefault("read_uncommitted")
+                .dest("isolationLevel")
+                .help("Set the isolation level to either read_committed to filter out uncommitted transactional messages, or read_uncommitted to read everything");
+
         return parser;
     }
 
@@ -577,7 +585,6 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         int maxMessages = res.getInt("maxMessages");
         boolean verbose = res.getBoolean("verbose");
         String configFile = res.getString("consumer.config");
-
         Properties consumerProps = new Properties();
         if (configFile != null) {
             try {
@@ -593,6 +600,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
         consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, res.getString("resetPolicy"));
         consumerProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, Integer.toString(res.getInt("sessionTimeout")));
         consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, res.getString("assignmentStrategy"));
+        consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, res.get("isolationLevel"));
 
         StringDeserializer deserializer = new StringDeserializer();
         KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps, deserializer, deserializer);


### PR DESCRIPTION
Since the consumer can consume duplicate offsets due to rebalances, we should dedup consumed messages by offset in order to ensure that the test doesn't fail spuriously.

This achieved by transitioning to the VerifiableConsumer, which returns the offsets of the consumed records as well.