### PR TITLE
KAFKA-5438: Fix UnsupportedOperationException in writeTxnMarkersRequest

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1503,7 +1503,10 @@ class KafkaApis(val requestChannel: RequestChannel,
 
     def sendResponseCallback(producerId: Long, result: TransactionResult)(responseStatus: Map[TopicPartition, PartitionResponse]): Unit = {
       trace(s"End transaction marker append for producer id $producerId completed with status: $responseStatus")
-      val partitionErrors = responseStatus.mapValues(_.error).asJava
+      val partitionErrors = new util.HashMap[TopicPartition, Errors]()
+      responseStatus.foreach { case (topicPartition, partitionResponse) =>
+        partitionErrors.put(topicPartition, partitionResponse.error)
+      }
       val previous = errors.putIfAbsent(producerId, partitionErrors)
       if (previous != null)
         previous.putAll(partitionErrors)

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -44,8 +44,6 @@ class TransactionsTest extends KafkaServerTestHarness {
 
   val topic1 = "topic1"
   val topic2 = "topic2"
-  val topicWith100Partitions = "largeTopic"
-  val topicWith100PartitionsAndOneReplica = "largeTopicOneReplica"
 
   val transactionalProducers = Buffer[KafkaProducer[Array[Byte], Array[Byte]]]()
   val transactionalConsumers = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
@@ -63,8 +61,6 @@ class TransactionsTest extends KafkaServerTestHarness {
     topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
     TestUtils.createTopic(zkUtils, topic1, numPartitions, numServers, servers, topicConfig)
     TestUtils.createTopic(zkUtils, topic2, numPartitions, numServers, servers, topicConfig)
-    TestUtils.createTopic(zkUtils, topicWith100Partitions, 100, numServers, servers, topicConfig)
-    TestUtils.createTopic(zkUtils, topicWith100PartitionsAndOneReplica, 100, 1, servers, new Properties())
 
     for (_ <- 0 until transactionalProducerCount)
       createTransactionalProducer("transactional-producer")
@@ -443,6 +439,13 @@ class TransactionsTest extends KafkaServerTestHarness {
     val firstProducer = transactionalProducers.head
     val consumer = transactionalConsumers.head
     val unCommittedConsumer = nonTransactionalConsumers.head
+    val topicWith100Partitions = "largeTopic"
+    val topicWith100PartitionsAndOneReplica = "largeTopicOneReplica"
+    val topicConfig = new Properties()
+    topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
+
+    TestUtils.createTopic(zkUtils, topicWith100Partitions, 100, numServers, servers, topicConfig)
+    TestUtils.createTopic(zkUtils, topicWith100PartitionsAndOneReplica, 100, 1, servers, new Properties())
 
     firstProducer.initTransactions()
 

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -439,27 +439,27 @@ class TransactionsTest extends KafkaServerTestHarness {
     val firstProducer = transactionalProducers.head
     val consumer = transactionalConsumers.head
     val unCommittedConsumer = nonTransactionalConsumers.head
-    val topicWith100Partitions = "largeTopic"
-    val topicWith100PartitionsAndOneReplica = "largeTopicOneReplica"
+    val topicWith10Partitions = "largeTopic"
+    val topicWith10PartitionsAndOneReplica = "largeTopicOneReplica"
     val topicConfig = new Properties()
     topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
 
-    TestUtils.createTopic(zkUtils, topicWith100Partitions, 10, numServers, servers, topicConfig)
-    TestUtils.createTopic(zkUtils, topicWith100PartitionsAndOneReplica, 10, 1, servers, new Properties())
+    TestUtils.createTopic(zkUtils, topicWith10Partitions, 10, numServers, servers, topicConfig)
+    TestUtils.createTopic(zkUtils, topicWith10PartitionsAndOneReplica, 10, 1, servers, new Properties())
 
     firstProducer.initTransactions()
 
     firstProducer.beginTransaction()
-    sendTransactionalMessagesWithValueRange(firstProducer, topicWith100Partitions, 0, 5000, willBeCommitted = false)
-    sendTransactionalMessagesWithValueRange(firstProducer, topicWith100PartitionsAndOneReplica, 5000, 10000, willBeCommitted = false)
+    sendTransactionalMessagesWithValueRange(firstProducer, topicWith10Partitions, 0, 5000, willBeCommitted = false)
+    sendTransactionalMessagesWithValueRange(firstProducer, topicWith10PartitionsAndOneReplica, 5000, 10000, willBeCommitted = false)
     firstProducer.abortTransaction()
 
     firstProducer.beginTransaction()
-    sendTransactionalMessagesWithValueRange(firstProducer, topicWith100Partitions, 10000, 11000, willBeCommitted = true)
+    sendTransactionalMessagesWithValueRange(firstProducer, topicWith10Partitions, 10000, 11000, willBeCommitted = true)
     firstProducer.commitTransaction()
 
-    consumer.subscribe(List(topicWith100PartitionsAndOneReplica, topicWith100Partitions).asJava)
-    unCommittedConsumer.subscribe(List(topicWith100PartitionsAndOneReplica, topicWith100Partitions).asJava)
+    consumer.subscribe(List(topicWith10PartitionsAndOneReplica, topicWith10Partitions).asJava)
+    unCommittedConsumer.subscribe(List(topicWith10PartitionsAndOneReplica, topicWith10Partitions).asJava)
 
     val records = consumeRecords(consumer, 1000)
     records.foreach { record =>

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -475,7 +475,7 @@ class TransactionsTest extends KafkaServerTestHarness {
 
   private def sendTransactionalMessagesWithValueRange(producer: KafkaProducer[Array[Byte], Array[Byte]], topic: String,
                                                       start: Int, end: Int, willBeCommitted: Boolean): Unit = {
-    for (i <- Range(start, end)) {
+    for (i <- start until end) {
       producer.send(TestUtils.producerRecordWithExpectedTransactionStatus(topic, i.toString, i.toString, willBeCommitted))
     }
     producer.flush()

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -444,8 +444,8 @@ class TransactionsTest extends KafkaServerTestHarness {
     val topicConfig = new Properties()
     topicConfig.put(KafkaConfig.MinInSyncReplicasProp, 2.toString)
 
-    TestUtils.createTopic(zkUtils, topicWith100Partitions, 100, numServers, servers, topicConfig)
-    TestUtils.createTopic(zkUtils, topicWith100PartitionsAndOneReplica, 100, 1, servers, new Properties())
+    TestUtils.createTopic(zkUtils, topicWith100Partitions, 10, numServers, servers, topicConfig)
+    TestUtils.createTopic(zkUtils, topicWith100PartitionsAndOneReplica, 10, 1, servers, new Properties())
 
     firstProducer.initTransactions()
 


### PR DESCRIPTION
Before this patch, the `partitionErrors` was an immutable map. As a result if a single producer had a marker for multiple partitions, and if there were multiple response callbacks for a single append, we would get an `UnsupportedOperationException` in the `writeTxnMarker` handler.