### PR TITLE
KAFKA-5437: Always send a sig_kill when cleaning the message copier

### DIFF
--- a/tests/kafkatest/services/transactional_message_copier.py
+++ b/tests/kafkatest/services/transactional_message_copier.py
@@ -123,8 +123,8 @@ class TransactionalMessageCopier(KafkaPathResolverMixin, BackgroundThreadService
 
         return cmd
 
-    def clean_node(self, node, clean_shutdown=True):
-        self.kill_node(node, clean_shutdown)
+    def clean_node(self, node):
+        self.kill_node(node, clean_shutdown=False)
         node.account.ssh("rm -rf " + self.PERSISTENT_ROOT, allow_fail=False)
         self.security_config.clean_node(node)
 


### PR DESCRIPTION
When the message copier hangs (like when there is a bug in the client), it ignores the sigterm and doesn't shut down. this leaves the cluster in an unclean state causing future tests to fail. 

In this patch we always send SIGKILL when cleaning the node if the process isn't already dead. This is consistent with the other services.