### PR TITLE
KAFKA-5596: TopicCommand methods fail to handle topic name with "."

### DIFF
--- a/core/src/main/scala/kafka/consumer/TopicFilter.scala
+++ b/core/src/main/scala/kafka/consumer/TopicFilter.scala
@@ -29,6 +29,7 @@ sealed abstract class TopicFilter(rawRegex: String) extends Logging {
           .trim
           .replace(',', '|')
           .replace(" ", "")
+          .replaceAll("\\.", "\\\\.")
           .replaceAll("""^["']+""","")
           .replaceAll("""["']+$""","") // property files may bring quotes
 


### PR DESCRIPTION
When there is one topic which name includes `.`, then we invoke `list`, `describe`, `alter`, `delete` functions and set this topic name, those functions will not only operate this topic, but also operate all other topics that have same name regex pattern.
For example, there are two topics on Kafka cluster:
- test.a
- test_a

If you run command `--describe --topic test.a`, it will return both of `test.a` and `test_a`. Other functions have the same effect.