### PR TITLE
KAFKA-5274: AdminClient Javadoc improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -780,6 +780,7 @@ project(':clients') {
     include "**/org/apache/kafka/clients/producer/*"
     include "**/org/apache/kafka/common/*"
     include "**/org/apache/kafka/common/acl/*"
+    include "**/org/apache/kafka/common/annotation/*"
     include "**/org/apache/kafka/common/errors/*"
     include "**/org/apache/kafka/common/header/*"
     include "**/org/apache/kafka/common/resource/*"

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -51,6 +51,7 @@
     <allow pkg="org.apache.kafka.test" />
 
     <subpackage name="acl">
+      <allow pkg="org.apache.kafka.common.annotation" />
       <allow pkg="org.apache.kafka.common.acl" />
       <allow pkg="org.apache.kafka.common.resource" />
     </subpackage>

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -47,6 +47,7 @@
   <subpackage name="common">
     <disallow pkg="org.apache.kafka.clients" />
     <allow pkg="org.apache.kafka.common" exact-match="true" />
+    <allow pkg="org.apache.kafka.common.annotation" />
     <allow pkg="org.apache.kafka.common.internals" exact-match="true" />
     <allow pkg="org.apache.kafka.test" />
 
@@ -75,6 +76,7 @@
     </subpackage>
 
     <subpackage name="resource">
+      <allow pkg="org.apache.kafka.common.annotation" />
       <allow pkg="org.apache.kafka.common.resource" />
     </subpackage>
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -30,6 +30,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * The administrative client for Kafka, which supports managing and inspecting topics, brokers, configurations and ACLs.
  *
+ * The minimum broker version required is 0.10.0.0. Methods with stricter requirements will specify the minimum broker
+ * version required.
+ *
  * This client was introduced in 0.11.0.0 and the API is still evolving. We will try to evolve the API in a compatible
  * manner, but we reserve the right to make breaking changes in minor releases, if necessary. We will update the
  * {@code InterfaceStability} annotation and this notice once the API is considered stable.
@@ -83,6 +86,8 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Create a batch of new topics with the default options.
      *
+     * This operation is supported by brokers with version 0.10.1.0 or higher.
+     *
      * @param newTopics         The new topics to create.
      * @return                  The CreateTopicsResult.
      */
@@ -98,6 +103,9 @@ public abstract class AdminClient implements AutoCloseable {
      * During this time, AdminClient#listTopics and AdminClient#describeTopics
      * may not return information about the new topics.
      *
+     * This operation is supported by brokers with version 0.10.1.0 or higher. The validateOnly option is supported
+     * from version 0.10.2.0.
+     *
      * @param newTopics         The new topics to create.
      * @param options           The options to use when creating the new topics.
      * @return                  The CreateTopicsResult.
@@ -108,6 +116,8 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Similar to #{@link AdminClient#deleteTopics(Collection<String>, DeleteTopicsOptions)},
      * but uses the default options.
+     *
+     * This operation is supported by brokers with version 0.10.1.0 or higher.
      *
      * @param topics            The topic names to delete.
      * @return                  The DeleteTopicsResult.
@@ -127,6 +137,8 @@ public abstract class AdminClient implements AutoCloseable {
      * If delete.topic.enable is false on the brokers, deleteTopics will mark
      * the topics for deletion, but not actually delete them.  The futures will
      * return successfully in this case.
+     *
+     * This operation is supported by brokers with version 0.10.1.0 or higher.
      *
      * @param topics            The topic names to delete.
      * @param options           The options to use when deleting the topics.
@@ -196,6 +208,8 @@ public abstract class AdminClient implements AutoCloseable {
      * Similar to #{@link AdminClient#describeAcls(AclBindingFilter, DescribeAclsOptions)},
      * but uses the default options.
      *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
+     *
      * @param filter            The filter to use.
      * @return                  The DeleteAclsResult.
      */
@@ -209,6 +223,8 @@ public abstract class AdminClient implements AutoCloseable {
      * Note: it may take some time for changes made by createAcls or deleteAcls to be reflected
      * in the output of describeAcls.
      *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
+     *
      * @param filter            The filter to use.
      * @param options           The options to use when listing the ACLs.
      * @return                  The DeleteAclsResult.
@@ -218,6 +234,8 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Similar to #{@link AdminClient#createAcls(Collection<AclBinding>, CreateAclsOptions)},
      * but uses the default options.
+     *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
      *
      * @param acls              The ACLs to create
      * @return                  The CreateAclsResult.
@@ -232,6 +250,8 @@ public abstract class AdminClient implements AutoCloseable {
      * If you attempt to add an ACL that duplicates an existing ACL, no error will be raised, but
      * no changes will be made.
      *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
+     *
      * @param acls              The ACLs to create
      * @param options           The options to use when creating the ACLs.
      * @return                  The CreateAclsResult.
@@ -242,6 +262,8 @@ public abstract class AdminClient implements AutoCloseable {
      * Similar to #{@link AdminClient#deleteAcls(Collection<AclBinding>, DeleteAclsOptions)},
      * but uses the default options.
      *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
+     *
      * @param filters           The filters to use.
      * @return                  The DeleteAclsResult.
      */
@@ -251,6 +273,8 @@ public abstract class AdminClient implements AutoCloseable {
 
     /**
      * Deletes access control lists (ACLs) according to the supplied filters.
+     *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
      *
      * @param filters           The filters to use.
      * @param options           The options to use when deleting the ACLs.
@@ -263,6 +287,8 @@ public abstract class AdminClient implements AutoCloseable {
      * Get the configuration for the specified resources with the default options.
      *
      * See {@link #describeConfigs(Collection, DescribeConfigsOptions)} for more details.
+      *
+      * This operation is supported by brokers with version 0.11.0.0 or higher.
      *
      * @param resources         The resources (topic and broker resource types are currently supported)
      * @return                  The DescribeConfigsResult
@@ -282,6 +308,8 @@ public abstract class AdminClient implements AutoCloseable {
      *
      * Config entries where isReadOnly() is true cannot be updated.
      *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
+     *
      * @param resources         The resources (topic and broker resource types are currently supported)
      * @param options           The options to use when describing configs
      * @return                  The DescribeConfigsResult
@@ -293,6 +321,8 @@ public abstract class AdminClient implements AutoCloseable {
      * Update the configuration for the specified resources with the default options.
      *
      * See {@link #alterConfigs(Map, AlterConfigsOptions)} for more details.
+     *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
      *
      * @param configs         The resources with their configs (topic is the only resource type with configs that can
      *                        be updated currently)
@@ -307,6 +337,8 @@ public abstract class AdminClient implements AutoCloseable {
      *
      * Updates are not transactional so they may succeed for some resources while fail for others. The configs for
      * a particular resource are updated atomically.
+     *
+     * This operation is supported by brokers with version 0.11.0.0 or higher.
      *
      * @param configs         The resources with their configs (topic is the only resource type with configs that can
      *                        be updated currently)

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -28,12 +28,13 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 /**
- * The public interface for the {@link KafkaAdminClient}, which supports managing and inspecting topics,
- * brokers, and configurations.
+ * The administrative client for Kafka, which supports managing and inspecting topics, brokers, configurations and ACLs.
  *
- * @see KafkaAdminClient
+ * This client was introduced in 0.11.0.0 and the API is still evolving. We will try to evolve the API in a compatible
+ * manner, but we reserve the right to make breaking changes in minor releases, if necessary. We will update the
+ * {@code InterfaceStability} annotation and this notice once the API is considered stable.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public abstract class AdminClient implements AutoCloseable {
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -31,7 +31,7 @@ import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 
 /**
- * The AdminClient configuration keys
+ * The AdminClient configuration class, which also contains constants for configuration entry names.
  */
 public class AdminClientConfig extends AbstractConfig {
     private static final ConfigDef CONFIG;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
@@ -19,25 +19,46 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
-@InterfaceStability.Unstable
+import java.util.Map;
+
+/**
+ * Options for {@link AdminClient#alterConfigs(Map)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
 public class AlterConfigsOptions {
 
     private Integer timeoutMs = null;
     private boolean validateOnly = false;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
+    public AlterConfigsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
 
+    /**
+     * Return true if the request should be validated without altering the configs.
+     */
     public boolean isValidateOnly() {
         return validateOnly;
     }
 
-    public AlterConfigsOptions timeoutMs(Integer timeout) {
-        this.timeoutMs = timeout;
-        return this;
-    }
-
+    /**
+     * Set to true if the request should be validated without altering the configs.
+     */
     public AlterConfigsOptions validateOnly(boolean validateOnly) {
         this.validateOnly = validateOnly;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsResult.java
@@ -45,7 +45,7 @@ public class AlterConfigsResult {
     }
 
     /**
-     * Return a future which succeeds only if all the alter configs succeed.
+     * Return a future which succeeds only if all the alter configs operations succeed.
      */
     public KafkaFuture<Void> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsResult.java
@@ -23,7 +23,12 @@ import org.apache.kafka.common.config.ConfigResource;
 
 import java.util.Map;
 
-@InterfaceStability.Unstable
+/**
+ * The result of the {@link AdminClient#alterConfigs(Map)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
 public class AlterConfigsResult {
 
     private final Map<ConfigResource, KafkaFuture<Void>> futures;
@@ -32,10 +37,16 @@ public class AlterConfigsResult {
         this.futures = futures;
     }
 
+    /**
+     * Return a map from resources to futures which can be used to check the status of the operation on each resource.
+     */
     public Map<ConfigResource, KafkaFuture<Void>> results() {
         return futures;
     }
 
+    /**
+     * Return a future which succeeds only if all the alter configs succeed.
+     */
     public KafkaFuture<Void> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
@@ -17,21 +17,38 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * A configuration object containing the configuration entries for a resource.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
 public class Config {
 
     private final Collection<ConfigEntry> entries;
 
+    /**
+     * Create a configuration instance with the provided entries.
+     */
     public Config(Collection<ConfigEntry> entries) {
-        this.entries = entries;
+        this.entries = Collections.unmodifiableCollection(entries);
     }
 
+    /**
+     * Configuration entries for a resource.
+     */
     public Collection<ConfigEntry> entries() {
-        return Collections.unmodifiableCollection(entries);
+        return entries;
     }
 
+    /**
+     * Get the configuration entry with the provided name or null if there isn't one.
+     */
     public ConfigEntry get(String name) {
         for (ConfigEntry entry : entries)
             if (entry.name().equals(name))

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConfigEntry.java
@@ -17,6 +17,16 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Objects;
+
+/**
+ * A class representing a configuration entry containing name, value and additional metadata.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
 public class ConfigEntry {
 
     private final String name;
@@ -25,11 +35,27 @@ public class ConfigEntry {
     private final boolean isSensitive;
     private final boolean isReadOnly;
 
+    /**
+     * Create a configuration entry with the provided values.
+     *
+     * @param name the non-null config name
+     * @param value the config value or null
+     */
     public ConfigEntry(String name, String value) {
         this(name, value, false, false, false);
     }
 
+    /**
+     * Create a configuration with the provided values.
+     *
+     * @param name the non-null config name
+     * @param value the config value or null
+     * @param isDefault whether the config value is the default or if it's been explicitly set
+     * @param isSensitive whether the config value is sensitive, the broker never returns the value if it is sensitive
+     * @param isReadOnly whether the config is read-only and cannot be updated
+     */
     public ConfigEntry(String name, String value, boolean isDefault, boolean isSensitive, boolean isReadOnly) {
+        Objects.requireNonNull(name, "name should not be null");
         this.name = name;
         this.value = value;
         this.isDefault = isDefault;
@@ -37,22 +63,38 @@ public class ConfigEntry {
         this.isReadOnly = isReadOnly;
     }
 
+    /**
+     * Return the config name.
+     */
     public String name() {
         return name;
     }
 
+    /**
+     * Return the value or null. Null is returned if the config is unset or if isSensitive is true.
+     */
     public String value() {
         return value;
     }
 
+    /**
+     * Return whether the config value is the default or if it's been explicitly set.
+     */
     public boolean isDefault() {
         return isDefault;
     }
 
+    /**
+     * Return whether the config value is sensitive. The value is always set to null by the broker if the config value
+     * is sensitive.
+     */
     public boolean isSensitive() {
         return isSensitive;
     }
 
+    /**
+     * Return whether the config is read-only and cannot be updated.
+     */
     public boolean isReadOnly() {
         return isReadOnly;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
@@ -17,18 +17,34 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
 /**
- * Options for the createAcls call.
+ * Options for {@link AdminClient#createAcls(Collection)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
+@InterfaceStability.Evolving
 public class CreateAclsOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public CreateAclsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsResult.java
@@ -19,12 +19,17 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
- * The result of the createAcls call.
+ * The result of the {@link AdminClient#createAcls(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
+@InterfaceStability.Evolving
 public class CreateAclsResult {
     private final Map<AclBinding, KafkaFuture<Void>> futures;
 
@@ -33,15 +38,15 @@ public class CreateAclsResult {
     }
 
     /**
-     * Return a map from topic names to futures which can be used to check the status of
-     * individual deletions.
+     * Return a map from ACL bindings to futures which can be used to check the status of the creation of each ACL
+     * binding.
      */
     public Map<AclBinding, KafkaFuture<Void>> results() {
         return futures;
     }
 
     /**
-     * Return a future which succeeds only if all the topic deletions succeed.
+     * Return a future which succeeds only if all the ACL creations succeed.
      */
     public KafkaFuture<Void> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
@@ -19,29 +19,48 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
+
 /**
- * Options for newTopics.
+ * Options for {@link AdminClient#createTopics(Collection)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class CreateTopicsOptions {
     private Integer timeoutMs = null;
     private boolean validateOnly = false;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public CreateTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
 
+    /**
+     * Set to true if the request should be validated without creating the topic.
+     */
     public CreateTopicsOptions validateOnly(boolean validateOnly) {
         this.validateOnly = validateOnly;
         return this;
     }
 
+    /**
+     * Return true if the request should be validated without creating the topic.
+     */
     public boolean validateOnly() {
         return validateOnly;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsResult.java
@@ -19,12 +19,15 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
- * The result of newTopics.
+ * The result of {@link AdminClient#createTopics(Collection)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class CreateTopicsResult {
     private final Map<String, KafkaFuture<Void>> futures;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
@@ -17,18 +17,34 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
 /**
- * Options for the deleteAcls call.
+ * Options for the {@link AdminClient#deleteAcls(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
+@InterfaceStability.Evolving
 public class DeleteAclsOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public DeleteAclsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsResult.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.errors.ApiException;
 
 import java.util.ArrayList;
@@ -29,9 +30,16 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * The result of the deleteAcls call.
+ * The result of the {@link AdminClient#deleteAcls(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
+@InterfaceStability.Evolving
 public class DeleteAclsResult {
+
+    /**
+     * A class containing either the deleted ACL or an exception if the delete failed.
+     */
     public static class FilterResult {
         private final AclBinding acl;
         private final ApiException exception;
@@ -41,15 +49,24 @@ public class DeleteAclsResult {
             this.exception = exception;
         }
 
+        /**
+         * Return the deleted ACL or null if there was an error.
+         */
         public AclBinding acl() {
             return acl;
         }
 
+        /**
+         * Return an exception if the ACL delete was not successful or null if it was.
+         */
         public ApiException exception() {
             return exception;
         }
     }
 
+    /**
+     * A class containing the results of the delete ACLs operation.
+     */
     public static class FilterResults {
         private final List<FilterResult> acls;
 
@@ -57,6 +74,9 @@ public class DeleteAclsResult {
             this.acls = acls;
         }
 
+        /**
+         * Return a list of delete ACLs results.
+         */
         public List<FilterResult> acls() {
             return acls;
         }
@@ -69,8 +89,8 @@ public class DeleteAclsResult {
     }
 
     /**
-     * Return a map from topic names to futures which can be used to check the status of
-     * individual deletions.
+     * Return a map from acl filters to futures which can be used to check the status of the deletions by each
+     * filter.
      */
     public Map<AclBindingFilter, KafkaFuture<FilterResults>> results() {
         return futures;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
@@ -19,19 +19,32 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
+
 /**
- * Options for deleteTopics.
+ * Options for {@link AdminClient#deleteTopics(Collection)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DeleteTopicsOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public DeleteTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsResult.java
@@ -20,12 +20,15 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
- * The result of the deleteTopics call.
+ * The result of the {@link AdminClient#deleteTopics(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DeleteTopicsResult {
     final Map<String, KafkaFuture<Void>> futures;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
@@ -17,18 +17,33 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 /**
- * Options for the describeAcls call.
+ * Options for {@link AdminClient#describeAcls(AclBindingFilter)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
+@InterfaceStability.Evolving
 public class DescribeAclsOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public DescribeAclsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsResult.java
@@ -19,12 +19,17 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
 
 /**
- * The result of the describeAcls call.
+ * The result of the {@link KafkaAdminClient#describeAcls(AclBindingFilter)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
+@InterfaceStability.Evolving
 public class DescribeAclsResult {
     private final KafkaFuture<Collection<AclBinding>> future;
 
@@ -32,6 +37,9 @@ public class DescribeAclsResult {
         this.future = future;
     }
 
+    /**
+     * Return a future containing the ACLs requested.
+     */
     public KafkaFuture<Collection<AclBinding>> all() {
         return future;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
@@ -20,18 +20,29 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 /**
- * Options for the describeCluster call.
+ * Options for {@link AdminClient#describeCluster()}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DescribeClusterOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public DescribeClusterOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
@@ -58,8 +58,8 @@ public class DescribeClusterResult {
     }
 
     /**
-     * Returns a future which yields the current cluster Id.
-     * Note that this may yield null, if the cluster version is too old.
+     * Returns a future which yields the current cluster id. The future value will be non-null if the
+     * broker version is 0.10.1.0 or higher and null otherwise.
      */
     public KafkaFuture<String> clusterId() {
         return clusterId;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterResult.java
@@ -24,17 +24,19 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 import java.util.Collection;
 
 /**
- * The results of the describeCluster call.
+ * The result of the {@link KafkaAdminClient#describeCluster()} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DescribeClusterResult {
     private final KafkaFuture<Collection<Node>> nodes;
     private final KafkaFuture<Node> controller;
     private final KafkaFuture<String> clusterId;
 
     DescribeClusterResult(KafkaFuture<Collection<Node>> nodes,
-                           KafkaFuture<Node> controller,
-                           KafkaFuture<String> clusterId) {
+                          KafkaFuture<Node> controller,
+                          KafkaFuture<String> clusterId) {
         this.nodes = nodes;
         this.controller = controller;
         this.clusterId = clusterId;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
@@ -19,18 +19,30 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
+
 /**
- * Options for describeConfigs.
+ * Options for {@link AdminClient#describeConfigs(Collection)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DescribeConfigsOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public DescribeConfigsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsResult.java
@@ -21,11 +21,17 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.config.ConfigResource;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
-@InterfaceStability.Unstable
+/**
+ * The result of the {@link KafkaAdminClient#describeConfigs(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
 public class DescribeConfigsResult {
 
     private final Map<ConfigResource, KafkaFuture<Config>> futures;
@@ -34,10 +40,17 @@ public class DescribeConfigsResult {
         this.futures = futures;
     }
 
+    /**
+     * Return a map from resources to futures which can be used to check the status of the configuration for each
+     * resource.
+     */
     public Map<ConfigResource, KafkaFuture<Config>> results() {
         return futures;
     }
 
+    /**
+     * Return a future which succeeds only if all the config descriptions succeed.
+     */
     public KafkaFuture<Map<ConfigResource, Config>> all() {
         return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).
                 thenApply(new KafkaFuture.Function<Void, Map<ConfigResource, Config>>() {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
@@ -19,19 +19,32 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
+
 /**
- * Options for describeTopics.
+ * Options for {@link AdminClient#describeTopics(Collection)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DescribeTopicsOptions {
     private Integer timeoutMs = null;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public DescribeTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsResult.java
@@ -20,14 +20,17 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 /**
- * The results of the describeTopic call.
+ * The result of the {@link KafkaAdminClient#describeTopics(Collection)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class DescribeTopicsResult {
     private final Map<String, KafkaFuture<TopicDescription>> futures;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -103,10 +103,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 
 /**
- * An administrative client for Kafka which supports managing and inspecting topics, brokers,
- * and configurations.
+ * The default implementation of {@link AdminClient}. An instance of this class is created by invoking one of the
+ * {@code create()} methods in {@code AdminClient}. Users should not refer to this class directly.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class KafkaAdminClient extends AdminClient {
     private static final Logger log = LoggerFactory.getLogger(KafkaAdminClient.class);
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
@@ -20,18 +20,28 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 /**
- * Options for listTopics.
+ * Options for {@link AdminClient#listTopics()}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class ListTopicsOptions {
     private Integer timeoutMs = null;
     private boolean listInternal = false;
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public ListTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }
 
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     */
     public Integer timeoutMs() {
         return timeoutMs;
     }
@@ -48,6 +58,9 @@ public class ListTopicsOptions {
         return this;
     }
 
+    /**
+     * Return true if we should list internal topics.
+     */
     public boolean listInternal() {
         return listInternal;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsResult.java
@@ -24,9 +24,11 @@ import java.util.Collection;
 import java.util.Map;
 
 /**
- * The result of the listTopics call.
+ * The result of the {@link AdminClient#listTopics()} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
  */
-@InterfaceStability.Unstable
+@InterfaceStability.Evolving
 public class ListTopicsResult {
     final KafkaFuture<Map<String, TopicListing>> future;
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewTopic.java
@@ -19,11 +19,13 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 /**
- * A request to create a new topic through the AdminClient API. 
+ * A new topic to be created via {@link AdminClient#createTopics(Collection)}.
  */
 public class NewTopic {
     private final String name;
@@ -33,7 +35,7 @@ public class NewTopic {
     private Map<String, String> configs = null;
 
     /**
-     * Create a new topic with a fixed replication factor and number of partitions.
+     * A new topic with the specified replication factor and number of partitions.
      */
     public NewTopic(String name, int numPartitions, short replicationFactor) {
         this.name = name;
@@ -43,25 +45,46 @@ public class NewTopic {
     }
 
     /**
-     * A request to create a new topic with a specific replica assignment configuration.
+     * A new topic with the specified replica assignment configuration.
+     *
+     * @param name the topic name.
+     * @param replicasAssignments a map from partition id to replica ids (i.e. broker ids). Although not enforced, it is
+     *                            generally a good idea for all partitions to have the same number of replicas.
      */
     public NewTopic(String name, Map<Integer, List<Integer>> replicasAssignments) {
         this.name = name;
         this.numPartitions = -1;
         this.replicationFactor = -1;
-        this.replicasAssignments = replicasAssignments;
+        this.replicasAssignments = Collections.unmodifiableMap(replicasAssignments);
     }
 
+    /**
+     * The name of the topic to be created.
+     */
     public String name() {
         return name;
     }
 
+    /**
+     * The number of partitions for the new topic or -1 if a replica assignment has been specified.
+     */
     public int partitions() {
         return numPartitions;
     }
 
+    /**
+     * The replication factor for the new topic or -1 if a replica assignment has been specified.
+     */
     public short replicationFactor() {
         return replicationFactor;
+    }
+
+    /**
+     * A map from partition id to replica ids (i.e. broker ids) or null if the number of partitions and replication
+     * factor have been specified instead.
+     */
+    public Map<Integer, List<Integer>> replicasAssignments() {
+        return replicasAssignments;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
@@ -60,7 +60,7 @@ public class TopicDescription {
     }
 
     /**
-     * A map from partition id to its leadership and replica information.
+     * A map from partition id to the leadership and replica information for that partition.
      */
     public NavigableMap<Integer, TopicPartitionInfo> partitions() {
         return partitions;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicDescription.java
@@ -30,6 +30,13 @@ public class TopicDescription {
     private final boolean internal;
     private final NavigableMap<Integer, TopicPartitionInfo> partitions;
 
+    /**
+     * Create an instance with the specified parameters.
+     *
+     * @param name The topic name
+     * @param internal Whether the topic is internal to Kafka
+     * @param partitions A map from partition id to its leadership and replica information
+     */
     public TopicDescription(String name, boolean internal,
                     NavigableMap<Integer, TopicPartitionInfo> partitions) {
         this.name = name;
@@ -37,14 +44,24 @@ public class TopicDescription {
         this.partitions = partitions;
     }
 
+    /**
+     * The name of the topic.
+     */
     public String name() {
         return name;
     }
 
+    /**
+     * Whether the topic is internal to Kafka. An example of an internal topic is the offsets and group management topic:
+     * __consumer_offsets.
+     */
     public boolean internal() {
         return internal;
     }
 
+    /**
+     * A map from partition id to its leadership and replica information.
+     */
     public NavigableMap<Integer, TopicPartitionInfo> partitions() {
         return partitions;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/TopicListing.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/TopicListing.java
@@ -24,15 +24,28 @@ public class TopicListing {
     private final String name;
     private final boolean internal;
 
+    /**
+     * Create an instance with the specified parameters.
+     *
+     * @param name The topic name
+     * @param internal Whether the topic is internal to Kafka
+     */
     public TopicListing(String name, boolean internal) {
         this.name = name;
         this.internal = internal;
     }
 
+    /**
+     * The name of the topic.
+     */
     public String name() {
         return name;
     }
 
+    /**
+     * Whether the topic is internal to Kafka. An example of an internal topic is the offsets and group management topic:
+     * __consumer_offsets.
+     */
     public boolean internal() {
         return internal;
     }

--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
 import java.util.concurrent.ExecutionException;
@@ -24,8 +25,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A flexible future which supports call chaining and other asynchronous programming patterns.
+ * A flexible future which supports call chaining and other asynchronous programming patterns. This will
+ * eventually become a thin shim on top of Java 8's CompletableFuture.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public abstract class KafkaFuture<T> implements Future<T> {
     /**
      * A function which takes objects of type A and returns objects of type B.
@@ -85,7 +90,7 @@ public abstract class KafkaFuture<T> implements Future<T> {
      * an exception, which one gets returned is arbitrarily chosen.
      */
     public static KafkaFuture<Void> allOf(KafkaFuture<?>... futures) {
-        KafkaFuture<Void> allOfFuture = new KafkaFutureImpl<Void>();
+        KafkaFuture<Void> allOfFuture = new KafkaFutureImpl<>();
         AllOfAdapter allOfWaiter = new AllOfAdapter(futures.length, allOfFuture);
         for (KafkaFuture<?> future : futures) {
             future.addWaiter(allOfWaiter);

--- a/clients/src/main/java/org/apache/kafka/common/TopicPartitionInfo.java
+++ b/clients/src/main/java/org/apache/kafka/common/TopicPartitionInfo.java
@@ -21,12 +21,24 @@ import org.apache.kafka.common.utils.Utils;
 
 import java.util.List;
 
+/**
+ * A class containing leadership, replicas and ISR information for a topic partition.
+ */
 public class TopicPartitionInfo {
     private final int partition;
     private final Node leader;
     private final List<Node> replicas;
     private final List<Node> isr;
 
+    /**
+     * Create an instance of this class with the provided parameters.
+     *
+     * @param partition the partition id
+     * @param leader the leader of the partition or {@link Node#noNode()} if there is none.
+     * @param replicas the replicas of the partition in the same order as the replica assignment (the preferred replica
+     *                 is the head of the list)
+     * @param isr the in-sync replicas
+     */
     public TopicPartitionInfo(int partition, Node leader, List<Node> replicas, List<Node> isr) {
         this.partition = partition;
         this.leader = leader;
@@ -34,18 +46,33 @@ public class TopicPartitionInfo {
         this.isr = isr;
     }
 
+    /**
+     * Return the partition id.
+     */
     public int partition() {
         return partition;
     }
 
+    /**
+     * Return the leader of the partition or {@link Node#noNode()} if there is none.
+     */
     public Node leader() {
         return leader;
     }
 
+    /**
+     * Return the replicas of the partition in the same order as the replica assignment. The preferred replica is the
+     * head of the list.
+     *
+     * Brokers with version lower than 0.11.0.0 return the replicas in unspecified order due to a bug.
+     */
     public List<Node> replicas() {
         return replicas;
     }
 
+    /**
+     * Return the in-sync replicas of the partition. Note that the ordering of the result is unspecified.
+     */
     public List<Node> isr() {
         return isr;
     }

--- a/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntry.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntry.java
@@ -42,7 +42,7 @@ public class AccessControlEntry {
         Objects.requireNonNull(principal);
         Objects.requireNonNull(host);
         Objects.requireNonNull(operation);
-        assert(operation != AclOperation.ANY);
+        assert operation != AclOperation.ANY;
         Objects.requireNonNull(permissionType);
         assert permissionType != AclPermissionType.ANY;
         this.data = new AccessControlEntryData(principal, host, operation, permissionType);

--- a/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntry.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntry.java
@@ -17,37 +17,61 @@
 
 package org.apache.kafka.common.acl;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Objects;
 
 /**
- * Represents an access control entry.  ACEs are a tuple of principal, host,
- * operation, and permissionType.
+ * Represents an access control entry.  ACEs are a tuple of principal, host, operation, and permissionType.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public class AccessControlEntry {
     final AccessControlEntryData data;
 
+    /**
+     * Create an instance of an access control entry with the provided parameters.
+     *
+     * @param principal non-null principal
+     * @param host non-null host
+     * @param operation non-null operation, ANY is not an allowed operation
+     * @param permissionType non-null permission type, ANY is not an allowed type
+     */
     public AccessControlEntry(String principal, String host, AclOperation operation, AclPermissionType permissionType) {
         Objects.requireNonNull(principal);
         Objects.requireNonNull(host);
         Objects.requireNonNull(operation);
-        assert operation != AclOperation.ANY;
+        assert(operation != AclOperation.ANY);
         Objects.requireNonNull(permissionType);
         assert permissionType != AclPermissionType.ANY;
         this.data = new AccessControlEntryData(principal, host, operation, permissionType);
     }
 
+    /**
+     * Return the principal for this entry.
+     */
     public String principal() {
         return data.principal();
     }
 
+    /**
+     * Return the host or `*` for all hosts.
+     */
     public String host() {
         return data.host();
     }
 
+    /**
+     * Return the AclOperation. This method will never return AclOperation.ANY.
+     */
     public AclOperation operation() {
         return data.operation();
     }
 
+    /**
+     * Return the AclPermissionType. This method will never return AclPermissionType.ANY.
+     */
     public AclPermissionType permissionType() {
         return data.permissionType();
     }

--- a/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntryFilter.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntryFilter.java
@@ -30,6 +30,9 @@ import java.util.Objects;
 public class AccessControlEntryFilter {
     private final AccessControlEntryData data;
 
+    /**
+     * Matches any access control entry.
+     */
     public static final AccessControlEntryFilter ANY =
         new AccessControlEntryFilter(null, null, AclOperation.ANY, AclPermissionType.ANY);
 
@@ -112,7 +115,7 @@ public class AccessControlEntryFilter {
     }
 
     /**
-     * Returns true if this filter could only match one ACE-- in other words, if
+     * Returns true if this filter could only match one ACE -- in other words, if
      * there are no ANY or UNKNOWN fields.
      */
     public boolean matchesAtMostOne() {

--- a/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntryFilter.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AccessControlEntryFilter.java
@@ -17,17 +17,30 @@
 
 package org.apache.kafka.common.acl;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Objects;
 
 /**
  * Represents a filter which matches access control entries.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public class AccessControlEntryFilter {
     private final AccessControlEntryData data;
 
     public static final AccessControlEntryFilter ANY =
         new AccessControlEntryFilter(null, null, AclOperation.ANY, AclPermissionType.ANY);
 
+    /**
+     * Create an instance of an access control entry filter with the provided parameters.
+     *
+     * @param principal the principal or null
+     * @param host the host or null
+     * @param operation non-null operation
+     * @param permissionType non-null permission type
+     */
     public AccessControlEntryFilter(String principal, String host, AclOperation operation, AclPermissionType permissionType) {
         Objects.requireNonNull(operation);
         Objects.requireNonNull(permissionType);
@@ -43,18 +56,30 @@ public class AccessControlEntryFilter {
         this.data = data;
     }
 
+    /**
+     * Return the principal or null.
+     */
     public String principal() {
         return data.principal();
     }
 
+    /**
+     * Return the host or null. The value `*` means any host.
+     */
     public String host() {
         return data.host();
     }
 
+    /**
+     * Return the AclOperation.
+     */
     public AclOperation operation() {
         return data.operation();
     }
 
+    /**
+     * Return the AclPermissionType.
+     */
     public AclPermissionType permissionType() {
         return data.permissionType();
     }

--- a/clients/src/main/java/org/apache/kafka/common/acl/AclBinding.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclBinding.java
@@ -17,17 +17,27 @@
 
 package org.apache.kafka.common.acl;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.resource.Resource;
 
 import java.util.Objects;
 
 /**
  * Represents a binding between a resource and an access control entry.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public class AclBinding {
     private final Resource resource;
     private final AccessControlEntry entry;
 
+    /**
+     * Create an instance of this class with the provided parameters.
+     *
+     * @param resource non-null resource
+     * @param entry non-null entry
+     */
     public AclBinding(Resource resource, AccessControlEntry entry) {
         Objects.requireNonNull(resource);
         this.resource = resource;
@@ -42,10 +52,16 @@ public class AclBinding {
         return resource.unknown() || entry.unknown();
     }
 
+    /**
+     * Return the resource for this binding.
+     */
     public Resource resource() {
         return resource;
     }
 
+    /**
+     * Return the access control entry for this binding.
+     */
     public final AccessControlEntry entry() {
         return entry;
     }

--- a/clients/src/main/java/org/apache/kafka/common/acl/AclBindingFilter.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclBindingFilter.java
@@ -17,6 +17,7 @@
 
 package org.apache.kafka.common.acl;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.resource.ResourceFilter;
 import org.apache.kafka.common.resource.ResourceType;
 
@@ -24,7 +25,10 @@ import java.util.Objects;
 
 /**
  * A filter which can match AclBinding objects.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public class AclBindingFilter {
     private final ResourceFilter resourceFilter;
     private final AccessControlEntryFilter entryFilter;
@@ -36,6 +40,12 @@ public class AclBindingFilter {
         new ResourceFilter(ResourceType.ANY, null),
         new AccessControlEntryFilter(null, null, AclOperation.ANY, AclPermissionType.ANY));
 
+    /**
+     * Create an instance of this filter with the provided parameters.
+     *
+     * @param resourceFilter non-null resource filter
+     * @param entryFilter non-null access control entry filter
+     */
     public AclBindingFilter(ResourceFilter resourceFilter, AccessControlEntryFilter entryFilter) {
         Objects.requireNonNull(resourceFilter);
         this.resourceFilter = resourceFilter;
@@ -50,10 +60,16 @@ public class AclBindingFilter {
         return resourceFilter.unknown() || entryFilter.unknown();
     }
 
+    /**
+     * Return the resource filter.
+     */
     public ResourceFilter resourceFilter() {
         return resourceFilter;
     }
 
+    /**
+     * Return the access control entry filter.
+     */
     public final AccessControlEntryFilter entryFilter() {
         return entryFilter;
     }
@@ -71,10 +87,17 @@ public class AclBindingFilter {
         return resourceFilter.equals(other.resourceFilter) && entryFilter.equals(other.entryFilter);
     }
 
+    /**
+     * Return true if the resource and entry filters can only match one ACE. In other words, if
+     * there are no ANY or UNKNOWN fields.
+     */
     public boolean matchesAtMostOne() {
         return resourceFilter.matchesAtMostOne() && entryFilter.matchesAtMostOne();
     }
 
+    /**
+     * Return a string describing an ANY or UNKNOWN field, or null if there is no such field.
+     */
     public String findIndefiniteField() {
         String indefinite = resourceFilter.findIndefiniteField();
         if (indefinite != null)
@@ -82,6 +105,9 @@ public class AclBindingFilter {
         return entryFilter.findIndefiniteField();
     }
 
+    /**
+     * Return true if the resource filter matches the binding's resource and the entry filter matches binding's entry.
+     */
     public boolean matches(AclBinding binding) {
         return resourceFilter.matches(binding.resource()) && entryFilter.matches(binding.entry());
     }

--- a/clients/src/main/java/org/apache/kafka/common/acl/AclOperation.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclOperation.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.common.acl;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.HashMap;
 import java.util.Locale;
 
@@ -35,7 +37,10 @@ import java.util.Locale;
  * ALLOW ALTER implies ALLOW DESCRIBE
  *
  * ALLOW ALTER_CONFIGS implies ALLOW DESCRIBE_CONFIGS
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public enum AclOperation {
     /**
      * Represents any AclOperation which this client cannot understand, perhaps because this
@@ -126,6 +131,9 @@ public enum AclOperation {
         }
     }
 
+    /**
+     * Return the AclOperation with the provided code or `AclOperation.UNKNOWN` if one cannot be found.
+     */
     public static AclOperation fromCode(byte code) {
         AclOperation operation = CODE_TO_VALUE.get(code);
         if (operation == null) {
@@ -140,10 +148,16 @@ public enum AclOperation {
         this.code = code;
     }
 
+    /**
+     * Return the code of this operation.
+     */
     public byte code() {
         return code;
     }
 
+    /**
+     * Return true if this operation is UNKNOWN.
+     */
     public boolean unknown() {
         return this == UNKNOWN;
     }

--- a/clients/src/main/java/org/apache/kafka/common/acl/AclPermissionType.java
+++ b/clients/src/main/java/org/apache/kafka/common/acl/AclPermissionType.java
@@ -17,12 +17,17 @@
 
 package org.apache.kafka.common.acl;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.HashMap;
 import java.util.Locale;
 
 /**
  * Represents whether an ACL grants or denies permissions.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public enum AclPermissionType {
     /**
      * Represents any AclPermissionType which this client cannot understand,
@@ -68,6 +73,9 @@ public enum AclPermissionType {
         }
     }
 
+    /**
+     * Return the AclPermissionType with the provided code or `AclPermissionType.UNKNOWN` if one cannot be found.
+     */
     public static AclPermissionType fromCode(byte code) {
         AclPermissionType permissionType = CODE_TO_VALUE.get(code);
         if (permissionType == null) {
@@ -82,10 +90,16 @@ public enum AclPermissionType {
         this.code = code;
     }
 
+    /**
+     * Return the code of this permission type.
+     */
     public byte code() {
         return code;
     }
 
+    /**
+     * Return true if this permission type is UNKNOWN.
+     */
     public boolean unknown() {
         return this == UNKNOWN;
     }

--- a/clients/src/main/java/org/apache/kafka/common/annotation/InterfaceStability.java
+++ b/clients/src/main/java/org/apache/kafka/common/annotation/InterfaceStability.java
@@ -21,30 +21,32 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 /**
- * Annotation to inform users of how much to rely on a particular package,
- * class or method not changing over time. Currently the stability can be
- * {@link Stable}, {@link Evolving} or {@link Unstable}. <br>
+ * Annotation to inform users of how much to rely on a particular package, class or method not changing over time.
+ * Currently the stability can be {@link Stable}, {@link Evolving} or {@link Unstable}.
  */
 @InterfaceStability.Evolving
 public class InterfaceStability {
     /**
-     * Can evolve while retaining compatibility for minor release boundaries.;
-     * can break compatibility only at major release (ie. at m.0).
+     * Compatibility is maintained in major, minor and patch releases with one exception: compatibility may be broken
+     * in a major release (i.e. 0.m) for APIs that have been deprecated for at least one major/minor release cycle.
+     * In cases where the impact of breaking compatibility is significant, there is also a minimum deprecation period
+     * of one year.
+     *
+     * This is the default stability level for public APIs that are not annotated.
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Stable { }
 
     /**
-     * Evolving, but can break compatibility at minor release (i.e. m.x)
+     * Compatibility may be broken at minor release (i.e. m.x).
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
     public @interface Evolving { }
 
     /**
-     * No guarantee is provided as to reliability or stability across any
-     * level of release granularity.
+     * No guarantee is provided as to reliability or stability across any level of release granularity.
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -17,8 +17,16 @@
 
 package org.apache.kafka.common.config;
 
+import java.util.Objects;
+
+/**
+ * A class representing resources that have configs.
+ */
 public final class ConfigResource {
 
+    /**
+     * Type of resource.
+     */
     public enum Type {
         BROKER, TOPIC, UNKNOWN;
     }
@@ -26,15 +34,29 @@ public final class ConfigResource {
     private final Type type;
     private final String name;
 
+    /**
+     * Create an instance of this class with the provided parameters.
+     *
+     * @param type a non-null resource type
+     * @param name a non-null resource name
+     */
     public ConfigResource(Type type, String name) {
+        Objects.requireNonNull(type, "type should not be null");
+        Objects.requireNonNull(name, "name should not be null");
         this.type = type;
         this.name = name;
     }
 
+    /**
+     * Return the resource type.
+     */
     public Type type() {
         return type;
     }
 
+    /**
+     * Return the resource name.
+     */
     public String name() {
         return name;
     }

--- a/clients/src/main/java/org/apache/kafka/common/resource/Resource.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/Resource.java
@@ -17,11 +17,16 @@
 
 package org.apache.kafka.common.resource;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Objects;
 
 /**
  * Represents a cluster resource with a tuple of (type, name).
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public class Resource {
     private final ResourceType resourceType;
     private final String name;

--- a/clients/src/main/java/org/apache/kafka/common/resource/Resource.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/Resource.java
@@ -36,6 +36,12 @@ public class Resource {
      */
     public final static Resource CLUSTER = new Resource(ResourceType.CLUSTER, CLUSTER_NAME);
 
+    /**
+     * Create an instance of this class with the provided parameters.
+     *
+     * @param resourceType non-null resource type
+     * @param name non-null resource name
+     */
     public Resource(ResourceType resourceType, String name) {
         Objects.requireNonNull(resourceType);
         this.resourceType = resourceType;
@@ -43,10 +49,16 @@ public class Resource {
         this.name = name;
     }
 
+    /**
+     * Return the resource type.
+     */
     public ResourceType resourceType() {
         return resourceType;
     }
 
+    /**
+     * Return the resource name.
+     */
     public String name() {
         return name;
     }

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceFilter.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceFilter.java
@@ -26,18 +26,33 @@ public class ResourceFilter {
     private final ResourceType resourceType;
     private final String name;
 
+    /**
+     * Matches any resource.
+     */
     public static final ResourceFilter ANY = new ResourceFilter(ResourceType.ANY, null);
 
+    /**
+     * Create an instance of this class with the provided parameters.
+     *
+     * @param resourceType non-null resource type
+     * @param name resource name or null
+     */
     public ResourceFilter(ResourceType resourceType, String name) {
         Objects.requireNonNull(resourceType);
         this.resourceType = resourceType;
         this.name = name;
     }
 
+    /**
+     * Return the resource type.
+     */
     public ResourceType resourceType() {
         return resourceType;
     }
 
+    /**
+     * Return the resource name or null.
+     */
     public String name() {
         return name;
     }
@@ -67,6 +82,9 @@ public class ResourceFilter {
         return Objects.hash(resourceType, name);
     }
 
+    /**
+     * Return true if this filter matches the given Resource.
+     */
     public boolean matches(Resource other) {
         if ((name != null) && (!name.equals(other.name())))
             return false;
@@ -75,10 +93,16 @@ public class ResourceFilter {
         return true;
     }
 
+    /**
+     * Return true if this filter could only match one ACE. In other words, if there are no ANY or UNKNOWN fields.
+     */
     public boolean matchesAtMostOne() {
         return findIndefiniteField() == null;
     }
 
+    /**
+     * Return a string describing an ANY or UNKNOWN field, or null if there is no such field.
+     */
     public String findIndefiniteField() {
         if (resourceType == ResourceType.ANY)
             return "Resource type is ANY.";

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceFilter.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceFilter.java
@@ -17,11 +17,16 @@
 
 package org.apache.kafka.common.resource;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.Objects;
 
 /**
  * A filter which matches Resource objects.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public class ResourceFilter {
     private final ResourceType resourceType;
     private final String name;

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
@@ -17,12 +17,17 @@
 
 package org.apache.kafka.common.resource;
 
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 import java.util.HashMap;
 import java.util.Locale;
 
 /**
  * Represents a type of resource which an ACL can be applied to.
+ *
+ * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
+@InterfaceStability.Evolving
 public enum ResourceType {
     /**
      * Represents any ResourceType which this client cannot understand,

--- a/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
+++ b/clients/src/main/java/org/apache/kafka/common/resource/ResourceType.java
@@ -78,6 +78,9 @@ public enum ResourceType {
         }
     }
 
+    /**
+     * Return the ResourceType with the provided code or `ResourceType.UNKNOWN` if one cannot be found.
+     */
     public static ResourceType fromCode(byte code) {
         ResourceType resourceType = CODE_TO_VALUE.get(code);
         if (resourceType == null) {
@@ -92,10 +95,16 @@ public enum ResourceType {
         this.code = code;
     }
 
+    /**
+     * Return the code of this resource.
+     */
     public byte code() {
         return code;
     }
 
+    /**
+     * Return whether this resource type is UNKNOWN.
+     */
     public boolean unknown() {
         return this == UNKNOWN;
     }


### PR DESCRIPTION
Publish Javadoc for common.annotation package, which contains
InterfaceStability.

Finally, mark AdminClient classes with `Evolving` instead of `Unstable`.