### PR TITLE
KAFKA-5584: fix integer overflow in Log.size

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1144,7 +1144,7 @@ class Log(@volatile var dir: File,
   /**
    * The size of the log in bytes
    */
-  def size: Long = logSegments.map(_.size).sum
+  def size: Long = logSegments.map(_.size).foldLeft(0L)(_ + _)
 
   /**
    * The offset metadata of the next message that will be appended to the log

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1144,7 +1144,7 @@ class Log(@volatile var dir: File,
   /**
    * The size of the log in bytes
    */
-  def size: Long = logSegments.map(_.size).foldLeft(0L)(_ + _)
+  def size: Long = logSegments.map(_.size.toLong).sum
 
   /**
    * The offset metadata of the next message that will be appended to the log

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1144,7 +1144,7 @@ class Log(@volatile var dir: File,
   /**
    * The size of the log in bytes
    */
-  def size: Long = logSegments.map(_.size.toLong).sum
+  def size: Long = Log.size(logSegments)
 
   /**
    * The offset metadata of the next message that will be appended to the log
@@ -1646,6 +1646,15 @@ object Log {
 
   def offsetFromFilename(filename: String): Long =
     filename.substring(0, filename.indexOf('.')).toLong
+
+  /**
+    * Calculate a log's size (in bytes) based on its log segments
+    *
+    * @param segments The log segments to calculate the size of
+    * @return Sum of the log segments' sizes (in bytes)
+    */
+  def size(segments: Iterable[LogSegment]): Long =
+    segments.map(_.size.toLong).sum
 
   /**
    * Parse the topic and partition out of the directory name of a log

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -200,19 +200,16 @@ class LogTest {
 
   @Test
   def testSizeForLargeLogs(): Unit = {
-    val megaByte = 1024 * 1024
-    val log = createLog(megaByte, messagesPerSegment = 1024)
-    val blob = new Array[Byte](1024)
-    val maximum = Int.MaxValue / 1024
+    val largeSize = Int.MaxValue.toLong * 2
+    val logSegment = EasyMock.createMock(classOf[LogSegment])
 
-    assertEquals(0L, log.size)
+    EasyMock.expect(logSegment.size).andReturn(Int.MaxValue)
+    EasyMock.expectLastCall().anyTimes()
+    EasyMock.replay(logSegment)
 
-    for (_ <- 1 to maximum) {
-      log.appendAsLeader(TestUtils.records(List(new SimpleRecord(blob))), leaderEpoch = 0)
-    }
-
-    assertTrue(log.size > Int.MaxValue)
-    log.close()
+    assertEquals(Int.MaxValue, Log.size(Seq(logSegment)))
+    assertEquals(largeSize, Log.size(Seq(logSegment, logSegment)))
+    assertTrue(Log.size(Seq(logSegment, logSegment)) > Int.MaxValue)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -199,6 +199,23 @@ class LogTest {
   }
 
   @Test
+  def testSizeForLargeLogs(): Unit = {
+    val megaByte = 1024 * 1024
+    val log = createLog(megaByte, messagesPerSegment = 1024)
+    val blob = new Array[Byte](1024)
+    val maximum = Int.MaxValue / 1024
+
+    assertEquals(0L, log.size)
+
+    for (_ <- 1 to maximum) {
+      log.appendAsLeader(TestUtils.records(List(new SimpleRecord(blob))), leaderEpoch = 0)
+    }
+
+    assertTrue(log.size > Int.MaxValue)
+    log.close()
+  }
+
+  @Test
   def testPidMapOffsetUpdatedForNonIdempotentData() {
     val log = createLog(2048)
     val records = TestUtils.records(List(new SimpleRecord(time.milliseconds, "key".getBytes, "value".getBytes)))


### PR DESCRIPTION
As described in [KAFKA-5584](https://issues.apache.org/jira/browse/KAFKA-5584) the integer overflow in `Log.size` may lead to wrong metrics and broken size-based retention via `log.retention.bytes` or `retention.bytes` on rather large topic partitions.