### PR TITLE
KAFKA-5483: Shutdown of scheduler should come after LogManager

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -590,8 +590,6 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         if (requestHandlerPool != null)
           CoreUtils.swallow(requestHandlerPool.shutdown())
 
-        CoreUtils.swallow(kafkaScheduler.shutdown())
-
         if (apis != null)
           CoreUtils.swallow(apis.close())
         CoreUtils.swallow(authorizer.foreach(_.close()))
@@ -607,6 +605,8 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           CoreUtils.swallow(replicaManager.shutdown())
         if (logManager != null)
           CoreUtils.swallow(logManager.shutdown())
+
+        CoreUtils.swallow(kafkaScheduler.shutdown())
 
         if (kafkaController != null)
           CoreUtils.swallow(kafkaController.shutdown())


### PR DESCRIPTION
Close the scheduler after all components using it have been shutdown

@hachikuji Can you have a look ?