### PR TITLE
WIP: SimpleRegexAclAuthorizer

### DIFF
--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -64,25 +64,25 @@ object SimpleAclAuthorizer {
   //prefix of all the change notification sequence node.
   val AclChangedPrefix = "acl_changes_"
 
-  private case class VersionedAcls(acls: Set[Acl], zkVersion: Int)
+  case class VersionedAcls(acls: Set[Acl], zkVersion: Int)
 }
 
 class SimpleAclAuthorizer extends Authorizer with Logging {
-  private val authorizerLogger = Logger.getLogger("kafka.authorizer.logger")
-  private var superUsers = Set.empty[KafkaPrincipal]
-  private var shouldAllowEveryoneIfNoAclIsFound = false
-  private var zkUtils: ZkUtils = null
-  private var aclChangeListener: ZkNodeChangeNotificationListener = null
+  protected val authorizerLogger: Logger = Logger.getLogger("kafka.authorizer.logger")
+  protected var superUsers = Set.empty[KafkaPrincipal]
+  protected var shouldAllowEveryoneIfNoAclIsFound = false
+  protected var zkUtils: ZkUtils = null
+  protected var aclChangeListener: ZkNodeChangeNotificationListener = null
 
-  private val aclCache = new scala.collection.mutable.HashMap[Resource, VersionedAcls]
-  private val lock = new ReentrantReadWriteLock()
+  protected val aclCache = new scala.collection.mutable.HashMap[Resource, VersionedAcls]
+  protected val lock = new ReentrantReadWriteLock()
 
   // The maximum number of times we should try to update the resource acls in zookeeper before failing;
   // This should never occur, but is a safeguard just in case.
   protected[auth] var maxUpdateRetries = 10
 
-  private val retryBackoffMs = 100
-  private val retryBackoffJitterMs = 50
+  protected val retryBackoffMs = 100
+  protected val retryBackoffJitterMs = 50
 
   /**
    * Guaranteed to be called before any authorize call is made.

--- a/core/src/main/scala/kafka/security/auth/SimpleRegexAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleRegexAclAuthorizer.scala
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.security.auth
 
 import java.util

--- a/core/src/main/scala/kafka/security/auth/SimpleRegexAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleRegexAclAuthorizer.scala
@@ -1,0 +1,50 @@
+package kafka.security.auth
+
+import java.util
+import java.util.regex.Pattern
+
+import kafka.security.auth.SimpleAclAuthorizer.VersionedAcls
+import kafka.utils.CoreUtils.inReadLock
+import scala.collection.JavaConverters._
+
+object SimpleRegexAclAuthorizer extends SimpleAclAuthorizer {
+  val AuthorizerRegexPrefix = "authorizer.regex.prefix"
+}
+
+class SimpleRegexAclAuthorizer extends SimpleAclAuthorizer {
+
+  protected var regexPrefix: String = _
+  protected var patternCache = new scala.collection.mutable.HashMap[String, Pattern]
+
+  /**
+    * Guaranteed to be called before any authorize call is made.
+    */
+  override def configure(javaConfigs: util.Map[String, _]): Unit = {
+    super.configure(javaConfigs)
+    val configs = javaConfigs.asScala
+    regexPrefix = configs.getOrElse(SimpleRegexAclAuthorizer.AuthorizerRegexPrefix, "r:").toString
+  }
+
+  override def getAcls(resource: Resource): Set[Acl] = {
+    val curriedRegexNameMatcher = (t: (Resource, VersionedAcls)) => regexNameMatcher(resource, t._1)
+    inReadLock(lock) {
+      aclCache.filter(curriedRegexNameMatcher).values.flatMap(_.acls).toSet
+    }
+  }
+
+  def regexNameMatcher(resource: Resource, r2: Resource): Boolean = {
+    resource.name.equals(r2.name) || getPattern(r2.name)
+        .map(_.matcher(resource.name).matches())
+      .getOrElse(resource.name.equals(r2.name))
+  }
+
+  private def getPattern(pattern: String): Option[Pattern] = {
+    if (pattern != null && pattern.startsWith(regexPrefix)) {
+      val p = pattern.substring(2)
+      Some(patternCache.getOrElseUpdate(p, Pattern.compile(p)))
+    } else {
+      None
+    }
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleRegexAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleRegexAclAuthorizerTest.scala
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package kafka.security.auth
 
 import java.net.InetAddress

--- a/core/src/test/scala/unit/kafka/security/auth/SimpleRegexAclAuthorizerTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/SimpleRegexAclAuthorizerTest.scala
@@ -1,0 +1,97 @@
+package kafka.security.auth
+
+import java.net.InetAddress
+import java.util.UUID
+import java.net.InetAddress
+import java.util.UUID
+
+import kafka.network.RequestChannel.Session
+import kafka.security.auth.Acl.WildCardHost
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.junit.Assert._
+import org.junit.{After, Before, Test}
+
+class SimpleRegexAclAuthorizerTest extends ZooKeeperTestHarness {
+
+  val simpleAclAuthorizer = new SimpleRegexAclAuthorizer
+  val simpleAclAuthorizer2 = new SimpleRegexAclAuthorizer
+  val testPrincipal = Acl.WildCardPrincipal
+  val testHostName: InetAddress = InetAddress.getByName("192.168.0.1")
+  val session = new Session(testPrincipal, testHostName)
+  var resource: Resource = _
+  val superUsers = "User:superuser1; User:superuser2"
+  val username = "alice"
+  var config: KafkaConfig = _
+
+  @Before
+  override def setUp() {
+    super.setUp()
+
+    // Increase maxUpdateRetries to avoid transient failures
+    simpleAclAuthorizer.maxUpdateRetries = Int.MaxValue
+    simpleAclAuthorizer2.maxUpdateRetries = Int.MaxValue
+
+    val props = TestUtils.createBrokerConfig(0, zkConnect)
+    props.put(SimpleAclAuthorizer.SuperUsersProp, superUsers)
+
+    config = KafkaConfig.fromProps(props)
+    simpleAclAuthorizer.configure(config.originals)
+    simpleAclAuthorizer2.configure(config.originals)
+    resource = new Resource(Topic, s"regex-${UUID.randomUUID().toString}")
+  }
+
+  @After
+  override def tearDown(): Unit = {
+    simpleAclAuthorizer.close()
+    simpleAclAuthorizer2.close()
+  }
+
+  @Test
+  def testTopicWithRegexAcls(): Unit = {
+    assertFalse("when acls = [],  authorizer should fail close.", simpleAclAuthorizer.authorize(session, Read, resource))
+
+    val user1 = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, username)
+    val host1 = InetAddress.getByName("192.168.3.1")
+    val readAcl = new Acl(user1, Allow, host1.getHostAddress, Read)
+    val regexResource = new Resource(resource.resourceType, "r:regex-.*")
+
+    val acls = changeAclAndVerify(Set.empty[Acl], Set[Acl](readAcl), Set.empty[Acl], regexResource)
+
+    val host1Session = new Session(user1, host1)
+    assertTrue("User1 should have Read access from host1", simpleAclAuthorizer.authorize(host1Session, Read, resource))
+
+    //allow Write to specific topic.
+    val writeAcl = new Acl(user1, Allow, host1.getHostAddress, Write)
+    changeAclAndVerify(Set.empty[Acl], Set[Acl](readAcl, writeAcl), Set.empty[Acl])
+
+    //deny Write to wild card topic.
+    val denyWriteOnWildCardResourceAcl = new Acl(user1, Deny, host1.getHostAddress, Write)
+    changeAclAndVerify(acls, Set[Acl](denyWriteOnWildCardResourceAcl), Set.empty[Acl], regexResource)
+
+    // expected acls Set(User:alice has Allow permission for operations: Read from hosts: 192.168.3.1, User:alice has Deny permission for operations: Write from hosts: 192.168.3.1)
+    //       but got Set(User:alice has Deny permission for operations: Write from hosts: 192.168.3.1)
+    assertFalse("User1 should not have Write access from host1", simpleAclAuthorizer.authorize(host1Session, Write, resource))
+  }
+
+  private def changeAclAndVerify(originalAcls: Set[Acl], addedAcls: Set[Acl], removedAcls: Set[Acl], resource: Resource = resource): Set[Acl] = {
+    var acls = originalAcls
+
+    if(addedAcls.nonEmpty) {
+      simpleAclAuthorizer.addAcls(addedAcls, resource)
+      acls ++= addedAcls
+    }
+
+    if(removedAcls.nonEmpty) {
+      simpleAclAuthorizer.removeAcls(removedAcls, resource)
+      acls --=removedAcls
+    }
+
+    TestUtils.waitAndVerifyAcls(acls, simpleAclAuthorizer, resource)
+
+    acls
+  }
+
+}


### PR DESCRIPTION
I extended the SimpleAclAuthorizer to support regex. In order to keep backwards compatibility, I added a prefix to the Resource name (default is "r:") to allow otherwise-valid regex patterns to be used as Resource names without applying regex matching logic.

Given the criticality of this, any feedback would be _greatly_ appreciated.

I had to move a bunch of stuff from private -> protected in order to maximize code reuse.