### PR TITLE
KAFKA-5416: Re-prepare transition to CompleteCommit/Abort upon retrying append to log

### DIFF
--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -169,7 +169,7 @@ class TransactionCoordinator(brokerId: Int,
                   s"${Topic.TRANSACTION_STATE_TOPIC_NAME}-${txnManager.partitionFor(transactionalId)}")
                 responseCallback(initTransactionMetadata(newMetadata))
               } else {
-                info(s"Returning $error error code to client for $transactionalId's init pid request")
+                info(s"Returning $error error code to client for $transactionalId's InitProducerId request")
                 responseCallback(initTransactionError(error))
               }
             }
@@ -224,7 +224,7 @@ class TransactionCoordinator(brokerId: Int,
                                        partitions: collection.Set[TopicPartition],
                                        responseCallback: AddPartitionsCallback): Unit = {
     if (transactionalId == null || transactionalId.isEmpty) {
-      info(s"Returning ${Errors.INVALID_REQUEST} error code to client for $transactionalId's add partitions request")
+      debug(s"Returning ${Errors.INVALID_REQUEST} error code to client for $transactionalId's AddPartitions request")
       responseCallback(Errors.INVALID_REQUEST)
     } else {
       // try to update the transaction metadata and append the updated metadata to txn log;
@@ -262,7 +262,7 @@ class TransactionCoordinator(brokerId: Int,
 
       result match {
         case Left(err) =>
-          info(s"Returning $err error code to client for $transactionalId's add partitions request")
+          info(s"Returning $err error code to client for $transactionalId's AddPartitions request")
           responseCallback(err)
 
         case Right((coordinatorEpoch, newMetadata)) =>
@@ -353,7 +353,7 @@ class TransactionCoordinator(brokerId: Int,
 
       preAppendResult match {
         case Left(err) =>
-          info(s"Aborting to append $txnMarkerResult transaction log with coordinator and returning $err error to client for $transactionalId's end transaction request")
+          info(s"Aborting append of $txnMarkerResult to transaction log with coordinator and returning $err error to client for $transactionalId's EndTransaction request")
           responseCallback(err)
 
         case Right((coordinatorEpoch, newMetadata)) =>
@@ -393,8 +393,8 @@ class TransactionCoordinator(brokerId: Int,
                       }
                     }
                   } else {
-                    debug(s"The transaction coordinator epoch has been changed to ${epochAndMetadata.coordinatorEpoch} after $txnMarkerResult has " +
-                      s"been successfully appended to the log for $transactionalId with old epoch $coordinatorEpoch")
+                    debug(s"The transaction coordinator epoch has changed to ${epochAndMetadata.coordinatorEpoch} after $txnMarkerResult was " +
+                      s"successfully appended to the log for $transactionalId with old epoch $coordinatorEpoch")
 
                     Left(Errors.NOT_COORDINATOR)
                   }
@@ -406,7 +406,7 @@ class TransactionCoordinator(brokerId: Int,
 
               preSendResult match {
                 case Left(err) =>
-                  info(s"Aborting to sending transaction markers after appended $txnMarkerResult to transaction log and returning $err error to client for $transactionalId's end transaction request")
+                  info(s"Aborting sending of transaction markers after appended $txnMarkerResult to transaction log and returning $err error to client for $transactionalId's EndTransaction request")
 
                   responseCallback(err)
 
@@ -418,7 +418,7 @@ class TransactionCoordinator(brokerId: Int,
                   txnMarkerChannelManager.addTxnMarkersToSend(transactionalId, coordinatorEpoch, txnMarkerResult, txnMetadata, newPreSendMetadata)
               }
             } else {
-              info(s"Aborting to sending transaction markers and returning $error error to client for $transactionalId's end transaction request of $txnMarkerResult, " +
+              info(s"Aborting sending of transaction markers and returning $error error to client for $transactionalId's EndTransaction request of $txnMarkerResult, " +
                 s"since appending $newMetadata to transaction log with coordinator epoch $coordinatorEpoch failed")
 
               responseCallback(error)

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -169,6 +169,7 @@ class TransactionCoordinator(brokerId: Int,
                   s"${Topic.TRANSACTION_STATE_TOPIC_NAME}-${txnManager.partitionFor(transactionalId)}")
                 responseCallback(initTransactionMetadata(newMetadata))
               } else {
+                info(s"Returning $error error code to client for $transactionalId's init pid request")
                 responseCallback(initTransactionError(error))
               }
             }
@@ -223,6 +224,7 @@ class TransactionCoordinator(brokerId: Int,
                                        partitions: collection.Set[TopicPartition],
                                        responseCallback: AddPartitionsCallback): Unit = {
     if (transactionalId == null || transactionalId.isEmpty) {
+      info(s"Returning ${Errors.INVALID_REQUEST} error code to client for $transactionalId's add partitions request")
       responseCallback(Errors.INVALID_REQUEST)
     } else {
       // try to update the transaction metadata and append the updated metadata to txn log;
@@ -260,6 +262,7 @@ class TransactionCoordinator(brokerId: Int,
 
       result match {
         case Left(err) =>
+          info(s"Returning $err error code to client for $transactionalId's add partitions request")
           responseCallback(err)
 
         case Right((coordinatorEpoch, newMetadata)) =>
@@ -350,6 +353,7 @@ class TransactionCoordinator(brokerId: Int,
 
       preAppendResult match {
         case Left(err) =>
+          info(s"Aborting to append $txnMarkerResult transaction log with coordinator and returning $err error to client for $transactionalId's end transaction request")
           responseCallback(err)
 
         case Right((coordinatorEpoch, newMetadata)) =>
@@ -389,8 +393,8 @@ class TransactionCoordinator(brokerId: Int,
                       }
                     }
                   } else {
-                    info(s"Updating $transactionalId's transaction state to $newMetadata with coordinator epoch $coordinatorEpoch for $transactionalId failed since the transaction coordinator epoch " +
-                      s"has been changed to ${epochAndMetadata.coordinatorEpoch} after the transaction metadata has been successfully appended to the log")
+                    debug(s"The transaction coordinator epoch has been changed to ${epochAndMetadata.coordinatorEpoch} after $txnMarkerResult has " +
+                      s"been successfully appended to the log for $transactionalId with old epoch $coordinatorEpoch")
 
                     Left(Errors.NOT_COORDINATOR)
                   }
@@ -402,6 +406,8 @@ class TransactionCoordinator(brokerId: Int,
 
               preSendResult match {
                 case Left(err) =>
+                  info(s"Aborting to sending transaction markers after appended $txnMarkerResult to transaction log and returning $err error to client for $transactionalId's end transaction request")
+
                   responseCallback(err)
 
                 case Right((txnMetadata, newPreSendMetadata)) =>
@@ -412,8 +418,8 @@ class TransactionCoordinator(brokerId: Int,
                   txnMarkerChannelManager.addTxnMarkersToSend(transactionalId, coordinatorEpoch, txnMarkerResult, txnMetadata, newPreSendMetadata)
               }
             } else {
-              info(s"Updating $transactionalId's transaction state to $newMetadata with coordinator epoch $coordinatorEpoch for $transactionalId failed since the transaction message " +
-                s"cannot be appended to the log. Returning error code $error to the client")
+              info(s"Aborting to sending transaction markers and returning $error error to client for $transactionalId's end transaction request of $txnMarkerResult, " +
+                s"since appending $newMetadata to transaction log with coordinator epoch $coordinatorEpoch failed")
 
               responseCallback(error)
             }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -138,7 +138,9 @@ class TransactionCoordinator(brokerId: Int,
           }
 
         case Right(None) =>
-          throw new IllegalStateException("Trying to add metadata to the cache still returns NONE; this is not expected")
+          val errorMsg = "Trying to add metadata to the cache still returns NONE; this is not expected"
+          fatal(errorMsg)
+          throw new IllegalStateException(errorMsg)
       }
 
       result match {
@@ -212,8 +214,11 @@ class TransactionCoordinator(brokerId: Int,
           // then when the client retries, we will generate a new producerId.
           Right(coordinatorEpoch, txnMetadata.prepareFenceProducerEpoch())
         case Dead =>
-          throw new IllegalStateException(s"Found transactionalId $transactionalId with state ${txnMetadata.state}. " +
-            s"This is illegal as we should never have transitioned to this state.")
+          val errorMsg = s"Found transactionalId $transactionalId with state ${txnMetadata.state}. " +
+            s"This is illegal as we should never have transitioned to this state."
+          fatal(errorMsg)
+          throw new IllegalStateException(errorMsg)
+
       }
     }
   }
@@ -344,8 +349,10 @@ class TransactionCoordinator(brokerId: Int,
               case Empty =>
                 logInvalidStateTransitionAndReturnError(transactionalId, txnMetadata.state, txnMarkerResult)
               case Dead =>
-                throw new IllegalStateException(s"Found transactionalId $transactionalId with state ${txnMetadata.state}. " +
-                  s"This is illegal as we should never have transitioned to this state.")
+                val errorMsg = s"Found transactionalId $transactionalId with state ${txnMetadata.state}. " +
+                  s"This is illegal as we should never have transitioned to this state."
+                fatal(errorMsg)
+                throw new IllegalStateException(errorMsg)
 
             }
           }
@@ -387,8 +394,10 @@ class TransactionCoordinator(brokerId: Int,
                           else
                             Right(txnMetadata, txnMetadata.prepareComplete(time.milliseconds()))
                         case Dead =>
-                          throw new IllegalStateException(s"Found transactionalId $transactionalId with state ${txnMetadata.state}. " +
-                            s"This is illegal as we should never have transitioned to this state.")
+                          val errorMsg = s"Found transactionalId $transactionalId with state ${txnMetadata.state}. " +
+                            s"This is illegal as we should never have transitioned to this state."
+                          fatal(errorMsg)
+                          throw new IllegalStateException(errorMsg)
 
                       }
                     }
@@ -400,8 +409,10 @@ class TransactionCoordinator(brokerId: Int,
                   }
 
                 case Right(None) =>
-                  throw new IllegalStateException(s"The coordinator still owns the transaction partition for $transactionalId, but there is " +
-                    s"no metadata in the cache; this is not expected")
+                  val errorMsg = s"The coordinator still owns the transaction partition for $transactionalId, but there is " +
+                    s"no metadata in the cache; this is not expected"
+                  fatal(errorMsg)
+                  throw new IllegalStateException(errorMsg)
               }
 
               preSendResult match {

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -301,6 +301,10 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
           // enqueue for retry
           txnLogAppendRetryQueue.add(txnLogAppend)
 
+        case Errors.COORDINATOR_LOAD_IN_PROGRESS =>
+          info(s"Coordinator is loading the partition ${txnStateManager.partitionFor(txnLogAppend.transactionalId)} and hence cannot complete append of $txnLogAppend; " +
+            s"skip writing to transaction log as the loading process should complete it")
+
         case other: Errors =>
           throw new IllegalStateException(s"Unexpected error ${other.exceptionName} while appending to transaction log for ${txnLogAppend.transactionalId}")
       }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -269,12 +269,16 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
               }
 
             case Right(None) =>
-              throw new IllegalStateException(s"The coordinator still owns the transaction partition for $transactionalId, but there is " +
-                s"no metadata in the cache; this is not expected")
+              val errorMsg = s"The coordinator still owns the transaction partition for $transactionalId, but there is " +
+                s"no metadata in the cache; this is not expected"
+              fatal(errorMsg)
+              throw new IllegalStateException(errorMsg)
           }
 
         case other =>
-          throw new IllegalStateException(s"Unexpected error ${other.exceptionName} before appending to txn log for $transactionalId")
+          val errorMsg = s"Unexpected error ${other.exceptionName} before appending to txn log for $transactionalId"
+          fatal(errorMsg)
+          throw new IllegalStateException(errorMsg)
       }
     }
 
@@ -306,7 +310,9 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
             s"skip writing to transaction log as the loading process should complete it")
 
         case other: Errors =>
-          throw new IllegalStateException(s"Unexpected error ${other.exceptionName} while appending to transaction log for ${txnLogAppend.transactionalId}")
+          val errorMsg = s"Unexpected error ${other.exceptionName} while appending to transaction log for ${txnLogAppend.transactionalId}"
+          fatal(errorMsg)
+          throw new IllegalStateException(errorMsg)
       }
 
     txnStateManager.appendTransactionToLog(txnLogAppend.transactionalId, txnLogAppend.coordinatorEpoch, txnLogAppend.newMetadata, appendCallback,
@@ -361,8 +367,11 @@ class TransactionMarkerChannelManager(config: KafkaConfig,
               }
 
             case Right(None) =>
-              throw new IllegalStateException(s"The coordinator still owns the transaction partition for $transactionalId, but there is " +
-                s"no metadata in the cache; this is not expected")
+              val errorMsg = s"The coordinator still owns the transaction partition for $transactionalId, but there is " +
+                s"no metadata in the cache; this is not expected"
+              fatal(errorMsg)
+              throw new IllegalStateException(errorMsg)
+
           }
       }
     }

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandler.scala
@@ -30,6 +30,9 @@ class TransactionMarkerRequestCompletionHandler(brokerId: Int,
                                                 txnStateManager: TransactionStateManager,
                                                 txnMarkerChannelManager: TransactionMarkerChannelManager,
                                                 txnIdAndMarkerEntries: java.util.List[TxnIdAndMarkerEntry]) extends RequestCompletionHandler with Logging {
+
+  this.logIdent = "[Transaction Marker Request Completion Handler " + brokerId + "]: "
+
   override def onComplete(response: ClientResponse): Unit = {
     val requestHeader = response.requestHeader
     val correlationId = requestHeader.correlationId

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -283,7 +283,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     // if valid, transition is done via overwriting the whole object to ensure synchronization
 
     val toState = pendingState.getOrElse {
-      fatal(s"${this.toString}'s transition to $toState failed since pendingState is not defined: this should not happen")
+      fatal(s"${this.toString}'s transition to $transitMetadata failed since pendingState is not defined: this should not happen")
 
       throw new IllegalStateException(s"TransactionalId $transactionalId " +
         "completing transaction state transition while it does not have a pending state")

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -282,11 +282,15 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     //
     // if valid, transition is done via overwriting the whole object to ensure synchronization
 
-    val toState = pendingState.getOrElse(throw new IllegalStateException(s"TransactionalId $transactionalId " +
-      "completing transaction state transition while it does not have a pending state"))
+    val toState = pendingState.getOrElse {
+      fatal(s"${this.toString}'s transition to $toState failed since pendingState is not defined: this should not happen")
+
+      throw new IllegalStateException(s"TransactionalId $transactionalId " +
+        "completing transaction state transition while it does not have a pending state")
+    }
 
     if (toState != transitMetadata.txnState || txnLastUpdateTimestamp > transitMetadata.txnLastUpdateTimestamp) {
-      throwStateTransitionFailure(toState)
+      throwStateTransitionFailure(transitMetadata)
     } else {
       toState match {
         case Empty => // from initPid
@@ -294,7 +298,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
             transitMetadata.topicPartitions.nonEmpty ||
             transitMetadata.txnStartTimestamp != -1) {
 
-            throwStateTransitionFailure(toState)
+            throwStateTransitionFailure(transitMetadata)
           } else {
             txnTimeoutMs = transitMetadata.txnTimeoutMs
             producerEpoch = transitMetadata.producerEpoch
@@ -307,7 +311,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
             txnTimeoutMs != transitMetadata.txnTimeoutMs ||
             txnStartTimestamp > transitMetadata.txnStartTimestamp) {
 
-            throwStateTransitionFailure(toState)
+            throwStateTransitionFailure(transitMetadata)
           } else {
             txnStartTimestamp = transitMetadata.txnStartTimestamp
             addPartitions(transitMetadata.topicPartitions)
@@ -319,7 +323,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
             txnTimeoutMs != transitMetadata.txnTimeoutMs ||
             txnStartTimestamp != transitMetadata.txnStartTimestamp) {
 
-            throwStateTransitionFailure(toState)
+            throwStateTransitionFailure(transitMetadata)
           }
 
         case CompleteAbort | CompleteCommit => // from write markers
@@ -327,7 +331,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
             txnTimeoutMs != transitMetadata.txnTimeoutMs ||
             transitMetadata.txnStartTimestamp == -1) {
 
-            throwStateTransitionFailure(toState)
+            throwStateTransitionFailure(transitMetadata)
           } else {
             txnStartTimestamp = transitMetadata.txnStartTimestamp
             topicPartitions.clear()
@@ -360,8 +364,10 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     transitEpoch == producerEpoch + 1 || (transitEpoch == 0 && transitProducerId != producerId)
   }
 
-  private def throwStateTransitionFailure(toState: TransactionState): Unit = {
-    throw new IllegalStateException(s"TransactionalId $transactionalId failed transition to state $toState " +
+  private def throwStateTransitionFailure(txnTransitMetadata: TxnTransitMetadata): Unit = {
+    fatal(s"${this.toString}'s transition to $txnTransitMetadata failed: this should not happen")
+
+    throw new IllegalStateException(s"TransactionalId $transactionalId failed transition to state $txnTransitMetadata " +
       "due to unexpected metadata")
   }
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala
@@ -283,7 +283,7 @@ private[transaction] class TransactionMetadata(val transactionalId: String,
     // if valid, transition is done via overwriting the whole object to ensure synchronization
 
     val toState = pendingState.getOrElse {
-      fatal(s"${this.toString}'s transition to $transitMetadata failed since pendingState is not defined: this should not happen")
+      fatal(s"$this's transition to $transitMetadata failed since pendingState is not defined: this should not happen")
 
       throw new IllegalStateException(s"TransactionalId $transactionalId " +
         "completing transaction state transition while it does not have a pending state")

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -589,6 +589,8 @@ class TransactionStateManager(brokerId: Int,
                 recordsPerPartition,
                 updateCacheCallback,
                 delayedProduceLock = Some(newMetadata))
+
+              trace(s"Appending new metadata $newMetadata for transaction id $transactionalId with coordinator epoch $coordinatorEpoch to the local transaction log")
             }
           }
       }

--- a/core/src/main/scala/kafka/utils/ReplicationUtils.scala
+++ b/core/src/main/scala/kafka/utils/ReplicationUtils.scala
@@ -32,7 +32,7 @@ object ReplicationUtils extends Logging {
 
   def updateLeaderAndIsr(zkUtils: ZkUtils, topic: String, partitionId: Int, newLeaderAndIsr: LeaderAndIsr, controllerEpoch: Int,
     zkVersion: Int): (Boolean,Int) = {
-    debug("Updated ISR for partition [%s,%d] to %s".format(topic, partitionId, newLeaderAndIsr.isr.mkString(",")))
+    debug(s"Updated ISR for $topic-$partitionId to ${newLeaderAndIsr.isr.mkString(",")}")
     val path = getTopicPartitionLeaderAndIsrPath(topic, partitionId)
     val newLeaderData = zkUtils.leaderAndIsrZkData(newLeaderAndIsr, controllerEpoch)
     // use the epoch of the controller that made the leadership decision, instead of the current controller epoch
@@ -44,7 +44,7 @@ object ReplicationUtils extends Logging {
     val isrChangeNotificationPath: String = zkUtils.createSequentialPersistentPath(
       ZkUtils.IsrChangeNotificationPath + "/" + IsrChangeNotificationPrefix,
       generateIsrChangeJson(isrChangeSet))
-    debug("Added " + isrChangeNotificationPath + " for " + isrChangeSet)
+    debug(s"Added $isrChangeNotificationPath for $isrChangeSet")
   }
 
   private def checkLeaderAndIsrZkData(zkUtils: ZkUtils, path: String, expectedLeaderAndIsrInfo: String): (Boolean, Int) = {
@@ -73,7 +73,7 @@ object ReplicationUtils extends Logging {
   def getLeaderIsrAndEpochForPartition(zkUtils: ZkUtils, topic: String, partition: Int): Option[LeaderIsrAndControllerEpoch] = {
     val leaderAndIsrPath = getTopicPartitionLeaderAndIsrPath(topic, partition)
     val (leaderAndIsrOpt, stat) = zkUtils.readDataMaybeNull(leaderAndIsrPath)
-    debug("Read leaderISR " + leaderAndIsrOpt + " for " + topic + "-" + partition)
+    debug(s"Read leaderISR $leaderAndIsrOpt for $topic-$partition")
     leaderAndIsrOpt.flatMap(leaderAndIsrStr => parseLeaderAndIsr(leaderAndIsrStr, leaderAndIsrPath, stat))
   }
 
@@ -86,8 +86,7 @@ object ReplicationUtils extends Logging {
       val isr = leaderIsrAndEpochInfo.get("isr").get.asInstanceOf[List[Int]]
       val controllerEpoch = leaderIsrAndEpochInfo.get("controller_epoch").get.asInstanceOf[Int]
       val zkPathVersion = stat.getVersion
-      trace("Leader %d, Epoch %d, Isr %s, Zk path version %d for leaderAndIsrPath %s".format(leader, epoch,
-        isr.toString(), zkPathVersion, path))
+      trace(s"Leader $leader, Epoch $epoch, Isr $isr, Zk path version $zkPathVersion for leaderAndIsrPath $path")
       Some(LeaderIsrAndControllerEpoch(LeaderAndIsr(leader, epoch, isr, zkPathVersion), controllerEpoch))}
   }
 

--- a/core/src/main/scala/kafka/utils/ReplicationUtils.scala
+++ b/core/src/main/scala/kafka/utils/ReplicationUtils.scala
@@ -47,7 +47,7 @@ object ReplicationUtils extends Logging {
     debug("Added " + isrChangeNotificationPath + " for " + isrChangeSet)
   }
 
-  def checkLeaderAndIsrZkData(zkUtils: ZkUtils, path: String, expectedLeaderAndIsrInfo: String): (Boolean,Int) = {
+  private def checkLeaderAndIsrZkData(zkUtils: ZkUtils, path: String, expectedLeaderAndIsrInfo: String): (Boolean, Int) = {
     try {
       val writtenLeaderAndIsrInfo = zkUtils.readDataMaybeNull(path)
       val writtenLeaderOpt = writtenLeaderAndIsrInfo._1
@@ -67,12 +67,13 @@ object ReplicationUtils extends Logging {
     } catch {
       case _: Exception =>
     }
-    (false,-1)
+    (false, -1)
   }
 
-  def getLeaderIsrAndEpochForPartition(zkUtils: ZkUtils, topic: String, partition: Int):Option[LeaderIsrAndControllerEpoch] = {
+  def getLeaderIsrAndEpochForPartition(zkUtils: ZkUtils, topic: String, partition: Int): Option[LeaderIsrAndControllerEpoch] = {
     val leaderAndIsrPath = getTopicPartitionLeaderAndIsrPath(topic, partition)
     val (leaderAndIsrOpt, stat) = zkUtils.readDataMaybeNull(leaderAndIsrPath)
+    debug("Read leaderISR " + leaderAndIsrOpt + " for " + topic + "-" + partition)
     leaderAndIsrOpt.flatMap(leaderAndIsrStr => parseLeaderAndIsr(leaderAndIsrStr, leaderAndIsrPath, stat))
   }
 
@@ -85,7 +86,7 @@ object ReplicationUtils extends Logging {
       val isr = leaderIsrAndEpochInfo.get("isr").get.asInstanceOf[List[Int]]
       val controllerEpoch = leaderIsrAndEpochInfo.get("controller_epoch").get.asInstanceOf[Int]
       val zkPathVersion = stat.getVersion
-      debug("Leader %d, Epoch %d, Isr %s, Zk path version %d for leaderAndIsrPath %s".format(leader, epoch,
+      trace("Leader %d, Epoch %d, Isr %s, Zk path version %d for leaderAndIsrPath %s".format(leader, epoch,
         isr.toString(), zkPathVersion, path))
       Some(LeaderIsrAndControllerEpoch(LeaderAndIsr(leader, epoch, isr, zkPathVersion), controllerEpoch))}
   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorTest.scala
@@ -120,7 +120,8 @@ class TransactionCoordinatorTest {
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.anyObject().asInstanceOf[TxnTransitMetadata],
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
           capturedErrorsCallback.getValue.apply(Errors.NONE)
@@ -147,7 +148,8 @@ class TransactionCoordinatorTest {
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.anyObject().asInstanceOf[TxnTransitMetadata],
-      EasyMock.capture(capturedErrorsCallback)
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()
     )).andAnswer(new IAnswer[Unit] {
       override def answer(): Unit = {
         capturedErrorsCallback.getValue.apply(Errors.NONE)
@@ -293,7 +295,8 @@ class TransactionCoordinatorTest {
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.anyObject().asInstanceOf[TxnTransitMetadata],
-      EasyMock.capture(capturedErrorsCallback)
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()
     ))
 
     EasyMock.replay(transactionManager)
@@ -523,7 +526,8 @@ class TransactionCoordinatorTest {
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.eq(originalMetadata.prepareAbortOrCommit(PrepareAbort, time.milliseconds())),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
           capturedErrorsCallback.getValue.apply(Errors.NONE)
@@ -566,7 +570,8 @@ class TransactionCoordinatorTest {
         topicPartitions = partitions.toSet,
         txnStartTimestamp = time.milliseconds(),
         txnLastUpdateTimestamp = time.milliseconds())),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
           capturedErrorsCallback.getValue.apply(Errors.NONE)
@@ -612,7 +617,8 @@ class TransactionCoordinatorTest {
     EasyMock.expect(transactionManager.appendTransactionToLog(EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.eq(expectedTransition),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {}
       })
@@ -677,7 +683,8 @@ class TransactionCoordinatorTest {
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.capture(capturedNewMetadata),
-      EasyMock.capture(capturedErrorsCallback)
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()
     )).andAnswer(new IAnswer[Unit] {
       override def answer(): Unit = {
         metadata.completeTransitionTo(capturedNewMetadata.getValue)
@@ -712,7 +719,8 @@ class TransactionCoordinatorTest {
       EasyMock.eq(transactionalId),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.eq(transition),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
           if (runCallback)

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -282,7 +282,8 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.eq(transactionalId2),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.eq(txnTransitionMetadata2),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
           txnMetadata2.completeTransitionTo(txnTransitionMetadata2)
@@ -329,7 +330,8 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.eq(transactionalId2),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.eq(txnTransitionMetadata2),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
           txnMetadata2.pendingState = None
@@ -376,10 +378,10 @@ class TransactionMarkerChannelManagerTest {
       EasyMock.eq(transactionalId2),
       EasyMock.eq(coordinatorEpoch),
       EasyMock.eq(txnTransitionMetadata2),
-      EasyMock.capture(capturedErrorsCallback)))
+      EasyMock.capture(capturedErrorsCallback),
+      EasyMock.anyObject()))
       .andAnswer(new IAnswer[Unit] {
         override def answer(): Unit = {
-          txnMetadata2.pendingState = None
           capturedErrorsCallback.getValue.apply(Errors.COORDINATOR_NOT_AVAILABLE)
         }
       })

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -19,15 +19,16 @@ package kafka.coordinator.transaction
 import kafka.server.{DelayedOperationPurgatory, KafkaConfig, MetadataCache}
 import kafka.utils.timer.MockTimer
 import kafka.utils.TestUtils
-import org.apache.kafka.clients.NetworkClient
-import org.apache.kafka.common.requests.{TransactionResult, WriteTxnMarkersRequest}
+import org.apache.kafka.clients.{ClientResponse, NetworkClient}
+import org.apache.kafka.common.requests.{RequestHeader, TransactionResult, WriteTxnMarkersRequest, WriteTxnMarkersResponse}
 import org.apache.kafka.common.utils.{MockTime, Utils}
 import org.apache.kafka.common.{Node, TopicPartition}
-import org.easymock.EasyMock
+import org.easymock.{Capture, EasyMock, IAnswer}
 import org.junit.Assert._
 import org.junit.Test
-
 import com.yammer.metrics.Metrics
+import kafka.common.RequestAndCompletionHandler
+import org.apache.kafka.common.protocol.Errors
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -56,6 +57,8 @@ class TransactionMarkerChannelManagerTest {
     PrepareCommit, mutable.Set[TopicPartition](partition1, partition2), 0L, 0L)
   private val txnMetadata2 = new TransactionMetadata(transactionalId2, producerId2, producerEpoch, txnTimeoutMs,
     PrepareCommit, mutable.Set[TopicPartition](partition1), 0L, 0L)
+
+  private val capturedErrorsCallback: Capture[Errors => Unit] = EasyMock.newCapture()
 
   private val txnMarkerPurgatory = new DelayedOperationPurgatory[DelayedTxnMarker]("txn-purgatory-name",
     new MockTimer,
@@ -86,7 +89,6 @@ class TransactionMarkerChannelManagerTest {
       .andReturn(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata2))))
       .anyTimes()
 
-    EasyMock.replay(txnStateManager)
   }
 
   @Test
@@ -97,6 +99,7 @@ class TransactionMarkerChannelManagerTest {
   @Test
   def shouldGenerateRequestPerPartitionPerBroker(): Unit = {
     mockCache()
+    EasyMock.replay(txnStateManager)
 
     EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
       EasyMock.eq(partition1.topic),
@@ -139,6 +142,7 @@ class TransactionMarkerChannelManagerTest {
   @Test
   def shouldSkipSendMarkersWhenLeaderNotFound(): Unit = {
     mockCache()
+    EasyMock.replay(txnStateManager)
 
     EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
       EasyMock.eq(partition1.topic),
@@ -166,6 +170,7 @@ class TransactionMarkerChannelManagerTest {
   @Test
   def shouldSaveForLaterWhenLeaderUnknownButNotAvailable(): Unit = {
     mockCache()
+    EasyMock.replay(txnStateManager)
 
     EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
       EasyMock.eq(partition1.topic),
@@ -219,6 +224,7 @@ class TransactionMarkerChannelManagerTest {
   @Test
   def shouldRemoveMarkersForTxnPartitionWhenPartitionEmigrated(): Unit = {
     mockCache()
+    EasyMock.replay(txnStateManager)
 
     EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
       EasyMock.eq(partition1.topic),
@@ -253,6 +259,165 @@ class TransactionMarkerChannelManagerTest {
     assertEquals(0, channelManager.queueForBroker(broker2.id).get.totalNumMarkers)
     assertEquals(0, channelManager.queueForBroker(broker2.id).get.totalNumMarkers(txnTopicPartition1))
     assertEquals(0, channelManager.queueForBroker(broker2.id).get.totalNumMarkers(txnTopicPartition2))
+  }
+
+  @Test
+  def shouldCompleteAppendToLogOnEndTxnWhenSendMarkersSucceed(): Unit = {
+    mockCache()
+
+    EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
+      EasyMock.eq(partition1.topic),
+      EasyMock.eq(partition1.partition),
+      EasyMock.anyObject())
+    ).andReturn(Some(broker1)).anyTimes()
+    EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
+      EasyMock.eq(partition2.topic),
+      EasyMock.eq(partition2.partition),
+      EasyMock.anyObject())
+    ).andReturn(Some(broker2)).anyTimes()
+
+    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.milliseconds())
+
+    EasyMock.expect(txnStateManager.appendTransactionToLog(
+      EasyMock.eq(transactionalId2),
+      EasyMock.eq(coordinatorEpoch),
+      EasyMock.eq(txnTransitionMetadata2),
+      EasyMock.capture(capturedErrorsCallback)))
+      .andAnswer(new IAnswer[Unit] {
+        override def answer(): Unit = {
+          txnMetadata2.completeTransitionTo(txnTransitionMetadata2)
+          capturedErrorsCallback.getValue.apply(Errors.NONE)
+        }
+      }).once()
+    EasyMock.replay(txnStateManager, metadataCache)
+
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
+
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = senderThread.generateRequests()
+
+    val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
+    for (requestAndHandler <- requestAndHandlers) {
+      requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(0, 0, "client", 1), null, null, 0, 0, false, null, response))
+    }
+
+    EasyMock.verify(txnStateManager)
+
+    assertEquals(0, txnMarkerPurgatory.watched)
+    assertEquals(0, channelManager.queueForBroker(broker1.id).get.totalNumMarkers)
+    assertEquals(None, txnMetadata2.pendingState)
+    assertEquals(CompleteCommit, txnMetadata2.state)
+  }
+
+  @Test
+  def shouldAbortAppendToLogOnEndTxnWhenNotCoordinatorError(): Unit = {
+    mockCache()
+
+    EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
+      EasyMock.eq(partition1.topic),
+      EasyMock.eq(partition1.partition),
+      EasyMock.anyObject())
+    ).andReturn(Some(broker1)).anyTimes()
+    EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
+      EasyMock.eq(partition2.topic),
+      EasyMock.eq(partition2.partition),
+      EasyMock.anyObject())
+    ).andReturn(Some(broker2)).anyTimes()
+
+    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.milliseconds())
+
+    EasyMock.expect(txnStateManager.appendTransactionToLog(
+      EasyMock.eq(transactionalId2),
+      EasyMock.eq(coordinatorEpoch),
+      EasyMock.eq(txnTransitionMetadata2),
+      EasyMock.capture(capturedErrorsCallback)))
+      .andAnswer(new IAnswer[Unit] {
+        override def answer(): Unit = {
+          txnMetadata2.pendingState = None
+          capturedErrorsCallback.getValue.apply(Errors.NOT_COORDINATOR)
+        }
+      }).once()
+    EasyMock.replay(txnStateManager, metadataCache)
+
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
+
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = senderThread.generateRequests()
+
+    val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
+    for (requestAndHandler <- requestAndHandlers) {
+      requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(0, 0, "client", 1), null, null, 0, 0, false, null, response))
+    }
+
+    EasyMock.verify(txnStateManager)
+
+    assertEquals(0, txnMarkerPurgatory.watched)
+    assertEquals(0, channelManager.queueForBroker(broker1.id).get.totalNumMarkers)
+    assertEquals(None, txnMetadata2.pendingState)
+    assertEquals(PrepareCommit, txnMetadata2.state)
+  }
+
+  @Test
+  def shouldRetryAppendToLogOnEndTxnWhenCoordinatorNotAvailableError(): Unit = {
+    mockCache()
+
+    EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
+      EasyMock.eq(partition1.topic),
+      EasyMock.eq(partition1.partition),
+      EasyMock.anyObject())
+    ).andReturn(Some(broker1)).anyTimes()
+    EasyMock.expect(metadataCache.getPartitionLeaderEndpoint(
+      EasyMock.eq(partition2.topic),
+      EasyMock.eq(partition2.partition),
+      EasyMock.anyObject())
+    ).andReturn(Some(broker2)).anyTimes()
+
+    val txnTransitionMetadata2 = txnMetadata2.prepareComplete(time.milliseconds())
+
+    EasyMock.expect(txnStateManager.appendTransactionToLog(
+      EasyMock.eq(transactionalId2),
+      EasyMock.eq(coordinatorEpoch),
+      EasyMock.eq(txnTransitionMetadata2),
+      EasyMock.capture(capturedErrorsCallback)))
+      .andAnswer(new IAnswer[Unit] {
+        override def answer(): Unit = {
+          txnMetadata2.pendingState = None
+          capturedErrorsCallback.getValue.apply(Errors.COORDINATOR_NOT_AVAILABLE)
+        }
+      })
+      .andAnswer(new IAnswer[Unit] {
+      override def answer(): Unit = {
+        txnMetadata2.completeTransitionTo(txnTransitionMetadata2)
+        capturedErrorsCallback.getValue.apply(Errors.NONE)
+      }
+    })
+
+    EasyMock.replay(txnStateManager, metadataCache)
+
+    channelManager.addTxnMarkersToSend(transactionalId2, coordinatorEpoch, txnResult, txnMetadata2, txnTransitionMetadata2)
+
+    val requestAndHandlers: Iterable[RequestAndCompletionHandler] = senderThread.generateRequests()
+
+    val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
+    for (requestAndHandler <- requestAndHandlers) {
+      requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(0, 0, "client", 1), null, null, 0, 0, false, null, response))
+    }
+
+    // call this again so that append log will be retried
+    senderThread.generateRequests()
+
+    EasyMock.verify(txnStateManager)
+
+    assertEquals(0, txnMarkerPurgatory.watched)
+    assertEquals(0, channelManager.queueForBroker(broker1.id).get.totalNumMarkers)
+    assertEquals(None, txnMetadata2.pendingState)
+    assertEquals(CompleteCommit, txnMetadata2.state)
+  }
+
+  private def createPidErrorMap(errors: Errors) = {
+    val pidMap = new java.util.HashMap[java.lang.Long, java.util.Map[TopicPartition, Errors]]()
+    val errorsMap = new java.util.HashMap[TopicPartition, Errors]()
+    errorsMap.put(partition1, errors)
+    pidMap.put(producerId2, errorsMap)
+    pidMap
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -208,7 +208,7 @@ class TransactionStateManagerTest {
   }
 
   @Test
-  def testAppendTransactionToLog() {
+  def testCompleteTransitionWhenAppendSucceeded(): Unit = {
     transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
 
     // first insert the initial transaction metadata
@@ -226,54 +226,116 @@ class TransactionStateManagerTest {
 
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
+  }
 
-    // append to log again with expected failures
-    txnMetadata1.pendingState = None
-    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+  @Test
+  def testAppendFailToCoordinatorNotAvailableError(): Unit = {
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
 
-    // test COORDINATOR_NOT_AVAILABLE cases
     expectedError = Errors.COORDINATOR_NOT_AVAILABLE
+    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
 
     prepareForTxnMessageAppend(Errors.UNKNOWN_TOPIC_OR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
     prepareForTxnMessageAppend(Errors.NOT_ENOUGH_REPLICAS)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
     prepareForTxnMessageAppend(Errors.NOT_ENOUGH_REPLICAS_AFTER_APPEND)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
     prepareForTxnMessageAppend(Errors.REQUEST_TIMED_OUT)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
+  }
 
-    // test NOT_COORDINATOR cases
+  @Test
+  def testAppendFailToNotCoordinatorError(): Unit = {
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+
     expectedError = Errors.NOT_COORDINATOR
+    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
 
     prepareForTxnMessageAppend(Errors.NOT_LEADER_FOR_PARTITION)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
-    // test Unknown cases
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+    prepareForTxnMessageAppend(Errors.NONE)
+    transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
+    transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
+
+    prepareForTxnMessageAppend(Errors.NONE)
+    transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch + 1, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+    transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
+
+    prepareForTxnMessageAppend(Errors.NONE)
+    transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
+  }
+
+  @Test
+  def testAppendFailToCoordinatorLoadingError(): Unit = {
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+
+    expectedError = Errors.COORDINATOR_LOAD_IN_PROGRESS
+    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+
+    prepareForTxnMessageAppend(Errors.NONE)
+    transactionManager.removeTransactionsForTxnTopicPartition(partitionId, coordinatorEpoch)
+    transactionManager.addLoadingPartition(partitionId, coordinatorEpoch + 1)
+    transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
+  }
+
+  @Test
+  def testAppendFailToUnknownError() {
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+
     expectedError = Errors.UNKNOWN
+    var failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
 
     prepareForTxnMessageAppend(Errors.MESSAGE_TOO_LARGE)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
 
+    failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
     prepareForTxnMessageAppend(Errors.RECORD_LIST_TOO_LARGE)
     transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback)
     assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
     assertTrue(txnMetadata1.pendingState.isEmpty)
+  }
+
+  @Test
+  def testPendingStateNotResetOnRetryAppend() {
+    transactionManager.addLoadedTransactionsToCache(partitionId, coordinatorEpoch, new Pool[String, TransactionMetadata]())
+    transactionManager.putTransactionStateIfNotExists(transactionalId1, txnMetadata1)
+
+    expectedError = Errors.COORDINATOR_NOT_AVAILABLE
+    val failedMetadata = txnMetadata1.prepareAddPartitions(Set[TopicPartition](new TopicPartition("topic2", 0)), time.milliseconds())
+
+    prepareForTxnMessageAppend(Errors.UNKNOWN_TOPIC_OR_PARTITION)
+    transactionManager.appendTransactionToLog(transactionalId1, coordinatorEpoch = 10, failedMetadata, assertCallback, _ => true)
+    assertEquals(Right(Some(CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata1))), transactionManager.getTransactionState(transactionalId1))
+    assertEquals(Some(Ongoing), txnMetadata1.pendingState)
   }
 
   @Test


### PR DESCRIPTION
In `TransationStateManager`, we reset the pending state if an error occurred while appending to log; this is correct except that for the `TransactionMarkerChannelManager`, as it will retry appending to log and if eventually it succeeded, the transaction metadata's completing transition will throw an IllegalStateException since pending state is None, this will be thrown all the way to the `KafkaApis` and be swallowed.

1. When re-enqueueing to the retry append queue, re-prepare transition to set its pending state.
2. A bunch of log4j improvements based the debugging experience. The main principle is to make sure all error codes that is about to sent to the client will be logged, and unnecessary log4j entries to be removed.
3. Also moved some log entries in ReplicationUtils.scala to `trace`: this is rather orthogonal to this PR but I found it rather annoying while debugging the logs.
4. A couple of unrelated bug fixes as pointed by @hachikuji and @apurvam .