### PR TITLE
KAFKA-5418: ZkUtils.getAllPartitions() may fail if a topic is marked for deletion

### DIFF
--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -906,10 +906,11 @@ class ZkUtils(val zkClient: ZkClient,
     if(topics == null) Set.empty[TopicAndPartition]
     else {
       topics.flatMap { topic =>
-        val path = getTopicPartitionsPath(topic)
-        if (pathExists(path))
-          getChildren(path).map(_.toInt).map(TopicAndPartition(topic, _))
-        else None
+        try {
+          getChildren(getTopicPartitionsPath(topic)).map(_.toInt).map(TopicAndPartition(topic, _))
+        } catch {
+          case _: ZkNoNodeException => None
+        }
       }.toSet
     }
   }

--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -906,7 +906,10 @@ class ZkUtils(val zkClient: ZkClient,
     if(topics == null) Set.empty[TopicAndPartition]
     else {
       topics.flatMap { topic =>
-        getChildren(getTopicPartitionsPath(topic)).map(_.toInt).map(TopicAndPartition(topic, _))
+        val path = getTopicPartitionsPath(topic)
+        if (pathExists(path))
+          getChildren(path).map(_.toInt).map(TopicAndPartition(topic, _))
+        else None
       }.toSet
     }
   }

--- a/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ZkUtilsTest.scala
@@ -17,6 +17,7 @@
 
 package kafka.utils
 
+import kafka.common.TopicAndPartition
 import kafka.zk.ZooKeeperTestHarness
 import org.junit.Assert._
 import org.junit.Test
@@ -72,5 +73,15 @@ class ZkUtilsTest extends ZooKeeperTestHarness {
   def testClusterIdentifierJsonParsing() {
     val clusterId = "test"
     assertEquals(zkUtils.ClusterId.fromJson(zkUtils.ClusterId.toJson(clusterId)), clusterId)
+  }
+
+  @Test
+  def testGetAllPartitionsTopicWithoutPartitions() {
+    val topic = "testtopic"
+    // Create a regular topic and a topic without any partitions
+    zkUtils.createPersistentPath(ZkUtils.getTopicPartitionPath(topic, 0))
+    zkUtils.createPersistentPath(ZkUtils.getTopicPath("nopartitions"))
+
+    assertEquals(Set(TopicAndPartition(topic, 0)), zkUtils.getAllPartitions())
   }
 }


### PR DESCRIPTION
Skip topics that don't have any partitions in zkUtils.getAllPartitions()