### PR TITLE
KAFKA-5665: Heartbeat thread should use correct interruption method to restore status

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -975,7 +975,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     }
                 }
             } catch (InterruptedException | InterruptException e) {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
                 log.error("Unexpected interrupt received in heartbeat thread for group {}", groupId, e);
                 this.failed.set(new RuntimeException(e));
             } catch (RuntimeException e) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -975,9 +975,9 @@ public abstract class AbstractCoordinator implements Closeable {
                     }
                 }
             } catch (InterruptedException | InterruptException e) {
-                Thread.currentThread().interrupt();
                 log.error("Unexpected interrupt received in heartbeat thread for group {}", groupId, e);
                 this.failed.set(new RuntimeException(e));
+                Thread.currentThread().interrupt();
             } catch (RuntimeException e) {
                 log.error("Heartbeat thread for group {} failed due to unexpected error", groupId, e);
                 this.failed.set(e);


### PR DESCRIPTION
When interrupting the background heartbeat thread, `Thread.interrupted();` is used. Actually, `Thread.currentThread().interrupt();` should be used to restore the interruption status. An alternative way to solve is to remove `Thread.interrupted();` since HeartbeatThread extends Thread and all code higher up on the call stack is controlled, so we could safely swallow this exception. Anyway, `Thread.interrupted();` should not be used here. It's a test method not an action.