### PR TITLE
KAFKA-5431: cleanSegments should not set length for cleanable segment files

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -417,7 +417,7 @@ private[log] class Cleaner(val id: Int,
     txnIndexFile.delete()
 
     val startOffset = segments.head.baseOffset
-    val records = FileRecords.open(logFile, false, log.initFileSize(), false)
+    val records = FileRecords.open(logFile, false, log.initFileSize(), log.config.preallocate)
     val index = new OffsetIndex(indexFile, startOffset, segments.head.index.maxIndexSize)
     val timeIndex = new TimeIndex(timeIndexFile, startOffset, segments.head.timeIndex.maxIndexSize)
     val txnIndex = new TransactionIndex(startOffset, txnIndexFile)
@@ -445,6 +445,9 @@ private[log] class Cleaner(val id: Int,
 
         currentSegmentOpt = nextSegmentOpt
       }
+
+      // trim log segment
+      cleaned.log.trim()
 
       // trim excess index
       index.trimToValidSize()

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -417,7 +417,7 @@ private[log] class Cleaner(val id: Int,
     txnIndexFile.delete()
 
     val startOffset = segments.head.baseOffset
-    val records = FileRecords.open(logFile, false, log.initFileSize(), log.config.preallocate)
+    val records = FileRecords.open(logFile, false, log.initFileSize(), false)
     val index = new OffsetIndex(indexFile, startOffset, segments.head.index.maxIndexSize)
     val timeIndex = new TimeIndex(timeIndexFile, startOffset, segments.head.timeIndex.maxIndexSize)
     val txnIndex = new TransactionIndex(startOffset, txnIndexFile)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -109,8 +109,8 @@ class LogCleanerTest extends JUnitSuite {
     // clean the log with only one message removed
     cleaner.clean(LogToClean(new TopicPartition("test", 0), log, 2, log.activeSegment.baseOffset))
 
-    assert(log.logSegments.iterator.next.log.channel().size() < originalMaxFileSize,
-      "Cleaned segment file should be trimmed to its real size.")
+    assertTrue("Cleaned segment file should be trimmed to its real size.",
+      log.logSegments.iterator.next.log.channel().size() < originalMaxFileSize)
   }
 
   @Test


### PR DESCRIPTION
For a compacted topic with preallocate enabled, during log cleaning, LogCleaner.cleanSegments does not have to pre-allocate the underlying file size since we only want to store the cleaned data in the file.

It's believed that this fix should also solve KAFKA-5582.