### PR TITLE
KAFKA-3465: Clarify warning message of ConsumerOffsetChecker

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerOffsetChecker.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerOffsetChecker.scala
@@ -101,7 +101,7 @@ object ConsumerOffsetChecker extends Logging {
   }
 
   def main(args: Array[String]) {
-    warn("WARNING: ConsumerOffsetChecker is deprecated and will be dropped in releases following 0.9.0. Use ConsumerGroupCommand instead.")
+    warn("WARNING: ConsumerOffsetChecker supports the old consumer only and does not report offsets for new consumer-based groups. It is deprecated and will be dropped in releases following 0.9.0. Use ConsumerGroupCommand instead.")
 
     val parser = new OptionParser(false)
 


### PR DESCRIPTION
Add that the tool works with the old consumer only.