### PR TITLE
MINOR: Implement `toString` in some Validator instances

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -125,7 +125,7 @@ public class ConsumerConfig extends AbstractConfig {
     public static final String FETCH_MAX_BYTES_CONFIG = "fetch.max.bytes";
     private static final String FETCH_MAX_BYTES_DOC = "The maximum amount of data the server should return for a fetch request. " +
             "Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than " +
-            "this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum." +
+            "this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. " +
             "The maximum record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
             "<code>max.message.bytes</code> (topic config). Note that the consumer performs multiple fetches in parallel.";
     public static final int DEFAULT_FETCH_MAX_BYTES = 50 * 1024 * 1024;

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -904,12 +904,18 @@ public class ConfigDef {
     }
 
     public static class NonEmptyString implements Validator {
+
         @Override
         public void ensureValid(String name, Object o) {
             String s = (String) o;
             if (s != null && s.isEmpty()) {
                 throw new ConfigException(name, o, "String must be non-empty");
             }
+        }
+
+        @Override
+        public String toString() {
+            return "non-empty string";
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/TopicConfig.java
@@ -78,7 +78,7 @@ public class TopicConfig {
         "is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that " +
         "the they can fetch record batches this large.</p>" +
         "<p>In the latest message format version, records are always grouped into batches for efficiency. In previous " +
-        "message format versions, uncompressed records are not grouped into batches and this limit only applies to a" +
+        "message format versions, uncompressed records are not grouped into batches and this limit only applies to a " +
         "single record in that case.</p>";
 
     public static final String INDEX_INTERVAL_BYTES_CONFIG = "index.interval.bytes";

--- a/core/src/main/scala/kafka/server/ConfigHandler.scala
+++ b/core/src/main/scala/kafka/server/ConfigHandler.scala
@@ -199,12 +199,16 @@ object ThrottledReplicaListValidator extends Validator {
     def check(proposed: Seq[Any]): Unit = {
       if (!(proposed.forall(_.toString.trim.matches("([0-9]+:[0-9]+)?"))
         || proposed.headOption.exists(_.toString.trim.equals("*"))))
-        throw new ConfigException(name, value, s"$name  must match for format [partitionId],[brokerId]:[partitionId],[brokerId]:[partitionId],[brokerId] etc")
+        throw new ConfigException(name, value,
+          s"$name must be the literal '*' or a list of replicas in the following format: [partitionId],[brokerId]:[partitionId],[brokerId]:...")
     }
     value match {
       case scalaSeq: Seq[_] => check(scalaSeq)
       case javaList: java.util.List[_] => check(javaList.asScala)
-      case _ => throw new ConfigException(name, value, s"$name  must be a List but was ${value.getClass.getName}")
+      case _ => throw new ConfigException(name, value, s"$name must be a List but was ${value.getClass.getName}")
     }
   }
+
+  override def toString: String = "[partitionId],[brokerId]:[partitionId],[brokerId]:..."
+
 }


### PR DESCRIPTION
This is used in the generated config table. Also fix a couple
of typos in the process.