### PR TITLE
KAFKA-5664: Disable auto offset commit in ConsoleConsumer if no group is provided

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -405,6 +405,8 @@ object ConsoleConsumer extends Logging {
     //Provide the consumer with a randomly assigned group id
     if (!consumerProps.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
       consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, s"console-consumer-${new Random().nextInt(100000)}")
+      // Avoid polluting the coordinator cache since the group won't likely be used again
+      consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
       groupIdPassed = false
     }
 

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -405,8 +405,10 @@ object ConsoleConsumer extends Logging {
     //Provide the consumer with a randomly assigned group id
     if (!consumerProps.containsKey(ConsumerConfig.GROUP_ID_CONFIG)) {
       consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, s"console-consumer-${new Random().nextInt(100000)}")
-      // Avoid polluting the coordinator cache since the group won't likely be used again
-      consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
+      // By default, avoid polluting the coordinator cache since the auto-generated group
+      // and its offsets won't likely be used again
+      if (!consumerProps.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))
+        consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
       groupIdPassed = false
     }
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -58,6 +58,8 @@
         whether there is offline log directory. </li>
     <li>Added KafkaStorageException which is a retriable exception. KafkaStorageException will be converted to NotLeaderForPartitionException in the response
         if the version of client's FetchRequest or ProducerRequest does not support KafkaStorageException. </li>
+    <li>The default for console consumer's <code>enable.auto.commit</code> property when no <code>group.id</code> is provided is now set to <code>false</code>.
+        This is to avoid polluting the consumer coordinator cache as the auto-generated group is not likely to be used by other consumers.
 </ul>
 
 <h5><a id="upgrade_100_new_protocols" href="#upgrade_100_new_protocols">New Protocol Versions</a></h5>


### PR DESCRIPTION
This is to avoid polluting the Consumer Coordinator cache as the auto-generated group and its offsets are unlikely to be reused.