### PR TITLE
KAFKA-5413: Log cleaner fails due to large offset in segment file

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -630,7 +630,7 @@ private[log] class Cleaner(val id: Int,
             logSize + segs.head.size <= maxSize &&
             indexSize + segs.head.index.sizeInBytes <= maxIndexSize &&
             timeIndexSize + segs.head.timeIndex.sizeInBytes <= maxIndexSize &&
-        lastOffsetForFirstSegment(segs, firstUncleanableOffset) - group.last.baseOffset <= Int.MaxValue) {
+            lastOffsetForFirstSegment(segs, firstUncleanableOffset) - group.last.baseOffset <= Int.MaxValue) {
         group = segs.head :: group
         logSize += segs.head.size
         indexSize += segs.head.index.sizeInBytes
@@ -650,8 +650,8 @@ private[log] class Cleaner(val id: Int,
     * the base offset of the next segment in the list.
     * If the next segment doesn't exist, first Uncleanable Offset will be used.
     *
-    * @param segs - remaining segments to group. The current head is segment were estimating the lastOffset for.
-    * @return The estimated last offset => The upper bound of the last offset
+    * @param segs - remaining segments to group.
+    * @return The estimated last offset for the first segment in segs
     */
   private def lastOffsetForFirstSegment(segs: List[LogSegment], firstUncleanableOffset: Long): Long = {
     if (segs.size > 1) {
@@ -663,7 +663,6 @@ private[log] class Cleaner(val id: Int,
       firstUncleanableOffset - 1
     }
   }
-
 
   /**
    * Build a map of key_hash => offset for the keys in the cleanable dirty portion of the log to use in cleaning.


### PR DESCRIPTION
the contribution is my original work and I license the work to the project under the project's open source license.

@junrao , I had already made the code change before your last comment.  I've done pretty much what you said, except that I've not used the current segment because I wasn't sure if it will always be available.
I'm happy to change it if you prefer.
I've run all the unit and integration tests which all passed.