### PR TITLE
KAFKA-5572 - ConfigDef should be able to escape comma(s)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -695,8 +695,12 @@ public class ConfigDef {
                     else if (value instanceof String)
                         if (trimmed.isEmpty())
                             return Collections.emptyList();
-                        else
-                            return Arrays.asList(trimmed.split("\\s*,\\s*", -1));
+                        else {
+                            final String[] parts = trimmed.split("\\s*(?<!\\\\),\\s*", -1);
+                            for (int i = 0; i < parts.length; i++)
+                                parts[i] = parts[i].replace("\\,", ",");
+                            return Arrays.asList(parts);
+                        }
                     else
                         throw new ConfigException(name, value, "Expected a comma separated list.");
                 case CLASS:

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigDefTest.java
@@ -29,6 +29,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +41,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class ConfigDefTest {
@@ -384,6 +387,27 @@ public class ConfigDefTest {
         final ConfigDef configDef = new ConfigDef()
                 .define("parent", Type.STRING, Importance.HIGH, "parent docs", "group", 1, Width.LONG, "Parent", Collections.singletonList("child"));
         configDef.parse(Collections.emptyMap());
+    }
+
+    void assertList(List<String> expected, Object actual) {
+        assertTrue("actual should be a List", actual instanceof List);
+        final List<String> actualList = (List<String>) actual;
+        final Set<String> expectedSet = new LinkedHashSet<>(expected);
+        final Set<String> actualSet = new LinkedHashSet<>(actualList);
+        assertEquals("Lists do not match.", expectedSet, actualSet);
+    }
+
+    @Test
+    public void testEscapedComma() {
+        final ConfigDef configdef = new ConfigDef()
+            .define("test", Type.LIST, Importance.HIGH, "test");
+        final Map<String, String> settings = new LinkedHashMap<>();
+        settings.put("test", "one,two,three");
+
+        assertList(Arrays.asList("one", "two", "three"), configdef.parse(settings).get("test"));
+
+        settings.put("test", "'first' , 'second\\,escaped',normal,value");
+        assertList(Arrays.asList("'first'", "'second,escaped'", "normal", "value"), configdef.parse(settings).get("test"));
     }
 
     @Test


### PR DESCRIPTION
Allow escaping ',' character with '\,' as an escape sequence.