### PR TITLE
KAFKA-5724: AbstractPartitionAssignor should support assignment for topics with non-consecutive partitions

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RangeAssignor.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,20 +72,7 @@ public class RangeAssignor extends AbstractPartitionAssignor {
             if (partitionInfos == null || partitionInfos.isEmpty()) {
                 continue;
             }
-            Collections.sort(partitionInfos, new Comparator<PartitionInfo>() {
-                @Override
-                public int compare(PartitionInfo o1, PartitionInfo o2) {
-                    if (o1 == null || o2 == null) {
-                        return -1;
-                    } else if (o1.partition() < o2.partition()) {
-                        return -1;
-                    } else if (o1.partition() == o2.partition()) {
-                        return 0;
-                    } else {
-                        return 1;
-                    }
-                }
-            });
+            Collections.sort(partitionInfos);
             Collections.sort(consumersForTopic);
 
             int totalPartitions = partitionInfos.size();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.utils.Utils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,20 +85,7 @@ public class RoundRobinAssignor extends AbstractPartitionAssignor {
         for (String topic : topics) {
             List<PartitionInfo> partitionInfos = partitionsPerTopic.get(topic);
             if (partitionInfos != null && !partitionInfos.isEmpty()) {
-                Collections.sort(partitionInfos, new Comparator<PartitionInfo>() {
-                    @Override
-                    public int compare(PartitionInfo o1, PartitionInfo o2) {
-                        if (o1 == null || o2 == null) {
-                            return -1;
-                        } else if (o1.partition() < o2.partition()) {
-                            return -1;
-                        } else if (o1.partition() == o2.partition()) {
-                            return 0;
-                        } else {
-                            return 1;
-                        }
-                    }
-                });
+                Collections.sort(partitionInfos);
                 allPartitions.addAll(AbstractPartitionAssignor.partitions(partitionInfos));
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/RoundRobinAssignor.java
@@ -17,11 +17,14 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.CircularIterator;
 import org.apache.kafka.common.utils.Utils;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +59,7 @@ import java.util.TreeSet;
 public class RoundRobinAssignor extends AbstractPartitionAssignor {
 
     @Override
-    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+    public Map<String, List<TopicPartition>> assign(Map<String, List<PartitionInfo>> partitionsPerTopic,
                                                     Map<String, Subscription> subscriptions) {
         Map<String, List<TopicPartition>> assignment = new HashMap<>();
         for (String memberId : subscriptions.keySet())
@@ -73,7 +76,7 @@ public class RoundRobinAssignor extends AbstractPartitionAssignor {
     }
 
 
-    public List<TopicPartition> allPartitionsSorted(Map<String, Integer> partitionsPerTopic,
+    public List<TopicPartition> allPartitionsSorted(Map<String, List<PartitionInfo>> partitionsPerTopic,
                                                     Map<String, Subscription> subscriptions) {
         SortedSet<String> topics = new TreeSet<>();
         for (Subscription subscription : subscriptions.values())
@@ -81,9 +84,24 @@ public class RoundRobinAssignor extends AbstractPartitionAssignor {
 
         List<TopicPartition> allPartitions = new ArrayList<>();
         for (String topic : topics) {
-            Integer numPartitionsForTopic = partitionsPerTopic.get(topic);
-            if (numPartitionsForTopic != null)
-                allPartitions.addAll(AbstractPartitionAssignor.partitions(topic, numPartitionsForTopic));
+            List<PartitionInfo> partitionInfos = partitionsPerTopic.get(topic);
+            if (partitionInfos != null && !partitionInfos.isEmpty()) {
+                Collections.sort(partitionInfos, new Comparator<PartitionInfo>() {
+                    @Override
+                    public int compare(PartitionInfo o1, PartitionInfo o2) {
+                        if (o1 == null || o2 == null) {
+                            return -1;
+                        } else if (o1.partition() < o2.partition()) {
+                            return -1;
+                        } else if (o1.partition() == o2.partition()) {
+                            return 0;
+                        } else {
+                            return 1;
+                        }
+                    }
+                });
+                allPartitions.addAll(AbstractPartitionAssignor.partitions(partitionInfos));
+            }
         }
         return allPartitions;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -206,20 +206,7 @@ public class StickyAssignor extends AbstractPartitionAssignor {
         // initialize partition2AllPotentialConsumers and consumer2AllPotentialPartitions in the following two for loops
         for (Entry<String, List<PartitionInfo>> entry: partitionsPerTopic.entrySet()) {
             List<PartitionInfo> partitionInfos = entry.getValue();
-            Collections.sort(partitionInfos, new Comparator<PartitionInfo>() {
-                @Override
-                public int compare(PartitionInfo o1, PartitionInfo o2) {
-                    if (o1 == null || o2 == null) {
-                        return -1;
-                    } else if (o1.partition() < o2.partition()) {
-                        return -1;
-                    } else if (o1.partition() == o2.partition()) {
-                        return 0;
-                    } else {
-                        return 1;
-                    }
-                }
-            });
+            Collections.sort(partitionInfos);
             for (PartitionInfo partitionInfo : partitionInfos) {
                 partition2AllPotentialConsumers.put(
                         new TopicPartition(entry.getKey(), partitionInfo.partition()), new ArrayList<String>());
@@ -231,20 +218,7 @@ public class StickyAssignor extends AbstractPartitionAssignor {
             consumer2AllPotentialPartitions.put(consumer, new ArrayList<TopicPartition>());
             for (String topic: entry.getValue().topics()) {
                 List<PartitionInfo> partitionInfos = partitionsPerTopic.get(topic);
-                Collections.sort(partitionInfos, new Comparator<PartitionInfo>() {
-                    @Override
-                    public int compare(PartitionInfo o1, PartitionInfo o2) {
-                        if (o1 == null || o2 == null) {
-                            return -1;
-                        } else if (o1.partition() < o2.partition()) {
-                            return -1;
-                        } else if (o1.partition() == o2.partition()) {
-                            return 0;
-                        } else {
-                            return 1;
-                        }
-                    }
-                });
+                Collections.sort(partitionInfos);
                 for (PartitionInfo partitionInfo: partitionInfos) {
                     TopicPartition topicPartition = new TopicPartition(topic, partitionInfo.partition());
                     consumer2AllPotentialPartitions.get(consumer).add(topicPartition);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
@@ -90,14 +90,7 @@ public abstract class AbstractPartitionAssignor implements PartitionAssignor {
         }
         list.add(value);
     }
-
-    protected static List<TopicPartition> partitions(String topic, int numPartitions) {
-        List<TopicPartition> partitions = new ArrayList<>(numPartitions);
-        for (int i = 0; i < numPartitions; i++)
-            partitions.add(new TopicPartition(topic, i));
-        return partitions;
-    }
-
+    
     protected static List<TopicPartition> partitions(List<PartitionInfo> partitionInfos) {
         if (partitionInfos == null || partitionInfos.isEmpty()) {
             return Collections.emptyList();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractPartitionAssignor.java
@@ -17,11 +17,13 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,12 +39,12 @@ public abstract class AbstractPartitionAssignor implements PartitionAssignor {
 
     /**
      * Perform the group assignment given the partition counts and member subscriptions
-     * @param partitionsPerTopic The number of partitions for each subscribed topic. Topics not in metadata will be excluded
+     * @param partitionsPerTopic The partitionInfo list for each subscribed topic. Topics not in metadata will be excluded
      *                           from this map.
      * @param subscriptions Map from the memberId to their respective topic subscription
      * @return Map from each member to the list of partitions assigned to them.
      */
-    public abstract Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+    public abstract Map<String, List<TopicPartition>> assign(Map<String, List<PartitionInfo>> partitionsPerTopic,
                                                              Map<String, Subscription> subscriptions);
 
     @Override
@@ -56,13 +58,14 @@ public abstract class AbstractPartitionAssignor implements PartitionAssignor {
         for (Map.Entry<String, Subscription> subscriptionEntry : subscriptions.entrySet())
             allSubscribedTopics.addAll(subscriptionEntry.getValue().topics());
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         for (String topic : allSubscribedTopics) {
-            Integer numPartitions = metadata.partitionCountForTopic(topic);
-            if (numPartitions != null && numPartitions > 0)
-                partitionsPerTopic.put(topic, numPartitions);
-            else
+            List<PartitionInfo> partitionsForThisTopic = new ArrayList<>(metadata.partitionsForTopic(topic));
+            if (partitionsForThisTopic.isEmpty()) {
                 log.debug("Skipping assignment for topic {} since no metadata is available", topic);
+            } else {
+                partitionsPerTopic.put(topic, partitionsForThisTopic);
+            }
         }
 
         Map<String, List<TopicPartition>> rawAssignments = assign(partitionsPerTopic, subscriptions);
@@ -92,6 +95,17 @@ public abstract class AbstractPartitionAssignor implements PartitionAssignor {
         List<TopicPartition> partitions = new ArrayList<>(numPartitions);
         for (int i = 0; i < numPartitions; i++)
             partitions.add(new TopicPartition(topic, i));
+        return partitions;
+    }
+
+    protected static List<TopicPartition> partitions(List<PartitionInfo> partitionInfos) {
+        if (partitionInfos == null || partitionInfos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<TopicPartition> partitions = new ArrayList<>(partitionInfos.size());
+        for (PartitionInfo partitionInfo: partitionInfos) {
+            partitions.add(new TopicPartition(partitionInfo.topic(), partitionInfo.partition()));
+        }
         return partitions;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
+++ b/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
@@ -19,7 +19,7 @@ package org.apache.kafka.common;
 /**
  * This is used to describe per-partition state in the MetadataResponse.
  */
-public class PartitionInfo {
+public class PartitionInfo implements Comparable<PartitionInfo> {
 
     private final String topic;
     private final int partition;
@@ -108,4 +108,8 @@ public class PartitionInfo {
         return b.toString();
     }
 
+    @Override
+    public int compareTo(PartitionInfo o) {
+        return partition - o.partition();
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RangeAssignorTest.java
@@ -17,9 +17,11 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor.Subscription;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,7 +41,7 @@ public class RangeAssignorTest {
     public void testOneConsumerNoTopic() {
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(Collections.<String>emptyList())));
@@ -53,7 +55,7 @@ public class RangeAssignorTest {
         String topic = "topic";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic))));
         assertEquals(Collections.singleton(consumerId), assignment.keySet());
@@ -65,8 +67,12 @@ public class RangeAssignorTest {
         String topic = "topic";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic))));
@@ -81,9 +87,15 @@ public class RangeAssignorTest {
         String otherTopic = "other";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(otherTopic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos1.add(new PartitionInfo(topic, i, null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos1);
+        partitionsPerTopic.put(otherTopic, partitionInfos2);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic))));
@@ -97,9 +109,17 @@ public class RangeAssignorTest {
         String topic2 = "topic2";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(1);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(2);
+        partitionInfos1.add(new PartitionInfo(topic1, 0, null, null, null));
+
+        for (int i = 0; i < 2; ++i) {
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2))));
@@ -114,8 +134,10 @@ public class RangeAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(1);
+        partitionInfos.add(new PartitionInfo(topic, 0, null, null, null));
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic)));
@@ -133,8 +155,13 @@ public class RangeAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(2);
+        for (int i = 0; i < 2; ++i) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic)));
@@ -153,9 +180,18 @@ public class RangeAssignorTest {
         String consumer2 = "consumer2";
         String consumer3 = "consumer3";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos1.add(new PartitionInfo(topic1, i, null, null, null));
+            if (i != 2) {
+                partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+            }
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1)));
@@ -175,9 +211,16 @@ public class RangeAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos1.add(new PartitionInfo(topic1, i, null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
@@ -186,6 +229,32 @@ public class RangeAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertAssignment(partitions(tp(topic1, 0), tp(topic1, 1), tp(topic2, 0), tp(topic2, 1)), assignment.get(consumer1));
         assertAssignment(partitions(tp(topic1, 2), tp(topic2, 2)), assignment.get(consumer2));
+    }
+
+    @Test
+    public void testAssignForNonZeroBasedPartitions() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 2; i >= 0; i--) { // partitions can be sorted in an ascending order
+            partitionInfos1.add(new PartitionInfo(topic1, 2 * i + 1, null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic2, 2 * i + 1, null, null, null));
+        }
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertAssignment(partitions(tp(topic1, 1), tp(topic1, 3), tp(topic2, 1), tp(topic2, 3)), assignment.get(consumer1));
+        assertAssignment(partitions(tp(topic1, 5), tp(topic2, 5)), assignment.get(consumer2));
     }
 
     private void assertAssignment(List<TopicPartition> expected, List<TopicPartition> actual) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/RoundRobinAssignorTest.java
@@ -17,9 +17,11 @@
 package org.apache.kafka.clients.consumer;
 
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor.Subscription;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,7 +40,7 @@ public class RoundRobinAssignorTest {
     public void testOneConsumerNoTopic() {
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(Collections.<String>emptyList())));
@@ -51,7 +53,7 @@ public class RoundRobinAssignorTest {
         String topic = "topic";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic))));
 
@@ -64,8 +66,12 @@ public class RoundRobinAssignorTest {
         String topic = "topic";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic))));
@@ -78,9 +84,15 @@ public class RoundRobinAssignorTest {
         String otherTopic = "other";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(otherTopic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos1.add(new PartitionInfo(topic, i, null, null, null));
+            partitionInfos2.add(new PartitionInfo(otherTopic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos1);
+        partitionsPerTopic.put(otherTopic, partitionInfos2);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic))));
@@ -93,9 +105,16 @@ public class RoundRobinAssignorTest {
         String topic2 = "topic2";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(1);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(2);
+        partitionInfos1.add(new PartitionInfo(topic1, 0, null, null, null));
+        for (int i = 0; i < 2; ++i) {
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic,
                 Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2))));
@@ -108,8 +127,10 @@ public class RoundRobinAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(1);
+        partitionInfos.add(new PartitionInfo(topic, 0, null, null, null));
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic)));
@@ -126,8 +147,12 @@ public class RoundRobinAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(2);
+        for (int i = 0; i < 2; i++) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic)));
@@ -146,9 +171,17 @@ public class RoundRobinAssignorTest {
         String consumer2 = "consumer2";
         String consumer3 = "consumer3";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos1.add(new PartitionInfo(topic1, i, null, null, null));
+            if (i != 2) {
+                partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+            }
+        }
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1)));
@@ -168,9 +201,15 @@ public class RoundRobinAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos1.add(new PartitionInfo(topic1, i, null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, Subscription> consumers = new HashMap<>();
         consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
@@ -179,6 +218,42 @@ public class RoundRobinAssignorTest {
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
         assertEquals(partitions(tp(topic1, 0), tp(topic1, 2), tp(topic2, 1)), assignment.get(consumer1));
         assertEquals(partitions(tp(topic1, 1), tp(topic2, 0), tp(topic2, 2)), assignment.get(consumer2));
+    }
+
+    @Test
+    public void testAssignForNonZeroBasedPartitions() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+
+        int[] partitionIdsForTopic1 = {4, 5, 3};
+        int[] partitionIdsForTopic2 = {102, 101, 100};
+
+        for (int i = 0; i < partitionIdsForTopic1.length; i++) {
+            partitionInfos1.add(new PartitionInfo(topic1, partitionIdsForTopic1[i], null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic2, partitionIdsForTopic2[i], null, null, null));
+        }
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
+
+        Map<String, Subscription> consumers = new HashMap<>();
+        consumers.put(consumer1, new Subscription(topics(topic1, topic2)));
+        consumers.put(consumer2, new Subscription(topics(topic1, topic2)));
+
+        // adjust back the partitions by an ascending order
+        Arrays.sort(partitionIdsForTopic1);
+        Arrays.sort(partitionIdsForTopic2);
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, consumers);
+        assertEquals(partitions(tp(topic1, partitionIdsForTopic1[0]),
+                tp(topic1, partitionIdsForTopic1[2]), tp(topic2, partitionIdsForTopic2[1])), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic1, partitionIdsForTopic1[1]),
+                tp(topic2, partitionIdsForTopic2[0]), tp(topic2, partitionIdsForTopic2[2])), assignment.get(consumer2));
     }
 
     private static List<String> topics(String... topics) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -31,6 +31,7 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.kafka.clients.consumer.internals.PartitionAssignor.Subscription;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.CollectionUtils;
 import org.apache.kafka.common.utils.Utils;
@@ -44,7 +45,7 @@ public class StickyAssignorTest {
     public void testOneConsumerNoTopic() {
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
         Map<String, Subscription> subscriptions =
                 Collections.singletonMap(consumerId, new Subscription(Collections.<String>emptyList()));
 
@@ -61,8 +62,8 @@ public class StickyAssignorTest {
         String topic = "topic";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 0);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        partitionsPerTopic.put(topic, Collections.<PartitionInfo>emptyList());
         Map<String, Subscription> subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
@@ -79,8 +80,12 @@ public class StickyAssignorTest {
         String topic = "topic";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos);
         Map<String, Subscription> subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
@@ -96,9 +101,15 @@ public class StickyAssignorTest {
         String otherTopic = "other";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
-        partitionsPerTopic.put(otherTopic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos1.add(new PartitionInfo(topic, i, null, null, null));
+            partitionInfos2.add(new PartitionInfo(otherTopic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos1);
+        partitionsPerTopic.put(otherTopic, partitionInfos1);
         Map<String, Subscription> subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
@@ -114,9 +125,15 @@ public class StickyAssignorTest {
         String topic2 = "topic2";
         String consumerId = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 1);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(1);
+        partitionInfos1.add(new PartitionInfo(topic1, 0, null, null, null));
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(2);
+        for (int i = 0; i < 2; ++i) {
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
         Map<String, Subscription> subscriptions = Collections.singletonMap(consumerId, new Subscription(topics(topic1, topic2)));
 
         Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
@@ -132,8 +149,10 @@ public class StickyAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(1);
+        partitionInfos.add(new PartitionInfo(topic, 0, null, null, null));
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put(consumer1, new Subscription(topics(topic)));
@@ -153,8 +172,12 @@ public class StickyAssignorTest {
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(2);
+        for (int i = 0; i < 2; ++i) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic, partitionInfos);
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put(consumer1, new Subscription(topics(topic)));
@@ -176,9 +199,18 @@ public class StickyAssignorTest {
         String consumer2 = "consumer2";
         String consumer3 = "consumer3";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 2);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(2);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos1.add(new PartitionInfo(topic1, i, null, null, null));
+            if (i != 2) {
+                partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+            }
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put(consumer1, new Subscription(topics(topic1)));
@@ -195,15 +227,60 @@ public class StickyAssignorTest {
     }
 
     @Test
+    public void testAssignForTopicsWithNonZeroBasedPartitions() {
+        String topic1 = "topic1";
+        String topic2 = "topic2";
+        String consumer1 = "consumer1";
+        String consumer2 = "consumer2";
+        int[] partitionIdsForTopic1 = {4, 5, 3};
+        int[] partitionIdsForTopic2 = {102, 101, 100};
+
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos1.add(new PartitionInfo(topic1, partitionIdsForTopic1[i], null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic2, partitionIdsForTopic2[i], null, null, null));
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
+
+        Map<String, Subscription> subscriptions = new HashMap<>();
+        subscriptions.put(consumer1, new Subscription(topics(topic1, topic2)));
+        subscriptions.put(consumer2, new Subscription(topics(topic1, topic2)));
+
+        // adjust back the partitions by an ascending order
+        Arrays.sort(partitionIdsForTopic1);
+        Arrays.sort(partitionIdsForTopic2);
+
+        Map<String, List<TopicPartition>> assignment = assignor.assign(partitionsPerTopic, subscriptions);
+        assertEquals(partitions(tp(topic1, partitionIdsForTopic1[0]), tp(topic1, partitionIdsForTopic1[2]),
+                tp(topic2, partitionIdsForTopic2[1])), assignment.get(consumer1));
+        assertEquals(partitions(tp(topic1, partitionIdsForTopic1[1]), tp(topic2, partitionIdsForTopic2[0]),
+                tp(topic2, partitionIdsForTopic2[2])), assignment.get(consumer2));
+
+        verifyValidityAndBalance(subscriptions, assignment);
+        assertTrue(isFullyBalanced(assignment));
+    }
+
+    @Test
     public void testTwoConsumersTwoTopicsSixPartitions() {
         String topic1 = "topic1";
         String topic2 = "topic2";
         String consumer1 = "consumer1";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic1, 3);
-        partitionsPerTopic.put(topic2, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos1.add(new PartitionInfo(topic1, i, null, null, null));
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic1, partitionInfos1);
+        partitionsPerTopic.put(topic2, partitionInfos2);
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put(consumer1, new Subscription(topics(topic1, topic2)));
@@ -222,8 +299,13 @@ public class StickyAssignorTest {
         String topic = "topic";
         String consumer1 = "consumer";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            partitionInfos.add(new PartitionInfo(topic, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic, partitionInfos);
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put(consumer1, new Subscription(topics(topic)));
 
@@ -279,9 +361,15 @@ public class StickyAssignorTest {
      */
     @Test
     public void testPoorRoundRobinAssignmentScenario() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i <= 5; i++)
-            partitionsPerTopic.put(String.format("topic%d", i), (i % 2) + 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i <= 5; i++) {
+            int numPartitions = (i % 2) + 1;
+            List<PartitionInfo> partitionInfos = new ArrayList<>(numPartitions);
+            for (int j = 0; j < numPartitions; j++) {
+                partitionInfos.add(new PartitionInfo(String.format("topic%d", i), j, null, null, null));
+            }
+            partitionsPerTopic.put(String.format("topic%d", i), partitionInfos);
+        }
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer1", new Subscription(topics("topic1", "topic2", "topic3", "topic4", "topic5")));
@@ -299,8 +387,13 @@ public class StickyAssignorTest {
         String consumer1 = "consumer";
         String consumer2 = "consumer2";
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put(topic, 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos1 = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos1.add(new PartitionInfo(topic, i, null, null, null));
+        }
+
+        partitionsPerTopic.put(topic, partitionInfos1);
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put(consumer1, new Subscription(topics(topic)));
         subscriptions.put(consumer2, new Subscription(topics(topic)));
@@ -316,7 +409,11 @@ public class StickyAssignorTest {
                    (consumer1Assignment1.size() == 2 && consumer2Assignment1.size() == 1));
 
         String topic2 = "topic2";
-        partitionsPerTopic.put(topic2, 3);
+        List<PartitionInfo> partitionInfos2 = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos2.add(new PartitionInfo(topic2, i, null, null, null));
+        }
+        partitionsPerTopic.put(topic2, partitionInfos2);
         subscriptions.put(consumer1,
                 new Subscription(topics(topic, topic2), StickyAssignor.serializeTopicPartitionAssignment(assignment.get(consumer1))));
         subscriptions.put(consumer2,
@@ -354,9 +451,15 @@ public class StickyAssignorTest {
 
     @Test
     public void testReassignmentAfterOneConsumerLeaves() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 20; i++)
-            partitionsPerTopic.put(getTopicName(i, 20), i);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 20; i++) {
+            String topic = getTopicName(i, 20);
+            List<PartitionInfo> partitionInfos = new ArrayList<>(i);
+            for (int j = 0; j < i; ++j) {
+                partitionInfos.add(new PartitionInfo(topic, j, null, null, null));
+            }
+            partitionsPerTopic.put(topic, partitionInfos);
+        }
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         for (int i = 1; i < 20; i++) {
@@ -383,8 +486,12 @@ public class StickyAssignorTest {
 
     @Test
     public void testReassignmentAfterOneConsumerAdded() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put("topic", 20);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(20);
+        for (int i = 0; i < 20; ++i) {
+            partitionInfos.add(new PartitionInfo("topic", i, null, null, null));
+        }
+        partitionsPerTopic.put("topic", partitionInfos);
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         for (int i = 1; i < 10; i++)
@@ -403,9 +510,15 @@ public class StickyAssignorTest {
 
     @Test
     public void testSameSubscriptions() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 15; i++)
-            partitionsPerTopic.put(getTopicName(i, 15), i);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 15; i++) {
+            String topic = getTopicName(i, 15);
+            List<PartitionInfo> partitionInfos = new ArrayList<>();
+            for (int j = 0; j < i; ++j) {
+                partitionInfos.add(new PartitionInfo(topic, j, null, null, null));
+            }
+            partitionsPerTopic.put(topic, partitionInfos);
+        }
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         for (int i = 1; i < 9; i++) {
@@ -436,9 +549,16 @@ public class StickyAssignorTest {
         int topicCount = 40;
         int consumerCount = 200;
 
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 0; i < topicCount; i++)
-            partitionsPerTopic.put(getTopicName(i, topicCount), rand.nextInt(10) + 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 0; i < topicCount; i++) {
+            String topic = getTopicName(i, topicCount);
+            List<PartitionInfo> partitionInfos = new ArrayList<>();
+            int numPartitions = rand.nextInt(10) + 1;
+            for (int j = 0; j < numPartitions; ++j) {
+                partitionInfos.add(new PartitionInfo(topic, j, null, null, null));
+            }
+            partitionsPerTopic.put(topic, partitionInfos);
+        }
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         for (int i = 0; i < consumerCount; i++) {
@@ -468,9 +588,13 @@ public class StickyAssignorTest {
 
     @Test
     public void testNewSubscription() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i < 5; i++)
-            partitionsPerTopic.put(getTopicName(i, 5), 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i < 5; i++) {
+            String topic = getTopicName(i, 5);
+            List<PartitionInfo> partitionInfos = new ArrayList<>(1);
+            partitionInfos.add(new PartitionInfo(topic, 0, null, null, null));
+            partitionsPerTopic.put(topic, partitionInfos);
+        }
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         for (int i = 0; i < 3; i++) {
@@ -504,9 +628,15 @@ public class StickyAssignorTest {
             for (int i = 0; i < numTopics; ++i)
                 topics.add(getTopicName(i, maxNumTopics));
 
-            Map<String, Integer> partitionsPerTopic = new HashMap<>();
-            for (int i = 0; i < numTopics; ++i)
-                partitionsPerTopic.put(getTopicName(i, maxNumTopics), i + 1);
+            Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+            for (int i = 0; i < numTopics; ++i) {
+                String topic = getTopicName(i, maxNumTopics);
+                List<PartitionInfo> partitionInfos = new ArrayList<>(i + 1);
+                for (int j = 0; j < i + 1; ++j) {
+                    partitionInfos.add(new PartitionInfo(topic, j, null, null, null));
+                }
+                partitionsPerTopic.put(topic, partitionInfos);
+            }
 
             int numConsumers = minNumConsumers + new Random().nextInt(maxNumConsumers - minNumConsumers);
 
@@ -537,9 +667,13 @@ public class StickyAssignorTest {
 
     @Test
     public void testMoveExistingAssignments() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        for (int i = 1; i <= 6; i++)
-            partitionsPerTopic.put(String.format("topic%02d", i), 1);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        for (int i = 1; i <= 6; i++) {
+            String topic = String.format("topic%02d", i);
+            List<PartitionInfo> partitionInfos = new ArrayList<>(1);
+            partitionInfos.add(new PartitionInfo(topic, 0, null, null, null));
+            partitionsPerTopic.put(topic, partitionInfos);
+        }
 
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer01",
@@ -558,8 +692,12 @@ public class StickyAssignorTest {
 
     @Test
     public void testStickiness() {
-        Map<String, Integer> partitionsPerTopic = new HashMap<>();
-        partitionsPerTopic.put("topic01", 3);
+        Map<String, List<PartitionInfo>> partitionsPerTopic = new HashMap<>();
+        List<PartitionInfo> partitionInfos = new ArrayList<>(3);
+        for (int i = 0; i < 3; ++i) {
+            partitionInfos.add(new PartitionInfo("topic01", i, null, null, null));
+        }
+        partitionsPerTopic.put("topic01", partitionInfos);
         Map<String, Subscription> subscriptions = new HashMap<>();
         subscriptions.put("consumer01", new Subscription(topics("topic01")));
         subscriptions.put("consumer02", new Subscription(topics("topic01")));
@@ -676,7 +814,7 @@ public class StickyAssignorTest {
      * - there is no topic partition that can be moved from one consumer to another with 2+ fewer topic partitions
      *
      * @param subscriptions: topic subscriptions of each consumer
-     * @param assignment: given assignment for balance check
+     * @param assignments: given assignment for balance check
      */
     private static void verifyValidityAndBalance(Map<String, Subscription> subscriptions, Map<String, List<TopicPartition>> assignments) {
         int size = subscriptions.size();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MockPartitionAssignor.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/MockPartitionAssignor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.List;
@@ -26,7 +27,7 @@ public class MockPartitionAssignor extends AbstractPartitionAssignor {
     private Map<String, List<TopicPartition>> result = null;
 
     @Override
-    public Map<String, List<TopicPartition>> assign(Map<String, Integer> partitionsPerTopic,
+    public Map<String, List<TopicPartition>> assign(Map<String, List<PartitionInfo>> partitionsPerTopic,
                                                     Map<String, Subscription> subscriptions) {
         if (result == null)
             throw new IllegalStateException("Call to assign with no result prepared");


### PR DESCRIPTION
Current design does consider the siutation when user creates a topic via KafkaAdminClient whose partitions are not consecutive or zero-based. In such case, consumer does not work since assignor failed to assign partitions.