### PR TITLE
MINOR: Cleanups for TransactionsTest

### DIFF
--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -47,12 +47,7 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
   override def generateConfigs = {
     val cfgs = TestUtils.createBrokerConfigs(serverCount, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
       trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties)
-    cfgs.foreach { config =>
-      config.setProperty(KafkaConfig.ListenersProp, s"${listenerName.value}://localhost:${TestUtils.RandomPort}")
-      config.remove(KafkaConfig.InterBrokerSecurityProtocolProp)
-      config.setProperty(KafkaConfig.InterBrokerListenerNameProp, listenerName.value)
-      config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"${listenerName.value}:${securityProtocol.name}")
-    }
+    setupListenersOnRandomPorts(cfgs)
     cfgs.foreach(_.putAll(serverConfig))
     cfgs.map(KafkaConfig.fromProps)
   }

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -50,7 +50,10 @@ class TransactionsTest extends KafkaServerTestHarness {
   val nonTransactionalConsumers = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
 
   override def generateConfigs: Seq[KafkaConfig] = {
-    TestUtils.createBrokerConfigs(numServers, zkConnect).map(KafkaConfig.fromProps(_, serverProps()))
+    val cfgs = TestUtils.createBrokerConfigs(numServers, zkConnect, interBrokerSecurityProtocol = Some(securityProtocol),
+      trustStoreFile = trustStoreFile, saslProperties = serverSaslProperties)
+    setupListenersOnRandomPorts(cfgs)
+    cfgs.map(KafkaConfig.fromProps(_, serverProps()))
   }
 
   @Before
@@ -75,6 +78,9 @@ class TransactionsTest extends KafkaServerTestHarness {
     transactionalProducers.foreach(_.close())
     transactionalConsumers.foreach(_.close())
     nonTransactionalConsumers.foreach(_.close())
+    transactionalProducers.clear()
+    transactionalConsumers.clear()
+    nonTransactionalConsumers.clear()
     super.tearDown()
   }
 

--- a/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/integration/KafkaServerTestHarness.scala
@@ -129,4 +129,14 @@ abstract class KafkaServerTestHarness extends ZooKeeperTestHarness {
       alive(i) = true
     }
   }
+
+  def setupListenersOnRandomPorts(configs: Seq[Properties]) : Seq[Properties] = {
+    configs.foreach { config =>
+      config.setProperty(KafkaConfig.ListenersProp, s"${listenerName.value}://localhost:${TestUtils.RandomPort}")
+      config.remove(KafkaConfig.InterBrokerSecurityProtocolProp)
+      config.setProperty(KafkaConfig.InterBrokerListenerNameProp, listenerName.value)
+      config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"${listenerName.value}:${securityProtocol.name}")
+    }
+    configs
+  }
 }


### PR DESCRIPTION
The motivation is that KAFKA-5449 seems to indicate that producer instances can be shared across tests, and that producers from one test seem to be hitting brokers in another test.

So this patch does two things: 
1. Make transactionsTest use random ports in each test case. 
2. Clear producers and consumers between tests.

