### PR TITLE
KAFKA-5610: KafkaApis.HandleWriteTxnMarkerRequest should return UNKNOWN_TOPIC_OR_PARTITION on partition emigration.

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1543,34 +1543,29 @@ class KafkaApis(val requestChannel: RequestChannel,
     var skippedMarkers = 0
     for (marker <- markers.asScala) {
       val producerId = marker.producerId
-      val partitionsWithCorrectMessageFormat = new mutable.ArrayBuffer[TopicPartition]
-      val partitionsWithIncorrectMessageFormat = new mutable.ArrayBuffer[TopicPartition]
-      val unknownPartitions = new mutable.ArrayBuffer[TopicPartition]
+      val partitionsWithCompatibleMessageFormat = new mutable.ArrayBuffer[TopicPartition]
 
+      val currentErrors = new ConcurrentHashMap[TopicPartition, Errors]()
       marker.partitions.asScala.foreach { partition =>
         replicaManager.getMagic(partition) match {
           case Some(magic) =>
             if (magic < RecordBatch.MAGIC_VALUE_V2)
-              partitionsWithIncorrectMessageFormat += partition
+              currentErrors.put(partition, Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT)
             else
-              partitionsWithCorrectMessageFormat += partition
+              partitionsWithCompatibleMessageFormat += partition
           case None =>
-            unknownPartitions += partition
+            currentErrors.put(partition, Errors.UNKNOWN_TOPIC_OR_PARTITION)
         }
       }
 
-      if (unknownPartitions.nonEmpty || partitionsWithIncorrectMessageFormat.nonEmpty) {
-        val currentErrors = new ConcurrentHashMap[TopicPartition, Errors]()
-        unknownPartitions.foreach { partition => currentErrors.put(partition, Errors.UNKNOWN_TOPIC_OR_PARTITION)}
-        partitionsWithIncorrectMessageFormat.foreach { partition => currentErrors.put(partition, Errors.UNSUPPORTED_FOR_MESSAGE_FORMAT) }
+      if (!currentErrors.isEmpty)
         updateErrors(producerId, currentErrors)
-      }
 
-      if (partitionsWithCorrectMessageFormat.isEmpty) {
+      if (partitionsWithCompatibleMessageFormat.isEmpty) {
         numAppends.decrementAndGet()
         skippedMarkers += 1
       } else {
-        val controlRecords = partitionsWithCorrectMessageFormat.map { partition =>
+        val controlRecords = partitionsWithCompatibleMessageFormat.map { partition =>
           val controlRecordType = marker.transactionResult match {
             case TransactionResult.COMMIT => ControlRecordType.COMMIT
             case TransactionResult.ABORT => ControlRecordType.ABORT

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1543,19 +1543,19 @@ class KafkaApis(val requestChannel: RequestChannel,
     var skippedMarkers = 0
     for (marker <- markers.asScala) {
       val producerId = marker.producerId
-      val partitionsWithCorrectMessageFormat = new mutable.ListBuffer[TopicPartition]
-      val partitionsWithIncorrectMessageFormat = new mutable.ListBuffer[TopicPartition]
-      val unknownPartitions = new mutable.ListBuffer[TopicPartition]
+      val partitionsWithCorrectMessageFormat = new mutable.ArrayBuffer[TopicPartition]
+      val partitionsWithIncorrectMessageFormat = new mutable.ArrayBuffer[TopicPartition]
+      val unknownPartitions = new mutable.ArrayBuffer[TopicPartition]
 
       marker.partitions.asScala.foreach { partition =>
         replicaManager.getMagic(partition) match {
           case Some(magic) =>
             if (magic < RecordBatch.MAGIC_VALUE_V2)
-              partitionsWithIncorrectMessageFormat.append(partition)
+              partitionsWithIncorrectMessageFormat += partition
             else
-              partitionsWithCorrectMessageFormat.append(partition)
+              partitionsWithCorrectMessageFormat += partition
           case None =>
-            unknownPartitions.append(partition)
+            unknownPartitions += partition
         }
       }
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -129,11 +129,8 @@ class KafkaApisTest {
 
     EasyMock.expect(replicaManager.getMagic(topicPartition))
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
-    EasyMock.expect(metadataCache.contains(topicPartition))
-      .andReturn(true)
     EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
     EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
-    EasyMock.replay(metadataCache)
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
@@ -151,11 +148,8 @@ class KafkaApisTest {
 
     EasyMock.expect(replicaManager.getMagic(topicPartition))
       .andReturn(None)
-    EasyMock.expect(metadataCache.contains(topicPartition))
-      .andReturn(false)
     EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
     EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
-    EasyMock.replay(metadataCache)
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
@@ -178,10 +172,6 @@ class KafkaApisTest {
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
     EasyMock.expect(replicaManager.getMagic(tp2))
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V2))
-    EasyMock.expect(metadataCache.contains(tp1))
-      .andReturn(true)
-    EasyMock.expect(metadataCache.contains(tp2))
-      .andReturn(true)
 
     EasyMock.expect(replicaManager.appendRecords(EasyMock.anyLong(),
       EasyMock.anyShort(),
@@ -197,7 +187,6 @@ class KafkaApisTest {
 
     EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
     EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
-    EasyMock.replay(metadataCache)
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
@@ -221,10 +210,6 @@ class KafkaApisTest {
       .andReturn(None)
     EasyMock.expect(replicaManager.getMagic(tp2))
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V2))
-    EasyMock.expect(metadataCache.contains(tp1))
-      .andReturn(false)
-    EasyMock.expect(metadataCache.contains(tp2))
-      .andReturn(true)
 
     EasyMock.expect(replicaManager.appendRecords(EasyMock.anyLong(),
       EasyMock.anyShort(),
@@ -240,7 +225,6 @@ class KafkaApisTest {
 
     EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
     EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
-    EasyMock.replay(metadataCache)
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -129,8 +129,33 @@ class KafkaApisTest {
 
     EasyMock.expect(replicaManager.getMagic(topicPartition))
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
+    EasyMock.expect(metadataCache.contains(topicPartition))
+      .andReturn(true)
     EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
     EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
+    EasyMock.replay(metadataCache)
+
+    createKafkaApis().handleWriteTxnMarkersRequest(request)
+
+    val markersResponse = readResponse(ApiKeys.WRITE_TXN_MARKERS, writeTxnMarkersRequest, capturedResponse)
+      .asInstanceOf[WriteTxnMarkersResponse]
+    assertEquals(expectedErrors, markersResponse.errors(1))
+  }
+
+  @Test
+  def shouldRespondWithUnknownTopicWhenPartitionIsNotHosted(): Unit = {
+    val topicPartition = new TopicPartition("t", 0)
+    val (writeTxnMarkersRequest, request) = createWriteTxnMarkersRequest(Utils.mkList(topicPartition))
+    val expectedErrors = Map(topicPartition -> Errors.UNKNOWN_TOPIC_OR_PARTITION).asJava
+    val capturedResponse: Capture[RequestChannel.Response] = EasyMock.newCapture()
+
+    EasyMock.expect(replicaManager.getMagic(topicPartition))
+      .andReturn(None)
+    EasyMock.expect(metadataCache.contains(topicPartition))
+      .andReturn(false)
+    EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
+    EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
+    EasyMock.replay(metadataCache)
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
@@ -153,6 +178,10 @@ class KafkaApisTest {
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V1))
     EasyMock.expect(replicaManager.getMagic(tp2))
       .andReturn(Some(RecordBatch.MAGIC_VALUE_V2))
+    EasyMock.expect(metadataCache.contains(tp1))
+      .andReturn(true)
+    EasyMock.expect(metadataCache.contains(tp2))
+      .andReturn(true)
 
     EasyMock.expect(replicaManager.appendRecords(EasyMock.anyLong(),
       EasyMock.anyShort(),
@@ -168,6 +197,50 @@ class KafkaApisTest {
 
     EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
     EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
+    EasyMock.replay(metadataCache)
+
+    createKafkaApis().handleWriteTxnMarkersRequest(request)
+
+    val markersResponse = readResponse(ApiKeys.WRITE_TXN_MARKERS, writeTxnMarkersRequest, capturedResponse)
+      .asInstanceOf[WriteTxnMarkersResponse]
+    assertEquals(expectedErrors, markersResponse.errors(1))
+    EasyMock.verify(replicaManager)
+  }
+
+  @Test
+  def shouldRespondWithUnknownTopicOrPartitionForBadPartitionAndNoErrorsForGoodPartition(): Unit = {
+    val tp1 = new TopicPartition("t", 0)
+    val tp2 = new TopicPartition("t1", 0)
+    val (writeTxnMarkersRequest, request) = createWriteTxnMarkersRequest(Utils.mkList(tp1, tp2))
+    val expectedErrors = Map(tp1 -> Errors.UNKNOWN_TOPIC_OR_PARTITION, tp2 -> Errors.NONE).asJava
+
+    val capturedResponse: Capture[RequestChannel.Response] = EasyMock.newCapture()
+    val responseCallback: Capture[Map[TopicPartition, PartitionResponse] => Unit]  = EasyMock.newCapture()
+
+    EasyMock.expect(replicaManager.getMagic(tp1))
+      .andReturn(None)
+    EasyMock.expect(replicaManager.getMagic(tp2))
+      .andReturn(Some(RecordBatch.MAGIC_VALUE_V2))
+    EasyMock.expect(metadataCache.contains(tp1))
+      .andReturn(false)
+    EasyMock.expect(metadataCache.contains(tp2))
+      .andReturn(true)
+
+    EasyMock.expect(replicaManager.appendRecords(EasyMock.anyLong(),
+      EasyMock.anyShort(),
+      EasyMock.eq(true),
+      EasyMock.eq(false),
+      EasyMock.anyObject(),
+      EasyMock.capture(responseCallback),
+      EasyMock.anyObject())).andAnswer(new IAnswer[Unit] {
+      override def answer(): Unit = {
+        responseCallback.getValue.apply(Map(tp2 -> new PartitionResponse(Errors.NONE)))
+      }
+    })
+
+    EasyMock.expect(requestChannel.sendResponse(EasyMock.capture(capturedResponse)))
+    EasyMock.replay(replicaManager, replicaQuotaManager, requestChannel)
+    EasyMock.replay(metadataCache)
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 


### PR DESCRIPTION
Before this patch, we would return the non-retriable `UNSUPPORTED_FOR_MESSAGE_FORMAT` error when leadership changed, causing markers to be lost.