### PR TITLE
KAFKA-5477: Lower retryBackoff for AddPartitionsRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -440,7 +440,8 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         if (idempotenceEnabled) {
             String transactionalId = config.getString(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
             int transactionTimeoutMs = config.getInt(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG);
-            transactionManager = new TransactionManager(transactionalId, transactionTimeoutMs);
+            long retryBackoffMs = config.getLong(ProducerConfig.RETRY_BACKOFF_MS_CONFIG);
+            transactionManager = new TransactionManager(transactionalId, transactionTimeoutMs, retryBackoffMs);
             if (transactionManager.isTransactional())
                 log.info("Instantiated a transactional producer.");
             else

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -339,7 +339,7 @@ public class Sender implements Runnable {
 
                 if (targetNode != null) {
                     if (nextRequestHandler.isRetry())
-                        time.sleep(Math.min(retryBackoffMs, nextRequestHandler.retryBackoffMs()));
+                        time.sleep(nextRequestHandler.retryBackoffMs());
 
                     ClientRequest clientRequest = client.newClientRequest(targetNode.idString(),
                             requestBuilder, now, true, nextRequestHandler);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -340,7 +340,7 @@ public class Sender implements Runnable {
                 if (targetNode != null) {
                     if (nextRequestHandler.isRetry()) {
                         if (0 <= nextRequestHandler.retryBackoffMs())
-                            time.sleep(nextRequestHandler.retryBackoffMs());
+                            time.sleep(Math.min(retryBackoffMs, nextRequestHandler.retryBackoffMs()));
                         else
                             time.sleep(retryBackoffMs);
                     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -338,8 +338,13 @@ public class Sender implements Runnable {
                 }
 
                 if (targetNode != null) {
-                    if (nextRequestHandler.isRetry())
-                        time.sleep(retryBackoffMs);
+                    if (nextRequestHandler.isRetry()) {
+                        if (0 <= nextRequestHandler.retryBackoffMs())
+                            time.sleep(nextRequestHandler.retryBackoffMs());
+                        else
+                            time.sleep(retryBackoffMs);
+                    }
+
 
                     ClientRequest clientRequest = client.newClientRequest(targetNode.idString(),
                             requestBuilder, now, true, nextRequestHandler);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -341,7 +341,6 @@ public class Sender implements Runnable {
                     if (nextRequestHandler.isRetry())
                         time.sleep(Math.min(retryBackoffMs, nextRequestHandler.retryBackoffMs()));
 
-
                     ClientRequest clientRequest = client.newClientRequest(targetNode.idString(),
                             requestBuilder, now, true, nextRequestHandler);
                     transactionManager.setInFlightRequestCorrelationId(clientRequest.correlationId());

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -338,12 +338,8 @@ public class Sender implements Runnable {
                 }
 
                 if (targetNode != null) {
-                    if (nextRequestHandler.isRetry()) {
-                        if (0 <= nextRequestHandler.retryBackoffMs())
-                            time.sleep(Math.min(retryBackoffMs, nextRequestHandler.retryBackoffMs()));
-                        else
-                            time.sleep(retryBackoffMs);
-                    }
+                    if (nextRequestHandler.isRetry())
+                        time.sleep(Math.min(retryBackoffMs, nextRequestHandler.retryBackoffMs()));
 
 
                     ClientRequest clientRequest = client.newClientRequest(targetNode.idString(),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -813,7 +813,7 @@ public class TransactionManager {
 
         private void maybeOverrideRetryBackoffMs() {
             // We only want to reduce the backoff when retrying the first AddPartition which errored out due to a
-            // CONCURRENT_TRANSACTIONS error since this means that the previous transaction is still completeing and
+            // CONCURRENT_TRANSACTIONS error since this means that the previous transaction is still completing and
             // we don't want to wait too long before trying to start the new one.
             //
             // This is only a temporary fix, the long term solution is being tracked in

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -64,6 +64,7 @@ public class TransactionManager {
 
     private final String transactionalId;
     private final int transactionTimeoutMs;
+
     public final String logPrefix;
 
     private final Map<TopicPartition, Integer> sequenceNumbers;
@@ -77,6 +78,10 @@ public class TransactionManager {
     // For instance, this value is lowered by the AddPartitionsToTxnHandler when it receives a CONCURRENT_TRANSACTIONS
     // error for the first AddPartitionsRequest in a transaction.
     private final long retryBackoffMs;
+
+    // The retryBackoff is overridden to the following value if the first AddPartitions receives a
+    // CONCURRENT_TRANSACTIONS error.
+    private static final long ADD_PARTITIONS_RETRY_BACKOFF_MS = 20L;
 
     private int inFlightRequestCorrelationId = NO_INFLIGHT_REQUEST_CORRELATION_ID;
     private Node transactionCoordinator;
@@ -819,7 +824,7 @@ public class TransactionManager {
             // This is only a temporary fix, the long term solution is being tracked in
             // https://issues.apache.org/jira/browse/KAFKA-5482
             if (partitionsInTransaction.isEmpty())
-                this.retryBackoffMs = 20L;
+                this.retryBackoffMs = ADD_PARTITIONS_RETRY_BACKOFF_MS;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -751,7 +751,7 @@ public class TransactionManager {
                     reenqueue();
                     return;
                 } else if (error == Errors.CONCURRENT_TRANSACTIONS) {
-                    retryBackoffMs = 5;
+                    maybeOverrideRetryBackoffMs();
                     reenqueue();
                     return;
                 } else if (error == Errors.COORDINATOR_LOAD_IN_PROGRESS || error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
@@ -802,6 +802,11 @@ public class TransactionManager {
         @Override
         public long retryBackoffMs() {
             return retryBackoffMs;
+        }
+
+        private void maybeOverrideRetryBackoffMs() {
+            if (partitionsInTransaction.isEmpty())
+                retryBackoffMs = 15;
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/SenderTest.java
@@ -613,7 +613,7 @@ public class SenderTest {
     public void testTransactionalSplitBatchAndSend() throws Exception {
         ProducerIdAndEpoch producerIdAndEpoch = new ProducerIdAndEpoch(123456L, (short) 0);
         TopicPartition tp = new TopicPartition("testSplitBatchAndSend", 1);
-        TransactionManager txnManager = new TransactionManager("testSplitBatchAndSend", 60000);
+        TransactionManager txnManager = new TransactionManager("testSplitBatchAndSend", 60000, 100);
 
         setupWithTransactionState(txnManager);
         doInitTransactions(txnManager, producerIdAndEpoch);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -115,7 +115,7 @@ public class TransactionManagerTest {
         int batchSize = 16 * 1024;
         MetricConfig metricConfig = new MetricConfig().tags(metricTags);
         this.brokerNode = new Node(0, "localhost", 2211);
-        this.transactionManager = new TransactionManager(transactionalId, transactionTimeoutMs);
+        this.transactionManager = new TransactionManager(transactionalId, transactionTimeoutMs, 100);
         Metrics metrics = new Metrics(metricConfig, time);
         this.accumulator = new RecordAccumulator(batchSize, 1024 * 1024, CompressionType.NONE, 0L, 0L, metrics, time, apiVersions, transactionManager);
         this.sender = new Sender(this.client, this.metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL,
@@ -338,7 +338,7 @@ public class TransactionManagerTest {
 
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
-        assertEquals(15, handler.retryBackoffMs());
+        assertEquals(20, handler.retryBackoffMs());
     }
 
     @Test
@@ -359,7 +359,7 @@ public class TransactionManagerTest {
 
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
-        assertEquals(-1, handler.retryBackoffMs());
+        assertEquals(100, handler.retryBackoffMs());
     }
 
     @Test
@@ -385,7 +385,7 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxn(otherPartition, Errors.CONCURRENT_TRANSACTIONS);
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
-        assertEquals(-1, handler.retryBackoffMs());
+        assertEquals(100, handler.retryBackoffMs());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -91,6 +91,7 @@ public class TransactionManagerTest {
     private static final String CLIENT_ID = "clientId";
     private static final int MAX_BLOCK_TIMEOUT = 1000;
     private static final int REQUEST_TIMEOUT = 1000;
+    private static final long DEFAULT_RETRY_BACKOFF_MS = 100L;
     private final String transactionalId = "foobar";
     private final int transactionTimeoutMs = 1121;
 
@@ -115,7 +116,7 @@ public class TransactionManagerTest {
         int batchSize = 16 * 1024;
         MetricConfig metricConfig = new MetricConfig().tags(metricTags);
         this.brokerNode = new Node(0, "localhost", 2211);
-        this.transactionManager = new TransactionManager(transactionalId, transactionTimeoutMs, 100);
+        this.transactionManager = new TransactionManager(transactionalId, transactionTimeoutMs, DEFAULT_RETRY_BACKOFF_MS);
         Metrics metrics = new Metrics(metricConfig, time);
         this.accumulator = new RecordAccumulator(batchSize, 1024 * 1024, CompressionType.NONE, 0L, 0L, metrics, time, apiVersions, transactionManager);
         this.sender = new Sender(this.client, this.metadata, this.accumulator, true, MAX_REQUEST_SIZE, ACKS_ALL,
@@ -359,7 +360,7 @@ public class TransactionManagerTest {
 
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
-        assertEquals(100, handler.retryBackoffMs());
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, handler.retryBackoffMs());
     }
 
     @Test
@@ -385,7 +386,7 @@ public class TransactionManagerTest {
         prepareAddPartitionsToTxn(otherPartition, Errors.CONCURRENT_TRANSACTIONS);
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
-        assertEquals(100, handler.retryBackoffMs());
+        assertEquals(DEFAULT_RETRY_BACKOFF_MS, handler.retryBackoffMs());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/TransactionManagerTest.java
@@ -321,7 +321,7 @@ public class TransactionManagerTest {
     }
 
     @Test
-    public void testMaybeAddPartitionToTransactionOverridesRetryBackoffForConcurrentTransactions() {
+    public void testAddPartitionToTransactionOverridesRetryBackoffForConcurrentTransactions() {
         long pid = 13131L;
         short epoch = 1;
         TopicPartition partition = new TopicPartition("foo", 0);
@@ -339,11 +339,10 @@ public class TransactionManagerTest {
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
         assertNotNull(handler);
         assertEquals(5, handler.retryBackoffMs());
-
     }
 
     @Test
-    public void testMaybeAddPartitionToTransactionRetainsRetryBackoffForRegularRetriableError() {
+    public void testAddPartitionToTransactionRetainsRetryBackoffForRegularRetriableError() {
         long pid = 13131L;
         short epoch = 1;
         TopicPartition partition = new TopicPartition("foo", 0);
@@ -359,8 +358,8 @@ public class TransactionManagerTest {
         sender.run(time.milliseconds());
 
         TransactionManager.TxnRequestHandler handler = transactionManager.nextRequestHandler(false);
+        assertNotNull(handler);
         assertEquals(-1, handler.retryBackoffMs());
-
     }
 
 

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -256,7 +256,7 @@ class TransactionCoordinator(brokerId: Int,
 
       result match {
         case Left(err) =>
-          info(s"Returning $err error code to client for $transactionalId's AddPartitions request")
+          debug(s"Returning $err error code to client for $transactionalId's AddPartitions request")
           responseCallback(err)
 
         case Right((coordinatorEpoch, newMetadata)) =>

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionCoordinator.scala
@@ -346,7 +346,7 @@ class TransactionCoordinator(brokerId: Int,
 
       preAppendResult match {
         case Left(err) =>
-          info(s"Aborting append of $txnMarkerResult to transaction log with coordinator and returning $err error to client for $transactionalId's EndTransaction request")
+          debug(s"Aborting append of $txnMarkerResult to transaction log with coordinator and returning $err error to client for $transactionalId's EndTransaction request")
           responseCallback(err)
 
         case Right((coordinatorEpoch, newMetadata)) =>


### PR DESCRIPTION
This patch lowers the retry backoff when receiving a CONCURRENT_TRANSACTIONS error from an AddPartitions request. The default of 100ms would mean that back to back transactions would be 100ms long at minimum, making things to slow.