### PR TITLE
KAFKA-5495: Update docs to use `kafka-consumer-groups.sh` for checking consumer offsets

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -162,8 +162,6 @@
   my-topic                       2          2               3               1          my-group_consumer-2
   </pre>
 
-  NOTE: Since 0.9.0.0, the old kafka.tools.ConsumerOffsetChecker tool for checking consumer offsets has been deprecated. You should use the kafka.admin.ConsumerGroupCommand (or the bin/kafka-consumer-groups.sh script) to manage consumer groups.
-
   <h4><a id="basic_ops_consumer_group" href="#basic_ops_consumer_group">Managing Consumer Groups</a></h4>
 
   With the ConsumerGroupCommand tool, we can list, describe, or delete consumer groups. Note that deletion is only available when the group metadata is stored in
@@ -173,7 +171,7 @@
   For example, to list all consumer groups across all topics:
 
   <pre class="brush: bash;">
-  &gt; bin/kafka-consumer-groups.sh --bootstrap-server broker1:9092 --list
+  &gt; bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --list
 
   test-consumer-group
   </pre>
@@ -181,7 +179,7 @@
   To view offsets, as mentioned earlier, we "describe" the consumer group like this:
 
   <pre class="brush: bash;">
-  &gt; bin/kafka-consumer-groups.sh --bootstrap-server broker1:9092 --describe --group test-consumer-group
+  &gt; bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --group test-consumer-group
 
   TOPIC                          PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG        CONSUMER-ID                                       HOST                           CLIENT-ID
   test-foo                       0          1               3               2          consumer-1-a5d61779-4d04-4c50-a6d6-fb35d942642d   /127.0.0.1                     consumer-1

--- a/docs/ops.html
+++ b/docs/ops.html
@@ -140,14 +140,29 @@
   <h4><a id="basic_ops_consumer_lag" href="#basic_ops_consumer_lag">Checking consumer position</a></h4>
   Sometimes it's useful to see the position of your consumers. We have a tool that will show the position of all consumers in a consumer group as well as how far behind the end of the log they are. To run this tool on a consumer group named <i>my-group</i> consuming a topic named <i>my-topic</i> would look like this:
   <pre class="brush: bash;">
-  &gt; bin/kafka-run-class.sh kafka.tools.ConsumerOffsetChecker --zookeeper localhost:2181 --group test
-  Group           Topic                          Pid Offset          logSize         Lag             Owner
-  my-group        my-topic                       0   0               0               0               test_jkreps-mn-1394154511599-60744496-0
-  my-group        my-topic                       1   0               0               0               test_jkreps-mn-1394154521217-1a0be913-0
+  &gt; bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --describe --group my-group
+
+  Note: This will only show information about consumers that use the Java consumer API (non-ZooKeeper-based consumers).
+  
+  TOPIC                          PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG        CONSUMER-ID                                       HOST                           CLIENT-ID
+  my-topic                       0          2               4               2          consumer-1-029af89c-873c-4751-a720-cefd41a669d6   /127.0.0.1                     consumer-1
+  my-topic                       1          2               3               1          consumer-1-029af89c-873c-4751-a720-cefd41a669d6   /127.0.0.1                     consumer-1
+  my-topic                       2          2               3               1          consumer-2-42c1abd4-e3b2-425d-a8bb-e1ea49b29bb2   /127.0.0.1                     consumer-2
   </pre>
 
+  This tool also works with ZooKeeper-based consumers:
+  <pre class="brush: bash;">
+  &gt; bin/kafka-consumer-groups.sh --zookeeper localhost:2181 --describe --group my-group
 
-  NOTE: Since 0.9.0.0, the kafka.tools.ConsumerOffsetChecker tool has been deprecated. You should use the kafka.admin.ConsumerGroupCommand (or the bin/kafka-consumer-groups.sh script) to manage consumer groups, including consumers created with the <a href="http://kafka.apache.org/documentation.html#newconsumerapi">new consumer API</a>.
+  Note: This will only show information about consumers that use ZooKeeper (not those using the Java consumer API).
+
+  TOPIC                          PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG        CONSUMER-ID
+  my-topic                       0          2               4               2          my-group_consumer-1
+  my-topic                       1          2               3               1          my-group_consumer-1
+  my-topic                       2          2               3               1          my-group_consumer-2
+  </pre>
+
+  NOTE: Since 0.9.0.0, the old kafka.tools.ConsumerOffsetChecker tool for checking consumer offsets has been deprecated. You should use the kafka.admin.ConsumerGroupCommand (or the bin/kafka-consumer-groups.sh script) to manage consumer groups.
 
   <h4><a id="basic_ops_consumer_group" href="#basic_ops_consumer_group">Managing Consumer Groups</a></h4>
 
@@ -163,7 +178,7 @@
   test-consumer-group
   </pre>
 
-  To view offsets as in the previous example with the ConsumerOffsetChecker, we "describe" the consumer group like this:
+  To view offsets, as mentioned earlier, we "describe" the consumer group like this:
 
   <pre class="brush: bash;">
   &gt; bin/kafka-consumer-groups.sh --bootstrap-server broker1:9092 --describe --group test-consumer-group


### PR DESCRIPTION
And remove the deprecated `ConsumerOffsetChecker` example.