### PR TITLE
MINOR: Added a couple of unit tests for KStreamPrint node when values are bytes

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -56,36 +56,6 @@ public class KStreamPrintTest {
     }
 
     @Test
-    public void testPrintKeyValueWithName() {
-        final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
-            @Override
-            public String apply(final Integer key, final String value) {
-                return String.format("%d, %s", key, value);
-            }
-        };
-        final KStreamPrint<Integer, String> kStreamPrint = new KStreamPrint<>(new PrintForeachAction<>(printWriter, mapper, "test-stream"), intSerd, stringSerd);
-
-        final List<KeyValue<Integer, String>> inputRecords = Arrays.asList(
-                new KeyValue<>(0, "zero"),
-                new KeyValue<>(1, "one"),
-                new KeyValue<>(2, "two"),
-                new KeyValue<>(3, "three"));
-        
-        final String[] expectedResult = {"[test-stream]: 0, zero", "[test-stream]: 1, one", "[test-stream]: 2, two", "[test-stream]: 3, three"};
-        
-        final StreamsBuilder builder = new StreamsBuilder();
-        final KStream<Integer, String> stream = builder.stream(intSerd, stringSerd, topicName);
-        stream.process(kStreamPrint);
-        
-        driver.setUp(builder);
-        for (KeyValue<Integer, String> record: inputRecords) {
-            driver.process(topicName, record.key, record.value);
-        }
-        printWriter.flush();
-        assertFlushData(expectedResult, byteOutStream);
-    }
-
-    @Test
     public void testPrintStreamWithProvidedKeyValueMapper() {
         final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -49,21 +49,26 @@ public class KStreamPrintTest {
     @Rule
     public KStreamTestDriver driver = new KStreamTestDriver();
 
+    private KeyValueMapper<Integer, String, String> mapper;
+    private KStreamPrint<Integer, String> kStreamPrint;
+
     @Before
     public void setUp() {
         byteOutStream = new ByteArrayOutputStream();
         printWriter = new PrintWriter(new OutputStreamWriter(byteOutStream, StandardCharsets.UTF_8));
+
+        mapper = new KeyValueMapper<Integer, String, String>() {
+            @Override
+            public String apply(final Integer key, final String value) {
+                return String.format("%d, %s", key, value);
+            }
+        };
+
+        kStreamPrint = new KStreamPrint<>(new PrintForeachAction<>(printWriter, mapper, "test-stream"), intSerd, stringSerd);
     }
 
     @Test
     public void testPrintStreamWithProvidedKeyValueMapper() {
-        final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
-            @Override
-            public String apply(final Integer key, final String value) {
-                return String.format("(%d, %s)", key, value);
-            }
-        };
-        final KStreamPrint<Integer, String> kStreamPrint = new KStreamPrint<>(new PrintForeachAction<>(printWriter, mapper, "test-stream"), intSerd, stringSerd);
 
         final List<KeyValue<Integer, String>> inputRecords = Arrays.asList(
                 new KeyValue<>(0, "zero"),
@@ -71,7 +76,7 @@ public class KStreamPrintTest {
                 new KeyValue<>(2, "two"),
                 new KeyValue<>(3, "three"));
 
-        final String[] expectedResult = {"[test-stream]: (0, zero)", "[test-stream]: (1, one)", "[test-stream]: (2, two)", "[test-stream]: (3, three)"};
+        final String[] expectedResult = {"[test-stream]: 0, zero", "[test-stream]: 1, one", "[test-stream]: 2, two", "[test-stream]: 3, three"};
 
         final StreamsBuilder builder = new StreamsBuilder();
         final KStream<Integer, String> stream = builder.stream(intSerd, stringSerd, topicName);
@@ -87,13 +92,6 @@ public class KStreamPrintTest {
 
     @Test
     public void testPrintKeyValueStringBytesArray() {
-        final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
-            @Override
-            public String apply(final Integer key, final String value) {
-                return String.format("%d, %s", key, value);
-            }
-        };
-        final KStreamPrint<Integer, String> kStreamPrint = new KStreamPrint<>(new PrintForeachAction<>(printWriter, mapper, "test-stream"), intSerd, stringSerd);
 
         final List<KeyValue<Integer, byte[]>> inputRecords = Arrays.asList(
                 new KeyValue<>(0, stringSerd.serializer().serialize(topicName, "zero")),
@@ -115,37 +113,7 @@ public class KStreamPrintTest {
         assertFlushData(expectedResult, byteOutStream);
     }
 
-    @Test
-    public void testPrintKeyValueIntegerBytesArray() {
-        final KeyValueMapper<Integer, Integer, String> mapper = new KeyValueMapper<Integer, Integer, String>() {
-            @Override
-            public String apply(final Integer key, final Integer value) {
-                return String.format("%d, %d", key, value);
-            }
-        };
-        final KStreamPrint<Integer, Integer> kStreamPrint = new KStreamPrint<>(new PrintForeachAction<>(printWriter, mapper, "test-stream"), intSerd, intSerd);
-
-        final List<KeyValue<Integer, byte[]>> inputRecords = Arrays.asList(
-                new KeyValue<>(0, intSerd.serializer().serialize(topicName, 0)),
-                new KeyValue<>(1, intSerd.serializer().serialize(topicName, 1)),
-                new KeyValue<>(2, intSerd.serializer().serialize(topicName, 2)),
-                new KeyValue<>(3, intSerd.serializer().serialize(topicName, 3)));
-
-        final String[] expectedResult = {"[test-stream]: 0, 0", "[test-stream]: 1, 1", "[test-stream]: 2, 2", "[test-stream]: 3, 3"};
-
-        final StreamsBuilder builder = new StreamsBuilder();
-        final KStream<Integer, Integer> stream = builder.stream(intSerd, intSerd, topicName);
-        stream.process(kStreamPrint);
-
-        driver.setUp(builder);
-        for (KeyValue<Integer, byte[]> record: inputRecords) {
-            driver.process(topicName, record.key, record.value);
-        }
-        printWriter.flush();
-        assertFlushData(expectedResult, byteOutStream);
-    }
-
-    private void assertFlushData(String[] expectedResult, ByteArrayOutputStream byteOutStream) {
+    private void assertFlushData(final String[] expectedResult, final ByteArrayOutputStream byteOutStream) {
 
         final String[] flushOutDatas = new String(byteOutStream.toByteArray(), Charset.forName("UTF-8")).split("\\r*\\n");
         for (int i = 0; i < flushOutDatas.length; i++) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -113,6 +113,7 @@ public class KStreamPrintTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private <K, V> void doTest(final List<KeyValue<K, V>> inputRecords, final String[] expectedResult) {
 
         for (KeyValue<K, V> record: inputRecords) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -166,9 +166,9 @@ public class KStreamPrintTest {
 
         final List<KeyValue<Integer, byte[]>> inputRecords = Arrays.asList(
                 new KeyValue<>(0, intSerd.serializer().serialize(topicName, 0)),
-                new KeyValue<>(1, intSerd.serializer().serialize(topicName,1)),
-                new KeyValue<>(2, intSerd.serializer().serialize(topicName,2)),
-                new KeyValue<>(3, intSerd.serializer().serialize(topicName,3)));
+                new KeyValue<>(1, intSerd.serializer().serialize(topicName, 1)),
+                new KeyValue<>(2, intSerd.serializer().serialize(topicName, 2)),
+                new KeyValue<>(3, intSerd.serializer().serialize(topicName, 3)));
 
         final String[] expectedResult = {"[test-stream]: 0, 0", "[test-stream]: 1, 1", "[test-stream]: 2, 2", "[test-stream]: 3, 3"};
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -59,7 +59,7 @@ public class KStreamPrintTest {
     public void testPrintKeyValueWithName() {
         final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
             @Override
-            public String apply(Integer key, String value) {
+            public String apply(final Integer key, final String value) {
                 return String.format("%d, %s", key, value);
             }
         };
@@ -82,17 +82,14 @@ public class KStreamPrintTest {
             driver.process(topicName, record.key, record.value);
         }
         printWriter.flush();
-        final String[] flushOutDatas = new String(byteOutStream.toByteArray(), Charset.forName("UTF-8")).split("\\r*\\n");
-        for (int i = 0; i < flushOutDatas.length; i++) {
-            assertEquals(expectedResult[i], flushOutDatas[i]);
-        }
+        assertFlushData(expectedResult, byteOutStream);
     }
 
     @Test
     public void testPrintStreamWithProvidedKeyValueMapper() {
         final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
             @Override
-            public String apply(Integer key, String value) {
+            public String apply(final Integer key, final String value) {
                 return String.format("(%d, %s)", key, value);
             }
         };
@@ -115,17 +112,14 @@ public class KStreamPrintTest {
             driver.process(topicName, record.key, record.value);
         }
         printWriter.flush();
-        final String[] results = new String(byteOutStream.toByteArray(), Charset.forName("UTF-8")).split("\\r*\\n");
-        for (int i = 0; i < results.length; i++) {
-            assertEquals(expectedResult[i], results[i]);
-        }
+        assertFlushData(expectedResult, byteOutStream);
     }
 
     @Test
     public void testPrintKeyValueStringBytesArray() {
         final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
             @Override
-            public String apply(Integer key, String value) {
+            public String apply(final Integer key, final String value) {
                 return String.format("%d, %s", key, value);
             }
         };
@@ -148,17 +142,14 @@ public class KStreamPrintTest {
             driver.process(topicName, record.key, record.value);
         }
         printWriter.flush();
-        final String[] flushOutDatas = new String(byteOutStream.toByteArray(), Charset.forName("UTF-8")).split("\\r*\\n");
-        for (int i = 0; i < flushOutDatas.length; i++) {
-            assertEquals(expectedResult[i], flushOutDatas[i]);
-        }
+        assertFlushData(expectedResult, byteOutStream);
     }
 
     @Test
     public void testPrintKeyValueIntegerBytesArray() {
         final KeyValueMapper<Integer, Integer, String> mapper = new KeyValueMapper<Integer, Integer, String>() {
             @Override
-            public String apply(Integer key, Integer value) {
+            public String apply(final Integer key, final Integer value) {
                 return String.format("%d, %d", key, value);
             }
         };
@@ -181,6 +172,11 @@ public class KStreamPrintTest {
             driver.process(topicName, record.key, record.value);
         }
         printWriter.flush();
+        assertFlushData(expectedResult, byteOutStream);
+    }
+
+    private void assertFlushData(String[] expectedResult, ByteArrayOutputStream byteOutStream) {
+
         final String[] flushOutDatas = new String(byteOutStream.toByteArray(), Charset.forName("UTF-8")).split("\\r*\\n");
         for (int i = 0; i < flushOutDatas.length; i++) {
             assertEquals(expectedResult[i], flushOutDatas[i]);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -57,7 +57,7 @@ public class KStreamPrintTest {
 
     @Test
     public void testPrintKeyValueWithName() {
-        KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
+        final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
             @Override
             public String apply(Integer key, String value) {
                 return String.format("%d, %s", key, value);
@@ -123,7 +123,7 @@ public class KStreamPrintTest {
 
     @Test
     public void testPrintKeyValueStringBytesArray() {
-        KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
+        final KeyValueMapper<Integer, String, String> mapper = new KeyValueMapper<Integer, String, String>() {
             @Override
             public String apply(Integer key, String value) {
                 return String.format("%d, %s", key, value);
@@ -156,7 +156,7 @@ public class KStreamPrintTest {
 
     @Test
     public void testPrintKeyValueIntegerBytesArray() {
-        KeyValueMapper<Integer, Integer, String> mapper = new KeyValueMapper<Integer, Integer, String>() {
+        final KeyValueMapper<Integer, Integer, String> mapper = new KeyValueMapper<Integer, Integer, String>() {
             @Override
             public String apply(Integer key, Integer value) {
                 return String.format("%d, %d", key, value);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamPrintTest.java
@@ -23,11 +23,9 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.PrintForeachAction;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.test.KStreamTestDriver;
 
 import org.easymock.EasyMock;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -46,8 +44,6 @@ public class KStreamPrintTest {
     private final Serde<String> stringSerd = Serdes.String();
     private PrintWriter printWriter;
     private ByteArrayOutputStream byteOutStream;
-    @Rule
-    public KStreamTestDriver driver = new KStreamTestDriver();
 
     private KeyValueMapper<Integer, String, String> mapper;
     private KStreamPrint kStreamPrint;


### PR DESCRIPTION
With current tests, the deserialization inside the KStreamPrint node processor which happens when key and/or values are byte[] isn't tested. This PR fixes that.