### PR TITLE
MINOR: change log level in ThreadCache to trace

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -249,7 +249,7 @@ public class ThreadCache {
             numEvicted++;
         }
 
-        log.debug("{} Evicted {} entries from cache {}", logPrefix, numEvicted, namespace);
+        log.trace("{} Evicted {} entries from cache {}", logPrefix, numEvicted, namespace);
     }
 
     private synchronized NamedCache getCache(final String namespace) {


### PR DESCRIPTION
cache eviction logging at debug level is too high volume. This was already done on trunk but didn't make it into 0.11