### PR TITLE
KAFKA-3575: Use console consumer access topic that does not exist, ca…

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -19,7 +19,7 @@ package kafka.tools
 
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Locale, Properties, Random}
 
 import joptsimple._
@@ -45,7 +45,7 @@ object ConsoleConsumer extends Logging {
 
   var messageCount = 0
 
-  private val shutdownLatch = new CountDownLatch(1)
+  private val doneShutdown = new AtomicBoolean(false)
 
   def main(args: Array[String]) {
     val conf = new ConsumerConfig(args)
@@ -77,16 +77,19 @@ object ConsoleConsumer extends Logging {
     try {
       process(conf.maxMessages, conf.formatter, consumer, System.out, conf.skipMessageOnError)
     } finally {
-      consumer.cleanup()
-      conf.formatter.close()
-      reportRecordCount()
-
-      // if we generated a random group id (as none specified explicitly) then avoid polluting zookeeper with persistent group data, this is a hack
-      if (!conf.groupIdPassed)
-        ZkUtils.maybeDeletePath(conf.options.valueOf(conf.zkConnectOpt), "/consumers/" + conf.consumerProps.get("group.id"))
-
-      shutdownLatch.countDown()
+      shutdown(conf, consumer)
     }
+  }
+
+  private def shutdown(conf: ConsumerConfig, consumer: BaseConsumer) = {
+    if (!doneShutdown.getAndSet(true))
+    consumer.cleanup()
+    conf.formatter.close()
+    reportRecordCount()
+
+    // if we generated a random group id (as none specified explicitly) then avoid polluting zookeeper with persistent group data, this is a hack
+    if (!conf.groupIdPassed)
+      ZkUtils.maybeDeletePath(conf.options.valueOf(conf.zkConnectOpt), "/consumers/" + conf.consumerProps.get("group.id"))
   }
 
   def checkZk(config: ConsumerConfig) {
@@ -104,11 +107,10 @@ object ConsoleConsumer extends Logging {
   }
 
   def addShutdownHook(consumer: BaseConsumer, conf: ConsumerConfig) {
-    Runtime.getRuntime.addShutdownHook(new Thread() {
+    Runtime.getRuntime.addShutdownHook(new Thread("ConsoleConsumer shutdown hook") {
       override def run() {
         consumer.stop()
-
-        shutdownLatch.await()
+        shutdown(conf, consumer)
 
         if (conf.enableSystestEventsLogging) {
           System.out.println("shutdown_complete")


### PR DESCRIPTION
…n not use "Control + C" to exit process

A finally block is not guaranteed to execute in the event of Ctrl+C happening
while in the try or catch blocks. Decrementing the latch in the finally block
therefore made the shutdown hook hang waiting for something that would
never happen and the JVM couldn't exit while it was running the shutdown hook.

Replacing the latch with an atomic flag to say whether we've run the cleanup
code allows us to either run it from the shutdown hook, or the finally block.
It should thus definitely run once. When run from the shutdown hook the main
thread would no longer be running, so it should be threadsafe.

The contribution is my original work and I license the work to the project under the project's open source license.