### PR TITLE
KAFKA-5708: jackson upgrade (2.8.5 -> 2.9.1)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ versions += [
   argparse4j: "0.7.0",
   bcpkix: "1.58",
   easymock: "3.4",
-  jackson: "2.8.5",
+  jackson: "2.9.1",
   jetty: "9.2.22.v20170606",
   jersey: "2.25.1",
   jmh: "1.19",


### PR DESCRIPTION
**_Prologue:_** PR #3116

**_Jackson release notes:_**
- https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8
- https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9

**_Note:_** you may want to wait for [Jackson 2.9.1 release ](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.1)

@ewencp: FYI