### PR TITLE
KAFKA-5501: introduce async ZookeeperClient

### DIFF
--- a/core/src/main/scala/kafka/controller/ZookeeperClient.scala
+++ b/core/src/main/scala/kafka/controller/ZookeeperClient.scala
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.controller
+
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap, CountDownLatch}
+
+import kafka.utils.CoreUtils.inLock
+import org.apache.zookeeper.AsyncCallback.{ACLCallback, Children2Callback, DataCallback, StatCallback, StringCallback, VoidCallback}
+import org.apache.zookeeper.Watcher.Event.EventType
+import org.apache.zookeeper.ZooKeeper.States
+import org.apache.zookeeper.data.{ACL, Stat}
+import org.apache.zookeeper.{CreateMode, WatchedEvent, Watcher, ZooKeeper}
+
+class ZookeeperClient(connectString: String, sessionTimeout: Int) {
+  private val initializationLock = new ReentrantLock()
+  private val isConnectedOrExpiredLock = new ReentrantLock()
+  private val isConnectedOrExpiredCondition = isConnectedOrExpiredLock.newCondition()
+  private val zNodeChangeHandlers = new ConcurrentHashMap[String, ZNodeChangeHandler]()
+  private val zNodeChildChangeHandlers = new ConcurrentHashMap[String, ZNodeChildChangeHandler]()
+  @volatile private var stateChangeHandlerOpt: Option[StateChangeHandler] = None
+  @volatile private var zooKeeper = new ZooKeeper(connectString, sessionTimeout, ZookeeperClientWatcher)
+  private val sessionContext = new ThreadLocal[ZooKeeper] {
+    override def initialValue(): ZooKeeper = zooKeeper
+  }
+
+  def handle(request: AsyncRequest): AsyncResponse = {
+    batch(Seq(request)).head
+  }
+
+  def batch(requests: Seq[AsyncRequest]): Seq[AsyncResponse] = {
+    import scala.collection.JavaConverters._
+    val countDownLatch = new CountDownLatch(requests.size)
+    val responseQueue = new ArrayBlockingQueue[AsyncResponse](requests.size)
+    requests.foreach {
+      case CreateRequest(path, data, acl, createMode, ctx) => sessionContext.get().create(path, data, acl.asJava, createMode, new StringCallback {
+        override def processResult(rc: Int, path: String, ctx: Any, name: String) = {
+          responseQueue.add(CreateResponse(rc, path, ctx, name))
+          countDownLatch.countDown()
+        }}, ctx)
+      case DeleteRequest(path, version, ctx) => sessionContext.get().delete(path, version, new VoidCallback {
+        override def processResult(rc: Int, path: String, ctx: Any) = {
+          responseQueue.add(DeleteResponse(rc, path, ctx))
+          countDownLatch.countDown()
+        }}, ctx)
+      case ExistsRequest(path, ctx) => sessionContext.get().exists(path, false, new StatCallback {
+        override def processResult(rc: Int, path: String, ctx: Any, stat: Stat) = {
+          responseQueue.add(ExistsResponse(rc, path, ctx, stat))
+          countDownLatch.countDown()
+        }}, ctx)
+      case GetDataRequest(path, ctx) => sessionContext.get().getData(path, false, new DataCallback {
+        override def processResult(rc: Int, path: String, ctx: Any, data: Array[Byte], stat: Stat) = {
+          responseQueue.add(GetDataResponse(rc, path, ctx, data, stat))
+          countDownLatch.countDown()
+        }}, ctx)
+      case SetDataRequest(path, data, version, ctx) => sessionContext.get().setData(path, data, version, new StatCallback {
+        override def processResult(rc: Int, path: String, ctx: Any, stat: Stat) = {
+          responseQueue.add(SetDataResponse(rc, path, ctx, stat))
+          countDownLatch.countDown()
+        }}, ctx)
+      case GetACLRequest(path, ctx) => sessionContext.get().getACL(path, null, new ACLCallback {
+        override def processResult(rc: Int, path: String, ctx: Any, acl: java.util.List[ACL], stat: Stat): Unit = {
+          responseQueue.add(GetACLResponse(rc, path, ctx, Option(acl).map(_.asScala).orNull, stat))
+          countDownLatch.countDown()
+        }}, ctx)
+      case SetACLRequest(path, acl, version, ctx) => sessionContext.get().setACL(path, acl.asJava, version, new StatCallback {
+        override def processResult(rc: Int, path: String, ctx: Any, stat: Stat) = {
+          responseQueue.add(SetACLResponse(rc, path, ctx, stat))
+          countDownLatch.countDown()
+        }}, ctx)
+      case GetChildrenRequest(path, ctx) => sessionContext.get().getChildren(path, false, new Children2Callback {
+        override def processResult(rc: Int, path: String, ctx: Any, children: java.util.List[String], stat: Stat) = {
+          responseQueue.add(GetChildrenResponse(rc, path, ctx, Option(children).map(_.asScala).orNull, stat))
+          countDownLatch.countDown()
+        }}, ctx)
+    }
+    countDownLatch.await()
+    responseQueue.asScala.toSeq
+  }
+
+  def getState: States = sessionContext.get().getState
+
+  def waitUntilConnectedOrExpired: Boolean = inLock(isConnectedOrExpiredLock) {
+    var state = sessionContext.get().getState
+    while (!state.isConnected && state.isAlive) {
+      isConnectedOrExpiredCondition.await()
+      state = sessionContext.get().getState
+    }
+    state.isConnected
+  }
+
+  def registerStateChangeHandler(stateChangeHandler: StateChangeHandler): Unit = {
+    stateChangeHandlerOpt = Option(stateChangeHandler)
+  }
+
+  def unregisterStateChangeHandler(): Unit = {
+    stateChangeHandlerOpt = None
+  }
+
+  def registerZNodeChangeHandler(zNodeChangeHandler: ZNodeChangeHandler): Unit = {
+    zNodeChangeHandlers.put(zNodeChangeHandler.path, zNodeChangeHandler)
+    sessionContext.get().exists(zNodeChangeHandler.path, true)
+  }
+
+  def unregisterZNodeChangeHandler(path: String): Unit = {
+    zNodeChangeHandlers.remove(path)
+  }
+
+  def registerZNodeChildChangeHandler(zNodeChildChangeHandler: ZNodeChildChangeHandler): Unit = {
+    zNodeChildChangeHandlers.put(zNodeChildChangeHandler.path, zNodeChildChangeHandler)
+    sessionContext.get().getChildren(zNodeChildChangeHandler.path, true)
+  }
+
+  def unregisterZNodeChildChangeHandler(path: String): Unit = {
+    zNodeChildChangeHandlers.remove(path)
+  }
+
+  def initialize(): Unit = inLock(initializationLock) {
+    if (!zooKeeper.getState.isAlive) {
+      zNodeChangeHandlers.clear()
+      zNodeChildChangeHandlers.clear()
+      zooKeeper = new ZooKeeper(connectString, sessionTimeout, ZookeeperClientWatcher)
+    }
+    sessionContext.set(zooKeeper)
+  }
+
+  def close(): Unit = inLock(initializationLock) {
+    zNodeChangeHandlers.clear()
+    zNodeChildChangeHandlers.clear()
+    zooKeeper.close()
+  }
+
+  private object ZookeeperClientWatcher extends Watcher {
+    override def process(event: WatchedEvent): Unit = {
+      if (event.getPath == null) {
+        inLock(isConnectedOrExpiredLock) {
+          isConnectedOrExpiredCondition.signalAll()
+        }
+        stateChangeHandlerOpt.foreach(_.handleStateChange)
+      } else if (event.getType == EventType.NodeCreated) {
+        Option(zNodeChangeHandlers.remove(event.getPath)).foreach(_.handleCreation)
+      } else if (event.getType == EventType.NodeDeleted) {
+        Option(zNodeChangeHandlers.remove(event.getPath)).foreach(_.handleDeletion)
+      } else if (event.getType == EventType.NodeDataChanged) {
+        Option(zNodeChangeHandlers.remove(event.getPath)).foreach(_.handleDataChange)
+      } else if (event.getType == EventType.NodeChildrenChanged) {
+        Option(zNodeChildChangeHandlers.remove(event.getPath)).foreach(_.handleChildChange)
+      }
+    }
+  }
+}
+
+trait StateChangeHandler {
+  def handleStateChange: Unit
+}
+
+trait ZNodeChangeHandler {
+  val path: String
+  def handleCreation: Unit
+  def handleDeletion: Unit
+  def handleDataChange: Unit
+}
+
+trait ZNodeChildChangeHandler {
+  val path: String
+  def handleChildChange: Unit
+}
+
+sealed trait AsyncRequest
+case class CreateRequest(path: String, data: Array[Byte], acl: Seq[ACL], createMode: CreateMode, ctx: Any) extends AsyncRequest
+case class DeleteRequest(path: String, version: Int, ctx: Any) extends AsyncRequest
+case class ExistsRequest(path: String, ctx: Any) extends AsyncRequest
+case class GetDataRequest(path: String, ctx: Any) extends AsyncRequest
+case class SetDataRequest(path: String, data: Array[Byte], version: Int, ctx: Any) extends AsyncRequest
+case class GetACLRequest(path: String, ctx: Any) extends AsyncRequest
+case class SetACLRequest(path: String, acl: Seq[ACL], version: Int, ctx: Any) extends AsyncRequest
+case class GetChildrenRequest(path: String, ctx: Any) extends AsyncRequest
+
+sealed trait AsyncResponse
+case class CreateResponse(rc: Int, path: String, ctx: Any, name: String) extends AsyncResponse
+case class DeleteResponse(rc: Int, path: String, ctx: Any) extends AsyncResponse
+case class ExistsResponse(rc: Int, path: String, ctx: Any, stat: Stat) extends AsyncResponse
+case class GetDataResponse(rc: Int, path: String, ctx: Any, data: Array[Byte], stat: Stat) extends AsyncResponse
+case class SetDataResponse(rc: Int, path: String, ctx: Any, stat: Stat) extends AsyncResponse
+case class GetACLResponse(rc: Int, path: String, ctx: Any, acl: Seq[ACL], stat: Stat) extends AsyncResponse
+case class SetACLResponse(rc: Int, path: String, ctx: Any, stat: Stat) extends AsyncResponse
+case class GetChildrenResponse(rc: Int, path: String, ctx: Any, children: Seq[String], stat: Stat) extends AsyncResponse

--- a/core/src/main/scala/kafka/controller/ZookeeperClient.scala
+++ b/core/src/main/scala/kafka/controller/ZookeeperClient.scala
@@ -37,6 +37,7 @@ import org.apache.zookeeper.{CreateMode, WatchedEvent, Watcher, ZooKeeper}
   * @param stateChangeHandler state change handler callbacks called by the underlying zookeeper client's EventThread.
   */
 class ZookeeperClient(connectString: String, sessionTimeoutMs: Int, connectionTimeoutMs: Int, stateChangeHandler: StateChangeHandler) extends Logging {
+  this.logIdent = "[ZookeeperClient]: "
   private val initializationLock = new ReentrantReadWriteLock()
   private val isConnectedOrExpiredLock = new ReentrantLock()
   private val isConnectedOrExpiredCondition = isConnectedOrExpiredLock.newCondition()

--- a/core/src/main/scala/kafka/controller/ZookeeperClient.scala
+++ b/core/src/main/scala/kafka/controller/ZookeeperClient.scala
@@ -34,7 +34,7 @@ class ZookeeperClient(connectString: String, sessionTimeout: Int, sessionExpirat
   private val zNodeChildChangeHandlers = new ConcurrentHashMap[String, ZNodeChildChangeHandler]()
   @volatile private var zooKeeper = new ZooKeeper(connectString, sessionTimeout, ZookeeperClientWatcher)
 
-  def handle(request: AsyncRequest): AsyncResponse = inReadLock(initializationLock) {
+  def handle(request: AsyncRequest): AsyncResponse = {
     handle(Seq(request)).head
   }
 
@@ -107,31 +107,31 @@ class ZookeeperClient(connectString: String, sessionTimeout: Int, sessionExpirat
     state.isConnected
   }
 
-  def registerZNodeChangeHandler(zNodeChangeHandler: ZNodeChangeHandler): ExistsResponse = inReadLock(initializationLock) {
+  def registerZNodeChangeHandler(zNodeChangeHandler: ZNodeChangeHandler): ExistsResponse = {
     registerZNodeChangeHandlers(Seq(zNodeChangeHandler)).head
   }
 
-  def registerZNodeChangeHandlers(handlers: Seq[ZNodeChangeHandler]): Seq[ExistsResponse] = inReadLock(initializationLock) {
+  def registerZNodeChangeHandlers(handlers: Seq[ZNodeChangeHandler]): Seq[ExistsResponse] = {
     handlers.foreach(handler => zNodeChangeHandlers.put(handler.path, handler))
     val asyncRequests = handlers.map(handler => ExistsWithWatcherRequest(handler.path))
     handle(asyncRequests).asInstanceOf[Seq[ExistsResponse]]
   }
 
-  def unregisterZNodeChangeHandler(path: String): Unit = inReadLock(initializationLock) {
+  def unregisterZNodeChangeHandler(path: String): Unit = {
     zNodeChangeHandlers.remove(path)
   }
 
-  def registerZNodeChildChangeHandler(zNodeChildChangeHandler: ZNodeChildChangeHandler): GetChildrenResponse = inReadLock(initializationLock) {
+  def registerZNodeChildChangeHandler(zNodeChildChangeHandler: ZNodeChildChangeHandler): GetChildrenResponse = {
     registerZNodeChildChangeHandlers(Seq(zNodeChildChangeHandler)).head
   }
 
-  def registerZNodeChildChangeHandlers(handlers: Seq[ZNodeChildChangeHandler]): Seq[GetChildrenResponse] = inReadLock(initializationLock) {
+  def registerZNodeChildChangeHandlers(handlers: Seq[ZNodeChildChangeHandler]): Seq[GetChildrenResponse] = {
     handlers.foreach(handler => zNodeChildChangeHandlers.put(handler.path, handler))
     val asyncRequests = handlers.map(handler => GetChildrenWithWatcherRequest(handler.path))
     handle(asyncRequests).asInstanceOf[Seq[GetChildrenResponse]]
   }
 
-  def unregisterZNodeChildChangeHandler(path: String): Unit = inReadLock(initializationLock) {
+  def unregisterZNodeChildChangeHandler(path: String): Unit = {
     zNodeChildChangeHandlers.remove(path)
   }
 

--- a/core/src/main/scala/kafka/controller/ZookeeperClient.scala
+++ b/core/src/main/scala/kafka/controller/ZookeeperClient.scala
@@ -91,12 +91,7 @@ class ZookeeperClient(connectString: String, sessionTimeoutMs: Int, connectionTi
   }
 
   def waitUntilConnectedOrExpired: Boolean = inLock(isConnectedOrExpiredLock) {
-    var state = zooKeeper.getState
-    while (!state.isConnected && state.isAlive) {
-      isConnectedOrExpiredCondition.await()
-      state = zooKeeper.getState
-    }
-    state.isConnected
+    waitUntilConnectedOrExpired(Long.MaxValue, TimeUnit.MILLISECONDS)
   }
 
   private def waitUntilConnectedOrExpired(timeout: Long, timeUnit: TimeUnit): Boolean = {

--- a/core/src/main/scala/kafka/controller/ZookeeperClient.scala
+++ b/core/src/main/scala/kafka/controller/ZookeeperClient.scala
@@ -154,13 +154,13 @@ class ZookeeperClient(connectString: String, sessionTimeoutMs: Int, connectionTi
       val threshold = now + connectionTimeoutMs
       while (now < threshold) {
         try {
+          zooKeeper.close()
           zooKeeper = new ZooKeeper(connectString, sessionTimeoutMs, ZookeeperClientWatcher)
           if (waitUntilConnectedOrExpired(threshold - now, TimeUnit.MILLISECONDS)) {
             return
           }
         } catch {
           case _: Exception =>
-            zooKeeper.close()
             now = time.milliseconds()
             if (now < threshold) {
               time.sleep(1000)

--- a/core/src/main/scala/kafka/controller/ZookeeperClient.scala
+++ b/core/src/main/scala/kafka/controller/ZookeeperClient.scala
@@ -172,8 +172,12 @@ class ZookeeperClient(connectString: String, sessionTimeout: Int, sessionExpirat
     }
   }
 
-  private[this] case class ExistsWithWatcherRequest(path: String) extends AsyncRequest
-  private[this] case class GetChildrenWithWatcherRequest(path: String) extends AsyncRequest
+  private[this] case class ExistsWithWatcherRequest(path: String) extends AsyncRequest {
+    val ctx = null
+  }
+  private[this] case class GetChildrenWithWatcherRequest(path: String) extends AsyncRequest {
+    val ctx = null
+  }
 }
 
 trait SessionExpirationHandler {
@@ -193,7 +197,10 @@ trait ZNodeChildChangeHandler {
   def handleChildChange: Unit
 }
 
-sealed trait AsyncRequest
+sealed trait AsyncRequest {
+  val path: String
+  val ctx: Any
+}
 case class CreateRequest(path: String, data: Array[Byte], acl: Seq[ACL], createMode: CreateMode, ctx: Any) extends AsyncRequest
 case class DeleteRequest(path: String, version: Int, ctx: Any) extends AsyncRequest
 case class ExistsRequest(path: String, ctx: Any) extends AsyncRequest
@@ -203,7 +210,11 @@ case class GetACLRequest(path: String, ctx: Any) extends AsyncRequest
 case class SetACLRequest(path: String, acl: Seq[ACL], version: Int, ctx: Any) extends AsyncRequest
 case class GetChildrenRequest(path: String, ctx: Any) extends AsyncRequest
 
-sealed trait AsyncResponse
+sealed trait AsyncResponse {
+  val rc: Int
+  val path: String
+  val ctx: Any
+}
 case class CreateResponse(rc: Int, path: String, ctx: Any, name: String) extends AsyncResponse
 case class DeleteResponse(rc: Int, path: String, ctx: Any) extends AsyncResponse
 case class ExistsResponse(rc: Int, path: String, ctx: Any, stat: Stat) extends AsyncResponse

--- a/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.controller
 
 import java.net.UnknownHostException

--- a/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
@@ -1,0 +1,268 @@
+package kafka.controller
+
+import java.net.UnknownHostException
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.zookeeper.KeeperException.Code
+import org.apache.zookeeper.{CreateMode, ZooDefs}
+import org.junit.Assert.{assertArrayEquals, assertEquals, assertTrue}
+import org.junit.Test
+
+class ZookeeperClientTest extends ZooKeeperTestHarness {
+  private val mockPath = "/foo"
+
+  @Test(expected = classOf[UnknownHostException])
+  def testUnresolvableConnectString(): Unit = {
+    new ZookeeperClient("-1", -1, -1, null, null)
+  }
+
+  @Test(expected = classOf[ZookeeperClientTimeoutException])
+  def testConnectionTimeout(): Unit = {
+    zookeeper.shutdown()
+    new ZookeeperClient(zkConnect, zkSessionTimeout, connectionTimeoutMs = 100, null, null)
+  }
+
+  @Test
+  def testConnection(): Unit = {
+    new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+  }
+
+  @Test
+  def testDeleteNonExistentZNode(): Unit = {
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val deleteResponse = zookeeperClient.handle(DeleteRequest(mockPath, -1, null)).asInstanceOf[DeleteResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(deleteResponse.rc))
+  }
+
+  @Test
+  def testDeleteExistingZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val deleteResponse = zookeeperClient.handle(DeleteRequest(mockPath, -1, null)).asInstanceOf[DeleteResponse]
+    assertEquals("Response code for delete should be OK", Code.OK, Code.get(deleteResponse.rc))
+  }
+
+  @Test
+  def testExistsNonExistentZNode(): Unit = {
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val existsResponse = zookeeperClient.handle(ExistsRequest(mockPath, null)).asInstanceOf[ExistsResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(existsResponse.rc))
+  }
+
+  @Test
+  def testExistsExistingZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val existsResponse = zookeeperClient.handle(ExistsRequest(mockPath, null)).asInstanceOf[ExistsResponse]
+    assertEquals("Response code for exists should be OK", Code.OK, Code.get(existsResponse.rc))
+  }
+
+  @Test
+  def testGetDataNonExistentZNode(): Unit = {
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val getDataResponse = zookeeperClient.handle(GetDataRequest(mockPath, null)).asInstanceOf[GetDataResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(getDataResponse.rc))
+  }
+
+  @Test
+  def testGetDataExistingZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val data = bytes
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, data, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val getDataResponse = zookeeperClient.handle(GetDataRequest(mockPath, null)).asInstanceOf[GetDataResponse]
+    assertEquals("Response code for getData should be OK", Code.OK, Code.get(getDataResponse.rc))
+    assertArrayEquals("Data for getData should match created znode data", data, getDataResponse.data)
+  }
+
+  @Test
+  def testSetDataNonExistentZNode(): Unit = {
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val setDataResponse = zookeeperClient.handle(SetDataRequest(mockPath, Array.empty[Byte], -1, null)).asInstanceOf[SetDataResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(setDataResponse.rc))
+  }
+
+  @Test
+  def testSetDataExistingZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val data = bytes
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val setDataResponse = zookeeperClient.handle(SetDataRequest(mockPath, data, -1, null)).asInstanceOf[SetDataResponse]
+    assertEquals("Response code for setData should be OK", Code.OK, Code.get(setDataResponse.rc))
+    val getDataResponse = zookeeperClient.handle(GetDataRequest(mockPath, null)).asInstanceOf[GetDataResponse]
+    assertEquals("Response code for getData should be OK", Code.OK, Code.get(getDataResponse.rc))
+    assertArrayEquals("Data for getData should match setData's data", data, getDataResponse.data)
+  }
+
+  @Test
+  def testGetACLNonExistentZNode(): Unit = {
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val getACLResponse = zookeeperClient.handle(GetACLRequest(mockPath, null)).asInstanceOf[GetACLResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(getACLResponse.rc))
+  }
+
+  @Test
+  def testGetACLExistingZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val getACLResponse = zookeeperClient.handle(GetACLRequest(mockPath, null)).asInstanceOf[GetACLResponse]
+    assertEquals("Response code for getACL should be OK", Code.OK, Code.get(getACLResponse.rc))
+    assertEquals("ACL should be " + ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, getACLResponse.acl)
+  }
+
+  @Test
+  def testSetACLNonExistentZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val setACLResponse = zookeeperClient.handle(SetACLRequest(mockPath, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, -1, null)).asInstanceOf[SetACLResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(setACLResponse.rc))
+  }
+
+  @Test
+  def testGetChildrenNonExistentZNode(): Unit = {
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val getChildrenResponse = zookeeperClient.handle(GetChildrenRequest(mockPath, null)).asInstanceOf[GetChildrenResponse]
+    assertEquals("Response code should be NONODE", Code.NONODE, Code.get(getChildrenResponse.rc))
+  }
+
+  @Test
+  def testGetChildrenExistingZNode(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val getChildrenResponse = zookeeperClient.handle(GetChildrenRequest(mockPath, null)).asInstanceOf[GetChildrenResponse]
+    assertEquals("Response code for getChildren should be OK", Code.OK, Code.get(getChildrenResponse.rc))
+    assertEquals("getChildren should return no children", Seq.empty[String], getChildrenResponse.children)
+  }
+
+  @Test
+  def testGetChildrenExistingZNodeWithChildren(): Unit = {
+    import scala.collection.JavaConverters._
+    val child1 = "child1"
+    val child2 = "child2"
+    val child1Path = mockPath + "/" + child1
+    val child2Path = mockPath + "/" + child2
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val createResponseChild1 = zookeeperClient.handle(CreateRequest(child1Path, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create child1 should be OK", Code.OK, Code.get(createResponseChild1.rc))
+    val createResponseChild2 = zookeeperClient.handle(CreateRequest(child2Path, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create child2 should be OK", Code.OK, Code.get(createResponseChild2.rc))
+
+    val getChildrenResponse = zookeeperClient.handle(GetChildrenRequest(mockPath, null)).asInstanceOf[GetChildrenResponse]
+    assertEquals("Response code for getChildren should be OK", Code.OK, Code.get(getChildrenResponse.rc))
+    assertEquals("getChildren should return two children", Seq(child1, child2), getChildrenResponse.children.sorted)
+  }
+
+  @Test
+  def testPipelinedGetData(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createRequests = (1 to 3).map(x => CreateRequest("/" + x, (x * 2).toString.getBytes, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    val createResponses = createRequests.map(zookeeperClient.handle)
+    createResponses.foreach(createResponse => assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc)))
+    val getDataRequests = (1 to 3).map(x => GetDataRequest("/" + x, null))
+    val getDataResponses = zookeeperClient.handle(getDataRequests)
+    getDataResponses.foreach(getDataResponse => assertEquals("Response code for getData should be OK", Code.OK, Code.get(getDataResponse.rc)))
+    getDataResponses.zipWithIndex.foreach { case (getDataResponse, i) =>
+      assertEquals("Response code for getData should be OK", Code.OK, Code.get(getDataResponse.rc))
+      assertEquals("Data for getData should match", ((i + 1) * 2), Integer.valueOf(new String(getDataResponse.asInstanceOf[GetDataResponse].data)))
+    }
+  }
+
+  @Test
+  def testMixedPipeline(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    val getDataRequest = GetDataRequest(mockPath, null)
+    val setDataRequest = SetDataRequest("/nonexistent", Array.empty[Byte], -1, null)
+    val responses = zookeeperClient.handle(Seq(getDataRequest, setDataRequest))
+    assertEquals("Response code for getData should be OK", Code.OK, Code.get(responses.head.rc))
+    assertArrayEquals("Data for getData should be empty", Array.empty[Byte], responses.head.asInstanceOf[GetDataResponse].data)
+    assertEquals("Response code for setData should be NONODE", Code.NONODE, Code.get(responses.last.rc))
+  }
+
+  @Test
+  def testZNodeChangeHandlerForDeletion(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val dataChangeHandlerCountDownLatch = new CountDownLatch(1)
+    val zNodeChangeHandler = new ZNodeChangeHandler {
+      override def handleCreation = {}
+      override def handleDeletion = {
+        dataChangeHandlerCountDownLatch.countDown()
+      }
+      override def handleDataChange = {}
+      override val path: String = mockPath
+    }
+
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    zookeeperClient.registerZNodeChangeHandler(zNodeChangeHandler)
+    val deleteResponse = zookeeperClient.handle(DeleteRequest(mockPath, -1, null)).asInstanceOf[DeleteResponse]
+    assertEquals("Response code for delete should be OK", Code.OK, Code.get(deleteResponse.rc))
+    assertTrue("Failed to receive delete notification", dataChangeHandlerCountDownLatch.await(5, TimeUnit.SECONDS))
+  }
+
+  @Test
+  def testZNodeChangeHandlerForDataChange(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val znodeChangeHandlerCountDownLatch = new CountDownLatch(1)
+    val zNodeChangeHandler = new ZNodeChangeHandler {
+      override def handleCreation = {}
+      override def handleDeletion = {}
+      override def handleDataChange = {
+        znodeChangeHandlerCountDownLatch.countDown()
+      }
+      override val path: String = mockPath
+    }
+
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    zookeeperClient.registerZNodeChangeHandler(zNodeChangeHandler)
+    val setDataResponse = zookeeperClient.handle(SetDataRequest(mockPath, Array.empty[Byte], -1, null)).asInstanceOf[SetDataResponse]
+    assertEquals("Response code for setData should be OK", Code.OK, Code.get(setDataResponse.rc))
+    assertTrue("Failed to receive data change notification", znodeChangeHandlerCountDownLatch.await(5, TimeUnit.SECONDS))
+  }
+
+  @Test
+  def testZNodeChildChangeHandlerForChildChange(): Unit = {
+    import scala.collection.JavaConverters._
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zNodeChildChangeHandlerCountDownLatch = new CountDownLatch(1)
+    val zNodeChildChangeHandler = new ZNodeChildChangeHandler {
+      override def handleChildChange = {
+        zNodeChildChangeHandlerCountDownLatch.countDown()
+      }
+      override val path: String = mockPath
+    }
+
+    val child1 = "child1"
+    val child1Path = mockPath + "/" + child1
+    val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
+    zookeeperClient.registerZNodeChildChangeHandler(zNodeChildChangeHandler)
+    val createResponseChild1 = zookeeperClient.handle(CreateRequest(child1Path, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
+    assertEquals("Response code for create child1 should be OK", Code.OK, Code.get(createResponseChild1.rc))
+    assertTrue("Failed to receive child change notification", zNodeChildChangeHandlerCountDownLatch.await(5, TimeUnit.SECONDS))
+  }
+
+  private def bytes = UUID.randomUUID().toString.getBytes(StandardCharsets.UTF_8)
+}

--- a/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
@@ -32,23 +32,23 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
 
   @Test(expected = classOf[UnknownHostException])
   def testUnresolvableConnectString(): Unit = {
-    new ZookeeperClient("-1", -1, -1, null, null)
+    new ZookeeperClient("-1", -1, -1, null)
   }
 
   @Test(expected = classOf[ZookeeperClientTimeoutException])
   def testConnectionTimeout(): Unit = {
     zookeeper.shutdown()
-    new ZookeeperClient(zkConnect, zkSessionTimeout, connectionTimeoutMs = 100, null, null)
+    new ZookeeperClient(zkConnect, zkSessionTimeout, connectionTimeoutMs = 100, null)
   }
 
   @Test
   def testConnection(): Unit = {
-    new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
   }
 
   @Test
   def testDeleteNonExistentZNode(): Unit = {
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val deleteResponse = zookeeperClient.handle(DeleteRequest(mockPath, -1, null)).asInstanceOf[DeleteResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(deleteResponse.rc))
   }
@@ -56,7 +56,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testDeleteExistingZNode(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val deleteResponse = zookeeperClient.handle(DeleteRequest(mockPath, -1, null)).asInstanceOf[DeleteResponse]
@@ -65,7 +65,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
 
   @Test
   def testExistsNonExistentZNode(): Unit = {
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val existsResponse = zookeeperClient.handle(ExistsRequest(mockPath, null)).asInstanceOf[ExistsResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(existsResponse.rc))
   }
@@ -73,7 +73,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testExistsExistingZNode(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val existsResponse = zookeeperClient.handle(ExistsRequest(mockPath, null)).asInstanceOf[ExistsResponse]
@@ -82,7 +82,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
 
   @Test
   def testGetDataNonExistentZNode(): Unit = {
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val getDataResponse = zookeeperClient.handle(GetDataRequest(mockPath, null)).asInstanceOf[GetDataResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(getDataResponse.rc))
   }
@@ -91,7 +91,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   def testGetDataExistingZNode(): Unit = {
     import scala.collection.JavaConverters._
     val data = bytes
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, data, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val getDataResponse = zookeeperClient.handle(GetDataRequest(mockPath, null)).asInstanceOf[GetDataResponse]
@@ -101,7 +101,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
 
   @Test
   def testSetDataNonExistentZNode(): Unit = {
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val setDataResponse = zookeeperClient.handle(SetDataRequest(mockPath, Array.empty[Byte], -1, null)).asInstanceOf[SetDataResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(setDataResponse.rc))
   }
@@ -110,7 +110,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   def testSetDataExistingZNode(): Unit = {
     import scala.collection.JavaConverters._
     val data = bytes
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val setDataResponse = zookeeperClient.handle(SetDataRequest(mockPath, data, -1, null)).asInstanceOf[SetDataResponse]
@@ -122,7 +122,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
 
   @Test
   def testGetACLNonExistentZNode(): Unit = {
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val getACLResponse = zookeeperClient.handle(GetACLRequest(mockPath, null)).asInstanceOf[GetACLResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(getACLResponse.rc))
   }
@@ -130,7 +130,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testGetACLExistingZNode(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val getACLResponse = zookeeperClient.handle(GetACLRequest(mockPath, null)).asInstanceOf[GetACLResponse]
@@ -141,14 +141,14 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testSetACLNonExistentZNode(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val setACLResponse = zookeeperClient.handle(SetACLRequest(mockPath, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, -1, null)).asInstanceOf[SetACLResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(setACLResponse.rc))
   }
 
   @Test
   def testGetChildrenNonExistentZNode(): Unit = {
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val getChildrenResponse = zookeeperClient.handle(GetChildrenRequest(mockPath, null)).asInstanceOf[GetChildrenResponse]
     assertEquals("Response code should be NONODE", Code.NONODE, Code.get(getChildrenResponse.rc))
   }
@@ -156,7 +156,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testGetChildrenExistingZNode(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val getChildrenResponse = zookeeperClient.handle(GetChildrenRequest(mockPath, null)).asInstanceOf[GetChildrenResponse]
@@ -171,7 +171,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
     val child2 = "child2"
     val child1Path = mockPath + "/" + child1
     val child2Path = mockPath + "/" + child2
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val createResponseChild1 = zookeeperClient.handle(CreateRequest(child1Path, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
@@ -187,7 +187,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testPipelinedGetData(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createRequests = (1 to 3).map(x => CreateRequest("/" + x, (x * 2).toString.getBytes, ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     val createResponses = createRequests.map(zookeeperClient.handle)
     createResponses.foreach(createResponse => assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc)))
@@ -203,7 +203,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testMixedPipeline(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val createResponse = zookeeperClient.handle(CreateRequest(mockPath, Array.empty[Byte], ZooDefs.Ids.OPEN_ACL_UNSAFE.asScala, CreateMode.PERSISTENT, null))
     assertEquals("Response code for create should be OK", Code.OK, Code.get(createResponse.rc))
     val getDataRequest = GetDataRequest(mockPath, null)
@@ -217,7 +217,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testZNodeChangeHandlerForDeletion(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val dataChangeHandlerCountDownLatch = new CountDownLatch(1)
     val zNodeChangeHandler = new ZNodeChangeHandler {
       override def handleCreation = {}
@@ -239,7 +239,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testZNodeChangeHandlerForDataChange(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val znodeChangeHandlerCountDownLatch = new CountDownLatch(1)
     val zNodeChangeHandler = new ZNodeChangeHandler {
       override def handleCreation = {}
@@ -261,7 +261,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
   @Test
   def testZNodeChildChangeHandlerForChildChange(): Unit = {
     import scala.collection.JavaConverters._
-    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null, null)
+    val zookeeperClient = new ZookeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, null)
     val zNodeChildChangeHandlerCountDownLatch = new CountDownLatch(1)
     val zNodeChildChangeHandler = new ZNodeChildChangeHandler {
       override def handleChildChange = {


### PR DESCRIPTION
Synchronous zookeeper writes means that we wait an entire round trip before doing the next write. With respect to the controller, these synchronous writes are happening at a per-partition granularity in several places, so partition-heavy clusters suffer from the controller doing many sequential round trips to zookeeper.
- PartitionStateMachine.electLeaderForPartition updates leaderAndIsr in zookeeper on transition to OnlinePartition. This gets triggered per-partition sequentially with synchronous writes during controlled shutdown of the shutting down broker's replicas for which it is the leader.
- ReplicaStateMachine updates leaderAndIsr in zookeeper on transition to OfflineReplica when calling KafkaController.removeReplicaFromIsr. This gets triggered per-partition sequentially with synchronous writes for failed or controlled shutdown brokers.