### PR TITLE
KAFKA-5481: ListOffsetResponse isn't logged in the right way with trace level enabled

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -191,4 +191,15 @@ public class ListOffsetResponse extends AbstractResponse {
 
         return struct;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder bld = new StringBuilder();
+        bld.append("(type=ListOffsetResponse")
+            .append(", throttleTimeMs=").append(throttleTimeMs)
+            .append(", responseData=").append(responseData);
+
+        bld.append(")");
+        return bld.toString();
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetResponse.java
@@ -197,9 +197,8 @@ public class ListOffsetResponse extends AbstractResponse {
         StringBuilder bld = new StringBuilder();
         bld.append("(type=ListOffsetResponse")
             .append(", throttleTimeMs=").append(throttleTimeMs)
-            .append(", responseData=").append(responseData);
-
-        bld.append(")");
+            .append(", responseData=").append(responseData)
+            .append(")");
         return bld.toString();
     }
 }


### PR DESCRIPTION
Added toString() method to ListOffsetResponse for logging