### PR TITLE
KAFKA-5469: Created state changelog topics not logged correctly

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopicConfig.java
@@ -112,4 +112,14 @@ public class InternalTopicConfig {
     public int hashCode() {
         return Objects.hash(name, logConfig, retentionMs, cleanupPolicies);
     }
+
+    @Override
+    public String toString() {
+        return "InternalTopicConfig(" +
+                "name=" + name +
+                ", logConfig=" + logConfig +
+                ", cleanupPolicies=" + cleanupPolicies +
+                ", retentionMs=" + retentionMs +
+                ")";
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -145,6 +145,14 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             this.config = config;
             this.numPartitions = UNKNOWN;
         }
+
+        @Override
+        public String toString() {
+            return "InternalTopicMetadata(" +
+                    "config=" + config +
+                    ", numPartitions=" + numPartitions +
+                    ")";
+        }
     }
 
     private static final Comparator<TopicPartition> PARTITION_COMPARATOR = new Comparator<TopicPartition>() {
@@ -474,7 +482,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
         prepareTopic(changelogTopicMetadata);
 
-        log.debug("stream-thread [{}] Created state changelog topics {} from the parsed topology.", streamThread.getName(), changelogTopicMetadata);
+        log.debug("stream-thread [{}] Created state changelog topics {} from the parsed topology.", streamThread.getName(), changelogTopicMetadata.values());
 
         // ---------------- Step Two ---------------- //
 


### PR DESCRIPTION
Fixed debug logging for the created state changelog topics
Added toString() for InternalTopicMetadata and InternalTopicConfig for above debug logging