### PR TITLE
KAFKA-3856: Refactoring for KIP-120

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -452,7 +452,7 @@ public class KafkaStreams {
         GlobalStreamThread.State globalThreadState = null;
 
         final ArrayList<StateStoreProvider> storeProviders = new ArrayList<>();
-        streamsMetadataState = new StreamsMetadataState(builder, parseHostInfo(config.getString(StreamsConfig.APPLICATION_SERVER_CONFIG)));
+        streamsMetadataState = new StreamsMetadataState(builder.internalTopologyBuilder, parseHostInfo(config.getString(StreamsConfig.APPLICATION_SERVER_CONFIG)));
 
         final ProcessorTopology globalTaskTopology = builder.buildGlobalStateTopology();
 
@@ -476,7 +476,7 @@ public class KafkaStreams {
         }
 
         for (int i = 0; i < threads.length; i++) {
-            threads[i] = new StreamThread(builder,
+            threads[i] = new StreamThread(builder.internalTopologyBuilder,
                                           config,
                                           clientSupplier,
                                           applicationId,

--- a/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
@@ -14,9 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.processor;
+package org.apache.kafka.streams;
 
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 
 import java.util.Set;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -19,38 +19,24 @@ package org.apache.kafka.streams.processor;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.TopologyBuilderException;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.InternalTopicConfig;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.ProcessorNode;
-import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.processor.internals.ProcessorTopology;
-import org.apache.kafka.streams.processor.internals.QuickUnion;
 import org.apache.kafka.streams.processor.internals.SinkNode;
 import org.apache.kafka.streams.processor.internals.SourceNode;
 import org.apache.kafka.streams.processor.internals.StreamPartitionAssignor.SubscriptionUpdates;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.internals.WindowStoreSupplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 
 /**
  * A component that is used to build a {@link ProcessorTopology}. A topology contains an acyclic graph of sources, processors,
@@ -63,85 +49,6 @@ import java.util.regex.Pattern;
  */
 @InterfaceStability.Evolving
 public class TopologyBuilder {
-
-    private static final Logger log = LoggerFactory.getLogger(TopologyBuilder.class);
-
-    private static final Pattern EMPTY_ZERO_LENGTH_PATTERN = Pattern.compile("");
-
-    // node factories in a topological order
-    private final LinkedHashMap<String, NodeFactory> nodeFactories = new LinkedHashMap<>();
-
-    // state factories
-    private final Map<String, StateStoreFactory> stateFactories = new HashMap<>();
-
-    // global state factories
-    private final Map<String, StateStore> globalStateStores = new LinkedHashMap<>();
-
-    // all topics subscribed from source processors (without application-id prefix for internal topics)
-    private final Set<String> sourceTopicNames = new HashSet<>();
-
-    // all internal topics auto-created by the topology builder and used in source / sink processors
-    private final Set<String> internalTopicNames = new HashSet<>();
-
-    // groups of source processors that need to be copartitioned
-    private final List<Set<String>> copartitionSourceGroups = new ArrayList<>();
-
-    // map from source processor names to subscribed topics (without application-id prefix for internal topics)
-    private final HashMap<String, List<String>> nodeToSourceTopics = new HashMap<>();
-
-    // map from source processor names to regex subscription patterns
-    private final HashMap<String, Pattern> nodeToSourcePatterns = new LinkedHashMap<>();
-
-    // map from sink processor names to subscribed topic (without application-id prefix for internal topics)
-    private final HashMap<String, String> nodeToSinkTopic = new HashMap<>();
-
-    // map from topics to their matched regex patterns, this is to ensure one topic is passed through on source node
-    // even if it can be matched by multiple regex patterns
-    private final HashMap<String, Pattern> topicToPatterns = new HashMap<>();
-
-    // map from state store names to all the topics subscribed from source processors that
-    // are connected to these state stores
-    private final Map<String, Set<String>> stateStoreNameToSourceTopics = new HashMap<>();
-
-    // map from state store names to all the regex subscribed topics from source processors that
-    // are connected to these state stores
-    private final Map<String, Set<Pattern>> stateStoreNameToSourceRegex = new HashMap<>();
-
-    // map from state store names to this state store's corresponding changelog topic if possible,
-    // this is used in the extended KStreamBuilder.
-    private final Map<String, String> storeToChangelogTopic = new HashMap<>();
-
-    // all global topics
-    private final Set<String> globalTopics = new HashSet<>();
-
-    private final Set<String> earliestResetTopics = new HashSet<>();
-
-    private final Set<String> latestResetTopics = new HashSet<>();
-
-    private final Set<Pattern> earliestResetPatterns = new HashSet<>();
-
-    private final Set<Pattern> latestResetPatterns = new HashSet<>();
-
-    private final QuickUnion<String> nodeGrouper = new QuickUnion<>();
-
-    private SubscriptionUpdates subscriptionUpdates = new SubscriptionUpdates();
-
-    private String applicationId = null;
-
-    private Pattern topicPattern = null;
-
-    private Map<Integer, Set<String>> nodeGroups = null;
-
-    private static class StateStoreFactory {
-        public final Set<String> users;
-
-        public final StateStoreSupplier supplier;
-
-        StateStoreFactory(StateStoreSupplier supplier) {
-            this.supplier = supplier;
-            this.users = new HashSet<>();
-        }
-    }
 
     private static abstract class NodeFactory {
         final String name;
@@ -289,13 +196,20 @@ public class TopologyBuilder {
         }
     }
 
+    @Deprecated
+    public final InternalTopologyBuilder internalTopologyBuilder = new InternalTopologyBuilder();
+
+    @Deprecated
     public static class TopicsInfo {
         public Set<String> sinkTopics;
         public Set<String> sourceTopics;
         public Map<String, InternalTopicConfig> stateChangelogTopics;
         public Map<String, InternalTopicConfig> repartitionSourceTopics;
 
-        TopicsInfo(Set<String> sinkTopics, Set<String> sourceTopics, Map<String, InternalTopicConfig> repartitionSourceTopics, Map<String, InternalTopicConfig> stateChangelogTopics) {
+        public TopicsInfo(final Set<String> sinkTopics,
+                          final Set<String> sourceTopics,
+                          final Map<String, InternalTopicConfig> repartitionSourceTopics,
+                          final Map<String, InternalTopicConfig> stateChangelogTopics) {
             this.sinkTopics = sinkTopics;
             this.sourceTopics = sourceTopics;
             this.stateChangelogTopics = stateChangelogTopics;
@@ -303,10 +217,10 @@ public class TopologyBuilder {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(final Object o) {
             if (o instanceof TopicsInfo) {
-                TopicsInfo other = (TopicsInfo) o;
-                return other.sourceTopics.equals(this.sourceTopics) && other.stateChangelogTopics.equals(this.stateChangelogTopics);
+                final TopicsInfo other = (TopicsInfo) o;
+                return other.sourceTopics.equals(sourceTopics) && other.stateChangelogTopics.equals(stateChangelogTopics);
             } else {
                 return false;
             }
@@ -314,7 +228,7 @@ public class TopologyBuilder {
 
         @Override
         public int hashCode() {
-            long n = ((long) sourceTopics.hashCode() << 32) | (long) stateChangelogTopics.hashCode();
+            final long n = ((long) sourceTopics.hashCode() << 32) | (long) stateChangelogTopics.hashCode();
             return (int) (n % 0xFFFFFFFFL);
         }
 
@@ -350,10 +264,9 @@ public class TopologyBuilder {
      * @param applicationId the streams applicationId. Should be the same as set by
      * {@link org.apache.kafka.streams.StreamsConfig#APPLICATION_ID_CONFIG}
      */
+    @Deprecated
     public synchronized final TopologyBuilder setApplicationId(final String applicationId) {
-        Objects.requireNonNull(applicationId, "applicationId can't be null");
-        this.applicationId = applicationId;
-
+        internalTopologyBuilder.setApplicationId(applicationId);
         return this;
     }
 
@@ -369,8 +282,10 @@ public class TopologyBuilder {
      * @param topics the name of one or more Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-    public synchronized final TopologyBuilder addSource(final String name, final String... topics) {
-        return addSource(null, name, null, null, null, topics);
+    public synchronized final TopologyBuilder addSource(final String name,
+                                                        final String... topics) {
+        internalTopologyBuilder.addSource(null, name, null, null, null, topics);
+        return this;
     }
 
     /**
@@ -386,9 +301,10 @@ public class TopologyBuilder {
      * @param topics the name of one or more Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-
-    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset, final String name, final String... topics) {
-        return addSource(offsetReset, name, null, null, null, topics);
+    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
+                                                        final String name, final String... topics) {
+        internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topics);
+        return this;
     }
 
     /**
@@ -404,8 +320,10 @@ public class TopologyBuilder {
      * @param topics             the name of one or more Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-    public synchronized final TopologyBuilder addSource(final TimestampExtractor timestampExtractor, final String name, final String... topics) {
-        return addSource(null, name, timestampExtractor, null, null, topics);
+    public synchronized final TopologyBuilder addSource(final TimestampExtractor timestampExtractor,
+                                                        final String name, final String... topics) {
+        internalTopologyBuilder.addSource(null, name, timestampExtractor, null, null, topics);
+        return this;
     }
 
     /**
@@ -423,8 +341,10 @@ public class TopologyBuilder {
      * @param topics             the name of one or more Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset, final TimestampExtractor timestampExtractor, final String name, final String... topics) {
-        return addSource(offsetReset, name, timestampExtractor, null, null, topics);
+    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
+                                                        final TimestampExtractor timestampExtractor, final String name, final String... topics) {
+        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, null, null, topics);
+        return this;
     }
 
     /**
@@ -440,9 +360,10 @@ public class TopologyBuilder {
      * @param topicPattern regular expression pattern to match Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-
-    public synchronized final TopologyBuilder addSource(final String name, final Pattern topicPattern) {
-        return addSource(null, name, null, null, null, topicPattern);
+    public synchronized final TopologyBuilder addSource(final String name,
+                                                        final Pattern topicPattern) {
+        internalTopologyBuilder.addSource(null, name, null, null, null, topicPattern);
+        return this;
     }
 
     /**
@@ -459,9 +380,11 @@ public class TopologyBuilder {
      * @param topicPattern regular expression pattern to match Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-
-    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset, final String name, final Pattern topicPattern) {
-        return addSource(offsetReset, name, null, null, null, topicPattern);
+    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
+                                                        final String name,
+                                                        final Pattern topicPattern) {
+        internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topicPattern);
+        return this;
     }
 
 
@@ -479,8 +402,11 @@ public class TopologyBuilder {
      * @param topicPattern       regular expression pattern to match Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-    public synchronized final TopologyBuilder addSource(final TimestampExtractor timestampExtractor, final String name, final   Pattern topicPattern) {
-        return addSource(null, name, timestampExtractor, null, null, topicPattern);
+    public synchronized final TopologyBuilder addSource(final TimestampExtractor timestampExtractor,
+                                                        final String name,
+                                                        final Pattern topicPattern) {
+        internalTopologyBuilder.addSource(null, name, timestampExtractor, null, null, topicPattern);
+        return this;
     }
 
 
@@ -500,8 +426,12 @@ public class TopologyBuilder {
      * @param topicPattern       regular expression pattern to match Kafka topics that this source is to consume
      * @return this builder instance so methods can be chained together; never null
      */
-    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset, final TimestampExtractor timestampExtractor, final String name, final Pattern topicPattern) {
-        return addSource(offsetReset, name, timestampExtractor, null, null, topicPattern);
+    public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
+                                                        final TimestampExtractor timestampExtractor,
+                                                        final String name,
+                                                        final Pattern topicPattern) {
+        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, null, null, topicPattern);
+        return this;
     }
 
 
@@ -521,8 +451,12 @@ public class TopologyBuilder {
      * @throws TopologyBuilderException if processor is already added or if topics have already been registered by another source
      */
 
-    public synchronized final TopologyBuilder addSource(final String name, final Deserializer keyDeserializer, final Deserializer valDeserializer, final String... topics) {
-        return addSource(null, name, null, keyDeserializer, valDeserializer, topics);
+    public synchronized final TopologyBuilder addSource(final String name,
+                                                        final Deserializer keyDeserializer,
+                                                        final Deserializer valDeserializer,
+                                                        final String... topics) {
+        internalTopologyBuilder.addSource(null, name, null, keyDeserializer, valDeserializer, topics);
+        return this;
     }
 
     /**
@@ -550,24 +484,7 @@ public class TopologyBuilder {
                                                         final Deserializer keyDeserializer,
                                                         final Deserializer valDeserializer,
                                                         final String... topics) {
-        if (topics.length == 0) {
-            throw new TopologyBuilderException("You must provide at least one topic");
-        }
-        Objects.requireNonNull(name, "name must not be null");
-        if (nodeFactories.containsKey(name))
-            throw new TopologyBuilderException("Processor " + name + " is already added.");
-
-        for (String topic : topics) {
-            Objects.requireNonNull(topic, "topic names cannot be null");
-            validateTopicNotAlreadyRegistered(topic);
-            maybeAddToResetList(earliestResetTopics, latestResetTopics, offsetReset, topic);
-            sourceTopicNames.add(topic);
-        }
-
-        nodeFactories.put(name, new SourceNodeFactory(name, topics, null, timestampExtractor, keyDeserializer, valDeserializer));
-        nodeToSourceTopics.put(name, Arrays.asList(topics));
-        nodeGrouper.add(name);
-
+        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, keyDeserializer, valDeserializer, topics);
         return this;
     }
 
@@ -600,10 +517,9 @@ public class TopologyBuilder {
                                                        final String topic,
                                                        final String processorName,
                                                        final ProcessorSupplier stateUpdateSupplier) {
-        return addGlobalStore(storeSupplier, sourceName, null, keyDeserializer, valueDeserializer, topic, processorName, stateUpdateSupplier);
+        internalTopologyBuilder.addGlobalStore(storeSupplier, sourceName, null, keyDeserializer, valueDeserializer, topic, processorName, stateUpdateSupplier);
+        return this;
     }
-
-
 
     /**
      * Adds a global {@link StateStore} to the topology. The {@link StateStore} sources its data
@@ -636,58 +552,8 @@ public class TopologyBuilder {
                                                        final String topic,
                                                        final String processorName,
                                                        final ProcessorSupplier stateUpdateSupplier) {
-        Objects.requireNonNull(storeSupplier, "store supplier must not be null");
-        Objects.requireNonNull(sourceName, "sourceName must not be null");
-        Objects.requireNonNull(topic, "topic must not be null");
-        Objects.requireNonNull(stateUpdateSupplier, "supplier must not be null");
-        Objects.requireNonNull(processorName, "processorName must not be null");
-        if (nodeFactories.containsKey(sourceName)) {
-            throw new TopologyBuilderException("Processor " + sourceName + " is already added.");
-        }
-        if (nodeFactories.containsKey(processorName)) {
-            throw new TopologyBuilderException("Processor " + processorName + " is already added.");
-        }
-        if (stateFactories.containsKey(storeSupplier.name()) || globalStateStores.containsKey(storeSupplier.name())) {
-            throw new TopologyBuilderException("StateStore " + storeSupplier.name() + " is already added.");
-        }
-        if (storeSupplier.loggingEnabled()) {
-            throw new TopologyBuilderException("StateStore " + storeSupplier.name() + " for global table must not have logging enabled.");
-        }
-        if (sourceName.equals(processorName)) {
-            throw new TopologyBuilderException("sourceName and processorName must be different.");
-        }
-
-        validateTopicNotAlreadyRegistered(topic);
-
-        globalTopics.add(topic);
-        final String[] topics = {topic};
-        nodeFactories.put(sourceName, new SourceNodeFactory(sourceName, topics, null, timestampExtractor, keyDeserializer, valueDeserializer));
-        nodeToSourceTopics.put(sourceName, Arrays.asList(topics));
-        nodeGrouper.add(sourceName);
-
-        final String[] parents = {sourceName};
-        final ProcessorNodeFactory nodeFactory = new ProcessorNodeFactory(processorName, parents, stateUpdateSupplier);
-        nodeFactory.addStateStore(storeSupplier.name());
-        nodeFactories.put(processorName, nodeFactory);
-        nodeGrouper.add(processorName);
-        nodeGrouper.unite(processorName, parents);
-
-        globalStateStores.put(storeSupplier.name(), storeSupplier.get());
-        connectSourceStoreAndTopic(storeSupplier.name(), topic);
+        internalTopologyBuilder.addGlobalStore(storeSupplier, sourceName, timestampExtractor, keyDeserializer, valueDeserializer, topic, processorName, stateUpdateSupplier);
         return this;
-
-    }
-
-    private void validateTopicNotAlreadyRegistered(final String topic) {
-        if (sourceTopicNames.contains(topic) || globalTopics.contains(topic)) {
-            throw new TopologyBuilderException("Topic " + topic + " has already been registered by another source.");
-        }
-
-        for (Pattern pattern : nodeToSourcePatterns.values()) {
-            if (pattern.matcher(topic).matches()) {
-                throw new TopologyBuilderException("Topic " + topic + " matches a Pattern already registered by another source.");
-            }
-        }
     }
 
     /**
@@ -708,9 +574,12 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if processor is already added or if topics have already been registered by name
      */
-
-    public synchronized final TopologyBuilder addSource(final String name, final Deserializer keyDeserializer, final Deserializer valDeserializer, final Pattern topicPattern) {
-        return addSource(null, name, null, keyDeserializer, valDeserializer, topicPattern);
+    public synchronized final TopologyBuilder addSource(final String name,
+                                                        final Deserializer keyDeserializer,
+                                                        final Deserializer valDeserializer,
+                                                        final Pattern topicPattern) {
+        internalTopologyBuilder.addSource(null, name, null, keyDeserializer, valDeserializer, topicPattern);
+        return this;
     }
 
     /**
@@ -734,35 +603,15 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if processor is already added or if topics have already been registered by name
      */
-
     public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
                                                         final String name,
                                                         final TimestampExtractor timestampExtractor,
                                                         final Deserializer keyDeserializer,
                                                         final Deserializer valDeserializer,
                                                         final Pattern topicPattern) {
-        Objects.requireNonNull(topicPattern, "topicPattern can't be null");
-        Objects.requireNonNull(name, "name can't be null");
-
-        if (nodeFactories.containsKey(name)) {
-            throw new TopologyBuilderException("Processor " + name + " is already added.");
-        }
-
-        for (String sourceTopicName : sourceTopicNames) {
-            if (topicPattern.matcher(sourceTopicName).matches()) {
-                throw new TopologyBuilderException("Pattern  " + topicPattern + " will match a topic that has already been registered by another source.");
-            }
-        }
-
-        maybeAddToResetList(earliestResetPatterns, latestResetPatterns, offsetReset, topicPattern);
-
-        nodeFactories.put(name, new SourceNodeFactory(name, null, topicPattern, timestampExtractor, keyDeserializer, valDeserializer));
-        nodeToSourcePatterns.put(name, topicPattern);
-        nodeGrouper.add(name);
-
+        internalTopologyBuilder.addSource(offsetReset, name, timestampExtractor, keyDeserializer, valDeserializer, topicPattern);
         return this;
     }
-
 
     /**
      * Add a new source that consumes from topics matching the given pattern
@@ -783,13 +632,13 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if processor is already added or if topics have already been registered by name
      */
-
     public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
                                                         final String name,
                                                         final Deserializer keyDeserializer,
                                                         final Deserializer valDeserializer,
                                                         final Pattern topicPattern) {
-        return addSource(offsetReset, name, null, keyDeserializer, valDeserializer, topicPattern);
+        internalTopologyBuilder.addSource(offsetReset, name, null, keyDeserializer, valDeserializer, topicPattern);
+        return this;
     }
 
 
@@ -808,8 +657,11 @@ public class TopologyBuilder {
      * @see #addSink(String, String, Serializer, Serializer, String...)
      * @see #addSink(String, String, Serializer, Serializer, StreamPartitioner, String...)
      */
-    public synchronized final TopologyBuilder addSink(final String name, final String topic, final String... parentNames) {
-        return addSink(name, topic, null, null, parentNames);
+    public synchronized final TopologyBuilder addSink(final String name,
+                                                      final String topic,
+                                                      final String... parentNames) {
+        internalTopologyBuilder.addSink(name, topic, null, null, null, parentNames);
+        return this;
     }
 
     /**
@@ -835,8 +687,12 @@ public class TopologyBuilder {
      * @see #addSink(String, String, Serializer, Serializer, String...)
      * @see #addSink(String, String, Serializer, Serializer, StreamPartitioner, String...)
      */
-    public synchronized final TopologyBuilder addSink(final String name, final String topic, final StreamPartitioner partitioner, final String... parentNames) {
-        return addSink(name, topic, null, null, partitioner, parentNames);
+    public synchronized final TopologyBuilder addSink(final String name,
+                                                      final String topic,
+                                                      final StreamPartitioner partitioner,
+                                                      final String... parentNames) {
+        internalTopologyBuilder.addSink(name, topic, null, null, partitioner, parentNames);
+        return this;
     }
 
     /**
@@ -858,8 +714,13 @@ public class TopologyBuilder {
      * @see #addSink(String, String, StreamPartitioner, String...)
      * @see #addSink(String, String, Serializer, Serializer, StreamPartitioner, String...)
      */
-    public synchronized final TopologyBuilder addSink(final String name, final String topic, final Serializer keySerializer, final Serializer valSerializer, final String... parentNames) {
-        return addSink(name, topic, keySerializer, valSerializer, null, parentNames);
+    public synchronized final TopologyBuilder addSink(final String name,
+                                                      final String topic,
+                                                      final Serializer keySerializer,
+                                                      final Serializer valSerializer,
+                                                      final String... parentNames) {
+        internalTopologyBuilder.addSink(name, topic, keySerializer, valSerializer, null, parentNames);
+        return this;
     }
 
     /**
@@ -883,25 +744,13 @@ public class TopologyBuilder {
      * @see #addSink(String, String, Serializer, Serializer, String...)
      * @throws TopologyBuilderException if parent processor is not added yet, or if this processor's name is equal to the parent's name
      */
-    public synchronized final <K, V> TopologyBuilder addSink(final String name, final String topic, final Serializer<K> keySerializer, final Serializer<V> valSerializer, final StreamPartitioner<? super K, ? super V> partitioner, final String... parentNames) {
-        Objects.requireNonNull(name, "name must not be null");
-        Objects.requireNonNull(topic, "topic must not be null");
-        if (nodeFactories.containsKey(name))
-            throw new TopologyBuilderException("Processor " + name + " is already added.");
-
-        for (final String parent : parentNames) {
-            if (parent.equals(name)) {
-                throw new TopologyBuilderException("Processor " + name + " cannot be a parent of itself.");
-            }
-            if (!nodeFactories.containsKey(parent)) {
-                throw new TopologyBuilderException("Parent processor " + parent + " is not added yet.");
-            }
-        }
-
-        nodeFactories.put(name, new SinkNodeFactory<>(name, parentNames, topic, keySerializer, valSerializer, partitioner));
-        nodeToSinkTopic.put(name, topic);
-        nodeGrouper.add(name);
-        nodeGrouper.unite(name, parentNames);
+    public synchronized final <K, V> TopologyBuilder addSink(final String name,
+                                                             final String topic,
+                                                             final Serializer<K> keySerializer,
+                                                             final Serializer<V> valSerializer,
+                                                             final StreamPartitioner<? super K, ? super V> partitioner,
+                                                             final String... parentNames) {
+        internalTopologyBuilder.addSink(name, topic, keySerializer, valSerializer, partitioner, parentNames);
         return this;
     }
 
@@ -915,26 +764,13 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if parent processor is not added yet, or if this processor's name is equal to the parent's name
      */
-    public synchronized final TopologyBuilder addProcessor(final String name, final ProcessorSupplier supplier, final String... parentNames) {
-        Objects.requireNonNull(name, "name must not be null");
-        Objects.requireNonNull(supplier, "supplier must not be null");
-        if (nodeFactories.containsKey(name))
-            throw new TopologyBuilderException("Processor " + name + " is already added.");
-
-        for (final String parent : parentNames) {
-            if (parent.equals(name)) {
-                throw new TopologyBuilderException("Processor " + name + " cannot be a parent of itself.");
-            }
-            if (!nodeFactories.containsKey(parent)) {
-                throw new TopologyBuilderException("Parent processor " + parent + " is not added yet.");
-            }
-        }
-
-        nodeFactories.put(name, new ProcessorNodeFactory(name, parentNames, supplier));
-        nodeGrouper.add(name);
-        nodeGrouper.unite(name, parentNames);
+    public synchronized final TopologyBuilder addProcessor(final String name,
+                                                           final ProcessorSupplier supplier,
+                                                           final String... parentNames) {
+        internalTopologyBuilder.addProcessor(name, supplier, parentNames);
         return this;
     }
+
     /**
      * Adds a state store
      *
@@ -942,20 +778,9 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if state store supplier is already added
      */
-    public synchronized final TopologyBuilder addStateStore(final StateStoreSupplier supplier, final String... processorNames) {
-        Objects.requireNonNull(supplier, "supplier can't be null");
-        if (stateFactories.containsKey(supplier.name())) {
-            throw new TopologyBuilderException("StateStore " + supplier.name() + " is already added.");
-        }
-
-        stateFactories.put(supplier.name(), new StateStoreFactory(supplier));
-
-        if (processorNames != null) {
-            for (String processorName : processorNames) {
-                connectProcessorAndStateStore(processorName, supplier.name());
-            }
-        }
-
+    public synchronized final TopologyBuilder addStateStore(final StateStoreSupplier supplier,
+                                                            final String... processorNames) {
+        internalTopologyBuilder.addStateStore(supplier, processorNames);
         return this;
     }
 
@@ -966,14 +791,9 @@ public class TopologyBuilder {
      * @param stateStoreNames the names of state stores that the processor uses
      * @return this builder instance so methods can be chained together; never null
      */
-    public synchronized final TopologyBuilder connectProcessorAndStateStores(final String processorName, final String... stateStoreNames) {
-        Objects.requireNonNull(processorName, "processorName can't be null");
-        if (stateStoreNames != null) {
-            for (String stateStoreName : stateStoreNames) {
-                connectProcessorAndStateStore(processorName, stateStoreName);
-            }
-        }
-
+    public synchronized final TopologyBuilder connectProcessorAndStateStores(final String processorName,
+                                                                             final String... stateStoreNames) {
+        internalTopologyBuilder.connectProcessorAndStateStores(processorName, stateStoreNames);
         return this;
     }
 
@@ -981,11 +801,10 @@ public class TopologyBuilder {
      * This is used only for KStreamBuilder: when adding a KTable from a source topic,
      * we need to add the topic as the KTable's materialized state store's changelog.
      */
-    protected synchronized final TopologyBuilder connectSourceStoreAndTopic(final String sourceStoreName, final String topic) {
-        if (storeToChangelogTopic.containsKey(sourceStoreName)) {
-            throw new TopologyBuilderException("Source store " + sourceStoreName + " is already added.");
-        }
-        storeToChangelogTopic.put(sourceStoreName, topic);
+    @Deprecated
+    protected synchronized final TopologyBuilder connectSourceStoreAndTopic(final String sourceStoreName,
+                                                                            final String topic) {
+        internalTopologyBuilder.connectSourceStoreAndTopic(sourceStoreName, topic);
         return this;
     }
 
@@ -999,20 +818,9 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if less than two processors are specified, or if one of the processors is not added yet
      */
+    @Deprecated
     public synchronized final TopologyBuilder connectProcessors(final String... processorNames) {
-        if (processorNames.length < 2)
-            throw new TopologyBuilderException("At least two processors need to participate in the connection.");
-
-        for (String processorName : processorNames) {
-            if (!nodeFactories.containsKey(processorName))
-                throw new TopologyBuilderException("Processor " + processorName + " is not added yet.");
-
-        }
-
-        String firstProcessorName = processorNames[0];
-
-        nodeGrouper.unite(firstProcessorName, Arrays.copyOfRange(processorNames, 1, processorNames.length));
-
+        internalTopologyBuilder.connectProcessors(processorNames);
         return this;
     }
 
@@ -1022,10 +830,9 @@ public class TopologyBuilder {
      * @param topicName the name of the topic
      * @return this builder instance so methods can be chained together; never null
      */
+    @Deprecated
     public synchronized final TopologyBuilder addInternalTopic(final String topicName) {
-        Objects.requireNonNull(topicName, "topicName can't be null");
-        this.internalTopicNames.add(topicName);
-
+        internalTopologyBuilder.addInternalTopic(topicName);
         return this;
     }
 
@@ -1035,97 +842,10 @@ public class TopologyBuilder {
      * @param sourceNodes a set of source node names
      * @return this builder instance so methods can be chained together; never null
      */
+    @Deprecated
     public synchronized final TopologyBuilder copartitionSources(final Collection<String> sourceNodes) {
-        copartitionSourceGroups.add(Collections.unmodifiableSet(new HashSet<>(sourceNodes)));
+        internalTopologyBuilder.copartitionSources(sourceNodes);
         return this;
-    }
-
-    private void connectProcessorAndStateStore(final String processorName, final String stateStoreName) {
-        if (!stateFactories.containsKey(stateStoreName))
-            throw new TopologyBuilderException("StateStore " + stateStoreName + " is not added yet.");
-        if (!nodeFactories.containsKey(processorName))
-            throw new TopologyBuilderException("Processor " + processorName + " is not added yet.");
-
-        final StateStoreFactory stateStoreFactory = stateFactories.get(stateStoreName);
-        final Iterator<String> iter = stateStoreFactory.users.iterator();
-        if (iter.hasNext()) {
-            final String user = iter.next();
-            nodeGrouper.unite(user, processorName);
-        }
-        stateStoreFactory.users.add(processorName);
-
-        NodeFactory nodeFactory = nodeFactories.get(processorName);
-        if (nodeFactory instanceof ProcessorNodeFactory) {
-            final ProcessorNodeFactory processorNodeFactory = (ProcessorNodeFactory) nodeFactory;
-            processorNodeFactory.addStateStore(stateStoreName);
-            connectStateStoreNameToSourceTopicsOrPattern(stateStoreName, processorNodeFactory);
-        } else {
-            throw new TopologyBuilderException("cannot connect a state store " + stateStoreName + " to a source node or a sink node.");
-        }
-    }
-
-    private Set<SourceNodeFactory> findSourcesForProcessorParents(final String[] parents) {
-        final Set<SourceNodeFactory> sourceNodes = new HashSet<>();
-        for (String parent : parents) {
-            final NodeFactory nodeFactory = nodeFactories.get(parent);
-            if (nodeFactory instanceof SourceNodeFactory) {
-                sourceNodes.add((SourceNodeFactory) nodeFactory);
-            } else if (nodeFactory instanceof ProcessorNodeFactory) {
-                sourceNodes.addAll(findSourcesForProcessorParents(((ProcessorNodeFactory) nodeFactory).parents));
-            }
-        }
-        return sourceNodes;
-    }
-
-    private void connectStateStoreNameToSourceTopicsOrPattern(final String stateStoreName,
-                                                              final ProcessorNodeFactory processorNodeFactory) {
-
-        // we should never update the mapping from state store names to source topics if the store name already exists
-        // in the map; this scenario is possible, for example, that a state store underlying a source KTable is
-        // connecting to a join operator whose source topic is not the original KTable's source topic but an internal repartition topic.
-
-        if (stateStoreNameToSourceTopics.containsKey(stateStoreName) || stateStoreNameToSourceRegex.containsKey(stateStoreName)) {
-            return;
-        }
-
-        final Set<String> sourceTopics = new HashSet<>();
-        final Set<Pattern> sourcePatterns = new HashSet<>();
-        final Set<SourceNodeFactory> sourceNodesForParent = findSourcesForProcessorParents(processorNodeFactory.parents);
-
-        for (SourceNodeFactory sourceNodeFactory : sourceNodesForParent) {
-            if (sourceNodeFactory.pattern != null) {
-                sourcePatterns.add(sourceNodeFactory.pattern);
-            } else {
-                sourceTopics.addAll(sourceNodeFactory.topics);
-            }
-        }
-        
-        if (!sourceTopics.isEmpty()) {
-            stateStoreNameToSourceTopics.put(stateStoreName,
-                    Collections.unmodifiableSet(sourceTopics));
-        }
-
-        if (!sourcePatterns.isEmpty()) {
-            stateStoreNameToSourceRegex.put(stateStoreName,
-                    Collections.unmodifiableSet(sourcePatterns));
-        }
-
-    }
-
-
-    private <T> void maybeAddToResetList(final Collection<T> earliestResets, final Collection<T> latestResets, final AutoOffsetReset offsetReset, final T item) {
-        if (offsetReset != null) {
-            switch (offsetReset) {
-                case EARLIEST:
-                    earliestResets.add(item);
-                    break;
-                case LATEST:
-                    latestResets.add(item);
-                    break;
-                default:
-                    throw new TopologyBuilderException(String.format("Unrecognized reset format %s", offsetReset));
-            }
-        }
     }
 
     /**
@@ -1133,49 +853,9 @@ public class TopologyBuilder {
      *
      * @return groups of node names
      */
+    @Deprecated
     public synchronized Map<Integer, Set<String>> nodeGroups() {
-        if (nodeGroups == null)
-            nodeGroups = makeNodeGroups();
-
-        return nodeGroups;
-    }
-
-    private Map<Integer, Set<String>> makeNodeGroups() {
-        final HashMap<Integer, Set<String>> nodeGroups = new LinkedHashMap<>();
-        final HashMap<String, Set<String>> rootToNodeGroup = new HashMap<>();
-
-        int nodeGroupId = 0;
-
-        // Go through source nodes first. This makes the group id assignment easy to predict in tests
-        final HashSet<String> allSourceNodes = new HashSet<>(nodeToSourceTopics.keySet());
-        allSourceNodes.addAll(nodeToSourcePatterns.keySet());
-
-        for (String nodeName : Utils.sorted(allSourceNodes)) {
-            final String root = nodeGrouper.root(nodeName);
-            Set<String> nodeGroup = rootToNodeGroup.get(root);
-            if (nodeGroup == null) {
-                nodeGroup = new HashSet<>();
-                rootToNodeGroup.put(root, nodeGroup);
-                nodeGroups.put(nodeGroupId++, nodeGroup);
-            }
-            nodeGroup.add(nodeName);
-        }
-
-        // Go through non-source nodes
-        for (String nodeName : Utils.sorted(nodeFactories.keySet())) {
-            if (!nodeToSourceTopics.containsKey(nodeName)) {
-                final String root = nodeGrouper.root(nodeName);
-                Set<String> nodeGroup = rootToNodeGroup.get(root);
-                if (nodeGroup == null) {
-                    nodeGroup = new HashSet<>();
-                    rootToNodeGroup.put(root, nodeGroup);
-                    nodeGroups.put(nodeGroupId++, nodeGroup);
-                }
-                nodeGroup.add(nodeName);
-            }
-        }
-
-        return nodeGroups;
+        return internalTopologyBuilder.nodeGroups();
     }
 
     /**
@@ -1184,122 +864,18 @@ public class TopologyBuilder {
      *
      * @see org.apache.kafka.streams.KafkaStreams#KafkaStreams(TopologyBuilder, org.apache.kafka.streams.StreamsConfig)
      */
+    @Deprecated
     public synchronized ProcessorTopology build(final Integer topicGroupId) {
-        Set<String> nodeGroup;
-        if (topicGroupId != null) {
-            nodeGroup = nodeGroups().get(topicGroupId);
-        } else {
-            // when topicGroupId is null, we build the full topology minus the global groups
-            final Set<String> globalNodeGroups = globalNodeGroups();
-            final Collection<Set<String>> values = nodeGroups().values();
-            nodeGroup = new HashSet<>();
-            for (Set<String> value : values) {
-                nodeGroup.addAll(value);
-            }
-            nodeGroup.removeAll(globalNodeGroups);
-
-
-        }
-        return build(nodeGroup);
+        return internalTopologyBuilder.build(topicGroupId);
     }
 
     /**
      * Builds the topology for any global state stores
      * @return ProcessorTopology
      */
+    @Deprecated
     public synchronized ProcessorTopology buildGlobalStateTopology() {
-        final Set<String> globalGroups = globalNodeGroups();
-        if (globalGroups.isEmpty()) {
-            return null;
-        }
-        return build(globalGroups);
-    }
-
-    private Set<String> globalNodeGroups() {
-        final Set<String> globalGroups = new HashSet<>();
-        for (final Map.Entry<Integer, Set<String>> nodeGroup : nodeGroups().entrySet()) {
-            final Set<String> nodes = nodeGroup.getValue();
-            for (String node : nodes) {
-                if (isGlobalSource(node)) {
-                    globalGroups.addAll(nodes);
-                }
-            }
-        }
-        return globalGroups;
-    }
-
-    private ProcessorTopology build(final Set<String> nodeGroup) {
-        final List<ProcessorNode> processorNodes = new ArrayList<>(nodeFactories.size());
-        final Map<String, ProcessorNode> processorMap = new HashMap<>();
-        final Map<String, SourceNode> topicSourceMap = new HashMap<>();
-        final Map<String, SinkNode> topicSinkMap = new HashMap<>();
-        final Map<String, StateStore> stateStoreMap = new LinkedHashMap<>();
-
-        // create processor nodes in a topological order ("nodeFactories" is already topologically sorted)
-        for (NodeFactory factory : nodeFactories.values()) {
-            if (nodeGroup == null || nodeGroup.contains(factory.name)) {
-                final ProcessorNode node = factory.build();
-                processorNodes.add(node);
-                processorMap.put(node.name(), node);
-
-                if (factory instanceof ProcessorNodeFactory) {
-                    for (String parent : ((ProcessorNodeFactory) factory).parents) {
-                        final ProcessorNode<?, ?> parentNode = processorMap.get(parent);
-                        parentNode.addChild(node);
-                    }
-                    for (String stateStoreName : ((ProcessorNodeFactory) factory).stateStoreNames) {
-                        if (!stateStoreMap.containsKey(stateStoreName)) {
-                            StateStore stateStore;
-
-                            if (stateFactories.containsKey(stateStoreName)) {
-                                final StateStoreSupplier supplier = stateFactories.get(stateStoreName).supplier;
-                                stateStore = supplier.get();
-
-                                // remember the changelog topic if this state store is change-logging enabled
-                                if (supplier.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
-                                    final String changelogTopic = ProcessorStateManager.storeChangelogTopic(this.applicationId, stateStoreName);
-                                    storeToChangelogTopic.put(stateStoreName, changelogTopic);
-                                }
-                            } else {
-                                stateStore = globalStateStores.get(stateStoreName);
-                            }
-
-                            stateStoreMap.put(stateStoreName, stateStore);
-                        }
-                    }
-                } else if (factory instanceof SourceNodeFactory) {
-                    final SourceNodeFactory sourceNodeFactory = (SourceNodeFactory) factory;
-                    final List<String> topics = (sourceNodeFactory.pattern != null) ?
-                            sourceNodeFactory.getTopics(subscriptionUpdates.getUpdates()) :
-                            sourceNodeFactory.topics;
-
-                    for (String topic : topics) {
-                        if (internalTopicNames.contains(topic)) {
-                            // prefix the internal topic name with the application id
-                            topicSourceMap.put(decorateTopic(topic), (SourceNode) node);
-                        } else {
-                            topicSourceMap.put(topic, (SourceNode) node);
-                        }
-                    }
-                } else if (factory instanceof SinkNodeFactory) {
-                    final SinkNodeFactory sinkNodeFactory = (SinkNodeFactory) factory;
-
-                    for (String parent : sinkNodeFactory.parents) {
-                        processorMap.get(parent).addChild(node);
-                        if (internalTopicNames.contains(sinkNodeFactory.topic)) {
-                            // prefix the internal topic name with the application id
-                            topicSinkMap.put(decorateTopic(sinkNodeFactory.topic), (SinkNode) node);
-                        } else {
-                            topicSinkMap.put(sinkNodeFactory.topic, (SinkNode) node);
-                        }
-                    }
-                } else {
-                    throw new TopologyBuilderException("Unknown definition class: " + factory.getClass().getName());
-                }
-            }
-        }
-
-        return new ProcessorTopology(processorNodes, topicSourceMap, topicSinkMap, new ArrayList<>(stateStoreMap.values()), storeToChangelogTopic, new ArrayList<>(globalStateStores.values()));
+        return internalTopologyBuilder.buildGlobalStateTopology();
     }
 
     /**
@@ -1307,8 +883,9 @@ public class TopologyBuilder {
      * topology
      * @return map containing all global {@link StateStore}s
      */
+    @Deprecated
     public Map<String, StateStore> globalStateStores() {
-        return Collections.unmodifiableMap(globalStateStores);
+        return internalTopologyBuilder.globalStateStores();
     }
 
     /**
@@ -1317,197 +894,35 @@ public class TopologyBuilder {
      *
      * @return groups of topic names
      */
+    @Deprecated
     public synchronized Map<Integer, TopicsInfo> topicGroups() {
-        final Map<Integer, TopicsInfo> topicGroups = new LinkedHashMap<>();
-
-        if (nodeGroups == null)
-            nodeGroups = makeNodeGroups();
-
-        for (Map.Entry<Integer, Set<String>> entry : nodeGroups.entrySet()) {
-            final Set<String> sinkTopics = new HashSet<>();
-            final Set<String> sourceTopics = new HashSet<>();
-            final Map<String, InternalTopicConfig> internalSourceTopics = new HashMap<>();
-            final Map<String, InternalTopicConfig> stateChangelogTopics = new HashMap<>();
-            for (String node : entry.getValue()) {
-                // if the node is a source node, add to the source topics
-                final List<String> topics = nodeToSourceTopics.get(node);
-                if (topics != null) {
-                    // if some of the topics are internal, add them to the internal topics
-                    for (String topic : topics) {
-                        // skip global topic as they don't need partition assignment
-                        if (globalTopics.contains(topic)) {
-                            continue;
-                        }
-                        if (this.internalTopicNames.contains(topic)) {
-                            // prefix the internal topic name with the application id
-                            final String internalTopic = decorateTopic(topic);
-                            internalSourceTopics.put(internalTopic, new InternalTopicConfig(internalTopic,
-                                                                                            Collections.singleton(InternalTopicConfig.CleanupPolicy.delete),
-                                                                                            Collections.<String, String>emptyMap()));
-                            sourceTopics.add(internalTopic);
-                        } else {
-                            sourceTopics.add(topic);
-                        }
-                    }
-                }
-
-                // if the node is a sink node, add to the sink topics
-                final String topic = nodeToSinkTopic.get(node);
-                if (topic != null) {
-                    if (internalTopicNames.contains(topic)) {
-                        // prefix the change log topic name with the application id
-                        sinkTopics.add(decorateTopic(topic));
-                    } else {
-                        sinkTopics.add(topic);
-                    }
-                }
-
-                // if the node is connected to a state, add to the state topics
-                for (StateStoreFactory stateFactory : stateFactories.values()) {
-                    final StateStoreSupplier supplier = stateFactory.supplier;
-                    if (supplier.loggingEnabled() && stateFactory.users.contains(node)) {
-                        final String name = ProcessorStateManager.storeChangelogTopic(applicationId, supplier.name());
-                        final InternalTopicConfig internalTopicConfig = createInternalTopicConfig(supplier, name);
-                        stateChangelogTopics.put(name, internalTopicConfig);
-                    }
-                }
-            }
-            if (!sourceTopics.isEmpty()) {
-                topicGroups.put(entry.getKey(), new TopicsInfo(
-                        Collections.unmodifiableSet(sinkTopics),
-                        Collections.unmodifiableSet(sourceTopics),
-                        Collections.unmodifiableMap(internalSourceTopics),
-                        Collections.unmodifiableMap(stateChangelogTopics)));
-            }
-        }
-
-        return Collections.unmodifiableMap(topicGroups);
-    }
-
-    private void setRegexMatchedTopicsToSourceNodes() {
-        if (subscriptionUpdates.hasUpdates()) {
-            for (Map.Entry<String, Pattern> stringPatternEntry : nodeToSourcePatterns.entrySet()) {
-                final SourceNodeFactory sourceNode = (SourceNodeFactory) nodeFactories.get(stringPatternEntry.getKey());
-                //need to update nodeToSourceTopics with topics matched from given regex
-                nodeToSourceTopics.put(stringPatternEntry.getKey(), sourceNode.getTopics(subscriptionUpdates.getUpdates()));
-                log.debug("nodeToSourceTopics {}", nodeToSourceTopics);
-            }
-        }
-    }
-
-    private void setRegexMatchedTopicToStateStore() {
-        if (subscriptionUpdates.hasUpdates()) {
-            for (Map.Entry<String, Set<Pattern>> storePattern : stateStoreNameToSourceRegex.entrySet()) {
-                final Set<String> updatedTopicsForStateStore = new HashSet<>();
-                for (String subscriptionUpdateTopic : subscriptionUpdates.getUpdates()) {
-                    for (Pattern pattern : storePattern.getValue()) {
-                        if (pattern.matcher(subscriptionUpdateTopic).matches()) {
-                            updatedTopicsForStateStore.add(subscriptionUpdateTopic);
-                        }
-                    }
-                }
-                if (!updatedTopicsForStateStore.isEmpty()) {
-                    Collection<String> storeTopics = stateStoreNameToSourceTopics.get(storePattern.getKey());
-                    if (storeTopics != null) {
-                        updatedTopicsForStateStore.addAll(storeTopics);
-                    }
-                    stateStoreNameToSourceTopics.put(storePattern.getKey(), Collections.unmodifiableSet(updatedTopicsForStateStore));
-                }
-            }
-        }
-    }
-    
-    private InternalTopicConfig createInternalTopicConfig(final StateStoreSupplier<?> supplier, final String name) {
-        if (!(supplier instanceof WindowStoreSupplier)) {
-            return new InternalTopicConfig(name, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), supplier.logConfig());
-        }
-
-        final WindowStoreSupplier windowStoreSupplier = (WindowStoreSupplier) supplier;
-        final InternalTopicConfig config = new InternalTopicConfig(name,
-                                                                   Utils.mkSet(InternalTopicConfig.CleanupPolicy.compact,
-                                                                           InternalTopicConfig.CleanupPolicy.delete),
-                                                                   supplier.logConfig());
-        config.setRetentionMs(windowStoreSupplier.retentionPeriod());
-        return config;
+        return internalTopologyBuilder.topicGroups();
     }
 
     /**
      * Get the Pattern to match all topics requiring to start reading from earliest available offset
      * @return the Pattern for matching all topics reading from earliest offset, never null
      */
+    @Deprecated
     public synchronized Pattern earliestResetTopicsPattern() {
-        final List<String> topics = maybeDecorateInternalSourceTopics(earliestResetTopics);
-        final Pattern earliestPattern =  buildPatternForOffsetResetTopics(topics, earliestResetPatterns);
-
-        ensureNoRegexOverlap(earliestPattern, latestResetPatterns, latestResetTopics);
-
-        return earliestPattern;
+        return internalTopologyBuilder.earliestResetTopicsPattern();
     }
 
     /**
      * Get the Pattern to match all topics requiring to start reading from latest available offset
      * @return the Pattern for matching all topics reading from latest offset, never null
      */
+    @Deprecated
     public synchronized Pattern latestResetTopicsPattern() {
-        final List<String> topics = maybeDecorateInternalSourceTopics(latestResetTopics);
-        final Pattern latestPattern = buildPatternForOffsetResetTopics(topics, latestResetPatterns);
-
-        ensureNoRegexOverlap(latestPattern, earliestResetPatterns, earliestResetTopics);
-
-        return  latestPattern;
-    }
-
-    private void ensureNoRegexOverlap(final Pattern builtPattern, final Set<Pattern> otherPatterns, final Set<String> otherTopics) {
-
-        for (Pattern otherPattern : otherPatterns) {
-            if (builtPattern.pattern().contains(otherPattern.pattern())) {
-                throw new TopologyBuilderException(String.format("Found overlapping regex [%s] against [%s] for a KStream with auto offset resets", otherPattern.pattern(), builtPattern.pattern()));
-            }
-        }
-
-        for (String otherTopic : otherTopics) {
-            if (builtPattern.matcher(otherTopic).matches()) {
-                throw new TopologyBuilderException(String.format("Found overlapping regex [%s] matching topic [%s] for a KStream with auto offset resets", builtPattern.pattern(), otherTopic));
-            }
-        }
-    }
-
-    /**
-     * Builds a composite pattern out of topic names and Pattern object for matching topic names.  If the provided
-     * arrays are empty a Pattern.compile("") instance is returned.
-     *
-     * @param sourceTopics  the name of source topics to add to a composite pattern
-     * @param sourcePatterns Patterns for matching source topics to add to a composite pattern
-     * @return a Pattern that is composed of the literal source topic names and any Patterns for matching source topics
-     */
-    private static synchronized Pattern buildPatternForOffsetResetTopics(final Collection<String> sourceTopics, final Collection<Pattern> sourcePatterns) {
-        final StringBuilder builder = new StringBuilder();
-
-        for (String topic : sourceTopics) {
-            builder.append(topic).append("|");
-        }
-
-        for (Pattern sourcePattern : sourcePatterns) {
-            builder.append(sourcePattern.pattern()).append("|");
-        }
-
-        if (builder.length() > 0) {
-            builder.setLength(builder.length() - 1);
-            return Pattern.compile(builder.toString());
-        }
-
-        return EMPTY_ZERO_LENGTH_PATTERN;
+        return internalTopologyBuilder.latestResetTopicsPattern();
     }
 
     /**
      * @return a mapping from state store name to a Set of source Topics.
      */
+    @Deprecated
     public Map<String, List<String>> stateStoreNameToSourceTopics() {
-        final Map<String, List<String>> results = new HashMap<>();
-        for (Map.Entry<String, Set<String>> entry : stateStoreNameToSourceTopics.entrySet()) {
-            results.put(entry.getKey(), maybeDecorateInternalSourceTopics(entry.getValue()));
-        }
-        return results;
+        return internalTopologyBuilder.stateStoreNameToSourceTopics();
     }
 
     /**
@@ -1516,67 +931,25 @@ public class TopologyBuilder {
      *
      * @return groups of topic names
      */
+    @Deprecated
     public synchronized Collection<Set<String>> copartitionGroups() {
-        final List<Set<String>> list = new ArrayList<>(copartitionSourceGroups.size());
-        for (Set<String> nodeNames : copartitionSourceGroups) {
-            Set<String> copartitionGroup = new HashSet<>();
-            for (String node : nodeNames) {
-                final List<String> topics = nodeToSourceTopics.get(node);
-                if (topics != null)
-                    copartitionGroup.addAll(maybeDecorateInternalSourceTopics(topics));
-            }
-            list.add(Collections.unmodifiableSet(copartitionGroup));
-        }
-        return Collections.unmodifiableList(list);
+        return internalTopologyBuilder.copartitionGroups();
     }
 
-    private List<String> maybeDecorateInternalSourceTopics(final Collection<String> sourceTopics) {
-        final List<String> decoratedTopics = new ArrayList<>();
-        for (String topic : sourceTopics) {
-            if (internalTopicNames.contains(topic)) {
-                decoratedTopics.add(decorateTopic(topic));
-            } else {
-                decoratedTopics.add(topic);
-            }
-        }
-        return decoratedTopics;
-    }
-
-    private String decorateTopic(final String topic) {
-        if (applicationId == null) {
-            throw new TopologyBuilderException("there are internal topics and "
-                    + "applicationId hasn't been set. Call "
-                    + "setApplicationId first");
-        }
-
-        return applicationId + "-" + topic;
-    }
-
+    @Deprecated
     public SubscriptionUpdates subscriptionUpdates() {
-        return subscriptionUpdates;
+        return internalTopologyBuilder.subscriptionUpdates();
     }
 
+    @Deprecated
     public synchronized Pattern sourceTopicPattern() {
-        if (this.topicPattern == null) {
-            final List<String> allSourceTopics = new ArrayList<>();
-            if (!nodeToSourceTopics.isEmpty()) {
-                for (List<String> topics : nodeToSourceTopics.values()) {
-                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(topics));
-                }
-            }
-            Collections.sort(allSourceTopics);
-
-            this.topicPattern = buildPatternForOffsetResetTopics(allSourceTopics, nodeToSourcePatterns.values());
-        }
-
-        return this.topicPattern;
+        return internalTopologyBuilder.sourceTopicPattern();
     }
 
-    public synchronized void updateSubscriptions(final SubscriptionUpdates subscriptionUpdates, final String threadId) {
-        log.debug("stream-thread [{}] updating builder with {} topic(s) with possible matching regex subscription(s)", threadId, subscriptionUpdates);
-        this.subscriptionUpdates = subscriptionUpdates;
-        setRegexMatchedTopicsToSourceNodes();
-        setRegexMatchedTopicToStateStore();
+    @Deprecated
+    public synchronized void updateSubscriptions(final SubscriptionUpdates subscriptionUpdates,
+                                                 final String threadId) {
+        internalTopologyBuilder.updateSubscriptions(subscriptionUpdates, threadId);
     }
 
     private boolean isGlobalSource(final String nodeName) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyBuilder.java
@@ -196,9 +196,19 @@ public class TopologyBuilder {
         }
     }
 
+    /**
+     * NOTE this member would not needed by developers working with the processor APIs, but only used
+     * for internal functionalities.
+     * @deprecated not part of public API and for internal usage only
+     */
     @Deprecated
     public final InternalTopologyBuilder internalTopologyBuilder = new InternalTopologyBuilder();
 
+    /**
+     * NOTE this class would not needed by developers working with the processor APIs, but only used
+     * for internal functionalities.
+     * @deprecated not part of public API and for internal usage only
+     */
     @Deprecated
     public static class TopicsInfo {
         public Set<String> sinkTopics;
@@ -255,15 +265,7 @@ public class TopologyBuilder {
      */
     public TopologyBuilder() {}
 
-    /**
-     * Set the applicationId to be used for auto-generated internal topics.
-     *
-     * This is required before calling {@link #topicGroups}, {@link #copartitionSources},
-     * {@link #stateStoreNameToSourceTopics} and {@link #build(Integer)}.
-     *
-     * @param applicationId the streams applicationId. Should be the same as set by
-     * {@link org.apache.kafka.streams.StreamsConfig#APPLICATION_ID_CONFIG}
-     */
+    /** @deprecated This class is not part of public API and should never be used by a developer. */
     @Deprecated
     public synchronized final TopologyBuilder setApplicationId(final String applicationId) {
         internalTopologyBuilder.setApplicationId(applicationId);
@@ -302,7 +304,8 @@ public class TopologyBuilder {
      * @return this builder instance so methods can be chained together; never null
      */
     public synchronized final TopologyBuilder addSource(final AutoOffsetReset offsetReset,
-                                                        final String name, final String... topics) {
+                                                        final String name,
+                                                        final String... topics) {
         internalTopologyBuilder.addSource(offsetReset, name, null, null, null, topics);
         return this;
     }
@@ -800,6 +803,11 @@ public class TopologyBuilder {
     /**
      * This is used only for KStreamBuilder: when adding a KTable from a source topic,
      * we need to add the topic as the KTable's materialized state store's changelog.
+     *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     protected synchronized final TopologyBuilder connectSourceStoreAndTopic(final String sourceStoreName,
@@ -817,6 +825,7 @@ public class TopologyBuilder {
      * @param processorNames the name of the processors
      * @return this builder instance so methods can be chained together; never null
      * @throws TopologyBuilderException if less than two processors are specified, or if one of the processors is not added yet
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized final TopologyBuilder connectProcessors(final String... processorNames) {
@@ -827,8 +836,12 @@ public class TopologyBuilder {
     /**
      * Adds an internal topic
      *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @param topicName the name of the topic
      * @return this builder instance so methods can be chained together; never null
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized final TopologyBuilder addInternalTopic(final String topicName) {
@@ -839,8 +852,12 @@ public class TopologyBuilder {
     /**
      * Asserts that the streams of the specified source nodes must be copartitioned.
      *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @param sourceNodes a set of source node names
      * @return this builder instance so methods can be chained together; never null
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized final TopologyBuilder copartitionSources(final Collection<String> sourceNodes) {
@@ -851,7 +868,11 @@ public class TopologyBuilder {
     /**
      * Returns the map of node groups keyed by the topic group id.
      *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return groups of node names
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized Map<Integer, Set<String>> nodeGroups() {
@@ -862,7 +883,11 @@ public class TopologyBuilder {
      * Build the topology for the specified topic group. This is called automatically when passing this builder into the
      * {@link org.apache.kafka.streams.KafkaStreams#KafkaStreams(TopologyBuilder, org.apache.kafka.streams.StreamsConfig)} constructor.
      *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @see org.apache.kafka.streams.KafkaStreams#KafkaStreams(TopologyBuilder, org.apache.kafka.streams.StreamsConfig)
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized ProcessorTopology build(final Integer topicGroupId) {
@@ -871,7 +896,12 @@ public class TopologyBuilder {
 
     /**
      * Builds the topology for any global state stores
+     *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return ProcessorTopology
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized ProcessorTopology buildGlobalStateTopology() {
@@ -881,7 +911,12 @@ public class TopologyBuilder {
     /**
      * Get any global {@link StateStore}s that are part of the
      * topology
+     *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return map containing all global {@link StateStore}s
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public Map<String, StateStore> globalStateStores() {
@@ -892,7 +927,11 @@ public class TopologyBuilder {
      * Returns the map of topic groups keyed by the group id.
      * A topic group is a group of topics in the same task.
      *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return groups of topic names
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized Map<Integer, TopicsInfo> topicGroups() {
@@ -901,7 +940,12 @@ public class TopologyBuilder {
 
     /**
      * Get the Pattern to match all topics requiring to start reading from earliest available offset
+     *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return the Pattern for matching all topics reading from earliest offset, never null
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized Pattern earliestResetTopicsPattern() {
@@ -910,7 +954,12 @@ public class TopologyBuilder {
 
     /**
      * Get the Pattern to match all topics requiring to start reading from latest available offset
+     *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return the Pattern for matching all topics reading from latest offset, never null
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized Pattern latestResetTopicsPattern() {
@@ -918,7 +967,11 @@ public class TopologyBuilder {
     }
 
     /**
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return a mapping from state store name to a Set of source Topics.
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public Map<String, List<String>> stateStoreNameToSourceTopics() {
@@ -929,23 +982,45 @@ public class TopologyBuilder {
      * Returns the copartition groups.
      * A copartition group is a group of source topics that are required to be copartitioned.
      *
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
      * @return groups of topic names
+     * @deprecated not part of public API and for internal usage only
      */
     @Deprecated
     public synchronized Collection<Set<String>> copartitionGroups() {
         return internalTopologyBuilder.copartitionGroups();
     }
 
+    /**
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
+     * @deprecated not part of public API and for internal usage only
+     */
     @Deprecated
     public SubscriptionUpdates subscriptionUpdates() {
         return internalTopologyBuilder.subscriptionUpdates();
     }
 
+    /**
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
+     * @deprecated not part of public API and for internal usage only
+     */
     @Deprecated
     public synchronized Pattern sourceTopicPattern() {
         return internalTopologyBuilder.sourceTopicPattern();
     }
 
+    /**
+     * NOTE this function would not needed by developers working with the processor APIs, but only used
+     * for the high-level DSL parsing functionalities.
+     *
+     * @deprecated not part of public API and for internal usage only
+     */
     @Deprecated
     public synchronized void updateSubscriptions(final SubscriptionUpdates subscriptionUpdates,
                                                  final String threadId) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopologyDescription.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopologyDescription.java
@@ -19,9 +19,6 @@ package org.apache.kafka.streams.processor;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -32,13 +29,10 @@ import java.util.Set;
  * sub-topology {@link Topology#addSink(String, String, String...) writes} into a topic and another sub-topology
  * {@link Topology#addSource(String, String...) reads} from the same topic.
  * <p>
- * For {@link KafkaStreams#start() execution} sub-topologies are translated into {@link StreamTask tasks}.
+ * When {@link KafkaStreams#start()} is called, different sub-topologies will be constructed and executed as independent
+ * {@link StreamTask tasks}.
  */
-// TODO make public (hide until KIP-120 if fully implemented)
-final class TopologyDescription {
-    private final Set<Subtopology> subtopologies = new HashSet<>();
-    private final Set<GlobalStore> globalStores = new HashSet<>();
-
+public interface TopologyDescription {
     /**
      * A connected sub-graph of a {@link Topology}.
      * <p>
@@ -46,65 +40,18 @@ final class TopologyDescription {
      * directly} or indirectly via {@link Topology#connectProcessorAndStateStores(String, String...) state stores}
      * (i.e., if multiple processors share the same state).
      */
-    public final static class Subtopology {
-        private final int id;
-        private final Set<Node> nodes;
-
-        Subtopology(final int id,
-                    final Set<Node> nodes) {
-            this.id = id;
-            this.nodes = nodes;
-        }
-
+    interface Subtopology {
         /**
          * Internally assigned unique ID.
          * @return the ID of the sub-topology
          */
-        public int id() {
-            return id;
-        }
+        int id();
 
         /**
          * All nodes of this sub-topology.
          * @return set of all nodes within the sub-topology
          */
-        public Set<Node> nodes() {
-            return Collections.unmodifiableSet(nodes);
-        }
-
-        @Override
-        public String toString() {
-            return "Sub-topology: " + id + "\n" + nodesAsString();
-        }
-
-        private String nodesAsString() {
-            final StringBuilder sb = new StringBuilder();
-            for (final Node node : nodes) {
-                sb.append("    ");
-                sb.append(node);
-                sb.append('\n');
-            }
-            return sb.toString();
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Subtopology that = (Subtopology) o;
-            return id == that.id
-                && nodes.equals(that.nodes);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(id, nodes);
-        }
+        Set<Node> nodes();
     }
 
     /**
@@ -117,66 +64,24 @@ final class TopologyDescription {
      * Furthermore, global stores are available to all processors without connecting them explicitly, and thus global
      * stores will never be part of any {@link Subtopology}.
      */
-    public final static class GlobalStore {
-        private final Source source;
-        private final Processor processor;
-
-        GlobalStore(final String sourceName,
-                    final String processorName,
-                    final String storeName,
-                    final String topicName) {
-            source = new Source(sourceName, topicName);
-            processor = new Processor(processorName, Collections.singleton(storeName));
-            source.successors.add(processor);
-            processor.predecessors.add(source);
-        }
-
+    interface GlobalStore {
         /**
          * The source node reading from a "global" topic.
          * @return the "global" source node
          */
-        public Source source() {
-            return source;
-        }
+        Source source();
 
         /**
          * The processor node maintaining the global store.
          * @return the "global" processor node
          */
-        public Processor processor() {
-            return processor;
-        }
-
-        @Override
-        public String toString() {
-            return "GlobalStore: " + source.name + "(topic: " + source.topics + ") -> "
-                + processor.name + "(store: " + processor.stores.iterator().next() + ")\n";
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final GlobalStore that = (GlobalStore) o;
-            return source.equals(that.source)
-                && processor.equals(that.processor);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(source, processor);
-        }
+        Processor processor();
     }
 
     /**
      * A node of a topology. Can be a source, sink, or processor node.
      */
-    public interface Node {
+    interface Node {
         /**
          * The name of the node. Will never be {@code null}.
          * @return the name of the node
@@ -198,279 +103,51 @@ final class TopologyDescription {
         Set<Node> successors();
     }
 
-    abstract static class AbstractNode implements Node {
-        final String name;
-        final Set<Node> predecessors = new HashSet<>();
-        final Set<Node> successors = new HashSet<>();
-
-        AbstractNode(final String name) {
-            this.name = name;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public Set<Node> predecessors() {
-            return Collections.unmodifiableSet(predecessors);
-        }
-
-        @Override
-        public Set<Node> successors() {
-            return Collections.unmodifiableSet(successors);
-        }
-
-        void addPredecessor(final Node predecessor) {
-            predecessors.add(predecessor);
-        }
-
-        void addSuccessor(final Node successor) {
-            successors.add(successor);
-        }
-    }
 
     /**
      * A source node of a topology.
      */
-    public final static class Source extends AbstractNode {
-        private final String topics;
-
-        Source(final String name,
-               final String topics) {
-            super(name);
-            this.topics = topics;
-        }
-
+    interface Source extends Node {
         /**
          * The topic names this source node is reading from.
          * @return comma separated list of topic names or pattern (as String)
          */
-        public String topics() {
-            return topics;
-        }
-
-        @Override
-        void addPredecessor(final Node predecessor) {
-            throw new UnsupportedOperationException("Sources don't have predecessors.");
-        }
-
-        @Override
-        public String toString() {
-            return "Source: " + name + "(topics: " + topics + ") --> " + nodeNames(successors);
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Source source = (Source) o;
-            // omit successor to avoid infinite loops
-            return name.equals(source.name)
-                && topics.equals(source.topics);
-        }
-
-        @Override
-        public int hashCode() {
-            // omit successor as it might change and alter the hash code
-            return Objects.hash(name, topics);
-        }
+        String topics();
     }
 
     /**
      * A processor node of a topology.
      */
-    public final static class Processor extends AbstractNode {
-        private final Set<String> stores;
-
-        Processor(final String name,
-                  final Set<String> stores) {
-            super(name);
-            this.stores = stores;
-        }
-
+    interface Processor extends Node {
         /**
          * The names of all connected stores.
          * @return set of store names
          */
-        public Set<String> stores() {
-            return Collections.unmodifiableSet(stores);
-        }
-
-        @Override
-        public String toString() {
-            return "Processor: " + name + "(stores: " + stores + ") --> " + nodeNames(successors) + " <-- " + nodeNames(predecessors);
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Processor processor = (Processor) o;
-            // omit successor to avoid infinite loops
-            return name.equals(processor.name)
-                && stores.equals(processor.stores)
-                && predecessors.equals(processor.predecessors);
-        }
-
-        @Override
-        public int hashCode() {
-            // omit successor as it might change and alter the hash code
-            return Objects.hash(name, stores);
-        }
+        Set<String> stores();
     }
 
     /**
      * A sink node of a topology.
      */
-    public final static class Sink extends AbstractNode {
-        private final String topic;
-
-        Sink(final String name,
-             final String topic) {
-            super(name);
-            this.topic = topic;
-        }
-
+    interface Sink extends Node {
         /**
          * The topic name this sink node is writing to.
          * @return a topic name
          */
-        public String topic() {
-            return topic;
-        }
-
-        @Override
-        void addSuccessor(final Node successor) {
-            throw new UnsupportedOperationException("Sinks don't have successors.");
-        }
-
-        @Override
-        public String toString() {
-            return "Sink: " + name + "(topic: " + topic + ") <-- " + nodeNames(predecessors);
-        }
-
-        @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            final Sink sink = (Sink) o;
-            return name.equals(sink.name)
-                && topic.equals(sink.topic)
-                && predecessors.equals(sink.predecessors);
-        }
-
-        @Override
-        public int hashCode() {
-            // omit predecessors as it might change and alter the hash code
-            return Objects.hash(name, topic);
-        }
-    }
-
-    void addSubtopology(final Subtopology subtopology) {
-        subtopologies.add(subtopology);
-    }
-
-    void addGlobalStore(final GlobalStore globalStore) {
-        globalStores.add(globalStore);
+        String topic();
     }
 
     /**
      * All sub-topologies of the represented topology.
      * @return set of all sub-topologies
      */
-    public Set<Subtopology> subtopologies() {
-        return Collections.unmodifiableSet(subtopologies);
-    }
+    Set<Subtopology> subtopologies();
 
     /**
      * All global stores of the represented topology.
      * @return set of all global stores
      */
-    public Set<GlobalStore> globalStores() {
-        return Collections.unmodifiableSet(globalStores);
-    }
-
-    @Override
-    public String toString() {
-        return subtopologiesAsString() + globalStoresAsString();
-    }
-
-    private static String nodeNames(final Set<Node> nodes) {
-        final StringBuilder sb = new StringBuilder();
-        if (!nodes.isEmpty()) {
-            for (final Node n : nodes) {
-                sb.append(n.name());
-                sb.append(", ");
-            }
-            sb.deleteCharAt(sb.length() - 1);
-            sb.deleteCharAt(sb.length() - 1);
-        }
-        return sb.toString();
-    }
-
-    private String subtopologiesAsString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Sub-topologies: \n");
-        if (subtopologies.isEmpty()) {
-            sb.append("  none\n");
-        } else {
-            for (final Subtopology st : subtopologies) {
-                sb.append("  ");
-                sb.append(st);
-            }
-        }
-        return sb.toString();
-    }
-
-    private String globalStoresAsString() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Global Stores:\n");
-        if (globalStores.isEmpty()) {
-            sb.append("  none\n");
-        } else {
-            for (final GlobalStore gs : globalStores) {
-                sb.append("  ");
-                sb.append(gs);
-            }
-        }
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        final TopologyDescription that = (TopologyDescription) o;
-        return subtopologies.equals(that.subtopologies)
-            && globalStores.equals(that.globalStores);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(subtopologies, globalStores);
-    }
+    Set<GlobalStore> globalStores();
 
 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1,0 +1,1011 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.errors.TopologyBuilderException;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreSupplier;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.apache.kafka.streams.processor.TopologyBuilder;
+import org.apache.kafka.streams.processor.internals.StreamPartitionAssignor.SubscriptionUpdates;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.internals.WindowStoreSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+
+public class InternalTopologyBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(InternalTopologyBuilder.class);
+
+    private static final Pattern EMPTY_ZERO_LENGTH_PATTERN = Pattern.compile("");
+
+    // node factories in a topological order
+    private final LinkedHashMap<String, NodeFactory> nodeFactories = new LinkedHashMap<>();
+
+    // state factories
+    private final Map<String, StateStoreFactory> stateFactories = new HashMap<>();
+
+    // global state factories
+    private final Map<String, StateStore> globalStateStores = new LinkedHashMap<>();
+
+    // all topics subscribed from source processors (without application-id prefix for internal topics)
+    private final Set<String> sourceTopicNames = new HashSet<>();
+
+    // all internal topics auto-created by the topology builder and used in source / sink processors
+    private final Set<String> internalTopicNames = new HashSet<>();
+
+    // groups of source processors that need to be copartitioned
+    private final List<Set<String>> copartitionSourceGroups = new ArrayList<>();
+
+    // map from source processor names to subscribed topics (without application-id prefix for internal topics)
+    private final HashMap<String, List<String>> nodeToSourceTopics = new HashMap<>();
+
+    // map from source processor names to regex subscription patterns
+    private final HashMap<String, Pattern> nodeToSourcePatterns = new LinkedHashMap<>();
+
+    // map from sink processor names to subscribed topic (without application-id prefix for internal topics)
+    private final HashMap<String, String> nodeToSinkTopic = new HashMap<>();
+
+    // map from topics to their matched regex patterns, this is to ensure one topic is passed through on source node
+    // even if it can be matched by multiple regex patterns
+    private final HashMap<String, Pattern> topicToPatterns = new HashMap<>();
+
+    // map from state store names to all the topics subscribed from source processors that
+    // are connected to these state stores
+    private final Map<String, Set<String>> stateStoreNameToSourceTopics = new HashMap<>();
+
+    // map from state store names to all the regex subscribed topics from source processors that
+    // are connected to these state stores
+    private final Map<String, Set<Pattern>> stateStoreNameToSourceRegex = new HashMap<>();
+
+    // map from state store names to this state store's corresponding changelog topic if possible,
+    // this is used in the extended KStreamBuilder.
+    private final Map<String, String> storeToChangelogTopic = new HashMap<>();
+
+    // all global topics
+    private final Set<String> globalTopics = new HashSet<>();
+
+    private final Set<String> earliestResetTopics = new HashSet<>();
+
+    private final Set<String> latestResetTopics = new HashSet<>();
+
+    private final Set<Pattern> earliestResetPatterns = new HashSet<>();
+
+    private final Set<Pattern> latestResetPatterns = new HashSet<>();
+
+    private final QuickUnion<String> nodeGrouper = new QuickUnion<>();
+
+    private SubscriptionUpdates subscriptionUpdates = new SubscriptionUpdates();
+
+    private String applicationId = null;
+
+    private Pattern topicPattern = null;
+
+    private Map<Integer, Set<String>> nodeGroups = null;
+
+    private static class StateStoreFactory {
+        public final Set<String> users;
+
+        public final StateStoreSupplier supplier;
+
+        StateStoreFactory(final StateStoreSupplier supplier) {
+            this.supplier = supplier;
+            users = new HashSet<>();
+        }
+    }
+
+    private static abstract class NodeFactory {
+        public final String name;
+
+        NodeFactory(final String name) {
+            this.name = name;
+        }
+
+        public abstract ProcessorNode build();
+    }
+
+    private static class ProcessorNodeFactory extends NodeFactory {
+        private final String[] parents;
+        private final ProcessorSupplier<?, ?> supplier;
+        private final Set<String> stateStoreNames = new HashSet<>();
+
+        ProcessorNodeFactory(final String name,
+                             final String[] parents,
+                             final ProcessorSupplier<?, ?> supplier) {
+            super(name);
+            this.parents = parents.clone();
+            this.supplier = supplier;
+        }
+
+        public void addStateStore(final String stateStoreName) {
+            stateStoreNames.add(stateStoreName);
+        }
+
+        @Override
+        public ProcessorNode build() {
+            return new ProcessorNode<>(name, supplier.get(), stateStoreNames);
+        }
+    }
+
+    private class SourceNodeFactory extends NodeFactory {
+        private final List<String> topics;
+        private final Pattern pattern;
+        private final Deserializer<?> keyDeserializer;
+        private final Deserializer<?> valDeserializer;
+        private final TimestampExtractor timestampExtractor;
+
+        private SourceNodeFactory(final String name,
+                                  final String[] topics,
+                                  final Pattern pattern,
+                                  final TimestampExtractor timestampExtractor,
+                                  final Deserializer<?> keyDeserializer,
+                                  final Deserializer<?> valDeserializer) {
+            super(name);
+            this.topics = topics != null ? Arrays.asList(topics) : new ArrayList<String>();
+            this.pattern = pattern;
+            this.keyDeserializer = keyDeserializer;
+            this.valDeserializer = valDeserializer;
+            this.timestampExtractor = timestampExtractor;
+        }
+
+        List<String> getTopics(final Collection<String> subscribedTopics) {
+            // if it is subscribed via patterns, it is possible that the topic metadata has not been updated
+            // yet and hence the map from source node to topics is stale, in this case we put the pattern as a place holder;
+            // this should only happen for debugging since during runtime this function should always be called after the metadata has updated.
+            if (subscribedTopics.isEmpty()) {
+                return Collections.singletonList("" + pattern + "");
+            }
+
+            final List<String> matchedTopics = new ArrayList<>();
+            for (final String update : subscribedTopics) {
+                if (pattern == topicToPatterns.get(update)) {
+                    matchedTopics.add(update);
+                } else if (topicToPatterns.containsKey(update) && isMatch(update)) {
+                    // the same topic cannot be matched to more than one pattern
+                    // TODO: we should lift this requirement in the future
+                    throw new TopologyBuilderException("Topic " + update +
+                            " is already matched for another regex pattern " + topicToPatterns.get(update) +
+                            " and hence cannot be matched to this regex pattern " + pattern + " any more.");
+                } else if (isMatch(update)) {
+                    topicToPatterns.put(update, pattern);
+                    matchedTopics.add(update);
+                }
+            }
+            return matchedTopics;
+        }
+
+        @Override
+        public ProcessorNode build() {
+            final List<String> sourceTopics = nodeToSourceTopics.get(name);
+
+            // if it is subscribed via patterns, it is possible that the topic metadata has not been updated
+            // yet and hence the map from source node to topics is stale, in this case we put the pattern as a place holder;
+            // this should only happen for debugging since during runtime this function should always be called after the metadata has updated.
+            if (sourceTopics == null) {
+                return new SourceNode<>(name, Collections.singletonList("" + pattern + ""), timestampExtractor, keyDeserializer, valDeserializer);
+            } else {
+                return new SourceNode<>(name, maybeDecorateInternalSourceTopics(sourceTopics), timestampExtractor, keyDeserializer, valDeserializer);
+            }
+        }
+
+        private boolean isMatch(final String topic) {
+            return pattern.matcher(topic).matches();
+        }
+    }
+
+    private class SinkNodeFactory<K, V> extends NodeFactory {
+        private final String[] parents;
+        private final String topic;
+        private final Serializer<K> keySerializer;
+        private final Serializer<V> valSerializer;
+        private final StreamPartitioner<? super K, ? super V> partitioner;
+
+        private SinkNodeFactory(final String name,
+                                final String[] parents,
+                                final String topic,
+                                final Serializer<K> keySerializer,
+                                final Serializer<V> valSerializer,
+                                final StreamPartitioner<? super K, ? super V> partitioner) {
+            super(name);
+            this.parents = parents.clone();
+            this.topic = topic;
+            this.keySerializer = keySerializer;
+            this.valSerializer = valSerializer;
+            this.partitioner = partitioner;
+        }
+
+        @Override
+        public ProcessorNode build() {
+            if (internalTopicNames.contains(topic)) {
+                // prefix the internal topic name with the application id
+                return new SinkNode<>(name, decorateTopic(topic), keySerializer, valSerializer, partitioner);
+            } else {
+                return new SinkNode<>(name, topic, keySerializer, valSerializer, partitioner);
+            }
+        }
+    }
+
+    public synchronized final InternalTopologyBuilder setApplicationId(final String applicationId) {
+        Objects.requireNonNull(applicationId, "applicationId can't be null");
+        this.applicationId = applicationId;
+
+        return this;
+    }
+
+    public final void addSource(final TopologyBuilder.AutoOffsetReset offsetReset,
+                                final String name,
+                                final TimestampExtractor timestampExtractor,
+                                final Deserializer keyDeserializer,
+                                final Deserializer valDeserializer,
+                                final String... topics) {
+        if (topics.length == 0) {
+            throw new TopologyBuilderException("You must provide at least one topic");
+        }
+        Objects.requireNonNull(name, "name must not be null");
+        if (nodeFactories.containsKey(name)) {
+            throw new TopologyBuilderException("Processor " + name + " is already added.");
+        }
+
+        for (final String topic : topics) {
+            Objects.requireNonNull(topic, "topic names cannot be null");
+            validateTopicNotAlreadyRegistered(topic);
+            maybeAddToResetList(earliestResetTopics, latestResetTopics, offsetReset, topic);
+            sourceTopicNames.add(topic);
+        }
+
+        nodeFactories.put(name, new SourceNodeFactory(name, topics, null, timestampExtractor, keyDeserializer, valDeserializer));
+        nodeToSourceTopics.put(name, Arrays.asList(topics));
+        nodeGrouper.add(name);
+    }
+
+    public final void addGlobalStore(final StateStoreSupplier<KeyValueStore> storeSupplier,
+                                     final String sourceName,
+                                     final TimestampExtractor timestampExtractor,
+                                     final Deserializer keyDeserializer,
+                                     final Deserializer valueDeserializer,
+                                     final String topic,
+                                     final String processorName,
+                                     final ProcessorSupplier stateUpdateSupplier) {
+        Objects.requireNonNull(storeSupplier, "store supplier must not be null");
+        Objects.requireNonNull(sourceName, "sourceName must not be null");
+        Objects.requireNonNull(topic, "topic must not be null");
+        Objects.requireNonNull(stateUpdateSupplier, "supplier must not be null");
+        Objects.requireNonNull(processorName, "processorName must not be null");
+        if (nodeFactories.containsKey(sourceName)) {
+            throw new TopologyBuilderException("Processor " + sourceName + " is already added.");
+        }
+        if (nodeFactories.containsKey(processorName)) {
+            throw new TopologyBuilderException("Processor " + processorName + " is already added.");
+        }
+        if (stateFactories.containsKey(storeSupplier.name()) || globalStateStores.containsKey(storeSupplier.name())) {
+            throw new TopologyBuilderException("StateStore " + storeSupplier.name() + " is already added.");
+        }
+        if (storeSupplier.loggingEnabled()) {
+            throw new TopologyBuilderException("StateStore " + storeSupplier.name() + " for global table must not have logging enabled.");
+        }
+        if (sourceName.equals(processorName)) {
+            throw new TopologyBuilderException("sourceName and processorName must be different.");
+        }
+
+        validateTopicNotAlreadyRegistered(topic);
+
+        globalTopics.add(topic);
+        final String[] topics = {topic};
+        nodeFactories.put(sourceName, new SourceNodeFactory(sourceName, topics, null, timestampExtractor, keyDeserializer, valueDeserializer));
+        nodeToSourceTopics.put(sourceName, Arrays.asList(topics));
+        nodeGrouper.add(sourceName);
+
+        final String[] parents = {sourceName};
+        final ProcessorNodeFactory nodeFactory = new ProcessorNodeFactory(processorName, parents, stateUpdateSupplier);
+        nodeFactory.addStateStore(storeSupplier.name());
+        nodeFactories.put(processorName, nodeFactory);
+        nodeGrouper.add(processorName);
+        nodeGrouper.unite(processorName, parents);
+
+        globalStateStores.put(storeSupplier.name(), storeSupplier.get());
+        connectSourceStoreAndTopic(storeSupplier.name(), topic);
+    }
+
+    private void validateTopicNotAlreadyRegistered(final String topic) {
+        if (sourceTopicNames.contains(topic) || globalTopics.contains(topic)) {
+            throw new TopologyBuilderException("Topic " + topic + " has already been registered by another source.");
+        }
+
+        for (final Pattern pattern : nodeToSourcePatterns.values()) {
+            if (pattern.matcher(topic).matches()) {
+                throw new TopologyBuilderException("Topic " + topic + " matches a Pattern already registered by another source.");
+            }
+        }
+    }
+
+    public final void addSource(final TopologyBuilder.AutoOffsetReset offsetReset,
+                                final String name,
+                                final TimestampExtractor timestampExtractor,
+                                final Deserializer keyDeserializer,
+                                final Deserializer valDeserializer,
+                                final Pattern topicPattern) {
+        Objects.requireNonNull(topicPattern, "topicPattern can't be null");
+        Objects.requireNonNull(name, "name can't be null");
+
+        if (nodeFactories.containsKey(name)) {
+            throw new TopologyBuilderException("Processor " + name + " is already added.");
+        }
+
+        for (final String sourceTopicName : sourceTopicNames) {
+            if (topicPattern.matcher(sourceTopicName).matches()) {
+                throw new TopologyBuilderException("Pattern  " + topicPattern + " will match a topic that has already been registered by another source.");
+            }
+        }
+
+        maybeAddToResetList(earliestResetPatterns, latestResetPatterns, offsetReset, topicPattern);
+
+        nodeFactories.put(name, new SourceNodeFactory(name, null, topicPattern, timestampExtractor, keyDeserializer, valDeserializer));
+        nodeToSourcePatterns.put(name, topicPattern);
+        nodeGrouper.add(name);
+    }
+
+    public final <K, V> void addSink(final String name,
+                                     final String topic,
+                                     final Serializer<K> keySerializer,
+                                     final Serializer<V> valSerializer,
+                                     final StreamPartitioner<? super K, ? super V> partitioner,
+                                     final String... parentNames) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(topic, "topic must not be null");
+        if (nodeFactories.containsKey(name)) {
+            throw new TopologyBuilderException("Processor " + name + " is already added.");
+        }
+
+        for (final String parent : parentNames) {
+            if (parent.equals(name)) {
+                throw new TopologyBuilderException("Processor " + name + " cannot be a parent of itself.");
+            }
+            if (!nodeFactories.containsKey(parent)) {
+                throw new TopologyBuilderException("Parent processor " + parent + " is not added yet.");
+            }
+        }
+
+        nodeFactories.put(name, new SinkNodeFactory<>(name, parentNames, topic, keySerializer, valSerializer, partitioner));
+        nodeToSinkTopic.put(name, topic);
+        nodeGrouper.add(name);
+        nodeGrouper.unite(name, parentNames);
+    }
+
+    public final void addProcessor(final String name,
+                                   final ProcessorSupplier supplier,
+                                   final String... parentNames) {
+        Objects.requireNonNull(name, "name must not be null");
+        Objects.requireNonNull(supplier, "supplier must not be null");
+        if (nodeFactories.containsKey(name)) {
+            throw new TopologyBuilderException("Processor " + name + " is already added.");
+        }
+
+        for (final String parent : parentNames) {
+            if (parent.equals(name)) {
+                throw new TopologyBuilderException("Processor " + name + " cannot be a parent of itself.");
+            }
+            if (!nodeFactories.containsKey(parent)) {
+                throw new TopologyBuilderException("Parent processor " + parent + " is not added yet.");
+            }
+        }
+
+        nodeFactories.put(name, new ProcessorNodeFactory(name, parentNames, supplier));
+        nodeGrouper.add(name);
+        nodeGrouper.unite(name, parentNames);
+    }
+
+    public final void addStateStore(final StateStoreSupplier supplier,
+                                    final String... processorNames) {
+        Objects.requireNonNull(supplier, "supplier can't be null");
+        if (stateFactories.containsKey(supplier.name())) {
+            throw new TopologyBuilderException("StateStore " + supplier.name() + " is already added.");
+        }
+
+        stateFactories.put(supplier.name(), new StateStoreFactory(supplier));
+
+        if (processorNames != null) {
+            for (final String processorName : processorNames) {
+                connectProcessorAndStateStore(processorName, supplier.name());
+            }
+        }
+    }
+
+    public final void connectProcessorAndStateStores(final String processorName,
+                                                     final String... stateStoreNames) {
+        Objects.requireNonNull(processorName, "processorName can't be null");
+        if (stateStoreNames != null) {
+            for (final String stateStoreName : stateStoreNames) {
+                connectProcessorAndStateStore(processorName, stateStoreName);
+            }
+        }
+    }
+
+    public final void connectSourceStoreAndTopic(final String sourceStoreName,
+                                                  final String topic) {
+        if (storeToChangelogTopic.containsKey(sourceStoreName)) {
+            throw new TopologyBuilderException("Source store " + sourceStoreName + " is already added.");
+        }
+        storeToChangelogTopic.put(sourceStoreName, topic);
+    }
+
+    public final void connectProcessors(final String... processorNames) {
+        if (processorNames.length < 2) {
+            throw new TopologyBuilderException("At least two processors need to participate in the connection.");
+        }
+
+        for (final String processorName : processorNames) {
+            if (!nodeFactories.containsKey(processorName)) {
+                throw new TopologyBuilderException("Processor " + processorName + " is not added yet.");
+            }
+        }
+
+        nodeGrouper.unite(processorNames[0], Arrays.copyOfRange(processorNames, 1, processorNames.length));
+    }
+
+    public final void addInternalTopic(final String topicName) {
+        Objects.requireNonNull(topicName, "topicName can't be null");
+        internalTopicNames.add(topicName);
+    }
+
+    public final void copartitionSources(final Collection<String> sourceNodes) {
+        copartitionSourceGroups.add(Collections.unmodifiableSet(new HashSet<>(sourceNodes)));
+    }
+
+    private void connectProcessorAndStateStore(final String processorName,
+                                               final String stateStoreName) {
+        if (!stateFactories.containsKey(stateStoreName)) {
+            throw new TopologyBuilderException("StateStore " + stateStoreName + " is not added yet.");
+        }
+        if (!nodeFactories.containsKey(processorName)) {
+            throw new TopologyBuilderException("Processor " + processorName + " is not added yet.");
+        }
+
+        final StateStoreFactory stateStoreFactory = stateFactories.get(stateStoreName);
+        final Iterator<String> iter = stateStoreFactory.users.iterator();
+        if (iter.hasNext()) {
+            final String user = iter.next();
+            nodeGrouper.unite(user, processorName);
+        }
+        stateStoreFactory.users.add(processorName);
+
+        final NodeFactory nodeFactory = nodeFactories.get(processorName);
+        if (nodeFactory instanceof ProcessorNodeFactory) {
+            final ProcessorNodeFactory processorNodeFactory = (ProcessorNodeFactory) nodeFactory;
+            processorNodeFactory.addStateStore(stateStoreName);
+            connectStateStoreNameToSourceTopicsOrPattern(stateStoreName, processorNodeFactory);
+        } else {
+            throw new TopologyBuilderException("cannot connect a state store " + stateStoreName + " to a source node or a sink node.");
+        }
+    }
+
+    private Set<SourceNodeFactory> findSourcesForProcessorParents(final String[] parents) {
+        final Set<SourceNodeFactory> sourceNodes = new HashSet<>();
+        for (final String parent : parents) {
+            final NodeFactory nodeFactory = nodeFactories.get(parent);
+            if (nodeFactory instanceof SourceNodeFactory) {
+                sourceNodes.add((SourceNodeFactory) nodeFactory);
+            } else if (nodeFactory instanceof ProcessorNodeFactory) {
+                sourceNodes.addAll(findSourcesForProcessorParents(((ProcessorNodeFactory) nodeFactory).parents));
+            }
+        }
+        return sourceNodes;
+    }
+
+    private void connectStateStoreNameToSourceTopicsOrPattern(final String stateStoreName,
+                                                              final ProcessorNodeFactory processorNodeFactory) {
+        // we should never update the mapping from state store names to source topics if the store name already exists
+        // in the map; this scenario is possible, for example, that a state store underlying a source KTable is
+        // connecting to a join operator whose source topic is not the original KTable's source topic but an internal repartition topic.
+
+        if (stateStoreNameToSourceTopics.containsKey(stateStoreName) || stateStoreNameToSourceRegex.containsKey(stateStoreName)) {
+            return;
+        }
+
+        final Set<String> sourceTopics = new HashSet<>();
+        final Set<Pattern> sourcePatterns = new HashSet<>();
+        final Set<SourceNodeFactory> sourceNodesForParent = findSourcesForProcessorParents(processorNodeFactory.parents);
+
+        for (final SourceNodeFactory sourceNodeFactory : sourceNodesForParent) {
+            if (sourceNodeFactory.pattern != null) {
+                sourcePatterns.add(sourceNodeFactory.pattern);
+            } else {
+                sourceTopics.addAll(sourceNodeFactory.topics);
+            }
+        }
+
+        if (!sourceTopics.isEmpty()) {
+            stateStoreNameToSourceTopics.put(stateStoreName,
+                    Collections.unmodifiableSet(sourceTopics));
+        }
+
+        if (!sourcePatterns.isEmpty()) {
+            stateStoreNameToSourceRegex.put(stateStoreName,
+                    Collections.unmodifiableSet(sourcePatterns));
+        }
+
+    }
+
+    private <T> void maybeAddToResetList(final Collection<T> earliestResets,
+                                         final Collection<T> latestResets,
+                                         final TopologyBuilder.AutoOffsetReset offsetReset,
+                                         final T item) {
+        if (offsetReset != null) {
+            switch (offsetReset) {
+                case EARLIEST:
+                    earliestResets.add(item);
+                    break;
+                case LATEST:
+                    latestResets.add(item);
+                    break;
+                default:
+                    throw new TopologyBuilderException(String.format("Unrecognized reset format %s", offsetReset));
+            }
+        }
+    }
+
+    public synchronized Map<Integer, Set<String>> nodeGroups() {
+        if (nodeGroups == null) {
+            nodeGroups = makeNodeGroups();
+        }
+        return nodeGroups;
+    }
+
+    private Map<Integer, Set<String>> makeNodeGroups() {
+        final HashMap<Integer, Set<String>> nodeGroups = new LinkedHashMap<>();
+        final HashMap<String, Set<String>> rootToNodeGroup = new HashMap<>();
+
+        int nodeGroupId = 0;
+
+        // Go through source nodes first. This makes the group id assignment easy to predict in tests
+        final HashSet<String> allSourceNodes = new HashSet<>(nodeToSourceTopics.keySet());
+        allSourceNodes.addAll(nodeToSourcePatterns.keySet());
+
+        for (final String nodeName : Utils.sorted(allSourceNodes)) {
+            final String root = nodeGrouper.root(nodeName);
+            Set<String> nodeGroup = rootToNodeGroup.get(root);
+            if (nodeGroup == null) {
+                nodeGroup = new HashSet<>();
+                rootToNodeGroup.put(root, nodeGroup);
+                nodeGroups.put(nodeGroupId++, nodeGroup);
+            }
+            nodeGroup.add(nodeName);
+        }
+
+        // Go through non-source nodes
+        for (final String nodeName : Utils.sorted(nodeFactories.keySet())) {
+            if (!nodeToSourceTopics.containsKey(nodeName)) {
+                final String root = nodeGrouper.root(nodeName);
+                Set<String> nodeGroup = rootToNodeGroup.get(root);
+                if (nodeGroup == null) {
+                    nodeGroup = new HashSet<>();
+                    rootToNodeGroup.put(root, nodeGroup);
+                    nodeGroups.put(nodeGroupId++, nodeGroup);
+                }
+                nodeGroup.add(nodeName);
+            }
+        }
+
+        return nodeGroups;
+    }
+
+    public synchronized ProcessorTopology build(final Integer topicGroupId) {
+        final Set<String> nodeGroup;
+        if (topicGroupId != null) {
+            nodeGroup = nodeGroups().get(topicGroupId);
+        } else {
+            // when topicGroupId is null, we build the full topology minus the global groups
+            final Set<String> globalNodeGroups = globalNodeGroups();
+            final Collection<Set<String>> values = nodeGroups().values();
+            nodeGroup = new HashSet<>();
+            for (final Set<String> value : values) {
+                nodeGroup.addAll(value);
+            }
+            nodeGroup.removeAll(globalNodeGroups);
+
+
+        }
+        return build(nodeGroup);
+    }
+
+    /**
+     * Builds the topology for any global state stores
+     * @return ProcessorTopology
+     */
+    public synchronized ProcessorTopology buildGlobalStateTopology() {
+        final Set<String> globalGroups = globalNodeGroups();
+        if (globalGroups.isEmpty()) {
+            return null;
+        }
+        return build(globalGroups);
+    }
+
+    private Set<String> globalNodeGroups() {
+        final Set<String> globalGroups = new HashSet<>();
+        for (final Map.Entry<Integer, Set<String>> nodeGroup : nodeGroups().entrySet()) {
+            final Set<String> nodes = nodeGroup.getValue();
+            for (final String node : nodes) {
+                final NodeFactory nodeFactory = nodeFactories.get(node);
+                if (nodeFactory instanceof SourceNodeFactory) {
+                    final List<String> topics = ((SourceNodeFactory) nodeFactory).topics;
+                    if (topics != null && topics.size() == 1 && globalTopics.contains(topics.get(0))) {
+                        globalGroups.addAll(nodes);
+                    }
+                }
+            }
+        }
+        return globalGroups;
+    }
+
+    private ProcessorTopology build(final Set<String> nodeGroup) {
+        final List<ProcessorNode> processorNodes = new ArrayList<>(nodeFactories.size());
+        final Map<String, ProcessorNode> processorMap = new HashMap<>();
+        final Map<String, SourceNode> topicSourceMap = new HashMap<>();
+        final Map<String, SinkNode> topicSinkMap = new HashMap<>();
+        final Map<String, StateStore> stateStoreMap = new LinkedHashMap<>();
+
+        // create processor nodes in a topological order ("nodeFactories" is already topologically sorted)
+        for (final NodeFactory factory : nodeFactories.values()) {
+            if (nodeGroup == null || nodeGroup.contains(factory.name)) {
+                final ProcessorNode node = factory.build();
+                processorNodes.add(node);
+                processorMap.put(node.name(), node);
+
+                if (factory instanceof ProcessorNodeFactory) {
+                    for (final String parent : ((ProcessorNodeFactory) factory).parents) {
+                        final ProcessorNode<?, ?> parentNode = processorMap.get(parent);
+                        parentNode.addChild(node);
+                    }
+                    for (final String stateStoreName : ((ProcessorNodeFactory) factory).stateStoreNames) {
+                        if (!stateStoreMap.containsKey(stateStoreName)) {
+                            final StateStore stateStore;
+
+                            if (stateFactories.containsKey(stateStoreName)) {
+                                final StateStoreSupplier supplier = stateFactories.get(stateStoreName).supplier;
+                                stateStore = supplier.get();
+
+                                // remember the changelog topic if this state store is change-logging enabled
+                                if (supplier.loggingEnabled() && !storeToChangelogTopic.containsKey(stateStoreName)) {
+                                    final String changelogTopic = ProcessorStateManager.storeChangelogTopic(this.applicationId, stateStoreName);
+                                    storeToChangelogTopic.put(stateStoreName, changelogTopic);
+                                }
+                            } else {
+                                stateStore = globalStateStores.get(stateStoreName);
+                            }
+
+                            stateStoreMap.put(stateStoreName, stateStore);
+                        }
+                    }
+                } else if (factory instanceof SourceNodeFactory) {
+                    final SourceNodeFactory sourceNodeFactory = (SourceNodeFactory) factory;
+                    final List<String> topics = (sourceNodeFactory.pattern != null) ?
+                            sourceNodeFactory.getTopics(subscriptionUpdates.getUpdates()) :
+                            sourceNodeFactory.topics;
+
+                    for (final String topic : topics) {
+                        if (internalTopicNames.contains(topic)) {
+                            // prefix the internal topic name with the application id
+                            topicSourceMap.put(decorateTopic(topic), (SourceNode) node);
+                        } else {
+                            topicSourceMap.put(topic, (SourceNode) node);
+                        }
+                    }
+                } else if (factory instanceof SinkNodeFactory) {
+                    final SinkNodeFactory sinkNodeFactory = (SinkNodeFactory) factory;
+
+                    for (final String parent : sinkNodeFactory.parents) {
+                        processorMap.get(parent).addChild(node);
+                        if (internalTopicNames.contains(sinkNodeFactory.topic)) {
+                            // prefix the internal topic name with the application id
+                            topicSinkMap.put(decorateTopic(sinkNodeFactory.topic), (SinkNode) node);
+                        } else {
+                            topicSinkMap.put(sinkNodeFactory.topic, (SinkNode) node);
+                        }
+                    }
+                } else {
+                    throw new TopologyBuilderException("Unknown definition class: " + factory.getClass().getName());
+                }
+            }
+        }
+
+        return new ProcessorTopology(processorNodes, topicSourceMap, topicSinkMap, new ArrayList<>(stateStoreMap.values()), storeToChangelogTopic, new ArrayList<>(globalStateStores.values()));
+    }
+
+    /**
+     * Get any global {@link StateStore}s that are part of the
+     * topology
+     * @return map containing all global {@link StateStore}s
+     */
+    public Map<String, StateStore> globalStateStores() {
+        return Collections.unmodifiableMap(globalStateStores);
+    }
+
+    /**
+     * Returns the map of topic groups keyed by the group id.
+     * A topic group is a group of topics in the same task.
+     *
+     * @return groups of topic names
+     */
+    public synchronized Map<Integer, TopologyBuilder.TopicsInfo> topicGroups() {
+        final Map<Integer, TopologyBuilder.TopicsInfo> topicGroups = new LinkedHashMap<>();
+
+        if (nodeGroups == null) {
+            nodeGroups = makeNodeGroups();
+        }
+
+        for (final Map.Entry<Integer, Set<String>> entry : nodeGroups.entrySet()) {
+            final Set<String> sinkTopics = new HashSet<>();
+            final Set<String> sourceTopics = new HashSet<>();
+            final Map<String, InternalTopicConfig> internalSourceTopics = new HashMap<>();
+            final Map<String, InternalTopicConfig> stateChangelogTopics = new HashMap<>();
+            for (final String node : entry.getValue()) {
+                // if the node is a source node, add to the source topics
+                final List<String> topics = nodeToSourceTopics.get(node);
+                if (topics != null) {
+                    // if some of the topics are internal, add them to the internal topics
+                    for (final String topic : topics) {
+                        // skip global topic as they don't need partition assignment
+                        if (globalTopics.contains(topic)) {
+                            continue;
+                        }
+                        if (this.internalTopicNames.contains(topic)) {
+                            // prefix the internal topic name with the application id
+                            final String internalTopic = decorateTopic(topic);
+                            internalSourceTopics.put(internalTopic, new InternalTopicConfig(internalTopic,
+                                                                                            Collections.singleton(InternalTopicConfig.CleanupPolicy.delete),
+                                                                                            Collections.<String, String>emptyMap()));
+                            sourceTopics.add(internalTopic);
+                        } else {
+                            sourceTopics.add(topic);
+                        }
+                    }
+                }
+
+                // if the node is a sink node, add to the sink topics
+                final String topic = nodeToSinkTopic.get(node);
+                if (topic != null) {
+                    if (internalTopicNames.contains(topic)) {
+                        // prefix the change log topic name with the application id
+                        sinkTopics.add(decorateTopic(topic));
+                    } else {
+                        sinkTopics.add(topic);
+                    }
+                }
+
+                // if the node is connected to a state, add to the state topics
+                for (final StateStoreFactory stateFactory : stateFactories.values()) {
+                    final StateStoreSupplier supplier = stateFactory.supplier;
+                    if (supplier.loggingEnabled() && stateFactory.users.contains(node)) {
+                        final String name = ProcessorStateManager.storeChangelogTopic(applicationId, supplier.name());
+                        final InternalTopicConfig internalTopicConfig = createInternalTopicConfig(supplier, name);
+                        stateChangelogTopics.put(name, internalTopicConfig);
+                    }
+                }
+            }
+            if (!sourceTopics.isEmpty()) {
+                topicGroups.put(entry.getKey(), new TopologyBuilder.TopicsInfo(
+                        Collections.unmodifiableSet(sinkTopics),
+                        Collections.unmodifiableSet(sourceTopics),
+                        Collections.unmodifiableMap(internalSourceTopics),
+                        Collections.unmodifiableMap(stateChangelogTopics)));
+            }
+        }
+
+        return Collections.unmodifiableMap(topicGroups);
+    }
+
+    private void setRegexMatchedTopicsToSourceNodes() {
+        if (subscriptionUpdates.hasUpdates()) {
+            for (final Map.Entry<String, Pattern> stringPatternEntry : nodeToSourcePatterns.entrySet()) {
+                final SourceNodeFactory sourceNode = (SourceNodeFactory) nodeFactories.get(stringPatternEntry.getKey());
+                //need to update nodeToSourceTopics with topics matched from given regex
+                nodeToSourceTopics.put(stringPatternEntry.getKey(), sourceNode.getTopics(subscriptionUpdates.getUpdates()));
+                log.debug("nodeToSourceTopics {}", nodeToSourceTopics);
+            }
+        }
+    }
+
+    private void setRegexMatchedTopicToStateStore() {
+        if (subscriptionUpdates.hasUpdates()) {
+            for (final Map.Entry<String, Set<Pattern>> storePattern : stateStoreNameToSourceRegex.entrySet()) {
+                final Set<String> updatedTopicsForStateStore = new HashSet<>();
+                for (final String subscriptionUpdateTopic : subscriptionUpdates.getUpdates()) {
+                    for (final Pattern pattern : storePattern.getValue()) {
+                        if (pattern.matcher(subscriptionUpdateTopic).matches()) {
+                            updatedTopicsForStateStore.add(subscriptionUpdateTopic);
+                        }
+                    }
+                }
+                if (!updatedTopicsForStateStore.isEmpty()) {
+                    final Collection<String> storeTopics = stateStoreNameToSourceTopics.get(storePattern.getKey());
+                    if (storeTopics != null) {
+                        updatedTopicsForStateStore.addAll(storeTopics);
+                    }
+                    stateStoreNameToSourceTopics.put(storePattern.getKey(), Collections.unmodifiableSet(updatedTopicsForStateStore));
+                }
+            }
+        }
+    }
+    
+    private InternalTopicConfig createInternalTopicConfig(final StateStoreSupplier<?> supplier,
+                                                          final String name) {
+        if (!(supplier instanceof WindowStoreSupplier)) {
+            return new InternalTopicConfig(name, Collections.singleton(InternalTopicConfig.CleanupPolicy.compact), supplier.logConfig());
+        }
+
+        final WindowStoreSupplier windowStoreSupplier = (WindowStoreSupplier) supplier;
+        final InternalTopicConfig config = new InternalTopicConfig(name,
+                                                                   Utils.mkSet(InternalTopicConfig.CleanupPolicy.compact,
+                                                                           InternalTopicConfig.CleanupPolicy.delete),
+                                                                   supplier.logConfig());
+        config.setRetentionMs(windowStoreSupplier.retentionPeriod());
+        return config;
+    }
+
+    public synchronized Pattern earliestResetTopicsPattern() {
+        final List<String> topics = maybeDecorateInternalSourceTopics(earliestResetTopics);
+        final Pattern earliestPattern =  buildPatternForOffsetResetTopics(topics, earliestResetPatterns);
+
+        ensureNoRegexOverlap(earliestPattern, latestResetPatterns, latestResetTopics);
+
+        return earliestPattern;
+    }
+
+    public synchronized Pattern latestResetTopicsPattern() {
+        final List<String> topics = maybeDecorateInternalSourceTopics(latestResetTopics);
+        final Pattern latestPattern = buildPatternForOffsetResetTopics(topics, latestResetPatterns);
+
+        ensureNoRegexOverlap(latestPattern, earliestResetPatterns, earliestResetTopics);
+
+        return  latestPattern;
+    }
+
+    private void ensureNoRegexOverlap(final Pattern builtPattern,
+                                      final Set<Pattern> otherPatterns,
+                                      final Set<String> otherTopics) {
+        for (final Pattern otherPattern : otherPatterns) {
+            if (builtPattern.pattern().contains(otherPattern.pattern())) {
+                throw new TopologyBuilderException(
+                    String.format("Found overlapping regex [%s] against [%s] for a KStream with auto offset resets",
+                        otherPattern.pattern(),
+                        builtPattern.pattern()));
+            }
+        }
+
+        for (final String otherTopic : otherTopics) {
+            if (builtPattern.matcher(otherTopic).matches()) {
+                throw new TopologyBuilderException(
+                    String.format("Found overlapping regex [%s] matching topic [%s] for a KStream with auto offset resets",
+                        builtPattern.pattern(),
+                        otherTopic));
+            }
+        }
+    }
+
+    private static Pattern buildPatternForOffsetResetTopics(final Collection<String> sourceTopics,
+                                                            final Collection<Pattern> sourcePatterns) {
+        final StringBuilder builder = new StringBuilder();
+
+        for (final String topic : sourceTopics) {
+            builder.append(topic).append("|");
+        }
+
+        for (final Pattern sourcePattern : sourcePatterns) {
+            builder.append(sourcePattern.pattern()).append("|");
+        }
+
+        if (builder.length() > 0) {
+            builder.setLength(builder.length() - 1);
+            return Pattern.compile(builder.toString());
+        }
+
+        return EMPTY_ZERO_LENGTH_PATTERN;
+    }
+
+    public Map<String, List<String>> stateStoreNameToSourceTopics() {
+        final Map<String, List<String>> results = new HashMap<>();
+        for (final Map.Entry<String, Set<String>> entry : stateStoreNameToSourceTopics.entrySet()) {
+            results.put(entry.getKey(), maybeDecorateInternalSourceTopics(entry.getValue()));
+        }
+        return results;
+    }
+
+    public synchronized Collection<Set<String>> copartitionGroups() {
+        final List<Set<String>> list = new ArrayList<>(copartitionSourceGroups.size());
+        for (final Set<String> nodeNames : copartitionSourceGroups) {
+            final Set<String> copartitionGroup = new HashSet<>();
+            for (final String node : nodeNames) {
+                final List<String> topics = nodeToSourceTopics.get(node);
+                if (topics != null) {
+                    copartitionGroup.addAll(maybeDecorateInternalSourceTopics(topics));
+                }
+            }
+            list.add(Collections.unmodifiableSet(copartitionGroup));
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    private List<String> maybeDecorateInternalSourceTopics(final Collection<String> sourceTopics) {
+        final List<String> decoratedTopics = new ArrayList<>();
+        for (final String topic : sourceTopics) {
+            if (internalTopicNames.contains(topic)) {
+                decoratedTopics.add(decorateTopic(topic));
+            } else {
+                decoratedTopics.add(topic);
+            }
+        }
+        return decoratedTopics;
+    }
+
+    private String decorateTopic(final String topic) {
+        if (applicationId == null) {
+            throw new TopologyBuilderException("there are internal topics and "
+                    + "applicationId hasn't been set. Call "
+                    + "setApplicationId first");
+        }
+
+        return applicationId + "-" + topic;
+    }
+
+    public SubscriptionUpdates subscriptionUpdates() {
+        return subscriptionUpdates;
+    }
+
+    public synchronized Pattern sourceTopicPattern() {
+        if (topicPattern == null) {
+            final List<String> allSourceTopics = new ArrayList<>();
+            if (!nodeToSourceTopics.isEmpty()) {
+                for (final List<String> topics : nodeToSourceTopics.values()) {
+                    allSourceTopics.addAll(maybeDecorateInternalSourceTopics(topics));
+                }
+            }
+            Collections.sort(allSourceTopics);
+
+            topicPattern = buildPatternForOffsetResetTopics(allSourceTopics, nodeToSourcePatterns.values());
+        }
+
+        return topicPattern;
+    }
+
+    public synchronized void updateSubscriptions(final SubscriptionUpdates subscriptionUpdates,
+                                                 final String threadId) {
+        log.debug("stream-thread [{}] updating builder with {} topic(s) with possible matching regex subscription(s)",
+            threadId, subscriptionUpdates);
+        this.subscriptionUpdates = subscriptionUpdates;
+        setRegexMatchedTopicsToSourceNodes();
+        setRegexMatchedTopicToStateStore();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -1342,12 +1342,12 @@ public class InternalTopologyBuilder {
         }
     }
 
-    public final static class Subtopology implements org.apache.kafka.streams.processor.TopologyDescription.Subtopology {
+    public final static class Subtopology implements org.apache.kafka.streams.TopologyDescription.Subtopology {
         private final int id;
-        private final Set<org.apache.kafka.streams.processor.TopologyDescription.Node> nodes;
+        private final Set<org.apache.kafka.streams.TopologyDescription.Node> nodes;
 
         public Subtopology(final int id,
-                    final Set<org.apache.kafka.streams.processor.TopologyDescription.Node> nodes) {
+                    final Set<org.apache.kafka.streams.TopologyDescription.Node> nodes) {
             this.id = id;
             this.nodes = nodes;
         }
@@ -1358,7 +1358,7 @@ public class InternalTopologyBuilder {
         }
 
         @Override
-        public Set<org.apache.kafka.streams.processor.TopologyDescription.Node> nodes() {
+        public Set<org.apache.kafka.streams.TopologyDescription.Node> nodes() {
             return Collections.unmodifiableSet(nodes);
         }
 
@@ -1369,7 +1369,7 @@ public class InternalTopologyBuilder {
 
         private String nodesAsString() {
             final StringBuilder sb = new StringBuilder();
-            for (final org.apache.kafka.streams.processor.TopologyDescription.Node node : nodes) {
+            for (final org.apache.kafka.streams.TopologyDescription.Node node : nodes) {
                 sb.append("    ");
                 sb.append(node);
                 sb.append('\n');
@@ -1397,25 +1397,25 @@ public class InternalTopologyBuilder {
         }
     }
 
-    public final static class TopologyDescription implements org.apache.kafka.streams.processor.TopologyDescription {
-        private final Set<org.apache.kafka.streams.processor.TopologyDescription.Subtopology> subtopologies = new HashSet<>();
-        private final Set<org.apache.kafka.streams.processor.TopologyDescription.GlobalStore> globalStores = new HashSet<>();
+    public final static class TopologyDescription implements org.apache.kafka.streams.TopologyDescription {
+        private final Set<org.apache.kafka.streams.TopologyDescription.Subtopology> subtopologies = new HashSet<>();
+        private final Set<org.apache.kafka.streams.TopologyDescription.GlobalStore> globalStores = new HashSet<>();
 
-        public void addSubtopology(final org.apache.kafka.streams.processor.TopologyDescription.Subtopology subtopology) {
+        public void addSubtopology(final org.apache.kafka.streams.TopologyDescription.Subtopology subtopology) {
             subtopologies.add(subtopology);
         }
 
-        public void addGlobalStore(final org.apache.kafka.streams.processor.TopologyDescription.GlobalStore globalStore) {
+        public void addGlobalStore(final org.apache.kafka.streams.TopologyDescription.GlobalStore globalStore) {
             globalStores.add(globalStore);
         }
 
         @Override
-        public Set<org.apache.kafka.streams.processor.TopologyDescription.Subtopology> subtopologies() {
+        public Set<org.apache.kafka.streams.TopologyDescription.Subtopology> subtopologies() {
             return Collections.unmodifiableSet(subtopologies);
         }
 
         @Override
-        public Set<org.apache.kafka.streams.processor.TopologyDescription.GlobalStore> globalStores() {
+        public Set<org.apache.kafka.streams.TopologyDescription.GlobalStore> globalStores() {
             return Collections.unmodifiableSet(globalStores);
         }
 
@@ -1430,7 +1430,7 @@ public class InternalTopologyBuilder {
             if (subtopologies.isEmpty()) {
                 sb.append("  none\n");
             } else {
-                for (final org.apache.kafka.streams.processor.TopologyDescription.Subtopology st : subtopologies) {
+                for (final org.apache.kafka.streams.TopologyDescription.Subtopology st : subtopologies) {
                     sb.append("  ");
                     sb.append(st);
                 }
@@ -1444,7 +1444,7 @@ public class InternalTopologyBuilder {
             if (globalStores.isEmpty()) {
                 sb.append("  none\n");
             } else {
-                for (final org.apache.kafka.streams.processor.TopologyDescription.GlobalStore gs : globalStores) {
+                for (final org.apache.kafka.streams.TopologyDescription.GlobalStore gs : globalStores) {
                     sb.append("  ");
                     sb.append(gs);
                 }
@@ -1482,6 +1482,8 @@ public class InternalTopologyBuilder {
             }
             sb.deleteCharAt(sb.length() - 1);
             sb.deleteCharAt(sb.length() - 1);
+        } else {
+            return "none";
         }
         return sb.toString();
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -356,8 +356,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                             if (otherSinkTopics.contains(topicName)) {
                                 // if this topic is one of the sink topics of this topology,
                                 // use the maximum of all its source topic partitions as the number of partitions
-                                for (String sourceTopicName : otherTopicsInfo.sourceTopics) {
-                                    Integer numPartitionsCandidate;
+                                for (final String sourceTopicName : otherTopicsInfo.sourceTopics) {
+                                    final Integer numPartitionsCandidate;
                                     // It is possible the sourceTopic is another internal topic, i.e,
                                     // map().join().join(map())
                                     if (repartitionTopicMetadata.containsKey(sourceTopicName)) {
@@ -377,10 +377,11 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                         }
                         // if we still have not find the right number of partitions,
                         // another iteration is needed
-                        if (numPartitions == UNKNOWN)
+                        if (numPartitions == UNKNOWN) {
                             numPartitionsNeeded = true;
-                        else
+                        } else {
                             repartitionTopicMetadata.get(topicName).numPartitions = numPartitions;
+                        }
                     }
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -34,9 +34,9 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Count;
-import org.apache.kafka.common.metrics.stats.Sum;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.Sum;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
@@ -45,7 +45,6 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskIdFormatException;
 import org.apache.kafka.streams.processor.PartitionGrouper;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.slf4j.Logger;
@@ -398,7 +397,7 @@ public class StreamThread extends Thread {
     public final UUID processId;
 
     protected final StreamsConfig config;
-    protected final TopologyBuilder builder;
+    protected final InternalTopologyBuilder builder;
     Producer<byte[], byte[]> threadProducer;
     private final KafkaClientSupplier clientSupplier;
     protected final Consumer<byte[], byte[]> consumer;
@@ -441,7 +440,7 @@ public class StreamThread extends Thread {
     final ConsumerRebalanceListener rebalanceListener;
     private final static int UNLIMITED_RECORDS = -1;
 
-    public StreamThread(final TopologyBuilder builder,
+    public StreamThread(final InternalTopologyBuilder builder,
                         final StreamsConfig config,
                         final KafkaClientSupplier clientSupplier,
                         final String applicationId,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
-import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.StreamsMetadata;
 
@@ -44,14 +43,14 @@ import java.util.Set;
  */
 public class StreamsMetadataState {
     public static final HostInfo UNKNOWN_HOST = new HostInfo("unknown", -1);
-    private final TopologyBuilder builder;
+    private final InternalTopologyBuilder builder;
     private final List<StreamsMetadata> allMetadata = new ArrayList<>();
     private final Set<String> globalStores;
     private final HostInfo thisHost;
     private Cluster clusterMetadata;
     private StreamsMetadata myMetadata;
 
-    public StreamsMetadataState(final TopologyBuilder builder, final HostInfo thisHost) {
+    public StreamsMetadataState(final InternalTopologyBuilder builder, final HostInfo thisHost) {
         this.builder = builder;
         this.globalStores = builder.globalStateStores().keySet();
         this.thisHost = thisHost;

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * Factory for creating state stores in Kafka Streams.
  */
 @InterfaceStability.Evolving
-public class  Stores {
+public class Stores {
 
     private static final Logger log = LoggerFactory.getLogger(Stores.class);
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -36,7 +36,7 @@ import java.util.Map;
  * Factory for creating state stores in Kafka Streams.
  */
 @InterfaceStability.Evolving
-public class Stores {
+public class  Stores {
 
     private static final Logger log = LoggerFactory.getLogger(Stores.class);
 

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -81,7 +81,7 @@ public class KafkaStreamsTest {
         final KStreamBuilder builder = new KStreamBuilder();
         final KafkaStreams streams = new KafkaStreams(builder, props);
 
-        StateListenerStub stateListener = new StateListenerStub();
+        final StateListenerStub stateListener = new StateListenerStub();
         streams.setStateListener(stateListener);
         Assert.assertEquals(streams.state(), KafkaStreams.State.CREATED);
         Assert.assertEquals(stateListener.numChanges, 0);
@@ -102,7 +102,7 @@ public class KafkaStreamsTest {
         final KStreamBuilder builder = new KStreamBuilder();
         final KafkaStreams streams = new KafkaStreams(builder, props);
 
-        StateListenerStub stateListener = new StateListenerStub();
+        final StateListenerStub stateListener = new StateListenerStub();
         streams.setStateListener(stateListener);
         streams.close();
         Assert.assertEquals(streams.state(), KafkaStreams.State.NOT_RUNNING);
@@ -161,7 +161,7 @@ public class KafkaStreamsTest {
 
         final java.lang.reflect.Field globalThreadField = streams.getClass().getDeclaredField("globalStreamThread");
         globalThreadField.setAccessible(true);
-        GlobalStreamThread globalStreamThread = (GlobalStreamThread) globalThreadField.get(streams);
+        final GlobalStreamThread globalStreamThread = (GlobalStreamThread) globalThreadField.get(streams);
         assertEquals(globalStreamThread, null);
     }
 
@@ -269,8 +269,7 @@ public class KafkaStreamsTest {
         props.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         props.setProperty(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, "illegalConfig");
         final KStreamBuilder builder = new KStreamBuilder();
-        final KafkaStreams streams = new KafkaStreams(builder, props);
-
+        new KafkaStreams(builder, props);
     }
 
     @Test
@@ -285,8 +284,7 @@ public class KafkaStreamsTest {
 
         props.setProperty(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, Sensor.RecordingLevel.DEBUG.toString());
         final KStreamBuilder builder2 = new KStreamBuilder();
-        final KafkaStreams streams2 = new KafkaStreams(builder2, props);
-
+        new KafkaStreams(builder2, props);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -337,7 +335,7 @@ public class KafkaStreamsTest {
                                 while (keepRunning.get()) {
                                     Thread.sleep(10);
                                 }
-                            } catch (InterruptedException e) {
+                            } catch (final InterruptedException e) {
                                 // no-op
                             }
                         }
@@ -415,29 +413,28 @@ public class KafkaStreamsTest {
     @Test
     public void testToString() {
         streams.start();
-        String streamString = streams.toString();
+        final String streamString = streams.toString();
         streams.close();
-        String appId = streamString.split("\\n")[1].split(":")[1].trim();
+        final String appId = streamString.split("\\n")[1].split(":")[1].trim();
         Assert.assertNotEquals("streamString should not be empty", "", streamString);
         Assert.assertNotNull("streamString should not be null", streamString);
         Assert.assertNotEquals("streamString contains non-empty appId", "", appId);
         Assert.assertNotNull("streamString contains non-null appId", appId);
     }
 
-
     public static class StateListenerStub implements KafkaStreams.StateListener {
-        public int numChanges = 0;
-        public KafkaStreams.State oldState;
-        public KafkaStreams.State newState;
+        int numChanges = 0;
+        KafkaStreams.State oldState;
+        KafkaStreams.State newState;
         public Map<KafkaStreams.State, Long> mapStates = new HashMap<>();
 
         @Override
         public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
-            long prevCount = this.mapStates.containsKey(newState) ? this.mapStates.get(newState) : 0;
-            this.numChanges++;
+            final long prevCount = mapStates.containsKey(newState) ? mapStates.get(newState) : 0;
+            numChanges++;
             this.oldState = oldState;
             this.newState = newState;
-            this.mapStates.put(newState, prevCount + 1);
+            mapStates.put(newState, prevCount + 1);
         }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RegexSourceIntegrationTest.java
@@ -36,12 +36,13 @@ import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
+import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockStateStoreSupplier;
-import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
@@ -152,9 +153,15 @@ public class RegexSourceIntegrationTest {
         final StreamThread[] streamThreads = (StreamThread[]) streamThreadsField.get(streams);
         final StreamThread originalThread = streamThreads[0];
 
-        final TestStreamThread testStreamThread = new TestStreamThread(builder, streamsConfig,
+        final TestStreamThread testStreamThread = new TestStreamThread(
+            builder.internalTopologyBuilder,
+            streamsConfig,
             new DefaultKafkaClientSupplier(),
-            originalThread.applicationId, originalThread.clientId, originalThread.processId, new Metrics(), Time.SYSTEM);
+            originalThread.applicationId,
+            originalThread.clientId,
+            originalThread.processId,
+            new Metrics(),
+            Time.SYSTEM);
 
         final TestCondition oneTopicAdded = new TestCondition() {
             @Override
@@ -206,9 +213,15 @@ public class RegexSourceIntegrationTest {
         final StreamThread[] streamThreads = (StreamThread[]) streamThreadsField.get(streams);
         final StreamThread originalThread = streamThreads[0];
 
-        final TestStreamThread testStreamThread = new TestStreamThread(builder, streamsConfig,
+        final TestStreamThread testStreamThread = new TestStreamThread(
+            builder.internalTopologyBuilder,
+            streamsConfig,
             new DefaultKafkaClientSupplier(),
-            originalThread.applicationId, originalThread.clientId, originalThread.processId, new Metrics(), Time.SYSTEM);
+            originalThread.applicationId,
+            originalThread.clientId,
+            originalThread.processId,
+            new Metrics(),
+            Time.SYSTEM);
 
         streamThreads[0] = testStreamThread;
 
@@ -347,9 +360,15 @@ public class RegexSourceIntegrationTest {
         final StreamThread[] leaderStreamThreads = (StreamThread[]) leaderStreamThreadsField.get(partitionedStreamsLeader);
         final StreamThread originalLeaderThread = leaderStreamThreads[0];
 
-        final TestStreamThread leaderTestStreamThread = new TestStreamThread(builderLeader, streamsConfig,
-                new DefaultKafkaClientSupplier(),
-                originalLeaderThread.applicationId, originalLeaderThread.clientId, originalLeaderThread.processId, new Metrics(), Time.SYSTEM);
+        final TestStreamThread leaderTestStreamThread = new TestStreamThread(
+            builderLeader.internalTopologyBuilder,
+            streamsConfig,
+            new DefaultKafkaClientSupplier(),
+            originalLeaderThread.applicationId,
+            originalLeaderThread.clientId,
+            originalLeaderThread.processId,
+            new Metrics(),
+            Time.SYSTEM);
 
         leaderStreamThreads[0] = leaderTestStreamThread;
 
@@ -367,9 +386,15 @@ public class RegexSourceIntegrationTest {
         final StreamThread[] followerStreamThreads = (StreamThread[]) followerStreamThreadsField.get(partitionedStreamsFollower);
         final StreamThread originalFollowerThread = followerStreamThreads[0];
 
-        final TestStreamThread followerTestStreamThread = new TestStreamThread(builderFollower, streamsConfig,
-                new DefaultKafkaClientSupplier(),
-                originalFollowerThread.applicationId, originalFollowerThread.clientId, originalFollowerThread.processId, new Metrics(), Time.SYSTEM);
+        final TestStreamThread followerTestStreamThread = new TestStreamThread(
+            builderFollower.internalTopologyBuilder,
+            streamsConfig,
+            new DefaultKafkaClientSupplier(),
+            originalFollowerThread.applicationId,
+            originalFollowerThread.clientId,
+            originalFollowerThread.processId,
+            new Metrics(),
+            Time.SYSTEM);
 
         followerStreamThreads[0] = followerTestStreamThread;
 
@@ -438,7 +463,7 @@ public class RegexSourceIntegrationTest {
     private class TestStreamThread extends StreamThread {
         public volatile List<String> assignedTopicPartitions = new ArrayList<>();
 
-        public TestStreamThread(final TopologyBuilder builder, final StreamsConfig config, final KafkaClientSupplier clientSupplier, final String applicationId, final String clientId, final UUID processId, final Metrics metrics, final Time time) {
+        public TestStreamThread(final InternalTopologyBuilder builder, final StreamsConfig config, final KafkaClientSupplier clientSupplier, final String applicationId, final String clientId, final UUID processId, final Metrics metrics, final Time time) {
             super(builder, config, clientSupplier, applicationId, clientId, processId, metrics, time, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
                   0);
         }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor;
 
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockStateStoreSupplier;
 import org.junit.Test;
@@ -29,11 +30,11 @@ import java.util.regex.Pattern;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-// TODO (remove this comment) Test name ok, we just use TopologyBuilder for now in this test until Topology gets added
+// TODO (remove this comment) Test name ok, we just use InternalTopologyBuilder for now in this test until Topology gets added
 public class TopologyTest {
-    // TODO change from TopologyBuilder to Topology
-    private final TopologyBuilder topology = new TopologyBuilder();
-    private final TopologyDescription expectedDescription = new TopologyDescription();
+    // TODO change from InternalTopologyBuilder to Topology
+    private final InternalTopologyBuilder topology = new InternalTopologyBuilder();
+    private final InternalTopologyBuilder.TopologyDescription expectedDescription = new InternalTopologyBuilder.TopologyDescription();
 
     @Test
     public void shouldDescribeEmptyTopology() {
@@ -45,7 +46,7 @@ public class TopologyTest {
         final TopologyDescription.Source expectedSourceNode = addSource("source", "topic");
 
         expectedDescription.addSubtopology(
-            new TopologyDescription.Subtopology(0,
+            new InternalTopologyBuilder.Subtopology(0,
                 Collections.<TopologyDescription.Node>singleton(expectedSourceNode)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
@@ -56,7 +57,7 @@ public class TopologyTest {
         final TopologyDescription.Source expectedSourceNode = addSource("source", "topic1", "topic2", "topic3");
 
         expectedDescription.addSubtopology(
-            new TopologyDescription.Subtopology(0,
+            new InternalTopologyBuilder.Subtopology(0,
                 Collections.<TopologyDescription.Node>singleton(expectedSourceNode)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
@@ -67,7 +68,7 @@ public class TopologyTest {
         final TopologyDescription.Source expectedSourceNode = addSource("source", Pattern.compile("topic[0-9]"));
 
         expectedDescription.addSubtopology(
-            new TopologyDescription.Subtopology(0,
+            new InternalTopologyBuilder.Subtopology(0,
                 Collections.<TopologyDescription.Node>singleton(expectedSourceNode)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
@@ -77,17 +78,17 @@ public class TopologyTest {
     public void multipleSourcesShouldHaveDistinctSubtopologies() {
         final TopologyDescription.Source expectedSourceNode1 = addSource("source1", "topic1");
         expectedDescription.addSubtopology(
-            new TopologyDescription.Subtopology(0,
+            new InternalTopologyBuilder.Subtopology(0,
                 Collections.<TopologyDescription.Node>singleton(expectedSourceNode1)));
 
         final TopologyDescription.Source expectedSourceNode2 = addSource("source2", "topic2");
         expectedDescription.addSubtopology(
-            new TopologyDescription.Subtopology(1,
+            new InternalTopologyBuilder.Subtopology(1,
                 Collections.<TopologyDescription.Node>singleton(expectedSourceNode2)));
 
         final TopologyDescription.Source expectedSourceNode3 = addSource("source3", "topic3");
         expectedDescription.addSubtopology(
-            new TopologyDescription.Subtopology(2,
+            new InternalTopologyBuilder.Subtopology(2,
                 Collections.<TopologyDescription.Node>singleton(expectedSourceNode3)));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
@@ -101,7 +102,7 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes = new HashSet<>();
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -116,7 +117,7 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes = new HashSet<>();
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -132,7 +133,7 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes = new HashSet<>();
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -147,7 +148,7 @@ public class TopologyTest {
         allNodes.add(expectedSourceNode);
         allNodes.add(expectedProcessorNode1);
         allNodes.add(expectedProcessorNode2);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -162,7 +163,7 @@ public class TopologyTest {
         allNodes.add(expectedSourceNode1);
         allNodes.add(expectedSourceNode2);
         allNodes.add(expectedProcessorNode);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -181,17 +182,17 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes1 = new HashSet<>();
         allNodes1.add(expectedSourceNode1);
         allNodes1.add(expectedProcessorNode1);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes1));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes1));
 
         final Set<TopologyDescription.Node> allNodes2 = new HashSet<>();
         allNodes2.add(expectedSourceNode2);
         allNodes2.add(expectedProcessorNode2);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(1, allNodes2));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(1, allNodes2));
 
         final Set<TopologyDescription.Node> allNodes3 = new HashSet<>();
         allNodes3.add(expectedSourceNode3);
         allNodes3.add(expectedProcessorNode3);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(2, allNodes3));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(2, allNodes3));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -210,17 +211,17 @@ public class TopologyTest {
         final Set<TopologyDescription.Node> allNodes1 = new HashSet<>();
         allNodes1.add(expectedSourceNode1);
         allNodes1.add(expectedSinkNode1);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes1));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes1));
 
         final Set<TopologyDescription.Node> allNodes2 = new HashSet<>();
         allNodes2.add(expectedSourceNode2);
         allNodes2.add(expectedSinkNode2);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(1, allNodes2));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(1, allNodes2));
 
         final Set<TopologyDescription.Node> allNodes3 = new HashSet<>();
         allNodes3.add(expectedSourceNode3);
         allNodes3.add(expectedSinkNode3);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(2, allNodes3));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(2, allNodes3));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -251,7 +252,7 @@ public class TopologyTest {
         allNodes.add(expectedSourceNode3);
         allNodes.add(expectedProcessorNode3);
         allNodes.add(expectedSinkNode);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -281,7 +282,7 @@ public class TopologyTest {
         allNodes.add(expectedProcessorNode2);
         allNodes.add(expectedSourceNode3);
         allNodes.add(expectedProcessorNode3);
-        expectedDescription.addSubtopology(new TopologyDescription.Subtopology(0, allNodes));
+        expectedDescription.addSubtopology(new InternalTopologyBuilder.Subtopology(0, allNodes));
 
         assertThat(topology.describe(), equalTo(expectedDescription));
     }
@@ -301,41 +302,41 @@ public class TopologyTest {
 
     private TopologyDescription.Source addSource(final String sourceName,
                                                  final String... sourceTopic) {
-        topology.addSource(sourceName, sourceTopic);
+        topology.addSource(null, sourceName, null, null, null, sourceTopic);
         String allSourceTopics = sourceTopic[0];
         for (int i = 1; i < sourceTopic.length; ++i) {
             allSourceTopics += ", " + sourceTopic[i];
         }
-        return new TopologyDescription.Source(sourceName, allSourceTopics);
+        return new InternalTopologyBuilder.Source(sourceName, allSourceTopics);
     }
 
     private TopologyDescription.Source addSource(final String sourceName,
                                                  final Pattern sourcePattern) {
-        topology.addSource(sourceName, sourcePattern);
-        return new TopologyDescription.Source(sourceName, sourcePattern.toString());
+        topology.addSource(null, sourceName, null, null, null, sourcePattern);
+        return new InternalTopologyBuilder.Source(sourceName, sourcePattern.toString());
     }
 
     private TopologyDescription.Processor addProcessor(final String processorName,
-                                                       final TopologyDescription.AbstractNode... parents) {
+                                                       final TopologyDescription.Node... parents) {
         return addProcessorWithNewStore(processorName, new String[0], parents);
     }
 
     private TopologyDescription.Processor addProcessorWithNewStore(final String processorName,
                                                                    final String[] storeNames,
-                                                                   final TopologyDescription.AbstractNode... parents) {
+                                                                   final TopologyDescription.Node... parents) {
         return addProcessorWithStore(processorName, storeNames, true, parents);
     }
 
     private TopologyDescription.Processor addProcessorWithExistingStore(final String processorName,
                                                                         final String[] storeNames,
-                                                                        final TopologyDescription.AbstractNode... parents) {
+                                                                        final TopologyDescription.Node... parents) {
         return addProcessorWithStore(processorName, storeNames, false, parents);
     }
 
     private TopologyDescription.Processor addProcessorWithStore(final String processorName,
                                                                 final String[] storeNames,
                                                                 final boolean newStores,
-                                                                final TopologyDescription.AbstractNode... parents) {
+                                                                final TopologyDescription.Node... parents) {
         final String[] parentNames = new String[parents.length];
         for (int i = 0; i < parents.length; ++i) {
             parentNames[i] = parents[i].name();
@@ -350,11 +351,11 @@ public class TopologyTest {
             topology.connectProcessorAndStateStores(processorName, storeNames);
         }
         final TopologyDescription.Processor expectedProcessorNode
-            = new TopologyDescription.Processor(processorName, new HashSet<>(Arrays.asList(storeNames)));
+            = new InternalTopologyBuilder.Processor(processorName, new HashSet<>(Arrays.asList(storeNames)));
 
-        for (final TopologyDescription.AbstractNode parent : parents) {
-            parent.addSuccessor(expectedProcessorNode);
-            expectedProcessorNode.addPredecessor(parent);
+        for (final TopologyDescription.Node parent : parents) {
+            ((InternalTopologyBuilder.AbstractNode) parent).addSuccessor(expectedProcessorNode);
+            ((InternalTopologyBuilder.AbstractNode) expectedProcessorNode).addPredecessor(parent);
         }
 
         return expectedProcessorNode;
@@ -362,19 +363,19 @@ public class TopologyTest {
 
     private TopologyDescription.Sink addSink(final String sinkName,
                                              final String sinkTopic,
-                                             final TopologyDescription.AbstractNode... parents) {
+                                             final TopologyDescription.Node... parents) {
         final String[] parentNames = new String[parents.length];
         for (int i = 0; i < parents.length; ++i) {
             parentNames[i] = parents[i].name();
         }
 
-        topology.addSink(sinkName, sinkTopic, parentNames);
+        topology.addSink(sinkName, sinkTopic, null, null, null, parentNames);
         final TopologyDescription.Sink expectedSinkNode
-            = new TopologyDescription.Sink(sinkName, sinkTopic);
+            = new InternalTopologyBuilder.Sink(sinkName, sinkTopic);
 
-        for (final TopologyDescription.AbstractNode parent : parents) {
-            parent.addSuccessor(expectedSinkNode);
-            expectedSinkNode.addPredecessor(parent);
+        for (final TopologyDescription.Node parent : parents) {
+            ((InternalTopologyBuilder.AbstractNode) parent).addSuccessor(expectedSinkNode);
+            ((InternalTopologyBuilder.AbstractNode) expectedSinkNode).addPredecessor(parent);
         }
 
         return expectedSinkNode;
@@ -389,11 +390,12 @@ public class TopologyTest {
             sourceName,
             null,
             null,
+            null,
             globalTopicName,
             processorName,
             new MockProcessorSupplier());
 
-        final TopologyDescription.GlobalStore expectedGlobalStore = new TopologyDescription.GlobalStore(
+        final TopologyDescription.GlobalStore expectedGlobalStore = new InternalTopologyBuilder.GlobalStore(
             sourceName,
             processorName,
             globalStoreName,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/TopologyTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams.processor;
 
+import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockStateStoreSupplier;

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorTopologyTest.java
@@ -121,9 +121,9 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingSimpleTopology() {
+    public void testDrivingSimpleTopology() throws Exception {
         int partition = 10;
-        driver = new ProcessorTopologyTestDriver(config, createSimpleTopology(partition));
+        driver = new ProcessorTopologyTestDriver(config, createSimpleTopology(partition).internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         assertNextOutputRecord(OUTPUT_TOPIC_1, "key1", "value1", partition);
         assertNoOutputRecord(OUTPUT_TOPIC_2);
@@ -143,8 +143,8 @@ public class ProcessorTopologyTest {
 
 
     @Test
-    public void testDrivingMultiplexingTopology() {
-        driver = new ProcessorTopologyTestDriver(config, createMultiplexingTopology());
+    public void testDrivingMultiplexingTopology() throws Exception {
+        driver = new ProcessorTopologyTestDriver(config, createMultiplexingTopology().internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         assertNextOutputRecord(OUTPUT_TOPIC_1, "key1", "value1(1)");
         assertNextOutputRecord(OUTPUT_TOPIC_2, "key1", "value1(2)");
@@ -165,8 +165,8 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingMultiplexByNameTopology() {
-        driver = new ProcessorTopologyTestDriver(config, createMultiplexByNameTopology());
+    public void testDrivingMultiplexByNameTopology() throws Exception {
+        driver = new ProcessorTopologyTestDriver(config, createMultiplexByNameTopology().internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         assertNextOutputRecord(OUTPUT_TOPIC_1, "key1", "value1(1)");
         assertNextOutputRecord(OUTPUT_TOPIC_2, "key1", "value1(2)");
@@ -187,9 +187,9 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingStatefulTopology() {
+    public void testDrivingStatefulTopology() throws Exception {
         String storeName = "entries";
-        driver = new ProcessorTopologyTestDriver(config, createStatefulTopology(storeName));
+        driver = new ProcessorTopologyTestDriver(config, createStatefulTopology(storeName).internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key2", "value2", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key3", "value3", STRING_SERIALIZER, STRING_SERIALIZER);
@@ -213,7 +213,7 @@ public class ProcessorTopologyTest {
         final TopologyBuilder topologyBuilder = this.builder
                 .addGlobalStore(storeSupplier, global, STRING_DESERIALIZER, STRING_DESERIALIZER, topic, "processor", define(new StatefulProcessor("my-store")));
 
-        driver = new ProcessorTopologyTestDriver(config, topologyBuilder);
+        driver = new ProcessorTopologyTestDriver(config, topologyBuilder.internalTopologyBuilder);
         final KeyValueStore<String, String> globalStore = (KeyValueStore<String, String>) topologyBuilder.globalStateStores().get("my-store");
         driver.process(topic, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(topic, "key2", "value2", STRING_SERIALIZER, STRING_SERIALIZER);
@@ -222,9 +222,9 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingSimpleMultiSourceTopology() {
+    public void testDrivingSimpleMultiSourceTopology() throws Exception {
         int partition = 10;
-        driver = new ProcessorTopologyTestDriver(config, createSimpleMultiSourceTopology(partition));
+        driver = new ProcessorTopologyTestDriver(config, createSimpleMultiSourceTopology(partition).internalTopologyBuilder);
 
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         assertNextOutputRecord(OUTPUT_TOPIC_1, "key1", "value1", partition);
@@ -236,8 +236,8 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingForwardToSourceTopology() {
-        driver = new ProcessorTopologyTestDriver(config, createForwardToSourceTopology());
+    public void testDrivingForwardToSourceTopology() throws Exception {
+        driver = new ProcessorTopologyTestDriver(config, createForwardToSourceTopology().internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key2", "value2", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key3", "value3", STRING_SERIALIZER, STRING_SERIALIZER);
@@ -247,8 +247,8 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingInternalRepartitioningTopology() {
-        driver = new ProcessorTopologyTestDriver(config, createInternalRepartitioningTopology());
+    public void testDrivingInternalRepartitioningTopology() throws Exception {
+        driver = new ProcessorTopologyTestDriver(config, createInternalRepartitioningTopology().internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key2", "value2", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key3", "value3", STRING_SERIALIZER, STRING_SERIALIZER);
@@ -258,8 +258,8 @@ public class ProcessorTopologyTest {
     }
 
     @Test
-    public void testDrivingInternalRepartitioningForwardingTimestampTopology() {
-        driver = new ProcessorTopologyTestDriver(config, createInternalRepartitioningWithValueTimestampTopology());
+    public void testDrivingInternalRepartitioningForwardingTimestampTopology() throws Exception {
+        driver = new ProcessorTopologyTestDriver(config, createInternalRepartitioningWithValueTimestampTopology().internalTopologyBuilder);
         driver.process(INPUT_TOPIC_1, "key1", "value1@1000", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key2", "value2@2000", STRING_SERIALIZER, STRING_SERIALIZER);
         driver.process(INPUT_TOPIC_1, "key3", "value3@3000", STRING_SERIALIZER, STRING_SERIALIZER);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -68,20 +68,20 @@ import static org.junit.Assert.assertThat;
 
 public class StreamPartitionAssignorTest {
 
-    private TopicPartition t1p0 = new TopicPartition("topic1", 0);
-    private TopicPartition t1p1 = new TopicPartition("topic1", 1);
-    private TopicPartition t1p2 = new TopicPartition("topic1", 2);
-    private TopicPartition t2p0 = new TopicPartition("topic2", 0);
-    private TopicPartition t2p1 = new TopicPartition("topic2", 1);
-    private TopicPartition t2p2 = new TopicPartition("topic2", 2);
-    private TopicPartition t3p0 = new TopicPartition("topic3", 0);
-    private TopicPartition t3p1 = new TopicPartition("topic3", 1);
-    private TopicPartition t3p2 = new TopicPartition("topic3", 2);
-    private TopicPartition t3p3 = new TopicPartition("topic3", 3);
+    private final TopicPartition t1p0 = new TopicPartition("topic1", 0);
+    private final TopicPartition t1p1 = new TopicPartition("topic1", 1);
+    private final TopicPartition t1p2 = new TopicPartition("topic1", 2);
+    private final TopicPartition t2p0 = new TopicPartition("topic2", 0);
+    private final TopicPartition t2p1 = new TopicPartition("topic2", 1);
+    private final TopicPartition t2p2 = new TopicPartition("topic2", 2);
+    private final TopicPartition t3p0 = new TopicPartition("topic3", 0);
+    private final TopicPartition t3p1 = new TopicPartition("topic3", 1);
+    private final TopicPartition t3p2 = new TopicPartition("topic3", 2);
+    private final TopicPartition t3p3 = new TopicPartition("topic3", 3);
 
-    private Set<String> allTopics = Utils.mkSet("topic1", "topic2");
+    private final Set<String> allTopics = Utils.mkSet("topic1", "topic2");
 
-    private List<PartitionInfo> infos = Arrays.asList(
+    private final List<PartitionInfo> infos = Arrays.asList(
             new PartitionInfo("topic1", 0, Node.noNode(), new Node[0], new Node[0]),
             new PartitionInfo("topic1", 1, Node.noNode(), new Node[0], new Node[0]),
             new PartitionInfo("topic1", 2, Node.noNode(), new Node[0], new Node[0]),
@@ -94,8 +94,11 @@ public class StreamPartitionAssignorTest {
             new PartitionInfo("topic3", 3, Node.noNode(), new Node[0], new Node[0])
     );
 
-    private Cluster metadata = new Cluster("cluster", Collections.singletonList(Node.noNode()), infos, Collections.<String>emptySet(),
-            Collections.<String>emptySet());
+    private final Cluster metadata = new Cluster(
+        "cluster",
+        Collections.singletonList(Node.noNode()),
+        infos, Collections.<String>emptySet(),
+        Collections.<String>emptySet());
 
     private final TaskId task0 = new TaskId(0, 0);
     private final TaskId task1 = new TaskId(0, 1);
@@ -104,7 +107,7 @@ public class StreamPartitionAssignorTest {
     private final String userEndPoint = "localhost:2171";
     private final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
     private final MockClientSupplier mockClientSupplier = new MockClientSupplier();
-    private final TopologyBuilder builder = new TopologyBuilder();
+    private final InternalTopologyBuilder builder = new InternalTopologyBuilder();
     private final StreamsConfig config = new StreamsConfig(configProps());
     private final StreamThread mockStreamThread = new StreamThread(builder, config,
                                                                    mockClientSupplier, "appID",
@@ -133,8 +136,8 @@ public class StreamPartitionAssignorTest {
 
     @Test
     public void testSubscription() throws Exception {
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
 
         final Set<TaskId> prevTasks = Utils.mkSet(
@@ -145,8 +148,19 @@ public class StreamPartitionAssignorTest {
 
         String clientId = "client-id";
         UUID processId = UUID.randomUUID();
-        StreamThread thread = new StreamThread(builder, config, new MockClientSupplier(), "test", clientId, processId, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                               0) {
+        StreamThread thread = new StreamThread(
+            builder,
+            config,
+            new MockClientSupplier(),
+            "test",
+            clientId,
+            processId,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder,
+                StreamsMetadataState.UNKNOWN_HOST),
+            0) {
+
             @Override
             public Set<TaskId> prevActiveTasks() {
                 return prevTasks;
@@ -173,8 +187,8 @@ public class StreamPartitionAssignorTest {
 
     @Test
     public void testAssignBasic() throws Exception {
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
         List<String> topics = Utils.mkList("topic1", "topic2");
         Set<TaskId> allTasks = Utils.mkSet(task0, task1, task2);
@@ -191,8 +205,17 @@ public class StreamPartitionAssignorTest {
         String client1 = "client1";
 
 
-        StreamThread thread10 = new StreamThread(builder, config, mockClientSupplier, "test", client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            "test",
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, "test", client1));
@@ -245,10 +268,10 @@ public class StreamPartitionAssignorTest {
         props.put(StreamsConfig.PARTITION_GROUPER_CLASS_CONFIG, SingleGroupPartitionGrouperStub.class);
         StreamsConfig config = new StreamsConfig(props);
 
-        builder.addSource("source1", "topic1");
+        builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
         builder.addStateStore(new MockStateStoreSupplier("store1", false), "processor1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor2", new MockProcessorSupplier(), "source2");
         builder.addStateStore(new MockStateStoreSupplier("store2", false), "processor2");
         List<String> topics = Utils.mkList("topic1", "topic2");
@@ -257,7 +280,17 @@ public class StreamPartitionAssignorTest {
         UUID uuid1 = UUID.randomUUID();
         String client1 = "client1";
 
-        StreamThread thread10 = new StreamThread(builder, config, mockClientSupplier, "test", client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            "test",
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, "test", client1));
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(thread10.config, mockClientSupplier.restoreConsumer));
@@ -281,8 +314,8 @@ public class StreamPartitionAssignorTest {
 
     @Test
     public void testAssignEmptyMetadata() throws Exception {
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
         List<String> topics = Utils.mkList("topic1", "topic2");
         Set<TaskId> allTasks = Utils.mkSet(task0, task1, task2);
@@ -296,7 +329,17 @@ public class StreamPartitionAssignorTest {
         UUID uuid1 = UUID.randomUUID();
         String client1 = "client1";
 
-        StreamThread thread10 = new StreamThread(builder, config, new MockClientSupplier(), "test", client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            new MockClientSupplier(),
+            "test",
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, "test", client1));
 
@@ -338,9 +381,9 @@ public class StreamPartitionAssignorTest {
 
     @Test
     public void testAssignWithNewTasks() throws Exception {
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
-        builder.addSource("source3", "topic3");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
+        builder.addSource(null, "source3", null, null, null, "topic3");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2", "source3");
         List<String> topics = Utils.mkList("topic1", "topic2", "topic3");
         Set<TaskId> allTasks = Utils.mkSet(task0, task1, task2, task3);
@@ -354,8 +397,17 @@ public class StreamPartitionAssignorTest {
         UUID uuid2 = UUID.randomUUID();
         String client1 = "client1";
 
-        StreamThread thread10 = new StreamThread(builder, config, mockClientSupplier, "test", client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            "test",
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, "test", client1));
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(thread10.config, mockClientSupplier.restoreConsumer));
@@ -397,8 +449,8 @@ public class StreamPartitionAssignorTest {
     public void testAssignWithStates() throws Exception {
         String applicationId = "test";
         builder.setApplicationId(applicationId);
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
 
         builder.addProcessor("processor-1", new MockProcessorSupplier(), "source1");
         builder.addStateStore(new MockStateStoreSupplier("store1", false), "processor-1");
@@ -422,8 +474,17 @@ public class StreamPartitionAssignorTest {
         String client1 = "client1";
 
 
-        StreamThread thread10 = new StreamThread(builder, config, mockClientSupplier, applicationId, client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, applicationId, client1));
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(thread10.config, mockClientSupplier.restoreConsumer));
@@ -488,8 +549,8 @@ public class StreamPartitionAssignorTest {
         props.setProperty(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, "1");
         StreamsConfig config = new StreamsConfig(props);
 
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
         List<String> topics = Utils.mkList("topic1", "topic2");
         Set<TaskId> allTasks = Utils.mkSet(task0, task1, task2);
@@ -506,8 +567,17 @@ public class StreamPartitionAssignorTest {
         UUID uuid2 = UUID.randomUUID();
         String client1 = "client1";
 
-        StreamThread thread10 = new StreamThread(builder, config, mockClientSupplier, "test", client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            "test",
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, "test", client1));
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(thread10.config, mockClientSupplier.restoreConsumer));
@@ -559,16 +629,24 @@ public class StreamPartitionAssignorTest {
     public void testOnAssignment() throws Exception {
         TopicPartition t2p3 = new TopicPartition("topic2", 3);
 
-        TopologyBuilder builder = new TopologyBuilder();
-        builder.addSource("source1", "topic1");
-        builder.addSource("source2", "topic2");
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source1", "source2");
 
         UUID uuid = UUID.randomUUID();
         String client1 = "client1";
 
-        StreamThread thread = new StreamThread(builder, config, mockClientSupplier, "test", client1, uuid, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                               0);
+        StreamThread thread = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            "test",
+            client1,
+            uuid,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread, "test", client1));
 
@@ -593,10 +671,10 @@ public class StreamPartitionAssignorTest {
         String applicationId = "test";
         builder.setApplicationId(applicationId);
         builder.addInternalTopic("topicX");
-        builder.addSource("source1", "topic1");
+        builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
-        builder.addSink("sink1", "topicX", "processor1");
-        builder.addSource("source2", "topicX");
+        builder.addSink("sink1", "topicX", null, null, null, "processor1");
+        builder.addSource(null, "source2", null, null, null, "topicX");
         builder.addProcessor("processor2", new MockProcessorSupplier(), "source2");
         List<String> topics = Utils.mkList("topic1", "test-topicX");
         Set<TaskId> allTasks = Utils.mkSet(task0, task1, task2);
@@ -605,8 +683,17 @@ public class StreamPartitionAssignorTest {
         String client1 = "client1";
 
 
-        StreamThread thread10 = new StreamThread(builder, config, mockClientSupplier, applicationId, client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                 0);
+        StreamThread thread10 = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(thread10, applicationId, client1));
         MockInternalTopicManager internalTopicManager = new MockInternalTopicManager(thread10.config, mockClientSupplier.restoreConsumer);
@@ -629,14 +716,14 @@ public class StreamPartitionAssignorTest {
         String applicationId = "test";
         builder.setApplicationId(applicationId);
         builder.addInternalTopic("topicX");
-        builder.addSource("source1", "topic1");
+        builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addProcessor("processor1", new MockProcessorSupplier(), "source1");
-        builder.addSink("sink1", "topicX", "processor1");
-        builder.addSource("source2", "topicX");
+        builder.addSink("sink1", "topicX", null, null, null, "processor1");
+        builder.addSource(null, "source2", null, null, null, "topicX");
         builder.addInternalTopic("topicZ");
         builder.addProcessor("processor2", new MockProcessorSupplier(), "source2");
-        builder.addSink("sink2", "topicZ", "processor2");
-        builder.addSource("source3", "topicZ");
+        builder.addSink("sink2", "topicZ", null, null, null, "processor2");
+        builder.addSource(null, "source3", null, null, null, "topicZ");
         List<String> topics = Utils.mkList("topic1", "test-topicX", "test-topicZ");
         Set<TaskId> allTasks = Utils.mkSet(task0, task1, task2);
 
@@ -669,9 +756,9 @@ public class StreamPartitionAssignorTest {
         final StreamsConfig config = new StreamsConfig(properties);
         final String applicationId = "application-id";
         builder.setApplicationId(applicationId);
-        builder.addSource("source", "input");
+        builder.addSource(null, "source", null, null, null, "input");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source");
-        builder.addSink("sink", "output", "processor");
+        builder.addSink("sink", "output", null, null, null, "processor");
 
         final UUID uuid1 = UUID.randomUUID();
         final String client1 = "client1";
@@ -693,17 +780,26 @@ public class StreamPartitionAssignorTest {
         final StreamsConfig config = new StreamsConfig(properties);
         final String applicationId = "application-id";
         builder.setApplicationId(applicationId);
-        builder.addSource("source", "topic1");
+        builder.addSource(null, "source", null, null, null, "topic1");
         builder.addProcessor("processor", new MockProcessorSupplier(), "source");
-        builder.addSink("sink", "output", "processor");
+        builder.addSink("sink", "output", null, null, null, "processor");
 
         final List<String> topics = Utils.mkList("topic1");
 
         final UUID uuid1 = UUID.randomUUID();
         final String client1 = "client1";
 
-        final StreamThread streamThread = new StreamThread(builder, config, mockClientSupplier, applicationId, client1, uuid1, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                           0);
+        final StreamThread streamThread = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
         partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client1));
@@ -734,9 +830,17 @@ public class StreamPartitionAssignorTest {
         final String applicationId = "application-id";
         builder.setApplicationId(applicationId);
 
-        final StreamThread streamThread = new StreamThread(builder, config, mockClientSupplier, applicationId, client1, uuid1,
-                                                           new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                           0);
+        final StreamThread streamThread = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamThread.config, mockClientSupplier.restoreConsumer));
 
@@ -760,9 +864,17 @@ public class StreamPartitionAssignorTest {
         builder.setApplicationId(applicationId);
 
 
-        final StreamThread streamThread = new StreamThread(builder, config, mockClientSupplier, applicationId, client1, uuid1,
-                                                           new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
-                                                           0);
+        final StreamThread streamThread = new StreamThread(
+            builder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client1,
+            uuid1,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         try {
             partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client1));
@@ -874,10 +986,22 @@ public class StreamPartitionAssignorTest {
         final UUID uuid = UUID.randomUUID();
         final String client = "client1";
 
-        final StreamThread streamThread = new StreamThread(builder, config, mockClientSupplier, applicationId, client, uuid, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0);
+        final StreamThread streamThread = new StreamThread(
+            builder.internalTopologyBuilder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client,
+            uuid,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client));
-        final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(streamThread.config, mockClientSupplier.restoreConsumer);
+        final MockInternalTopicManager mockInternalTopicManager = new MockInternalTopicManager(
+            streamThread.config,
+            mockClientSupplier.restoreConsumer);
         partitionAssignor.setInternalTopicManager(mockInternalTopicManager);
 
         final Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
@@ -953,10 +1077,22 @@ public class StreamPartitionAssignorTest {
         final UUID uuid = UUID.randomUUID();
         final String client = "client1";
 
-        final StreamThread streamThread = new StreamThread(builder, config, mockClientSupplier, applicationId, client, uuid, new Metrics(), Time.SYSTEM, new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0);
+        final StreamThread streamThread = new StreamThread(
+            builder.internalTopologyBuilder,
+            config,
+            mockClientSupplier,
+            applicationId,
+            client,
+            uuid,
+            new Metrics(),
+            Time.SYSTEM,
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
+            0);
 
         partitionAssignor.configure(config.getConsumerConfigs(streamThread, applicationId, client));
-        partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamThread.config, mockClientSupplier.restoreConsumer));
+        partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(
+            streamThread.config,
+            mockClientSupplier.restoreConsumer));
 
         final Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
         final Set<TaskId> emptyTasks = Collections.emptySet();
@@ -1046,9 +1182,10 @@ public class StreamPartitionAssignorTest {
             }
         }
 
-        if (info.standbyTasks.size() > 0)
+        if (info.standbyTasks.size() > 0) {
             // check if standby partitions cover all topics
             assertEquals(expectedTopics, standbyTopics);
+        }
 
         return info;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -36,7 +36,6 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.TopologyBuilder;
 import org.apache.kafka.streams.processor.internals.assignment.AssignmentInfo;
 import org.apache.kafka.streams.state.HostInfo;
 import org.apache.kafka.streams.state.Stores;
@@ -98,6 +97,7 @@ public class StreamThreadTest {
     @Before
     public void setUp() throws Exception {
         processId = UUID.randomUUID();
+        builder.setApplicationId(applicationId);
     }
 
     private final TopicPartition t1p1 = new TopicPartition("topic1", 1);
@@ -442,7 +442,7 @@ public class StreamThreadTest {
     public void testStateChangeStartClose() throws InterruptedException {
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -450,7 +450,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             Time.SYSTEM,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final StateListenerStub stateListener = new StateListenerStub();
@@ -494,7 +494,7 @@ public class StreamThreadTest {
         //clientSupplier.consumer.assign(Arrays.asList(new TopicPartition(TOPIC, 0), new TopicPartition(TOPIC, 1)));
 
         final StreamThread thread1 = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -502,10 +502,10 @@ public class StreamThreadTest {
             processId,
             metrics,
             Time.SYSTEM,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
         final StreamThread thread2 = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -513,7 +513,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             Time.SYSTEM,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final Map<TaskId, Set<TopicPartition>> task0 = Collections.singletonMap(new TaskId(0, 0), task0Assignment);
@@ -617,7 +617,7 @@ public class StreamThreadTest {
     @Test
     public void testMetrics() {
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -625,7 +625,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
         final String defaultGroupName = "stream-metrics";
         final String defaultPrefix = "thread." + thread.threadClientId();
@@ -678,7 +678,7 @@ public class StreamThreadTest {
             extraDir.mkdir();
             builder.addSource("source1", "topic1");
             final StreamThread thread = new StreamThread(
-                builder,
+                builder.internalTopologyBuilder,
                 config,
                 clientSupplier,
                 applicationId,
@@ -686,7 +686,7 @@ public class StreamThreadTest {
                 processId,
                 metrics,
                 mockTime,
-                new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+                new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
                 0) {
                 @Override
                 public void maybeClean(final long now) {
@@ -815,7 +815,7 @@ public class StreamThreadTest {
             builder.addSource("source1", "topic1");
 
             final StreamThread thread = new StreamThread(
-                builder,
+                builder.internalTopologyBuilder,
                 config,
                 clientSupplier,
                 applicationId,
@@ -823,7 +823,7 @@ public class StreamThreadTest {
                 processId,
                 metrics,
                 mockTime,
-                new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+                new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
                 0) {
 
                 @Override
@@ -907,7 +907,7 @@ public class StreamThreadTest {
         builder.addSource("source1", "someTopic");
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -915,7 +915,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
@@ -943,7 +943,7 @@ public class StreamThreadTest {
 
         final MockClientSupplier clientSupplier = new MockClientSupplier(applicationId);
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             new StreamsConfig(configProps(true)),
             clientSupplier,
             applicationId,
@@ -951,7 +951,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
@@ -982,7 +982,7 @@ public class StreamThreadTest {
 
         final MockClientSupplier clientSupplier = new MockClientSupplier(applicationId);
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             new StreamsConfig(configProps(true)),
             clientSupplier,
             applicationId,
@@ -990,7 +990,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
@@ -1015,7 +1015,7 @@ public class StreamThreadTest {
         builder.addSource("source1", "someTopic");
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1023,7 +1023,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final Map<TaskId, Set<TopicPartition>> assignment = new HashMap<>();
@@ -1046,7 +1046,7 @@ public class StreamThreadTest {
         builder.addSource("name", "topic").addSink("out", "output");
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1054,7 +1054,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         thread.setPartitionAssignor(new StreamPartitionAssignor() {
@@ -1086,7 +1086,7 @@ public class StreamThreadTest {
                 new StateDirectory(applicationId, config.getString(StreamsConfig.STATE_DIR_CONFIG), mockTime));
 
         final StreamThread thread = new StreamThread(
-                builder,
+                builder.internalTopologyBuilder,
                 config,
                 clientSupplier,
                 applicationId,
@@ -1094,7 +1094,7 @@ public class StreamThreadTest {
                 processId,
                 metrics,
                 mockTime,
-                new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+                new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
                 0) {
 
             @Override
@@ -1133,13 +1133,11 @@ public class StreamThreadTest {
 
     @Test
     public void shouldInitializeRestoreConsumerWithOffsetsFromStandbyTasks()  {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey().count("count-one");
         builder.stream("t2").groupByKey().count("count-two");
 
         final StreamThread thread = new StreamThread(
-                builder,
+                builder.internalTopologyBuilder,
                 config,
                 clientSupplier,
                 applicationId,
@@ -1147,7 +1145,7 @@ public class StreamThreadTest {
                 processId,
                 metrics,
                 mockTime,
-                new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+                new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
                 0);
 
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
@@ -1190,18 +1188,13 @@ public class StreamThreadTest {
                 new TopicPartition("stream-thread-test-count-two-changelog", 0))));
     }
 
-
-
-
     @Test
     public void shouldCloseSuspendedTasksThatAreNoLongerAssignedToThisStreamThreadBeforeCreatingNewTasks() throws Exception {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey().count("count-one");
         builder.stream("t2").groupByKey().count("count-two");
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1209,7 +1202,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
         final MockConsumer<byte[], byte[]> restoreConsumer = clientSupplier.restoreConsumer;
         restoreConsumer.updatePartitions("stream-thread-test-count-one-changelog",
@@ -1268,14 +1261,12 @@ public class StreamThreadTest {
 
     @Test
     public void shouldCloseActiveTasksThatAreAssignedToThisStreamThreadButAssignmentHasChangedBeforeCreatingNewTasks() throws Exception {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream(Pattern.compile("t.*")).to("out");
 
         final Map<Collection<TopicPartition>, TestStreamTask> createdTasks = new HashMap<>();
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1283,7 +1274,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0) {
 
             @Override
@@ -1355,7 +1346,7 @@ public class StreamThreadTest {
 
         final MockClientSupplier clientSupplier = new MockClientSupplier(applicationId);
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             new StreamsConfig(configProps(true)),
             clientSupplier,
             applicationId,
@@ -1363,7 +1354,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final MockConsumer consumer = clientSupplier.consumer;
@@ -1451,7 +1442,7 @@ public class StreamThreadTest {
 
         final MockClientSupplier clientSupplier = new MockClientSupplier(applicationId);
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             new StreamsConfig(configProps(true)),
             clientSupplier,
             applicationId,
@@ -1459,7 +1450,7 @@ public class StreamThreadTest {
             processId,
             new Metrics(),
             new MockTime(),
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final Map<TaskId, Set<TopicPartition>> activeTasks = new HashMap<>();
@@ -1484,8 +1475,6 @@ public class StreamThreadTest {
 
     @Test
     public void shouldNotViolateAtLeastOnceWhenAnExceptionOccursOnTaskCloseDuringShutdown() throws Exception {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey();
 
         final TestStreamTask testStreamTask = new TestStreamTask(
@@ -1507,7 +1496,7 @@ public class StreamThreadTest {
         };
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1515,7 +1504,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0) {
 
             @Override
@@ -1561,7 +1550,7 @@ public class StreamThreadTest {
         };
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1569,7 +1558,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0) {
 
             @Override
@@ -1606,8 +1595,6 @@ public class StreamThreadTest {
 
     @Test
     public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringTaskSuspension() throws Exception {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey();
 
         final TestStreamTask testStreamTask = new TestStreamTask(
@@ -1629,7 +1616,7 @@ public class StreamThreadTest {
         };
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1637,7 +1624,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0) {
 
             @Override
@@ -1667,8 +1654,6 @@ public class StreamThreadTest {
 
     @Test
     public void shouldNotViolateAtLeastOnceWhenExceptionOccursDuringFlushStateWhileSuspendingState() throws Exception {
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream("t1").groupByKey();
 
         final TestStreamTask testStreamTask = new TestStreamTask(
@@ -1690,7 +1675,7 @@ public class StreamThreadTest {
         };
 
         final StreamThread thread = new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1698,7 +1683,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0) {
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST), 0) {
 
             @Override
             protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitions) {
@@ -1729,12 +1714,11 @@ public class StreamThreadTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAlwaysUpdateWithLatestTopicsFromStreamPartitionAssignor() throws Exception {
-        final TopologyBuilder topologyBuilder = new TopologyBuilder();
-        topologyBuilder.addSource("source", Pattern.compile("t.*"));
-        topologyBuilder.addProcessor("processor", new MockProcessorSupplier(), "source");
+        builder.addSource("source", Pattern.compile("t.*"));
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source");
 
         final StreamThread thread = new StreamThread(
-            topologyBuilder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -1742,7 +1726,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             mockTime,
-            new StreamsMetadataState(topologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0);
 
         final StreamPartitionAssignor partitionAssignor = new StreamPartitionAssignor();
@@ -1756,11 +1740,11 @@ public class StreamThreadTest {
 
         final Field
             nodeToSourceTopicsField =
-            topologyBuilder.getClass().getDeclaredField("nodeToSourceTopics");
+            builder.internalTopologyBuilder.getClass().getDeclaredField("nodeToSourceTopics");
         nodeToSourceTopicsField.setAccessible(true);
         final Map<String, List<String>>
             nodeToSourceTopics =
-            (Map<String, List<String>>) nodeToSourceTopicsField.get(topologyBuilder);
+            (Map<String, List<String>>) nodeToSourceTopicsField.get(builder.internalTopologyBuilder);
         final List<TopicPartition> topicPartitions = new ArrayList<>();
 
         final TopicPartition topicPartition1 = new TopicPartition("topic-1", 0);
@@ -1856,8 +1840,6 @@ public class StreamThreadTest {
     }
 
     private StreamThread setupTest(final TaskId taskId) throws InterruptedException {
-        final TopologyBuilder builder = new TopologyBuilder();
-        builder.setApplicationId(applicationId);
         builder.addSource("source", "topic");
 
         final MockClientSupplier clientSupplier = new MockClientSupplier();
@@ -1883,9 +1865,18 @@ public class StreamThreadTest {
             }
         };
 
-        final StreamThread thread = new StreamThread(builder, config, clientSupplier, applicationId,
-            clientId, processId, new Metrics(), new MockTime(),
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0) {
+        final StreamThread thread = new StreamThread(
+            builder.internalTopologyBuilder,
+            config,
+            clientSupplier,
+            applicationId,
+            clientId,
+            processId,
+            new Metrics(),
+            new MockTime(),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
+            0) {
+
             @Override
             protected StreamTask createStreamTask(final TaskId id, final Collection<TopicPartition> partitions) {
                 return testStreamTask;
@@ -1968,8 +1959,6 @@ public class StreamThreadTest {
         final String storeName = "store";
         final String changelogTopic = applicationId + "-" + storeName + "-changelog";
 
-        final KStreamBuilder builder = new KStreamBuilder();
-        builder.setApplicationId(applicationId);
         builder.stream("topic1").groupByKey().count(storeName);
 
         final MockClientSupplier clientSupplier = new MockClientSupplier();
@@ -1986,9 +1975,17 @@ public class StreamThreadTest {
             }
         });
 
-        final StreamThread thread = new StreamThread(builder, config, clientSupplier, applicationId,
-            clientId, processId, new Metrics(), new MockTime(),
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST), 0) {
+        final StreamThread thread = new StreamThread(
+            builder.internalTopologyBuilder,
+            config,
+            clientSupplier,
+            applicationId,
+            clientId,
+            processId,
+            new Metrics(),
+            new MockTime(),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
+            0) {
 
             @Override
             protected StandbyTask createStandbyTask(final TaskId id, final Collection<TopicPartition> partitions) {
@@ -2060,7 +2057,7 @@ public class StreamThreadTest {
 
     private StreamThread getStreamThread() {
         return new StreamThread(
-            builder,
+            builder.internalTopologyBuilder,
             config,
             clientSupplier,
             applicationId,
@@ -2068,7 +2065,7 @@ public class StreamThreadTest {
             processId,
             metrics,
             Time.SYSTEM,
-            new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+            new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
             0) {
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -115,7 +115,7 @@ public class StreamsMetadataStateTest {
                 new PartitionInfo("topic-four", 0, null, null, null));
 
         cluster = new Cluster(null, Collections.<Node>emptyList(), partitionInfos, Collections.<String>emptySet(), Collections.<String>emptySet());
-        discovery = new StreamsMetadataState(builder, hostOne);
+        discovery = new StreamsMetadataState(builder.internalTopologyBuilder, hostOne);
         discovery.onChange(hostToPartitions, cluster);
         partitioner = new StreamPartitioner<String, Object>() {
             @Override
@@ -127,7 +127,7 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldNotThrowNPEWhenOnChangeNotCalled() throws Exception {
-        new StreamsMetadataState(builder, hostOne).getAllMetadataForStore("store");
+        new StreamsMetadataState(builder.internalTopologyBuilder, hostOne).getAllMetadataForStore("store");
     }
 
     @Test
@@ -294,7 +294,7 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldGetAnyHostForGlobalStoreByKeyIfMyHostUnknown() throws Exception {
-        final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST);
+        final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST);
         streamsMetadataState.onChange(hostToPartitions, cluster);
         assertNotNull(streamsMetadataState.getMetadataWithKey(globalTable, "key", Serdes.String().serializer()));
     }
@@ -307,7 +307,7 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldGetAnyHostForGlobalStoreByKeyAndPartitionerIfMyHostUnknown() throws Exception {
-        final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST);
+        final StreamsMetadataState streamsMetadataState = new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST);
         streamsMetadataState.onChange(hostToPartitions, cluster);
         assertNotNull(streamsMetadataState.getMetadataWithKey(globalTable, "key", partitioner));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -113,7 +113,7 @@ public class StreamThreadStateStoreProviderTest {
         storesAvailable = true;
         provider = new StreamThreadStateStoreProvider(
             new StreamThread(
-                builder,
+                builder.internalTopologyBuilder,
                 streamsConfig,
                 clientSupplier,
                 applicationId,
@@ -121,7 +121,7 @@ public class StreamThreadStateStoreProviderTest {
                 UUID.randomUUID(),
                 new Metrics(),
                 Time.SYSTEM,
-                new StreamsMetadataState(builder, StreamsMetadataState.UNKNOWN_HOST),
+                new StreamsMetadataState(builder.internalTopologyBuilder, StreamsMetadataState.UNKNOWN_HOST),
                 0) {
 
                 @Override

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.GlobalStateManagerImpl;
 import org.apache.kafka.streams.processor.internals.GlobalStateUpdateTask;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
@@ -160,7 +161,7 @@ public class ProcessorTopologyTestDriver {
      * @param builder the topology builder that will be used to create the topology instance
      */
     public ProcessorTopologyTestDriver(final StreamsConfig config,
-                                       final TopologyBuilder builder) {
+                                       final InternalTopologyBuilder builder) {
         topology = builder.setApplicationId(APPLICATION_ID).build(null);
         final ProcessorTopology globalTopology  = builder.buildGlobalStateTopology();
 
@@ -351,7 +352,7 @@ public class ProcessorTopologyTestDriver {
 
     /**
      * Get the {@link StateStore} with the given name. The name should have been supplied via
-     * {@link #ProcessorTopologyTestDriver(StreamsConfig, TopologyBuilder) this object's constructor}, and is
+     * {@link #ProcessorTopologyTestDriver(StreamsConfig, InternalTopologyBuilder) this object's constructor}, and is
      * presumed to be used by a Processor within the topology.
      * <p>
      * This is often useful in test cases to pre-populate the store before the test case instructs the topology to
@@ -367,7 +368,7 @@ public class ProcessorTopologyTestDriver {
 
     /**
      * Get the {@link KeyValueStore} with the given name. The name should have been supplied via
-     * {@link #ProcessorTopologyTestDriver(StreamsConfig, TopologyBuilder) this object's constructor}, and is
+     * {@link #ProcessorTopologyTestDriver(StreamsConfig, InternalTopologyBuilder) this object's constructor}, and is
      * presumed to be used by a Processor within the topology.
      * <p>
      * This is often useful in test cases to pre-populate the store before the test case instructs the topology to


### PR DESCRIPTION
 - extract InternalTopologyBuilder from TopologyBuilder
 - deprecate all "leaking" methods from public TopologyBuilder API
 - changed TopologyDescription and all nested classed into interfaces