### PR TITLE
KAFKA-5354: MirrorMaker not preserving headers

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -650,7 +650,8 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
                          record.timestamp,
                          record.timestampType,
                          record.key,
-                         record.value)
+                         record.value,
+                         record.headers)
     }
 
     override def stop() {
@@ -754,7 +755,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
   private[tools] object defaultMirrorMakerMessageHandler extends MirrorMakerMessageHandler {
     override def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
       val timestamp: java.lang.Long = if (record.timestamp == RecordBatch.NO_TIMESTAMP) null else record.timestamp
-      Collections.singletonList(new ProducerRecord[Array[Byte], Array[Byte]](record.topic, null, timestamp, record.key, record.value))
+      Collections.singletonList(new ProducerRecord[Array[Byte], Array[Byte]](record.topic, null, timestamp, record.key, record.value, record.headers))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -19,6 +19,7 @@ package kafka.tools
 
 import kafka.consumer.BaseConsumerRecord
 import org.apache.kafka.common.record.{RecordBatch, TimestampType}
+import scala.collection.JavaConverters._
 import org.junit.Assert._
 import org.junit.Test
 
@@ -55,4 +56,21 @@ class MirrorMakerTest {
     assertEquals("value", new String(producerRecord.value))
   }
 
+  @Test
+  def testDefaultMirrorMakerMessageHandlerHeaders() {
+    val now = 12345L
+    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, now, TimestampType.CREATE_TIME, "key".getBytes, "value".getBytes)
+    consumerRecord.headers.add("headerKey", "headerValue".getBytes);
+    val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
+    assertEquals(1, result.size)
+
+    val producerRecord = result.get(0)
+    assertEquals(now, producerRecord.timestamp)
+    assertEquals("topic", producerRecord.topic)
+    assertNull(producerRecord.partition)
+    assertEquals("key", new String(producerRecord.key))
+    assertEquals("value", new String(producerRecord.value))
+    assertEquals("headerValue", new String(producerRecord.headers.lastHeader("headerKey").value()))
+    assertEquals(1, producerRecord.headers.asScala.size)
+  }
 }


### PR DESCRIPTION
Add test case to ensure fix and avoid regression
Update mirror maker for new consumer to preserve headers