### PR TITLE
KAFKA-4218: Add withkey methods to KTable

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/InitializerWithKey.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code InitializerWithKey} interface for creating an initial value in aggregations with read-only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * {@code InitializerWithKey} is used in combination with {@link Aggregator}.
+ *
+ * @param <K> key type
+ * @param <VA> aggregate value type
+ * @see Aggregator
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Windows, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Windows, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Merger, SessionWindows, org.apache.kafka.common.serialization.Serde, String)
+ * @see KGroupedStream#aggregate(InitializerWithKey, Aggregator, Merger, SessionWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.streams.processor.StateStoreSupplier)
+ */
+public interface InitializerWithKey<K, VA> {
+    /**
+     * Return the initial value for an aggregation given read-only key.
+     *
+     * @return the initial value for an aggregation
+     */
+    VA apply(K key);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ReducerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ReducerWithKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.KeyValue;
+
+/**
+ * The {@code ReducerWithKey} interface for combining two values of the same type into a new value with read-only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * In contrast to {@link Aggregator} the result type must be the same as the input type.
+ * <p>
+ * The provided values can be either original values from input {@link KeyValue} pair records or be a previously
+ * computed result from {@link Reducer#apply(Object, Object)}.
+ * <p>
+ * {@code ReducerWithKey} can be used to implement aggregation functions like sum, min, or max.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ * @see KGroupedStream#reduce(ReducerWithKey, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#reduce(ReducerWithKey, Windows, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see KGroupedStream#reduce(ReducerWithKey, SessionWindows, String)
+ * @see KGroupedStream#reduce(ReducerWithKey, SessionWindows, org.apache.kafka.streams.processor.StateStoreSupplier)
+ * @see Aggregator
+ */
+public interface ReducerWithKey<K, V> {
+
+    /**
+     * Aggregate the two given values into a single one.
+     *
+     * @param key the read-only key
+     * @param value1 the first value for the aggregation
+     * @param value2 the second value for the aggregation
+     * @return the aggregated value
+     */
+    V apply(final K key, final V value1, final V value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueJoinerWithKey.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code ValueJoinerWithKey} interface for joining two values into a new value of arbitrary type given read-only
+ * key. Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateless operation, i.e, {@link #apply(Object, Object, Object)} is invoked individually for each joining
+ * record-pair of a {@link KStream}-{@link KStream}, {@link KStream}-{@link KTable}, or {@link KTable}-{@link KTable}
+ * join.
+ *
+ * @param <K> key type
+ * @param <V1> first value type
+ * @param <V2> second value type
+ * @param <VR> joined value type
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#join(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#leftJoin(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows)
+ * @see KStream#outerJoin(KStream, ValueJoinerWithKey, JoinWindows, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#join(KTable, ValueJoinerWithKey)
+ * @see KStream#join(KTable, ValueJoinerWithKey, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KStream#leftJoin(KTable, ValueJoinerWithKey, org.apache.kafka.common.serialization.Serde, org.apache.kafka.common.serialization.Serde)
+ * @see KTable#join(KTable, ValueJoinerWithKey)
+ * @see KTable#leftJoin(KTable, ValueJoinerWithKey)
+ * @see KTable#outerJoin(KTable, ValueJoinerWithKey)
+ */
+public interface ValueJoinerWithKey<K, V1, V2, VR> {
+
+    /**
+     * Return a joined value consisting of {@code value1} and {@code value2} with given read-only {@code key}. Any
+     * modification to {@code key} can result in corrupt partitioning.
+     *
+     * @param key the read-only key of particular record.
+     * @param value1 the first value for joining
+     * @param value2 the second value for joining
+     * @return the joined value
+     */
+    VR apply(final K key, final V1 value1, final V2 value2);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueMapperWithKey.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * The {@code ValueMapperWithKey} interface for mapping a value to a new value of arbitrary type given read-only key.
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateless record-by-record operation, i.e, {@link #apply(Object, Object)} is invoked individually for each
+ * record of a stream (cf. {@link ValueTransformer} for stateful value transformation).
+ * If {@code ValueMapper} is applied to a {@link org.apache.kafka.streams.KeyValue key-value pair} record the record's
+ * key is preserved.
+ * If a record's key and value should be modified {@link KeyValueMapper} can be used.
+ *
+ * @param <K>  key type
+ * @param <V>  value type
+ * @param <VR> mapped value type
+ * @see KeyValueMapper
+ * @see ValueTransformerWithKey
+ * @see KStream#mapValues(ValueMapperWithKey)
+ * @see KStream#flatMapValues(ValueMapperWithKey)
+ * @see KTable#mapValues(ValueMapperWithKey)
+ */
+public interface ValueMapperWithKey<K, V, VR> {
+
+    /**
+     * Map the given value to a new value. {@code key} is read-only and any modification to {@code key} can result in
+     * corrupt partitioning.
+     *
+     * @param key the read-only key of particular record
+     * @param value the value to be mapped
+     * @return the new value
+     */
+    VR apply(final K key, final V value);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKey.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKey.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.TimestampExtractor;
+
+/**
+ * The {@code ValueTransformerWithKey} interface for stateful mapping of a value to a new value (with possible new type).
+ * Note that provided keys are read-only and should not be modified. Any key modification can result in corrupt
+ * partitioning.
+ * This is a stateful record-by-record operation, i.e, {@link #transform(Object, Object)} is invoked individually for
+ * each record of a stream and can access and modify a state that is available beyond a single call of
+ * {@link #transform(Object, Object)} (cf. {@link ValueMapperWithKey} for stateless value transformation).
+ * Additionally, this {@code ValueTransformer} can {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule}
+ * a method to be {@link Punctuator#punctuate(long) called periodically} with the provided context.
+ * If {@code ValueTransformer} is applied to a {@link KeyValue} pair record the record's key is preserved.
+ * <p>
+ * Use {@link ValueTransformerSupplier} to provide new instances of {@code ValueTransformer} to Kafka Stream's runtime.
+ * <p>
+ * If a record's key and value should be modified {@link Transformer} can be used.
+ *
+ * @param <K>  key type
+ * @param <V>  value type
+ * @param <VR> transformed value type
+ * @see ValueTransformerWithKeySupplier
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see Transformer
+ */
+public interface ValueTransformerWithKey<K, V, VR> {
+
+    /**
+     * Initialize this transformer.
+     * This is called once per instance when the topology gets initialized.
+     * <p>
+     * The provided {@link ProcessorContext context} can be used to access topology and record meta data, to
+     * {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule} a method to be
+     * {@link Punctuator#punctuate(long) called periodically} and to access attached {@link StateStore}s.
+     * <p>
+     * Note that {@link ProcessorContext} is updated in the background with the current record's meta data.
+     * Thus, it only contains valid record meta data when accessed within {@link #transform(Object, Object)}.
+     * <p>
+     * Note that using {@link ProcessorContext#forward(Object, Object)},
+     * {@link ProcessorContext#forward(Object, Object, int)}, or
+     * {@link ProcessorContext#forward(Object, Object, String)} is not allowed within any method of
+     * {@code ValueTransformer} and will result in an {@link StreamsException exception}.
+     *
+     * @param context the context
+     */
+    void init(final ProcessorContext context);
+
+    /**
+     * Transform the given value to a new value. {@code key} is read-only and should not be modified. Any modification
+     * to {@code key} can result in corrupt partitioning.
+     * Additionally, any {@link StateStore} that is {@link KStream#transformValues(ValueTransformerSupplier, String...)
+     * attached} to this operator can be accessed and modified arbitrarily (cf.
+     * {@link ProcessorContext#getStateStore(String)}).
+     * <p>
+     * Note, that using {@link ProcessorContext#forward(Object, Object)},
+     * {@link ProcessorContext#forward(Object, Object, int)}, and
+     * {@link ProcessorContext#forward(Object, Object, String)} is not allowed within {@code transform} and
+     * will result in an {@link StreamsException exception}.
+     *
+     * @param key the read-only key of particular record.
+     * @param value the value to be transformed
+     * @return the new value
+     */
+    VR transform(final K key, final V value);
+
+    /**
+     * Perform any periodic operations if this processor {@link ProcessorContext#schedule(long) schedule itself} with
+     * the context during {@link #init(ProcessorContext) initialization}.
+     * <p>
+     * It is not possible to return any new output records within {@code punctuate}.
+     * Using {@link ProcessorContext#forward(Object, Object)}, {@link ProcessorContext#forward(Object, Object, int)},
+     * or {@link ProcessorContext#forward(Object, Object, String)} will result in an
+     * {@link StreamsException exception}.
+     * Furthermore, {@code punctuate} must return {@code null}.
+     * <p>
+     * Note, that {@code punctuate} is called base on <it>stream time</it> (i.e., time progress with regard to
+     * timestamps return by the used {@link TimestampExtractor})
+     * and not based on wall-clock time.
+     *
+     * @deprecated Please use {@link Punctuator} functional interface instead.
+     *
+     * @param timestamp the stream time when {@code punctuate} is being called
+     * @return must return {@code null}&mdash;otherwise, an {@link StreamsException exception} will be thrown
+     */
+    @Deprecated
+    VR punctuate(final long timestamp);
+
+    /**
+     * Close this processor and clean up any resources.
+     * <p>
+     * It is not possible to return any new output records within {@code close()}.
+     * Using {@link ProcessorContext#forward(Object, Object)}, {@link ProcessorContext#forward(Object, Object, int)},
+     * or {@link ProcessorContext#forward(Object, Object, String)} will result in an {@link StreamsException exception}.
+     */
+    void close();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformerWithKeySupplier.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream;
+
+/**
+ * A {@code ValueTransformerWithKeySupplier} interface which can create one or more {@link ValueTransformerWithKey}
+ * instances.
+ *
+ * @param <K>  value type
+ * @param <V>  value type
+ * @param <VR> transformed value type
+ * @see ValueTransformerWithKey
+ * TODO
+ * @see KStream#transformValues(ValueTransformerWithKeySupplier, String...)
+ * @see Transformer
+ * @see TransformerSupplier
+ * @see KStream#transform(TransformerSupplier, String...)
+ */
+public interface ValueTransformerWithKeySupplier<K, V, VR> {
+
+    /**
+     * Return a new {@link ValueTransformerWithKey} instance.
+     *
+     * @return a new {@link ValueTransformerWithKey} instance.
+     */
+    ValueTransformerWithKey<K, V, VR> get();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -178,7 +178,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         Objects.requireNonNull(mapper, "mapper can't be null");
         String name = topology.newName(MAPVALUES_NAME);
 
-        topology.addProcessor(name, new KStreamMapValues<>(mapper), this.name);
+        topology.addProcessor(name, new KStreamMapValues<>(withKey(mapper)), this.name);
 
         return new KStreamImpl<>(topology, name, sourceNodes, this.repartitionRequired);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamMapValues.java
@@ -16,17 +16,17 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
 
 class KStreamMapValues<K, V, V1> implements ProcessorSupplier<K, V> {
 
-    private final ValueMapper<V, V1> mapper;
+    private final ValueMapperWithKey<K, V, V1> mapperWithKey;
 
-    public KStreamMapValues(ValueMapper<V, V1> mapper) {
-        this.mapper = mapper;
+    public KStreamMapValues(ValueMapperWithKey<K, V, V1> mapperWithKey) {
+        this.mapperWithKey = mapperWithKey;
     }
 
     @Override
@@ -37,7 +37,7 @@ class KStreamMapValues<K, V, V1> implements ProcessorSupplier<K, V> {
     private class KStreamMapProcessor extends AbstractProcessor<K, V> {
         @Override
         public void process(final K key, final V value) {
-            V1 newValue = mapper.apply(value);
+            V1 newValue = mapperWithKey.apply(key, value);
             context().forward(key, newValue);
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableAbstractJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableAbstractJoin.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 
 abstract class KTableKTableAbstractJoin<K, R, V1, V2> implements KTableProcessorSupplier<K, V1, R> {
 
@@ -24,18 +24,18 @@ abstract class KTableKTableAbstractJoin<K, R, V1, V2> implements KTableProcessor
     protected final KTableImpl<K, ?, V2> table2;
     protected final KTableValueGetterSupplier<K, V1> valueGetterSupplier1;
     protected final KTableValueGetterSupplier<K, V2> valueGetterSupplier2;
-    protected final ValueJoiner<? super V1, ? super V2, ? extends R> joiner;
+    protected final ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joinerWithKey;
 
     protected boolean sendOldValues = false;
 
     KTableKTableAbstractJoin(KTableImpl<K, ?, V1> table1,
                              KTableImpl<K, ?, V2> table2,
-                             ValueJoiner<? super V1, ? super V2, ? extends R> joiner) {
+                             ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joinerWithKey) {
         this.table1 = table1;
         this.table2 = table2;
         this.valueGetterSupplier1 = table1.valueGetterSupplier();
         this.valueGetterSupplier2 = table2.valueGetterSupplier();
-        this.joiner = joiner;
+        this.joinerWithKey = joinerWithKey;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoin.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -31,8 +31,10 @@ class KTableKTableJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, 
         }
     };
 
-    KTableKTableJoin(KTableImpl<K, ?, V1> table1, KTableImpl<K, ?, V2> table2, ValueJoiner<? super V1, ? super V2, ? extends R> joiner) {
-        super(table1, table2, joiner);
+    KTableKTableJoin(KTableImpl<K, ?, V1> table1,
+                     KTableImpl<K, ?, V2> table2,
+                     ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joinerWithKey) {
+        super(table1, table2, joinerWithKey);
     }
 
     @Override
@@ -54,7 +56,7 @@ class KTableKTableJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, 
         public KTableValueGetter<K, R> get() {
             return new KTableKTableJoinValueGetter<>(valueGetterSupplier1.get(),
                                                      valueGetterSupplier2.get(),
-                                                     joiner,
+                                                     joinerWithKey,
                                                      keyValueMapper);
         }
     }
@@ -89,11 +91,11 @@ class KTableKTableJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, 
             }
 
             if (change.newValue != null) {
-                newValue = joiner.apply(change.newValue, value2);
+                newValue = joinerWithKey.apply(key, change.newValue, value2);
             }
 
             if (sendOldValues && change.oldValue != null) {
-                oldValue = joiner.apply(change.oldValue, value2);
+                oldValue = joinerWithKey.apply(key, change.oldValue, value2);
             }
 
             context().forward(key, new Change<>(newValue, oldValue));

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinValueGetter.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableJoinValueGetter.java
@@ -17,23 +17,23 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
 class KTableKTableJoinValueGetter<K1, V1, K2, V2, R> implements KTableValueGetter<K1, R> {
 
     private final KTableValueGetter<K1, V1> valueGetter1;
     private final KTableValueGetter<K2, V2> valueGetter2;
-    private final ValueJoiner<? super V1, ? super V2, ? extends R>  joiner;
+    private final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R>  joinerWithKey;
     private final KeyValueMapper<K1, V1, K2> keyValueMapper;
 
     public KTableKTableJoinValueGetter(final KTableValueGetter<K1, V1> valueGetter1,
                                        final KTableValueGetter<K2, V2> valueGetter2,
-                                       final ValueJoiner<? super V1, ? super V2, ? extends R>  joiner,
+                                       final ValueJoinerWithKey<? super K1, ? super V1, ? super V2, ? extends R> joinerWithKey,
                                        final KeyValueMapper<K1, V1, K2> keyValueMapper) {
         this.valueGetter1 = valueGetter1;
         this.valueGetter2 = valueGetter2;
-        this.joiner = joiner;
+        this.joinerWithKey = joinerWithKey;
         this.keyValueMapper = keyValueMapper;
     }
 
@@ -52,7 +52,7 @@ class KTableKTableJoinValueGetter<K1, V1, K2, V2, R> implements KTableValueGette
             V2 value2 = valueGetter2.get(keyValueMapper.apply(key, value1));
 
             if (value2 != null) {
-                newValue = joiner.apply(value1, value2);
+                newValue = joinerWithKey.apply(key, value1, value2);
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableOuterJoin.java
@@ -16,15 +16,17 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 
 class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, V2> {
 
-    KTableKTableOuterJoin(KTableImpl<K, ?, V1> table1, KTableImpl<K, ?, V2> table2, ValueJoiner<? super V1, ? super V2, ? extends R> joiner) {
-        super(table1, table2, joiner);
+    KTableKTableOuterJoin(KTableImpl<K, ?, V1> table1,
+                          KTableImpl<K, ?, V2> table2,
+                          ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joinerWithKey) {
+        super(table1, table2, joinerWithKey);
     }
 
     @Override
@@ -78,11 +80,11 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
             }
 
             if (value2 != null || change.newValue != null) {
-                newValue = joiner.apply(change.newValue, value2);
+                newValue = joinerWithKey.apply(key, change.newValue, value2);
             }
 
             if (sendOldValues && (value2 != null || change.oldValue != null)) {
-                oldValue = joiner.apply(change.oldValue, value2);
+                oldValue = joinerWithKey.apply(key, change.oldValue, value2);
             }
 
             context().forward(key, new Change<>(newValue, oldValue));
@@ -112,7 +114,7 @@ class KTableKTableOuterJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
             V2 value2 = valueGetter2.get(key);
 
             if (value1 != null || value2 != null)
-                newValue = joiner.apply(value1, value2);
+                newValue = joinerWithKey.apply(key, value1, value2);
 
             return newValue;
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableKTableRightJoin.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.apache.kafka.streams.kstream.ValueJoinerWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -24,8 +24,10 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R, V1, V2> {
 
 
-    KTableKTableRightJoin(KTableImpl<K, ?, V1> table1, KTableImpl<K, ?, V2> table2, ValueJoiner<? super V1, ? super V2, ? extends R> joiner) {
-        super(table1, table2, joiner);
+    KTableKTableRightJoin(KTableImpl<K, ?, V1> table1,
+                          KTableImpl<K, ?, V2> table2,
+                          ValueJoinerWithKey<? super K, ? super V1, ? super V2, ? extends R> joinerWithKey) {
+        super(table1, table2, joinerWithKey);
     }
 
     @Override
@@ -78,10 +80,10 @@ class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
                 return;
             }
 
-            newValue = joiner.apply(change.newValue, value2);
+            newValue = joinerWithKey.apply(key, change.newValue, value2);
 
             if (sendOldValues) {
-                oldValue = joiner.apply(change.oldValue, value2);
+                oldValue = joinerWithKey.apply(key, change.oldValue, value2);
             }
 
             context().forward(key, new Change<>(newValue, oldValue));
@@ -111,7 +113,7 @@ class KTableKTableRightJoin<K, R, V1, V2> extends KTableKTableAbstractJoin<K, R,
 
             if (value2 != null) {
                 V1 value1 = valueGetter1.get(key);
-                return joiner.apply(value1, value2);
+                return joinerWithKey.apply(key, value1, value2);
             } else {
                 return null;
             }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableMapValues.java
@@ -16,7 +16,7 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 import org.apache.kafka.streams.processor.AbstractProcessor;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
@@ -26,14 +26,14 @@ import org.apache.kafka.streams.state.KeyValueStore;
 class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
 
     private final KTableImpl<K, ?, V> parent;
-    private final ValueMapper<? super V, ? extends V1> mapper;
+    private final ValueMapperWithKey<? super K, ? super V, ? extends V1> mapperWithKey;
     private final String queryableName;
     private boolean sendOldValues = false;
 
-    public KTableMapValues(final KTableImpl<K, ?, V> parent, final ValueMapper<? super V, ? extends V1> mapper,
+    public KTableMapValues(final KTableImpl<K, ?, V> parent, final ValueMapperWithKey<? super K, ? super V, ? extends V1> mapperWithKey,
                            final String queryableName) {
         this.parent = parent;
-        this.mapper = mapper;
+        this.mapperWithKey = mapperWithKey;
         this.queryableName = queryableName;
     }
 
@@ -65,11 +65,11 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
         sendOldValues = true;
     }
 
-    private V1 computeValue(V value) {
+    private V1 computeValue(K key, V value) {
         V1 newValue = null;
 
         if (value != null)
-            newValue = mapper.apply(value);
+            newValue = mapperWithKey.apply(key, value);
 
         return newValue;
     }
@@ -91,8 +91,8 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
 
         @Override
         public void process(K key, Change<V> change) {
-            V1 newValue = computeValue(change.newValue);
-            V1 oldValue = sendOldValues ? computeValue(change.oldValue) : null;
+            V1 newValue = computeValue(key, change.newValue);
+            V1 oldValue = sendOldValues ? computeValue(key, change.oldValue) : null;
 
             if (queryableName != null) {
                 store.put(key, newValue);
@@ -118,7 +118,7 @@ class KTableMapValues<K, V, V1> implements KTableProcessorSupplier<K, V, V1> {
 
         @Override
         public V1 get(K key) {
-            return computeValue(parentGetter.get(key));
+            return computeValue(key, parentGetter.get(key));
         }
 
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -402,7 +402,7 @@ public class KTableImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullMapperOnMapValues() throws Exception {
-        table.mapValues(null);
+        table.mapValues((ValueMapper<? super String, ?>) null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -462,7 +462,7 @@ public class KTableImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullJoinerJoin() throws Exception {
-        table.join(table, null);
+        table.join(table, (ValueJoiner<? super String, ? super String, ?>) null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -472,12 +472,12 @@ public class KTableImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullJoinerOnOuterJoin() throws Exception {
-        table.outerJoin(table, null);
+        table.outerJoin(table, (ValueJoiner<? super String, ? super String, ?>) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldNotAllowNullJoinerOnLeftJoin() throws Exception {
-        table.leftJoin(table, null);
+        table.leftJoin(table, (ValueJoiner<? super String, ? super String, ?>) null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
This PR aims to add withKey methods to KTable interface. 
This PR is part of [KIP-149](https://cwiki.apache.org/confluence/display/KAFKA/KIP-149%3A+Enabling+key+access+in+ValueTransformer%2C+ValueMapper%2C+and+ValueJoiner).
I separated the complete PR into 4 parts as discussed in [here](https://github.com/apache/kafka/pull/3570#issuecomment-317645747). So, this PR concentrates on adding withKey methods to KTable interface. 