### PR TITLE
MINOR: Generate deprecated warning for static default quota config

### DIFF
--- a/core/src/main/scala/kafka/server/QuotaFactory.scala
+++ b/core/src/main/scala/kafka/server/QuotaFactory.scala
@@ -17,6 +17,7 @@
 package kafka.server
 
 import kafka.server.QuotaType._
+import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.utils.Time
@@ -30,7 +31,7 @@ object QuotaType  {
 }
 sealed trait QuotaType
 
-object QuotaFactory {
+object QuotaFactory extends Logging {
 
   object UnboundedQuota extends ReplicaQuota {
     override def isThrottled(topicPartition: TopicPartition): Boolean = false
@@ -55,19 +56,25 @@ object QuotaFactory {
     )
   }
 
-  def clientProduceConfig(cfg: KafkaConfig): ClientQuotaManagerConfig =
+  def clientProduceConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
+  if (cfg.producerQuotaBytesPerSecondDefault != Long.MaxValue)
+    warn(s"${KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp} has been deprecated in 0.11.0 and will be removed in a future release. Use dynamic quota defaults instead.")
     ClientQuotaManagerConfig(
       quotaBytesPerSecondDefault = cfg.producerQuotaBytesPerSecondDefault,
       numQuotaSamples = cfg.numQuotaSamples,
       quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds
     )
+  }
 
-  def clientFetchConfig(cfg: KafkaConfig): ClientQuotaManagerConfig =
+  def clientFetchConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
+    if (cfg.consumerQuotaBytesPerSecondDefault != Long.MaxValue)
+      warn(s"${KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp} has been deprecated in 0.11.0 and will be removed in a future release. Use dynamic quota defaults instead.")
     ClientQuotaManagerConfig(
       quotaBytesPerSecondDefault = cfg.consumerQuotaBytesPerSecondDefault,
       numQuotaSamples = cfg.numQuotaSamples,
       quotaWindowSizeSeconds = cfg.quotaWindowSizeSeconds
     )
+  }
 
   def clientRequestConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
     ClientQuotaManagerConfig(

--- a/core/src/main/scala/kafka/server/QuotaFactory.scala
+++ b/core/src/main/scala/kafka/server/QuotaFactory.scala
@@ -57,8 +57,8 @@ object QuotaFactory extends Logging {
   }
 
   def clientProduceConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
-  if (cfg.producerQuotaBytesPerSecondDefault != Long.MaxValue)
-    warn(s"${KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp} has been deprecated in 0.11.0 and will be removed in a future release. Use dynamic quota defaults instead.")
+    if (cfg.producerQuotaBytesPerSecondDefault != Long.MaxValue)
+      warn(s"${KafkaConfig.ProducerQuotaBytesPerSecondDefaultProp} has been deprecated in 0.11.0.0 and will be removed in a future release. Use dynamic quota defaults instead.")
     ClientQuotaManagerConfig(
       quotaBytesPerSecondDefault = cfg.producerQuotaBytesPerSecondDefault,
       numQuotaSamples = cfg.numQuotaSamples,
@@ -68,7 +68,7 @@ object QuotaFactory extends Logging {
 
   def clientFetchConfig(cfg: KafkaConfig): ClientQuotaManagerConfig = {
     if (cfg.consumerQuotaBytesPerSecondDefault != Long.MaxValue)
-      warn(s"${KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp} has been deprecated in 0.11.0 and will be removed in a future release. Use dynamic quota defaults instead.")
+      warn(s"${KafkaConfig.ConsumerQuotaBytesPerSecondDefaultProp} has been deprecated in 0.11.0.0 and will be removed in a future release. Use dynamic quota defaults instead.")
     ClientQuotaManagerConfig(
       quotaBytesPerSecondDefault = cfg.consumerQuotaBytesPerSecondDefault,
       numQuotaSamples = cfg.numQuotaSamples,


### PR DESCRIPTION
The default client-id bandwidth quota config properties have been marked deprecated in the doc, but a warning may be useful before the property is removed in a future release.