### PR TITLE
KAFKA-4218: Add withkey methods to KGroupedStream

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code InitializerWithKey} interface for creating an initial value in aggregations with read-only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * {@code InitializerWithKey} is used in combination with {@link Aggregator}.
+ *
+ * @param <K> key type
+ * @param <VA> aggregate value type
+ * @see Aggregator
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Windows, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Windows, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Merger, SessionWindows, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Merger, SessionWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.streams.processor.StateStoreSupplier)
+ */
+public interface InitializerWithKey<K, VA> {
+    /**
+     * Return the initial value for an aggregation given read-only key.
+     *
+     * @return the initial value for an aggregation
+     */
+    VA apply(K key);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ReducerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ReducerWithKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.KeyValue;
+
+/**
+ * The {@code ReducerWithKey} interface for combining two values of the same type into a new value with read-only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * In contrast to {@link Aggregator} the result type must be the same as the input type.
+ * <p>
+ * The provided values can be either original values from input {@link KeyValue} pair records or be a previously
+ * computed result from {@link Reducer#apply(Object, Object)}.
+ * <p>
+ * {@code ReducerWithKey} can be used to implement aggregation functions like sum, min, or max.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ * @see KGroupedStream#reduce(ReducerWithKey, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#reduce(ReducerWithKey, Windows, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#reduce(ReducerWithKey, SessionWindows, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, SessionWindows, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see Aggregator
+ */
+public interface ReducerWithKey<K, V> {
+
+    /**
+     * Aggregate the two given values into a single one.
+     *
+     * @param key the read-only key
+     * @param value1 the first value for the aggregation
+     * @param value2 the second value for the aggregation
+     * @return the aggregated value
+     */
+    V apply(final K key, final V value1, final V value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code ValueJoinerWithKey} interface for joining two values into a new value of arbitrary type given read-only
+ * key. Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateless operation, i.e, {@link #apply(Object, Object, Object)} is invoked individually for each joining
+ * record-pair of a {@link KStream}-{@link KStream}, {@link KStream}-{@link KTable}, or {@link KTable}-{@link KTable}
+ * join.
+ *
+ * @param <K> key type
+ * @param <V1> first value type
+ * @param <V2> second value type
+ * @param <VR> joined value type
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#join(KTable, ValueJoinerWithKey)
+ * @see KStream#join(KTable, ValueJoinerWithKey, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KTable#join(KTable, ValueJoinerWithKey)
+ * @see KTable#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KTable#outerJoin(KTable, ValueJoinerWithKey)
+ */
+public interface ValueJoinerWithKey<K, V1, V2, VR> {
+
+    /**
+     * Return a joined value consisting of {@code value1} and {@code value2} with given read-only {@code key}. Any
+     * modification to {@code key} can result in corrupt partitioning.
+     *
+     * @param key the read-only key of particular record.
+     * @param value1 the first value for joining
+     * @param value2 the second value for joining
+     * @return the joined value
+     */
+    VR apply(final K key, final V1 value1, final V2 value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code ValueMapperWithKey} interface for mapping a value to a new value of arbitrary type given read-only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateless record-by-record operation, i.e, {@link #apply(Object, Object)} is invoked individually for each
+ * record of a stream (cf. {@link ValueTransformer} for stateful value transformation).
+ * If {@code ValueMapper} is applied to a {@link org.apache.kafka.streams.KeyValue key-value pair} record the record's
+ * key is preserved.
+ * If a record's key and value should be modified {@link KeyValueMapper} can be used.
+ *
+ * @param <K>  key type
+ * @param <V>  value type
+ * @param <VR> mapped value type
+ * @see KeyValueMapper
+ * @see ValueTransformerWithKey
+ * @see KStream#mapValues(ValueMapperWithKey)
+ * @see KStream#flatMapValues(ValueMapperWithKey)
+ * @see KTable#mapValues(ValueMapperWithKey)
+ */
+public interface ValueMapperWithKey<K, V, VR> {
+
+    /**
+     * Map the given value to a new value. {@code key} is read-only and any modification to {@code key} can result in
+     * corrupt partitioning.
+     *
+     * @param key the read-only key of particular record
+     * @param value the value to be mapped
+     * @return the new value
+     */
+    VR apply(final K key, final V value);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKey.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+
+/**
+ * The {@code ValueTransformerWithKey} interface for stateful mapping of a value to a new value (with possible new type).
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateful record-by-record operation, i.e, {@link #transform(Object, Object)} is invoked individually for
+ * each record of a stream and can access and modify a state that is available beyond a single call of
+ * {@link #transform(Object, Object)} (cf. {@link ValueMapperWithKey} for stateless value transformation).
+ * Additionally, this {@code ValueTransformer} can {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule}
+ * a method to be {@link Punctuator#punctuate(long) called periodically} with the provided context.
+ * If {@code ValueTransformer} is applied to a {@link KeyValue} pair record the record's key is preserved.
+ * <p>
+ * Use {@link ValueTransformerSupplier} to provide new instances of {@code ValueTransformer} to Kafka Stream's runtime.
+ * <p>
+ * If a record's key and value should be modified {@link Transformer} can be used.
+ *
+ * @param <K>  key type
+ * @param <V>  value type
+ * @param <VR> transformed value type
+ * @see ValueTransformerWithKeySupplier
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see Transformer
+ */
+public interface ValueTransformerWithKey<K, V, VR> {
+
+    /**
+     * Initialize this transformer.
+     * This is called once per instance when the topology gets initialized.
+     * <p>
+     * The provided {@link ProcessorContext context} can be used to access topology and record meta data, to
+     * {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule} a method to be
+     * {@link Punctuator#punctuate(long) called periodically} and to access attached {@link StateStore}s.
+     * <p>
+     * Note that {@link ProcessorContext} is updated in the background with the current record's meta data.
+     * Thus, it only contains valid record meta data when accessed within {@link #transform(Object, Object)}.
+     * <p>
+     * Note that using {@link ProcessorContext#forward(Object, Object)},
+     * {@link ProcessorContext#forward(Object, Object, int)}, or
+     * {@link ProcessorContext#forward(Object, Object, String)} is not allowed within any method of
+     * {@code ValueTransformer} and will result in an {@link StreamsException exception}.
+     *
+     * @param context the context
+     */
+    void init(final ProcessorContext context);
+
+    /**
+     * Transform the given value to a new value. {@code key} is read-only and should not be modified. Any modification
+     * to {@code key} can result in corrupt partitioning.
+     * Additionally, any {@link StateStore} that is {@link KStream#transformValues(ValueTransformerSupplier, String...)
+     * attached} to this operator can be accessed and modified arbitrarily (cf.
+     * {@link ProcessorContext#getStateStore(String)}).
+     * <p>
+     * Note, that using {@link ProcessorContext#forward(Object, Object)},
+     * {@link ProcessorContext#forward(Object, Object, int)}, and
+     * {@link ProcessorContext#forward(Object, Object, String)} is not allowed within {@code transform} and
+     * will result in an {@link StreamsException exception}.
+     *
+     * @param key the read-only key of particular record.
+     * @param value the value to be transformed
+     * @return the new value
+     */
+    VR transform(final K key, final V value);
+
+    /**
+     * Perform any periodic operations if this processor {@link ProcessorContext#schedule(long) schedule itself} with
+     * the context during {@link #init(ProcessorContext) initialization}.
+     * <p>
+     * It is not possible to return any new output records within {@code punctuate}.
+     * Using {@link ProcessorContext#forward(Object, Object)}, {@link ProcessorContext#forward(Object, Object, int)},
+     * or {@link ProcessorContext#forward(Object, Object, String)} will result in an
+     * {@link StreamsException exception}.
+     * Furthermore, {@code punctuate} must return {@code null}.
+     * <p>
+     * Note, that {@code punctuate} is called base on <it>stream time</it> (i.e., time progress with regard to
+     * timestamps return by the used {@link TimestampExtractor})
+     * and not based on wall-clock time.
+     *
+     * @deprecated Please use {@link Punctuator} functional interface instead.
+     *
+     * @param timestamp the stream time when {@code punctuate} is being called
+     * @return must return {@code null}&mdash;otherwise, an {@link StreamsException exception} will be thrown
+     */
+    @Deprecated
+    VR punctuate(final long timestamp);
+
+    /**
+     * Close this processor and clean up any resources.
+     * <p>
+     * It is not possible to return any new output records within {@code close()}.
+     * Using {@link ProcessorContext#forward(Object, Object)}, {@link ProcessorContext#forward(Object, Object, int)},
+     * or {@link ProcessorContext#forward(Object, Object, String)} will result in an {@link StreamsException exception}.
+     */
+    void close();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * A {@code ValueTransformerWithKeySupplier} interface which can create one or more {@link ValueTransformerWithKey}
+ * instances.
+ *
+ * @param <K>  value type
+ * @param <V>  value type
+ * @param <VR> transformed value type
+ * @see ValueTransformerWithKey
+ * TODO
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see Transformer
+ * @see TransformerSupplier
+ * @see KStream#transform(TransformerSupplier, String...)
+ */
+public interface ValueTransformerWithKeySupplier<K, V, VR> {
+
+    /**
+     * Return a new {@link ValueTransformerWithKey} instance.
+     *
+     * @return a new {@link ValueTransformerWithKey} instance.
+     */
+    ValueTransformerWithKey<K, V, VR> get();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamAggregate.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.Aggregator;
-import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.InitializerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -26,15 +26,15 @@ import org.apache.kafka.streams.state.KeyValueStore;
 public class KStreamAggregate<K, V, T> implements KStreamAggProcessorSupplier<K, K, V, T> {
 
     private final String storeName;
-    private final Initializer<T> initializer;
+    private final InitializerWithKey<K, T> initializerWithKey;
     private final Aggregator<? super K, ? super V, T> aggregator;
 
 
     private boolean sendOldValues = false;
 
-    public KStreamAggregate(String storeName, Initializer<T> initializer, Aggregator<? super K, ? super V, T> aggregator) {
+    public KStreamAggregate(String storeName, InitializerWithKey<K, T> initializerWithKey, Aggregator<? super K, ? super V, T> aggregator) {
         this.storeName = storeName;
-        this.initializer = initializer;
+        this.initializerWithKey = initializerWithKey;
         this.aggregator = aggregator;
     }
 
@@ -70,7 +70,7 @@ public class KStreamAggregate<K, V, T> implements KStreamAggProcessorSupplier<K,
             T oldAgg = store.get(key);
 
             if (oldAgg == null)
-                oldAgg = initializer.apply();
+                oldAgg = initializerWithKey.apply(key);
 
             T newAgg = oldAgg;
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamReduce.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.kstream.ReducerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -25,13 +25,13 @@ import org.apache.kafka.streams.state.KeyValueStore;
 public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V, V> {
 
     private final String storeName;
-    private final Reducer<V> reducer;
+    private final ReducerWithKey<K, V> reducerWithKey;
 
     private boolean sendOldValues = false;
 
-    public KStreamReduce(String storeName, Reducer<V> reducer) {
+    public KStreamReduce(String storeName, ReducerWithKey<K, V> reducerWithKey) {
         this.storeName = storeName;
-        this.reducer = reducer;
+        this.reducerWithKey = reducerWithKey;
     }
 
     @Override
@@ -73,7 +73,7 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
                 if (newAgg == null) {
                     newAgg = value;
                 } else {
-                    newAgg = reducer.apply(newAgg, value);
+                    newAgg = reducerWithKey.apply(key, newAgg, value);
                 }
             }
             // update the store with the new value
@@ -114,4 +114,3 @@ public class KStreamReduce<K, V> implements KStreamAggProcessorSupplier<K, K, V,
         }
     }
 }
-

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregate.java
@@ -18,7 +18,7 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.InitializerWithKey;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -30,19 +30,20 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 
 import java.util.Map;
 
+
 public class KStreamWindowAggregate<K, V, T, W extends Window> implements KStreamAggProcessorSupplier<K, Windowed<K>, V, T> {
 
     private final String storeName;
     private final Windows<W> windows;
-    private final Initializer<T> initializer;
+    private final InitializerWithKey<K, T> initializerWithKey;
     private final Aggregator<? super K, ? super V, T> aggregator;
 
     private boolean sendOldValues = false;
 
-    public KStreamWindowAggregate(Windows<W> windows, String storeName, Initializer<T> initializer, Aggregator<? super K, ? super V, T> aggregator) {
+    public KStreamWindowAggregate(Windows<W> windows, String storeName, InitializerWithKey<K, T> initializerWithKey, Aggregator<? super K, ? super V, T> aggregator) {
         this.windows = windows;
         this.storeName = storeName;
-        this.initializer = initializer;
+        this.initializerWithKey = initializerWithKey;
         this.aggregator = aggregator;
     }
 
@@ -102,7 +103,7 @@ public class KStreamWindowAggregate<K, V, T, W extends Window> implements KStrea
                         T oldAgg = entry.value;
 
                         if (oldAgg == null)
-                            oldAgg = initializer.apply();
+                            oldAgg = initializerWithKey.apply(key);
 
                         // try to add the new new value (there will never be old value)
                         T newAgg = aggregator.apply(key, value, oldAgg);
@@ -117,7 +118,7 @@ public class KStreamWindowAggregate<K, V, T, W extends Window> implements KStrea
 
             // create the new window for the rest of unmatched window that do not exist yet
             for (Map.Entry<Long, W> entry : matchedWindows.entrySet()) {
-                T oldAgg = initializer.apply();
+                T oldAgg = initializerWithKey.apply(key);
                 T newAgg = aggregator.apply(key, value, oldAgg);
                 windowStore.put(key, newAgg, entry.getKey());
                 tupleForwarder.maybeForward(new Windowed<>(key, entry.getValue()), newAgg, oldAgg);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowReduce.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamWindowReduce.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.kstream.ReducerWithKey;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.Windows;
@@ -29,18 +29,19 @@ import org.apache.kafka.streams.state.WindowStoreIterator;
 
 import java.util.Map;
 
+
 public class KStreamWindowReduce<K, V, W extends Window> implements KStreamAggProcessorSupplier<K, Windowed<K>, V, V> {
 
     private final String storeName;
     private final Windows<W> windows;
-    private final Reducer<V> reducer;
+    private final ReducerWithKey<K, V> reducerWithKey;
 
     private boolean sendOldValues = false;
 
-    public KStreamWindowReduce(Windows<W> windows, String storeName, Reducer<V> reducer) {
+    public KStreamWindowReduce(Windows<W> windows, String storeName, ReducerWithKey<K, V> reducerWithKey) {
         this.windows = windows;
         this.storeName = storeName;
-        this.reducer = reducer;
+        this.reducerWithKey = reducerWithKey;
     }
 
     @Override
@@ -102,7 +103,7 @@ public class KStreamWindowReduce<K, V, W extends Window> implements KStreamAggPr
                         if (newAgg == null) {
                             newAgg = value;
                         } else {
-                            newAgg = reducer.apply(newAgg, value);
+                            newAgg = reducerWithKey.apply(key, newAgg, value);
                         }
 
                         // update the store with the new value

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Aggregator;
-import org.apache.kafka.streams.kstream.Initializer;
+import org.apache.kafka.streams.kstream.InitializerWithKey;
 import org.apache.kafka.streams.kstream.Merger;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -47,14 +47,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+
 public class KStreamSessionWindowAggregateProcessorTest {
 
     private static final long GAP_MS = 5 * 60 * 1000L;
     private static final String STORE_NAME = "session-store";
 
-    private final Initializer<Long> initializer = new Initializer<Long>() {
+    private final InitializerWithKey<String, Long> initializer = new InitializerWithKey<String, Long>() {
         @Override
-        public Long apply() {
+        public Long apply(String key) {
             return 0L;
         }
     };
@@ -87,7 +88,7 @@ public class KStreamSessionWindowAggregateProcessorTest {
     public void initializeStore() {
         final File stateDir = TestUtils.tempDirectory();
         context = new MockProcessorContext(stateDir,
-            Serdes.String(), Serdes.String(), new NoOpRecordCollector(), new ThreadCache("testCache", 100000, new MockStreamsMetrics(new Metrics()))) {
+                Serdes.String(), Serdes.String(), new NoOpRecordCollector(), new ThreadCache("testCache", 100000, new MockStreamsMetrics(new Metrics()))) {
             @Override
             public <K, V> void forward(final K key, final V value) {
                 results.add(KeyValue.pair(key, value));


### PR DESCRIPTION
This PR aims to add withKey methods to KGroupedStream interface. 
This PR is part of [KIP-149](https://cwiki.apache.org/confluence/display/KAFKA/KIP-149%3A+Enabling+key+access+in+ValueTransformer%2C+ValueMapper%2C+and+ValueJoiner).
I separated the complete PR into 4 parts as discussed in [here](https://github.com/apache/kafka/pull/3570#issuecomment-317645747). So, this PR concentrates on adding withKey methods to KGroupedStream interface. 