### PR TITLE
KAFKA-5463: Controller incorrectly logs rack information when new brokers are added

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -106,8 +106,7 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
   private def addNewBroker(broker: Broker) {
     val messageQueue = new LinkedBlockingQueue[QueueItem]
     debug("Controller %d trying to connect to broker %d".format(config.brokerId, broker.id))
-    val brokerEndPoint = broker.getBrokerEndPoint(config.interBrokerListenerName)
-    val brokerNode = new Node(broker.id, brokerEndPoint.host, brokerEndPoint.port, broker.rack.orNull)
+    val brokerNode = broker.getNode(config.interBrokerListenerName)
     val networkClient = {
       val channelBuilder = ChannelBuilders.clientChannelBuilder(
         config.interBrokerSecurityProtocol,

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -107,7 +107,7 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
     val messageQueue = new LinkedBlockingQueue[QueueItem]
     debug("Controller %d trying to connect to broker %d".format(config.brokerId, broker.id))
     val brokerEndPoint = broker.getBrokerEndPoint(config.interBrokerListenerName)
-    val brokerNode = new Node(broker.id, brokerEndPoint.host, brokerEndPoint.port)
+    val brokerNode = new Node(broker.id, brokerEndPoint.host, brokerEndPoint.port, broker.rack.orNull)
     val networkClient = {
       val channelBuilder = ChannelBuilders.clientChannelBuilder(
         config.interBrokerSecurityProtocol,


### PR DESCRIPTION
This change is in response to https://issues.apache.org/jira/browse/KAFKA-5463.

When a new broker is added, the `ControllerChannelManager` doesn't log rack information even if configured.

This happens because `ControllerChannelManager` always instantiates a `Node` using the same constructor whether or not rack-aware is configured and causes some confusion when running with rack-aware replica placement.

Before:

```
pri=TRACE t=Controller-1-to-broker-0-send-thread at=logger Controller 1 epoch 1 received response {error_code=0} for a request sent to broker <ip>:<port> (id: 0 rack: null)
```

After:

```
pri=TRACE t=Controller-1-to-broker-0-send-thread at=logger Controller 1 epoch 1 received response {error_code=0} for a request sent to broker <ip>:<port> (id: 0 rack: us-east-1d)
```