### PR TITLE
KAFKA-5599: ConsoleConsumer : --new-consumer option as deprecated

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -269,7 +269,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("metrics directory")
       .ofType(classOf[java.lang.String])
-    val newConsumerOpt = parser.accepts("new-consumer", "DEPRECATED Use the new consumer implementation. This is the default.")
+    val newConsumerOpt = parser.accepts("new-consumer", "This is the default, so this option is deprecated and will be removed in a future release.")
     val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED (unless old consumer is used): The server to connect to.")
       .withRequiredArg
       .describedAs("server to connect to")
@@ -390,8 +390,8 @@ object ConsoleConsumer extends Logging {
       CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 
       if (options.has(newConsumerOpt)) {
-        Console.err.println("Using the --new-consumer option is deprecated and will be removed " +
-          "in a future major release. For using the new consumer just use only the --bootstrap-server option")
+        Console.err.println("The --new-consumer option is deprecated and will be removed in a future major release." +
+          "The new consumer is used by default if the --bootstrap-server option is provided.")
       }
     }
 

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -269,7 +269,7 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("metrics directory")
       .ofType(classOf[java.lang.String])
-    val newConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default.")
+    val newConsumerOpt = parser.accepts("new-consumer", "DEPRECATED Use the new consumer implementation. This is the default.")
     val bootstrapServerOpt = parser.accepts("bootstrap-server", "REQUIRED (unless old consumer is used): The server to connect to.")
       .withRequiredArg
       .describedAs("server to connect to")
@@ -386,8 +386,14 @@ object ConsoleConsumer extends Logging {
       else if (fromBeginning) OffsetRequest.EarliestTime
       else OffsetRequest.LatestTime
 
-    if (!useOldConsumer)
+    if (!useOldConsumer) {
       CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
+
+      if (options.has(newConsumerOpt)) {
+        Console.err.println("Using the --new-consumer option is deprecated and will be removed " +
+          "in a future major release. For using the new consumer just use only the --bootstrap-server option")
+      }
+    }
 
     if (options.has(csvMetricsReporterEnabledOpt)) {
       val csvReporterProps = new Properties()


### PR DESCRIPTION
Marking --new-consumer as deprecated in the help of ConsoleConsumer
Printing a warning on using the new consumer but adding the --new-consumer option