### PR TITLE
KAFKA-5370: Replace uses of the old consumer with the new consumer when possible

### DIFF
--- a/core/src/main/scala/kafka/admin/AdminUtils.scala
+++ b/core/src/main/scala/kafka/admin/AdminUtils.scala
@@ -17,6 +17,8 @@
 
 package kafka.admin
 
+import kafka.cluster.{Broker, BrokerEndPoint}
+import kafka.common.{BrokerEndPointNotAvailableException, TopicAlreadyMarkedForDeletionException}
 import kafka.log.LogConfig
 import kafka.server.{ConfigEntityName, ConfigType, DynamicConfig}
 import kafka.utils._
@@ -24,13 +26,20 @@ import kafka.utils.ZkUtils._
 import java.util.Random
 import java.util.Properties
 
-import kafka.common.TopicAlreadyMarkedForDeletionException
-import org.apache.kafka.common.errors.{BrokerNotAvailableException, InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidReplicationFactorException, InvalidTopicException, TopicExistsException, UnknownTopicOrPartitionException}
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.common.{KafkaException, Node, PartitionInfo}
+import org.apache.kafka.common.errors.{InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidReplicationFactorException, InvalidTopicException, LeaderNotAvailableException, ReplicaNotAvailableException, TopicExistsException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.internals.Topic
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.{Errors, SecurityProtocol}
+import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
+import org.apache.kafka.common.serialization.StringDeserializer
 
 import collection.{Map, Set, mutable, _}
 import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 import org.I0Itec.zkclient.exception.ZkNodeExistsException
-import org.apache.kafka.common.internals.Topic
 
 trait AdminUtilities {
   def changeTopicConfig(zkUtils: ZkUtils, topic: String, configs: Properties)
@@ -677,6 +686,81 @@ object AdminUtils extends Logging with AdminUtilities {
     entityPaths(zkUtils, None)
       .flatMap(entity => entityPaths(zkUtils, Some(entity + '/' + childEntityType)))
       .map(entityPath => (entityPath, fetchEntityConfig(zkUtils, rootEntityType, entityPath))).toMap
+  }
+
+  def fetchTopicMetadata(topics: Set[String], brokers: Seq[BrokerEndPoint], properties: Properties)
+    : Map[String, List[PartitionInfo]] = {
+    val deserializer = (new StringDeserializer).getClass.getName
+    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, deserializer)
+    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer)
+
+    var fetchMetaDataSucceeded: Boolean = false
+    var i: Int = 0
+    var metadataResponse: Map[String, List[PartitionInfo]] = null
+    var t: Throwable = null
+    // shuffle the list of brokers before sending metadata requests so that most requests don't get routed to the
+    // same broker
+    val shuffledBrokers = scala.util.Random.shuffle(brokers)
+    while (i < shuffledBrokers.size && !fetchMetaDataSucceeded) {
+      properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, shuffledBrokers.map(_.connectionString).mkString(","))
+      val consumer = new KafkaConsumer(properties)
+      info("Fetching metadata from broker %s for topic(s) %s".format(shuffledBrokers(i), topics.size, topics))
+      try {
+        metadataResponse = consumer.listTopics().asScala.filterKeys(topics.isEmpty || topics.contains(_)).map {
+          case (topic, metadata) => (topic, metadata.asScala.toList)
+        }
+        fetchMetaDataSucceeded = true
+      }
+      catch {
+        case e: Throwable =>
+          warn("Fetching topic metadata for topics [%s] from broker [%s] failed".format(topics, shuffledBrokers(i).toString), e)
+          t = e
+      } finally {
+        i = i + 1
+        consumer.close()
+      }
+    }
+
+    if (!fetchMetaDataSucceeded) {
+      throw new KafkaException("fetching topic metadata for topics [%s] from broker [%s] failed".format(topics, shuffledBrokers), t)
+    } else {
+      debug("Successfully fetched metadata for %d topic(s) %s".format(topics.size, topics))
+    }
+
+    metadataResponse
+  }
+
+  def fetchTopicMetadata(topics: Set[String], brokers: Seq[BrokerEndPoint], clientId: String, timeoutMs: Int)
+    : Map[String, List[PartitionInfo]] = {
+    val props = new Properties()
+    props.put("metadata.broker.list", brokers.map(_.connectionString).mkString(","))
+    props.put("client.id", clientId)
+    props.put("request.timeout.ms", timeoutMs.toString)
+    val consumerProps = new Properties(props)
+    fetchTopicMetadata(topics, brokers, consumerProps)
+  }
+
+  /**
+    * Returns the first end point from each broker with the PLAINTEXT security protocol.
+    */
+  def getPlaintextBrokerEndPoints(zkUtils: ZkUtils): Seq[BrokerEndPoint] = {
+    zkUtils.getAllBrokersInCluster().map { broker =>
+      broker.endPoints.collectFirst {
+        case endPoint if endPoint.securityProtocol == SecurityProtocol.PLAINTEXT =>
+          new BrokerEndPoint(broker.id, endPoint.host, endPoint.port)
+      }.getOrElse(throw new BrokerEndPointNotAvailableException(s"End point with security protocol PLAINTEXT not found for broker ${broker.id}"))
+    }
+  }
+
+  /**
+   * Parse a list of broker urls in the form host1:port1, host2:port2, ...
+   */
+  def parseBrokerList(brokerListStr: String): Seq[BrokerEndPoint] = {
+    val brokersStr = CoreUtils.parseCsvList(brokerListStr)
+
+    brokersStr.zipWithIndex.map { case (address, brokerId) =>
+      BrokerEndPoint.createBrokerEndPoint(brokerId, address)
+    }
   }
 
   private def replicaIndex(firstReplicaIndex: Int, secondReplicaShift: Int, replicaIndex: Int, nBrokers: Int): Int = {

--- a/core/src/main/scala/kafka/admin/AdminUtils.scala
+++ b/core/src/main/scala/kafka/admin/AdminUtils.scala
@@ -23,23 +23,24 @@ import kafka.log.LogConfig
 import kafka.server.{ConfigEntityName, ConfigType, DynamicConfig}
 import kafka.utils._
 import kafka.utils.ZkUtils._
+
 import java.util.Random
 import java.util.Properties
 
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.{KafkaException, Node, PartitionInfo}
-import org.apache.kafka.common.errors.{InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidReplicationFactorException, InvalidTopicException, LeaderNotAvailableException, ReplicaNotAvailableException, TopicExistsException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{BrokerNotAvailableException, InvalidPartitionsException, InvalidReplicaAssignmentException, InvalidReplicationFactorException, InvalidTopicException, LeaderNotAvailableException, ReplicaNotAvailableException, TopicExistsException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{Errors, SecurityProtocol}
 import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.I0Itec.zkclient.exception.ZkNodeExistsException
 
 import collection.{Map, Set, mutable, _}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import org.I0Itec.zkclient.exception.ZkNodeExistsException
 
 trait AdminUtilities {
   def changeTopicConfig(zkUtils: ZkUtils, topic: String, configs: Properties)

--- a/core/src/main/scala/kafka/client/ClientUtils.scala
+++ b/core/src/main/scala/kafka/client/ClientUtils.scala
@@ -16,20 +16,21 @@
  */
 package kafka.client
 
-import org.apache.kafka.common.protocol.{Errors, SecurityProtocol}
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.MetadataResponse
 
-import scala.collection._
-import kafka.cluster._
+import kafka.admin.AdminClient
 import kafka.api._
-import kafka.producer._
-import kafka.common.{BrokerEndPointNotAvailableException, KafkaException}
-import kafka.utils.{CoreUtils, Logging}
-import java.util.Properties
-
-import util.Random
+import kafka.cluster._
+import kafka.common.KafkaException
 import kafka.network.BlockingChannel
-import kafka.utils.ZkUtils
+import kafka.producer._
+import kafka.utils.{Logging, ZkUtils}
+
 import java.io.IOException
+import java.util.Properties
+import util.Random
 
  /**
  * Helper functions common to clients (producer, consumer, or admin)
@@ -97,14 +98,20 @@ object ClientUtils extends Logging {
   }
 
   /**
-   * Parse a list of broker urls in the form host1:port1, host2:port2, ...
+   * Used to send a metadata request using AdminClient
+   * @param topics The topics for which the metadata needs to be fetched
+   * @param brokers The brokers in the cluster as configured on the producer through metadata.broker.list
+   * @return metadata response
    */
-  def parseBrokerList(brokerListStr: String): Seq[BrokerEndPoint] = {
-    val brokersStr = CoreUtils.parseCsvList(brokerListStr)
+  def fetchMetadata(topics: Set[String], brokers: Seq[BrokerEndPoint], autoCreateTopic: Boolean = false): MetadataResponse = {
+    var fetchMetaDataSucceeded: Boolean = false
+    var i: Int = 0
 
-    brokersStr.zipWithIndex.map { case (address, brokerId) =>
-      BrokerEndPoint.createBrokerEndPoint(brokerId, address)
-    }
+    val props = new Properties()
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokers.map(_.connectionString()).mkString(","))
+    val adminClient = AdminClient.create(props)
+
+    adminClient.getTopicsMetadata(topics.toList, autoCreateTopic)
   }
 
   /**
@@ -114,7 +121,7 @@ object ClientUtils extends Logging {
     var channel: BlockingChannel = null
     var connected = false
     while (!connected) {
-      val allBrokers = getPlaintextBrokerEndPoints(zkUtils)
+      val allBrokers = BrokerEndPoint.getPlaintextBrokerEndPoints(zkUtils)
       Random.shuffle(allBrokers).find { broker =>
         trace("Connecting to broker %s:%d.".format(broker.host, broker.port))
         try {
@@ -137,79 +144,67 @@ object ClientUtils extends Logging {
   }
 
    /**
-    * Returns the first end point from each broker with the PLAINTEXT security protocol.
-    */
-  def getPlaintextBrokerEndPoints(zkUtils: ZkUtils): Seq[BrokerEndPoint] = {
-    zkUtils.getAllBrokersInCluster().map { broker =>
-      broker.endPoints.collectFirst {
-        case endPoint if endPoint.securityProtocol == SecurityProtocol.PLAINTEXT =>
-          new BrokerEndPoint(broker.id, endPoint.host, endPoint.port)
-      }.getOrElse(throw new BrokerEndPointNotAvailableException(s"End point with security protocol PLAINTEXT not found for broker ${broker.id}"))
-    }
-  }
-
-   /**
     * Creates a blocking channel to the offset manager of the given group
     */
-   def channelToOffsetManager(group: String, zkUtils: ZkUtils, socketTimeoutMs: Int = 3000, retryBackOffMs: Int = 1000) = {
-     var queryChannel = channelToAnyBroker(zkUtils)
+  def channelToOffsetManager(group: String, zkUtils: ZkUtils, socketTimeoutMs: Int = 3000, retryBackOffMs: Int = 1000) = {
+    var queryChannel = channelToAnyBroker(zkUtils)
 
-     var offsetManagerChannelOpt: Option[BlockingChannel] = None
+    var offsetManagerChannelOpt: Option[BlockingChannel] = None
 
-     while (offsetManagerChannelOpt.isEmpty) {
+    while (offsetManagerChannelOpt.isEmpty) {
 
-       var coordinatorOpt: Option[BrokerEndPoint] = None
+      var coordinatorOpt: Option[BrokerEndPoint] = None
 
-       while (coordinatorOpt.isEmpty) {
-         try {
-           if (!queryChannel.isConnected)
-             queryChannel = channelToAnyBroker(zkUtils)
-           debug("Querying %s:%d to locate offset manager for %s.".format(queryChannel.host, queryChannel.port, group))
-           queryChannel.send(GroupCoordinatorRequest(group))
-           val response = queryChannel.receive()
-           val consumerMetadataResponse =  GroupCoordinatorResponse.readFrom(response.payload())
-           debug("Consumer metadata response: " + consumerMetadataResponse.toString)
-           if (consumerMetadataResponse.error == Errors.NONE)
-             coordinatorOpt = consumerMetadataResponse.coordinatorOpt
-           else {
-             debug("Query to %s:%d to locate offset manager for %s failed - will retry in %d milliseconds."
-                  .format(queryChannel.host, queryChannel.port, group, retryBackOffMs))
-             Thread.sleep(retryBackOffMs)
-           }
-         }
-         catch {
-           case _: IOException =>
-             info("Failed to fetch consumer metadata from %s:%d.".format(queryChannel.host, queryChannel.port))
-             queryChannel.disconnect()
-         }
-       }
+      while (coordinatorOpt.isEmpty) {
+        try {
+          if (!queryChannel.isConnected)
+            queryChannel = channelToAnyBroker(zkUtils)
+          debug("Querying %s:%d to locate offset manager for %s.".format(queryChannel.host, queryChannel.port, group))
+          queryChannel.send(GroupCoordinatorRequest(group))
+          val response = queryChannel.receive()
+          val consumerMetadataResponse =  GroupCoordinatorResponse.readFrom(response.payload())
+          debug("Consumer metadata response: " + consumerMetadataResponse.toString)
+          if (consumerMetadataResponse.error == Errors.NONE)
+            coordinatorOpt = consumerMetadataResponse.coordinatorOpt
+          else {
+            debug("Query to %s:%d to locate offset manager for %s failed - will retry in %d milliseconds."
+                 .format(queryChannel.host, queryChannel.port, group, retryBackOffMs))
+            Thread.sleep(retryBackOffMs)
+          }
+        }
+        catch {
+          case _: IOException =>
+            info("Failed to fetch consumer metadata from %s:%d.".format(queryChannel.host, queryChannel.port))
+            queryChannel.disconnect()
+        }
+      }
 
-       val coordinator = coordinatorOpt.get
-       if (coordinator.host == queryChannel.host && coordinator.port == queryChannel.port) {
-         offsetManagerChannelOpt = Some(queryChannel)
-       } else {
-         val connectString = "%s:%d".format(coordinator.host, coordinator.port)
-         var offsetManagerChannel: BlockingChannel = null
-         try {
-           debug("Connecting to offset manager %s.".format(connectString))
-           offsetManagerChannel = new BlockingChannel(coordinator.host, coordinator.port,
-                                                      BlockingChannel.UseDefaultBufferSize,
-                                                      BlockingChannel.UseDefaultBufferSize,
-                                                      socketTimeoutMs)
-           offsetManagerChannel.connect()
-           offsetManagerChannelOpt = Some(offsetManagerChannel)
-           queryChannel.disconnect()
-         }
-         catch {
-           case _: IOException => // offsets manager may have moved
-             info("Error while connecting to %s.".format(connectString))
-             if (offsetManagerChannel != null) offsetManagerChannel.disconnect()
-             Thread.sleep(retryBackOffMs)
-             offsetManagerChannelOpt = None // just in case someone decides to change shutdownChannel to not swallow exceptions
-         }
-       }
-     }
+      val coordinator = coordinatorOpt.get
+      if (coordinator.host == queryChannel.host && coordinator.port == queryChannel.port) {
+        offsetManagerChannelOpt = Some(queryChannel)
+      } else {
+        val connectString = "%s:%d".format(coordinator.host, coordinator.port)
+        var offsetManagerChannel: BlockingChannel = null
+        try {
+          debug("Connecting to offset manager %s.".format(connectString))
+          offsetManagerChannel = new BlockingChannel(coordinator.host, coordinator.port,
+                                                     BlockingChannel.UseDefaultBufferSize,
+                                                     BlockingChannel.UseDefaultBufferSize,
+                                                     socketTimeoutMs)
+          offsetManagerChannel.connect()
+          offsetManagerChannelOpt = Some(offsetManagerChannel)
+          queryChannel.disconnect()
+        }
+        catch {
+          case _: IOException => // offsets manager may have moved
+            info("Error while connecting to %s.".format(connectString))
+            if (offsetManagerChannel != null) offsetManagerChannel.disconnect()
+            Thread.sleep(retryBackOffMs)
+            offsetManagerChannelOpt = None // just in case someone decides to change shutdownChannel to not swallow exceptions
+        }
+      }
+    }
 
-     offsetManagerChannelOpt.get
-   }
- }
+    offsetManagerChannelOpt.get
+  }
+}

--- a/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
+++ b/core/src/main/scala/kafka/consumer/ConsumerFetcherManager.scala
@@ -17,21 +17,20 @@
 
 package kafka.consumer
 
-import kafka.server.{AbstractFetcherManager, AbstractFetcherThread, BrokerAndInitialOffset}
+import kafka.client.ClientUtils
 import kafka.cluster.{BrokerEndPoint, Cluster}
+import kafka.server.{AbstractFetcherManager, AbstractFetcherThread, BrokerAndInitialOffset}
+import kafka.utils.CoreUtils.inLock
+import kafka.utils.{ShutdownableThread, ZkUtils}
+
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.utils.Time
 
-import scala.collection.immutable
 import collection.mutable.HashMap
+import scala.collection.immutable
 import scala.collection.mutable
-import java.util.concurrent.locks.ReentrantLock
-
-import kafka.utils.CoreUtils.inLock
-import kafka.utils.ZkUtils
-import kafka.utils.ShutdownableThread
-import kafka.client.ClientUtils
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.ReentrantLock
 
 /**
  *  Usage:
@@ -63,7 +62,7 @@ class ConsumerFetcherManager(private val consumerIdString: String,
         }
 
         trace("Partitions without leader %s".format(noLeaderPartitionSet))
-        val brokers = ClientUtils.getPlaintextBrokerEndPoints(zkUtils)
+        val brokers = BrokerEndPoint.getPlaintextBrokerEndPoints(zkUtils)
         val topicsMetadata = ClientUtils.fetchTopicMetadata(noLeaderPartitionSet.map(m => m.topic).toSet,
                                                             brokers,
                                                             config.clientId,

--- a/core/src/main/scala/kafka/producer/BrokerPartitionInfo.scala
+++ b/core/src/main/scala/kafka/producer/BrokerPartitionInfo.scala
@@ -19,10 +19,12 @@ package kafka.producer
 import org.apache.kafka.common.protocol.Errors
 
 import collection.mutable.HashMap
+
 import kafka.api.TopicMetadata
+import kafka.client.ClientUtils
+import kafka.cluster.BrokerEndPoint
 import kafka.common.KafkaException
 import kafka.utils.Logging
-import kafka.client.ClientUtils
 
 @deprecated("This class has been deprecated and will be removed in a future release.", "0.10.0.0")
 class BrokerPartitionInfo(producerConfig: ProducerConfig,
@@ -30,7 +32,7 @@ class BrokerPartitionInfo(producerConfig: ProducerConfig,
                           topicPartitionInfo: HashMap[String, TopicMetadata])
         extends Logging {
   val brokerList = producerConfig.brokerList
-  val brokers = ClientUtils.parseBrokerList(brokerList)
+  val brokers = BrokerEndPoint.parseBrokerList(brokerList)
 
   /**
    * Return a sequence of (brokerId, numPartitions).

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -22,17 +22,22 @@ import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicReference
 import java.util.regex.{Pattern, PatternSyntaxException}
-
 import joptsimple.OptionParser
+
+import kafka.admin.AdminUtils
 import kafka.api._
 import kafka.client.ClientUtils
 import kafka.cluster.BrokerEndPoint
 import kafka.common.TopicAndPartition
-import kafka.consumer.{ConsumerConfig, SimpleConsumer, Whitelist}
+import kafka.consumer.{SimpleConsumer, Whitelist}
 import kafka.message.{ByteBufferMessageSet, MessageSet}
 import kafka.utils._
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.utils.Time
+
+import scala.collection.JavaConverters._
 
 /**
  *  For verifying the consistency among replicas.
@@ -74,7 +79,7 @@ object ReplicaVerificationTool extends Logging {
                          .withRequiredArg
                          .describedAs("bytes")
                          .ofType(classOf[java.lang.Integer])
-                         .defaultsTo(ConsumerConfig.FetchSize)
+                         .defaultsTo(ConsumerConfig.DEFAULT_FETCH_MAX_BYTES)
     val maxWaitMsOpt = parser.accepts("max-wait-ms", "The max amount of time each fetch request waits.")
                          .withRequiredArg
                          .describedAs("ms")
@@ -121,29 +126,23 @@ object ReplicaVerificationTool extends Logging {
     info("Getting topic metadata...")
     val brokerList = options.valueOf(brokerListOpt)
     ToolsUtils.validatePortOrDie(parser,brokerList)
-    val metadataTargetBrokers = ClientUtils.parseBrokerList(brokerList)
-    val topicsMetadataResponse = ClientUtils.fetchTopicMetadata(Set[String](), metadataTargetBrokers, clientId, maxWaitMs)
-    val brokerMap = topicsMetadataResponse.brokers.map(b => (b.id, b)).toMap
-    val filteredTopicMetadata = topicsMetadataResponse.topicsMetadata.filter(
-        topicMetadata => if (topicWhiteListFiler.isTopicAllowed(topicMetadata.topic, excludeInternalTopics = false))
-          true
-        else
-          false
-    )
+    val metadataTargetBrokers = AdminUtils.parseBrokerList(brokerList)
+    val topicsMetadataResponse = AdminUtils.fetchTopicMetadata(Set[String](), metadataTargetBrokers, clientId, maxWaitMs)
+    val brokerMap = topicsMetadataResponse.values.flatten.map(m =>
+      (m.leader.id, BrokerEndPoint(m.leader.id, m.leader.host, m.leader.port))).toMap
+    val filteredTopicMetadata = topicsMetadataResponse.filterKeys(
+        topicWhiteListFiler.isTopicAllowed(_, excludeInternalTopics = false))
 
     if (filteredTopicMetadata.isEmpty) {
       error("No topics found. " + topicWhiteListOpt + ", if specified, is either filtering out all topics or there is no topic.")
       Exit.exit(1)
     }
 
-    val topicPartitionReplicaList: Seq[TopicPartitionReplica] = filteredTopicMetadata.flatMap(
-      topicMetadataResponse =>
-        topicMetadataResponse.partitionsMetadata.flatMap(
-          partitionMetadata =>
-            partitionMetadata.replicas.map(broker =>
-              TopicPartitionReplica(topic = topicMetadataResponse.topic, partitionId = partitionMetadata.partitionId, replicaId = broker.id))
-        )
-    )
+    val topicPartitionReplicaList: Seq[TopicPartitionReplica] = filteredTopicMetadata.values.flatten.flatMap {
+      partitionMetadata =>
+        partitionMetadata.replicas.map(broker =>
+          TopicPartitionReplica(topic = partitionMetadata.topic, partitionId = partitionMetadata.partition, replicaId = broker.id))
+    }.toSeq
     debug("Selected topic partitions: " + topicPartitionReplicaList)
     val topicAndPartitionsPerBroker: Map[Int, Seq[TopicAndPartition]] = topicPartitionReplicaList.groupBy(_.replicaId)
       .map { case (brokerId, partitions) =>
@@ -154,12 +153,12 @@ object ReplicaVerificationTool extends Logging {
           .map { case (topicAndPartition, replicaSet) => topicAndPartition -> replicaSet.size }
     debug("Expected replicas per topic partition: " + expectedReplicasPerTopicAndPartition)
     val leadersPerBroker: Map[Int, Seq[TopicAndPartition]] = filteredTopicMetadata.flatMap { topicMetadataResponse =>
-      topicMetadataResponse.partitionsMetadata.map { partitionMetadata =>
-        (TopicAndPartition(topicMetadataResponse.topic, partitionMetadata.partitionId), partitionMetadata.leader.get.id)
+      topicMetadataResponse._2.map { partitionMetadata =>
+        (TopicAndPartition(partitionMetadata.topic, partitionMetadata.partition), partitionMetadata.leader.id)
       }
     }.groupBy(_._2).mapValues(topicAndPartitionAndLeaderIds => topicAndPartitionAndLeaderIds.map { case (topicAndPartition, _) =>
        topicAndPartition
-     })
+     }.toSeq)
     debug("Leaders per broker: " + leadersPerBroker)
 
     val replicaBuffer = new ReplicaBuffer(expectedReplicasPerTopicAndPartition,

--- a/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
@@ -18,19 +18,16 @@
 package kafka.tools
 
 import joptsimple._
-
-import kafka.api.{FetchRequestBuilder, OffsetRequest, Request}
-import kafka.client.ClientUtils
-import kafka.cluster.BrokerEndPoint
-import kafka.consumer._
-import kafka.common.{MessageFormatter, TopicAndPartition}
 import kafka.utils._
-
-import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.utils.{KafkaThread, Utils}
-import org.apache.kafka.common.Node
+import kafka.consumer._
+import kafka.client.ClientUtils
+import kafka.api.{FetchRequestBuilder, OffsetRequest, Request}
+import kafka.cluster.BrokerEndPoint
 
 import scala.collection.JavaConverters._
+import kafka.common.{MessageFormatter, TopicAndPartition}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.utils.{KafkaThread, Utils}
 
 /**
  * Command line program to dump out messages to standard out using the simple consumer
@@ -135,32 +132,32 @@ object SimpleConsumerShell extends Logging {
     val brokerList = options.valueOf(brokerListOpt)
     ToolsUtils.validatePortOrDie(parser,brokerList)
     val metadataTargetBrokers = BrokerEndPoint.parseBrokerList(brokerList)
-    val topicsMetadata = ClientUtils.fetchMetadata(Set(topic), metadataTargetBrokers).topicMetadata.asScala
+    val topicsMetadata = ClientUtils.fetchTopicMetadata(Set(topic), metadataTargetBrokers, clientId, maxWaitMs).topicsMetadata
     if(topicsMetadata.size != 1 || !topicsMetadata.head.topic.equals(topic)) {
       System.err.println(("Error: no valid topic metadata for topic: %s, " + "what we get from server is only: %s").format(topic, topicsMetadata))
       Exit.exit(1)
     }
 
     // validating partition id
-    val partitionsMetadata = topicsMetadata.head.partitionMetadata.asScala
-    val partitionMetadataOpt = partitionsMetadata.find(p => p.partition == partitionId)
+    val partitionsMetadata = topicsMetadata.head.partitionsMetadata
+    val partitionMetadataOpt = partitionsMetadata.find(p => p.partitionId == partitionId)
     if (partitionMetadataOpt.isEmpty) {
       System.err.println("Error: partition %d does not exist for topic %s".format(partitionId, topic))
       Exit.exit(1)
     }
 
     // validating replica id and initializing target broker
-    var fetchTargetBroker: Node = null
-    var replicaOpt: Option[Node] = null
+    var fetchTargetBroker: BrokerEndPoint = null
+    var replicaOpt: Option[BrokerEndPoint] = null
     if (replicaId == UseLeaderReplica) {
-      replicaOpt = Some(partitionMetadataOpt.get.leader)
+      replicaOpt = partitionMetadataOpt.get.leader
       if (replicaOpt.isEmpty) {
         System.err.println("Error: user specifies to fetch from leader for partition (%s, %d) which has not been elected yet".format(topic, partitionId))
         Exit.exit(1)
       }
     }
     else {
-      val replicasForPartition = partitionMetadataOpt.get.replicas.asScala
+      val replicasForPartition = partitionMetadataOpt.get.replicas
       replicaOpt = replicasForPartition.find(r => r.id == replicaId)
       if(replicaOpt.isEmpty) {
         System.err.println("Error: replica %d does not exist for partition (%s, %d)".format(replicaId, topic, partitionId))

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -71,7 +71,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeNonExistingGroup() {
+  def testDescribeNonExistingGroupWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", "missing.group"))
@@ -81,7 +81,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeExistingGroup() {
+  def testDescribeExistingGroupWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", group))
@@ -96,7 +96,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeExistingGroupWithNoMembers() {
+  def testDescribeExistingGroupWithNoMembersWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", group))
@@ -120,7 +120,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeConsumersWithNoAssignedPartitions() {
+  def testDescribeConsumersWithNoAssignedPartitionsWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     createOldConsumer()
@@ -136,7 +136,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeNonExistingGroupWithNewConsumer() {
+  def testDescribeNonExistingGroup() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     // run one consumer in the group consuming from a single-partition topic
     consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
@@ -151,7 +151,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeExistingGroupWithNewConsumer() {
+  def testDescribeExistingGroup() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     // run one consumer in the group consuming from a single-partition topic
     consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
@@ -172,7 +172,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeExistingGroupWithNoMembersWithNewConsumer() {
+  def testDescribeExistingGroupWithNoMembers() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     // run one consumer in the group consuming from a single-partition topic
     consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
@@ -211,7 +211,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeConsumersWithNoAssignedPartitionsWithNewConsumer() {
+  def testDescribeConsumersWithNoAssignedPartitions() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     // run two consumers in the group consuming from a single-partition topic
     consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 2, group, topic)
@@ -231,7 +231,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeWithMultiPartitionTopicAndMultipleConsumersWithNewConsumer() {
+  def testDescribeWithMultiPartitionTopicAndMultipleConsumers() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     val topic2 = "foo2"
     AdminUtils.createTopic(zkUtils, topic2, 2, 1)
@@ -254,7 +254,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeGroupWithNewConsumerWithShortInitializationTimeout() {
+  def testDescribeGroupWithShortInitializationTimeout() {
     // Let creation of the offsets topic happen during group initialisation to ensure that initialization doesn't
     // complete before the timeout expires
 

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -19,6 +19,7 @@ package kafka.admin
 import java.util.Properties
 
 import org.easymock.EasyMock
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -95,7 +96,7 @@ class ListConsumerGroupTest extends KafkaServerTestHarness {
     val opts = new ConsumerGroupCommandOptions(Array("--bootstrap-server", brokerList))
     val consumerGroupCommand = new KafkaConsumerGroupService(opts)
     try {
-      assert(consumerGroupCommand.listGroups().isEmpty)
+      assertTrue(consumerGroupCommand.listGroups().isEmpty)
     } finally {
       consumerGroupCommand.close()
     }

--- a/core/src/test/scala/unit/kafka/integration/TopicMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/TopicMetadataTest.scala
@@ -19,15 +19,16 @@ package kafka.integration
 
 import kafka.admin.AdminUtils
 import kafka.api.TopicMetadataResponse
-import kafka.client.ClientUtils
 import kafka.cluster.BrokerEndPoint
 import kafka.server.{KafkaConfig, KafkaServer, NotRunning}
 import kafka.utils.TestUtils
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
+
+import org.apache.kafka.common.PartitionInfo
 import org.apache.kafka.common.protocol.Errors
+import org.junit.{After, Before, Test}
 import org.junit.Assert._
-import org.junit.{Test, After, Before}
 
 class TopicMetadataTest extends ZooKeeperTestHarness {
   private var server1: KafkaServer = null
@@ -62,15 +63,13 @@ class TopicMetadataTest extends ZooKeeperTestHarness {
     val topic = "test"
     createTopic(zkUtils, topic, numPartitions = 1, replicationFactor = 1, servers = Seq(server1))
 
-    val topicsMetadata = ClientUtils.fetchTopicMetadata(Set(topic), brokerEndPoints, "TopicMetadataTest-testBasicTopicMetadata",
-      2000, 0).topicsMetadata
-    assertEquals(Errors.NONE, topicsMetadata.head.error)
-    assertEquals(Errors.NONE, topicsMetadata.head.partitionsMetadata.head.error)
+    val topicsMetadata = AdminUtils.fetchTopicMetadata(
+        Set(topic), brokerEndPoints, "TopicMetadataTest-testBasicTopicMetadata", 2000)
     assertEquals("Expecting metadata only for 1 topic", 1, topicsMetadata.size)
-    assertEquals("Expecting metadata for the test topic", "test", topicsMetadata.head.topic)
-    val partitionMetadata = topicsMetadata.head.partitionsMetadata
+    assertEquals("Expecting metadata for the test topic", "test", topicsMetadata.keys.head)
+    val partitionMetadata = topicsMetadata.get(topic).getOrElse(List())
     assertEquals("Expecting metadata for 1 partition", 1, partitionMetadata.size)
-    assertEquals("Expecting partition id to be 0", 0, partitionMetadata.head.partitionId)
+    assertEquals("Expecting partition id to be 0", 0, partitionMetadata.head.partition)
     assertEquals(1, partitionMetadata.head.replicas.size)
   }
 
@@ -83,19 +82,16 @@ class TopicMetadataTest extends ZooKeeperTestHarness {
     createTopic(zkUtils, topic2, numPartitions = 1, replicationFactor = 1, servers = Seq(server1))
 
     // issue metadata request with empty list of topics
-    val topicsMetadata = ClientUtils.fetchTopicMetadata(Set.empty, brokerEndPoints, "TopicMetadataTest-testGetAllTopicMetadata",
-      2000, 0).topicsMetadata
-    assertEquals(Errors.NONE, topicsMetadata.head.error)
+    val topicsMetadata = AdminUtils.fetchTopicMetadata(
+        Set.empty, brokerEndPoints, "TopicMetadataTest-testGetAllTopicMetadata", 2000)
     assertEquals(2, topicsMetadata.size)
-    assertEquals(Errors.NONE, topicsMetadata.head.partitionsMetadata.head.error)
-    assertEquals(Errors.NONE, topicsMetadata.last.partitionsMetadata.head.error)
-    val partitionMetadataTopic1 = topicsMetadata.head.partitionsMetadata
-    val partitionMetadataTopic2 = topicsMetadata.last.partitionsMetadata
+    val partitionMetadataTopic1 = topicsMetadata.get(topic1).getOrElse(List())
+    val partitionMetadataTopic2 = topicsMetadata.get(topic2).getOrElse(List())
     assertEquals("Expecting metadata for 1 partition", 1, partitionMetadataTopic1.size)
-    assertEquals("Expecting partition id to be 0", 0, partitionMetadataTopic1.head.partitionId)
+    assertEquals("Expecting partition id to be 0", 0, partitionMetadataTopic1.head.partition)
     assertEquals(1, partitionMetadataTopic1.head.replicas.size)
     assertEquals("Expecting metadata for 1 partition", 1, partitionMetadataTopic2.size)
-    assertEquals("Expecting partition id to be 0", 0, partitionMetadataTopic2.head.partitionId)
+    assertEquals("Expecting partition id to be 0", 0, partitionMetadataTopic2.head.partition)
     assertEquals(1, partitionMetadataTopic2.head.replicas.size)
   }
 
@@ -141,12 +137,10 @@ class TopicMetadataTest extends ZooKeeperTestHarness {
 
     // auto create topic on "bad" endpoint
     val topic = "testAutoCreateTopic"
-    val topicsMetadata = ClientUtils.fetchTopicMetadata(Set(topic), Seq(adHocEndpoint), "TopicMetadataTest-testAutoCreateTopic",
-      2000, 0).topicsMetadata
-    assertEquals(Errors.INVALID_REPLICATION_FACTOR, topicsMetadata.head.error)
-    assertEquals("Expecting metadata only for 1 topic", 1, topicsMetadata.size)
-    assertEquals("Expecting metadata for the test topic", topic, topicsMetadata.head.topic)
-    assertEquals(0, topicsMetadata.head.partitionsMetadata.size)
+    val topicsMetadata = AdminUtils.fetchTopicMetadata(
+        Set(topic), Seq(adHocEndpoint), "TopicMetadataTest-testAutoCreateTopic", 2000)
+    assertEquals("Expecting no metadata for topic", 0, topicsMetadata.size)
+    assertEquals(None, topicsMetadata.get(topic))
   }
 
   @Test
@@ -180,30 +174,29 @@ class TopicMetadataTest extends ZooKeeperTestHarness {
 
   private def checkIsr(servers: Seq[KafkaServer]): Unit = {
     val activeBrokers: Seq[KafkaServer] = servers.filter(x => x.brokerState.currentState != NotRunning.state)
-    val expectedIsr: Seq[BrokerEndPoint] = activeBrokers.map { x =>
+    val expectedIsr: Set[BrokerEndPoint] = activeBrokers.map { x =>
       new BrokerEndPoint(x.config.brokerId,
         if (x.config.hostName.nonEmpty) x.config.hostName else "localhost",
         TestUtils.boundPort(x))
-    }
+    }.toSet
 
     // Assert that topic metadata at new brokers is updated correctly
     activeBrokers.foreach(x => {
-      var metadata: TopicMetadataResponse = new TopicMetadataResponse(Seq(), Seq(), -1)
+      var metadata: scala.collection.Map[String, List[PartitionInfo]] = Map()
       waitUntilTrue(() => {
-        metadata = ClientUtils.fetchTopicMetadata(Set.empty,
+        metadata = AdminUtils.fetchTopicMetadata(Set.empty[String],
                                 Seq(new BrokerEndPoint(x.config.brokerId,
                                                        if (x.config.hostName.nonEmpty) x.config.hostName else "localhost",
                                                        TestUtils.boundPort(x))),
-                                "TopicMetadataTest-testBasicTopicMetadata", 2000, 0)
-        metadata.topicsMetadata.nonEmpty &&
-          metadata.topicsMetadata.head.partitionsMetadata.nonEmpty &&
-          expectedIsr.sortBy(_.id) == metadata.topicsMetadata.head.partitionsMetadata.head.isr.sortBy(_.id)
+                                "TopicMetadataTest-testBasicTopicMetadata", 2000)
+        val actualIsr = metadata.values.head.head.inSyncReplicas.toSet
+        metadata.nonEmpty &&
+          expectedIsr.map(_.id) == actualIsr.map(_.id)
       },
         "Topic metadata is not correctly updated for broker " + x + ".\n" +
-        "Expected ISR: " + expectedIsr + "\n" +
-        "Actual ISR  : " + (if (metadata.topicsMetadata.nonEmpty &&
-                                metadata.topicsMetadata.head.partitionsMetadata.nonEmpty)
-                              metadata.topicsMetadata.head.partitionsMetadata.head.isr
+        "Expected ISR: " + expectedIsr.map(_.id) + "\n" +
+        "Actual ISR  : " + (if (metadata.nonEmpty)
+                              metadata.values.head.head.inSyncReplicas.map(_.id)
                             else
                               ""), 8000L)
     })
@@ -233,26 +226,26 @@ class TopicMetadataTest extends ZooKeeperTestHarness {
   }
 
   private def checkMetadata(servers: Seq[KafkaServer], expectedBrokersCount: Int): Unit = {
-    var topicMetadata: TopicMetadataResponse = new TopicMetadataResponse(Seq(), Seq(), -1)
+    var topicMetadata: scala.collection.Map[String, List[PartitionInfo]] = Map.empty
 
     // Get topic metadata from old broker
     // Wait for metadata to get updated by checking metadata from a new broker
     waitUntilTrue(() => {
-    topicMetadata = ClientUtils.fetchTopicMetadata(
-      Set.empty, brokerEndPoints, "TopicMetadataTest-testBasicTopicMetadata", 2000, 0)
-    topicMetadata.brokers.size == expectedBrokersCount},
-      "Alive brokers list is not correctly propagated by coordinator to brokers"
+      topicMetadata = AdminUtils.fetchTopicMetadata(
+        Set.empty, brokerEndPoints, "TopicMetadataTest-testBasicTopicMetadata", 2000)
+      topicMetadata.values.flatten.map(m => m.leader).toSet == expectedBrokersCount},
+        "Alive brokers list is not correctly propagated by coordinator to brokers"
     )
 
     // Assert that topic metadata at new brokers is updated correctly
     servers.filter(x => x.brokerState.currentState != NotRunning.state).foreach(x =>
       waitUntilTrue(() => {
-          val foundMetadata = ClientUtils.fetchTopicMetadata(
-            Set.empty,
-            Seq(new BrokerEndPoint(x.config.brokerId, x.config.hostName, TestUtils.boundPort(x))),
-            "TopicMetadataTest-testBasicTopicMetadata", 2000, 0)
-          topicMetadata.brokers.sortBy(_.id) == foundMetadata.brokers.sortBy(_.id) &&
-            topicMetadata.topicsMetadata.sortBy(_.topic) == foundMetadata.topicsMetadata.sortBy(_.topic)
+          val foundMetadata = AdminUtils.fetchTopicMetadata(
+            Set.empty, Seq(new BrokerEndPoint(x.config.brokerId, x.config.hostName, TestUtils.boundPort(x))),
+            "TopicMetadataTest-testBasicTopicMetadata", 2000)
+          topicMetadata.values.flatten.map(m => m.leader).toList.sortBy(_.id) ==
+            foundMetadata.values.flatten.map(m => m.leader).toList.sortBy(_.id) &&
+            topicMetadata.keys.toList.sorted == foundMetadata.keys.toList.sorted
         },
         s"Topic metadata is not correctly updated"))
   }


### PR DESCRIPTION
Also, methods in `ClientUtils` that are called by server or tools code are introduced in `AdminUtils` with the implementation living in `AdminUtils`. All the existing callers apart from the old clients call the `AdminUtils` methods.