### PR TITLE
KAFKA-5486: org.apache.kafka logging should go to server.log

### DIFF
--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, stdout
+# Unspecified loggers and loggers with additivity=true output to server.log and stdout
+# Note that INFO only applied
+log4j.rootLogger=INFO, stdout, kafkaAppender
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -55,22 +57,25 @@ log4j.appender.authorizerAppender.File=${kafka.logs.dir}/kafka-authorizer.log
 log4j.appender.authorizerAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.authorizerAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 
-# Turn on all our debugging info
-#log4j.logger.kafka.producer.async.DefaultEventHandler=DEBUG, kafkaAppender
-#log4j.logger.kafka.client.ClientUtils=DEBUG, kafkaAppender
-#log4j.logger.kafka.perf=DEBUG, kafkaAppender
-#log4j.logger.kafka.perf.ProducerPerformance$ProducerThread=DEBUG, kafkaAppender
-#log4j.logger.org.I0Itec.zkclient.ZkClient=DEBUG
-log4j.logger.kafka=INFO, kafkaAppender
+# ZkClient is verbose, so set it to WARN by default
+log4j.logger.org.I0Itec.zkclient.ZkClient=WARN
+log4j.logger.org.apache.zookeeper=WARN
 
-log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
-log4j.additivity.kafka.network.RequestChannel$=false
+# Change the two lines below to adjust the general broker logging level (output to server.log and stdout)
+log4j.logger.kafka=INFO
+log4j.logger.org.apache.kafka=INFO
 
+# Change to DEBUG or TRACE to enable request logging
+log4j.logger.kafka.request.logger=WARN, requestAppender
+log4j.additivity.kafka.request.logger=false
+
+# Uncomment the lines below and change log4j.logger.kafka.network.RequestChannel$ to TRACE for additional output
+# related to the handling of requests
 #log4j.logger.kafka.network.Processor=TRACE, requestAppender
 #log4j.logger.kafka.server.KafkaApis=TRACE, requestAppender
 #log4j.additivity.kafka.server.KafkaApis=false
-log4j.logger.kafka.request.logger=WARN, requestAppender
-log4j.additivity.kafka.request.logger=false
+log4j.logger.kafka.network.RequestChannel$=WARN, requestAppender
+log4j.additivity.kafka.network.RequestChannel$=false
 
 log4j.logger.kafka.controller=TRACE, controllerAppender
 log4j.additivity.kafka.controller=false
@@ -81,7 +86,7 @@ log4j.additivity.kafka.log.LogCleaner=false
 log4j.logger.state.change.logger=TRACE, stateChangeAppender
 log4j.additivity.state.change.logger=false
 
-#Change this to debug to get the actual audit log for authorizer.
+# Change to DEBUG to enable audit log for the authorizer
 log4j.logger.kafka.authorizer.logger=WARN, authorizerAppender
 log4j.additivity.kafka.authorizer.logger=false
 

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Unspecified loggers and loggers with additivity=true output to server.log and stdout
-# Note that INFO only applied
+# Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
 log4j.rootLogger=INFO, stdout, kafkaAppender
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
The current config sends org.apache.kafka and any unspecified logger to
stdout. They should go to `server.log` instead.