### PR TITLE
MINOR: compatibility tests for streams

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
@@ -55,7 +55,7 @@ class StreamsBrokerCompatibility(Test):
     def setUp(self):
         self.zk.start()
 
-    @parametrize(broker_version=str(LATEST_0_11_0))
+   
     @parametrize(broker_version=str(LATEST_0_10_2))
     @parametrize(broker_version=str(LATEST_0_10_1))
     def test_fail_fast_on_incompatible_brokers_if_eos_enabled(self, broker_version):

--- a/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_compatibility_test.py
@@ -21,7 +21,7 @@ from kafkatest.services.kafka import KafkaService
 from kafkatest.services.streams import StreamsBrokerCompatibilityService
 from kafkatest.services.verifiable_consumer import VerifiableConsumer
 from kafkatest.services.zookeeper import ZookeeperService
-from kafkatest.version import DEV_BRANCH, LATEST_0_10_2, LATEST_0_10_1, LATEST_0_10_0, LATEST_0_9, LATEST_0_8_2, KafkaVersion
+from kafkatest.version import DEV_BRANCH, LATEST_0_11_0, LATEST_0_10_2, LATEST_0_10_1, LATEST_0_10_0, LATEST_0_9, LATEST_0_8_2, KafkaVersion
 
 
 class StreamsBrokerCompatibility(Test):
@@ -55,6 +55,7 @@ class StreamsBrokerCompatibility(Test):
     def setUp(self):
         self.zk.start()
 
+    @parametrize(broker_version=str(LATEST_0_11_0))
     @parametrize(broker_version=str(LATEST_0_10_2))
     @parametrize(broker_version=str(LATEST_0_10_1))
     def test_fail_fast_on_incompatible_brokers_if_eos_enabled(self, broker_version):
@@ -72,6 +73,7 @@ class StreamsBrokerCompatibility(Test):
 
         self.kafka.stop()
 
+    @parametrize(broker_version=str(LATEST_0_11_0))
     @parametrize(broker_version=str(LATEST_0_10_2))
     @parametrize(broker_version=str(LATEST_0_10_1))
     def test_compatible_brokers_eos_disabled(self, broker_version):

--- a/tests/kafkatest/tests/streams/streams_upgrade_test.py
+++ b/tests/kafkatest/tests/streams/streams_upgrade_test.py
@@ -19,7 +19,7 @@ from ducktape.mark import parametrize, ignore
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.streams import StreamsSmokeTestDriverService, StreamsSmokeTestJobRunnerService
-from kafkatest.version import LATEST_0_10_1, LATEST_0_10_2, DEV_BRANCH, KafkaVersion
+from kafkatest.version import LATEST_0_10_1, LATEST_0_10_2, LATEST_0_11_0, DEV_BRANCH, KafkaVersion
 import time
 
 
@@ -80,6 +80,9 @@ class StreamsUpgradeTest(Test):
     @cluster(num_nodes=6)
     @parametrize(from_version=str(LATEST_0_10_1), to_version=str(DEV_BRANCH))
     @parametrize(from_version=str(LATEST_0_10_2), to_version=str(DEV_BRANCH))
+    @parametrize(from_version=str(LATEST_0_10_1), to_version=str(LATEST_0_11_0))
+    @parametrize(from_version=str(LATEST_0_10_2), to_version=str(LATEST_0_11_0))
+    @parametrize(from_version=str(LATEST_0_11_0), to_version=str(LATEST_0_10_2))
     @parametrize(from_version=str(DEV_BRANCH), to_version=str(LATEST_0_10_2))
     def test_upgrade_downgrade_streams(self, from_version, to_version):
         """


### PR DESCRIPTION
Update system tests to make use of the newly released 0.11 version.

Add on to https://github.com/apache/kafka/pull/3454