### PR TITLE
KAFKA-5570: Join request's timeout should be slightly higher than the rebalance timeout

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientRequest.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientRequest.java
@@ -30,6 +30,7 @@ public final class ClientRequest {
     private final int correlationId;
     private final String clientId;
     private final long createdTimeMs;
+    private final int timeoutMs;
     private final boolean expectResponse;
     private final RequestCompletionHandler callback;
 
@@ -39,6 +40,7 @@ public final class ClientRequest {
      * @param correlationId The correlation id for this client request
      * @param clientId The client ID to use for the header
      * @param createdTimeMs The unix timestamp in milliseconds for the time at which this request was created.
+*      @param timeoutMs The request timeout in milliseconds.
      * @param expectResponse Should we expect a response message or is this request complete once it is sent?
      * @param callback A callback to execute when the response has been received (or null if no callback is necessary)
      */
@@ -47,6 +49,7 @@ public final class ClientRequest {
                          int correlationId,
                          String clientId,
                          long createdTimeMs,
+                         int timeoutMs,
                          boolean expectResponse,
                          RequestCompletionHandler callback) {
         this.destination = destination;
@@ -54,6 +57,7 @@ public final class ClientRequest {
         this.correlationId = correlationId;
         this.clientId = clientId;
         this.createdTimeMs = createdTimeMs;
+        this.timeoutMs = timeoutMs;
         this.expectResponse = expectResponse;
         this.callback = callback;
     }
@@ -66,6 +70,7 @@ public final class ClientRequest {
             ", correlationId=" + correlationId +
             ", clientId=" + clientId +
             ", createdTimeMs=" + createdTimeMs +
+            ", timeoutMs=" + timeoutMs +
             ", requestBuilder=" + requestBuilder +
             ")";
     }
@@ -96,6 +101,10 @@ public final class ClientRequest {
 
     public long createdTimeMs() {
         return createdTimeMs;
+    }
+
+    public int timeoutMs() {
+        return timeoutMs;
     }
 
     public int correlationId() {

--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -167,4 +167,17 @@ public interface KafkaClient extends Closeable {
     ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
                                    boolean expectResponse, RequestCompletionHandler callback);
 
+    /**
+     * Create a new ClientRequest.
+     *
+     * @param nodeId the node to send to
+     * @param requestBuilder the request builder to use
+     * @param createdTimeMs the time in milliseconds to use as the creation time of the request
+     * @param expectResponse true iff we expect a response
+     * @param callback the callback to invoke when we get a response
+     * @param timeoutMs the request timeout in milliseconds
+     */
+    ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
+                                   boolean expectResponse, RequestCompletionHandler callback, int timeoutMs);
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -979,6 +979,10 @@ public class NetworkClient implements KafkaClient {
             this.timeoutMs = timeoutMs;
         }
 
+        public boolean hasExpired(long now) {
+            return now - sendTimeMs >= timeoutMs;
+        }
+
         public ClientResponse completed(AbstractResponse response, long timeMs) {
             return new ClientResponse(header, callback, destination, createdTimeMs, timeMs, false, null, response);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -60,7 +60,7 @@ public class ConsumerNetworkClient implements Closeable {
     private final Metadata metadata;
     private final Time time;
     private final long retryBackoffMs;
-    private final long unsentExpiryMs;
+    private final int unsentExpiryMs;
     private final AtomicBoolean wakeupDisabled = new AtomicBoolean();
 
     // when requests complete, they are transferred to this queue prior to invocation. The purpose
@@ -75,12 +75,12 @@ public class ConsumerNetworkClient implements Closeable {
                                  Metadata metadata,
                                  Time time,
                                  long retryBackoffMs,
-                                 long requestTimeoutMs) {
+                                 int defaultRequestTimeoutMs) {
         this.client = client;
         this.metadata = metadata;
         this.time = time;
         this.retryBackoffMs = retryBackoffMs;
-        this.unsentExpiryMs = requestTimeoutMs;
+        this.unsentExpiryMs = defaultRequestTimeoutMs;
     }
 
     public RequestFuture<ClientResponse> send(Node node, AbstractRequest.Builder<?> requestBuilder) {
@@ -240,7 +240,7 @@ public class ConsumerNetworkClient implements Closeable {
             // handler), the client will be woken up.
             if (pollCondition == null || pollCondition.shouldBlock()) {
                 // if there are no requests in flight, do not block longer than the retry backoff
-                if (client.inFlightRequestCount() == 0)
+                if (!client.hasInFlightRequests())
                     timeout = Math.min(timeout, retryBackoffMs);
                 client.poll(Math.min(MAX_POLL_TIMEOUT_MS, timeout), now);
                 now = time.milliseconds();

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -62,6 +62,8 @@ public class MockClient implements KafkaClient {
 
     }
 
+    private static final int DEFAUL_TIMEOUT_MS = 30_000;
+
     private final Time time;
     private final Metadata metadata;
     private Set<String> unavailableTopics;
@@ -350,8 +352,14 @@ public class MockClient implements KafkaClient {
     @Override
     public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
                                           boolean expectResponse, RequestCompletionHandler callback) {
+        return newClientRequest(nodeId, requestBuilder, createdTimeMs, expectResponse, callback, DEFAUL_TIMEOUT_MS);
+    }
+
+    @Override
+    public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
+                                          boolean expectResponse, RequestCompletionHandler callback, int timeoutMs) {
         return new ClientRequest(nodeId, requestBuilder, 0, "mockClientId", createdTimeMs,
-                expectResponse, callback);
+                timeoutMs, expectResponse, callback);
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -255,7 +255,9 @@ public class NetworkClientTest {
         long now = time.milliseconds();
         ClientRequest request = client.newClientRequest(node.idString(), builder, now, true);
         client.send(request, now);
-        client.poll(requestTimeoutMs, now);
+        // MockSelector.poll increments MockTime by timeoutMs, so we pass a value lower than the request timeout to
+        // avoid expiring the request
+        client.poll(requestTimeoutMs - 1, now);
         assertEquals(1, client.inFlightRequestCount(node.idString()));
         assertTrue(client.hasInFlightRequests(node.idString()));
         assertTrue(client.hasInFlightRequests());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1608,7 +1608,7 @@ public class KafkaConsumerTest {
         String groupId = "mock-group";
         String metricGroupPrefix = "consumer";
         long retryBackoffMs = 100;
-        long requestTimeoutMs = 30000;
+        int requestTimeoutMs = 30000;
         boolean excludeInternalTopics = true;
         int minBytes = 1;
         int maxBytes = Integer.MAX_VALUE;
@@ -1628,7 +1628,8 @@ public class KafkaConsumerTest {
         ConsumerMetrics metricsRegistry = new ConsumerMetrics(metricGroupPrefix);
 
         SubscriptionState subscriptions = new SubscriptionState(autoResetStrategy);
-        ConsumerNetworkClient consumerClient = new ConsumerNetworkClient(client, metadata, time, retryBackoffMs, requestTimeoutMs);
+        ConsumerNetworkClient consumerClient = new ConsumerNetworkClient(client, metadata, time, retryBackoffMs,
+                requestTimeoutMs);
         ConsumerCoordinator consumerCoordinator = new ConsumerCoordinator(
                 consumerClient,
                 groupId,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -57,7 +57,7 @@ public class AbstractCoordinatorTest {
     private static final int SESSION_TIMEOUT_MS = 10000;
     private static final int HEARTBEAT_INTERVAL_MS = 3000;
     private static final long RETRY_BACKOFF_MS = 100;
-    private static final long REQUEST_TIMEOUT_MS = 40000;
+    private static final int REQUEST_TIMEOUT_MS = 40000;
     private static final String GROUP_ID = "dummy-group";
     private static final String METRIC_GROUP_PREFIX = "consumer";
 
@@ -74,8 +74,8 @@ public class AbstractCoordinatorTest {
         this.mockClient = new MockClient(mockTime);
 
         Metadata metadata = new Metadata(100L, 60 * 60 * 1000L, true);
-        this.consumerClient = new ConsumerNetworkClient(mockClient, metadata, mockTime,
-                RETRY_BACKOFF_MS, REQUEST_TIMEOUT_MS);
+        this.consumerClient = new ConsumerNetworkClient(mockClient, metadata, mockTime, RETRY_BACKOFF_MS,
+                REQUEST_TIMEOUT_MS);
         Metrics metrics = new Metrics();
 
         Cluster cluster = TestUtils.singletonCluster("topic", 1);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -127,7 +127,8 @@ public class ConsumerNetworkClientTest {
         long retryBackoffMs = 100L;
 
         NetworkClient mockNetworkClient = EasyMock.mock(NetworkClient.class);
-        ConsumerNetworkClient consumerClient = new ConsumerNetworkClient(mockNetworkClient, metadata, time, retryBackoffMs, 1000L);
+        ConsumerNetworkClient consumerClient = new ConsumerNetworkClient(mockNetworkClient, metadata, time,
+                retryBackoffMs, 1000);
 
         EasyMock.expect(mockNetworkClient.inFlightRequestCount()).andReturn(0);
         EasyMock.expect(mockNetworkClient.poll(EasyMock.eq(retryBackoffMs), EasyMock.anyLong())).andReturn(Collections.<ClientResponse>emptyList());
@@ -166,7 +167,7 @@ public class ConsumerNetworkClientTest {
 
     @Test
     public void sendExpiry() throws InterruptedException {
-        long unsentExpiryMs = 10;
+        int unsentExpiryMs = 10;
         final AtomicBoolean isReady = new AtomicBoolean();
         final AtomicBoolean disconnected = new AtomicBoolean();
         client = new MockClient(time) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClientTest.java
@@ -107,7 +107,7 @@ public class ConsumerNetworkClientTest {
         NetworkClient mockNetworkClient = EasyMock.mock(NetworkClient.class);
         ConsumerNetworkClient consumerClient = new ConsumerNetworkClient(mockNetworkClient, metadata, time, 100, 1000);
 
-        EasyMock.expect(mockNetworkClient.inFlightRequestCount()).andReturn(1);
+        EasyMock.expect(mockNetworkClient.hasInFlightRequests()).andReturn(true);
         EasyMock.expect(mockNetworkClient.poll(EasyMock.eq(timeout), EasyMock.anyLong())).andReturn(Collections.<ClientResponse>emptyList());
 
         EasyMock.replay(mockNetworkClient);
@@ -130,7 +130,7 @@ public class ConsumerNetworkClientTest {
         ConsumerNetworkClient consumerClient = new ConsumerNetworkClient(mockNetworkClient, metadata, time,
                 retryBackoffMs, 1000);
 
-        EasyMock.expect(mockNetworkClient.inFlightRequestCount()).andReturn(0);
+        EasyMock.expect(mockNetworkClient.hasInFlightRequests()).andReturn(false);
         EasyMock.expect(mockNetworkClient.poll(EasyMock.eq(retryBackoffMs), EasyMock.anyLong())).andReturn(Collections.<ClientResponse>emptyList());
 
         EasyMock.replay(mockNetworkClient);

--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -473,7 +473,7 @@ object AdminClient {
       metadata,
       time,
       retryBackoffMs,
-      requestTimeoutMs.toLong)
+      requestTimeoutMs)
 
     new AdminClient(
       time,

--- a/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
+++ b/core/src/test/scala/kafka/common/InterBrokerSendThreadTest.scala
@@ -58,7 +58,7 @@ class InterBrokerSendThreadTest {
       override def generateRequests() = List[RequestAndCompletionHandler](handler)
     }
 
-    val clientRequest = new ClientRequest("dest", request, 0, "1", 0, true, handler.handler)
+    val clientRequest = new ClientRequest("dest", request, 0, "1", 0, 10, true, handler.handler)
 
     EasyMock.expect(networkClient.newClientRequest(EasyMock.eq("1"),
       EasyMock.same(handler.request),
@@ -92,7 +92,7 @@ class InterBrokerSendThreadTest {
       override def generateRequests() = List[RequestAndCompletionHandler](requestAndCompletionHandler)
     }
 
-    val clientRequest = new ClientRequest("dest", request, 0, "1", 0, true, requestAndCompletionHandler.handler)
+    val clientRequest = new ClientRequest("dest", request, 0, "1", 0, 10, true, requestAndCompletionHandler.handler)
 
     EasyMock.expect(networkClient.newClientRequest(EasyMock.eq("1"),
       EasyMock.same(requestAndCompletionHandler.request),


### PR DESCRIPTION
- Introduce per request timeouts in NetworkClient
- Use rebalanceTimeout + 5s for join request timeout
- A few minor clean-ups in NetworkClient and ConsumerNetworkClient

This should also fix the Streams issue that we set max.poll.interval.ms (aka
rebalanceTimeout) to infinite without bumping the request timeout.

Still to do:
- Tests