### PR TITLE
KAFKA-5152: move state restoration out of rebalance and into poll loop

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -275,7 +275,7 @@ public class KafkaStreams {
                 threadState.remove(thread.getId());
             }
             if (newState == StreamThread.State.PARTITIONS_REVOKED ||
-                newState == StreamThread.State.ASSIGNING_PARTITIONS) {
+                newState == StreamThread.State.PARTITIONS_ASSIGNED) {
                 setState(State.REBALANCING);
             } else if (newState == StreamThread.State.RUNNING) {
                 for (final StreamThread.State state : threadState.values()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -203,9 +203,10 @@ public abstract class AbstractTask {
                                                       logPrefix, id));
             }
         } catch (IOException e) {
-            throw new StreamsException(String.format("%s fatal error while trying to lock the state directory for task %s",
+            throw new StreamsException(String.format("%s Fatal error while trying to lock the state directory for task %s %s",
                                                      logPrefix,
-                                                     id));
+                                                     id,
+                                                     e.getMessage()));
         }
         log.trace("{} Initializing state stores", logPrefix);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -52,6 +52,7 @@ public abstract class AbstractTask {
     final String logPrefix;
     final boolean eosEnabled;
     private final StateDirectory stateDirectory;
+    boolean taskInitialized;
 
     InternalProcessorContext processorContext;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -251,6 +251,8 @@ public abstract class AbstractTask {
      */
     public abstract boolean initialize();
 
+    abstract boolean process();
+
     boolean hasStateStores() {
         return !topology.stateStores().isEmpty();
     }
@@ -258,4 +260,8 @@ public abstract class AbstractTask {
     Collection<TopicPartition> changelogPartitions() {
         return stateMgr.changelogPartitions();
     }
+
+    abstract boolean maybePunctuate();
+
+    abstract boolean commitNeeded();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -23,7 +23,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
@@ -39,6 +41,7 @@ import java.util.Set;
 
 public abstract class AbstractTask {
     private static final Logger log = LoggerFactory.getLogger(AbstractTask.class);
+    private static final int STATE_DIR_LOCK_RETRIES = 5;
 
     final TaskId id;
     final String applicationId;
@@ -48,6 +51,7 @@ public abstract class AbstractTask {
     final Consumer consumer;
     final String logPrefix;
     final boolean eosEnabled;
+    private final StateDirectory stateDirectory;
 
     InternalProcessorContext processorContext;
 
@@ -69,6 +73,7 @@ public abstract class AbstractTask {
         this.topology = topology;
         this.consumer = consumer;
         this.eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        this.stateDirectory = stateDirectory;
 
         logPrefix = String.format("%s [%s]", isStandby ? "standby-task" : "task", id());
 
@@ -93,7 +98,7 @@ public abstract class AbstractTask {
     public abstract void suspend();
     public abstract void close(final boolean clean);
 
-    public final TaskId id() {
+    public TaskId id() {
         return id;
     }
 
@@ -101,7 +106,7 @@ public abstract class AbstractTask {
         return applicationId;
     }
 
-    public final Set<TopicPartition> partitions() {
+    public Set<TopicPartition> partitions() {
         return partitions;
     }
 
@@ -188,6 +193,20 @@ public abstract class AbstractTask {
     }
 
     void initializeStateStores() {
+        if (topology.stateStores().isEmpty()) {
+            return;
+        }
+
+        try {
+            if (!stateDirectory.lock(id, STATE_DIR_LOCK_RETRIES)) {
+                throw new LockException(String.format("%s Failed to lock the state directory for task %s",
+                                                      logPrefix, id));
+            }
+        } catch (IOException e) {
+            throw new StreamsException(String.format("%s fatal error while trying to lock the state directory for task %s",
+                                                     logPrefix,
+                                                     id));
+        }
         log.trace("{} Initializing state stores", logPrefix);
 
         // set initial offset limits
@@ -204,8 +223,38 @@ public abstract class AbstractTask {
      * @param writeCheckpoint boolean indicating if a checkpoint file should be written
      */
     void closeStateManager(final boolean writeCheckpoint) throws ProcessorStateException {
+        ProcessorStateException exception = null;
         log.trace("{} Closing state manager", logPrefix);
-        stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
+        try {
+            stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
+        } catch (final ProcessorStateException e) {
+            exception = e;
+        } finally {
+            try {
+                stateDirectory.unlock(id);
+            } catch (IOException e) {
+                if (exception == null) {
+                    exception = new ProcessorStateException(String.format("%s Failed to release state dir lock", logPrefix), e);
+                }
+                log.error("{} Failed to release state dir lock: ", logPrefix, e);
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
     }
 
+    /**
+     * initialize the topology/state stores
+     * @return true if the topology is ready to run, i.e, all stores have been restored.
+     */
+    public abstract boolean initialize();
+
+    boolean hasStateStores() {
+        return !topology.stateStores().isEmpty();
+    }
+
+    Collection<TopicPartition> changelogPartitions() {
+        return stateMgr.changelogPartitions();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -72,7 +72,7 @@ class AssignedTasks<T extends AbstractTask> {
 
     void initializeNewTasks() {
         if (!created.isEmpty()) {
-            log.trace("{} initializing {}s {}", logPrefix, taskTypeName, created.keySet());
+            log.trace("{} Initializing {}s {}", logPrefix, taskTypeName, created.keySet());
         }
         for (final Iterator<Map.Entry<TaskId, T>> it = created.entrySet().iterator(); it.hasNext(); ) {
             final Map.Entry<TaskId, T> entry = it.next();
@@ -122,9 +122,9 @@ class AssignedTasks<T extends AbstractTask> {
 
     RuntimeException suspend() {
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
-        log.trace("{} suspending running {} {}", logPrefix, taskTypeName, runningTaskIds());
+        log.trace("{} Suspending running {} {}", logPrefix, taskTypeName, runningTaskIds());
         firstException.compareAndSet(null, suspendTasks(running.values(), suspended));
-        log.trace("{} close restoring {} {}", logPrefix, taskTypeName, restoring.keySet());
+        log.trace("{} Close restoring {} {}", logPrefix, taskTypeName, restoring.keySet());
         firstException.compareAndSet(null, closeRestoringTasks());
         running.clear();
         restoring.clear();
@@ -139,7 +139,7 @@ class AssignedTasks<T extends AbstractTask> {
             try {
                 task.close(false);
             } catch (final RuntimeException e) {
-                log.error("{} failed to close restoring {}, {}", logPrefix, taskTypeName, task.id, e);
+                log.error("{} Failed to close restoring {}, {}", logPrefix, taskTypeName, task.id, e);
                 if (exception == null) {
                     exception = e;
                 }
@@ -194,7 +194,7 @@ class AssignedTasks<T extends AbstractTask> {
             final T task = suspended.get(taskId);
             if (task.partitions().equals(partitions)) {
                 suspended.remove(taskId);
-                log.trace("{} resuming suspended {} {}", logPrefix, taskTypeName, taskId);
+                log.trace("{} Resuming suspended {} {}", logPrefix, taskTypeName, taskId);
                 task.resume();
                 transitionToRunning(task);
                 return true;
@@ -311,9 +311,5 @@ class AssignedTasks<T extends AbstractTask> {
         }
 
         return firstException;
-    }
-
-    public Collection<TaskId> restoringTaskIds() {
-        return restoring.keySet();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+class AssignedTasks<T extends AbstractTask> {
+    private static final Logger log = LoggerFactory.getLogger(AssignedTasks.class);
+    private final String logPrefix;
+    private final String taskTypeName;
+    private Map<TaskId, T> created = new HashMap<>();
+    private Map<TaskId, T> suspended = new HashMap<>();
+    private Map<TaskId, T> restoring = new HashMap<>();
+    private Set<TopicPartition> restoredPartitions = new HashSet<>();
+    // IQ may access this map.
+    private Map<TaskId, T> running = new ConcurrentHashMap<>();
+    private Map<TopicPartition, T> runningByPartition = new HashMap<>();
+
+    AssignedTasks(final String logPrefix, final String taskTypeName) {
+        this.logPrefix = logPrefix;
+        this.taskTypeName = taskTypeName;
+    }
+
+    void addNewTask(final T task) {
+        created.put(task.id(), task);
+    }
+
+    Set<TopicPartition> uninitializedPartitions() {
+        if (created.isEmpty()) {
+            return Collections.emptySet();
+        }
+        final Set<TopicPartition> partitions = new HashSet<>();
+        for (final Map.Entry<TaskId, T> entry : created.entrySet()) {
+            if (entry.getValue().hasStateStores()) {
+                partitions.addAll(entry.getValue().partitions());
+            }
+        }
+        return partitions;
+    }
+
+    void initializeNewTasks() {
+        if (!created.isEmpty()) {
+            log.trace("{} initializing {}s {}", logPrefix, taskTypeName, created.keySet());
+        }
+        for (final Iterator<Map.Entry<TaskId, T>> it = created.entrySet().iterator(); it.hasNext(); ) {
+            final Map.Entry<TaskId, T> entry = it.next();
+            try {
+                if (!entry.getValue().initialize()) {
+                    restoring.put(entry.getKey(), entry.getValue());
+                } else {
+                    transitionToRunning(entry.getValue());
+                }
+                it.remove();
+            } catch (final LockException e) {
+                log.warn("{} Could not create {} {} due to {}; will retry", logPrefix, taskTypeName, entry.getKey(), e);
+            }
+        }
+    }
+
+    Set<TopicPartition> updateRestored(final Collection<TopicPartition> restored) {
+        if (restored.isEmpty()) {
+            return Collections.emptySet();
+        }
+        final Set<TopicPartition> resume = new HashSet<>();
+        restoredPartitions.addAll(restored);
+        for (final Iterator<Map.Entry<TaskId, T>> it = restoring.entrySet().iterator(); it.hasNext(); ) {
+            final Map.Entry<TaskId, T> entry = it.next();
+            T task = entry.getValue();
+            if (restoredPartitions.containsAll(task.changelogPartitions())) {
+                transitionToRunning(task);
+                resume.addAll(task.partitions());
+                it.remove();
+            }
+        }
+        if (allTasksRunning()) {
+            restoredPartitions.clear();
+        }
+        return resume;
+    }
+
+    boolean allTasksRunning() {
+        return created.isEmpty()
+                && suspended.isEmpty()
+                && restoring.isEmpty();
+    }
+
+    Collection<T> running() {
+        return running.values();
+    }
+
+    RuntimeException suspend() {
+        final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
+        log.trace("{} suspending running {} {}", logPrefix, taskTypeName, runningTaskIds());
+        firstException.compareAndSet(null, suspendTasks(running.values(), suspended));
+        log.trace("{} close restoring {} {}", logPrefix, taskTypeName, restoring.keySet());
+        firstException.compareAndSet(null, closeRestoringTasks());
+        running.clear();
+        restoring.clear();
+        created.clear();
+        runningByPartition.clear();
+        return firstException.get();
+    }
+
+    private RuntimeException closeRestoringTasks() {
+        RuntimeException exception = null;
+        for (final T task : restoring.values()) {
+            try {
+                task.close(false);
+            } catch (final RuntimeException e) {
+                log.error("{} failed to close restoring {}, {}", logPrefix, taskTypeName, task.id, e);
+                if (exception == null) {
+                    exception = e;
+                }
+            }
+        }
+        return exception;
+    }
+
+    private RuntimeException suspendTasks(final Collection<T> tasks, final Map<TaskId, T> suspendedTasks) {
+        RuntimeException exception = null;
+        for (Iterator<T> it = tasks.iterator(); it.hasNext(); ) {
+            final T task = it.next();
+            try {
+                task.suspend();
+                suspendedTasks.put(task.id(), task);
+            } catch (final CommitFailedException e) {
+                // commit failed during suspension. Just log it.
+                log.warn("{} Failed to commit {} {} state when suspending due to CommitFailedException", logPrefix, taskTypeName, task.id);
+            } catch (final ProducerFencedException e) {
+                closeZombieTask(task);
+                it.remove();
+            } catch (final RuntimeException e) {
+                log.error("{} Suspending {} {} failed due to the following error:", logPrefix, taskTypeName, task.id, e);
+                try {
+                    task.close(false);
+                } catch (final Exception f) {
+                    log.error("{} After suspending failed, closing the same {} {} failed again due to the following error:", logPrefix, taskTypeName, task.id, f);
+                }
+                if (exception == null) {
+                    exception = e;
+                }
+            }
+        }
+        return exception;
+    }
+
+    private void closeZombieTask(final T task) {
+        log.warn("{} Producer of {} {} fenced; closing zombie task", logPrefix, taskTypeName, task.id);
+        try {
+            task.close(false);
+        } catch (final Exception e) {
+            log.warn("{} Failed to close zombie {} due to {}, ignore and proceed", taskTypeName, logPrefix, e);
+        }
+    }
+
+    boolean hasRunningTasks() {
+        return !running.isEmpty();
+    }
+
+    boolean maybeResumeSuspendedTask(final TaskId taskId, final Set<TopicPartition> partitions) {
+        if (suspended.containsKey(taskId)) {
+            final T task = suspended.get(taskId);
+            if (task.partitions().equals(partitions)) {
+                suspended.remove(taskId);
+                log.trace("{} resuming suspended {} {}", logPrefix, taskTypeName, taskId);
+                task.resume();
+                transitionToRunning(task);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void transitionToRunning(final T task) {
+        running.put(task.id(), task);
+        for (TopicPartition topicPartition : task.partitions()) {
+            runningByPartition.put(topicPartition, task);
+        }
+        for (TopicPartition topicPartition : task.changelogPartitions()) {
+            runningByPartition.put(topicPartition, task);
+        }
+    }
+
+    T runningTaskFor(final TopicPartition partition) {
+        return runningByPartition.get(partition);
+    }
+
+    Set<TaskId> runningTaskIds() {
+        return running.keySet();
+    }
+
+    Map<TaskId, T> runningTaskMap() {
+        return Collections.unmodifiableMap(running);
+    }
+
+    public String toString(final String indent) {
+        final StringBuilder builder = new StringBuilder();
+        describe(builder, running.values(), indent, "Running:");
+        describe(builder, suspended.values(), indent, "Suspended:");
+        describe(builder, restoring.values(), indent, "Restoring:");
+        describe(builder, created.values(), indent, "New:");
+        return builder.toString();
+    }
+
+    private void describe(final StringBuilder builder,
+                          final Collection<T> tasks,
+                          final String indent,
+                          final String name) {
+        builder.append(indent).append(name);
+        for (final T t : tasks) {
+            builder.append(indent).append(t.toString(indent + "\t\t"));
+        }
+        builder.append("\n");
+    }
+
+    List<AbstractTask> allInitializedTasks() {
+        final List<AbstractTask> tasks = new ArrayList<>();
+        tasks.addAll(running.values());
+        tasks.addAll(suspended.values());
+        tasks.addAll(restoring.values());
+        return tasks;
+    }
+
+    Collection<T> suspended() {
+        return suspended.values();
+    }
+
+    Collection<T> restoring() {
+        return Collections.unmodifiableCollection(restoring.values());
+    }
+
+    Collection<TaskId> allAssignedTaskIds() {
+        final List<TaskId> taskIds = new ArrayList<>();
+        taskIds.addAll(running.keySet());
+        taskIds.addAll(suspended.keySet());
+        taskIds.addAll(restoring.keySet());
+        taskIds.addAll(created.keySet());
+        return taskIds;
+    }
+
+    void clear() {
+        runningByPartition.clear();
+        running.clear();
+        created.clear();
+        suspended.clear();
+        restoredPartitions.clear();
+    }
+
+    Set<TaskId> previousTasks() {
+        final Set<TaskId> previous = new HashSet<>();
+        previous.addAll(suspended.keySet());
+        return previous;
+    }
+
+    RuntimeException applyToRunningTasks(final StreamThread.TaskAction<T> action, final boolean throwException) {
+        RuntimeException firstException = null;
+
+        for (Iterator<T> it = running().iterator(); it.hasNext(); ) {
+            final T task = it.next();
+            try {
+                action.apply(task);
+            } catch (final ProducerFencedException e) {
+                closeZombieTask(task);
+                it.remove();
+            } catch (final RuntimeException t) {
+                log.error("{} Failed to {} {} {} due to the following error:",
+                                       logPrefix,
+                                       action.name(),
+                                       taskTypeName,
+                                       task.id(),
+                                       t);
+                if (throwException) {
+                    throw t;
+                }
+                if (firstException == null) {
+                    firstException = t;
+                }
+            }
+        }
+
+        return firstException;
+    }
+
+    public Collection<TaskId> restoringTaskIds() {
+        return restoring.keySet();
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -42,11 +43,14 @@ public interface ChangelogReader {
 
     /**
      * Restore all registered state stores by reading from their changelogs.
+     * @return all topic partitions that have been restored
      */
-    void restore();
+    Collection<TopicPartition> restore();
 
     /**
      * @return the restored offsets for all persistent stores.
      */
     Map<TopicPartition, Long> restoredOffsets();
+
+    void reset();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -49,7 +49,6 @@ public class ProcessorStateManager implements StateManager {
     private final TaskId taskId;
     private final String logPrefix;
     private final boolean isStandby;
-    private final StateDirectory stateDirectory;
     private final ChangelogReader changelogReader;
     private final Map<String, StateStore> stores;
     private final Map<String, StateStore> globalStores;
@@ -58,7 +57,7 @@ public class ProcessorStateManager implements StateManager {
     private final Map<TopicPartition, Long> checkpointedOffsets;
     private final Map<String, StateRestoreCallback> restoreCallbacks; // used for standby tasks, keyed by state topic name
     private final Map<String, String> storeToChangelogTopic;
-    private final boolean eosEnabled;
+    private final List<TopicPartition> changelogPartitions = new ArrayList<>();
 
     // TODO: this map does not work with customized grouper where multiple partitions
     // of the same topic can be assigned to the same topic.
@@ -76,9 +75,8 @@ public class ProcessorStateManager implements StateManager {
                                  final StateDirectory stateDirectory,
                                  final Map<String, String> storeToChangelogTopic,
                                  final ChangelogReader changelogReader,
-                                 final boolean eosEnabled) throws LockException, IOException {
+                                 final boolean eosEnabled) throws IOException {
         this.taskId = taskId;
-        this.stateDirectory = stateDirectory;
         this.changelogReader = changelogReader;
         logPrefix = String.format("task [%s]", taskId);
 
@@ -93,12 +91,7 @@ public class ProcessorStateManager implements StateManager {
         this.isStandby = isStandby;
         restoreCallbacks = isStandby ? new HashMap<String, StateRestoreCallback>() : null;
         this.storeToChangelogTopic = storeToChangelogTopic;
-        this.eosEnabled = eosEnabled;
 
-        if (!stateDirectory.lock(taskId, 5)) {
-            throw new LockException(String.format("%s Failed to lock the state directory for task %s",
-                logPrefix, taskId));
-        }
         // get a handle on the parent/base directory of the task directory
         // note that the parent directory could have been accidentally deleted here,
         // so catch that exception if that is the case
@@ -170,16 +163,19 @@ public class ProcessorStateManager implements StateManager {
 
                 restoreCallbacks.put(topic, stateRestoreCallback);
             }
+
         } else {
             log.trace("{} Restoring state store {} from changelog topic {}", logPrefix, store.name(), topic);
             final StateRestorer restorer = new StateRestorer(storePartition,
                                                              stateRestoreCallback,
                                                              checkpointedOffsets.get(storePartition),
                                                              offsetLimit(storePartition),
-                                                             store.persistent());
+                                                             store.persistent(),
+                                                             store.name());
+
             changelogReader.register(restorer);
         }
-
+        changelogPartitions.add(storePartition);
         stores.put(store.name(), store);
     }
 
@@ -273,38 +269,26 @@ public class ProcessorStateManager implements StateManager {
     @Override
     public void close(final Map<TopicPartition, Long> ackedOffsets) throws ProcessorStateException {
         RuntimeException firstException = null;
-        try {
-            // attempting to close the stores, just in case they
-            // are not closed by a ProcessorNode yet
-            if (!stores.isEmpty()) {
-                log.debug("{} Closing its state manager and all the registered state stores", logPrefix);
-                for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
-                    log.debug("{} Closing storage engine {}", logPrefix, entry.getKey());
-                    try {
-                        entry.getValue().close();
-                    } catch (final Exception e) {
-                        if (firstException == null) {
-                            firstException = new ProcessorStateException(String.format("%s Failed to close state store %s", logPrefix, entry.getKey()), e);
-                        }
-                        log.error("{} Failed to close state store {}: ", logPrefix, entry.getKey(), e);
+        // attempting to close the stores, just in case they
+        // are not closed by a ProcessorNode yet
+        if (!stores.isEmpty()) {
+            log.debug("{} Closing its state manager and all the registered state stores", logPrefix);
+            for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
+                log.debug("{} Closing storage engine {}", logPrefix, entry.getKey());
+                try {
+                    entry.getValue().close();
+                } catch (final Exception e) {
+                    if (firstException == null) {
+                        firstException = new ProcessorStateException(String.format("%s Failed to close state store %s", logPrefix, entry.getKey()), e);
                     }
+                    log.error("{} Failed to close state store {}: ", logPrefix, entry.getKey(), e);
                 }
-
-                if (ackedOffsets != null) {
-                    checkpoint(ackedOffsets);
-                }
-
             }
-        } finally {
-            // release the state directory directoryLock
-            try {
-                stateDirectory.unlock(taskId);
-            } catch (final IOException e) {
-                if (firstException == null) {
-                    firstException = new ProcessorStateException(String.format("%s Failed to release state dir lock", logPrefix), e);
-                }
-                log.error("{} Failed to release state dir lock: ", logPrefix, e);
+
+            if (ackedOffsets != null) {
+                checkpoint(ackedOffsets);
             }
+
         }
 
         if (firstException != null) {
@@ -358,5 +342,9 @@ public class ProcessorStateManager implements StateManager {
     @Override
     public StateStore getGlobalStore(final String name) {
         return globalStores.get(name);
+    }
+
+    Collection<TopicPartition> changelogPartitions() {
+        return changelogPartitions;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -170,8 +170,8 @@ public class ProcessorStateManager implements StateManager {
                                                              stateRestoreCallback,
                                                              checkpointedOffsets.get(storePartition),
                                                              offsetLimit(storePartition),
-                                                             store.persistent(),
-                                                             store.name());
+                                                             store.persistent()
+            );
 
             changelogReader.register(restorer);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -152,4 +152,19 @@ public class StandbyTask extends AbstractTask {
         return true;
     }
 
+    @Override
+    boolean process() {
+        throw new UnsupportedOperationException("process not supported by standby task");
+    }
+
+    @Override
+    boolean maybePunctuate() {
+        throw new UnsupportedOperationException("maybePunctuate not supported by standby task");
+    }
+
+    @Override
+    boolean commitNeeded() {
+        throw new UnsupportedOperationException("commitNeeded not supported by standby task");
+    }
+
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ import java.util.Map;
 public class StandbyTask extends AbstractTask {
 
     private static final Logger log = LoggerFactory.getLogger(StandbyTask.class);
-    private final Map<TopicPartition, Long> checkpointedOffsets;
+    private Map<TopicPartition, Long> checkpointedOffsets = new HashMap<>();
 
     /**
      * Create {@link StandbyTask} with its assigned partitions
@@ -63,11 +64,6 @@ public class StandbyTask extends AbstractTask {
 
         // initialize the topology with its own context
         processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
-
-        log.debug("{} Initializing", logPrefix);
-        initializeStateStores();
-        processorContext.initialized();
-        checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
     /**
@@ -77,7 +73,7 @@ public class StandbyTask extends AbstractTask {
      */
     @Override
     public void resume() {
-        log.debug("{} " + "Resuming", logPrefix);
+        log.debug("{} Resuming", logPrefix);
         updateOffsetLimits();
     }
 
@@ -146,6 +142,13 @@ public class StandbyTask extends AbstractTask {
 
     Map<TopicPartition, Long> checkpointedOffsets() {
         return checkpointedOffsets;
+    }
+
+    public boolean initialize() {
+        initializeStateStores();
+        checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
+        processorContext.initialized();
+        return true;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -119,6 +119,9 @@ public class StandbyTask extends AbstractTask {
      */
     @Override
     public void close(final boolean clean) {
+        if (!taskInitialized) {
+            return;
+        }
         log.debug("{} Closing", logPrefix);
         boolean committedSuccessfully = false;
         try {
@@ -149,6 +152,7 @@ public class StandbyTask extends AbstractTask {
         initializeStateStores();
         checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
         processorContext.initialized();
+        taskInitialized = true;
         return true;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -145,6 +145,7 @@ public class StandbyTask extends AbstractTask {
     }
 
     public boolean initialize() {
+        log.debug("{} Initializing", logPrefix);
         initializeStateStores();
         checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
         processorContext.initialized();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -27,6 +27,7 @@ public class StateRestorer {
     private final boolean persistent;
     private final TopicPartition partition;
     private final StateRestoreCallback stateRestoreCallback;
+    private final String storeName;
 
     private long restoredOffset;
     private long startingOffset;
@@ -35,12 +36,14 @@ public class StateRestorer {
                   final StateRestoreCallback stateRestoreCallback,
                   final Long checkpoint,
                   final long offsetLimit,
-                  final boolean persistent) {
+                  final boolean persistent,
+                  final String storeName) {
         this.partition = partition;
         this.stateRestoreCallback = stateRestoreCallback;
         this.checkpoint = checkpoint;
         this.offsetLimit = offsetLimit;
         this.persistent = persistent;
+        this.storeName = storeName;
     }
 
     public TopicPartition partition() {
@@ -89,5 +92,9 @@ public class StateRestorer {
 
     private Long readTo(final long endOffset) {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
+    }
+
+    String storeName() {
+        return storeName;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -27,7 +27,6 @@ public class StateRestorer {
     private final boolean persistent;
     private final TopicPartition partition;
     private final StateRestoreCallback stateRestoreCallback;
-    private final String storeName;
 
     private long restoredOffset;
     private long startingOffset;
@@ -36,14 +35,12 @@ public class StateRestorer {
                   final StateRestoreCallback stateRestoreCallback,
                   final Long checkpoint,
                   final long offsetLimit,
-                  final boolean persistent,
-                  final String storeName) {
+                  final boolean persistent) {
         this.partition = partition;
         this.stateRestoreCallback = stateRestoreCallback;
         this.checkpoint = checkpoint;
         this.offsetLimit = offsetLimit;
         this.persistent = persistent;
-        this.storeName = storeName;
     }
 
     public TopicPartition partition() {
@@ -92,9 +89,5 @@ public class StateRestorer {
 
     private Long readTo(final long endOffset) {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
-    }
-
-    String storeName() {
-        return storeName;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -28,10 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,6 +45,9 @@ public class StoreChangelogReader implements ChangelogReader {
     private final long partitionValidationTimeoutMs;
     private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
     private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
+    private final Map<TopicPartition, StateRestorer> needsRestoring = new HashMap<>();
+    private final Map<TopicPartition, Long> endOffsets = new HashMap<>();
+    private boolean initialized = false;
 
     public StoreChangelogReader(final String threadId, final Consumer<byte[], byte[]> consumer, final Time time, final long partitionValidationTimeoutMs) {
         this.time = time;
@@ -92,69 +95,87 @@ public class StoreChangelogReader implements ChangelogReader {
 
     @Override
     public void register(final StateRestorer restorer) {
-        if (restorer.offsetLimit() > 0) {
-            stateRestorers.put(restorer.partition(), restorer);
-        }
+        stateRestorers.put(restorer.partition(), restorer);
     }
 
-    public void restore() {
-        final long start = time.milliseconds();
-        final Map<TopicPartition, StateRestorer> needsRestoring = new HashMap<>();
-        try {
-            if (!consumer.subscription().isEmpty()) {
-                throw new IllegalStateException(String.format("Restore consumer should have not subscribed to any partitions (%s) beforehand", consumer.subscription()));
-            }
-            final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(stateRestorers.keySet());
 
-            // remove any partitions where we already have all of the data
-            for (final Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
-                TopicPartition topicPartition = entry.getKey();
-                Long offset = entry.getValue();
-                final StateRestorer restorer = stateRestorers.get(topicPartition);
-                if (restorer.checkpoint() >= offset) {
-                    restorer.setRestoredOffset(restorer.checkpoint());
-                } else {
-                    needsRestoring.put(topicPartition, restorer);
-                }
-            }
-
-            log.debug("{} Starting restoring state stores from changelog topics {}", logPrefix, needsRestoring.keySet());
-
-            consumer.assign(needsRestoring.keySet());
-            final List<StateRestorer> needsPositionUpdate = new ArrayList<>();
-            for (final StateRestorer restorer : needsRestoring.values()) {
-                if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
-                    consumer.seek(restorer.partition(), restorer.checkpoint());
-                    logRestoreOffsets(restorer.partition(),
-                                      restorer.checkpoint(),
-                                      endOffsets.get(restorer.partition()));
-                    restorer.setStartingOffset(consumer.position(restorer.partition()));
-                } else {
-                    consumer.seekToBeginning(Collections.singletonList(restorer.partition()));
-                    needsPositionUpdate.add(restorer);
-                }
-            }
-
-            for (final StateRestorer restorer : needsPositionUpdate) {
-                final long position = consumer.position(restorer.partition());
-                restorer.setStartingOffset(position);
-                logRestoreOffsets(restorer.partition(),
-                                  position,
-                                  endOffsets.get(restorer.partition()));
-            }
-
-            final Set<TopicPartition> partitions = new HashSet<>(needsRestoring.keySet());
-            while (!partitions.isEmpty()) {
-                final ConsumerRecords<byte[], byte[]> allRecords = consumer.poll(10);
-                final Iterator<TopicPartition> partitionIterator = partitions.iterator();
-                while (partitionIterator.hasNext()) {
-                    restorePartition(endOffsets, allRecords, partitionIterator);
-                }
-            }
-        } finally {
-            consumer.assign(Collections.<TopicPartition>emptyList());
-            log.info("{} Completed restore all active states from changelog topics {} in {}ms ", logPrefix, needsRestoring.keySet(), time.milliseconds() - start);
+    public Collection<TopicPartition> restore() {
+        final List<TopicPartition> completed = new ArrayList<>();
+        if (!initialized) {
+            completed.addAll(initialize());
         }
+
+        if (needsRestoring.isEmpty()) {
+            consumer.assign(Collections.<TopicPartition>emptyList());
+            return completed;
+        }
+
+        final Set<TopicPartition> partitions = new HashSet<>(needsRestoring.keySet());
+        final ConsumerRecords<byte[], byte[]> allRecords = consumer.poll(10);
+        for (final TopicPartition partition : partitions) {
+            if (restorePartition(allRecords, partition)) {
+                completed.add(partition);
+            }
+        }
+
+        if (needsRestoring.isEmpty()) {
+            consumer.assign(Collections.<TopicPartition>emptyList());
+        }
+        return completed;
+    }
+
+    private Collection<TopicPartition> initialize() {
+        needsRestoring.clear();
+        if (!consumer.subscription().isEmpty()) {
+            throw new IllegalStateException(String.format("Restore consumer should have not subscribed to any partitions (%s) beforehand", consumer.subscription()));
+        }
+        endOffsets.putAll(consumer.endOffsets(stateRestorers.keySet()));
+
+        // remove any partitions where we already have all of the data
+        for (final Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            Long offset = entry.getValue();
+            final StateRestorer restorer = stateRestorers.get(topicPartition);
+            if (restorer.checkpoint() >= offset) {
+                log.debug("{} not restoring partition {} as checkpoint is >= offset", topicPartition);
+                restorer.setRestoredOffset(restorer.checkpoint());
+            } else if (restorer.offsetLimit() == 0) {
+                log.debug("{} not restoring partition {} as offset limit is 0", topicPartition);
+                restorer.setRestoredOffset(0);
+            } else {
+                needsRestoring.put(topicPartition, restorer);
+            }
+        }
+
+        log.debug("{} Starting restoring state stores from changelog topics {}", logPrefix, needsRestoring.keySet());
+
+        consumer.assign(needsRestoring.keySet());
+        final List<StateRestorer> needsPositionUpdate = new ArrayList<>();
+        for (final StateRestorer restorer : needsRestoring.values()) {
+            if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
+                consumer.seek(restorer.partition(), restorer.checkpoint());
+                logRestoreOffsets(restorer.partition(),
+                                  restorer.checkpoint(),
+                                  endOffsets.get(restorer.partition()));
+                restorer.setStartingOffset(consumer.position(restorer.partition()));
+            } else {
+                consumer.seekToBeginning(Collections.singletonList(restorer.partition()));
+                needsPositionUpdate.add(restorer);
+            }
+        }
+
+        for (final StateRestorer restorer : needsPositionUpdate) {
+            final long position = consumer.position(restorer.partition());
+            restorer.setStartingOffset(position);
+            logRestoreOffsets(restorer.partition(),
+                              position,
+                              endOffsets.get(restorer.partition()));
+        }
+
+        final Set<TopicPartition> completed = new HashSet<>(stateRestorers.keySet());
+        completed.removeAll(needsRestoring.keySet());
+        initialized = true;
+        return completed;
     }
 
     private void logRestoreOffsets(final TopicPartition partition, final long startingOffset, final Long endOffset) {
@@ -177,13 +198,21 @@ public class StoreChangelogReader implements ChangelogReader {
         return restoredOffsets;
     }
 
-    private void restorePartition(final Map<TopicPartition, Long> endOffsets,
-                                  final ConsumerRecords<byte[], byte[]> allRecords,
-                                  final Iterator<TopicPartition> partitionIterator) {
-        final TopicPartition topicPartition = partitionIterator.next();
+    @Override
+    public void reset() {
+        partitionInfo.clear();
+        stateRestorers.clear();
+        needsRestoring.clear();
+        endOffsets.clear();
+        initialized = false;
+    }
+
+    private boolean restorePartition(final ConsumerRecords<byte[], byte[]> allRecords,
+                                    final TopicPartition topicPartition) {
         final StateRestorer restorer = stateRestorers.get(topicPartition);
         final Long endOffset = endOffsets.get(topicPartition);
         final long pos = processNext(allRecords.records(topicPartition), restorer, endOffset);
+        restorer.setRestoredOffset(pos);
         if (restorer.hasCompleted(pos, endOffset)) {
             if (pos > endOffset + 1) {
                 throw new IllegalStateException(
@@ -193,8 +222,6 @@ public class StoreChangelogReader implements ChangelogReader {
                                       pos));
             }
 
-            restorer.setRestoredOffset(pos);
-
             log.debug("{} Completed restoring state from changelog {} with {} records ranging from offset {} to {}",
                     logPrefix,
                     topicPartition,
@@ -202,11 +229,14 @@ public class StoreChangelogReader implements ChangelogReader {
                     restorer.startingOffset(),
                     restorer.restoredOffset());
 
-            partitionIterator.remove();
+            needsRestoring.remove(topicPartition);
+            return true;
         }
+        return false;
     }
 
-    private long processNext(final List<ConsumerRecord<byte[], byte[]>> records, final StateRestorer restorer, final Long endOffset) {
+    private long processNext(final List<ConsumerRecord<byte[], byte[]>> records,
+                             final StateRestorer restorer, final Long endOffset) {
         for (final ConsumerRecord<byte[], byte[]> record : records) {
             final long offset = record.offset();
             if (restorer.hasCompleted(offset, endOffset)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -134,10 +134,10 @@ public class StoreChangelogReader implements ChangelogReader {
             Long offset = entry.getValue();
             final StateRestorer restorer = stateRestorers.get(topicPartition);
             if (restorer.checkpoint() >= offset) {
-                log.debug("{} not restoring partition {} as checkpoint is >= offset", topicPartition);
+                log.debug("{} not restoring partition {} as checkpoint {} is >= offset {}", logPrefix, topicPartition, restorer.checkpoint(), offset);
                 restorer.setRestoredOffset(restorer.checkpoint());
             } else if (restorer.offsetLimit() == 0) {
-                log.debug("{} not restoring partition {} as offset limit is 0", topicPartition);
+                log.debug("{} not restoring partition {} as offset limit is 0", logPrefix, topicPartition);
                 restorer.setRestoredOffset(0);
             } else {
                 needsRestoring.put(topicPartition, restorer);
@@ -235,7 +235,8 @@ public class StoreChangelogReader implements ChangelogReader {
     }
 
     private long processNext(final List<ConsumerRecord<byte[], byte[]>> records,
-                             final StateRestorer restorer, final Long endOffset) {
+                             final StateRestorer restorer,
+                             final Long endOffset) {
         for (final ConsumerRecord<byte[], byte[]> record : records) {
             final long offset = record.offset();
             if (restorer.hasCompleted(offset, endOffset)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -331,6 +331,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
                 processorContext.setCurrentNode(null);
             }
         }
+        taskInitialized = true;
     }
 
     /**
@@ -373,14 +374,16 @@ public class StreamTask extends AbstractTask implements Punctuator {
         // close the processors
         // make sure close() is called for each node even when there is a RuntimeException
         RuntimeException exception = null;
-        for (final ProcessorNode node : topology.processors()) {
-            processorContext.setCurrentNode(node);
-            try {
-                node.close();
-            } catch (final RuntimeException e) {
-                exception = e;
-            } finally {
-                processorContext.setCurrentNode(null);
+        if (taskInitialized) {
+            for (final ProcessorNode node : topology.processors()) {
+                processorContext.setCurrentNode(node);
+                try {
+                    node.close();
+                } catch (final RuntimeException e) {
+                    exception = e;
+                } finally {
+                    processorContext.setCurrentNode(null);
+                }
             }
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -154,7 +154,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
      */
     @Override
     public void resume() {
-        log.debug("{} Resuming {}", logPrefix, id);
+        log.debug("{} Resuming", logPrefix);
         if (eosEnabled) {
             producer.beginTransaction();
             transactionInFlight = true;
@@ -320,7 +320,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
         }
     }
 
-    void initTopology() {
+    private void initTopology() {
         // initialize the task by initializing all its processor nodes in the topology
         log.trace("{} Initializing processor nodes of the topology", logPrefix);
         for (final ProcessorNode node : topology.processors()) {
@@ -550,6 +550,7 @@ public class StreamTask extends AbstractTask implements Punctuator {
     }
 
     public boolean initialize() {
+        log.debug("{} Initializing", logPrefix);
         initializeStateStores();
         initTopology();
         processorContext.initialized();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -125,7 +125,7 @@ public class StreamThread extends Thread {
      * the coordinator repeatedly fails in-between revoking partitions and assigning new partitions.
      */
     public enum State {
-        CREATED(1, 5, 6), RUNNING(2, 5, 6), PARTITIONS_REVOKED(2, 3, 5, 6), ASSIGNING_PARTITIONS(4, 5, 6), PARTITIONS_ASSIGNED(1, 2, 5, 6), PENDING_SHUTDOWN(6), DEAD;
+        CREATED(1, 5), RUNNING(2, 5), PARTITIONS_REVOKED(2, 3, 5), ASSIGNING_PARTITIONS(4, 5), PARTITIONS_ASSIGNED(1, 2, 5), PENDING_SHUTDOWN(6), DEAD;
 
         private final Set<Integer> validTransitions = new HashSet<>();
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -761,25 +761,8 @@ public class StreamThread extends Thread {
      * Commit the states of all its tasks
      */
     private void commitAll() {
-
-        final RuntimeException e = active.applyToRunningTasks(new TaskAction<StreamTask>() {
-            @Override
-            public String name() {
-                return "commit";
-            }
-
-            @Override
-            public void apply(final StreamTask task1) {
-                commitOne(task1);
-            }
-        }, false);
-        if (e != null) {
-            throw e;
-        }
-
-        for (final StandbyTask task : standby.running()) {
-            commitOne(task);
-        }
+        active.commit();
+        standby.commit();
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -319,7 +319,7 @@ public class KafkaStreamsTest {
         CLUSTER.createTopic(topic);
         final KStreamBuilder builder = new KStreamBuilder();
 
-        builder.stream(Serdes.String(), Serdes.String(), topic);
+        builder.table(Serdes.String(), Serdes.String(), topic, topic);
 
         final KafkaStreams streams = new KafkaStreams(builder, props);
         final CountDownLatch latch = new CountDownLatch(1);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -132,7 +132,7 @@ public class ResetIntegrationTest {
     public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
         CLUSTER.createTopic(INTERMEDIATE_USER_TOPIC);
 
-        final Properties streamsConfiguration = prepareTest();
+        final Properties streamsConfiguration = prepareTest(4);
         final Properties resultTopicConsumerConfig = TestUtils.consumerConfig(
             CLUSTER.bootstrapServers(),
             APP_ID + "-standard-consumer-" + OUTPUT_TOPIC,
@@ -198,7 +198,7 @@ public class ResetIntegrationTest {
 
     @Test
     public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
-        final Properties streamsConfiguration = prepareTest();
+        final Properties streamsConfiguration = prepareTest(1);
         final Properties resultTopicConsumerConfig = TestUtils.consumerConfig(
                 CLUSTER.bootstrapServers(),
                 APP_ID + "-standard-consumer-" + OUTPUT_TOPIC,
@@ -241,14 +241,14 @@ public class ResetIntegrationTest {
         cleanGlobal(null);
     }
 
-    private Properties prepareTest() throws Exception {
+    private Properties prepareTest(final int threads) throws Exception {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID + testNo);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4);
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, threads);
         streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
         streamsConfiguration.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -140,6 +140,20 @@ public class AbstractTaskTest {
                 return false;
             }
 
+            @Override
+            boolean process() {
+                return false;
+            }
+
+            @Override
+            boolean maybePunctuate() {
+                return false;
+            }
+
+            @Override
+            boolean commitNeeded() {
+                return false;
+            }
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -24,60 +24,104 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.test.TestUtils;
+import org.easymock.EasyMock;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
+import static org.junit.Assert.fail;
+
 public class AbstractTaskTest {
+
+    private final TaskId id = new TaskId(0, 0);
+    private StateDirectory stateDirectory  = EasyMock.createMock(StateDirectory.class);
+
+    @Before
+    public void before() {
+        EasyMock.expect(stateDirectory.directoryForTask(id)).andReturn(TestUtils.tempDirectory());
+    }
 
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenAuthorizationException() throws Exception {
         final Consumer consumer = mockConsumer(new AuthorizationException("blah"));
-        final AbstractTask task = createTask(consumer);
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
         task.updateOffsetLimits();
     }
 
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenKafkaException() throws Exception {
         final Consumer consumer = mockConsumer(new KafkaException("blah"));
-        final AbstractTask task = createTask(consumer);
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
         task.updateOffsetLimits();
     }
 
     @Test(expected = WakeupException.class)
     public void shouldThrowWakeupExceptionOnInitializeOffsetsWhenWakeupException() throws Exception {
         final Consumer consumer = mockConsumer(new WakeupException());
-        final AbstractTask task = createTask(consumer);
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
         task.updateOffsetLimits();
     }
 
-    private AbstractTask createTask(final Consumer consumer) {
-        final MockTime time = new MockTime();
+    @Test
+    public void shouldThrowLockExceptionIfFailedToLockStateDirectoryWhenTopologyHasStores() throws IOException {
+        final Consumer consumer = EasyMock.createNiceMock(Consumer.class);
+        final StateStore store = EasyMock.createNiceMock(StateStore.class);
+        EasyMock.expect(stateDirectory.lock(id, 5)).andReturn(false);
+        EasyMock.replay(stateDirectory);
+
+        final AbstractTask task = createTask(consumer, Collections.singletonList(store));
+
+        try {
+            task.initializeStateStores();
+            fail("Should have thrown LockException");
+        } catch (final LockException e) {
+            // ok
+        }
+
+    }
+
+    @Test
+    public void shouldNotAttemptToLockIfNoStores() throws IOException {
+        final Consumer consumer = EasyMock.createNiceMock(Consumer.class);
+        EasyMock.replay(stateDirectory);
+
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
+
+        task.initializeStateStores();
+
+        // should fail if lock is called
+        EasyMock.verify(stateDirectory);
+    }
+
+    private AbstractTask createTask(final Consumer consumer, final List<StateStore> stateStores) {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-id");
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummyhost:9092");
         final StreamsConfig config = new StreamsConfig(properties);
-        return new AbstractTask(new TaskId(0, 0),
+        return new AbstractTask(id,
                                 "app",
                                 Collections.singletonList(new TopicPartition("t", 0)),
                                 new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
                                                       Collections.<String, SourceNode>emptyMap(),
                                                       Collections.<String, SinkNode>emptyMap(),
-                                                      Collections.<StateStore>emptyList(),
+                                                      stateStores,
                                                       Collections.<String, String>emptyMap(),
                                                       Collections.<StateStore>emptyList()),
                                 consumer,
                                 new StoreChangelogReader(consumer, Time.SYSTEM, 5000),
                                 false,
-                                new StateDirectory("app", TestUtils.tempDirectory().getPath(), time),
+                                stateDirectory,
                                 config) {
             @Override
             public void resume() {}
@@ -90,6 +134,12 @@ public class AbstractTaskTest {
 
             @Override
             public void close(final boolean clean) {}
+
+            @Override
+            public boolean initialize() {
+                return false;
+            }
+
         };
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
@@ -117,7 +117,7 @@ public class AssignedTasksTest {
 
         assignedTasks.initializeNewTasks();
 
-        Collection<AbstractTask> restoring = assignedTasks.restoring();
+        Collection<AbstractTask> restoring = assignedTasks.restoringTasks();
         assertThat(restoring.size(), equalTo(1));
         assertSame(restoring.iterator().next(), t1);
     }
@@ -161,7 +161,7 @@ public class AssignedTasksTest {
 
         suspendTask();
 
-        assertThat(assignedTasks.previousTasks(), equalTo(Collections.singleton(taskId1)));
+        assertThat(assignedTasks.previousTaskIds(), equalTo(Collections.singleton(taskId1)));
         EasyMock.verify(t1);
     }
 
@@ -195,7 +195,6 @@ public class AssignedTasksTest {
         EasyMock.replay(t1);
 
         assertThat(suspendTask(), not(nullValue()));
-        assertTrue(assignedTasks.previousTasks().isEmpty());
         EasyMock.verify(t1);
     }
 
@@ -209,7 +208,7 @@ public class AssignedTasksTest {
         EasyMock.replay(t1);
 
         assertThat(suspendTask(), nullValue());
-        assertTrue(assignedTasks.previousTasks().isEmpty());
+        assertTrue(assignedTasks.previousTaskIds().isEmpty());
         EasyMock.verify(t1);
     }
 
@@ -230,7 +229,6 @@ public class AssignedTasksTest {
 
         assertTrue(assignedTasks.maybeResumeSuspendedTask(taskId1, Collections.singleton(tp1)));
         assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
-        assertTrue(assignedTasks.previousTasks().isEmpty());
         EasyMock.verify(t1);
     }
 
@@ -260,7 +258,7 @@ public class AssignedTasksTest {
         assignedTasks.initializeNewTasks();
 
         assignedTasks.commit();
-        assertTrue(assignedTasks.running().isEmpty());
+        assertTrue(assignedTasks.runningTasks().isEmpty());
         EasyMock.verify(t1);
     }
 
@@ -322,7 +320,7 @@ public class AssignedTasksTest {
         assignedTasks.initializeNewTasks();
 
         assignedTasks.process();
-        assertTrue(assignedTasks.running().isEmpty());
+        assertTrue(assignedTasks.runningTasks().isEmpty());
         EasyMock.verify(t1);
     }
 
@@ -404,7 +402,7 @@ public class AssignedTasksTest {
         assignedTasks.initializeNewTasks();
 
         assignedTasks.punctuateAndCommit(commitSensor, punctuateSensor);
-        assertTrue(assignedTasks.running().isEmpty());
+        assertTrue(assignedTasks.runningTasks().isEmpty());
         EasyMock.verify(t1);
 
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
@@ -166,7 +166,9 @@ public class AssignedTasksTest {
     }
 
     @Test
-    public void shouldNotSuspendUnInitializedTasks() {
+    public void shouldCloseUnInitializedTasksOnSuspend() {
+        t1.close(false);
+        EasyMock.expectLastCall();
         EasyMock.replay(t1);
 
         assignedTasks.addNewTask(t1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.processor.TaskId;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class AssignedTasksTest {
+
+    private final AssignedTasks<AbstractTask> assignedTasks = new AssignedTasks<>("log", "task");
+    private final AbstractTask t1 = EasyMock.createMock(AbstractTask.class);
+    private final AbstractTask t2 = EasyMock.createMock(AbstractTask.class);
+    private final TopicPartition tp1 = new TopicPartition("t1", 0);
+    private final TopicPartition tp2 = new TopicPartition("t2", 0);
+    private final TopicPartition changeLog1 = new TopicPartition("cl1", 0);
+    private final TopicPartition changeLog2 = new TopicPartition("cl2", 0);
+    private final TaskId taskId1 = new TaskId(0, 0);
+    private final TaskId taskId2 = new TaskId(1, 0);
+
+    @Before
+    public void before() {
+        EasyMock.expect(t1.id()).andReturn(taskId1).anyTimes();
+        EasyMock.expect(t2.id()).andReturn(taskId2).anyTimes();
+    }
+
+    @Test
+    public void shouldGetPartitionsFromNewTasksThatHaveStateStores() {
+        EasyMock.expect(t1.hasStateStores()).andReturn(true);
+        EasyMock.expect(t2.hasStateStores()).andReturn(true);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
+        EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
+        EasyMock.replay(t1, t2);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.addNewTask(t2);
+
+        final Set<TopicPartition> partitions = assignedTasks.uninitializedPartitions();
+        assertThat(partitions, equalTo(Utils.mkSet(tp1, tp2)));
+        EasyMock.verify(t1, t2);
+    }
+
+    @Test
+    public void shouldNotGetPartitionsFromNewTasksWithoutStateStores() {
+        EasyMock.expect(t1.hasStateStores()).andReturn(false);
+        EasyMock.expect(t2.hasStateStores()).andReturn(false);
+        EasyMock.replay(t1, t2);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.addNewTask(t2);
+
+        final Set<TopicPartition> partitions = assignedTasks.uninitializedPartitions();
+        assertTrue(partitions.isEmpty());
+        EasyMock.verify(t1, t2);
+    }
+
+    @Test
+    public void shouldInitializeNewTasks() {
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        EasyMock.replay(t1);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldMoveInitializedTasksNeedingRestoreToRestoring() {
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        EasyMock.expect(t2.initialize()).andReturn(true);
+        EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
+        EasyMock.expect(t2.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
+
+        EasyMock.replay(t1, t2);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.addNewTask(t2);
+
+        assignedTasks.initializeNewTasks();
+
+        Collection<AbstractTask> restoring = assignedTasks.restoring();
+        assertThat(restoring.size(), equalTo(1));
+        assertSame(restoring.iterator().next(), t1);
+    }
+
+    @Test
+    public void shouldMoveInitializedTasksThatDontNeedRestoringToRunning() {
+        EasyMock.expect(t2.initialize()).andReturn(true);
+        EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
+        EasyMock.expect(t2.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
+
+        EasyMock.replay(t2);
+
+        assignedTasks.addNewTask(t2);
+        assignedTasks.initializeNewTasks();
+
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId2)));
+    }
+
+    @Test
+    public void shouldTransitionFullyRestoredTasksToRunning() {
+        final Set<TopicPartition> task1Partitions = Utils.mkSet(tp1);
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        EasyMock.expect(t1.partitions()).andReturn(task1Partitions).anyTimes();
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Utils.mkSet(changeLog1, changeLog2)).anyTimes();
+        EasyMock.replay(t1);
+
+        assignedTasks.addNewTask(t1);
+
+        assignedTasks.initializeNewTasks();
+
+        assertTrue(assignedTasks.updateRestored(Utils.mkSet(changeLog1)).isEmpty());
+        Set<TopicPartition> partitions = assignedTasks.updateRestored(Utils.mkSet(changeLog2));
+        assertThat(partitions, equalTo(task1Partitions));
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
+    }
+
+    @Test
+    public void shouldSuspendRunningTasks() {
+        mockRunningTaskSuspension();
+        EasyMock.replay(t1);
+
+        suspendTask();
+
+        assertThat(assignedTasks.previousTasks(), equalTo(Collections.singleton(taskId1)));
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldNotSuspendUnInitializedTasks() {
+        EasyMock.replay(t1);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.suspend();
+
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldNotSuspendSuspendedTasks() {
+        mockRunningTaskSuspension();
+        EasyMock.replay(t1);
+
+        suspendTask();
+        assignedTasks.suspend();
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldCloseTaskOnSuspendWhenRuntimeException() {
+        mockInitializedTask();
+        t1.suspend();
+        EasyMock.expectLastCall().andThrow(new RuntimeException("KABOOM!"));
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        assertThat(suspendTask(), not(nullValue()));
+        assertTrue(assignedTasks.previousTasks().isEmpty());
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldCloseTaskOnSuspendWhenProducerFencedException() {
+        mockInitializedTask();
+        t1.suspend();
+        EasyMock.expectLastCall().andThrow(new ProducerFencedException("KABOOM!"));
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        assertThat(suspendTask(), nullValue());
+        assertTrue(assignedTasks.previousTasks().isEmpty());
+        EasyMock.verify(t1);
+    }
+
+    private void mockInitializedTask() {
+        EasyMock.expect(t1.initialize()).andReturn(true);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
+    }
+
+    @Test
+    public void shouldResumeMatchingSuspendedTasks() {
+        mockRunningTaskSuspension();
+        t1.resume();
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        suspendTask();
+
+        assertTrue(assignedTasks.maybeResumeSuspendedTask(taskId1, Collections.singleton(tp1)));
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
+        assertTrue(assignedTasks.previousTasks().isEmpty());
+        EasyMock.verify(t1);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldApplyActionToRunningTasks() {
+        StreamThread.TaskAction taskAction = EasyMock.createMock(StreamThread.TaskAction.class);
+        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
+        EasyMock.expectLastCall();
+        mockInitializedTask();
+
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assignedTasks.applyToRunningTasks(taskAction, false);
+
+        EasyMock.verify(taskAction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotApplyActionToNotRunningTasks() {
+        final StreamThread.TaskAction taskAction = EasyMock.createMock(StreamThread.TaskAction.class);
+        EasyMock.expect(t1.initialize()).andReturn(false);
+
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assignedTasks.applyToRunningTasks(taskAction, false);
+
+        EasyMock.verify(taskAction);
+    }
+
+    @SuppressWarnings({"unchecked", "ThrowableNotThrown"})
+    @Test
+    public void shouldCloseTaskOnApplyToRunningIfProducerFencedException() {
+        final StreamThread.TaskAction taskAction = EasyMock.createMock(StreamThread.TaskAction.class);
+        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
+        EasyMock.expectLastCall().andThrow(new ProducerFencedException("BOOM!"));
+        mockInitializedTask();
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assignedTasks.applyToRunningTasks(taskAction, false);
+        assertTrue(assignedTasks.running().isEmpty());
+        EasyMock.verify(t1, taskAction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnExceptionAndNotCloseTaskOnApplyToRunningWhenRuntimeException() {
+        final StreamThread.TaskAction taskAction = EasyMock.createMock(StreamThread.TaskAction.class);
+        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
+        EasyMock.expectLastCall().andThrow(new RuntimeException("KABOOM!"));
+        EasyMock.expect(taskAction.name()).andReturn("name");
+        mockInitializedTask();
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assertThat(assignedTasks.applyToRunningTasks(taskAction, false), not(nullValue()));
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
+        EasyMock.verify(t1, taskAction);
+    }
+
+    private RuntimeException suspendTask() {
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+        return assignedTasks.suspend();
+    }
+
+    private void mockRunningTaskSuspension() {
+        EasyMock.expect(t1.initialize()).andReturn(true);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1)).anyTimes();
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList()).anyTimes();
+        t1.suspend();
+        EasyMock.expectLastCall();
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
@@ -34,9 +33,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.file.StandardOpenOption;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -389,33 +386,6 @@ public class ProcessorStateManagerTest {
         assertThat(read, equalTo(Collections.<TopicPartition, Long>emptyMap()));
     }
 
-    @Test
-    public void shouldThrowLockExceptionIfFailedToLockStateDirectory() throws Exception {
-        final File taskDirectory = stateDirectory.directoryForTask(taskId);
-        final FileChannel channel = FileChannel.open(new File(taskDirectory,
-                                                              StateDirectory.LOCK_FILE_NAME).toPath(),
-                                                     StandardOpenOption.CREATE,
-                                                     StandardOpenOption.WRITE);
-        // lock the task directory
-        final FileLock lock = channel.lock();
-
-        try {
-            new ProcessorStateManager(
-                taskId,
-                noPartitions,
-                false,
-                stateDirectory,
-                Collections.<String, String>emptyMap(),
-                changelogReader,
-                false);
-            fail("Should have thrown LockException");
-        } catch (final LockException e) {
-           // pass
-        } finally {
-            lock.release();
-            channel.close();
-        }
-    }
 
     @Test
     public void shouldThrowIllegalArgumentExceptionIfStoreNameIsSameAsCheckpointFileName() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -158,7 +158,7 @@ public class StandbyTaskTest {
     public void testStorePartitions() throws Exception {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
-
+        task.initialize();
         assertEquals(Utils.mkSet(partition2), new HashSet<>(task.checkpointedOffsets().keySet()));
 
     }
@@ -182,7 +182,7 @@ public class StandbyTaskTest {
     public void testUpdate() throws Exception {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
-
+        task.initialize();
         restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
@@ -240,7 +240,7 @@ public class StandbyTaskTest {
 
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, ktablePartitions, ktableTopology, consumer, changelogReader, config, null, stateDirectory);
-
+        task.initialize();
         restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
@@ -360,6 +360,7 @@ public class StandbyTaskTest {
                                                  null,
                                                  stateDirectory
         );
+        task.initialize();
 
 
         restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
@@ -28,7 +28,7 @@ public class StateRestorerTest {
 
     private static final long OFFSET_LIMIT = 50;
     private final MockRestoreCallback callback = new MockRestoreCallback();
-    private final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, OFFSET_LIMIT, true);
+    private final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, OFFSET_LIMIT, true, "store");
 
     @Test
     public void shouldCallRestoreOnRestoreCallback() throws Exception {
@@ -53,7 +53,7 @@ public class StateRestorerTest {
 
     @Test
     public void shouldBeCompletedIfOffsetAndOffsetLimitAreZero() throws Exception {
-        final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, 0, true);
+        final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, 0, true, "store");
         assertTrue(restorer.hasCompleted(0, 10));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateRestorerTest.java
@@ -28,7 +28,7 @@ public class StateRestorerTest {
 
     private static final long OFFSET_LIMIT = 50;
     private final MockRestoreCallback callback = new MockRestoreCallback();
-    private final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, OFFSET_LIMIT, true, "store");
+    private final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, OFFSET_LIMIT, true);
 
     @Test
     public void shouldCallRestoreOnRestoreCallback() throws Exception {
@@ -53,7 +53,7 @@ public class StateRestorerTest {
 
     @Test
     public void shouldBeCompletedIfOffsetAndOffsetLimitAreZero() throws Exception {
-        final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, 0, true, "store");
+        final StateRestorer restorer = new StateRestorer(new TopicPartition("topic", 1), callback, null, 0, true);
         assertTrue(restorer.hasCompleted(0, 10));
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -139,7 +139,7 @@ public class StoreChangelogReaderTest {
     public void shouldRestoreAllMessagesFromBeginningWhenCheckpointNull() throws Exception {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(messages));
@@ -149,7 +149,7 @@ public class StoreChangelogReaderTest {
     public void shouldRestoreMessagesFromCheckpoint() throws Exception {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, 5L, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(topicPartition, callback, 5L, Long.MAX_VALUE, true, "store"));
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(5));
@@ -159,7 +159,7 @@ public class StoreChangelogReaderTest {
     public void shouldClearAssignmentAtEndOfRestore() throws Exception {
         final int messages = 1;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
 
         changelogReader.restore();
         assertThat(consumer.assignment(), equalTo(Collections.<TopicPartition>emptySet()));
@@ -168,7 +168,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRestoreToLimitWhenSupplied() throws Exception {
         setupConsumer(10, topicPartition);
-        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, 3, true);
+        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, 3, true, "store");
         changelogReader.register(restorer);
 
         changelogReader.restore();
@@ -186,9 +186,9 @@ public class StoreChangelogReaderTest {
         setupConsumer(5, one);
         setupConsumer(3, two);
 
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
-        changelogReader.register(new StateRestorer(one, callbackOne, null, Long.MAX_VALUE, true));
-        changelogReader.register(new StateRestorer(two, callbackTwo, null, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
+        changelogReader.register(new StateRestorer(one, callbackOne, null, Long.MAX_VALUE, true, "store_1"));
+        changelogReader.register(new StateRestorer(two, callbackTwo, null, Long.MAX_VALUE, true, "store_2"));
 
         changelogReader.restore();
 
@@ -199,7 +199,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldNotRestoreAnythingWhenPartitionIsEmpty() throws Exception {
-        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true);
+        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store");
         setupConsumer(0, topicPartition);
         changelogReader.register(restorer);
 
@@ -212,7 +212,7 @@ public class StoreChangelogReaderTest {
     public void shouldNotRestoreAnythingWhenCheckpointAtEndOffset() throws Exception {
         final Long endOffset = 10L;
         setupConsumer(endOffset, topicPartition);
-        final StateRestorer restorer = new StateRestorer(topicPartition, callback, endOffset, Long.MAX_VALUE, true);
+        final StateRestorer restorer = new StateRestorer(topicPartition, callback, endOffset, Long.MAX_VALUE, true, "store");
 
         changelogReader.register(restorer);
 
@@ -224,7 +224,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldReturnRestoredOffsetsForPersistentStores() throws Exception {
         setupConsumer(10, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
         changelogReader.restore();
         final Map<TopicPartition, Long> restoredOffsets = changelogReader.restoredOffsets();
         assertThat(restoredOffsets, equalTo(Collections.singletonMap(topicPartition, 10L)));
@@ -233,7 +233,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotReturnRestoredOffsetsForNonPersistentStore() throws Exception {
         setupConsumer(10, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false, "store"));
         changelogReader.restore();
         final Map<TopicPartition, Long> restoredOffsets = changelogReader.restoredOffsets();
         assertThat(restoredOffsets, equalTo(Collections.<TopicPartition, Long>emptyMap()));
@@ -247,7 +247,7 @@ public class StoreChangelogReaderTest {
         consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), 1, (byte[]) null, bytes));
         consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), 2, bytes, bytes));
         consumer.assign(Collections.singletonList(topicPartition));
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false, "store"));
         changelogReader.restore();
 
         assertThat(callback.restored, CoreMatchers.equalTo(Utils.mkList(KeyValue.pair(bytes, bytes), KeyValue.pair(bytes, bytes))));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -31,12 +31,14 @@ import org.apache.kafka.test.MockRestoreCallback;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class StoreChangelogReaderTest {
@@ -251,6 +253,25 @@ public class StoreChangelogReaderTest {
         changelogReader.restore();
 
         assertThat(callback.restored, CoreMatchers.equalTo(Utils.mkList(KeyValue.pair(bytes, bytes), KeyValue.pair(bytes, bytes))));
+    }
+
+    @Test
+    public void shouldReturnCompletedPartitionsOnEachRestoreCall() {
+        assignPartition(10, topicPartition);
+        final byte[] bytes = new byte[0];
+        for (int i = 0; i < 5; i++) {
+            consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), i, bytes, bytes));
+        }
+        consumer.assign(Collections.singletonList(topicPartition));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false, "store"));
+
+        final Collection<TopicPartition> completedFirstTime = changelogReader.restore();
+        assertTrue(completedFirstTime.isEmpty());
+        for (int i = 5; i < 10; i++) {
+            consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), i, bytes, bytes));
+        }
+        final Collection<TopicPartition> expected = Collections.singleton(topicPartition);
+        assertThat(changelogReader.restore(), equalTo(expected));
     }
 
     private void setupConsumer(final long messages, final TopicPartition topicPartition) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -141,7 +141,7 @@ public class StoreChangelogReaderTest {
     public void shouldRestoreAllMessagesFromBeginningWhenCheckpointNull() throws Exception {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(messages));
@@ -151,7 +151,7 @@ public class StoreChangelogReaderTest {
     public void shouldRestoreMessagesFromCheckpoint() throws Exception {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, 5L, Long.MAX_VALUE, true, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, 5L, Long.MAX_VALUE, true));
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(5));
@@ -161,7 +161,7 @@ public class StoreChangelogReaderTest {
     public void shouldClearAssignmentAtEndOfRestore() throws Exception {
         final int messages = 1;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
 
         changelogReader.restore();
         assertThat(consumer.assignment(), equalTo(Collections.<TopicPartition>emptySet()));
@@ -170,7 +170,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRestoreToLimitWhenSupplied() throws Exception {
         setupConsumer(10, topicPartition);
-        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, 3, true, "store");
+        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, 3, true);
         changelogReader.register(restorer);
 
         changelogReader.restore();
@@ -188,9 +188,9 @@ public class StoreChangelogReaderTest {
         setupConsumer(5, one);
         setupConsumer(3, two);
 
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
-        changelogReader.register(new StateRestorer(one, callbackOne, null, Long.MAX_VALUE, true, "store_1"));
-        changelogReader.register(new StateRestorer(two, callbackTwo, null, Long.MAX_VALUE, true, "store_2"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(one, callbackOne, null, Long.MAX_VALUE, true));
+        changelogReader.register(new StateRestorer(two, callbackTwo, null, Long.MAX_VALUE, true));
 
         changelogReader.restore();
 
@@ -201,7 +201,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldNotRestoreAnythingWhenPartitionIsEmpty() throws Exception {
-        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store");
+        final StateRestorer restorer = new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true);
         setupConsumer(0, topicPartition);
         changelogReader.register(restorer);
 
@@ -214,7 +214,7 @@ public class StoreChangelogReaderTest {
     public void shouldNotRestoreAnythingWhenCheckpointAtEndOffset() throws Exception {
         final Long endOffset = 10L;
         setupConsumer(endOffset, topicPartition);
-        final StateRestorer restorer = new StateRestorer(topicPartition, callback, endOffset, Long.MAX_VALUE, true, "store");
+        final StateRestorer restorer = new StateRestorer(topicPartition, callback, endOffset, Long.MAX_VALUE, true);
 
         changelogReader.register(restorer);
 
@@ -226,7 +226,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldReturnRestoredOffsetsForPersistentStores() throws Exception {
         setupConsumer(10, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, true));
         changelogReader.restore();
         final Map<TopicPartition, Long> restoredOffsets = changelogReader.restoredOffsets();
         assertThat(restoredOffsets, equalTo(Collections.singletonMap(topicPartition, 10L)));
@@ -235,7 +235,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotReturnRestoredOffsetsForNonPersistentStore() throws Exception {
         setupConsumer(10, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false));
         changelogReader.restore();
         final Map<TopicPartition, Long> restoredOffsets = changelogReader.restoredOffsets();
         assertThat(restoredOffsets, equalTo(Collections.<TopicPartition, Long>emptyMap()));
@@ -249,7 +249,7 @@ public class StoreChangelogReaderTest {
         consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), 1, (byte[]) null, bytes));
         consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), 2, bytes, bytes));
         consumer.assign(Collections.singletonList(topicPartition));
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false));
         changelogReader.restore();
 
         assertThat(callback.restored, CoreMatchers.equalTo(Utils.mkList(KeyValue.pair(bytes, bytes), KeyValue.pair(bytes, bytes))));
@@ -263,7 +263,7 @@ public class StoreChangelogReaderTest {
             consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), i, bytes, bytes));
         }
         consumer.assign(Collections.singletonList(topicPartition));
-        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false, "store"));
+        changelogReader.register(new StateRestorer(topicPartition, callback, null, Long.MAX_VALUE, false));
 
         final Collection<TopicPartition> completedFirstTime = changelogReader.restore();
         assertTrue(completedFirstTime.isEmpty());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -114,7 +114,6 @@ public class StreamTaskTest {
     private final MockTime time = new MockTime();
     private File baseDir = TestUtils.tempDirectory();
     private StateDirectory stateDirectory;
-    private final RecordCollectorImpl recordCollector = new RecordCollectorImpl(producer, "taskId");
     private StreamsConfig config;
     private StreamsConfig eosConfig;
     private StreamTask task;
@@ -147,6 +146,7 @@ public class StreamTaskTest {
         stateDirectory = new StateDirectory("applicationId", baseDir.getPath(), new MockTime());
         task = new StreamTask(taskId00, applicationId, partitions, topology, consumer,
                               changelogReader, config, streamsMetrics, stateDirectory, null, time, producer);
+        task.initialize();
     }
 
     @After
@@ -377,6 +377,7 @@ public class StreamTaskTest {
 
         task = new StreamTask(taskId00, applicationId, partitions, topology, consumer, changelogReader, config,
             streamsMetrics, stateDirectory, null, time, producer);
+        task.initialize();
         final int offset = 20;
         task.addRecords(partition1, Collections.singletonList(
                 new ConsumerRecord<>(partition1.topic(), partition1.partition(), offset, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue)));
@@ -494,6 +495,7 @@ public class StreamTaskTest {
                 };
             }
         };
+        streamTask.initialize();
 
         time.sleep(config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -613,6 +613,7 @@ public class StreamTaskTest {
     public void shouldThrowExceptionIfAnyExceptionsRaisedDuringCloseButStillCloseAllProcessorNodesTopology() throws Exception {
         task.close(true);
         task = createTaskThatThrowsExceptionOnClose();
+        task.initialize();
         try {
             task.close(true);
             fail("should have thrown runtime exception");
@@ -778,6 +779,17 @@ public class StreamTaskTest {
         task = null;
         assertTrue(producer.closed());
     }
+
+    @Test
+    public void shouldNotCloseTopologyProcessorNodesIfNotInitialized() {
+        final StreamTask task = createTaskThatThrowsExceptionOnClose();
+        try {
+            task.close(true);
+        } catch (Exception e) {
+            fail("should have not closed unitialized topology");
+        }
+    }
+
 
     @SuppressWarnings("unchecked")
     private StreamTask createTaskThatThrowsExceptionOnClose() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -296,7 +296,7 @@ public class StreamThreadTest {
         activeTasks.put(new TaskId(0, 1), expectedGroup1);
         rebalanceListener.onPartitionsAssigned(assignedPartitions);
         Assert.assertEquals(stateListener.numChanges, 3);
-        Assert.assertEquals(stateListener.oldState, StreamThread.State.ASSIGNING_PARTITIONS);
+        Assert.assertEquals(stateListener.oldState, StreamThread.State.PARTITIONS_ASSIGNED);
         thread.runOnce(-1);
         assertEquals(thread.state(), StreamThread.State.RUNNING);
         assertTrue(thread.tasks().containsKey(task1));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -103,10 +103,12 @@ public class StreamThreadStateStoreProviderTest {
         stateDirectory = new StateDirectory(applicationId, stateConfigDir, new MockTime());
         taskOne = createStreamsTask(applicationId, streamsConfig, clientSupplier, topology,
                                     new TaskId(0, 0));
+        taskOne.initialize();
         tasks.put(new TaskId(0, 0),
                   taskOne);
         taskTwo = createStreamsTask(applicationId, streamsConfig, clientSupplier, topology,
                                     new TaskId(0, 1));
+        taskTwo.initialize();
         tasks.put(new TaskId(0, 1),
                   taskTwo);
 

--- a/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.internals.ChangelogReader;
 import org.apache.kafka.streams.processor.internals.StateRestorer;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,13 +40,18 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
-    public void restore() {
-
+    public Collection<TopicPartition> restore() {
+        return registered;
     }
 
     @Override
     public Map<TopicPartition, Long> restoredOffsets() {
         return Collections.emptyMap();
+    }
+
+    @Override
+    public void reset() {
+        registered.clear();
     }
 
     public boolean wasRegistered(final TopicPartition partition) {

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -225,6 +225,7 @@ public class ProcessorTopologyTestDriver {
                                   cache,
                                   new MockTime(),
                                   producer);
+            task.initialize();
         }
     }
 


### PR DESCRIPTION
In `onPartitionsAssigned`: 
1. release all locks for non-assigned suspended tasks.
2. resume any suspended tasks.
3. Create new tasks, but don't attempt to take the state lock.
4. Pause partitions for any new tasks.
5. set the state to `PARTITIONS_ASSIGNED`

In `StreamThread#runLoop`
1. poll
2. if state is `PARTITIONS_ASSIGNED`
 2.1  attempt to initialize any new tasks, i.e, take out the state locks and init state stores
 2.2 restore some data for changelogs, i.e., poll once on the restore consumer and return the partitions that have been fully restored
 2.3 update tasks with restored partitions and move any that have completed restoration to running
 2.4 resume consumption for any tasks where all partitions have been restored.
 2.5 if all active tasks are running, transition to `RUNNING` and assign standby partitions to the restoreConsumer.
 
