### PR TITLE
allow transactions in producer perf script

### DIFF
--- a/core/src/main/scala/kafka/producer/BaseProducer.scala
+++ b/core/src/main/scala/kafka/producer/BaseProducer.scala
@@ -25,6 +25,7 @@ import java.util.Properties
             "Please use org.apache.kafka.clients.producer.KafkaProducer instead.", "0.10.0.0")
 trait BaseProducer {
   def send(topic: String, key: Array[Byte], value: Array[Byte])
+  def initTransactions()
   def close()
 }
 
@@ -49,6 +50,10 @@ class NewShinyProducer(producerProps: Properties) extends BaseProducer {
     }
   }
 
+  override def initTransactions() {
+    this.producer.initTransactions()
+  }
+
   override def close() {
     this.producer.close()
   }
@@ -65,6 +70,10 @@ class OldProducer(producerProps: Properties) extends BaseProducer {
 
   override def send(topic: String, key: Array[Byte], value: Array[Byte]) {
     this.producer.send(new KeyedMessage[Array[Byte], Array[Byte]](topic, key, value))
+  }
+
+  override def initTransactions() {
+    throw new UnsupportedOperationException
   }
 
   override def close() {

--- a/core/src/main/scala/kafka/tools/ProducerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ProducerPerformance.scala
@@ -125,6 +125,7 @@ object ProducerPerformance extends Logging {
       .describedAs("metrics directory")
       .ofType(classOf[java.lang.String])
     val useNewProducerOpt = parser.accepts("new-producer", "Use the new producer implementation.")
+    val useTransactionsOpt = parser.accepts("use-transactions", "Use the transactional producer. Must be set with appropriate producer config")
 
     val options = parser.parse(args: _*)
     CommandLineUtils.checkRequiredArgs(parser, options, topicsOpt, brokerListOpt, numMessagesOpt)
@@ -152,6 +153,7 @@ object ProducerPerformance extends Logging {
     val producerNumRetries = options.valueOf(producerNumRetriesOpt).intValue()
     val producerRetryBackoffMs = options.valueOf(producerRetryBackOffMsOpt).intValue()
     val useNewProducer = options.has(useNewProducerOpt)
+    val useTransactions = options.has(useTransactionsOpt)
 
     val csvMetricsReporterEnabled = options.has(csvMetricsReporterEnabledOpt)
 
@@ -219,6 +221,9 @@ object ProducerPerformance extends Logging {
         props.put("serializer.class", classOf[DefaultEncoder].getName)
         props.put("key.serializer.class", classOf[NullEncoder[Long]].getName)
         new OldProducer(props)
+      }
+      if (config.useTransactions) {
+        producer.initTransactions()
       }
 
     // generate the sequential message ID


### PR DESCRIPTION
allow the transactional producer to be enabled in `producer-perf.sh`, with a new flag `--use-transactions`