### PR TITLE
KAFKA-5574: add thread.id header in show-detailed-stats report

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -59,7 +59,7 @@ object ConsumerPerformance {
       if (!config.showDetailedStats)
         println("start.time, end.time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec")
       else
-        println("time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec")
+        println("time, thread.id, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec")
     }
 
     var startMs, endMs = 0L


### PR DESCRIPTION
kafka-consumer-perf-test.sh report missing one header column: 

time, data.consumed.in.MB, MB.sec, data.consumed.in.nMsg, nMsg.sec
2017-07-09 21:40:40:369, 0, 0.1492, 2.6176, 5000, 87719.2982
2017-07-09 21:40:40:386, 0, 0.2983, 149.0479, 10000, 5000000.0000
2017-07-09 21:40:40:387, 0, 0.4473, 149.0812, 15000, 5000000.0000
there's one more column between "time" and "data.consumed.in.MB", should be thread.id .