### PR TITLE
KAFKA-4218: Add withkey methods to KStream

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream;
 
 /**
- * The {@code InitializerWithKey} interface for creating an initial value in aggregations with read-a only key.
+ * The {@code InitializerWithKey} interface for creating an initial value in aggregations with a read-only key.
  * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
  * partitioning.
  * {@code InitializerWithKey} is used in combination with {@link Aggregator}.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code InitializerWithKey} interface for creating an initial value in aggregations with read-a only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * {@code InitializerWithKey} is used in combination with {@link Aggregator}.
+ *
+ * @param <K> key type
+ * @param <VA> aggregate value type
+ * @see Aggregator
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Windows, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Windows, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Merger, SessionWindows, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Merger, SessionWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.streams.processor.StateStoreSupplier)
+ */
+public interface InitializerWithKey<K, VA> {
+    /**
+     * Return the initial value for an aggregation given a read-only key.
+     *
+     * @return the initial value for an aggregation
+     */
+    VA apply(K key);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -1316,7 +1316,7 @@ public interface KStream<K, V> {
      * <tr>
      * <td>&lt;K1:A&gt;</td>
      * <td></td>
-     * <td>&lt;K1:ValueJoiner(A,null)&gt;</td>
+     * <td></td>
      * </tr>
      * <tr>
      * <td>&lt;K2:B&gt;</td>
@@ -1396,7 +1396,7 @@ public interface KStream<K, V> {
      * <tr>
      * <td>&lt;K1:A&gt;</td>
      * <td></td>
-     * <td>&lt;K1:ValueJoiner(A,null)&gt;</td>
+     * <td></td>
      * </tr>
      * <tr>
      * <td>&lt;K2:B&gt;</td>
@@ -1417,7 +1417,7 @@ public interface KStream<K, V> {
      * If this requirement is not met, Kafka Streams will automatically repartition the data, i.e., it will create an
      * internal repartitioning topic in Kafka and write and re-read the data via this topic before the actual join.
      * The repartitioning topic will be named "${applicationId}-XXX-repartition", where "applicationId" is
-     * user-specified in {@link  StreamsConfig} via parameter
+     * user-specified in {@link StreamsConfig} via parameter
      * {@link StreamsConfig#APPLICATION_ID_CONFIG APPLICATION_ID_CONFIG}, "XXX" is an internally generated name, and
      * "-repartition" is a fixed suffix.
      * You can retrieve all generated internal topic names via {@link KafkaStreams#toString()}.
@@ -2715,7 +2715,9 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one output for each input {@code KStream} record
      * @see #join(KTable, ValueJoiner)
+     * @see #join(KTable, ValueJoinerWithKey)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
                                      final ValueJoiner<? super V, ? super VT, ? extends VR> joiner);
@@ -2793,9 +2795,11 @@ public interface KStream<K, V> {
      * @param <VT>          the value type of the table
      * @param <VR>          the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #join(KTable, ValueJoiner)
+     * @see #join(KTable, ValueJoinerWithKey)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
                                      final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner);
@@ -2875,7 +2879,9 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one output for each input {@code KStream} record
      * @see #join(KTable, ValueJoiner, Serde, Serde)
+     * @see #join(KTable, ValueJoinerWithKey, Serde, Serde)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
                                      final ValueJoiner<? super V, ? super VT, ? extends VR> joiner,
@@ -2958,9 +2964,11 @@ public interface KStream<K, V> {
      * @param <VT>          the value type of the table
      * @param <VR>          the value type of the result stream
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #join(KTable, ValueJoiner, Serde, Serde)
+     * @see #join(KTable, ValueJoinerWithKey, Serde, Serde)
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <VT, VR> KStream<K, VR> leftJoin(final KTable<K, VT> table,
                                      final ValueJoinerWithKey<? super K, ? super V, ? super VT, ? extends VR> joiner,
@@ -2993,6 +3001,7 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one output for each input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalKTable,
                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keyValueMapper,
@@ -3024,8 +3033,9 @@ public interface KStream<K, V> {
      * @param <GV>           the value type of the {@link GlobalKTable}
      * @param <RV>           the value type of the resulting {@code KStream}
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #leftJoin(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> join(final GlobalKTable<GK, GV> globalKTable,
                                      final KeyValueMapper<? super K, ? super V, ? extends GK> keyValueMapper,
@@ -3061,6 +3071,7 @@ public interface KStream<K, V> {
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one output for each input {@code KStream} record
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalKTable,
                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keyValueMapper,
@@ -3091,15 +3102,16 @@ public interface KStream<K, V> {
      * @param globalKTable       the {@link GlobalKTable} to be joined with this stream
      * @param keyValueMapper     instance of {@link KeyValueMapper} used to map from the (key, value) of this stream
      *                           to the key of the {@link GlobalKTable}
-     * @param valueJoinerWithKey a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
+     * @param joiner             a {@link ValueJoinerWithKey} that computes the join result for a pair of matching records
      * @param <GK>               the key type of {@link GlobalKTable}
      * @param <GV>               the value type of the {@link GlobalKTable}
      * @param <RV>               the value type of the resulting {@code KStream}
      * @return a {@code KStream} that contains join-records for each key and values computed by the given
-     * {@link ValueJoiner}, one output for each input {@code KStream} record
+     * {@link ValueJoinerWithKey}, one output for each input {@code KStream} record
      * @see #join(GlobalKTable, KeyValueMapper, ValueJoiner)
+     * @see #join(GlobalKTable, KeyValueMapper, ValueJoinerWithKey)
      */
     <GK, GV, RV> KStream<K, RV> leftJoin(final GlobalKTable<GK, GV> globalKTable,
                                          final KeyValueMapper<? super K, ? super V, ? extends GK> keyValueMapper,
-                                         final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> valueJoinerWithKey);
+                                         final ValueJoinerWithKey<? super K, ? super V, ? super GV, ? extends RV> joiner);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ReducerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ReducerWithKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.KeyValue;
+
+/**
+ * The {@code ReducerWithKey} interface for combining two values of the same type into a new value.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * In contrast to {@link Aggregator} the result type must be the same as the input type.
+ * <p>
+ * The provided values can be either original values from input {@link KeyValue} pair records or be a previously
+ * computed result from {@link Reducer#apply(Object, Object)}.
+ * <p>
+ * {@code ReducerWithKey} can be used to implement aggregation functions like sum, min, or max.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ * @see KGroupedStream#reduce(ReducerWithKey, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#reduce(ReducerWithKey, Windows, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#reduce(ReducerWithKey, SessionWindows, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, SessionWindows, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see Aggregator
+ */
+public interface ReducerWithKey<K, V> {
+
+    /**
+     * Aggregate the two given values into a single one.
+     *
+     * @param key the read-only key
+     * @param value1 the first value for the aggregation
+     * @param value2 the second value for the aggregation
+     * @return the aggregated value
+     */
+    V apply(final K key, final V value1, final V value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code ValueJoinerWithKey} interface for joining two values into a new value of arbitrary type.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateless operation, i.e, {@link #apply(Object, Object, Object)} is invoked individually for each joining
+ * record-pair of a {@link KStream}-{@link KStream}, {@link KStream}-{@link KTable}, or {@link KTable}-{@link KTable}
+ * join.
+ *
+ * @param <K> key type
+ * @param <V1> first value type
+ * @param <V2> second value type
+ * @param <VR> joined value type
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#join(KTable, ValueJoinerWithKey)
+ * @see KStream#join(KTable, ValueJoinerWithKey, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KTable#join(KTable, ValueJoinerWithKey)
+ * @see KTable#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KTable#outerJoin(KTable, ValueJoinerWithKey)
+ */
+public interface ValueJoinerWithKey<K, V1, V2, VR> {
+
+    /**
+     * Return a joined value consisting of {@code value1} and {@code value2} with given read-only {@code key}. Any
+     * modification to {@code key} can result in corrupt partitioning.
+     *
+     * @param key the read-only key of particular record.
+     * @param value1 the first value for joining
+     * @param value2 the second value for joining
+     * @return the joined value
+     */
+    VR apply(final K key, final V1 value1, final V2 value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code ValueMapperWithKey} interface for mapping a value to a new value of arbitrary type.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateless record-by-record operation, i.e, {@link #apply(Object, Object)} is invoked individually for each
+ * record of a stream (cf. {@link ValueTransformer} for stateful value transformation).
+ * If {@code ValueMapper} is applied to a {@link org.apache.kafka.streams.KeyValue key-value pair} record the record's
+ * key is preserved.
+ * If a record's key and value should be modified {@link KeyValueMapper} can be used.
+ *
+ * @param <K>  key type
+ * @param <V>  value type
+ * @param <VR> mapped value type
+ * @see KeyValueMapper
+ * @see ValueTransformerWithKey
+ * @see KStream#mapValues(ValueMapperWithKey)
+ * @see KStream#flatMapValues(ValueMapperWithKey)
+ * @see KTable#mapValues(ValueMapperWithKey)
+ */
+public interface ValueMapperWithKey<K, V, VR> {
+
+    /**
+     * Map the given value to a new value. {@code key} is read-only and any modification to {@code key} can result in
+     * corrupt partitioning.
+     *
+     * @param key the read-only key of particular record
+     * @param value the value to be mapped
+     * @return the new value
+     */
+    VR apply(final K key, final V value);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKey.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+
+/**
+ * The {@code ValueTransformerWithKey} interface for stateful mapping of a value to a new value (with possible new type).
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateful record-by-record operation, i.e, {@link #transform(Object, Object)} is invoked individually for
+ * each record of a stream and can access and modify a state that is available beyond a single call of
+ * {@link #transform(Object, Object)} (cf. {@link ValueMapperWithKey} for stateless value transformation).
+ * Additionally, this {@code ValueTransformerWithKey} can {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule}
+ * a method to be {@link Punctuator#punctuate(long) called periodically} with the provided context.
+ * If {@code ValueTransformer} is applied to a {@link KeyValue} pair record the record's key is preserved.
+ * <p>
+ * Use {@link ValueTransformerWithKeySupplier} to provide new instances of {@code ValueTransformer} to Kafka Stream's runtime.
+ * <p>
+ * If a record's key and value should be modified {@link Transformer} can be used.
+ *
+ * @param <K>  key type
+ * @param <V>  value type
+ * @param <VR> transformed value type
+ * @see ValueTransformerWithKeySupplier
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see Transformer
+ */
+public interface ValueTransformerWithKey<K, V, VR> {
+
+    /**
+     * Initialize this transformer.
+     * This is called once per instance when the topology gets initialized.
+     * <p>
+     * The provided {@link ProcessorContext context} can be used to access topology and record meta data, to
+     * {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule} a method to be
+     * {@link Punctuator#punctuate(long) called periodically} and to access attached {@link StateStore}s.
+     * <p>
+     * Note that {@link ProcessorContext} is updated in the background with the current record's meta data.
+     * Thus, it only contains valid record meta data when accessed within {@link #transform(Object, Object)}.
+     * <p>
+     * Note that using {@link ProcessorContext#forward(Object, Object)},
+     * {@link ProcessorContext#forward(Object, Object, int)}, or
+     * {@link ProcessorContext#forward(Object, Object, String)} is not allowed within any method of
+     * {@code ValueTransformerWithKey} and will result in an {@link StreamsException exception}.
+     *
+     * @param context the context
+     */
+    void init(final ProcessorContext context);
+
+    /**
+     * Transform the given value to a new value. {@code key} is read-only and should not be modified. Any modification
+     * to {@code key} can result in corrupt partitioning.
+     * Additionally, any {@link StateStore} that is {@link KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+     * attached} to this operator can be accessed and modified arbitrarily (cf.
+     * {@link ProcessorContext#getStateStore(String)}).
+     * <p>
+     * Note, that using {@link ProcessorContext#forward(Object, Object)},
+     * {@link ProcessorContext#forward(Object, Object, int)}, and
+     * {@link ProcessorContext#forward(Object, Object, String)} is not allowed within {@code transform} and
+     * will result in an {@link StreamsException exception}.
+     *
+     * @param key the read-only key of particular record.
+     * @param value the value to be transformed
+     * @return the new value
+     */
+    VR transform(final K key, final V value);
+
+    /**
+     * Perform any periodic operations if this processor {@link ProcessorContext#schedule(long) schedule itself} with
+     * the context during {@link #init(ProcessorContext) initialization}.
+     * <p>
+     * It is not possible to return any new output records within {@code punctuate}.
+     * Using {@link ProcessorContext#forward(Object, Object)}, {@link ProcessorContext#forward(Object, Object, int)},
+     * or {@link ProcessorContext#forward(Object, Object, String)} will result in an
+     * {@link StreamsException exception}.
+     * Furthermore, {@code punctuate} must return {@code null}.
+     * <p>
+     * Note, that {@code punctuate} is called base on <it>stream time</it> (i.e., time progress with regard to
+     * timestamps return by the used {@link TimestampExtractor})
+     * and not based on wall-clock time.
+     *
+     * @deprecated Please use {@link Punctuator} functional interface instead.
+     *
+     * @param timestamp the stream time when {@code punctuate} is being called
+     * @return must return {@code null}&mdash;otherwise, an {@link StreamsException exception} will be thrown
+     */
+    @Deprecated
+    VR punctuate(final long timestamp);
+
+    /**
+     * Close this processor and clean up any resources.
+     * <p>
+     * It is not possible to return any new output records within {@code close()}.
+     * Using {@link ProcessorContext#forward(Object, Object)}, {@link ProcessorContext#forward(Object, Object, int)},
+     * or {@link ProcessorContext#forward(Object, Object, String)} will result in an {@link StreamsException exception}.
+     */
+    void close();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
@@ -24,8 +24,8 @@ package org.apache.kafka.streams.kstream;
  * @param <V>  value type
  * @param <VR> transformed value type
  * @see ValueTransformerWithKey
- * TODO
  * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see KStream#transformValues(ValueTransformerWithKeyWithKeySupplier, String...)
  * @see Transformer
  * @see TransformerSupplier
  * @see KStream#transform(TransformerSupplier, String...)

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * A {@code ValueTransformerWithKeySupplier} interface which can create one or more {@link ValueTransformerWithKey}
+ * instances.
+ *
+ * @param <K>  value type
+ * @param <V>  value type
+ * @param <VR> transformed value type
+ * @see ValueTransformerWithKey
+ * TODO
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see Transformer
+ * @see TransformerSupplier
+ * @see KStream#transform(TransformerSupplier, String...)
+ */
+public interface ValueTransformerWithKeySupplier<K, V, VR> {
+
+    /**
+     * Return a new {@link ValueTransformerWithKey} instance.
+     *
+     * @return a new {@link ValueTransformerWithKey} instance.
+     */
+    ValueTransformerWithKey<K, V, VR> get();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -24,13 +24,9 @@ import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
-import org.apache.kafka.streams.kstream.ReducerWithKey;
-import org.apache.kafka.streams.kstream.Reducer;
-import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.apache.kafka.streams.kstream.ValueTransformer;
-import org.apache.kafka.streams.kstream.InitializerWithKey;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.processor.StateStoreSupplier;
@@ -184,26 +180,6 @@ public abstract class AbstractStream<K> {
             @Override
             public ValueTransformerWithKey<K, V, VR> get() {
                 return withKey(valueTransformerSupplier.get());
-            }
-        };
-    }
-
-    static <K, V> ReducerWithKey<K, V> withKey(final Reducer<V> reducer) {
-        Objects.requireNonNull(reducer, "reducer can't be null");
-        return new ReducerWithKey<K, V>() {
-            @Override
-            public V apply(K key, V value1, V value2) {
-                return reducer.apply(value1, value2);
-            }
-        };
-    }
-
-    static <K, VA> InitializerWithKey<K, VA> withKey(final Initializer<VA> initializer) {
-        Objects.requireNonNull(initializer, "initializer can't be null");
-        return new InitializerWithKey<K, VA>() {
-            @Override
-            public VA apply(K key) {
-                return initializer.apply();
             }
         };
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/AbstractStream.java
@@ -20,6 +20,18 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ReducerWithKey;
+import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueTransformer;
+import org.apache.kafka.streams.kstream.InitializerWithKey;
+import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.processor.StateStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -80,6 +92,15 @@ public abstract class AbstractStream<K> {
         };
     }
 
+    static <K, T2, T1, R> ValueJoinerWithKey<K, T2, T1, R> reverseJoiner(final ValueJoinerWithKey<K, T1, T2, R> joiner) {
+        return new ValueJoinerWithKey<K, T2, T1, R>() {
+            @Override
+            public R apply(K key, T2 value2, T1 value1) {
+                return joiner.apply(key, value1, value2);
+            }
+        };
+    }
+
     @SuppressWarnings("unchecked")
     static <T, K>  StateStoreSupplier<KeyValueStore> keyValueStore(final Serde<K> keySerde,
                                                                    final Serde<T> aggValueSerde,
@@ -111,5 +132,79 @@ public abstract class AbstractStream<K> {
                 .enableCaching();
     }
 
+    static <K, V, VR> ValueMapperWithKey<K, V, VR> withKey(final ValueMapper<V, VR> valueMapper) {
+        Objects.requireNonNull(valueMapper, "valueMapper can't be null");
+        return new ValueMapperWithKey<K, V, VR>() {
+            @Override
+            public VR apply(K key, V value) {
+                return valueMapper.apply(value);
+            }
+        };
+    }
 
+    static <K, V1, V2, VR> ValueJoinerWithKey<K, V1, V2, VR> withKey(final ValueJoiner<V1, V2, VR> valueJoiner) {
+        Objects.requireNonNull(valueJoiner, "valueJoiner can't be null");
+        return new ValueJoinerWithKey<K, V1, V2, VR>() {
+            @Override
+            public VR apply(K key, V1 value1, V2 value2) {
+                return valueJoiner.apply(value1, value2);
+            }
+        };
+    }
+
+    static <K, V, VR> ValueTransformerWithKey<K, V, VR> withKey(final ValueTransformer<V, VR> valueTransformer) {
+        Objects.requireNonNull(valueTransformer, "valueTransformer can't be null");
+        return new ValueTransformerWithKey<K, V, VR>() {
+            @Override
+            public void init(ProcessorContext context) {
+                valueTransformer.init(context);
+            }
+
+            @Override
+            public VR transform(K key, V value) {
+                return valueTransformer.transform(value);
+            }
+
+            @SuppressWarnings("deprecation")
+            @Override
+            public VR punctuate(long timestamp) {
+                return valueTransformer.punctuate(timestamp);
+            }
+
+            @Override
+            public void close() {
+                valueTransformer.close();
+            }
+        };
+    }
+
+    static <K, V, VR> ValueTransformerWithKeySupplier<K, V, VR> withKey(final ValueTransformerSupplier<V, VR> valueTransformerSupplier) {
+        Objects.requireNonNull(valueTransformerSupplier, "valueTransformerSupplier can't be null");
+        return new ValueTransformerWithKeySupplier<K, V, VR>() {
+            @Override
+            public ValueTransformerWithKey<K, V, VR> get() {
+                return withKey(valueTransformerSupplier.get());
+            }
+        };
+    }
+
+    static <K, V> ReducerWithKey<K, V> withKey(final Reducer<V> reducer) {
+        Objects.requireNonNull(reducer, "reducer can't be null");
+        return new ReducerWithKey<K, V>() {
+            @Override
+            public V apply(K key, V value1, V value2) {
+                return reducer.apply(value1, value2);
+            }
+        };
+    }
+
+    static <K, VA> InitializerWithKey<K, VA> withKey(final Initializer<VA> initializer) {
+        Objects.requireNonNull(initializer, "initializer can't be null");
+        return new InitializerWithKey<K, VA>() {
+            @Override
+            public VA apply(K key) {
+                return initializer.apply();
+            }
+        };
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapValues.java
@@ -16,16 +16,16 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
 class KStreamFlatMapValues<K, V, V1> implements ProcessorSupplier<K, V> {
 
-    private final ValueMapper<? super V, ? extends Iterable<? extends V1>> mapper;
+    private final ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends V1>> mapper;
 
-    KStreamFlatMapValues(ValueMapper<? super V, ? extends Iterable<? extends V1>> mapper) {
+    KStreamFlatMapValues(ValueMapperWithKey<? super K, ? super V, ? extends Iterable<? extends V1>> mapper) {
         this.mapper = mapper;
     }
 
@@ -37,7 +37,7 @@ class KStreamFlatMapValues<K, V, V1> implements ProcessorSupplier<K, V> {
     private class KStreamFlatMapValuesProcessor extends AbstractProcessor<K, V> {
         @Override
         public void process(K key, V value) {
-            Iterable<? extends V1> newValues = mapper.apply(value);
+            Iterable<? extends V1> newValues = mapper.apply(key, value);
             for (V1 v : newValues) {
                 context().forward(key, v);
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamGlobalKTableJoin.java
@@ -17,19 +17,19 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
 class KStreamGlobalKTableJoin<K1, K2, R, V1, V2> implements ProcessorSupplier<K1, V1> {
 
     private final KTableValueGetterSupplier<K2, V2> valueGetterSupplier;
-    private final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
+    private final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner;
     private final KeyValueMapper<? super K1, ? super V1, ? extends K2> mapper;
     private final boolean leftJoin;
 
     KStreamGlobalKTableJoin(final KTableValueGetterSupplier<K2, V2> valueGetterSupplier,
-                            final ValueJoiner<? super V1, ? super V2, ? extends R> joiner,
+                            final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner,
                             final KeyValueMapper<? super K1, ? super V1, ? extends K2> mapper,
                             final boolean leftJoin) {
         this.valueGetterSupplier = valueGetterSupplier;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoin.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
@@ -30,10 +30,12 @@ class KStreamKTableJoin<K, R, V1, V2> implements ProcessorSupplier<K, V1> {
         }
     };
     private final KTableValueGetterSupplier<K, V2> valueGetterSupplier;
-    private final ValueJoiner<? super V1, ? super V2, R> joiner;
+    private final ValueJoinerWithKey<? super K, ? super V1, ? super V2, R> joiner;
     private final boolean leftJoin;
 
-    KStreamKTableJoin(final KTableValueGetterSupplier<K, V2> valueGetterSupplier, final ValueJoiner<? super V1, ? super V2, R> joiner, final boolean leftJoin) {
+    KStreamKTableJoin(final KTableValueGetterSupplier<K, V2> valueGetterSupplier,
+                      final ValueJoinerWithKey<? super K, ? super V1, ? super V2, R> joiner,
+                      final boolean leftJoin) {
         this.valueGetterSupplier = valueGetterSupplier;
         this.joiner = joiner;
         this.leftJoin = leftJoin;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinProcessor.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
@@ -25,12 +25,12 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
 
     private final KTableValueGetter<K2, V2> valueGetter;
     private final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper;
-    private final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
+    private final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner;
     private final boolean leftJoin;
 
     KStreamKTableJoinProcessor(final KTableValueGetter<K2, V2> valueGetter,
                                final KeyValueMapper<? super K1, ? super V1, ? extends K2> keyMapper,
-                               final ValueJoiner<? super V1, ? super V2, ? extends R> joiner,
+                               final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joiner,
                                final boolean leftJoin) {
         this.valueGetter = valueGetter;
         this.keyMapper = keyMapper;
@@ -55,7 +55,7 @@ class KStreamKTableJoinProcessor<K1, K2, V1, V2, R> extends AbstractProcessor<K1
         if (key != null && value != null) {
             final V2 value2 = valueGetter.get(keyMapper.apply(key, value));
             if (leftJoin || value2 != null) {
-                context().forward(key, joiner.apply(value, value2));
+                context().forward(key, joiner.apply(key, value, value2));
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMapValues.java
@@ -16,16 +16,16 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
 class KStreamMapValues<K, V, V1> implements ProcessorSupplier<K, V> {
 
-    private final ValueMapper<V, V1> mapper;
+    private final ValueMapperWithKey<K, V, V1> mapper;
 
-    public KStreamMapValues(ValueMapper<V, V1> mapper) {
+    public KStreamMapValues(ValueMapperWithKey<K, V, V1> mapper) {
         this.mapper = mapper;
     }
 
@@ -37,7 +37,7 @@ class KStreamMapValues<K, V, V1> implements ProcessorSupplier<K, V> {
     private class KStreamMapProcessor extends AbstractProcessor<K, V> {
         @Override
         public void process(final K key, final V value) {
-            V1 newValue = mapper.apply(value);
+            V1 newValue = mapper.apply(key, value);
             context().forward(key, newValue);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
@@ -19,8 +19,8 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.kstream.ValueTransformer;
-import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.processor.Cancellable;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -36,29 +36,29 @@ import java.util.Map;
 
 public class KStreamTransformValues<K, V, R> implements ProcessorSupplier<K, V> {
 
-    private final ValueTransformerSupplier<V, R> valueTransformerSupplier;
+    private final ValueTransformerWithKeySupplier<K, V, R> valueTransformerWithKeySupplier;
 
-    public KStreamTransformValues(ValueTransformerSupplier<V, R> valueTransformerSupplier) {
-        this.valueTransformerSupplier = valueTransformerSupplier;
+    public KStreamTransformValues(ValueTransformerWithKeySupplier<K, V, R> valueTransformerWithKeySupplier) {
+        this.valueTransformerWithKeySupplier = valueTransformerWithKeySupplier;
     }
 
     @Override
     public Processor<K, V> get() {
-        return new KStreamTransformValuesProcessor<>(valueTransformerSupplier.get());
+        return new KStreamTransformValuesProcessor<>(valueTransformerWithKeySupplier.get());
     }
 
     public static class KStreamTransformValuesProcessor<K, V, R> implements Processor<K, V> {
 
-        private final ValueTransformer<V, R> valueTransformer;
+        private final ValueTransformerWithKey<K, V, R> valueTransformerWithKey;
         private ProcessorContext context;
 
-        public KStreamTransformValuesProcessor(ValueTransformer<V, R> valueTransformer) {
-            this.valueTransformer = valueTransformer;
+        public KStreamTransformValuesProcessor(ValueTransformerWithKey<K, V, R> valueTransformerWithKey) {
+            this.valueTransformerWithKey = valueTransformerWithKey;
         }
 
         @Override
         public void init(final ProcessorContext context) {
-            valueTransformer.init(
+            valueTransformerWithKey.init(
                 new ProcessorContext() {
                     @Override
                     public String applicationId() {
@@ -166,20 +166,20 @@ public class KStreamTransformValues<K, V, R> implements ProcessorSupplier<K, V> 
 
         @Override
         public void process(K key, V value) {
-            context.forward(key, valueTransformer.transform(value));
+            context.forward(key, valueTransformerWithKey.transform(key, value));
         }
 
         @SuppressWarnings("deprecation")
         @Override
         public void punctuate(long timestamp) {
-            if (valueTransformer.punctuate(timestamp) != null) {
+            if (valueTransformerWithKey.punctuate(timestamp) != null) {
                 throw new StreamsException("ValueTransformer#punctuate must return null.");
             }
         }
 
         @Override
         public void close() {
-            valueTransformer.close();
+            valueTransformerWithKey.close();
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValues.java
@@ -38,7 +38,7 @@ public class KStreamTransformValues<K, V, R> implements ProcessorSupplier<K, V> 
 
     private final ValueTransformerWithKeySupplier<K, V, R> valueTransformerWithKeySupplier;
 
-    public KStreamTransformValues(ValueTransformerWithKeySupplier<K, V, R> valueTransformerWithKeySupplier) {
+    public KStreamTransformValues(final ValueTransformerWithKeySupplier<K, V, R> valueTransformerWithKeySupplier) {
         this.valueTransformerWithKeySupplier = valueTransformerWithKeySupplier;
     }
 
@@ -52,7 +52,7 @@ public class KStreamTransformValues<K, V, R> implements ProcessorSupplier<K, V> 
         private final ValueTransformerWithKey<K, V, R> valueTransformerWithKey;
         private ProcessorContext context;
 
-        public KStreamTransformValuesProcessor(ValueTransformerWithKey<K, V, R> valueTransformerWithKey) {
+        public KStreamTransformValuesProcessor(final ValueTransformerWithKey<K, V, R> valueTransformerWithKey) {
             this.valueTransformerWithKey = valueTransformerWithKey;
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -455,9 +455,9 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
     public KStream<K, V> toStream() {
         String name = builder.newName(TOSTREAM_NAME);
 
-        builder.internalTopologyBuilder.addProcessor(name, new KStreamMapValues<K, Change<V>, V>(new ValueMapperWithKey<K, Change<V>, V>() {
+        builder.internalTopologyBuilder.addProcessor(name, new KStreamMapValues<>(new ValueMapperWithKey<K, Change<V>, V>() {
             @Override
-            public V apply(K key, Change<V> change) {
+            public V apply(final K key, final Change<V> change) {
                 return change.newValue;
             }
         }), this.name);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.PrintForeachAction;
 import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.processor.StateStoreSupplier;
@@ -454,9 +455,9 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
     public KStream<K, V> toStream() {
         String name = builder.newName(TOSTREAM_NAME);
 
-        builder.internalTopologyBuilder.addProcessor(name, new KStreamMapValues<K, Change<V>, V>(new ValueMapper<Change<V>, V>() {
+        builder.internalTopologyBuilder.addProcessor(name, new KStreamMapValues<K, Change<V>, V>(new ValueMapperWithKey<K, Change<V>, V>() {
             @Override
-            public V apply(Change<V> change) {
+            public V apply(K key, Change<V> change) {
                 return change.newValue;
             }
         }), this.name);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamFlatMapValuesTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.test.KStreamTestDriver;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.junit.Rule;
@@ -73,4 +74,43 @@ public class KStreamFlatMapValuesTest {
             assertEquals(expected[i], processor.processed.get(i));
         }
     }
+
+    @Test
+    public void testFlatMapValuesWithKeys() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        ValueMapperWithKey<Integer, Number, Iterable<String>> mapper =
+                new ValueMapperWithKey<Integer, Number, Iterable<String>>() {
+            @Override
+            public Iterable<String> apply(Integer key, Number value) {
+                ArrayList<String> result = new ArrayList<String>();
+                result.add("v" + value);
+                result.add("k" + key);
+                return result;
+            }
+        };
+
+        final int[] expectedKeys = {0, 1, 2, 3};
+
+        KStream<Integer, Integer> stream;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream = builder.stream(Serdes.Integer(), Serdes.Integer(), topicName);
+        stream.flatMapValues(mapper).process(processor);
+
+        driver.setUp(builder);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topicName, expectedKey, expectedKey);
+        }
+
+        assertEquals(8, processor.processed.size());
+
+        String[] expected = {"0:v0", "0:k0", "1:v1", "1:k1", "2:v2", "2:k2", "3:v3", "3:k3"};
+
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], processor.processed.get(i));
+        }
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamImplTest.java
@@ -85,9 +85,9 @@ public class KStreamImplTest {
                 }
             });
 
-        KStream<String, Integer> stream2 = stream1.mapValues(new ValueMapperWithKey<String, String, Integer>() {
+        KStream<String, Integer> stream2 = stream1.mapValues(new ValueMapper<String, Integer>() {
             @Override
-            public Integer apply(String key, String value) {
+            public Integer apply(String value) {
                 return new Integer(value);
             }
         });
@@ -130,9 +130,9 @@ public class KStreamImplTest {
         );
 
         final int anyWindowSize = 1;
-        KStream<String, Integer> stream4 = streams2[0].join(streams3[0], new ValueJoinerWithKey<String, Integer, Integer, Integer>() {
+        KStream<String, Integer> stream4 = streams2[0].join(streams3[0], new ValueJoiner<Integer, Integer, Integer>() {
             @Override
-            public Integer apply(String key, Integer value1, Integer value2) {
+            public Integer apply(Integer value1, Integer value2) {
                 return value1 + value2;
             }
         }, JoinWindows.of(anyWindowSize), stringSerde, intSerde, intSerde);
@@ -211,7 +211,7 @@ public class KStreamImplTest {
             }
         }
     }
-    
+
     @Test
     public void testToWithNullValueSerdeDoesntNPE() {
         final StreamsBuilder builder = new StreamsBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -156,6 +156,69 @@ public class KStreamKStreamJoinTest {
         processor.checkAndClearProcessResult("0:X0+YYY0", "0:X0+YYY0", "0:XX0+YYY0", "1:X1+YYY1", "1:X1+YYY1", "1:XX1+YYY1");
     }
 
+
+    @Test
+    public void testJoinWithKey() throws Exception {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        KStream<Integer, String> stream1;
+        KStream<Integer, String> stream2;
+        KStream<Integer, String> joined;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+        joined = stream1.join(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+        driver.setTime(0L);
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "0:0+X0+YY0", "1:1+X1+YY1", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "0:0+XX0+YY0", "1:1+XX1+Y1", "1:1+XX1+YY1", "2:2+XX2+YY2", "3:3+XX3+YY3");
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "YYY" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YYY0", "0:0+X0+YYY0", "0:0+XX0+YYY0", "1:1+X1+YYY1", "1:1+X1+YYY1", "1:1+XX1+YYY1");
+    }
+
     @Test
     public void testOuterJoin() throws Exception {
         StreamsBuilder builder = new StreamsBuilder();
@@ -252,6 +315,68 @@ public class KStreamKStreamJoinTest {
         }
 
         processor.checkAndClearProcessResult("0:X0+YYY0", "0:X0+YYY0", "0:XX0+YYY0", "1:X1+YYY1", "1:X1+YYY1", "1:XX1+YYY1");
+    }
+
+    @Test
+    public void testOuterJoinWithKey() throws Exception {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        KStream<Integer, String> stream1;
+        KStream<Integer, String> stream2;
+        KStream<Integer, String> joined;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+        joined = stream1.outerJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+        driver.setTime(0L);
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+null", "1:1+X1+null");
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1", "2:2+X2+null", "3:3+X3+null");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "0:0+X0+YY0", "1:1+X1+YY1", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "0:0+XX0+YY0", "1:1+XX1+Y1", "1:1+XX1+YY1", "2:2+XX2+YY2", "3:3+XX3+YY3");
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "YYY" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YYY0", "0:0+X0+YYY0", "0:0+XX0+YYY0", "1:1+X1+YYY1", "1:1+X1+YYY1", "1:1+XX1+YYY1");
     }
 
     @Test
@@ -482,6 +607,215 @@ public class KStreamKStreamJoinTest {
     }
 
     @Test
+    public void testWindowingWithKey() throws Exception {
+        long time = 0L;
+
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        KStream<Integer, String> stream1;
+        KStream<Integer, String> stream2;
+        KStream<Integer, String> joined;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+
+        joined = stream1.join(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+
+        setRecordContext(time, topic1);
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        setRecordContext(time, topic2);
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        // clear logically
+        time = 1000L;
+        setRecordContext(time, topic1);
+        for (int i = 0; i < expectedKeys.length; i++) {
+            setRecordContext(time + i, topic1);
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        processor.checkAndClearProcessResult();
+
+        time = 1000 + 100L;
+        setRecordContext(time, topic2);
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // go back to the time before expiration
+
+        time = 1000L - 100L - 1L;
+        setRecordContext(time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        // clear (logically)
+        time = 2000L;
+        for (int i = 0; i < expectedKeys.length; i++) {
+            setRecordContext(time + i, topic2);
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        time = 2000L + 100L;
+        setRecordContext(time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("2:2+XX2+Y2", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // go back to the time before expiration
+
+        time = 2000L - 100L - 1L;
+        setRecordContext(time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
+    }
+
+    @Test
     public void testAsymetricWindowingAfter() throws Exception {
         long time = 1000L;
 
@@ -591,6 +925,115 @@ public class KStreamKStreamJoinTest {
     }
 
     @Test
+    public void testWithKeyAsymetricWindowingAfter() throws Exception {
+        long time = 1000L;
+
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        KStream<Integer, String> stream1;
+        KStream<Integer, String> stream2;
+        KStream<Integer, String> joined;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+
+        joined = stream1.join(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(0).after(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+
+        for (int i = 0; i < expectedKeys.length; i++) {
+            setRecordContext(time + i, topic1);
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        processor.checkAndClearProcessResult();
+
+
+        time = 1000L - 1L;
+        setRecordContext(time, topic2);
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        time = 1000 + 100L;
+        setRecordContext(time, topic2);
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+    }
+
+    @Test
     public void testAsymetricWindowingBefore() throws Exception {
         long time = 1000L;
 
@@ -689,6 +1132,114 @@ public class KStreamKStreamJoinTest {
         }
 
         processor.checkAndClearProcessResult("3:X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+    }
+
+    @Test
+    public void testWithKeyAsymetricWindowingBefore() throws Exception {
+        long time = 1000L;
+
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        KStream<Integer, String> stream1;
+        KStream<Integer, String> stream2;
+        KStream<Integer, String> joined;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+
+        joined = stream1.join(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(0).before(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+
+        for (int i = 0; i < expectedKeys.length; i++) {
+            setRecordContext(time + i, topic1);
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        processor.checkAndClearProcessResult();
+
+
+        time = 1000L - 100L - 1L;
+
+        setRecordContext(time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+        time = 1000L;
+
+        setRecordContext(time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("2:2+X2+YY2", "3:3+X3+YY3");
+
+        setRecordContext(++time, topic2);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("3:3+X3+YY3");
 
         setRecordContext(++time, topic2);
         for (int expectedKey : expectedKeys) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.kafka.streams.kstream.internals.KStreamKStreamJoinTest.checkResult;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamKStreamLeftJoinTest {
@@ -58,8 +59,7 @@ public class KStreamKStreamLeftJoinTest {
         stateDir = TestUtils.tempDirectory("kafka-test");
     }
 
-    @Test
-    public void testLeftJoin() throws Exception {
+    private void testLeftJoin(boolean withKey) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
@@ -73,7 +73,11 @@ public class KStreamKStreamLeftJoinTest {
         stream1 = builder.stream(intSerde, stringSerde, topic1);
         stream2 = builder.stream(intSerde, stringSerde, topic2);
 
-        joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        if (withKey) {
+            joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        } else {
+            joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        }
         joined.process(processor);
 
         final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
@@ -84,401 +88,201 @@ public class KStreamKStreamLeftJoinTest {
         driver.setUp(builder, stateDir);
         driver.setTime(0L);
 
-        // push two items to the primary stream. the other window is empty
-        // w1 {}
-        // w2 {}
-        // --> w1 = { 0:X0, 1:X1 }
-        // --> w2 = {}
-
         for (int i = 0; i < 2; i++) {
             driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
         }
         driver.flushState();
-        processor.checkAndClearProcessResult("0:X0+null", "1:X1+null");
 
-        // push two items to the other stream. this should produce two items.
-        // w1 = { 0:X0, 1:X1 }
-        // w2 {}
-        // --> w1 = { 0:X0, 1:X1 }
-        // --> w2 = { 0:Y0, 1:Y1 }
+        checkResult(processor, withKey, "0:X0+null", "1:X1+null");
 
         for (int i = 0; i < 2; i++) {
             driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
         }
         driver.flushState();
 
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1");
-
-        // push three items to the primary stream. this should produce four items.
-        // w1 = { 0:X0, 1:X1 }
-        // w2 = { 0:Y0, 1:Y1 }
-        // --> w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
-        // --> w2 = { 0:Y0, 1:Y1 }
+        checkResult(processor, withKey, "0:X0+Y0", "1:X1+Y1");
 
         for (int i = 0; i < 3; i++) {
             driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
         }
         driver.flushState();
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1", "2:X2+null");
 
-        // push all items to the other stream. this should produce 5 items
-        // w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
-        // w2 = { 0:Y0, 1:Y1 }
-        // --> w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
-        // --> w2 = { 0:Y0, 1:Y1, 0:YY0, 1:YY1, 2:YY2, 3:YY3}
+        checkResult(processor, withKey, "0:X0+Y0", "1:X1+Y1", "2:X2+null");
 
         for (int expectedKey : expectedKeys) {
             driver.process(topic2, expectedKey, "YY" + expectedKey);
         }
         driver.flushState();
-        processor.checkAndClearProcessResult("0:X0+YY0", "0:X0+YY0", "1:X1+YY1", "1:X1+YY1", "2:X2+YY2");
 
-        // push all four items to the primary stream. this should produce six items.
-        // w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2 }
-        // w2 = { 0:Y0, 1:Y1, 0:YY0, 1:YY1, 2:YY2, 3:YY3}
-        // --> w1 = { 0:X0, 1:X1, 0:X0, 1:X1, 2:X2, 0:XX0, 1:XX1, 2:XX2, 3:XX3 }
-        // --> w2 = { 0:Y0, 1:Y1, 0:YY0, 1:YY1, 2:YY2, 3:YY3}
+        checkResult(processor, withKey, "0:X0+YY0", "0:X0+YY0", "1:X1+YY1", "1:X1+YY1", "2:X2+YY2");
 
         for (int expectedKey : expectedKeys) {
             driver.process(topic1, expectedKey, "XX" + expectedKey);
         }
         driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+Y0", "0:XX0+YY0", "1:XX1+Y1", "1:XX1+YY1", "2:XX2+YY2", "3:XX3+YY3");
+
+        checkResult(processor, withKey, "0:XX0+Y0", "0:XX0+YY0", "1:XX1+Y1", "1:XX1+YY1", "2:XX2+YY2", "3:XX3+YY3");
+    }
+
+    private void testWindowing(boolean withKey) {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        long time = 0L;
+
+        final KStream<Integer, String> stream1;
+        final KStream<Integer, String> stream2;
+        final KStream<Integer, String> joined;
+        final MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+
+        if (withKey) {
+            joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        } else {
+            joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        }
+        joined.process(processor);
+
+        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+
+        setRecordContext(time, topic1);
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:X0+null", "1:X1+null");
+
+        setRecordContext(time, topic2);
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:X0+Y0", "1:X1+Y1");
+
+        // clear logically
+        time = 1000L;
+        setRecordContext(time, topic2);
+
+        for (int i = 0; i < expectedKeys.length; i++) {
+            setRecordContext(time + i, topic2);
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult();
+
+        time = 1000L + 100L;
+        setRecordContext(time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+null", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+null", "1:XX1+null", "2:XX2+Y2", "3:XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+null");
+        // go back to the time before expiration
+
+        time = 1000L - 100L - 1L;
+        setRecordContext(time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+Y0", "1:XX1+null", "2:XX2+null", "3:XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+Y0", "1:XX1+Y1", "2:XX2+null", "3:XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+
+        checkResult(processor, withKey, "0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+    }
+
+    @Test
+    public void testLeftJoin() throws Exception {
+        testLeftJoin(false);
     }
 
     @Test
     public void testLeftJoinWithKey() throws Exception {
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        final int[] expectedKeys = new int[]{0, 1, 2, 3};
-
-        final KStream<Integer, String> stream1;
-        final KStream<Integer, String> stream2;
-        final KStream<Integer, String> joined;
-        final MockProcessorSupplier<Integer, String> processor;
-
-        processor = new MockProcessorSupplier<>();
-        stream1 = builder.stream(intSerde, stringSerde, topic1);
-        stream2 = builder.stream(intSerde, stringSerde, topic2);
-
-        joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
-        joined.process(processor);
-
-        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
-
-        assertEquals(1, copartitionGroups.size());
-        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
-
-        driver.setUp(builder, stateDir);
-        driver.setTime(0L);
-
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+X0+null", "1:1+X1+null");
-
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
-        }
-        driver.flushState();
-
-        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
-
-        for (int i = 0; i < 3; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1", "2:2+X2+null");
-
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic2, expectedKey, "YY" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+X0+YY0", "0:0+X0+YY0", "1:1+X1+YY1", "1:1+X1+YY1", "2:2+X2+YY2");
-
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+Y0", "0:0+XX0+YY0", "1:1+XX1+Y1", "1:1+XX1+YY1", "2:2+XX2+YY2", "3:3+XX3+YY3");
+        testLeftJoin(true);
     }
 
     @Test
     public void testWindowing() throws Exception {
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        final int[] expectedKeys = new int[]{0, 1, 2, 3};
-
-        long time = 0L;
-
-        final KStream<Integer, String> stream1;
-        final KStream<Integer, String> stream2;
-        final KStream<Integer, String> joined;
-        final MockProcessorSupplier<Integer, String> processor;
-
-        processor = new MockProcessorSupplier<>();
-        stream1 = builder.stream(intSerde, stringSerde, topic1);
-        stream2 = builder.stream(intSerde, stringSerde, topic2);
-
-        joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
-        joined.process(processor);
-
-        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
-
-        assertEquals(1, copartitionGroups.size());
-        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
-
-        driver.setUp(builder, stateDir);
-
-        // push two items to the primary stream. the other window is empty. this should produce two items
-        // w1 = {}
-        // w2 = {}
-        // --> w1 = { 0:X0, 1:X1 }
-        // --> w2 = {}
-
-        setRecordContext(time, topic1);
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:X0+null", "1:X1+null");
-
-        // push two items to the other stream. this should produce no items.
-        // w1 = { 0:X0, 1:X1 }
-        // w2 = {}
-        // --> w1 = { 0:X0, 1:X1 }
-        // --> w2 = { 0:Y0, 1:Y1 }
-
-        setRecordContext(time, topic2);
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1");
-
-        // clear logically
-        time = 1000L;
-        setRecordContext(time, topic2);
-
-        // push all items to the other stream. this should produce no items.
-        // w1 = {}
-        // w2 = {}
-        // --> w1 = {}
-        // --> w2 = { 0:Y0, 1:Y1, 2:Y2, 3:Y3 }
-        for (int i = 0; i < expectedKeys.length; i++) {
-            setRecordContext(time + i, topic2);
-            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult();
-
-        // gradually expire items in window 2.
-        // w1 = {}
-        // w2 = {}
-        // --> w1 = {}
-        // --> w2 = { 0:Y0, 1:Y1, 2:Y2, 3:Y3 }
-
-        time = 1000L + 100L;
-        setRecordContext(time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+Y2", "3:XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+null");
-
-        // go back to the time before expiration
-
-        time = 1000L - 100L - 1L;
-        setRecordContext(time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+null", "3:XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+null", "2:XX2+null", "3:XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+null", "3:XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+        testWindowing(false);
     }
 
     @Test
     public void testWindowingWithKey() throws Exception {
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        final int[] expectedKeys = new int[]{0, 1, 2, 3};
-
-        long time = 0L;
-
-        final KStream<Integer, String> stream1;
-        final KStream<Integer, String> stream2;
-        final KStream<Integer, String> joined;
-        final MockProcessorSupplier<Integer, String> processor;
-
-        processor = new MockProcessorSupplier<>();
-        stream1 = builder.stream(intSerde, stringSerde, topic1);
-        stream2 = builder.stream(intSerde, stringSerde, topic2);
-
-        joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
-        joined.process(processor);
-
-        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
-
-        assertEquals(1, copartitionGroups.size());
-        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
-
-        driver.setUp(builder, stateDir);
-
-        setRecordContext(time, topic1);
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+X0+null", "1:1+X1+null");
-
-        setRecordContext(time, topic2);
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
-
-        // clear logically
-        time = 1000L;
-        setRecordContext(time, topic2);
-
-        for (int i = 0; i < expectedKeys.length; i++) {
-            setRecordContext(time + i, topic2);
-            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult();
-
-        time = 1000L + 100L;
-        setRecordContext(time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+Y2", "3:3+XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+Y3");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+null");
-
-        // go back to the time before expiration
-
-        time = 1000L - 100L - 1L;
-        setRecordContext(time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+null", "3:3+XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+null");
-
-        setRecordContext(++time, topic1);
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-        driver.flushState();
-        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
+        testWindowing(true);
     }
 
     private void setRecordContext(final long time, final String topic) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -147,6 +147,64 @@ public class KStreamKStreamLeftJoinTest {
     }
 
     @Test
+    public void testLeftJoinWithKey() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        final KStream<Integer, String> stream1;
+        final KStream<Integer, String> stream2;
+        final KStream<Integer, String> joined;
+        final MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+
+        joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+        driver.setTime(0L);
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+X0+null", "1:1+X1+null");
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+        driver.flushState();
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        for (int i = 0; i < 3; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1", "2:2+X2+null");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "0:0+X0+YY0", "1:1+X1+YY1", "1:1+X1+YY1", "2:2+X2+YY2");
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "0:0+XX0+YY0", "1:1+XX1+Y1", "1:1+XX1+YY1", "2:2+XX2+YY2", "3:3+XX3+YY3");
+    }
+
+    @Test
     public void testWindowing() throws Exception {
         final StreamsBuilder builder = new StreamsBuilder();
 
@@ -294,6 +352,133 @@ public class KStreamKStreamLeftJoinTest {
         }
         driver.flushState();
         processor.checkAndClearProcessResult("0:XX0+Y0", "1:XX1+Y1", "2:XX2+Y2", "3:XX3+Y3");
+    }
+
+    @Test
+    public void testWindowingWithKey() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        long time = 0L;
+
+        final KStream<Integer, String> stream1;
+        final KStream<Integer, String> stream2;
+        final KStream<Integer, String> joined;
+        final MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream1 = builder.stream(intSerde, stringSerde, topic1);
+        stream2 = builder.stream(intSerde, stringSerde, topic2);
+
+        joined = stream1.leftJoin(stream2, MockValueJoiner.TOSTRING_JOINER_WITH_KEY, JoinWindows.of(100), intSerde, stringSerde, stringSerde);
+        joined.process(processor);
+
+        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+
+        setRecordContext(time, topic1);
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+X0+null", "1:1+X1+null");
+
+        setRecordContext(time, topic2);
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        // clear logically
+        time = 1000L;
+        setRecordContext(time, topic2);
+
+        for (int i = 0; i < expectedKeys.length; i++) {
+            setRecordContext(time + i, topic2);
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult();
+
+        time = 1000L + 100L;
+        setRecordContext(time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+Y2", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+Y3");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+null");
+
+        // go back to the time before expiration
+
+        time = 1000L - 100L - 1L;
+        setRecordContext(time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+null", "2:2+XX2+null", "3:3+XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+null", "3:3+XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+null");
+
+        setRecordContext(++time, topic1);
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+        driver.flushState();
+        processor.checkAndClearProcessResult("0:0+XX0+Y0", "1:1+XX1+Y1", "2:2+XX2+Y2", "3:3+XX3+Y3");
     }
 
     private void setRecordContext(final long time, final String topic) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -133,4 +133,83 @@ public class KStreamKTableJoinTest {
 
         processor.checkAndClearProcessResult("2:XX2+YY2", "3:XX3+YY3");
     }
+
+    @Test
+    public void testJoinWithKey() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        final KStream<Integer, String> stream;
+        final KTable<Integer, String> table;
+        final MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream = builder.stream(intSerde, stringSerde, topic1);
+        table = builder.table(intSerde, stringSerde, topic2, "anyStoreName");
+        stream.join(table, MockValueJoiner.TOSTRING_JOINER_WITH_KEY).process(processor);
+
+        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+        driver.setTime(0L);
+
+        // push two items to the primary stream. the other table is empty
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push two items to the other stream. this should not produce any item.
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push all four items to the primary stream. this should produce two items.
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
+
+        // push all items to the other stream. this should not produce any item
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push all four items to the primary stream. this should produce four items.
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        // push two items with null to the other stream as deletes. this should not produce any item.
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], null);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push all four items to the primary stream. this should produce two items.
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("2:2+XX2+YY2", "3:3+XX3+YY3");
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableJoinTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.kafka.streams.kstream.internals.KStreamKStreamJoinTest.checkResult;
 import static org.junit.Assert.assertEquals;
 
 public class KStreamKTableJoinTest {
@@ -55,8 +56,7 @@ public class KStreamKTableJoinTest {
         stateDir = TestUtils.tempDirectory("kafka-test");
     }
 
-    @Test
-    public void testJoin() throws Exception {
+    private void testJoin(boolean withKey) {
         final StreamsBuilder builder = new StreamsBuilder();
 
         final int[] expectedKeys = new int[]{0, 1, 2, 3};
@@ -68,7 +68,12 @@ public class KStreamKTableJoinTest {
         processor = new MockProcessorSupplier<>();
         stream = builder.stream(intSerde, stringSerde, topic1);
         table = builder.table(intSerde, stringSerde, topic2, "anyStoreName");
-        stream.join(table, MockValueJoiner.TOSTRING_JOINER).process(processor);
+
+        if (withKey) {
+            stream.join(table, MockValueJoiner.TOSTRING_JOINER_WITH_KEY).process(processor);
+        } else {
+            stream.join(table, MockValueJoiner.TOSTRING_JOINER).process(processor);
+        }
 
         final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
 
@@ -100,7 +105,7 @@ public class KStreamKTableJoinTest {
             driver.process(topic1, expectedKey, "X" + expectedKey);
         }
 
-        processor.checkAndClearProcessResult("0:X0+Y0", "1:X1+Y1");
+        checkResult(processor, withKey, "0:X0+Y0", "1:X1+Y1");
 
         // push all items to the other stream. this should not produce any item
         for (int expectedKey : expectedKeys) {
@@ -115,7 +120,7 @@ public class KStreamKTableJoinTest {
             driver.process(topic1, expectedKey, "X" + expectedKey);
         }
 
-        processor.checkAndClearProcessResult("0:X0+YY0", "1:X1+YY1", "2:X2+YY2", "3:X3+YY3");
+        checkResult(processor, withKey, "0:X0+YY0", "1:X1+YY1", "2:X2+YY2", "3:X3+YY3");
 
         // push two items with null to the other stream as deletes. this should not produce any item.
 
@@ -131,85 +136,16 @@ public class KStreamKTableJoinTest {
             driver.process(topic1, expectedKey, "XX" + expectedKey);
         }
 
-        processor.checkAndClearProcessResult("2:XX2+YY2", "3:XX3+YY3");
+        checkResult(processor, withKey, "2:XX2+YY2", "3:XX3+YY3");
+    }
+
+    @Test
+    public void testJoin() throws Exception {
+        testJoin(false);
     }
 
     @Test
     public void testJoinWithKey() throws Exception {
-        final StreamsBuilder builder = new StreamsBuilder();
-
-        final int[] expectedKeys = new int[]{0, 1, 2, 3};
-
-        final KStream<Integer, String> stream;
-        final KTable<Integer, String> table;
-        final MockProcessorSupplier<Integer, String> processor;
-
-        processor = new MockProcessorSupplier<>();
-        stream = builder.stream(intSerde, stringSerde, topic1);
-        table = builder.table(intSerde, stringSerde, topic2, "anyStoreName");
-        stream.join(table, MockValueJoiner.TOSTRING_JOINER_WITH_KEY).process(processor);
-
-        final Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
-
-        assertEquals(1, copartitionGroups.size());
-        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
-
-        driver.setUp(builder, stateDir);
-        driver.setTime(0L);
-
-        // push two items to the primary stream. the other table is empty
-
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
-        }
-
-        processor.checkAndClearProcessResult();
-
-        // push two items to the other stream. this should not produce any item.
-
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
-        }
-
-        processor.checkAndClearProcessResult();
-
-        // push all four items to the primary stream. this should produce two items.
-
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "X" + expectedKey);
-        }
-
-        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1");
-
-        // push all items to the other stream. this should not produce any item
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic2, expectedKey, "YY" + expectedKey);
-        }
-
-        processor.checkAndClearProcessResult();
-
-        // push all four items to the primary stream. this should produce four items.
-
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "X" + expectedKey);
-        }
-
-        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
-
-        // push two items with null to the other stream as deletes. this should not produce any item.
-
-        for (int i = 0; i < 2; i++) {
-            driver.process(topic2, expectedKeys[i], null);
-        }
-
-        processor.checkAndClearProcessResult();
-
-        // push all four items to the primary stream. this should produce two items.
-
-        for (int expectedKey : expectedKeys) {
-            driver.process(topic1, expectedKey, "XX" + expectedKey);
-        }
-
-        processor.checkAndClearProcessResult("2:2+XX2+YY2", "3:3+XX3+YY3");
+        testJoin(true);
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKTableLeftJoinTest.java
@@ -134,4 +134,83 @@ public class KStreamKTableLeftJoinTest {
 
         processor.checkAndClearProcessResult("0:XX0+null", "1:XX1+null", "2:XX2+YY2", "3:XX3+YY3");
     }
+
+    @Test
+    public void testJoinWithKey() throws Exception {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        final int[] expectedKeys = new int[]{0, 1, 2, 3};
+
+        KStream<Integer, String> stream;
+        KTable<Integer, String> table;
+        MockProcessorSupplier<Integer, String> processor;
+
+        processor = new MockProcessorSupplier<>();
+        stream = builder.stream(intSerde, stringSerde, topic1);
+        table = builder.table(intSerde, stringSerde, topic2, "anyStoreName");
+        stream.leftJoin(table, MockValueJoiner.TOSTRING_JOINER_WITH_KEY).process(processor);
+
+        Collection<Set<String>> copartitionGroups = StreamsBuilderTest.getCopartitionedGroups(builder);
+
+        assertEquals(1, copartitionGroups.size());
+        assertEquals(new HashSet<>(Arrays.asList(topic1, topic2)), copartitionGroups.iterator().next());
+
+        driver.setUp(builder, stateDir);
+        driver.setTime(0L);
+
+        // push two items to the primary stream. the other table is empty
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic1, expectedKeys[i], "X" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+null", "1:1+X1+null");
+
+        // push two items to the other stream. this should not produce any item.
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], "Y" + expectedKeys[i]);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push all four items to the primary stream. this should produce four items.
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+Y0", "1:1+X1+Y1", "2:2+X2+null", "3:3+X3+null");
+
+        // push all items to the other stream. this should not produce any item
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic2, expectedKey, "YY" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push all four items to the primary stream. this should produce four items.
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "X" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+X0+YY0", "1:1+X1+YY1", "2:2+X2+YY2", "3:3+X3+YY3");
+
+        // push two items with null to the other stream as deletes. this should not produce any item.
+
+        for (int i = 0; i < 2; i++) {
+            driver.process(topic2, expectedKeys[i], null);
+        }
+
+        processor.checkAndClearProcessResult();
+
+        // push all four items to the primary stream. this should produce four items.
+
+        for (int expectedKey : expectedKeys) {
+            driver.process(topic1, expectedKey, "XX" + expectedKey);
+        }
+
+        processor.checkAndClearProcessResult("0:0+XX0+null", "1:1+XX1+null", "2:2+XX2+YY2", "3:3+XX3+YY3");
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamTransformValuesTest.java
@@ -22,7 +22,9 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.ValueTransformer;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKey;
 import org.apache.kafka.streams.kstream.ValueTransformerSupplier;
+import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.test.KStreamTestDriver;
@@ -97,9 +99,9 @@ public class KStreamTransformValuesTest {
 
     @Test
     public void shouldNotAllowValueTransformerToCallInternalProcessorContextMethods() {
-        final KStreamTransformValues<Integer, Integer, Integer> transformValue = new KStreamTransformValues<>(new ValueTransformerSupplier<Integer, Integer>() {
+        final KStreamTransformValues<Integer, Integer, Integer> transformValue = new KStreamTransformValues<>(new ValueTransformerWithKeySupplier<Integer, Integer, Integer>() {
             @Override
-            public ValueTransformer<Integer, Integer> get() {
+            public ValueTransformerWithKey<Integer, Integer, Integer> get() {
                 return new BadValueTransformer();
             }
         });
@@ -136,7 +138,7 @@ public class KStreamTransformValuesTest {
         }
     }
 
-    private static final class BadValueTransformer implements ValueTransformer<Integer, Integer> {
+    private static final class BadValueTransformer implements ValueTransformerWithKey<Integer, Integer, Integer> {
         private ProcessorContext context;
 
         @Override
@@ -145,7 +147,7 @@ public class KStreamTransformValuesTest {
         }
 
         @Override
-        public Integer transform(Integer value) {
+        public Integer transform(Integer key, Integer value) {
             if (value == 0) {
                 context.forward(null, null);
             }

--- a/streams/src/test/java/org/apache/kafka/test/MockValueJoiner.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockValueJoiner.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.test;
 
 import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 
 public class MockValueJoiner {
 
@@ -30,4 +31,15 @@ public class MockValueJoiner {
             }
         };
     }
+
+    public static <K, V1, V2> ValueJoinerWithKey<K, V1, V2, String> instanceWithKey(final String separator) {
+        return new ValueJoinerWithKey<K, V1, V2, String>() {
+            @Override
+            public String apply(K key, V1 value1, V2 value2) {
+                return key + separator + value1 + separator + value2;
+            }
+        };
+    }
+    public final static ValueJoinerWithKey<Object, Object, Object, String> TOSTRING_JOINER_WITH_KEY = instanceWithKey("+");
+
 }


### PR DESCRIPTION
This PR aims to add withKey methods to KStream interface. 
This PR is part of [KIP-149](https://cwiki.apache.org/confluence/display/KAFKA/KIP-149%3A+Enabling+key+access+in+ValueTransformer%2C+ValueMapper%2C+and+ValueJoiner).
I separated the complete PR into 4 parts as discussed in [here](https://github.com/apache/kafka/pull/3570#issuecomment-317645747). So, this PR concentrates on adding withKey methods to KStream interface. 