### PR TITLE
HOTFIX: fix threading issue in MeteredKeyValueStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/MeteredKeyValueStore.java
@@ -19,9 +19,9 @@ package org.apache.kafka.streams.state.internals;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
-import org.apache.kafka.streams.processor.internals.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
@@ -39,7 +39,6 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
     private final KeyValueStore<K, V> inner;
     private final String metricScope;
     protected final Time time;
-
     private Sensor putTime;
     private Sensor putIfAbsentTime;
     private Sensor getTime;
@@ -48,57 +47,9 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
     private Sensor allTime;
     private Sensor rangeTime;
     private Sensor flushTime;
-    private Sensor restoreTime;
-    private StreamsMetricsImpl metrics;
-
-
-    private K key;
-    private V value;
-    private Runnable getDelegate = new Runnable() {
-        @Override
-        public void run() {
-            value = inner.get(key);
-        }
-    };
-    private Runnable putDelegate = new Runnable() {
-        @Override
-        public void run() {
-            inner.put(key, value);
-        }
-    };
-    private Runnable putIfAbsentDelegate = new Runnable() {
-        @Override
-        public void run() {
-            value = inner.putIfAbsent(key, value);
-        }
-    };
-    private List<KeyValue<K, V>> entries;
-    private Runnable putAllDelegate = new Runnable() {
-        @Override
-        public void run() {
-            inner.putAll(entries);
-        }
-    };
-    private Runnable deleteDelegate = new Runnable() {
-        @Override
-        public void run() {
-            value = inner.delete(key);
-        }
-    };
-    private Runnable flushDelegate = new Runnable() {
-        @Override
-        public void run() {
-            inner.flush();
-        }
-    };
+    private StreamsMetrics metrics;
     private ProcessorContext context;
     private StateStore root;
-    private Runnable initDelegate = new Runnable() {
-        @Override
-        public void run() {
-            inner.init(context, root);
-        }
-    };
 
     // always wrap the store with the metered store
     public MeteredKeyValueStore(final KeyValueStore<K, V> inner,
@@ -115,7 +66,7 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
         final String name = name();
         this.context = context;
         this.root = root;
-        this.metrics = (StreamsMetricsImpl) context.metrics();
+        this.metrics = context.metrics();
         this.putTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "put", Sensor.RecordingLevel.DEBUG);
         this.putIfAbsentTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "put-if-absent", Sensor.RecordingLevel.DEBUG);
         this.getTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "get", Sensor.RecordingLevel.DEBUG);
@@ -124,10 +75,21 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
         this.allTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "all", Sensor.RecordingLevel.DEBUG);
         this.rangeTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "range", Sensor.RecordingLevel.DEBUG);
         this.flushTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "flush", Sensor.RecordingLevel.DEBUG);
-        this.restoreTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "restore", Sensor.RecordingLevel.DEBUG);
+        final Sensor restoreTime = this.metrics.addLatencyAndThroughputSensor(metricScope, name, "restore", Sensor.RecordingLevel.DEBUG);
 
         // register and possibly restore the state from the logs
-        metrics.measureLatencyNs(time, initDelegate, this.restoreTime);
+        if (restoreTime.shouldRecord()) {
+            measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    inner.init(MeteredKeyValueStore.this.context, MeteredKeyValueStore.this.root);
+                    return null;
+                }
+            }, restoreTime);
+        } else {
+            inner.init(MeteredKeyValueStore.this.context, MeteredKeyValueStore.this.root);
+        }
+
     }
 
     @Override
@@ -135,39 +97,81 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
         return inner.approximateNumEntries();
     }
 
-    @Override
-    public V get(K key) {
-        this.key = key;
-        metrics.measureLatencyNs(time, getDelegate, this.getTime);
-        return value;
+    interface Action<V> {
+        V execute();
     }
 
     @Override
-    public void put(K key, V value) {
-        this.key = key;
-        this.value = value;
-        metrics.measureLatencyNs(time, putDelegate, this.putTime);
+    public V get(final K key) {
+        if (getTime.shouldRecord()) {
+            return measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    return inner.get(key);
+                }
+            }, getTime);
+        } else {
+            return inner.get(key);
+        }
     }
 
     @Override
-    public V putIfAbsent(K key, V value) {
-        this.key = key;
-        this.value = value;
-        metrics.measureLatencyNs(time, putIfAbsentDelegate, this.putIfAbsentTime);
-        return this.value;
+    public void put(final K key, final V value) {
+        if (putTime.shouldRecord()) {
+            measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    inner.put(key, value);
+                    return null;
+                }
+            }, putTime);
+        } else {
+            inner.put(key, value);
+        }
     }
 
     @Override
-    public void putAll(List<KeyValue<K, V>> entries) {
-        this.entries = entries;
-        metrics.measureLatencyNs(time, putAllDelegate, this.putAllTime);
+    public V putIfAbsent(final K key, final V value) {
+        if (putIfAbsentTime.shouldRecord()) {
+            return measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    return inner.putIfAbsent(key, value);
+                }
+            }, putIfAbsentTime);
+        } else {
+            return inner.putIfAbsent(key, value);
+        }
+
     }
 
     @Override
-    public V delete(K key) {
-        this.key = key;
-        metrics.measureLatencyNs(time, deleteDelegate, this.deleteTime);
-        return value;
+    public void putAll(final List<KeyValue<K, V>> entries) {
+        if (putAllTime.shouldRecord()) {
+            measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    inner.putAll(entries);
+                    return null;
+                }
+            }, putAllTime);
+        } else {
+            inner.putAll(entries);
+        }
+    }
+
+    @Override
+    public V delete(final K key) {
+        if (deleteTime.shouldRecord()) {
+            return measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    return inner.delete(key);
+                }
+            }, deleteTime);
+        } else {
+            return inner.delete(key);
+        }
     }
 
     @Override
@@ -182,7 +186,27 @@ public class MeteredKeyValueStore<K, V> extends WrappedStateStore.AbstractStateS
 
     @Override
     public void flush() {
-        metrics.measureLatencyNs(time, flushDelegate, this.flushTime);
+        if (flushTime.shouldRecord()) {
+            measureLatency(new Action<V>() {
+                @Override
+                public V execute() {
+                    inner.flush();
+                    return null;
+                }
+            }, flushTime);
+        } else {
+            inner.flush();
+        }
+
+    }
+
+    private V measureLatency(final Action<V> action, final Sensor sensor) {
+        final long startNs = time.nanoseconds();
+        try {
+            return action.execute();
+        } finally {
+            metrics.recordLatency(sensor, startNs, time.nanoseconds());
+        }
     }
 
     private class MeteredKeyValueIterator<K1, V1> implements KeyValueIterator<K1, V1> {


### PR DESCRIPTION
`MeteredKeyValueStore` wasn't thread safe. Interleaving operations could modify the state, i.e, the `key` and/or `value` which could result in incorrect behaviour.