### PR TITLE
MINOR: Use commitId property if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ directories.  Use -PxmlFindBugsReport=true to generate an XML report instead of 
 
 The following options should be set with a `-P` switch, for example `./gradlew -PmaxParallelForks=1 test`.
 
+* `commitId`: sets the build commit ID as .git/HEAD might not be correct if there are local commits added for build purposes.
 * `mavenUrl`: sets the URL of the maven deployment repository (`file://path/to/repo` can be used to point to a local repository).
 * `maxParallelForks`: limits the maximum number of processes for each task.
 * `showStandardStreams`: shows standard out and standard error of the test JVM(s) on the console.

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,8 @@ ext {
   userTestLoggingEvents = project.hasProperty("testLoggingEvents") ? Arrays.asList(testLoggingEvents.split(",")) : null
 
   generatedDocsDir = new File("${project.rootDir}/docs/generated")
+
+  commitId = project.hasProperty('commitId') ? commitId : null
 }
 
 apply from: file('wrapper.gradle')
@@ -751,20 +753,22 @@ project(':clients') {
   }
 
   task determineCommitId {
-    ext.commitId = "unknown"
     def takeFromHash = 16
-    if (file("$rootDir/.git/HEAD").exists()) {
+    if (commitId) {
+      commitId = commitId.take(takeFromHash)
+    } else if (file("$rootDir/.git/HEAD").exists()) {
       def headRef = file("$rootDir/.git/HEAD").text
       if (headRef.contains('ref: ')) {
         headRef = headRef.replaceAll('ref: ', '').trim()
         if (file("$rootDir/.git/$headRef").exists()) {
-        commitId = file("$rootDir/.git/$headRef").text.trim().take(takeFromHash)
+          commitId = file("$rootDir/.git/$headRef").text.trim().take(takeFromHash)
         }
       } else {
         commitId = headRef.trim().take(takeFromHash)
       }
+    } else {
+      commitId = "unknown"
     }
-    commitId
   }
 
   task createVersionFile(dependsOn: determineCommitId) {
@@ -773,7 +777,7 @@ project(':clients') {
     outputs.upToDateWhen { false }
     doLast {
       def data = [
-        commitId: determineCommitId.commitId,
+        commitId: commitId,
         version: version,
       ]
 


### PR DESCRIPTION
This allows a build system to set the correct commit ID when .git/HEAD would be wrong
if there are local commits for build purposes.