### PR TITLE
KAFKA-5415: Remove timestamp check in completeTransitionTo

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -285,7 +285,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     val toState = pendingState.getOrElse(throw new IllegalStateException(s"TransactionalId $transactionalId " +
       "completing transaction state transition while it does not have a pending state"))
 
-    if (toState != transitMetadata.txnState || txnLastUpdateTimestamp > transitMetadata.txnLastUpdateTimestamp) {
+    if (toState != transitMetadata.txnState) {
       throwStateTransitionFailure(toState)
     } else {
       toState match {


### PR DESCRIPTION
This assertion is hard to get right because the system time can roll backward on a host due to NTP (as shown in the ticket), and also because a transaction can start on one host and complete on another. Getting precise clock times across hosts is virtually impossible, and this check makes things fragile.