### PR TITLE
KAFKA-5630; The consumer should block on courrupt records and keeping throw exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -928,7 +928,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                                         key, value, headers);
         } catch (RuntimeException e) {
             throw new SerializationException("Error deserializing key/value for partition " + partition +
-                    " at offset " + record.offset(), e);
+                    " at offset " + record.offset() + ". If needed, please seek past the record to continue consumption.", e);
         }
     }
 
@@ -960,7 +960,6 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
         private CloseableIterator<Record> records;
         private long nextFetchOffset;
         private boolean isFetched = false;
-        // We have to cache the iterator exception because they are not reproducible.
         private Exception cachedRecordException = null;
         private boolean corruptLastRecord = false;
 
@@ -1080,7 +1079,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             // Error when fetching the next record before deserialization.
             if (corruptLastRecord)
                 throw new KafkaException("Received exception when fetching the next record from " + partition
-                                             + "If needed, please seek past the record to "
+                                             + ". If needed, please seek past the record to "
                                              + "continue consumption.", cachedRecordException);
 
             if (isFetched)
@@ -1114,7 +1113,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 cachedRecordException = e;
                 if (records.isEmpty())
                     throw new KafkaException("Received exception when fetching the next record from " + partition
-                                                 + "If needed, please seek past the record to "
+                                                 + ". If needed, please seek past the record to "
                                                  + "continue consumption.", e);
             }
             return records;

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1106,6 +1106,10 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                     // we allow user to move forward in this case.
                     cachedRecordException = null;
                 }
+            } catch (SerializationException se) {
+                cachedRecordException = se;
+                if (records.isEmpty())
+                    throw se;
             } catch (KafkaException e) {
                 cachedRecordException = e;
                 if (records.isEmpty())

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -265,7 +265,7 @@ public class FetcherTest {
             public byte[] deserialize(String topic, byte[] data) {
                 if (i++ % 2 == 1) {
                     // Should be blocked on the value deserialization of the first record.
-                    assertEquals(new String(data, StandardCharsets.UTF_8), "value-1");
+                    assertEquals("value-1", new String(data, StandardCharsets.UTF_8));
                     throw new SerializationException();
                 }
                 return data;
@@ -294,7 +294,7 @@ public class FetcherTest {
     }
 
     @Test
-    public void testParseInvalidRecord() throws Exception {
+    public void testParseCorruptedRecord() throws Exception {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         DataOutputStream out = new DataOutputStream(new ByteBufferOutputStream(buffer));
 
@@ -323,6 +323,15 @@ public class FetcherTest {
         out.writeInt(size);
         LegacyRecord.write(out, magic, crc, LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME), timestamp, key, value);
 
+        // Write a record whose size field is invalid.
+        out.writeLong(offset + 3);
+        out.writeInt(1);
+
+        // write one valid record
+        out.writeLong(offset + 4);
+        out.writeInt(size);
+        LegacyRecord.write(out, magic, crc, LegacyRecord.computeAttributes(magic, CompressionType.NONE, TimestampType.CREATE_TIME), timestamp, key, value);
+
         buffer.flip();
 
         subscriptions.assignFromUser(singleton(tp0));
@@ -337,28 +346,44 @@ public class FetcherTest {
         assertEquals(1, fetcher.fetchedRecords().get(tp0).size());
         assertEquals(1, subscriptions.position(tp0).longValue());
 
-        // the fetchedRecords() should always throw exception due to the second invalid message
+        ensureBlockOnRecord(1L);
+        seekAndConsumeRecord(buffer, 2L);
+        ensureBlockOnRecord(3L);
+        try {
+            // For a record that cannot be retrieved from the iterator, we cannot seek over it within the batch.
+            seekAndConsumeRecord(buffer, 4L);
+            fail("Should have thrown exception when fail to retrieve a record from iterator.");
+        } catch (KafkaException ke) {
+           // let it go
+        }
+        ensureBlockOnRecord(4L);
+    }
+
+    private void ensureBlockOnRecord(long blockedOffset) {
+        // the fetchedRecords() should always throw exception due to the invalid message at the starting offset.
         for (int i = 0; i < 2; i++) {
             try {
                 fetcher.fetchedRecords();
                 fail("fetchedRecords should have raised KafkaException");
             } catch (KafkaException e) {
-                assertEquals(1, subscriptions.position(tp0).longValue());
+                assertEquals(blockedOffset, subscriptions.position(tp0).longValue());
             }
         }
+    }
 
+    private void seekAndConsumeRecord(ByteBuffer responseBuffer, long toOffset) {
         // Seek to skip the bad record and fetch again.
-        subscriptions.seek(tp0, 2);
+        subscriptions.seek(tp0, toOffset);
         // Should not throw exception after the seek.
         fetcher.fetchedRecords();
         assertEquals(1, fetcher.sendFetches());
-        client.prepareResponse(fetchResponse(tp0, MemoryRecords.readableRecords(buffer), Errors.NONE, 100L, 0));
+        client.prepareResponse(fetchResponse(tp0, MemoryRecords.readableRecords(responseBuffer), Errors.NONE, 100L, 0));
         consumerClient.poll(0);
 
         List<ConsumerRecord<byte[], byte[]>> records = fetcher.fetchedRecords().get(tp0);
         assertEquals(1, records.size());
-        assertEquals(2L, records.get(0).offset());
-        assertEquals(3, subscriptions.position(tp0).longValue());
+        assertEquals(toOffset, records.get(0).offset());
+        assertEquals(toOffset + 1, subscriptions.position(tp0).longValue());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -286,8 +286,7 @@ public class FetcherTest {
             try {
                 fetcher.fetchedRecords();
                 fail("fetchedRecords should have raised");
-            } catch (KafkaException e) {
-                assertTrue(e.getCause() instanceof SerializationException);
+            } catch (SerializationException e) {
                 // the position should not advance since no data has been returned
                 assertEquals(1, subscriptions.position(tp0).longValue());
             }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -286,7 +286,8 @@ public class FetcherTest {
             try {
                 fetcher.fetchedRecords();
                 fail("fetchedRecords should have raised");
-            } catch (SerializationException e) {
+            } catch (KafkaException e) {
+                assertTrue(e.getCause() instanceof SerializationException);
                 // the position should not advance since no data has been returned
                 assertEquals(1, subscriptions.position(tp0).longValue());
             }


### PR DESCRIPTION
This patch handles the case that a CorruptRecordException is thrown from the iterator directly.
The fix is a little tricky as exceptions can be thrown from a few different scenarios. The current approach is to let the same record go through the exact same process as last time when exception is thrown, so the exception will be thrown at the same step. The only problem for that is the iterator state will change once it throws an exception. To handle that we cache the first iterator exception and put it into the suppressed exception of the IllegalStateException thrown in the future.