### PR TITLE
MINOR: Update dependencies for 1.0.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.1-rc-2"
+  gradleVersion = "4.1"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,10 @@ buildscript {
 
   dependencies {
     // For Apache Rat plugin to ignore non-Git files
-    classpath "org.ajoberstar:grgit:1.9.2"
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.14.0'
+    classpath "org.ajoberstar:grgit:1.9.3"
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
     classpath 'org.scoverage:gradle-scoverage:2.1.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
   }
 }
 
@@ -77,7 +77,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "3.5"
+  gradleVersion = "4.1-rc-2"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []
@@ -548,7 +548,7 @@ project(':core') {
     testCompile libs.apachedsMavibotPartition
     testCompile libs.apachedsJdbmPartition
     testCompile libs.junit
-    testCompile libs.scalaTest
+    testCompile libs.scalatest
     testCompile libs.jfreechart
 
     scoverage libs.scoveragePlugin
@@ -935,11 +935,11 @@ project(':jmh-benchmarks') {
   }
 
   dependencies {
-      compile project(':clients')
-      compile project(':streams')
-      compile 'org.openjdk.jmh:jmh-core:1.18'
-      compile 'org.openjdk.jmh:jmh-generator-annprocess:1.18'
-      compile 'org.openjdk.jmh:jmh-core-benchmarks:1.18'
+    compile project(':clients')
+    compile project(':streams')
+    compile libs.jmhCore
+    compile libs.jmhGeneratorAnnProcess
+    compile libs.jmhCoreBenchmarks
   }
 
   jar {

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -28,7 +28,6 @@ import java.util.{Locale, Properties, UUID}
 import kafka.utils.{CoreUtils, Exit, Logging}
 
 import scala.collection.JavaConverters._
-import org.apache.commons.io.IOUtils
 import org.apache.commons.lang.text.StrSubstitutor
 import org.apache.directory.api.ldap.model.entry.{DefaultEntry, Entry}
 import org.apache.directory.api.ldap.model.ldif.LdifReader
@@ -198,9 +197,15 @@ class MiniKdc(config: Properties, workDir: File) extends Logging {
         "3" -> orgDomain.toUpperCase(Locale.ENGLISH),
         "4" -> bindAddress
       )
-      val inputStream = MiniKdc.getResourceAsStream("minikdc.ldiff")
-      try addEntriesToDirectoryService(StrSubstitutor.replace(IOUtils.toString(inputStream), map.asJava))
-      finally CoreUtils.swallow(inputStream.close())
+      val reader = new BufferedReader(new InputStreamReader(MiniKdc.getResourceAsStream("minikdc.ldiff")))
+      try {
+        var line: String = null
+        val builder = new StringBuilder
+        while ({line = reader.readLine(); line != null})
+          builder.append(line).append("\n")
+        addEntriesToDirectoryService(StrSubstitutor.replace(builder, map.asJava))
+      }
+      finally CoreUtils.swallow(reader.close())
     }
 
     val bindAddress = config.getProperty(MiniKdc.KdcBindAddress)

--- a/core/src/test/scala/unit/kafka/message/MessageCompressionTest.scala
+++ b/core/src/test/scala/unit/kafka/message/MessageCompressionTest.scala
@@ -19,11 +19,10 @@ package kafka.message
 
 import java.io.ByteArrayOutputStream
 import scala.collection._
-import org.scalatest.junit.JUnitSuite
 import org.junit._
 import org.junit.Assert._
 
-class MessageCompressionTest extends JUnitSuite {
+class MessageCompressionTest {
 
   @Test
   def testSimpleCompressDecompress() {
@@ -49,7 +48,7 @@ class MessageCompressionTest extends JUnitSuite {
     testCompressSize(GZIPCompressionCodec, messages, 396)
 
     if (isSnappyAvailable)
-      testCompressSize(SnappyCompressionCodec, messages, 502)
+      testCompressSize(SnappyCompressionCodec, messages, 503)
 
     if (isLZ4Available)
       testCompressSize(LZ4CompressionCodec, messages, 387)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
 
 // Add Scala version
 def defaultScala211Version = '2.11.11'
-def defaultScala212Version = '2.12.2'
+def defaultScala212Version = '2.12.3'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
     versions["scala"] = defaultScala211Version
@@ -47,26 +47,27 @@ if (hasProperty('scalaVersion')) {
 versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
 
 versions += [
-  apacheda: "1.0.0-M33",
-  apacheds: "2.0.0-M21",
+  apacheda: "1.0.0",
+  apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.56",
+  bcpkix: "1.57",
   easymock: "3.4",
-  jackson: "2.8.5",
+  jackson: "2.9.0",
   jetty: "9.2.15.v20160210",
-  jersey: "2.24",
+  jersey: "2.25.1",
+  jmh: "1.19",
   log4j: "1.2.17",
-  jopt: "5.0.3",
+  jopt: "5.0.4",
   junit: "4.12",
-  lz4: "1.3.0",
+  lz4: "1.4",
   metrics: "2.2.0",
-  powermock: "1.6.4",
+  powermock: "1.7.0",
   reflections: "0.9.11",
   rocksDB: "5.3.6",
-  scalaTest: "3.0.2",
+  scalatest: "3.0.3",
   scoverage: "1.3.0",
   slf4j: "1.7.25",
-  snappy: "1.1.2.6",
+  snappy: "1.1.4",
   zkclient: "0.10",
   zookeeper: "3.4.10",
   jfreechart: "1.0.0",
@@ -92,10 +93,13 @@ libs += [
   jettyServlet: "org.eclipse.jetty:jetty-servlet:$versions.jetty",
   jettyServlets: "org.eclipse.jetty:jetty-servlets:$versions.jetty",
   jerseyContainerServlet: "org.glassfish.jersey.containers:jersey-container-servlet:$versions.jersey",
+  jmhCore: "org.openjdk.jmh:jmh-core:$versions.jmh",
+  jmhGeneratorAnnProcess: "org.openjdk.jmh:jmh-generator-annprocess:$versions.jmh",
+  jmhCoreBenchmarks: "org.openjdk.jmh:jmh-core-benchmarks:$versions.jmh",
   junit: "junit:junit:$versions.junit",
   log4j: "log4j:log4j:$versions.log4j",
   joptSimple: "net.sf.jopt-simple:jopt-simple:$versions.jopt",
-  lz4: "net.jpountz.lz4:lz4:$versions.lz4",
+  lz4: "org.lz4:lz4-java:$versions.lz4",
   metrics: "com.yammer.metrics:metrics-core:$versions.metrics",
   powermock: "org.powermock:powermock-module-junit4:$versions.powermock",
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
@@ -103,7 +107,7 @@ libs += [
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",
   scala: "org.scala-lang:scala-library:$versions.scala",
   scalaCompiler: "org.scala-lang:scala-compiler:$versions.scala",
-  scalaTest: "org.scalatest:scalatest_$versions.baseScala:$versions.scalaTest",
+  scalatest: "org.scalatest:scalatest_$versions.baseScala:$versions.scalatest",
   scoveragePlugin: "org.scoverage:scalac-scoverage-plugin_$versions.baseScala:$versions.scoverage",
   scoverageRuntime: "org.scoverage:scalac-scoverage-runtime_$versions.baseScala:$versions.scoverage",
   slf4jApi: "org.slf4j:slf4j-api:$versions.slf4j",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,7 +61,9 @@ versions += [
   junit: "4.12",
   lz4: "1.4",
   metrics: "2.2.0",
-  powermock: "1.7.0",
+  // A few connect tests fail with powermock 1.6.5 due to https://github.com/powermock/powermock/issues/828, which
+  // is easy to workaround. However, WorkerTest also fails and it seems to be for a different reason.
+  powermock: "1.6.4",
   reflections: "0.9.11",
   rocksDB: "5.3.6",
   scalatest: "3.0.3",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ versions += [
   argparse4j: "0.7.0",
   bcpkix: "1.57",
   easymock: "3.4",
-  jackson: "2.9.0",
+  jackson: "2.8.5",
   jetty: "9.2.15.v20160210",
   jersey: "2.25.1",
   jmh: "1.19",


### PR DESCRIPTION
Notable updates:

1. Gradle 4.1 includes a number of performance and
CLI improvements as well as initial Java 9 support.

2. Scala 2.12.3 has substantial compilation time
improvements.

3. lz4-java 1.4 allows us to remove a workaround in
KafkaLZ4BlockInputStream (not done in this PR).

4. snappy-java 1.1.4 improved performance of compression (5%)
and decompression (20%). There was a slight increase in the
compressed size in one of our tests.

Not updated:

1. PowerMock due to a couple of regressions. I investigated one of them
and filed https://github.com/powermock/powermock/issues/828.

2. Jackson, which will be done via #3631.

3. Rocksdb, which will be done via #3519.