### PR TITLE
KAFKA-5550 

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -211,7 +211,9 @@ public class Struct {
      * @return the Struct, to allow chaining of {@link #put(String, Object)} calls
      */
     public Struct put(Field field, Object value) {
-        ConnectSchema.validateValue(field.schema(), value);
+        if (null == field)
+            throw new DataException("field cannot be null.");
+        ConnectSchema.validateValue(field.name(), field.schema(), value);
         values[field.index()] = value;
         return this;
     }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -266,4 +266,28 @@ public class StructTest {
         thrown.expectMessage("Invalid Java object for schema type INT8: class java.lang.Object for field: \"field\"");
         ConnectSchema.validateValue(fieldName, Schema.INT8_SCHEMA, new Object());
     }
+
+    @Test
+    public void testPutNullField() {
+        final String fieldName = "fieldName";
+        Schema testSchema = SchemaBuilder.struct()
+            .field(fieldName, Schema.STRING_SCHEMA);
+        Struct struct = new Struct(testSchema);
+
+        thrown.expect(DataException.class);
+        Field field = null;
+        struct.put(field, "valid");
+    }
+
+    @Test
+    public void testInvalidPutIncludesFieldName() {
+        final String fieldName = "fieldName";
+        Schema testSchema = SchemaBuilder.struct()
+            .field(fieldName, Schema.STRING_SCHEMA);
+        Struct struct = new Struct(testSchema);
+
+        thrown.expect(DataException.class);
+        thrown.expectMessage("Invalid value: null used for required field: \"fieldName\", schema type: STRING");
+        struct.put(fieldName, null);
+    }
 }


### PR DESCRIPTION
Changed call to use the overload of ConnectSchema.validate method with the field name passed in. Ensure that field in put call is not null.