### PR TITLE
KAFKA-2360: Extract producer-specific configs out of the common PerfConfig

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -239,6 +239,8 @@ object ConsumerPerformance {
       .describedAs("config file")
       .ofType(classOf[String])
     val printMetricsOpt = parser.accepts("print-metrics", "Print out the metrics. This only applies to new consumer.")
+    val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
+      "interval as configured by reporting-interval")
 
     val options = parser.parse(args: _*)
 

--- a/core/src/main/scala/kafka/tools/PerfConfig.scala
+++ b/core/src/main/scala/kafka/tools/PerfConfig.scala
@@ -42,21 +42,3 @@ class PerfConfig(args: Array[String]) {
   val hideHeaderOpt = parser.accepts("hide-header", "If set, skips printing the header for the stats ")
   val helpOpt = parser.accepts("help", "Print usage.")
 }
-
-class LegacyProducerPerfConfig(args: Array[String]) extends PerfConfig(args) {
-  val messageSizeOpt = parser.accepts("message-size", "The size of each message.")
-    .withRequiredArg
-    .describedAs("size")
-    .ofType(classOf[java.lang.Integer])
-    .defaultsTo(100)
-  val batchSizeOpt = parser.accepts("batch-size", "Number of messages to write in a single batch.")
-    .withRequiredArg
-    .describedAs("size")
-    .ofType(classOf[java.lang.Integer])
-    .defaultsTo(200)
-  val compressionCodecOpt = parser.accepts("compression-codec", "If set, messages are sent compressed")
-    .withRequiredArg
-    .describedAs("supported codec: NoCompressionCodec as 0, GZIPCompressionCodec as 1, SnappyCompressionCodec as 2, LZ4CompressionCodec as 3")
-    .ofType(classOf[java.lang.Integer])
-    .defaultsTo(0)
-}

--- a/core/src/main/scala/kafka/tools/PerfConfig.scala
+++ b/core/src/main/scala/kafka/tools/PerfConfig.scala
@@ -37,8 +37,6 @@ class PerfConfig(args: Array[String]) {
     .describedAs("date format")
     .ofType(classOf[String])
     .defaultsTo("yyyy-MM-dd HH:mm:ss:SSS")
-  val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
-    "interval as configured by reporting-interval")
   val hideHeaderOpt = parser.accepts("hide-header", "If set, skips printing the header for the stats ")
   val helpOpt = parser.accepts("help", "Print usage.")
 }

--- a/core/src/main/scala/kafka/tools/PerfConfig.scala
+++ b/core/src/main/scala/kafka/tools/PerfConfig.scala
@@ -40,6 +40,10 @@ class PerfConfig(args: Array[String]) {
   val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
     "interval as configured by reporting-interval")
   val hideHeaderOpt = parser.accepts("hide-header", "If set, skips printing the header for the stats ")
+  val helpOpt = parser.accepts("help", "Print usage.")
+}
+
+class LegacyProducerPerfConfig(args: Array[String]) extends PerfConfig(args) {
   val messageSizeOpt = parser.accepts("message-size", "The size of each message.")
     .withRequiredArg
     .describedAs("size")
@@ -55,5 +59,4 @@ class PerfConfig(args: Array[String]) {
     .describedAs("supported codec: NoCompressionCodec as 0, GZIPCompressionCodec as 1, SnappyCompressionCodec as 2, LZ4CompressionCodec as 3")
     .ofType(classOf[java.lang.Integer])
     .defaultsTo(0)
-  val helpOpt = parser.accepts("help", "Print usage.")
 }

--- a/core/src/main/scala/kafka/tools/ProducerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ProducerPerformance.scala
@@ -70,7 +70,7 @@ object ProducerPerformance extends Logging {
     Exit.exit(0)
   }
 
-  class ProducerPerfConfig(args: Array[String]) extends LegacyProducerPerfConfig(args) {
+  class ProducerPerfConfig(args: Array[String]) extends PerfConfig(args) {
     val brokerListOpt = parser.accepts("broker-list", "REQUIRED: broker info the list of broker host and port for bootstrap.")
       .withRequiredArg
       .describedAs("hostname:port,..,hostname:port")
@@ -125,6 +125,21 @@ object ProducerPerformance extends Logging {
       .describedAs("metrics directory")
       .ofType(classOf[java.lang.String])
     val useNewProducerOpt = parser.accepts("new-producer", "Use the new producer implementation.")
+    val messageSizeOpt = parser.accepts("message-size", "The size of each message.")
+      .withRequiredArg
+      .describedAs("size")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(100)
+    val batchSizeOpt = parser.accepts("batch-size", "Number of messages to write in a single batch.")
+      .withRequiredArg
+      .describedAs("size")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(200)
+    val compressionCodecOpt = parser.accepts("compression-codec", "If set, messages are sent compressed")
+      .withRequiredArg
+      .describedAs("supported codec: NoCompressionCodec as 0, GZIPCompressionCodec as 1, SnappyCompressionCodec as 2, LZ4CompressionCodec as 3")
+      .ofType(classOf[java.lang.Integer])
+      .defaultsTo(0)
 
     val options = parser.parse(args: _*)
     CommandLineUtils.checkRequiredArgs(parser, options, topicsOpt, brokerListOpt, numMessagesOpt)

--- a/core/src/main/scala/kafka/tools/ProducerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ProducerPerformance.scala
@@ -70,7 +70,7 @@ object ProducerPerformance extends Logging {
     Exit.exit(0)
   }
 
-  class ProducerPerfConfig(args: Array[String]) extends PerfConfig(args) {
+  class ProducerPerfConfig(args: Array[String]) extends LegacyProducerPerfConfig(args) {
     val brokerListOpt = parser.accepts("broker-list", "REQUIRED: broker info the list of broker host and port for bootstrap.")
       .withRequiredArg
       .describedAs("hostname:port,..,hostname:port")

--- a/core/src/main/scala/kafka/tools/SimpleConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/SimpleConsumerPerformance.scala
@@ -145,6 +145,8 @@ object SimpleConsumerPerformance {
                            .describedAs("clientId")
                            .ofType(classOf[String])
                            .defaultsTo("SimpleConsumerPerformanceClient")
+    val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
+      "interval as configured by reporting-interval")
 
     val options = parser.parse(args : _*)
 


### PR DESCRIPTION
Separate `batch.size`, `message-size` and `compression-code` from PerfConfig to a newly-created ProducerPerfConfig in order to hide them in ConsumerPerf tool.