### PR TITLE
KAFKA-2111: Add help arguments and required fields

### DIFF
--- a/core/src/main/scala/kafka/admin/AclCommand.scala
+++ b/core/src/main/scala/kafka/admin/AclCommand.scala
@@ -275,7 +275,7 @@ object AclCommand extends Logging {
     val authorizerPropertiesOpt = parser.accepts("authorizer-properties", "Properties required to configure an instance of Authorizer. " +
       "These are key=val pairs. For the default authorizer, the example values are: zookeeper.connect=localhost:2181.")
       .withRequiredArg
-      .describedAs("properties(key=value pairs) for configuring instance of Authorizer")
+      .describedAs("properties to configure Authorizer instance")
       .ofType(classOf[String])
       .required
 

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -21,6 +21,7 @@ import java.io.PrintStream
 import java.util.Properties
 
 import kafka.utils.CommandLineUtils
+import kafka.utils.Exit;
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.clients.CommonClientConfigs
 import joptsimple._
@@ -60,7 +61,7 @@ object BrokerApiVersionsCommand {
   }
 
   class BrokerVersionCommandOptions(args: Array[String]) {
-    val BootstrapServerDoc = "REQUIRED: The server to connect to."
+    val BootstrapServerDoc = "The server to connect to."
     val CommandConfigDoc = "A property file containing configs to be passed to Admin Client."
 
     val parser = new OptionParser(false)
@@ -70,14 +71,17 @@ object BrokerApiVersionsCommand {
                                  .ofType(classOf[String])
     val bootstrapServerOpt = parser.accepts("bootstrap-server", BootstrapServerDoc)
                                    .withRequiredArg
-                                   .describedAs("server(s) to use for bootstrapping")
+                                   .describedAs("server(s) to connect to")
                                    .ofType(classOf[String])
-    val options = parser.parse(args : _*)
-    checkArgs()
+                                   .required
+    parser.accepts("help", "Print usage information.").forHelp()
 
-    def checkArgs() {
-      // check required args
-      CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
-    }
+    var commandDef = "Retrieve broker version information."
+    if(args.length == 0)
+      CommandLineUtils.printUsageAndDie(parser, commandDef) 
+    val options = CommandLineUtils.tryParse(parser, args)
+    
+    if (options.has("help"))
+       CommandLineUtils.printUsageAndDie(parser, commandDef)
   }
 }

--- a/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/BrokerApiVersionsCommand.scala
@@ -71,13 +71,13 @@ object BrokerApiVersionsCommand {
                                  .ofType(classOf[String])
     val bootstrapServerOpt = parser.accepts("bootstrap-server", BootstrapServerDoc)
                                    .withRequiredArg
-                                   .describedAs("server(s) to connect to")
+                                   .describedAs("server(s) to use for bootstrapping")
                                    .ofType(classOf[String])
                                    .required
     parser.accepts("help", "Print usage information.").forHelp()
 
     var commandDef = "Retrieve broker version information."
-    if(args.length == 0)
+    if (args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, commandDef) 
     val options = CommandLineUtils.tryParse(parser, args)
     

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -861,12 +861,11 @@ object ConsumerGroupCommand extends Logging {
     val StateDoc = "Describe the group state. This option may be used with '--describe' and '--bootstrap-server' options only." + nl +
       "Example: --bootstrap-server localhost:9092 --describe --group group1 --state"
 
-
     val parser = new OptionParser(false)
     val newConsumerOpt = parser.accepts("new-consumer", NewConsumerDoc)
     val bootstrapServerOpt = parser.accepts("bootstrap-server", BootstrapServerDoc)
                                    .withRequiredArg
-                                   .describedAs("server to connect to")
+                                   .describedAs("server to use for bootstrapping")
                                    .ofType(classOf[String])
     val zkConnectOpt = parser.accepts("zookeeper", ZkConnectDoc)
                              .requiredUnless("bootstrap-server")

--- a/core/src/main/scala/kafka/admin/DeleteRecordsCommand.scala
+++ b/core/src/main/scala/kafka/admin/DeleteRecordsCommand.scala
@@ -22,7 +22,7 @@ import java.util.Properties
 
 import kafka.admin.AdminClient.DeleteRecordsResult
 import kafka.common.AdminCommandFailedException
-import kafka.utils.{CoreUtils, Exit, Json, CommandLineUtils}
+import kafka.utils.{CoreUtils, Json, CommandLineUtils}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.clients.CommonClientConfigs
@@ -51,8 +51,7 @@ object DeleteRecordsCommand {
   }
 
   def execute(args: Array[String], out: PrintStream): Unit = {
-    var opts: DeleteRecordsCommandOptions = null
-    opts = new DeleteRecordsCommandOptions(args)
+    val opts = new DeleteRecordsCommandOptions(args)
     val adminClient = createAdminClient(opts)
     val offsetJsonFile =  opts.options.valueOf(opts.offsetJsonFileOpt)
     val offsetJsonString = Utils.readFileAsString(offsetJsonFile)
@@ -92,12 +91,12 @@ object DeleteRecordsCommand {
     val parser = new OptionParser(false)
     val bootstrapServerOpt = parser.accepts("bootstrap-server", BootstrapServerDoc)
                                    .withRequiredArg
-                                   .describedAs("server(s) to connect to")
+                                   .describedAs("server(s) to use for bootstrapping")
                                    .ofType(classOf[String])
                                    .required
     val offsetJsonFileOpt = parser.accepts("offset-json-file", offsetJsonFileDoc)
                                    .withRequiredArg
-                                   .describedAs("Offset json file path")
+                                   .describedAs("offset json file path")
                                    .ofType(classOf[String])
                                    .required
     val commandConfigOpt = parser.accepts("command-config", CommandConfigDoc)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -381,22 +381,22 @@ object ReassignPartitionsCommand extends Logging {
 
     // Should have exactly one action
     val actions = Seq(opts.generateOpt, opts.executeOpt, opts.verifyOpt).count(opts.options.has _)
-    if(actions != 1)
+    if (actions != 1)
       CommandLineUtils.printUsageAndDie(opts.parser, "Command must include exactly one action: --generate, --execute or --verify")
 
     //Validate arguments for each action
-    if(opts.options.has(opts.verifyOpt)) {
-      if(!opts.options.has(opts.reassignmentJsonFileOpt))
+    if (opts.options.has(opts.verifyOpt)) {
+      if (!opts.options.has(opts.reassignmentJsonFileOpt))
         CommandLineUtils.printUsageAndDie(opts.parser, "If --verify option is used, command must include --reassignment-json-file that was used during the --execute option")
       CommandLineUtils.checkInvalidArgs(opts.parser, opts.options, opts.verifyOpt, Set(opts.interBrokerThrottleOpt, opts.replicaAlterLogDirsThrottleOpt, opts.topicsToMoveJsonFileOpt, opts.disableRackAware, opts.brokerListOpt))
     }
     else if(opts.options.has(opts.generateOpt)) {
-      if(!(opts.options.has(opts.topicsToMoveJsonFileOpt) && opts.options.has(opts.brokerListOpt)))
+      if (!(opts.options.has(opts.topicsToMoveJsonFileOpt) && opts.options.has(opts.brokerListOpt)))
         CommandLineUtils.printUsageAndDie(opts.parser, "If --generate option is used, command must include both --topics-to-move-json-file and --broker-list options")
       CommandLineUtils.checkInvalidArgs(opts.parser, opts.options, opts.generateOpt, Set(opts.interBrokerThrottleOpt, opts.replicaAlterLogDirsThrottleOpt, opts.reassignmentJsonFileOpt))
     }
     else if (opts.options.has(opts.executeOpt)){
-      if(!opts.options.has(opts.reassignmentJsonFileOpt))
+      if (!opts.options.has(opts.reassignmentJsonFileOpt))
         CommandLineUtils.printUsageAndDie(opts.parser, "If --execute option is used, command must include --reassignment-json-file that was output " + "during the --generate option")
       CommandLineUtils.checkInvalidArgs(opts.parser, opts.options, opts.executeOpt, Set(opts.topicsToMoveJsonFileOpt, opts.disableRackAware, opts.brokerListOpt))
     }
@@ -408,7 +408,7 @@ object ReassignPartitionsCommand extends Logging {
     val bootstrapServerOpt = parser.accepts("bootstrap-server", "The server(s) to use for bootstrapping. This is required if " +
                       "an absolution path of the log directory is specified for any replica in the reassignment json file.")
                       .withRequiredArg
-                      .describedAs("server(s) to connect to")
+                      .describedAs("server(s) to use for bootstrapping")
                       .ofType(classOf[String])
     val zkConnectOpt = parser.accepts("zookeeper", "The connection string for the zookeeper connection in the " +
                       "form host:port. Multiple URLS can be given to allow fail-over.")
@@ -443,23 +443,23 @@ object ReassignPartitionsCommand extends Logging {
     val disableRackAware = parser.accepts("disable-rack-aware", "Disable rack aware replica assignment.")
     val interBrokerThrottleOpt = parser.accepts("throttle", "The movement of partitions between brokers will be throttled to this value (bytes/sec). Rerunning with this option, whilst a rebalance is in progress, will alter the throttle value. The throttle rate should be at least 1 KB/s.")
                       .withRequiredArg()
-                      .describedAs("throttle value(bytes/sec) related to the movement of partitions between brokers")
+                      .describedAs("throttle size(bytes/sec)")
                       .ofType(classOf[Long])
                       .defaultsTo(-1)
     val replicaAlterLogDirsThrottleOpt = parser.accepts("replica-alter-log-dirs-throttle", "The movement of replicas between log directories on the same broker will be throttled to this value (bytes/sec). Rerunning with this option, whilst a rebalance is in progress, will alter the throttle value. The throttle rate should be at least 1 KB/s.")
                       .withRequiredArg()
-                      .describedAs("throttle value(byes/sec) related to the movement of replicas between log directories on the same broker")
+                      .describedAs("throttle size(bytes/sec)")
                       .ofType(classOf[Long])
                       .defaultsTo(-1)
     val timeoutOpt = parser.accepts("timeout", "The maximum time in milliseconds allowed to wait for partition reassignment execution to be successfully initiated.")
                       .withRequiredArg()
-                      .describedAs("maximum time(in ms) to wait to initiate partition reassignment")
+                      .describedAs("timeout")
                       .ofType(classOf[Long])
                       .defaultsTo(10000)
     val helpOpt = parser.accepts("help", "Print usage information.").forHelp
 
     var commandDef: String = "This command moves topic partitions between replicas."
-    if(args.length == 0)
+    if (args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, commandDef)
 
     val options = CommandLineUtils.tryParse(parser, args)

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -45,7 +45,7 @@ object TopicCommand extends Logging {
  
     // should have exactly one action
     val actions = Seq(opts.createOpt, opts.listOpt, opts.alterOpt, opts.describeOpt, opts.deleteOpt).count(opts.options.has _)
-    if(actions != 1)
+    if (actions != 1)
       CommandLineUtils.printUsageAndDie(opts.parser, "Command must include exactly one action: --list, --describe, --create, --alter or --delete")
 
     opts.checkArgs()
@@ -136,7 +136,7 @@ object TopicCommand extends Logging {
         println("Updated config for topic \"%s\".".format(topic))
       }
 
-      if(opts.options.has(opts.partitionsOpt)) {
+      if (opts.options.has(opts.partitionsOpt)) {
         if (topic == Topic.GROUP_METADATA_TOPIC_NAME) {
           throw new IllegalArgumentException("The number of partitions for the offsets topic cannot be changed.")
         }
@@ -317,18 +317,18 @@ object TopicCommand extends Logging {
                                      "partitions for the given topic. Else, it will output the partition assignments of all topics. The details include a summary of all partitions for " +
                                      "a given topic followed by details about each partition which includes information regarding leader, replicas and In-sync replicas(Isr)")
     val helpOpt = parser.accepts("help", "Print usage information.").forHelp
-    val topicOpt = parser.accepts("topic", "The topic to create, alter or describe. Can also accept a regular " +
+    val topicOpt = parser.accepts("topic", "The topic to create, delete, alter or describe. Can also accept a regular " +
                                            "expression except for --create option.")
                          .requiredIf("create", "delete", "alter")
                          .withRequiredArg
-                         .describedAs("topic to create/alter/describe")
+                         .describedAs("topic to create/delete/alter/describe")
                          .ofType(classOf[String])
     val nl = System.getProperty("line.separator")
     val configOpt = parser.accepts("config", "A topic configuration override for the topic being created or altered."  +
                                              "The following is a list of valid configurations: " + nl + LogConfig.configNames.map("\t" + _).mkString(nl) + nl +
                                              "See the Kafka documentation for full details on the topic configs.")
                            .withRequiredArg
-                           .describedAs("config(name=value) override for given topic")
+                           .describedAs("config override for given topic")
                            .ofType(classOf[String])
     val deleteConfigOpt = parser.accepts("delete-config", "A topic configuration override to be removed for an existing topic (see the list of configurations under the --config option).")
                            .withRequiredArg
@@ -365,12 +365,12 @@ object TopicCommand extends Logging {
 
     val commandDef: String = "Create, delete, describe, or change a topic."
     
-    if(args.length == 0)
+    if (args.length == 0)
       CommandLineUtils.printUsageAndDie(parser, commandDef)
 
     val options: OptionSet = CommandLineUtils.tryParse(parser, args)
     
-    if(options.has("help"))
+    if (options.has("help"))
       CommandLineUtils.printUsageAndDie(parser, commandDef)
 
     val allTopicLevelOpts: Set[OptionSpec[_]] = Set(alterOpt, createOpt, describeOpt, listOpt, deleteOpt)

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -272,7 +272,7 @@ object ConsoleConsumer extends Logging {
       .ofType(classOf[java.lang.Integer])
     val offsetOpt = parser.accepts("offset", "The offset id to consume from (a non-negative number), or 'earliest' which means from beginning, or 'latest' which means from end")
       .withRequiredArg
-      .describedAs("consumer offset")
+      .describedAs("consume offset")
       .ofType(classOf[String])
       .defaultsTo("latest")
     val zkConnectOpt = parser.accepts("zookeeper", "The connection string for the zookeeper connection in the form host:port. " +
@@ -291,7 +291,7 @@ object ConsoleConsumer extends Logging {
       .ofType(classOf[String])
     val messageFormatterOpt = parser.accepts("formatter", "The name of a class to use for formatting Kafka messages for display.")
       .withRequiredArg
-      .describedAs("name of class used to format Kafka messages for display")
+      .describedAs("class name to format Kafka messages")
       .ofType(classOf[String])
       .defaultsTo(classOf[DefaultMessageFormatter].getName)
     val messageFormatterArgOpt = parser.accepts("property", "The properties to initialize the message formatter.")
@@ -307,7 +307,7 @@ object ConsoleConsumer extends Logging {
       .ofType(classOf[java.lang.Integer])
     val timeoutMsOpt = parser.accepts("timeout-ms", "If specified, exit if no message is available for consumption for the specified interval.")
       .withRequiredArg
-      .describedAs("interval to wait(in ms) for before exiting if no message is available")
+      .describedAs("wait time for messages to be available before exiting")
       .ofType(classOf[java.lang.Integer])
     val skipMessageOnErrorOpt = parser.accepts("skip-message-on-error", "If there is an error when processing a message, " +
       "skip it instead of halt.")
@@ -323,7 +323,7 @@ object ConsoleConsumer extends Logging {
         "(The new consumer implementation is used by default or can be explicitely set using the --new-consumer option.)")
       .requiredUnless("zookeeper")
       .withRequiredArg
-      .describedAs("server to connect to")
+      .describedAs("server to use for bootstrapping")
       .ofType(classOf[String])
     val keyDeserializerOpt = parser.accepts("key-deserializer")
       .withRequiredArg

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -64,7 +64,6 @@ object ConsoleProducer {
     } catch {
       case e: joptsimple.OptionException =>
         System.err.println(e.getMessage)
-        e.printStackTrace()
         Exit.exit(1)
       case e: Exception =>
         e.printStackTrace
@@ -138,12 +137,12 @@ object ConsoleProducer {
     val parser = new OptionParser(false)
     val topicOpt = parser.accepts("topic", "The topic id to produce messages to.")
       .withRequiredArg
-      .describedAs("topic id")
+      .describedAs("topic")
       .ofType(classOf[String])
       .required
     val brokerListOpt = parser.accepts("broker-list", "The broker list string in the form host1:port1,host2:port2.")
       .withRequiredArg
-      .describedAs("server(s) to connect to")
+      .describedAs("server(s) to use for bootstrapping")
       .ofType(classOf[String])
       .required
     val syncOpt = parser.accepts("sync", "If set, message requests are send to the brokers synchronously, one at a time as they arrive.")
@@ -154,29 +153,29 @@ object ConsoleProducer {
                                     .ofType(classOf[String])
     val batchSizeOpt = parser.accepts("batch-size", "Number of messages to send in a single batch if they are not being sent synchronously.")
       .withRequiredArg
-      .describedAs("Number of messages in a single batch")
+      .describedAs("number of messages in a single batch")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(200)
     val messageSendMaxRetriesOpt = parser.accepts("message-send-max-retries", "Brokers can fail receiving the message for multiple reasons, and being unavailable transiently is just one of them. This property specifies the number of retries before the producer gives up and drops this message.")
       .withRequiredArg
-      .describedAs("number of retries before producer drops the messages")
+      .describedAs("number of retries before dropping this message")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(3)
     val retryBackoffMsOpt = parser.accepts("retry-backoff-ms", "Before each retry, the producer refreshes the metadata of relevant topics. Since leader election takes a bit of time, this property specifies the amount of time that the producer waits before refreshing the metadata.")
       .withRequiredArg
-      .describedAs("time (in ms) that the producer waits before refreshing the metadata")
+      .describedAs("wait time before refreshing the metadata")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(100)
     val sendTimeoutOpt = parser.accepts("timeout", "If set and the producer is running in asynchronous mode, this gives the maximum amount of time" +
       " a message will queue awaiting sufficient batch size. The value is given in milliseconds.")
       .withRequiredArg
-      .describedAs("max time(in ms) message will queue awaiting sufficient batch size")
+      .describedAs("timeout_ms")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1000)
     val queueSizeOpt = parser.accepts("queue-size", "If set and the producer is running in asynchronous mode, this gives the maximum amount of " +
       " messages that will queue awaiting sufficient batch size.")
       .withRequiredArg
-      .describedAs("max number of messages in a queue to form sufficient batch size")
+      .describedAs("queue-size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(10000)
     val queueEnqueueTimeoutMsOpt = parser.accepts("queue-enqueuetimeout-ms", "Timeout for event enqueue in milliseconds.")
@@ -186,7 +185,7 @@ object ConsoleProducer {
       .defaultsTo(Int.MaxValue)
     val requestRequiredAcksOpt = parser.accepts("request-required-acks", "The required acks of the producer requests.")
       .withRequiredArg
-      .describedAs("request required acks")
+      .describedAs("required acks of requests")
       .ofType(classOf[java.lang.String])
       .defaultsTo("1")
     val requestTimeoutMsOpt = parser.accepts("request-timeout-ms", "The ack timeout of the producer requests. Value must be non-negative and non-zero.")
@@ -243,7 +242,7 @@ object ConsoleProducer {
     val propertyOpt = parser.accepts("property", "A mechanism to pass user-defined properties in the form key=value to the message reader. " +
       "This allows custom configuration for a user-defined message reader.")
       .withRequiredArg
-      .describedAs("user-defined properties for the messages reader")
+      .describedAs("user-defined properties for the message reader")
       .ofType(classOf[String])
     val producerPropertyOpt = parser.accepts("producer-property", "A mechanism to pass user-defined properties in the form key=value to the producer. ")
             .withRequiredArg

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -64,6 +64,7 @@ object ConsoleProducer {
     } catch {
       case e: joptsimple.OptionException =>
         System.err.println(e.getMessage)
+        e.printStackTrace()
         Exit.exit(1)
       case e: Exception =>
         e.printStackTrace
@@ -135,126 +136,135 @@ object ConsoleProducer {
 
   class ProducerConfig(args: Array[String]) {
     val parser = new OptionParser(false)
-    val topicOpt = parser.accepts("topic", "REQUIRED: The topic id to produce messages to.")
+    val topicOpt = parser.accepts("topic", "The topic id to produce messages to.")
       .withRequiredArg
-      .describedAs("topic")
+      .describedAs("topic id")
       .ofType(classOf[String])
-    val brokerListOpt = parser.accepts("broker-list", "REQUIRED: The broker list string in the form HOST1:PORT1,HOST2:PORT2.")
+      .required
+    val brokerListOpt = parser.accepts("broker-list", "The broker list string in the form host1:port1,host2:port2.")
       .withRequiredArg
-      .describedAs("broker-list")
+      .describedAs("server(s) to connect to")
       .ofType(classOf[String])
-    val syncOpt = parser.accepts("sync", "If set message send requests to the brokers are synchronously, one at a time as they arrive.")
-    val compressionCodecOpt = parser.accepts("compression-codec", "The compression codec: either 'none', 'gzip', 'snappy', or 'lz4'." +
-                                                                  "If specified without value, then it defaults to 'gzip'")
+      .required
+    val syncOpt = parser.accepts("sync", "If set, message requests are send to the brokers synchronously, one at a time as they arrive.")
+    val compressionCodecOpt = parser.accepts("compression-codec", "The compression codec is either: 'none', 'gzip', 'snappy', or 'lz4'." +
+                                                                  "If specified without value, then it defaults to 'gzip'.")
                                     .withOptionalArg()
                                     .describedAs("compression-codec")
                                     .ofType(classOf[String])
     val batchSizeOpt = parser.accepts("batch-size", "Number of messages to send in a single batch if they are not being sent synchronously.")
       .withRequiredArg
-      .describedAs("size")
+      .describedAs("Number of messages in a single batch")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(200)
-    val messageSendMaxRetriesOpt = parser.accepts("message-send-max-retries", "Brokers can fail receiving the message for multiple reasons, and being unavailable transiently is just one of them. This property specifies the number of retires before the producer give up and drop this message.")
+    val messageSendMaxRetriesOpt = parser.accepts("message-send-max-retries", "Brokers can fail receiving the message for multiple reasons, and being unavailable transiently is just one of them. This property specifies the number of retries before the producer gives up and drops this message.")
       .withRequiredArg
+      .describedAs("number of retries before producer drops the messages")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(3)
     val retryBackoffMsOpt = parser.accepts("retry-backoff-ms", "Before each retry, the producer refreshes the metadata of relevant topics. Since leader election takes a bit of time, this property specifies the amount of time that the producer waits before refreshing the metadata.")
       .withRequiredArg
+      .describedAs("time (in ms) that the producer waits before refreshing the metadata")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(100)
     val sendTimeoutOpt = parser.accepts("timeout", "If set and the producer is running in asynchronous mode, this gives the maximum amount of time" +
-      " a message will queue awaiting sufficient batch size. The value is given in ms.")
+      " a message will queue awaiting sufficient batch size. The value is given in milliseconds.")
       .withRequiredArg
-      .describedAs("timeout_ms")
+      .describedAs("max time(in ms) message will queue awaiting sufficient batch size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1000)
     val queueSizeOpt = parser.accepts("queue-size", "If set and the producer is running in asynchronous mode, this gives the maximum amount of " +
-      " messages will queue awaiting sufficient batch size.")
+      " messages that will queue awaiting sufficient batch size.")
       .withRequiredArg
-      .describedAs("queue_size")
+      .describedAs("max number of messages in a queue to form sufficient batch size")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(10000)
-    val queueEnqueueTimeoutMsOpt = parser.accepts("queue-enqueuetimeout-ms", "Timeout for event enqueue")
+    val queueEnqueueTimeoutMsOpt = parser.accepts("queue-enqueuetimeout-ms", "Timeout for event enqueue in milliseconds.")
       .withRequiredArg
-      .describedAs("queue enqueuetimeout ms")
+      .describedAs("queue enqueue timeout(in ms)")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(Int.MaxValue)
-    val requestRequiredAcksOpt = parser.accepts("request-required-acks", "The required acks of the producer requests")
+    val requestRequiredAcksOpt = parser.accepts("request-required-acks", "The required acks of the producer requests.")
       .withRequiredArg
       .describedAs("request required acks")
       .ofType(classOf[java.lang.String])
       .defaultsTo("1")
-    val requestTimeoutMsOpt = parser.accepts("request-timeout-ms", "The ack timeout of the producer requests. Value must be non-negative and non-zero")
+    val requestTimeoutMsOpt = parser.accepts("request-timeout-ms", "The ack timeout of the producer requests. Value must be non-negative and non-zero.")
       .withRequiredArg
-      .describedAs("request timeout ms")
+      .describedAs("request timeout(in ms)")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1500)
     val metadataExpiryMsOpt = parser.accepts("metadata-expiry-ms",
       "The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any leadership changes.")
       .withRequiredArg
-      .describedAs("metadata expiration interval")
+      .describedAs("metadata expiration interval(in ms)")
       .ofType(classOf[java.lang.Long])
       .defaultsTo(5*60*1000L)
     val maxBlockMsOpt = parser.accepts("max-block-ms",
-      "The max time that the producer will block for during a send request")
+      "The max time that the producer will block for during a send request.")
       .withRequiredArg
-      .describedAs("max block on send")
+      .describedAs("max block on send(in ms)")
       .ofType(classOf[java.lang.Long])
       .defaultsTo(60*1000L)
     val maxMemoryBytesOpt = parser.accepts("max-memory-bytes",
-      "The total memory used by the producer to buffer records waiting to be sent to the server.")
+      "The total memory in bytes used by the producer to buffer records waiting to be sent to the server.")
       .withRequiredArg
-      .describedAs("total memory in bytes")
+      .describedAs("total memory(in bytes)")
       .ofType(classOf[java.lang.Long])
       .defaultsTo(32 * 1024 * 1024L)
     val maxPartitionMemoryBytesOpt = parser.accepts("max-partition-memory-bytes",
-      "The buffer size allocated for a partition. When records are received which are smaller than this size the producer " +
+      "The buffer size allocated for a partition. When records are received which are smaller than this size, the producer " +
         "will attempt to optimistically group them together until this size is reached.")
       .withRequiredArg
-      .describedAs("memory in bytes per partition")
+      .describedAs("memory(in bytes) per partition")
       .ofType(classOf[java.lang.Long])
       .defaultsTo(16 * 1024L)
     val valueEncoderOpt = parser.accepts("value-serializer", "The class name of the message encoder implementation to use for serializing values.")
       .withRequiredArg
-      .describedAs("encoder_class")
+      .describedAs("encoder class for serializing values")
       .ofType(classOf[java.lang.String])
       .defaultsTo(classOf[DefaultEncoder].getName)
     val keyEncoderOpt = parser.accepts("key-serializer", "The class name of the message encoder implementation to use for serializing keys.")
       .withRequiredArg
-      .describedAs("encoder_class")
+      .describedAs("encoder class for serializing keys")
       .ofType(classOf[java.lang.String])
       .defaultsTo(classOf[DefaultEncoder].getName)
-    val messageReaderOpt = parser.accepts("line-reader", "The class name of the class to use for reading lines from standard in. " +
-      "By default each line is read as a separate message.")
+    val messageReaderOpt = parser.accepts("line-reader", "The class name of the class to use for reading lines from standard input. " +
+      "By default, each line is read as a separate message.")
       .withRequiredArg
-      .describedAs("reader_class")
+      .describedAs("reader class for reading lines from standard input")
       .ofType(classOf[java.lang.String])
       .defaultsTo(classOf[LineMessageReader].getName)
     val socketBufferSizeOpt = parser.accepts("socket-buffer-size", "The size of the tcp RECV size.")
       .withRequiredArg
-      .describedAs("size")
+      .describedAs("buffer size used for socket connections")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1024*100)
     val propertyOpt = parser.accepts("property", "A mechanism to pass user-defined properties in the form key=value to the message reader. " +
       "This allows custom configuration for a user-defined message reader.")
       .withRequiredArg
-      .describedAs("prop")
+      .describedAs("user-defined properties for the messages reader")
       .ofType(classOf[String])
     val producerPropertyOpt = parser.accepts("producer-property", "A mechanism to pass user-defined properties in the form key=value to the producer. ")
             .withRequiredArg
-            .describedAs("producer_prop")
+            .describedAs("user-defined properties for the producer")
             .ofType(classOf[String])
     val producerConfigOpt = parser.accepts("producer.config", s"Producer config properties file. Note that $producerPropertyOpt takes precedence over this config.")
       .withRequiredArg
-      .describedAs("config file")
+      .describedAs("config file for producer")
       .ofType(classOf[String])
     val useOldProducerOpt = parser.accepts("old-producer", "Use the old producer implementation.")
-
-    val options = parser.parse(args : _*)
+    val helpOpt = parser.accepts("help", "Print usage information.").forHelp
+    
+    var commandDef: String = "Read data from standard input and publish it to Kafka."
     if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "Read data from standard input and publish it to Kafka.")
-    CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, brokerListOpt)
-
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
+    
+    val options = CommandLineUtils.tryParse(parser, args)
+    if (options.has("help")) {
+       CommandLineUtils.printUsageAndDie(parser, commandDef)
+    }
+    
     val useOldProducer = options.has(useOldProducerOpt)
     val topic = options.valueOf(topicOpt)
     val brokerList = options.valueOf(brokerListOpt)
@@ -280,7 +290,6 @@ object ConsoleProducer {
     val socketBuffer = options.valueOf(socketBufferSizeOpt)
     val cmdLineProps = CommandLineUtils.parseKeyValueArgs(options.valuesOf(propertyOpt).asScala)
     val extraProducerProps = CommandLineUtils.parseKeyValueArgs(options.valuesOf(producerPropertyOpt).asScala)
-    /* new producer related configs */
     val maxMemoryBytes = options.valueOf(maxMemoryBytesOpt)
     val maxPartitionMemoryBytes = options.valueOf(maxPartitionMemoryBytesOpt)
     val metadataExpiryMs = options.valueOf(metadataExpiryMsOpt)

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -266,7 +266,7 @@ object ConsumerPerformance extends LazyLogging {
         "the new consumer implementation is set. User can also explicitely set the new consumer implementation using the --new-consumer option.")
       .requiredUnless("zookeeper")
       .withRequiredArg()
-      .describedAs("server(s) to connect to")
+      .describedAs("server(s) to use for bootstrapping")
       .ofType(classOf[String])
     val topicOpt = parser.accepts("topic", "The topic to consume from.")
       .withRequiredArg
@@ -297,7 +297,7 @@ object ConsumerPerformance extends LazyLogging {
       .defaultsTo(10)
     val numFetchersOpt = parser.accepts("num-fetch-threads", "Number of fetcher threads.")
       .withRequiredArg
-      .describedAs("Number of fetcher threads")
+      .describedAs("number of fetcher threads")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1)
     val newConsumerOpt = parser.accepts("new-consumer", "Use the new consumer implementation. This is the default, so " +

--- a/core/src/main/scala/kafka/tools/ExportZkOffsets.scala
+++ b/core/src/main/scala/kafka/tools/ExportZkOffsets.scala
@@ -61,7 +61,7 @@ object ExportZkOffsets extends Logging {
                             .ofType(classOf[String])
     val outFileOpt = parser.accepts("output-file", "Output file name to print the offset information of broker partitions.")
                             .withRequiredArg()
-                            .describedAs("file name for exporting offset information")
+                            .describedAs("file name to export offset information")
                             .ofType(classOf[String])
                             .required
     parser.accepts("help", "Print usage information.").forHelp

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -42,7 +42,7 @@ object GetOffsetShell {
                            .required
     val partitionOpt = parser.accepts("partitions", "Comma separated list of partition ids. If not specified, it will find offsets for all partitions.")
                            .withRequiredArg
-                           .describedAs("partition ids")
+                           .describedAs("partition id(s)")
                            .ofType(classOf[String])
                            .defaultsTo("")
     val timeOpt = parser.accepts("time", "Timestamp in milliseconds. The offsets before this timestamp will be fetched.")

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -30,41 +30,46 @@ object GetOffsetShell {
 
   def main(args: Array[String]): Unit = {
     val parser = new OptionParser(false)
-    val brokerListOpt = parser.accepts("broker-list", "REQUIRED: The list of hostname and port of the server to connect to.")
+    val brokerListOpt = parser.accepts("broker-list", "The list of hostname and port of the server to connect to.")
                            .withRequiredArg
-                           .describedAs("hostname:port,...,hostname:port")
+                           .describedAs("server(s) to connect to. e.g: hostname:port,...,hostname:port")
                            .ofType(classOf[String])
-    val topicOpt = parser.accepts("topic", "REQUIRED: The topic to get offset from.")
+                           .required
+    val topicOpt = parser.accepts("topic", "The topic to get offset from.")
                            .withRequiredArg
-                           .describedAs("topic")
+                           .describedAs("topic name")
                            .ofType(classOf[String])
-    val partitionOpt = parser.accepts("partitions", "comma separated list of partition ids. If not specified, it will find offsets for all partitions")
+                           .required
+    val partitionOpt = parser.accepts("partitions", "Comma separated list of partition ids. If not specified, it will find offsets for all partitions.")
                            .withRequiredArg
                            .describedAs("partition ids")
                            .ofType(classOf[String])
                            .defaultsTo("")
-    val timeOpt = parser.accepts("time", "timestamp of the offsets before that")
+    val timeOpt = parser.accepts("time", "Timestamp in milliseconds. The offsets before this timestamp will be fetched.")
                            .withRequiredArg
                            .describedAs("timestamp/-1(latest)/-2(earliest)")
                            .ofType(classOf[java.lang.Long])
                            .defaultsTo(-1)
-    val nOffsetsOpt = parser.accepts("offsets", "number of offsets returned")
+    val nOffsetsOpt = parser.accepts("offsets", "Number of offsets returned.")
                            .withRequiredArg
-                           .describedAs("count")
+                           .describedAs("number of offsets returned")
                            .ofType(classOf[java.lang.Integer])
                            .defaultsTo(1)
     val maxWaitMsOpt = parser.accepts("max-wait-ms", "The max amount of time each fetch request waits.")
                            .withRequiredArg
-                           .describedAs("ms")
+                           .describedAs("max fetch request wait time (in ms)")
                            .ofType(classOf[java.lang.Integer])
                            .defaultsTo(1000)
-                           
+    parser.accepts("help", "Print usage information.").forHelp
+                      
+   var commandDef: String = "An interactive shell for getting consumer offsets."
    if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "An interactive shell for getting consumer offsets.")
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
 
-    val options = parser.parse(args : _*)
+    val options = CommandLineUtils.tryParse(parser, args)
 
-    CommandLineUtils.checkRequiredArgs(parser, options, brokerListOpt, topicOpt)
+    if(options.has("help"))
+        CommandLineUtils.printUsageAndDie(parser, commandDef)
 
     val clientId = "GetOffsetShell"
     val brokerList = options.valueOf(brokerListOpt)

--- a/core/src/main/scala/kafka/tools/ImportZkOffsets.scala
+++ b/core/src/main/scala/kafka/tools/ImportZkOffsets.scala
@@ -52,7 +52,7 @@ object ImportZkOffsets extends Logging {
                             .ofType(classOf[String])
     val inFileOpt = parser.accepts("input-file", "Input file to import offsets for broker partitions.")
                             .withRequiredArg()
-                            .describedAs("file name for importing offset information")
+                            .describedAs("file name to import offset information")
                             .ofType(classOf[String])
                             .required
     parser.accepts("help", "Print usage information.").forHelp

--- a/core/src/main/scala/kafka/tools/ImportZkOffsets.scala
+++ b/core/src/main/scala/kafka/tools/ImportZkOffsets.scala
@@ -47,24 +47,24 @@ object ImportZkOffsets extends Logging {
     
     val zkConnectOpt = parser.accepts("zkconnect", "ZooKeeper connect string.")
                             .withRequiredArg()
+                            .describedAs("url(s) for the zookeeper connection")
                             .defaultsTo("localhost:2181")
                             .ofType(classOf[String])
-    val inFileOpt = parser.accepts("input-file", "Input file")
+    val inFileOpt = parser.accepts("input-file", "Input file to import offsets for broker partitions.")
                             .withRequiredArg()
+                            .describedAs("file name for importing offset information")
                             .ofType(classOf[String])
-    parser.accepts("help", "Print this message.")
+                            .required
+    parser.accepts("help", "Print usage information.").forHelp
     
+    var commandDef: String = "Import offsets to zookeeper from an input file."
     if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "Import offsets to zookeeper from files.")
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
             
-    val options = parser.parse(args : _*)
+    val options = CommandLineUtils.tryParse(parser, args)
     
-    if (options.has("help")) {
-       parser.printHelpOn(System.out)
-       Exit.exit(0)
-    }
-    
-    CommandLineUtils.checkRequiredArgs(parser, options, inFileOpt)
+    if (options.has("help")) 
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
     
     val zkConnect           = options.valueOf(zkConnectOpt)
     val partitionOffsetFile = options.valueOf(inFileOpt)

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -64,7 +64,7 @@ object JmxTool extends Logging {
     val dateFormatOpt = parser.accepts("date-format", "The date format to use for formatting the time field. " +
       "See java.text.SimpleDateFormat for options.")
       .withRequiredArg
-      .describedAs("date format to use for formatting time field")
+      .describedAs("date format for formatting time field")
       .ofType(classOf[String])
     val jmxServiceUrlOpt =
       parser.accepts("jmx-url", "The url to connect to poll JMX data. See Oracle javadoc for JMXServiceURL for details.")

--- a/core/src/main/scala/kafka/tools/JmxTool.scala
+++ b/core/src/main/scala/kafka/tools/JmxTool.scala
@@ -44,47 +44,47 @@ object JmxTool extends Logging {
     val parser = new OptionParser(false)
     val objectNameOpt =
       parser.accepts("object-name", "A JMX object name to use as a query. This can contain wild cards, and this option " +
-        "can be given multiple times to specify more than one query. If no objects are specified " +
+        "can be given multiple times to specify more than one query. If no objects are specified, " +
         "all objects will be queried.")
         .withRequiredArg
-        .describedAs("name")
+        .describedAs("JMX object name to query")
         .ofType(classOf[String])
     val attributesOpt =
       parser.accepts("attributes", "The whitelist of attributes to query. This is a comma-separated list. If no " +
-        "attributes are specified all objects will be queried.")
+        "attributes are specified, all objects will be queried.")
         .withRequiredArg
-        .describedAs("name")
+        .describedAs("attributes to query")
         .ofType(classOf[String])
-    val reportingIntervalOpt = parser.accepts("reporting-interval", "Interval in MS with which to poll jmx stats.")
+    val reportingIntervalOpt = parser.accepts("reporting-interval", "Interval in milliseconds with which to poll JMX stats.")
       .withRequiredArg
-      .describedAs("ms")
+      .describedAs("polling interval(in ms)")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(2000)
-    val helpOpt = parser.accepts("help", "Print usage information.")
+    val helpOpt = parser.accepts("help", "Print usage information.").forHelp
     val dateFormatOpt = parser.accepts("date-format", "The date format to use for formatting the time field. " +
       "See java.text.SimpleDateFormat for options.")
       .withRequiredArg
-      .describedAs("format")
+      .describedAs("date format to use for formatting time field")
       .ofType(classOf[String])
     val jmxServiceUrlOpt =
       parser.accepts("jmx-url", "The url to connect to poll JMX data. See Oracle javadoc for JMXServiceURL for details.")
         .withRequiredArg
-        .describedAs("service-url")
+        .describedAs("service url for polling JMX data")
         .ofType(classOf[String])
         .defaultsTo("service:jmx:rmi:///jndi/rmi://:9999/jmxrmi")
     val waitOpt = parser.accepts("wait", "Wait for requested JMX objects to become available before starting output. " +
       "Only supported when the list of objects is non-empty and contains no object name patterns.")
 
+    var commandDef: String = "Dump JMX values to standard output."
+    
     if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "Dump JMX values to standard output.")
-
-    val options = parser.parse(args : _*)
-
-    if(options.has(helpOpt)) {
-      parser.printHelpOn(System.out)
-      Exit.exit(0)
-    }
-
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
+    
+    val options = CommandLineUtils.tryParse(parser, args)
+    
+    if(options.has(helpOpt))
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
+     
     val url = new JMXServiceURL(options.valueOf(jmxServiceUrlOpt))
     val interval = options.valueOf(reportingIntervalOpt).intValue
     val attributesWhitelistExists = options.has(attributesOpt)
@@ -143,7 +143,7 @@ object JmxTool extends Logging {
 
     if (wait && !foundAllObjects) {
       val missing = (queries.toSet - namesSet).mkString(", ")
-      System.err.println(s"Could not find all requested object names after $waitTimeoutMs ms. Missing $missing")
+      System.err.println(s"Could not find all requested object names after $waitTimeoutMs ms. Missing $missing.")
       System.err.println("Exiting.")
       sys.exit(1)
     }

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -109,20 +109,20 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
       val numStreamsOpt = parser.accepts("num.streams",
         "Number of consumption streams.")
         .withRequiredArg()
-        .describedAs("Number of threads")
+        .describedAs("number of threads")
         .ofType(classOf[java.lang.Integer])
         .defaultsTo(1)
 
       val whitelistOpt = parser.accepts("whitelist",
         "Whitelist of topics to mirror.")
         .withRequiredArg()
-        .describedAs("Java regex (String)")
+        .describedAs("java regex (String)")
         .ofType(classOf[String])
 
       val blacklistOpt = parser.accepts("blacklist",
         "Blacklist of topics to mirror. Only old consumer supports blacklist.")
         .withRequiredArg()
-        .describedAs("Java regex (String)")
+        .describedAs("java regex (String)")
         .ofType(classOf[String])
 
       val offsetCommitIntervalMsOpt = parser.accepts("offset.commit.interval.ms",

--- a/core/src/main/scala/kafka/tools/PerfConfig.scala
+++ b/core/src/main/scala/kafka/tools/PerfConfig.scala
@@ -22,21 +22,23 @@ import joptsimple.OptionParser
 
 class PerfConfig(args: Array[String]) {
   val parser = new OptionParser(false)
-  val numMessagesOpt = parser.accepts("messages", "REQUIRED: The number of messages to send or consume")
+  val numMessagesOpt = parser.accepts("messages", "The number of messages to send or consume.")
     .withRequiredArg
-    .describedAs("count")
+    .describedAs("number of messages to send/receive")
     .ofType(classOf[java.lang.Long])
+    .required
   val reportingIntervalOpt = parser.accepts("reporting-interval", "Interval in milliseconds at which to print progress info.")
     .withRequiredArg
-    .describedAs("interval_ms")
+    .describedAs("reporting interval(in ms) for printing progress info")
     .ofType(classOf[java.lang.Integer])
     .defaultsTo(5000)
   val dateFormatOpt = parser.accepts("date-format", "The date format to use for formatting the time field. " +
     "See java.text.SimpleDateFormat for options.")
     .withRequiredArg
-    .describedAs("date format")
+    .describedAs("date format to use for formatting time field")
     .ofType(classOf[String])
     .defaultsTo("yyyy-MM-dd HH:mm:ss:SSS")
-  val hideHeaderOpt = parser.accepts("hide-header", "If set, skips printing the header for the stats ")
-  val helpOpt = parser.accepts("help", "Print usage.")
+  val hideHeaderOpt = parser.accepts("hide-header", "If set, skips printing the header for the stats.")
+  val helpOpt = parser.accepts("help", "Print usage information.")
+    .forHelp
 }

--- a/core/src/main/scala/kafka/tools/ProducerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ProducerPerformance.scala
@@ -73,7 +73,7 @@ object ProducerPerformance extends Logging {
   class ProducerPerfConfig(args: Array[String]) extends PerfConfig(args) {
     val brokerListOpt = parser.accepts("broker-list", "The list of broker host and port for bootstrap.")
       .withRequiredArg
-      .describedAs("server(s) to connect to (e.g: hostname:port,..,hostname:port)")
+      .describedAs("server(s) to use for bootstrapping (e.g: hostname:port,..,hostname:port)")
       .ofType(classOf[String])
       .required
     val producerConfigOpt = parser.accepts("producer.config", "Producer config properties file.")

--- a/core/src/main/scala/kafka/tools/ReplayLogProducer.scala
+++ b/core/src/main/scala/kafka/tools/ReplayLogProducer.scala
@@ -71,7 +71,7 @@ object ReplayLogProducer extends Logging {
       .defaultsTo("localhost:2181")
     val brokerListOpt = parser.accepts("broker-list", "The broker list must be specified.")
       .withRequiredArg
-      .describedAs("server(s) to connect to(e.g: hostname:port)")
+      .describedAs("server(s) to use for bootstrapping(e.g: hostname:port)")
       .ofType(classOf[String])
       .required
     val inputTopicOpt = parser.accepts("inputtopic", "The topic to consume from.")
@@ -91,7 +91,7 @@ object ReplayLogProducer extends Logging {
       .defaultsTo(-1)
     val numThreadsOpt = parser.accepts("threads", "Number of sending threads.")
       .withRequiredArg
-      .describedAs("number of threads")
+      .describedAs("number of sending threads")
       .ofType(classOf[java.lang.Integer])
       .defaultsTo(1)
     val reportingIntervalOpt = parser.accepts("reporting-interval", "Interval at which to print progress info.")

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -68,7 +68,7 @@ object ReplicaVerificationTool extends Logging {
     val parser = new OptionParser(false)
     val brokerListOpt = parser.accepts("broker-list", "The list of hostname and port of the server to connect to.")
                          .withRequiredArg
-                         .describedAs("server(s) to connect to(e.g. hostname:port,...,hostname:port)")
+                         .describedAs("server(s) to use for bootstrapping(e.g. hostname:port,...,hostname:port)")
                          .ofType(classOf[String])
                          .required
     val fetchSizeOpt = parser.accepts("fetch-size", "The fetch size of each request.")
@@ -132,7 +132,6 @@ object ReplicaVerificationTool extends Logging {
     val brokerMap = topicsMetadataResponse.brokers.map(b => (b.id, b)).toMap
     val filteredTopicMetadata = topicsMetadataResponse.topicsMetadata.filter(
         topicMetadata => topicWhiteListFiler.isTopicAllowed(topicMetadata.topic, excludeInternalTopics = false)
-  
     )
 
     if (filteredTopicMetadata.isEmpty) {

--- a/core/src/main/scala/kafka/tools/SimpleConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerPerformance.scala
@@ -36,7 +36,7 @@ object SimpleConsumerPerformance extends LazyLogging {
 
   def main(args: Array[String]) {
     logger.warn("WARNING: SimpleConsumerPerformance is deprecated and will be dropped in a future release following 0.11.0.0.")
-
+ 
     val config = new ConsumerPerfConfig(args)
     logger.info("Starting SimpleConsumer...")
 
@@ -118,38 +118,45 @@ object SimpleConsumerPerformance extends LazyLogging {
   }
 
   class ConsumerPerfConfig(args: Array[String]) extends PerfConfig(args) {
-    val urlOpt = parser.accepts("server", "REQUIRED: The hostname of the server to connect to.")
+    val urlOpt = parser.accepts("server", "The hostname of the server to connect to.")
                            .withRequiredArg
                            .describedAs("kafka://hostname:port")
                            .ofType(classOf[String])
-    val topicOpt = parser.accepts("topic", "REQUIRED: The topic to consume from.")
+                           .required
+    val topicOpt = parser.accepts("topic", "The topic to consume from.")
       .withRequiredArg
       .describedAs("topic")
       .ofType(classOf[String])
+      .required
     val resetBeginningOffsetOpt = parser.accepts("from-latest", "If the consumer does not already have an established " +
       "offset to consume from, start with the latest message present in the log rather than the earliest message.")
     val partitionOpt = parser.accepts("partition", "The topic partition to consume from.")
                            .withRequiredArg
-                           .describedAs("partition")
+                           .describedAs("topic partition to consume from")
                            .ofType(classOf[java.lang.Integer])
                            .defaultsTo(0)
-    val fetchSizeOpt = parser.accepts("fetch-size", "REQUIRED: The fetch size to use for consumption.")
+    val fetchSizeOpt = parser.accepts("fetch-size", "The fetch size to use for consumption.")
                            .withRequiredArg
-                           .describedAs("bytes")
+                           .describedAs("fetch size(in bytes)")
                            .ofType(classOf[java.lang.Integer])
                            .defaultsTo(1024*1024)
     val clientIdOpt = parser.accepts("clientId", "The ID of this client.")
                            .withRequiredArg
-                           .describedAs("clientId")
+                           .describedAs("client id")
                            .ofType(classOf[String])
                            .defaultsTo("SimpleConsumerPerformanceClient")
     val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
       "interval as configured by reporting-interval")
 
-    val options = parser.parse(args : _*)
+    var commandDef: String = "Run performance test for Simple Consumer."
+    if (args.length == 0)
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
+      
+    val options = CommandLineUtils.tryParse(parser, args)
 
-    CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, urlOpt, numMessagesOpt)
-
+    if (options.has("help"))
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
+    
     val url = new URI(options.valueOf(urlOpt))
     val fetchSize = options.valueOf(fetchSizeOpt).intValue
     val fromLatest = options.has(resetBeginningOffsetOpt)

--- a/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerShell.scala
@@ -43,7 +43,7 @@ object SimpleConsumerShell extends Logging {
     val parser = new OptionParser(false)
     val brokerListOpt = parser.accepts("broker-list", "The list of hostname and port of the server to connect to.")
                            .withRequiredArg
-                           .describedAs("server(s) to connect to (e.g. hostname:port,...,hostname:port)")
+                           .describedAs("server(s) to use for bootstrapping (e.g. hostname:port,...,hostname:port)")
                            .ofType(classOf[String])
                            .required
     val topicOpt = parser.accepts("topic", "The topic to consume from.")
@@ -78,7 +78,7 @@ object SimpleConsumerShell extends Logging {
                            .defaultsTo(1024 * 1024)
     val messageFormatterOpt = parser.accepts("formatter", "The name of a class to use for formatting Kafka messages for display.")
                            .withRequiredArg
-                           .describedAs("class name to use for formatting messages to display")
+                           .describedAs("class name to use for formatting messages for display")
                            .ofType(classOf[String])
                            .defaultsTo(classOf[DefaultMessageFormatter].getName)
     val messageFormatterArgOpt = parser.accepts("property", "The properties to initialize the message formatter.")

--- a/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
+++ b/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
@@ -61,47 +61,48 @@ object StateChangeLogMerger extends Logging {
 
     // Parse input arguments.
     val parser = new OptionParser(false)
-    val filesOpt = parser.accepts("logs", "Comma separated list of state change logs or a regex for the log file names")
+    val filesOpt = parser.accepts("logs", "Comma separated list of state change logs or a regex for the log file names.")
                               .withRequiredArg
-                              .describedAs("file1,file2,...")
+                              .describedAs("list or regex of state change logs(e.g: file1,file2,...)")
                               .ofType(classOf[String])
-    val regexOpt = parser.accepts("logs-regex", "Regex to match the state change log files to be merged")
+    val regexOpt = parser.accepts("logs-regex", "Regex to match the state change log files to be merged.")
                               .withRequiredArg
-                              .describedAs("for example: /tmp/state-change.log*")
+                              .describedAs("regex to match state change logs to be merged(e.g: /tmp/state-change.log*)")
                               .ofType(classOf[String])
-    val topicOpt = parser.accepts("topic", "The topic whose state change logs should be merged")
+    val topicOpt = parser.accepts("topic", "The topic whose state change logs should be merged.")
                               .withRequiredArg
-                              .describedAs("topic")
+                              .describedAs("topic name")
                               .ofType(classOf[String])
-    val partitionsOpt = parser.accepts("partitions", "Comma separated list of partition ids whose state change logs should be merged")
+    val partitionsOpt = parser.accepts("partitions", "Comma separated list of partition ids whose state change logs should be merged.")
                               .withRequiredArg
-                              .describedAs("0,1,2,...")
+                              .describedAs("list of partition ids(e.g: 0,1,2,...)")
                               .ofType(classOf[String])
-    val startTimeOpt = parser.accepts("start-time", "The earliest timestamp of state change log entries to be merged")
+    val startTimeOpt = parser.accepts("start-time", "The earliest timestamp of state change log entries to be merged.")
                               .withRequiredArg
                               .describedAs("start timestamp in the format " + dateFormat)
                               .ofType(classOf[String])
                               .defaultsTo("0000-00-00 00:00:00,000")
-    val endTimeOpt = parser.accepts("end-time", "The latest timestamp of state change log entries to be merged")
+    val endTimeOpt = parser.accepts("end-time", "The latest timestamp of state change log entries to be merged.")
                               .withRequiredArg
                               .describedAs("end timestamp in the format " + dateFormat)
                               .ofType(classOf[String])
                               .defaultsTo("9999-12-31 23:59:59,999")
-                              
+    parser.accepts("help", "Print usage information.").forHelp()
+
+    var commandDef: String = "A tool for merging the log files from several brokers to reconnstruct a unified history of what happened." 
     if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "A tool for merging the log files from several brokers to reconnstruct a unified history of what happened.")
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
 
-
-    val options = parser.parse(args : _*)
+    val options = CommandLineUtils.tryParse(parser, args)
+    
+    if(options.has("help"))
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
+      
     if ((!options.has(filesOpt) && !options.has(regexOpt)) || (options.has(filesOpt) && options.has(regexOpt))) {
-      System.err.println("Provide arguments to exactly one of the two options \"" + filesOpt + "\" or \"" + regexOpt + "\"")
-      parser.printHelpOn(System.err)
-      Exit.exit(1)
+      CommandLineUtils.printUsageAndDie(parser, "Provide arguments to exactly one of the two options \"" + filesOpt + "\" or \"" + regexOpt + "\"")
     }
     if (options.has(partitionsOpt) && !options.has(topicOpt)) {
-      System.err.println("The option \"" + topicOpt + "\" needs to be provided an argument when specifying partition ids")
-      parser.printHelpOn(System.err)
-      Exit.exit(1)
+      CommandLineUtils.printUsageAndDie(parser, "The option \"" + topicOpt + "\" needs to be provided an argument when specifying partition ids.")
     }
 
     // Populate data structures.

--- a/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
+++ b/core/src/main/scala/kafka/tools/StateChangeLogMerger.scala
@@ -63,11 +63,11 @@ object StateChangeLogMerger extends Logging {
     val parser = new OptionParser(false)
     val filesOpt = parser.accepts("logs", "Comma separated list of state change logs or a regex for the log file names.")
                               .withRequiredArg
-                              .describedAs("list or regex of state change logs(e.g: file1,file2,...)")
+                              .describedAs("list/regex of state change logs(e.g: file1,file2,...)")
                               .ofType(classOf[String])
     val regexOpt = parser.accepts("logs-regex", "Regex to match the state change log files to be merged.")
                               .withRequiredArg
-                              .describedAs("regex to match state change logs to be merged(e.g: /tmp/state-change.log*)")
+                              .describedAs("regex to match state change logs(e.g: /tmp/state-change.log*)")
                               .ofType(classOf[String])
     val topicOpt = parser.accepts("topic", "The topic whose state change logs should be merged.")
                               .withRequiredArg

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -173,7 +173,7 @@ public class StreamsResetter {
             .withRequiredArg()
             .ofType(String.class)
             .defaultsTo("localhost:9092")
-            .describedAs("server(s) to connect to");
+            .describedAs("server(s) to use for bootstrapping");
         inputTopicsOption = optionParser.accepts("input-topics", "Comma-separated list of user input topics. For these topics, the tool will reset the offset to the earliest available offset.")
             .withRequiredArg()
             .ofType(String.class)
@@ -205,7 +205,7 @@ public class StreamsResetter {
         commandConfigOption = optionParser.accepts("config-file", "Property file containing configs to be passed to admin clients and embedded consumer.")
             .withRequiredArg()
             .ofType(String.class)
-            .describedAs("fconfig ile name to be passed to admin clients and embedded consumers");
+            .describedAs("file name");
         dryRunOption = optionParser.accepts("dry-run", "Display the actions that would be performed without executing the reset commands.");
         optionParser.accepts("help", "Print usage information.").forHelp();
 

--- a/core/src/main/scala/kafka/tools/VerifyConsumerRebalance.scala
+++ b/core/src/main/scala/kafka/tools/VerifyConsumerRebalance.scala
@@ -27,23 +27,26 @@ object VerifyConsumerRebalance extends Logging {
     val parser = new OptionParser(false)
     warn("WARNING: VerifyConsumerRebalance is deprecated and will be dropped in a future release following 0.11.0.0.")
 
-    val zkConnectOpt = parser.accepts("zookeeper.connect", "ZooKeeper connect string.").
-      withRequiredArg().defaultsTo("localhost:2181").ofType(classOf[String])
-    val groupOpt = parser.accepts("group", "Consumer group.").
-      withRequiredArg().ofType(classOf[String])
-    parser.accepts("help", "Print this message.")
+    val zkConnectOpt = parser.accepts("zookeeper.connect", "ZooKeeper connect string.")
+      .withRequiredArg()
+      .describedAs("url(s) for the zookeeper connection")
+      .defaultsTo("localhost:2181")
+      .ofType(classOf[String])
+    val groupOpt = parser.accepts("group", "Consumer group.")
+      .withRequiredArg()
+      .describedAs("consumer group id")
+      .ofType(classOf[String])
+      .required
+    parser.accepts("help", "Print usage information.").forHelp
     
+    var commandDef: String = "Validate that all partitions have a consumer for a given consumer group."
     if(args.length == 0)
-      CommandLineUtils.printUsageAndDie(parser, "Validate that all partitions have a consumer for a given consumer group.")
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
 
-    val options = parser.parse(args : _*)
+    val options = CommandLineUtils.tryParse(parser, args)
 
-    if (options.has("help")) {
-      parser.printHelpOn(System.out)
-      Exit.exit(0)
-    }
-
-    CommandLineUtils.checkRequiredArgs(parser, options, groupOpt)
+    if (options.has("help")) 
+      CommandLineUtils.printUsageAndDie(parser, commandDef)
 
     val zkConnect = options.valueOf(zkConnectOpt)
     val group = options.valueOf(groupOpt)

--- a/core/src/main/scala/kafka/utils/CommandLineUtils.scala
+++ b/core/src/main/scala/kafka/utils/CommandLineUtils.scala
@@ -16,7 +16,7 @@
  */
  package kafka.utils
 
-import joptsimple.{OptionSpec, OptionSet, OptionParser}
+import joptsimple.{OptionSpec, OptionSet, OptionParser, OptionException}
 import scala.collection.Set
 import java.util.Properties
 
@@ -51,7 +51,7 @@ object CommandLineUtils extends Logging {
    * Print usage and exit
    */
   def printUsageAndDie(parser: OptionParser, message: String): Nothing = {
-    System.err.println(message)
+    System.err.println(System.lineSeparator() + message + System.lineSeparator())
     parser.printHelpOn(System.err)
     Exit.exit(1, Some(message))
   }
@@ -75,5 +75,19 @@ object CommandLineUtils extends Logging {
       }
     }
     props
+  }
+  
+  /**
+   * Parse the user-supplied command line. Any exceptions during processing
+   * the command line is caught and help message for the given command is
+   * printed.
+   */
+  def tryParse(parser: OptionParser, args: Array[String]): OptionSet = {
+      try
+        parser.parse(args: _*)
+      catch {
+        case e: OptionException =>
+          CommandLineUtils.printUsageAndDie(parser, e.getMessage)
+      }
   }
 }

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -28,6 +28,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with RackAw
 
     // create a non rack aware assignment topic first
     val createOpts = new kafka.admin.TopicCommand.TopicCommandOptions(Array(
+      "--zookeeper", zkConnect,
       "--partitions", numPartitions.toString,
       "--replication-factor", replicationFactor.toString,
       "--disable-rack-aware",

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -33,6 +33,7 @@ import scala.collection.mutable
 import scala.collection.JavaConverters._
 
 class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
+  
   @Test
   def shouldParseArgumentsForClientsEntityType() {
     testArgumentParse("clients")
@@ -407,7 +408,7 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
     val zkClient = EasyMock.createNiceMock(classOf[KafkaZkClient])
 
     def checkEntities(opts: Array[String], expectedFetches: Map[String, Seq[String]], expectedEntityNames: Seq[String]) {
-      val entity = ConfigCommand.parseEntity(new ConfigCommandOptions(opts :+ "--describe"))
+      val entity = ConfigCommand.parseEntity(new ConfigCommandOptions(Array("--zookeeper", zkConnect) ++ opts :+ "--describe"))
       expectedFetches.foreach {
         case (name, values) => EasyMock.expect(zkClient.getAllEntitiesWithConfig(name)).andReturn(values)
       }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
@@ -92,13 +92,14 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
 
   @Test
   def shouldFailIfNoArgs(): Unit = {
-    val args: Array[String]= Array()
-    shouldFailWith("This command moves topic partitions between replicas.", args)
+    val args: Array[String]= Array("")
+    shouldFailWith("Missing required option(s) [zookeeper]", args)
   }
-
+  
   @Test
-  def shouldFailIfBlankArg(): Unit = {
-    val args = Array(" ")
+  def shouldFailIfNoAction(): Unit = {
+    val args = Array(
+        "--zookeeper", "localhost:1234")
     shouldFailWith("Command must include exactly one action: --generate, --execute or --verify", args)
   }
 

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -78,7 +78,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     TopicCommand.createTopic(zkClient, createOpts)
 
     // delete the NormalTopic
-    val deleteOpts = new TopicCommandOptions(Array("--topic", normalTopic))
+    val deleteOpts = new TopicCommandOptions(Array("--topic", normalTopic, "--zookeeper", zkConnect))
     val deletePath = getDeleteTopicPath(normalTopic)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkUtils.pathExists(deletePath))
     TopicCommand.deleteTopic(zkClient, deleteOpts)
@@ -91,7 +91,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     TopicCommand.createTopic(zkClient, createOffsetTopicOpts)
 
     // try to delete the Topic.GROUP_METADATA_TOPIC_NAME and make sure it doesn't
-    val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
+    val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME, "--zookeeper", zkConnect))
     val deleteOffsetTopicPath = getDeleteTopicPath(Topic.GROUP_METADATA_TOPIC_NAME)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkUtils.pathExists(deleteOffsetTopicPath))
     intercept[AdminOperationException] {
@@ -107,7 +107,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     TestUtils.createBrokersInZk(zkClient, brokers)
 
     // delete a topic that does not exist without --if-exists
-    val deleteOpts = new TopicCommandOptions(Array("--topic", "test"))
+    val deleteOpts = new TopicCommandOptions(Array("--topic", "test", "--zookeeper", zkConnect))
     intercept[IllegalArgumentException] {
       TopicCommand.deleteTopic(zkClient, deleteOpts)
     }
@@ -124,7 +124,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     TestUtils.createBrokersInZk(zkClient, brokers)
 
     // alter a topic that does not exist without --if-exists
-    val alterOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1"))
+    val alterOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1", "--zookeeper", zkConnect))
     intercept[IllegalArgumentException] {
       TopicCommand.alterTopic(zkClient, alterOpts)
     }

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -17,13 +17,24 @@
 
 package kafka.tools
 
+import kafka.utils.Exit
 import kafka.producer.ProducerConfig
 import ConsoleProducer.LineMessageReader
 import org.apache.kafka.clients.producer.KafkaProducer
-import org.junit.{Assert, Test}
+import org.junit.{After, Assert, Before, Test}
 
 class ConsoleProducerTest {
 
+  @Before
+  def setUp() {
+    Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
+  }
+
+  @After
+  def tearDown() {
+    Exit.resetExitProcedure()
+  }
+  
   val validArgs: Array[String] = Array(
     "--broker-list",
     "localhost:1001,localhost:1002",
@@ -57,12 +68,13 @@ class ConsoleProducerTest {
   }
 
   @Test
-  def testInvalidConfigs() {
+  def testInvalidConfigs() : Unit = {
+    val msg = "t is not a recognized option"
     try {
       new ConsoleProducer.ProducerConfig(invalidArgs)
       Assert.fail("Should have thrown an UnrecognizedOptionException")
     } catch {
-      case _: joptsimple.OptionException => // expected exception
+      case e: Exception => Assert.assertTrue(s"Expected exception with message:\n[$msg]\nbut was\n[${e.getMessage}]", e.getMessage.startsWith(msg))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZooKeeperTestHarness.scala
@@ -19,7 +19,7 @@ package kafka.zk
 
 import javax.security.auth.login.Configuration
 
-import kafka.utils.{CoreUtils, Logging, TestUtils, ZkUtils}
+import kafka.utils.{CoreUtils, Exit, Logging, TestUtils, ZkUtils}
 import org.junit.{After, AfterClass, Before, BeforeClass}
 import org.junit.Assert._
 import org.scalatest.junit.JUnitSuite
@@ -71,6 +71,7 @@ abstract class ZooKeeperTestHarness extends JUnitSuite with Logging {
       CoreUtils.swallow(zookeeper.shutdown(), this)
     Configuration.setConfiguration(null)
   }
+  Exit.resetExitProcedure()
 }
 
 object ZooKeeperTestHarness {

--- a/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ProducerPerformance.java
@@ -196,14 +196,14 @@ public class ProducerPerformance {
         MutuallyExclusiveGroup payloadOptions = parser
                 .addMutuallyExclusiveGroup()
                 .required(true)
-                .description("either --record-size or --payload-file must be specified but not both.");
+                .description("Either --record-size or --payload-file must be specified but not both.");
 
         parser.addArgument("--topic")
                 .action(store())
                 .required(true)
                 .type(String.class)
                 .metavar("TOPIC")
-                .help("produce messages to this topic");
+                .help("Produce messages to this topic.");
 
         parser.addArgument("--num-records")
                 .action(store())
@@ -211,7 +211,7 @@ public class ProducerPerformance {
                 .type(Long.class)
                 .metavar("NUM-RECORDS")
                 .dest("numRecords")
-                .help("number of messages to produce");
+                .help("Number of messages to produce.");
 
         payloadOptions.addArgument("--record-size")
                 .action(store())
@@ -219,7 +219,7 @@ public class ProducerPerformance {
                 .type(Integer.class)
                 .metavar("RECORD-SIZE")
                 .dest("recordSize")
-                .help("message size in bytes. Note that you must provide exactly one of --record-size or --payload-file.");
+                .help("Message size in bytes. Note that you must provide exactly one of --record-size or --payload-file.");
 
         payloadOptions.addArgument("--payload-file")
                 .action(store())
@@ -227,7 +227,7 @@ public class ProducerPerformance {
                 .type(String.class)
                 .metavar("PAYLOAD-FILE")
                 .dest("payloadFile")
-                .help("file to read the message payloads from. This works only for UTF-8 encoded text files. " +
+                .help("File to read the message payloads from. This works only for UTF-8 encoded text files. " +
                         "Payloads will be read from this file and a payload will be randomly selected when sending messages. " +
                         "Note that you must provide exactly one of --record-size or --payload-file.");
 
@@ -238,7 +238,7 @@ public class ProducerPerformance {
                 .metavar("PAYLOAD-DELIMITER")
                 .dest("payloadDelimiter")
                 .setDefault("\\n")
-                .help("provides delimiter to be used when --payload-file is provided. " +
+                .help("Provides delimiter to be used when --payload-file is provided. " +
                         "Defaults to new line. " +
                         "Note that this parameter will be ignored if --payload-file is not provided.");
 
@@ -247,7 +247,7 @@ public class ProducerPerformance {
                 .required(true)
                 .type(Integer.class)
                 .metavar("THROUGHPUT")
-                .help("throttle maximum message throughput to *approximately* THROUGHPUT messages/sec");
+                .help("Throttle maximum message throughput to *approximately* THROUGHPUT messages/sec.");
 
         parser.addArgument("--producer-props")
                  .nargs("+")
@@ -255,7 +255,7 @@ public class ProducerPerformance {
                  .metavar("PROP-NAME=PROP-VALUE")
                  .type(String.class)
                  .dest("producerConfig")
-                 .help("kafka producer related configuration properties like bootstrap.servers,client.id etc. " +
+                 .help("Kafka producer related configuration properties like bootstrap.servers,client.id etc. " +
                          "These configs take precedence over those passed via --producer.config.");
 
         parser.addArgument("--producer.config")
@@ -264,14 +264,14 @@ public class ProducerPerformance {
                 .type(String.class)
                 .metavar("CONFIG-FILE")
                 .dest("producerConfigFile")
-                .help("producer config properties file.");
+                .help("Producer config properties file.");
 
         parser.addArgument("--print-metrics")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("PRINT-METRICS")
                 .dest("printMetrics")
-                .help("print out metrics at the end of the test.");
+                .help("Print out metrics at the end of the test.");
 
         parser.addArgument("--transactional-id")
                .action(store())

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableConsumer.java
@@ -513,7 +513,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(String.class)
                 .metavar("GROUP_ID")
                 .dest("groupId")
-                .help("The groupId shared among members of the consumer group");
+                .help("The groupId shared among members of the consumer group.");
 
         parser.addArgument("--max-messages")
                 .action(store())
@@ -522,7 +522,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .setDefault(-1)
                 .metavar("MAX-MESSAGES")
                 .dest("maxMessages")
-                .help("Consume this many messages. If -1 (the default), the consumer will consume until the process is killed externally");
+                .help("Consume this many messages. If -1 (the default), the consumer will consume until the process is killed externally.");
 
         parser.addArgument("--session-timeout")
                 .action(store())
@@ -531,20 +531,20 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .type(Integer.class)
                 .metavar("TIMEOUT_MS")
                 .dest("sessionTimeout")
-                .help("Set the consumer's session timeout");
+                .help("Set the consumer's session timeout.");
 
         parser.addArgument("--verbose")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("VERBOSE")
-                .help("Enable to log individual consumed records");
+                .help("Enable to log individual consumed records.");
 
         parser.addArgument("--enable-autocommit")
                 .action(storeTrue())
                 .type(Boolean.class)
                 .metavar("ENABLE-AUTOCOMMIT")
                 .dest("useAutoCommit")
-                .help("Enable offset auto-commit on consumer");
+                .help("Enable offset auto-commit on consumer.");
 
         parser.addArgument("--reset-policy")
                 .action(store())
@@ -552,7 +552,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .setDefault("earliest")
                 .type(String.class)
                 .dest("resetPolicy")
-                .help("Set reset policy (must be either 'earliest', 'latest', or 'none'");
+                .help("Set reset policy (must be either 'earliest', 'latest', or 'none').");
 
         parser.addArgument("--assignment-strategy")
                 .action(store())
@@ -560,7 +560,7 @@ public class VerifiableConsumer implements Closeable, OffsetCommitCallback, Cons
                 .setDefault(RangeAssignor.class.getName())
                 .type(String.class)
                 .dest("assignmentStrategy")
-                .help("Set assignment strategy (e.g. " + RoundRobinAssignor.class.getName() + ")");
+                .help("Set assignment strategy (e.g. " + RoundRobinAssignor.class.getName() + ").");
 
         parser.addArgument("--consumer.config")
                 .action(store())


### PR DESCRIPTION
This patch addresses the less invasive standardization of command
line arguments as an offshoot of KIP-14. The following changes have
been addressed in this patchset:
- Used the required() method of JOptSimple to identify required options
  for commands. Currently, an option is identified as required by
  mentioning the word REQUIRED in the description of the option.
- Used the requiredIf() and requiredUnless() methods to capture option
  requirements which met the condition - required if/unless some other
  option is present
- Removed calls to CommandLineUtils.checkRequiredArgs(). Since we use
  JOptSimple's required() function to mark options as required, when
  we parse the arguments using OptionParser, it automatically checks
  the required arguments in that call. So there is no need to do this
  check again externally.
- Added a help option to all the commands that were missing it. For
  some of the commands that had the help option, included the call to
  forHelp() method to mark the option as a help option. This means that
  specifying help option on the command line will not cause parsing to
  fail because of missing required options.
- Added try-catch statements to correctly capture OptionException. In
  the case an OptionException is caught, the command usage information
  will be printed along with the exception message. The stacktrace for
  all other exceptions will be printed to System.err. This addresses
  the issue in KAFKA-4220
- Made some minor changes to the description text and added some more
  description for some of the options