### PR TITLE
KAFKA-5648: make Merger extend Aggregator

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Merger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Merger.java
@@ -23,7 +23,7 @@ package org.apache.kafka.streams.kstream;
  * @param <K>   key type
  * @param <V>   aggregate value type
  */
-public interface Merger<K, V> {
+public interface Merger<K, V> extends Aggregator<K,V,V> {
 
     /**
      * Compute a new aggregate from the key and two aggregates.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Merger.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Merger.java
@@ -23,7 +23,7 @@ package org.apache.kafka.streams.kstream;
  * @param <K>   key type
  * @param <V>   aggregate value type
  */
-public interface Merger<K, V> extends Aggregator<K,V,V> {
+public interface Merger<K, V> extends Aggregator<K, V, V> {
 
     /**
      * Compute a new aggregate from the key and two aggregates.


### PR DESCRIPTION
I suggest that Merger<K,V> should extend Aggregator<K,V,V>.
reason:
Both classes usually do very similar things. A merger takes two sessions and combines them, an aggregator takes an existing session and aggregates new values into it.
in some use cases it is actually the same thing, e.g.:
<null, log_event> -> .map() to <session_id,SingletonList<log_event>> -> .groupByKey().aggregate() to <session_id, List<log_event>>
In this case both merger and aggregator do the same thing: take two lists and combine them into one.
With the proposed change we could pass the Merger as both the merger and aggregator to the .aggregate() method and keep our business logic within one merger class.
Or in other words: The Merger is simply an Aggregator that happens to aggregate two objects of the same class