### PR TITLE
KAFKA-5596: TopicCommand methods fail to handle topic name with "."

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -84,7 +84,7 @@ object TopicCommand extends Logging {
     val allTopics = zkUtils.getAllTopics().sorted
     if (opts.options.has(opts.topicOpt)) {
       val topicsSpec = opts.options.valueOf(opts.topicOpt)
-      val topicsFilter = new Whitelist(topicsSpec)
+      val topicsFilter = new Whitelist(topicsSpec.replaceAll("\\.", "\\\\."))
       allTopics.filter(topicsFilter.isTopicAllowed(_, excludeInternalTopics = false))
     } else
       allTopics


### PR DESCRIPTION
When there is one topic which name includes `.`, then we invoke `list`, `describe`, `alter`, `delete` functions and set this topic name, those functions will not only operate this topic, but also operate all other topics that have same name regex pattern.
For example, there are two topics on Kafka cluster:
- test.a
- test_a

If you run command `--describe --topic test.a`, it will return both of `test.a` and `test_a`. Other functions have the same effect.