### PR TITLE
KAFKA-5411: AdminClient javadoc and documentation improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -589,6 +589,13 @@ project(':core') {
     standardOutput = new File(generatedDocsDir, "protocol_messages.html").newOutputStream()
   }
 
+  task genAdminClientConfigDocs(type: JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.apache.kafka.clients.admin.AdminClientConfig'
+    if( !generatedDocsDir.exists() ) { generatedDocsDir.mkdirs() }
+    standardOutput = new File(generatedDocsDir, "admin_client_config.html").newOutputStream()
+  }
+
   task genProducerConfigDocs(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = 'org.apache.kafka.clients.producer.ProducerConfig'
@@ -625,8 +632,9 @@ project(':core') {
   }
 
   task siteDocsTar(dependsOn: ['genProtocolErrorDocs', 'genProtocolApiKeyDocs', 'genProtocolMessageDocs',
-                               'genProducerConfigDocs', 'genConsumerConfigDocs', 'genKafkaConfigDocs',
-                               'genTopicConfigDocs', ':connect:runtime:genConnectConfigDocs', ':connect:runtime:genConnectTransformationDocs',
+                               'genAdminClientConfigDocs', 'genProducerConfigDocs', 'genConsumerConfigDocs',
+                               'genKafkaConfigDocs', 'genTopicConfigDocs',
+                               ':connect:runtime:genConnectConfigDocs', ':connect:runtime:genConnectTransformationDocs',
                                ':streams:genStreamsConfigDocs', 'genConsumerMetricsDocs'], type: Tar) {
     classifier = 'site-docs'
     compression = Compression.GZIP
@@ -767,13 +775,17 @@ project(':clients') {
   }
 
   javadoc {
+    include "**/org/apache/kafka/clients/admin/*"
     include "**/org/apache/kafka/clients/consumer/*"
     include "**/org/apache/kafka/clients/producer/*"
     include "**/org/apache/kafka/common/*"
+    include "**/org/apache/kafka/common/acl/*"
     include "**/org/apache/kafka/common/errors/*"
     include "**/org/apache/kafka/common/header/*"
+    include "**/org/apache/kafka/common/resource/*"
     include "**/org/apache/kafka/common/serialization/*"
     include "**/org/apache/kafka/common/config/*"
+    include "**/org/apache/kafka/server/policy/*"
   }
 }
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -102,7 +102,7 @@
 	For more information about the AdminClient APIs, see the <a href="/{{version}}/javadoc/index.html?org/apache/kafka/clients/admin/AdminClient.html" title="Kafka {{dotVersion}} Javadoc">javadoc</a>.
 	<p>
 
-	<h3><a id="legacyapis" href="#streamsapi">2.6 Legacy APIs</a></h3>
+	<h3><a id="legacyapis" href="#legacyapis">2.6 Legacy APIs</a></h3>
 
 	<p>
 	A more limited legacy producer and consumer api is also included in Kafka. These old Scala APIs are deprecated and only still available for compatibility purposes. Information on them can be found here <a href="/081/documentation.html#producerapi"  title="Kafka 0.8.1 Docs">

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -253,6 +253,10 @@
   <h3><a id="streamsconfigs" href="#streamsconfigs">3.5 Kafka Streams Configs</a></h3>
   Below is the configuration of the Kafka Streams client library.
   <!--#include virtual="generated/streams_config.html" -->
+
+  <h3><a id="adminclientconfigs" href="#adminclientconfigs">3.6 AdminClient Configs</a></h3>
+  Below is the configuration of the Kafka Admin client library.
+  <!--#include virtual="generated/admin_client_config.html" -->
 </script>
 
 <div class="p-configuration"></div>

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -26,8 +26,8 @@
 	<div class="right">
 		<!--#include virtual="../includes/_docs_banner.htm" -->
     <h1>Documentation</h1>
-    <h3>Kafka 0.10.2 Documentation</h3>
-    Prior releases: <a href="/07/documentation.html">0.7.x</a>, <a href="/08/documentation.html">0.8.0</a>, <a href="/081/documentation.html">0.8.1.X</a>, <a href="/082/documentation.html">0.8.2.X</a>, <a href="/090/documentation.html">0.9.0.X</a>, <a href="/0100/documentation.html">0.10.0.X</a>, <a href="/0101/documentation.html">0.10.1.X</a>.
+    <h3>Kafka 0.11.0 Documentation</h3>
+    Prior releases: <a href="/07/documentation.html">0.7.x</a>, <a href="/08/documentation.html">0.8.0</a>, <a href="/081/documentation.html">0.8.1.X</a>, <a href="/082/documentation.html">0.8.2.X</a>, <a href="/090/documentation.html">0.9.0.X</a>, <a href="/0100/documentation.html">0.10.0.X</a>, <a href="/0101/documentation.html">0.10.1.X</a>, <a href="/0102/documentation.html">0.10.2.X</a>.
 
     <!--#include virtual="toc.html" -->
 

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -35,7 +35,8 @@
                 <li><a href="#consumerapi">2.2 Consumer API</a>
                 <li><a href="#streamsapi">2.3 Streams API</a>
                 <li><a href="#connectapi">2.4 Connect API</a>
-                <li><a href="#legacyapis">2.5 Legacy APIs</a>
+                <li><a href="#adminapi">2.5 AdminClient API</a>
+                <li><a href="#legacyapis">2.6 Legacy APIs</a>
             </ul>
         </li>
         <li><a href="#configuration">3. Configuration</a>
@@ -49,6 +50,7 @@
                     </ul>
                 <li><a href="#connectconfigs">3.4 Kafka Connect Configs</a>
                 <li><a href="#streamsconfigs">3.5 Kafka Streams Configs</a>
+                <li><a href="#adminclientconfigs">3.6 AdminClient Configs</a>
             </ul>
         </li>
         <li><a href="#design">4. Design</a>


### PR DESCRIPTION
- Show AdminClient configs in the docs.
- Update Javadoc config so that public classes exposed by
the AdminClient are included.
- Version and table of contents fixes.