### PR TITLE
MINOR: Avoid calling interceptors.onSendError() with null TopicPartition

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -633,6 +633,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                         " specified in value.serializer");
             }
             int partition = partition(record, serializedKey, serializedValue, cluster);
+            tp = new TopicPartition(record.topic(), partition);
 
             setReadOnly(record.headers());
             Header[] headers = record.headers().toArray();
@@ -640,7 +641,6 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
             int serializedSize = AbstractRecords.sizeInBytesUpperBound(apiVersions.maxUsableProduceMagic(),
                     serializedKey, serializedValue, headers);
             ensureValidRecordSize(serializedSize);
-            tp = new TopicPartition(record.topic(), partition);
             long timestamp = record.timestamp() == null ? time.milliseconds() : record.timestamp();
             log.trace("Sending record {} with callback {} to topic {} partition {}", record, callback, record.topic(), partition);
             // producer callback will make sure to call both 'callback' and interceptor callback

--- a/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/KafkaProducerTest.java
@@ -18,10 +18,12 @@ package org.apache.kafka.clients.producer;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.producer.internals.ProducerInterceptors;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
@@ -433,6 +435,43 @@ public class KafkaProducerTest {
         try (KafkaProducer producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer())) {
             assertEquals(Sensor.RecordingLevel.DEBUG, producer.metrics.config().recordLevel());
         }
+    }
+    
+    @PrepareOnlyThisForTest(Metadata.class)
+    @Test
+    public void testInterceptorPartitionSetOnTooLargeRecord() throws Exception {
+      
+        Properties props = new Properties();
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9999");
+        props.setProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, "1");
+        String topic = "topic";
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, "value");
+        
+        KafkaProducer<String, String> producer = new KafkaProducer<String, String>(
+                props, new StringSerializer(), new StringSerializer());
+        Metadata metadata = PowerMock.createNiceMock(Metadata.class);
+        MemberModifier.field(KafkaProducer.class, "metadata").set(producer, metadata);
+        final Cluster cluster = new Cluster(
+            "dummy",
+            Collections.singletonList(new Node(0, "host1", 1000)),
+            Arrays.asList(new PartitionInfo(topic, 0, null, null, null)),
+            Collections.<String>emptySet(),
+            Collections.<String>emptySet());
+        EasyMock.expect(metadata.fetch()).andReturn(cluster).once();
+        
+        // Mock interceptors field
+        ProducerInterceptors interceptors = PowerMock.createMock(ProducerInterceptors.class);
+        EasyMock.expect(interceptors.onSend(record)).andReturn(record);
+        interceptors.onSendError(EasyMock.eq(record), (TopicPartition) EasyMock.notNull(), (Exception) EasyMock.notNull());
+        EasyMock.expectLastCall();
+        MemberModifier.field(KafkaProducer.class, "interceptors").set(producer, interceptors);
+        
+        PowerMock.replay(metadata);
+        EasyMock.replay(interceptors);
+        producer.send(record);
+        
+        EasyMock.verify(interceptors);
+        
     }
 
 }


### PR DESCRIPTION
Assign non-null tp as soon as possible once we know the partition. This is
so that if ensureValidRecordSize() throws, the
interceptors.onSendError() call is made with a non-null tp.