### PR TITLE
MINOR: InFlightRequests#isEmpty(node) method corrected.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -109,7 +109,8 @@ final class InFlightRequests {
      * Return true if there is no in-flight request directed at the given node and false otherwise
      */
     public boolean isEmpty(String node) {
-        return count(node) == 0;
+        Deque<NetworkClient.InFlightRequest> queue = requests.get(node);
+        return queue == null || queue.isEmpty();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -109,8 +109,7 @@ final class InFlightRequests {
      * Return true if there is no in-flight request directed at the given node and false otherwise
      */
     public boolean isEmpty(String node) {
-        Deque<NetworkClient.InFlightRequest> queue = requests.get(node);
-        return queue == null || queue.isEmpty();
+        return count(node) == 0;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -482,7 +482,7 @@ public class NetworkClient implements KafkaClient {
 
     @Override
     public boolean hasInFlightRequests(String node) {
-        return this.inFlightRequests.isEmpty(node);
+        return !this.inFlightRequests.isEmpty(node);
     }
 
     @Override


### PR DESCRIPTION
- In clearAll method, get operation is removed.
- variable name `requestTimeout` changed to `requestTimeoutMs` for clarity