### PR TITLE
MINOR: consume from outputTopic in EosIntegrationTest.runSimpleCopyTest

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -192,7 +192,7 @@ public class EosIntegrationTest {
                                 put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT));
                             }
                         }),
-                    inputTopic,
+                    outputTopic,
                     inputData.size()
                 );
 


### PR DESCRIPTION
Previously, the code mistakenly consumed from inputTopic, which
worked, but didn't actually verify that the messages were correctly
copied from inputTopic to outputTopic.