### PR TITLE
KAFKA-5474: Streams StandbyTask should no checkpoint on commit if EOS is enabled

### DIFF
--- a/core/src/main/scala/kafka/serializer/Decoder.scala
+++ b/core/src/main/scala/kafka/serializer/Decoder.scala
@@ -54,17 +54,19 @@ class StringDecoder(props: VerifiableProperties = null) extends Decoder[String] 
 }
 
 /**
-  * The string decoder translates bytes into strings. It uses UTF8 by default but takes
-  * an optional property serializer.encoding to control this.
+  * The long decoder translates bytes into longs.
   */
 class LongDecoder(props: VerifiableProperties = null) extends Decoder[Long] {
-  val encoding =
-    if(props == null)
-      "UTF8"
-    else
-      props.getString("serializer.encoding", "UTF8")
-
   def fromBytes(bytes: Array[Byte]): Long = {
     ByteBuffer.wrap(bytes).getLong
+  }
+}
+
+/**
+  * The integer decoder translates bytes into integers.
+  */
+class IntegerDecoder(props: VerifiableProperties = null) extends Decoder[Integer] {
+  def fromBytes(bytes: Array[Byte]): Integer = {
+    ByteBuffer.wrap(bytes).getInt()
   }
 }

--- a/core/src/main/scala/kafka/serializer/Encoder.scala
+++ b/core/src/main/scala/kafka/serializer/Encoder.scala
@@ -17,6 +17,8 @@
 
 package kafka.serializer
 
+import java.nio.ByteBuffer
+
 import kafka.utils.VerifiableProperties
 
 /**
@@ -55,4 +57,26 @@ class StringEncoder(props: VerifiableProperties = null) extends Encoder[String] 
       null
     else
       s.getBytes(encoding)
+}
+
+/**
+  * The long encoder translates longs into bytes.
+  */
+class LongEncoder(props: VerifiableProperties = null) extends Encoder[Long] {
+  override def toBytes(l: Long): Array[Byte] =
+    if(l == null)
+      null
+    else
+      ByteBuffer.allocate(8).putLong(l).array()
+}
+
+/**
+  * The integer encoder translates integers into bytes.
+  */
+class IntegerEncoder(props: VerifiableProperties = null) extends Encoder[Integer] {
+  override def toBytes(i: Integer): Array[Byte] =
+    if(i == null)
+      null
+    else
+      ByteBuffer.allocate(4).putInt(i).array()
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -92,7 +92,9 @@ public class StandbyTask extends AbstractTask {
     public void commit() {
         log.trace("{} Committing", logPrefix);
         stateMgr.flush();
-        stateMgr.checkpoint(Collections.<TopicPartition, Long>emptyMap());
+        if (!eosEnabled) {
+            stateMgr.checkpoint(Collections.<TopicPartition, Long>emptyMap());
+        }
         // reinitialize offset limits
         updateOffsetLimits();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -101,20 +101,18 @@ public class StandbyTask extends AbstractTask {
 
     /**
      * <pre>
-     * - flush store
-     * - checkpoint store
+     * - {@link #commit()}
      * </pre>
      */
     @Override
     public void suspend() {
         log.debug("{} Suspending", logPrefix);
-        stateMgr.flush();
-        stateMgr.checkpoint(Collections.<TopicPartition, Long>emptyMap());
+        commit();
     }
 
     /**
      * <pre>
-     * - {@link #commit()}
+     * - {@link #suspend()}
      * - close state
      * <pre>
      * @param clean ignored by {@code StandbyTask} as it can always try to close cleanly
@@ -125,7 +123,7 @@ public class StandbyTask extends AbstractTask {
         log.debug("{} Closing", logPrefix);
         boolean committedSuccessfully = false;
         try {
-            commit();
+            suspend();
             committedSuccessfully = true;
         } finally {
             closeStateManager(committedSuccessfully);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -60,7 +60,6 @@ import static java.util.Collections.singleton;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 
 public class StandbyTaskTest {
@@ -114,10 +113,6 @@ public class StandbyTaskTest {
     private StateDirectory stateDirectory;
 
     private StreamsConfig createConfig(final File baseDir) throws Exception {
-        return createConfig(baseDir, StreamsConfig.AT_LEAST_ONCE);
-    }
-
-    private StreamsConfig createConfig(final File baseDir, final String eos) throws Exception {
         return new StreamsConfig(new Properties() {
             {
                 setProperty(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
@@ -125,7 +120,6 @@ public class StandbyTaskTest {
                 setProperty(StreamsConfig.BUFFERED_RECORDS_PER_PARTITION_CONFIG, "3");
                 setProperty(StreamsConfig.STATE_DIR_CONFIG, baseDir.getCanonicalPath());
                 setProperty(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockTimestampExtractor.class.getName());
-                setProperty(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, eos);
             }
         });
     }
@@ -383,49 +377,7 @@ public class StandbyTaskTest {
         final Map<TopicPartition, Long> checkpoint = new OffsetCheckpoint(new File(stateDirectory.directoryForTask(taskId),
                                                                                    ProcessorStateManager.CHECKPOINT_FILE_NAME)).read();
         assertThat(checkpoint, equalTo(Collections.singletonMap(ktable, 51L)));
-    }
 
-    @Test
-    public void shouldNotCheckpointStoreOffsetsOnCommitIfEosIsEnabled() throws Exception {
-        final StreamsConfig config = createConfig(baseDir, StreamsConfig.EXACTLY_ONCE);
-
-        consumer.assign(Utils.mkList(ktable));
-        final Map<TopicPartition, OffsetAndMetadata> committedOffsets = new HashMap<>();
-        committedOffsets.put(new TopicPartition(ktable.topic(), ktable.partition()), new OffsetAndMetadata(100L));
-        consumer.commitSync(committedOffsets);
-
-        restoreStateConsumer.updatePartitions("ktable1", Utils.mkList(
-            new PartitionInfo("ktable1", 0, Node.noNode(), new Node[0], new Node[0])));
-
-        final TaskId taskId = new TaskId(0, 0);
-        final MockTime time = new MockTime();
-        final StandbyTask task = new StandbyTask(taskId,
-            applicationId,
-            ktablePartitions,
-            ktableTopology,
-            consumer,
-            changelogReader,
-            config,
-            null,
-            stateDirectory
-        );
-
-
-        restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
-
-        final byte[] serializedValue = Serdes.Integer().serializer().serialize("", 1);
-        task.update(ktable, Collections.singletonList(new ConsumerRecord<>(ktable.topic(),
-            ktable.partition(),
-            50L,
-            serializedValue,
-            serializedValue)));
-
-        time.sleep(config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG));
-        task.commit();
-
-        final File checkpointFile = new File(stateDirectory.directoryForTask(taskId),
-                                             ProcessorStateManager.CHECKPOINT_FILE_NAME);
-        assertFalse(checkpointFile.exists());
     }
 
     private List<ConsumerRecord<byte[], byte[]>> records(ConsumerRecord<byte[], byte[]>... recs) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -339,12 +339,13 @@ public class EosTestDriver extends SmokeTestUtil {
 
                     Integer min = currentMinPerKey.get(key);
                     if (min == null) {
-                        min = Integer.MAX_VALUE;
+                        min = value;
+                    } else {
+                        min = Math.min(min, value);
                     }
-                    min = Math.min(min, value);
                     currentMinPerKey.put(key, min);
 
-                    if (!receivedKey.equals(key) || receivedValue != min.intValue()) {
+                    if (!receivedKey.equals(key) || receivedValue != min) {
                         throw new RuntimeException("Result verification failed for " + receivedRecord + " expected <" + key + "," + min + "> but was <" + receivedKey + "," + receivedValue + ">");
                     }
                 }
@@ -378,12 +379,13 @@ public class EosTestDriver extends SmokeTestUtil {
 
                     Long sum = currentSumPerKey.get(key);
                     if (sum == null) {
-                        sum = 0L;
+                        sum = (long) value;
+                    } else {
+                        sum += value;
                     }
-                    sum += value;
                     currentSumPerKey.put(key, sum);
 
-                    if (!receivedKey.equals(key) || receivedValue != sum.longValue()) {
+                    if (!receivedKey.equals(key) || receivedValue != sum) {
                         throw new RuntimeException("Result verification failed for " + receivedRecord + " expected <" + key + "," + sum + "> but was <" + receivedKey + "," + receivedValue + ">");
                     }
                 }

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -334,18 +334,18 @@ public class EosTestDriver extends SmokeTestUtil {
                     final String receivedKey = stringDeserializer.deserialize(receivedRecord.topic(), receivedRecord.key());
                     final int receivedValue = integerDeserializer.deserialize(receivedRecord.topic(), receivedRecord.value());
                     final String key = stringDeserializer.deserialize(input.topic(), input.key());
-                    final Integer value = integerDeserializer.deserialize(input.topic(), input.value());
+                    final int value = integerDeserializer.deserialize(input.topic(), input.value());
 
 
                     Integer min = currentMinPerKey.get(key);
                     if (min == null) {
-                        min = value;
+                        min = Integer.MAX_VALUE;
                     }
                     min = Math.min(min, value);
                     currentMinPerKey.put(key, min);
 
-                    if (!receivedKey.equals(key) || receivedValue != min) {
-                        throw new RuntimeException("Result verification failed for " + receivedRecord + " expected <" + key + "," + value + "> but was <" + receivedKey + "," + receivedValue + ">");
+                    if (!receivedKey.equals(key) || receivedValue != min.intValue()) {
+                        throw new RuntimeException("Result verification failed for " + receivedRecord + " expected <" + key + "," + min + "> but was <" + receivedKey + "," + receivedValue + ">");
                     }
                 }
             } catch (final NullPointerException e) {
@@ -374,7 +374,7 @@ public class EosTestDriver extends SmokeTestUtil {
                     final String receivedKey = stringDeserializer.deserialize(receivedRecord.topic(), receivedRecord.key());
                     final long receivedValue = longDeserializer.deserialize(receivedRecord.topic(), receivedRecord.value());
                     final String key = stringDeserializer.deserialize(input.topic(), input.key());
-                    final Integer value = integerDeserializer.deserialize(input.topic(), input.value());
+                    final int value = integerDeserializer.deserialize(input.topic(), input.value());
 
                     Long sum = currentSumPerKey.get(key);
                     if (sum == null) {
@@ -383,8 +383,8 @@ public class EosTestDriver extends SmokeTestUtil {
                     sum += value;
                     currentSumPerKey.put(key, sum);
 
-                    if (!receivedKey.equals(key) || receivedValue != sum) {
-                        throw new RuntimeException("Result verification failed for " + receivedRecord + " expected <" + key + "," + value + "> but was <" + receivedKey + "," + receivedValue + ">");
+                    if (!receivedKey.equals(key) || receivedValue != sum.longValue()) {
+                        throw new RuntimeException("Result verification failed for " + receivedRecord + " expected <" + key + "," + sum + "> but was <" + receivedKey + "," + receivedValue + ">");
                     }
                 }
             } catch (final NullPointerException e) {


### PR DESCRIPTION
<strike> - actual fix for `StandbyTask#commit()` </strike>

Additionally (for debugging):
 - EOS test, does not report "expected" value correctly
 - add `IntegerDecoder` (to be use with `kafka.tools.DumpLogSegments`)
 - add test for `StreamTask` to not checkpoint on commit if EOS enabled