### PR TITLE
KAFKA-5790, KAFKA-5607; Improve error handling in SocketServer to avoid issues later

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -294,8 +294,7 @@ public class Selector implements Selectable, AutoCloseable {
         String connectionId = send.destination();
         KafkaChannel channel = openOrClosingChannelOrFail(connectionId);
         if (closingChannels.containsKey(connectionId)) {
-            channel.state(ChannelState.FAILED_SEND);
-            // ensure notification via `disconnected`
+            // ensure notification via `disconnected`, leave channel in the state in which closing was triggered
             this.failedSends.add(connectionId);
         } else {
             try {
@@ -649,6 +648,7 @@ public class Selector implements Selectable, AutoCloseable {
             close(channel, false);
         } else {
             KafkaChannel closingChannel = this.closingChannels.remove(id);
+            // Close any closing channel, leave the channel in the state in which closing was triggered
             if (closingChannel != null)
                 doClose(closingChannel, false);
         }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -234,6 +234,9 @@ public class Selector implements Selectable, AutoCloseable {
      * Kafka brokers add an incrementing index to the connection id to avoid reuse in the timing window
      * where an existing connection may not yet have been closed by the broker when a new connection with
      * the same remote host:port is processed.
+     * </p><p>
+     * If a `KafkaChannel` cannot be created for this connection, the `socketChannel` is closed
+     * and its selection key cancelled.
      * </p>
      */
     public void register(String id, SocketChannel socketChannel) throws IOException {

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -292,15 +292,25 @@ public class Selector implements Selectable, AutoCloseable {
      */
     public void send(Send send) {
         String connectionId = send.destination();
-        if (closingChannels.containsKey(connectionId))
+        KafkaChannel channel = openOrClosingChannelOrFail(connectionId);
+        if (closingChannels.containsKey(connectionId)) {
+            channel.state(ChannelState.FAILED_SEND);
+            // ensure notification via `disconnected`
             this.failedSends.add(connectionId);
-        else {
-            KafkaChannel channel = channelOrFail(connectionId, false);
+        } else {
             try {
                 channel.setSend(send);
-            } catch (CancelledKeyException e) {
+            } catch (Exception e) {
+                // update the state for consistency, the channel will be discarded after `close`
+                channel.state(ChannelState.FAILED_SEND);
+                // ensure notification via `disconnected`
                 this.failedSends.add(connectionId);
                 close(channel, false);
+                if (!(e instanceof CancelledKeyException)) {
+                    log.error("Unexpected exception during send, closing connection {} and rethrowing exception {}",
+                            connectionId, e);
+                    throw e;
+                }
             }
         }
     }
@@ -535,7 +545,7 @@ public class Selector implements Selectable, AutoCloseable {
 
     @Override
     public void mute(String id) {
-        KafkaChannel channel = channelOrFail(id, true);
+        KafkaChannel channel = openOrClosingChannelOrFail(id);
         mute(channel);
     }
 
@@ -546,7 +556,7 @@ public class Selector implements Selectable, AutoCloseable {
 
     @Override
     public void unmute(String id) {
-        KafkaChannel channel = channelOrFail(id, true);
+        KafkaChannel channel = openOrClosingChannelOrFail(id);
         unmute(channel);
     }
 
@@ -603,12 +613,8 @@ public class Selector implements Selectable, AutoCloseable {
                 it.remove();
             }
         }
-        for (String channel : this.failedSends) {
-            KafkaChannel failedChannel = closingChannels.get(channel);
-            if (failedChannel != null)
-                failedChannel.state(ChannelState.FAILED_SEND);
+        for (String channel : this.failedSends)
             this.disconnected.put(channel, ChannelState.FAILED_SEND);
-        }
         this.failedSends.clear();
         this.madeReadProgressLastPoll = false;
     }
@@ -641,6 +647,10 @@ public class Selector implements Selectable, AutoCloseable {
             // channel state here anyway to avoid confusion.
             channel.state(ChannelState.LOCAL_CLOSE);
             close(channel, false);
+        } else {
+            KafkaChannel closingChannel = this.closingChannels.remove(id);
+            if (closingChannel != null)
+                doClose(closingChannel, false);
         }
     }
 
@@ -702,9 +712,9 @@ public class Selector implements Selectable, AutoCloseable {
         return channel != null && channel.ready();
     }
 
-    private KafkaChannel channelOrFail(String id, boolean maybeClosing) {
+    private KafkaChannel openOrClosingChannelOrFail(String id) {
         KafkaChannel channel = this.channels.get(id);
-        if (channel == null && maybeClosing)
+        if (channel == null)
             channel = this.closingChannels.get(id);
         if (channel == null)
             throw new IllegalStateException("Attempt to retrieve channel for which there is no connection. Connection id " + id + " existing connections " + channels.keySet());

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -293,7 +293,8 @@ public class SelectorTest {
         assertNull("Channel not expired", selector.channel(id));
         assertEquals(ChannelState.EXPIRED, channel.state());
         selector.close(id);
-        assertNull("Channel not closed", selector.closingChannel(id));
+        assertNull("Channel not removed from channels", selector.channel(id));
+        assertNull("Channel not removed from closingChannels", selector.closingChannel(id));
         assertTrue("Unexpected disconnect notification", selector.disconnected().isEmpty());
         assertEquals(ChannelState.EXPIRED, channel.state());
         selector.poll(0);

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -75,6 +75,11 @@ public class SslSelectorTest extends SelectorTest {
         this.metrics.close();
     }
 
+    @Override
+    public SecurityProtocol securityProtocol() {
+        return SecurityProtocol.PLAINTEXT;
+    }
+
     /**
      * Tests that SSL renegotiation initiated by the server are handled correctly by the client
      * @throws Exception

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -570,14 +570,12 @@ private[kafka] class Processor(val id: Int,
         val resp = inflightResponses.remove(send.destination).getOrElse {
           throw new IllegalStateException(s"Send for ${send.destination} completed, but not in `inflightResponses`")
         }
-        updateRequestMetrics(resp.request)
+        updateRequestMetrics(resp)
         selector.unmute(send.destination)
       } catch {
         case e: Throwable => processChannelException(send.destination,
             s"Exception while processing completed send to ${send.destination}", e)
       }
-      updateRequestMetrics(resp)
-      selector.unmute(send.destination)
     }
   }
 
@@ -617,7 +615,7 @@ private[kafka] class Processor(val id: Int,
         connectionQuotas.dec(address)
       selector.close(connectionId)
 
-      inflightResponses.remove(connectionId).foreach(response => updateRequestMetrics(response.request))
+      inflightResponses.remove(connectionId).foreach(response => updateRequestMetrics(response))
     }
   }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -641,7 +641,7 @@ private[kafka] class Processor(val id: Int,
       } catch {
         // We explicitly catch all exceptions and close the socket to avoid a socket leak.
         case e: Throwable =>
-          val remoteAddress = channel.getRemoteAddress
+          val remoteAddress = channel.socket.getRemoteSocketAddress
           // need to close the channel here to avoid a socket leak.
           close(channel)
           processException(s"Processor $id closed connection from $remoteAddress", e)


### PR DESCRIPTION
Changes:
  1. When an exception is encountered in any of the methods in `Processor` while processing a channel, log the exception and close the connection. Continue to process other channels.
  2. Fixes KAFKA-5790: SocketServer.processNewResponses should not skip a response if exception is thrown.
  3. For `IllegalStateException` and `IOException` in `poll()`, don't close the `Selector`. Log the exception and continue.
  4. Close channel on any failed send in `Selector`.
  5. When closing channel fails or is closed, leave channel state as-is, indicating the state in which the channel was moved to closing.
  6. Add tests for various failure scenarios.
  7. Fix timing issue in `SocketServerTest.testConnectionIdReuse` by waiting for new connections to be processed by the server.