### PR TITLE
KAFKA-5684: KStreamPrintProcessor as customized KStreamPeekProcessor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/PrintForeachAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/PrintForeachAction.java
@@ -22,7 +22,7 @@ public class PrintForeachAction<K, V> implements ForeachAction<K, V> {
 
     private final String label;
     private final PrintWriter printWriter;
-    private final KeyValueMapper<? super K, ? super V, String> mapper;
+    private KeyValueMapper<? super K, ? super V, String> mapper;
     /**
      * Print customized output with given writer. The PrintWriter can be null in order to
      * distinguish between {@code System.out} and the others. If the PrintWriter is {@code PrintWriter(System.out)},
@@ -31,12 +31,10 @@ public class PrintForeachAction<K, V> implements ForeachAction<K, V> {
      * Afterall, not to pass in {@code PrintWriter(System.out)} but {@code null} instead.
      *
      * @param printWriter Use {@code System.out.println} if {@code null}.
-     * @param mapper The mapper which can allow user to customize output will be printed.
      * @param label The given name will be printed.
      */
-    public PrintForeachAction(final PrintWriter printWriter, final KeyValueMapper<? super K, ? super V, String> mapper, final String label) {
+    public PrintForeachAction(final PrintWriter printWriter, final String label) {
         this.printWriter = printWriter;
-        this.mapper = mapper;
         this.label = label;
     }
 
@@ -58,4 +56,12 @@ public class PrintForeachAction<K, V> implements ForeachAction<K, V> {
         }
     }
 
+    /**
+     * Set the mapper which can allow user to customize output will be printed
+     *
+     * @param mapper The mapper which can allow user to customize output will be printed.
+     */
+    public void setMapper(final KeyValueMapper<? super K, ? super V, String> mapper) {
+        this.mapper = mapper;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPeek.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPeek.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.processor.ProcessorSupplier;
 class KStreamPeek<K, V> implements ProcessorSupplier<K, V> {
 
     private final boolean forwardDownStream;
-    private final ForeachAction<K, V> action;
+    protected final ForeachAction<K, V> action;
 
     public KStreamPeek(final ForeachAction<K, V> action, final boolean forwardDownStream) {
         this.action = action;
@@ -36,7 +36,7 @@ class KStreamPeek<K, V> implements ProcessorSupplier<K, V> {
         return new KStreamPeekProcessor();
     }
 
-    private class KStreamPeekProcessor extends AbstractProcessor<K, V> {
+    class KStreamPeekProcessor extends AbstractProcessor<K, V> {
         @Override
         public void process(final K key, final V value) {
             action.apply(key, value);

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPeek.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamPeek.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.processor.ProcessorSupplier;
 class KStreamPeek<K, V> implements ProcessorSupplier<K, V> {
 
     private final boolean forwardDownStream;
+    // it's protected for having it available from derived classes (i.e. KStreamPrint)
     protected final ForeachAction<K, V> action;
 
     public KStreamPeek(final ForeachAction<K, V> action, final boolean forwardDownStream) {
@@ -36,6 +37,7 @@ class KStreamPeek<K, V> implements ProcessorSupplier<K, V> {
         return new KStreamPeekProcessor();
     }
 
+    // it's package-private to be visible for inheritance (i.e. KStreamPrintProcessor)
     class KStreamPeekProcessor extends AbstractProcessor<K, V> {
         @Override
         public void process(final K key, final V value) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -75,8 +75,6 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
     private final ProcessorSupplier<?, ?> processorSupplier;
 
-    private final KeyValueMapper<K, V, String> defaultKeyValueMapper;
-
     private final String queryableStoreName;
     private final boolean isQueryable;
 
@@ -96,12 +94,6 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
         this.keySerde = null;
         this.valSerde = null;
         this.isQueryable = isQueryable;
-        this.defaultKeyValueMapper = new KeyValueMapper<K, V, String>() {
-            @Override
-            public String apply(K key, V value) {
-                return String.format("%s, %s", key, value);
-            }
-        };
     }
 
     public KTableImpl(final InternalStreamsBuilder builder,
@@ -118,12 +110,6 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
         this.keySerde = keySerde;
         this.valSerde = valSerde;
         this.isQueryable = isQueryable;
-        this.defaultKeyValueMapper = new KeyValueMapper<K, V, String>() {
-            @Override
-            public String apply(K key, V value) {
-                return String.format("%s, %s", key, value);
-            }
-        };
     }
 
     @Override
@@ -268,7 +254,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
                       final String label) {
         Objects.requireNonNull(label, "label can't be null");
         final String name = builder.newName(PRINTING_NAME);
-        builder.internalTopologyBuilder.addProcessor(name, new KStreamPrint<>(new PrintForeachAction(null, defaultKeyValueMapper, label), keySerde, valSerde), this.name);
+        builder.internalTopologyBuilder.addProcessor(name, new KStreamPrint<>(new PrintForeachAction<K, V>(null, label), keySerde, valSerde, null), this.name);
     }
 
     @SuppressWarnings("deprecation")
@@ -309,7 +295,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
         String name = builder.newName(PRINTING_NAME);
         try {
             PrintWriter printWriter = new PrintWriter(filePath, StandardCharsets.UTF_8.name());
-            builder.internalTopologyBuilder.addProcessor(name, new KStreamPrint<>(new PrintForeachAction(printWriter, defaultKeyValueMapper, label), keySerde, valSerde), this.name);
+            builder.internalTopologyBuilder.addProcessor(name, new KStreamPrint<>(new PrintForeachAction<K, V>(printWriter, label), keySerde, valSerde, null), this.name);
         } catch (final FileNotFoundException | UnsupportedEncodingException e) {
             throw new TopologyException(String.format("Unable to write stream to file at [%s] %s", filePath, e.getMessage()));
         }


### PR DESCRIPTION
This PR is intended for having KStreamPrint derived from KStreamPeek and avoiding the "instance of" check on byte[ ] every process call.