### PR TITLE
KAFKA-3123: Follower Broker cannot start if offsets are already out o…

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -324,18 +324,16 @@ class LogManager(val logDirs: Array[File],
       // If the log does not exist, skip it
       if (log != null) {
         //May need to abort and pause the cleaning of the log, and resume after truncation is done.
-        val needToStopCleaner: Boolean = truncateOffset < log.activeSegment.baseOffset
-        if (needToStopCleaner && cleaner != null)
+        val needToStopCleaner = cleaner != null && truncateOffset < log.activeSegment.baseOffset
+        if (needToStopCleaner)
           cleaner.abortAndPauseCleaning(topicPartition)
         try {
           log.truncateTo(truncateOffset)
-          if (needToStopCleaner && cleaner != null) {
+          if (needToStopCleaner)
             cleaner.maybeTruncateCheckpoint(log.dir.getParentFile, topicPartition, log.activeSegment.baseOffset)
-          }
         } finally {
-          if (needToStopCleaner && cleaner != null) {
+          if (needToStopCleaner)
             cleaner.resumeCleaning(topicPartition)
-          }
         }
       }
     }

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -327,10 +327,15 @@ class LogManager(val logDirs: Array[File],
         val needToStopCleaner: Boolean = truncateOffset < log.activeSegment.baseOffset
         if (needToStopCleaner && cleaner != null)
           cleaner.abortAndPauseCleaning(topicPartition)
-        log.truncateTo(truncateOffset)
-        if (needToStopCleaner && cleaner != null) {
-          cleaner.maybeTruncateCheckpoint(log.dir.getParentFile, topicPartition, log.activeSegment.baseOffset)
-          cleaner.resumeCleaning(topicPartition)
+        try {
+          log.truncateTo(truncateOffset)
+          if (needToStopCleaner && cleaner != null) {
+            cleaner.maybeTruncateCheckpoint(log.dir.getParentFile, topicPartition, log.activeSegment.baseOffset)
+          }
+        } finally {
+          if (needToStopCleaner && cleaner != null) {
+            cleaner.resumeCleaning(topicPartition)
+          }
         }
       }
     }


### PR DESCRIPTION
…f range

From https://github.com/apache/kafka/pull/1716#discussion_r112000498, ensure the cleaner is restarted if Log.truncateTo throws