### PR TITLE
KAFKA-5691- handle NOAUTH in zkUtils.CreateRecursive

### DIFF
--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -1111,6 +1111,10 @@ class ZKCheckedEphemeral(path: String,
                             case Code.INVALIDACL =>
                               error("Invalid ACL")
                               setResult(Code.INVALIDACL)
+                            case Code.NOAUTH =>
+                              // Allows old consumer to register with secure ZK
+                              error("NOAUTH raised on path %s (AUTH may not be needed to create children)".format(path))
+                              createRecursive(path, suffix)
                             case _ =>
                               warn("ZooKeeper event while creating registration node: %s %s".format(path, Code.get(rc)))
                               setResult(Code.get(rc))


### PR DESCRIPTION
Currently old consumers are unable to register with secure ZK installations. Handling NOAUTH prevents failures when checking /consumers