### PR TITLE
KAFKA-4931: stop script fails due 4096 ps output limit

### DIFF
--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -16,12 +16,16 @@
 
 # Which jps to use
 if [ -z "$JAVA_HOME" ]; then
-  JPS="jps"
+  JPS="$(which jps)"
 else
   JPS="$JAVA_HOME/bin/jps"
 fi
 
-PIDS=$(${JPS} -vl | grep -i 'kafka\.Kafka' | awk '{print $1}')
+if [ -x "$JPS" ]; then
+  PIDS=$(${JPS} -vl | grep -i 'kafka\.Kafka' | awk '{print $1}')
+else
+  PIDS=$(ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
+fi
 
 if [ -z "$PIDS" ]; then
   echo "No kafka server to stop"

--- a/bin/kafka-server-stop.sh
+++ b/bin/kafka-server-stop.sh
@@ -13,7 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-PIDS=$(ps ax | grep -i 'kafka\.Kafka' | grep java | grep -v grep | awk '{print $1}')
+
+# Which jps to use
+if [ -z "$JAVA_HOME" ]; then
+  JPS="jps"
+else
+  JPS="$JAVA_HOME/bin/jps"
+fi
+
+PIDS=$(${JPS} -vl | grep -i 'kafka\.Kafka' | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
   echo "No kafka server to stop"

--- a/bin/zookeeper-server-stop.sh
+++ b/bin/zookeeper-server-stop.sh
@@ -13,7 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-PIDS=$(ps ax | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $1}')
+
+# Which jps to use
+if [ -z "$JAVA_HOME" ]; then
+  JPS="jps"
+else
+  JPS="$JAVA_HOME/bin/jps"
+fi
+
+PIDS=$(${JPS} -vl | grep -i QuorumPeerMain | awk '{print $1}')
 
 if [ -z "$PIDS" ]; then
   echo "No zookeeper server to stop"

--- a/bin/zookeeper-server-stop.sh
+++ b/bin/zookeeper-server-stop.sh
@@ -16,12 +16,16 @@
 
 # Which jps to use
 if [ -z "$JAVA_HOME" ]; then
-  JPS="jps"
+  JPS="$(which jps)"
 else
   JPS="$JAVA_HOME/bin/jps"
 fi
 
-PIDS=$(${JPS} -vl | grep -i QuorumPeerMain | awk '{print $1}')
+if [ -x "$JPS" ]; then
+  PIDS=$(${JPS} -vl | grep -i QuorumPeerMain | awk '{print $1}')
+else
+  PIDS=$(ps ax | grep java | grep -i QuorumPeerMain | grep -v grep | awk '{print $1}')
+fi
 
 if [ -z "$PIDS" ]; then
   echo "No zookeeper server to stop"


### PR DESCRIPTION
This also fixes KAFKA-4389 and KAFKA-4297, which were exactly the same
issue but for kafka-server-stop.sh.