### PR TITLE
HOTFIX: use atomic boolean for inject errors in streams eos integration test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -45,7 +45,6 @@ import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -574,7 +573,6 @@ public class EosIntegrationTest {
         );
     }
 
-    @Ignore
     @Test
     public void shouldNotViolateEosIfOneTaskFailsWithState() throws Exception {
         // this test updates a store with 10 + 5 + 5 records per partition (running with 2 partitions)

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -456,7 +456,6 @@ public class EosIntegrationTest {
             public Transformer<Long, Long, KeyValue<Long, Long>> get() {
                 return new Transformer<Long, Long, KeyValue<Long, Long>>() {
                     ProcessorContext context;
-                    int processedRecords = 0;
                     KeyValueStore<Long, Long> state = null;
 
                     @Override
@@ -475,7 +474,7 @@ public class EosIntegrationTest {
                             throw new RuntimeException("Injected test exception.");
                         }
 
-                        if (++processedRecords % 10 == 0) {
+                        if ((value + 1) % 10 == 0) {
                             context.commit();
                             commitRequested.incrementAndGet();
                         }


### PR DESCRIPTION
Originally we assume the task will be created exactly three times (twice upon starting up, once for each thread, and then one more time when rebalancing upon the thread failure). However there is a likelihood that upon starting up more than one rebalance will be triggered, and hence the tasks will be initialized more than 3 times, i.e. there will be more than three hashcodes of the `Transformer` object, causing the `errorInjected` to never be taken and exception never thrown.

The current fix is to use an atomic boolean instead and let threads compete on compare-and-set to make sure exactly one thread will throw exception, and will only throw once.

Without this patch I can reproduce the issue on my local machine with a single core ever 3-5 times; with this patch I have been running successfully for 10+ runs.

Ping @mjsax @ijuma for reviews.