### PR TITLE
MINOR: Mention systemTestLibs in docker system test instructions

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -12,7 +12,7 @@ Docker containers can be used for running kafka system tests locally.
 * Requirements
   - Docker 1.12.3 is installed and running on the machine.
   - Test require a single kafka_*SNAPSHOT.tgz to be present in core/build/distributions.
-   This can be done by running ./gradlew clean releaseTarGz  
+   This can be done by running ./gradlew clean systemTestLibs releaseTarGz  
 * Run all tests
 ```
 bash tests/docker/run_tests.sh


### PR DESCRIPTION
Otherwise NoClassFoundExceptions are thrown for tests that attempt
to start MiniKdc.