### PR TITLE
HOTFIX: Don't check metadata unless you are creating topic

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -81,6 +81,26 @@ public class InternalTopicManagerTest {
         Assert.assertTrue(exceptionWasThrown);
     }
 
+    @Test
+    public void shouldNotThrowExceptionIfExistsWithDifferentReplication() throws Exception {
+
+        // create topic the first time with replication 2
+        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 2,
+            WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
+        internalTopicManager.makeReady(Collections.singletonMap(new InternalTopicConfig(topic, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 1));
+
+        // attempt to create it again with replication 1
+        InternalTopicManager internalTopicManager2 = new InternalTopicManager(streamsKafkaClient, 1,
+            WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
+        boolean exceptionWasThrown = false;
+        try {
+            internalTopicManager2.makeReady(Collections.singletonMap(new InternalTopicConfig(topic, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 1));
+        } catch (StreamsException e) {
+            exceptionWasThrown = true;
+        }
+        Assert.assertFalse(exceptionWasThrown);
+    }
+
     private Properties configProps() {
         return new Properties() {
             {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -92,13 +92,18 @@ public class InternalTopicManagerTest {
         // attempt to create it again with replication 1
         InternalTopicManager internalTopicManager2 = new InternalTopicManager(streamsKafkaClient, 1,
             WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
-        boolean exceptionWasThrown = false;
         try {
             internalTopicManager2.makeReady(Collections.singletonMap(new InternalTopicConfig(topic, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), null), 1));
         } catch (StreamsException e) {
-            exceptionWasThrown = true;
+            Assert.fail("did not expect an exception since topic is already there.");
         }
-        Assert.assertFalse(exceptionWasThrown);
+    }
+
+    @Test
+    public void shouldNotThrowExceptionForEmptyTopicMap() throws Exception {
+        InternalTopicManager internalTopicManager = new InternalTopicManager(streamsKafkaClient, 1,
+            WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_DEFAULT, time);
+        internalTopicManager.makeReady(Collections.EMPTY_MAP);
     }
 
     private Properties configProps() {


### PR DESCRIPTION
During a broker rolling upgrade, it's likely we don't have enough brokers ready yet. If streams does not need to create a topic it shouldn't check how many brokers are up. 

The system test for this is in a separate PR: https://github.com/apache/kafka/pull/3411