### PR TITLE
MINOR: Error when incompatible console producer configs.

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -284,6 +284,12 @@ object ConsoleProducer {
     val maxPartitionMemoryBytes = options.valueOf(maxPartitionMemoryBytesOpt)
     val metadataExpiryMs = options.valueOf(metadataExpiryMsOpt)
     val maxBlockMs = options.valueOf(maxBlockMsOpt)
+    if (!useOldProducer && options.has(keyEncoderOpt) && keyEncoderClass != "org.apache.kafka.common.serialization.ByteArraySerializer") {
+      throw new KafkaException(s"Unexpected serializer for key-serializer. Supplied $keyEncoderOpt, allowed: org.apache.kafka.common.serialization.ByteArraySerializer")
+    }
+    if (!useOldProducer  && options.has(keyEncoderOpt) && valueEncoderClass != "org.apache.kafka.common.serialization.ByteArraySerializer") {
+      throw new KafkaException(s"Unexpected serializer for key-serializer. Supplied $valueEncoderOpt, allowed: org.apache.kafka.common.serialization.ByteArraySerializer")
+    }
   }
 
   class LineMessageReader extends MessageReader {

--- a/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleProducerTest.scala
@@ -40,6 +40,8 @@ class ConsoleProducerTest {
     "t3"
   )
 
+  val invalidParseArgs: Array[String] = validArgs :+ "--key-serializer" :+ "org.apache.kafka.common.serialization.StringSerializer"
+
   @Test
   def testValidConfigsNewProducer() {
     val config = new ConsoleProducer.ProducerConfig(validArgs)
@@ -63,6 +65,16 @@ class ConsoleProducerTest {
       Assert.fail("Should have thrown an UnrecognizedOptionException")
     } catch {
       case _: joptsimple.OptionException => // expected exception
+    }
+  }
+
+  @Test
+  def testInvalidSerializer() {
+    try {
+      new ConsoleProducer.ProducerConfig(invalidParseArgs)
+      Assert.fail("Should have thrown a KafkaException")
+    } catch {
+      case _: kafka.common.KafkaException => // expected exception
     }
   }
 


### PR DESCRIPTION
Spinned off from [KAFKA-2526](https://issues.apache.org/jira/browse/KAFKA-2526), to throw an exception if the console producer is passed a key serializer or a value serializer.
To quote a comment on the JIRA:
> The longer term solution with a KIP is obviously a lot more involved, but you should feel free to work on it; it would be a useful improvement. Since there would be two separate steps, you'd probably want to either file a separate JIRA for the better error messages and leave this one to the KIP or just file that fix as a MINOR PR.

Hence opening as a MINOR PR
cc @ewencp 