### PR TITLE
KAFKA-5152: perform state restoration in poll loop

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -404,7 +404,7 @@ public class KafkaStreams {
                 threadState.put(thread.getId(), newState);
 
                 if (newState == StreamThread.State.PARTITIONS_REVOKED ||
-                        newState == StreamThread.State.ASSIGNING_PARTITIONS) {
+                        newState == StreamThread.State.PARTITIONS_ASSIGNED) {
                     setState(State.REBALANCING);
                 } else if (newState == StreamThread.State.RUNNING && state() != State.RUNNING) {
                     maybeSetRunning();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -244,11 +244,6 @@ public abstract class AbstractTask implements Task {
         }
     }
 
-    /**
-     * initialize the topology/state stores
-     * @return true if the topology is ready to run, i.e, all stores have been restored.
-     */
-    public abstract boolean initialize();
 
     public boolean hasStateStores() {
         return !topology.stateStores().isEmpty();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -23,7 +23,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
@@ -48,6 +50,7 @@ public abstract class AbstractTask implements Task {
     final Consumer consumer;
     final String logPrefix;
     final boolean eosEnabled;
+    private final StateDirectory stateDirectory;
 
     InternalProcessorContext processorContext;
 
@@ -69,6 +72,7 @@ public abstract class AbstractTask implements Task {
         this.topology = topology;
         this.consumer = consumer;
         this.eosEnabled = StreamsConfig.EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+        this.stateDirectory = stateDirectory;
 
         logPrefix = String.format("%s [%s]", isStandby ? "standby-task" : "task", id());
 
@@ -188,6 +192,20 @@ public abstract class AbstractTask implements Task {
     }
 
     void initializeStateStores() {
+        if (topology.stateStores().isEmpty()) {
+            return;
+        }
+
+        try {
+            if (!stateDirectory.lock(id, 5)) {
+                throw new LockException(String.format("%s Failed to lock the state directory for task %s",
+                                                      logPrefix, id));
+            }
+        } catch (IOException e) {
+            throw new StreamsException(String.format("%s fatal error while trying to lock the state directory for task %s",
+                                                     logPrefix,
+                                                     id));
+        }
         log.trace("{} Initializing state stores", logPrefix);
 
         // set initial offset limits
@@ -199,13 +217,43 @@ public abstract class AbstractTask implements Task {
         }
     }
 
+
     /**
      * @throws ProcessorStateException if there is an error while closing the state manager
      * @param writeCheckpoint boolean indicating if a checkpoint file should be written
      */
     void closeStateManager(final boolean writeCheckpoint) throws ProcessorStateException {
+        ProcessorStateException exception = null;
         log.trace("{} Closing state manager", logPrefix);
-        stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
+        try {
+            stateMgr.close(writeCheckpoint ? recordCollectorOffsets() : null);
+        } catch (final ProcessorStateException e) {
+            exception = e;
+        } finally {
+            try {
+                stateDirectory.unlock(id);
+            } catch (IOException e) {
+                if (exception == null) {
+                    exception = new ProcessorStateException(String.format("%s Failed to release state dir lock", logPrefix), e);
+                }
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
     }
 
+    /**
+     * initialize the topology/state stores
+     * @return true if the topology is ready to run, i.e, all stores have been restored.
+     */
+    public abstract boolean initialize();
+
+    public boolean hasStateStores() {
+        return !topology.stateStores().isEmpty();
+    }
+
+    public Collection<TopicPartition> changelogPartitions() {
+        return stateMgr.changelogPartitions();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -50,6 +50,7 @@ public abstract class AbstractTask implements Task {
     final Consumer consumer;
     final String logPrefix;
     final boolean eosEnabled;
+    boolean taskInitialized;
     private final StateDirectory stateDirectory;
 
     InternalProcessorContext processorContext;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -340,6 +340,9 @@ class AssignedTasks {
             final Task task = it.next();
             try {
                 action.apply(task);
+            } catch (final CommitFailedException e) {
+                // commit failed. This is already logged inside the task as WARN and we can just log it again here.
+                log.warn("{} Failed to commit {} {} during {} state due to CommitFailedException; this task may be no longer owned by the thread", logPrefix, taskTypeName, task.id(), action.name());
             } catch (final ProducerFencedException e) {
                 closeZombieTask(task);
                 it.remove();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.streams.errors.LockException;
+import org.apache.kafka.streams.processor.TaskId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+class AssignedTasks {
+    private static final Logger log = LoggerFactory.getLogger(AssignedTasks.class);
+    private final String logPrefix;
+    private final String taskTypeName;
+    private Map<TaskId, Task> created = new HashMap<>();
+    private Map<TaskId, Task> suspended = new HashMap<>();
+    private Map<TaskId, Task> restoring = new HashMap<>();
+    private Set<TopicPartition> restoredPartitions = new HashSet<>();
+    private Set<TaskId> previousActiveTasks = new HashSet<>();
+    // IQ may access this map.
+    private Map<TaskId, Task> running = new ConcurrentHashMap<>();
+    private Map<TopicPartition, Task> runningByPartition = new HashMap<>();
+
+    AssignedTasks(final String logPrefix,
+                  final String taskTypeName) {
+        this.logPrefix = logPrefix;
+        this.taskTypeName = taskTypeName;
+    }
+
+    void addNewTask(final Task task) {
+        created.put(task.id(), task);
+    }
+
+    Set<TopicPartition> uninitializedPartitions() {
+        if (created.isEmpty()) {
+            return Collections.emptySet();
+        }
+        final Set<TopicPartition> partitions = new HashSet<>();
+        for (final Map.Entry<TaskId, Task> entry : created.entrySet()) {
+            if (entry.getValue().hasStateStores()) {
+                partitions.addAll(entry.getValue().partitions());
+            }
+        }
+        return partitions;
+    }
+
+    void initializeNewTasks() {
+        if (!created.isEmpty()) {
+            log.trace("{} Initializing {}s {}", logPrefix, taskTypeName, created.keySet());
+        }
+        for (final Iterator<Map.Entry<TaskId, Task>> it = created.entrySet().iterator(); it.hasNext(); ) {
+            final Map.Entry<TaskId, Task> entry = it.next();
+            try {
+                if (!entry.getValue().initialize()) {
+                    restoring.put(entry.getKey(), entry.getValue());
+                } else {
+                    transitionToRunning(entry.getValue());
+                }
+                it.remove();
+            } catch (final LockException e) {
+                // made this trace as it will spam the logs in the poll loop.
+                log.trace("{} Could not create {} {} due to {}; will retry", logPrefix, taskTypeName, entry.getKey(), e.getMessage());
+            }
+        }
+    }
+
+    Set<TopicPartition> updateRestored(final Collection<TopicPartition> restored) {
+        if (restored.isEmpty()) {
+            return Collections.emptySet();
+        }
+        log.trace("{} {} partitions restored for ", logPrefix, taskTypeName, restored);
+        final Set<TopicPartition> resume = new HashSet<>();
+        restoredPartitions.addAll(restored);
+        for (final Iterator<Map.Entry<TaskId, Task>> it = restoring.entrySet().iterator(); it.hasNext(); ) {
+            final Map.Entry<TaskId, Task> entry = it.next();
+            Task task = entry.getValue();
+            if (restoredPartitions.containsAll(task.changelogPartitions())) {
+                transitionToRunning(task);
+                resume.addAll(task.partitions());
+                it.remove();
+            }
+        }
+        if (allTasksRunning()) {
+            restoredPartitions.clear();
+        }
+        return resume;
+    }
+
+    boolean allTasksRunning() {
+        return created.isEmpty()
+                && suspended.isEmpty()
+                && restoring.isEmpty();
+    }
+
+    Collection<Task> running() {
+        return running.values();
+    }
+
+    RuntimeException suspend() {
+        final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
+        log.trace("{} Suspending running {} {}", logPrefix, taskTypeName, runningTaskIds());
+        firstException.compareAndSet(null, suspendTasks(running.values()));
+        log.trace("{} Close restoring {} {}", logPrefix, taskTypeName, restoring.keySet());
+        firstException.compareAndSet(null, closeNonRunningTasks(restoring.values()));
+        log.trace("{} Close created {} {}", logPrefix, taskTypeName, created.keySet());
+        firstException.compareAndSet(null, closeNonRunningTasks(created.values()));
+        previousActiveTasks.clear();
+        previousActiveTasks.addAll(running.keySet());
+        running.clear();
+        restoring.clear();
+        created.clear();
+        runningByPartition.clear();
+        return firstException.get();
+    }
+
+    private RuntimeException closeNonRunningTasks(final Collection<Task> tasks) {
+        RuntimeException exception = null;
+        for (final Task task : tasks) {
+            try {
+                task.close(false);
+            } catch (final RuntimeException e) {
+                log.error("{} Failed to close {}, {}", logPrefix, taskTypeName, task.id(), e);
+                if (exception == null) {
+                    exception = e;
+                }
+            }
+        }
+        return exception;
+    }
+
+    private RuntimeException suspendTasks(final Collection<Task> tasks) {
+        RuntimeException exception = null;
+        for (Iterator<Task> it = tasks.iterator(); it.hasNext(); ) {
+            final Task task = it.next();
+            try {
+                task.suspend();
+                suspended.put(task.id(), task);
+            } catch (final CommitFailedException e) {
+                suspended.put(task.id(), task);
+                // commit failed during suspension. Just log it.
+                log.warn("{} Failed to commit {} {} state when suspending due to CommitFailedException", logPrefix, taskTypeName, task.id());
+            } catch (final ProducerFencedException e) {
+                closeZombieTask(task);
+                it.remove();
+            } catch (final RuntimeException e) {
+                log.error("{} Suspending {} {} failed due to the following error:", logPrefix, taskTypeName, task.id(), e);
+                try {
+                    task.close(false);
+                } catch (final Exception f) {
+                    log.error("{} After suspending failed, closing the same {} {} failed again due to the following error:", logPrefix, taskTypeName, task.id(), f);
+                }
+                if (exception == null) {
+                    exception = e;
+                }
+            }
+        }
+        return exception;
+    }
+
+    void closeZombieTask(final Task task) {
+        log.warn("{} Producer of task {} fenced; closing zombie task", logPrefix, task.id());
+        try {
+            task.close(false);
+        } catch (final Exception e) {
+            log.warn("{} Failed to close zombie {} due to {}, ignore and proceed", taskTypeName, logPrefix, e);
+        }
+    }
+
+    boolean hasRunningTasks() {
+        return !running.isEmpty();
+    }
+
+    boolean maybeResumeSuspendedTask(final TaskId taskId, final Set<TopicPartition> partitions) {
+        if (suspended.containsKey(taskId)) {
+            final Task task = suspended.get(taskId);
+            log.trace("{} found suspended {} {}", logPrefix, taskTypeName, taskId);
+            if (task.partitions().equals(partitions)) {
+                suspended.remove(taskId);
+                task.resume();
+                transitionToRunning(task);
+                log.trace("{} resuming suspended {} {}", logPrefix, taskTypeName, task.id());
+                return true;
+            } else {
+                log.trace("{} couldn't resume task {} assigned partitions {}, task partitions", logPrefix, taskId, partitions, task.partitions());
+            }
+        }
+        return false;
+    }
+
+    private void transitionToRunning(final Task task) {
+        running.put(task.id(), task);
+        for (TopicPartition topicPartition : task.partitions()) {
+            runningByPartition.put(topicPartition, task);
+        }
+        for (TopicPartition topicPartition : task.changelogPartitions()) {
+            runningByPartition.put(topicPartition, task);
+        }
+    }
+
+    Task runningTaskFor(final TopicPartition partition) {
+        return runningByPartition.get(partition);
+    }
+
+    Set<TaskId> runningTaskIds() {
+        return running.keySet();
+    }
+
+    Map<TaskId, Task> runningTaskMap() {
+        return Collections.unmodifiableMap(running);
+    }
+
+    public String toString(final String indent) {
+        final StringBuilder builder = new StringBuilder();
+        describe(builder, running.values(), indent, "Running:");
+        describe(builder, suspended.values(), indent, "Suspended:");
+        describe(builder, restoring.values(), indent, "Restoring:");
+        describe(builder, created.values(), indent, "New:");
+        return builder.toString();
+    }
+
+    private void describe(final StringBuilder builder,
+                          final Collection<Task> tasks,
+                          final String indent,
+                          final String name) {
+        builder.append(indent).append(name);
+        for (final Task t : tasks) {
+            builder.append(indent).append(t.toString(indent + "\t\t"));
+        }
+        builder.append("\n");
+    }
+
+    private List<Task> allInitializedTasks() {
+        final List<Task> tasks = new ArrayList<>();
+        tasks.addAll(running.values());
+        tasks.addAll(suspended.values());
+        tasks.addAll(restoring.values());
+        return tasks;
+    }
+
+    Collection<Task> suspendedTasks() {
+        return suspended.values();
+    }
+
+    Collection<Task> restoringTasks() {
+        return Collections.unmodifiableCollection(restoring.values());
+    }
+
+    Set<TaskId> allAssignedTaskIds() {
+        final Set<TaskId> taskIds = new HashSet<>();
+        taskIds.addAll(running.keySet());
+        taskIds.addAll(suspended.keySet());
+        taskIds.addAll(restoring.keySet());
+        taskIds.addAll(created.keySet());
+        return taskIds;
+    }
+
+    void clear() {
+        runningByPartition.clear();
+        running.clear();
+        created.clear();
+        suspended.clear();
+        restoredPartitions.clear();
+    }
+
+    Set<TaskId> previousTaskIds() {
+        return previousActiveTasks;
+    }
+
+    void commit() {
+        final RuntimeException exception = applyToRunningTasks(new TaskAction() {
+            @Override
+            public String name() {
+                return "commit";
+            }
+
+            @Override
+            public void apply(final Task task) {
+                task.commit();
+            }
+        }, false);
+
+        if (exception != null) {
+            throw exception;
+        }
+
+    }
+
+    int process() {
+        final AtomicInteger processed = new AtomicInteger(0);
+        applyToRunningTasks(new TaskAction() {
+            @Override
+            public String name() {
+                return "process";
+            }
+
+            @Override
+            public void apply(final Task task) {
+                if (task.process()) {
+                    processed.incrementAndGet();
+                }
+            }
+        }, true);
+        return processed.get();
+    }
+
+
+    RuntimeException applyToRunningTasks(final TaskAction action, final boolean throwException) {
+        RuntimeException firstException = null;
+
+        for (Iterator<Task> it = running().iterator(); it.hasNext(); ) {
+            final Task task = it.next();
+            try {
+                action.apply(task);
+            } catch (final ProducerFencedException e) {
+                closeZombieTask(task);
+                it.remove();
+            } catch (final RuntimeException t) {
+                log.error("{} Failed to {} {} {} due to the following error:",
+                          logPrefix,
+                          action.name(),
+                          taskTypeName,
+                          task.id(),
+                          t);
+                if (throwException) {
+                    throw t;
+                }
+
+                if (firstException == null) {
+                    firstException = t;
+                }
+            }
+        }
+
+        return firstException;
+    }
+
+    void closeNonAssignedSuspendedTasks(final Map<TaskId, Set<TopicPartition>> newAssignment) {
+        closeNonAssignedTask(newAssignment, suspended.values().iterator());
+    }
+
+    private void closeNonAssignedTask(final Map<TaskId, Set<TopicPartition>> newAssignment, final Iterator<Task> standByTaskIterator) {
+        while (standByTaskIterator.hasNext()) {
+            final Task suspendedTask = standByTaskIterator.next();
+            if (!newAssignment.containsKey(suspendedTask.id()) || !suspendedTask.partitions().equals(newAssignment.get(suspendedTask.id()))) {
+                log.debug("{} Closing suspended and not re-assigned {} {}", logPrefix, taskTypeName, suspendedTask.id());
+                try {
+                    suspendedTask.closeSuspended(true, null);
+                } catch (final Exception e) {
+                    log.error("{} Failed to remove suspended {} {} due to the following error:", logPrefix, taskTypeName, suspendedTask.id(), e);
+                } finally {
+                    standByTaskIterator.remove();
+                }
+            }
+        }
+    }
+    
+    void close(final boolean clean) {
+        close(allInitializedTasks(), clean);
+        close(created.values(), clean);
+        clear();
+    }
+
+    private void close(final Collection<Task> tasks, final boolean clean) {
+        for (final Task task : tasks) {
+            try {
+                task.close(clean);
+            } catch (final Throwable t) {
+                log.error("{} Failed while closing {} {} due to the following error:",
+                          logPrefix,
+                          task.getClass().getSimpleName(),
+                          task.id(),
+                          t);
+            }
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -235,7 +235,7 @@ class AssignedTasks {
         return exception;
     }
 
-    void closeZombieTask(final Task task) {
+    private void closeZombieTask(final Task task) {
         log.warn("{} Producer of task {} fenced; closing zombie task", logPrefix, task.id());
         try {
             task.close(false);
@@ -359,7 +359,6 @@ class AssignedTasks {
     int process() {
         timerStartedMs = time.milliseconds();
         int processed = 0;
-        timerStartedMs = time.milliseconds();
         for (final Task task : running()) {
             if (task.process()) {
                 processSensor.record(computeLatency(), timerStartedMs);
@@ -411,10 +410,7 @@ class AssignedTasks {
     }
 
     void closeNonAssignedSuspendedTasks(final Map<TaskId, Set<TopicPartition>> newAssignment) {
-        closeNonAssignedTask(newAssignment, suspended.values().iterator());
-    }
-
-    private void closeNonAssignedTask(final Map<TaskId, Set<TopicPartition>> newAssignment, final Iterator<Task> standByTaskIterator) {
+        final Iterator<Task> standByTaskIterator = suspended.values().iterator();
         while (standByTaskIterator.hasNext()) {
             final Task suspendedTask = standByTaskIterator.next();
             if (!newAssignment.containsKey(suspendedTask.id()) || !suspendedTask.partitions().equals(newAssignment.get(suspendedTask.id()))) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -42,16 +43,14 @@ public interface ChangelogReader {
 
     /**
      * Restore all registered state stores by reading from their changelogs.
+     * @return all topic partitions that have been restored
      */
-    void restore();
+    Collection<TopicPartition> restore();
 
     /**
      * @return the restored offsets for all persistent stores.
      */
     Map<TopicPartition, Long> restoredOffsets();
 
-    /**
-     * Clear out any internal state so this can be re-used
-     */
-    void clear();
+    void reset();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PartitionGroup.java
@@ -164,7 +164,6 @@ public class PartitionGroup {
     }
 
     public void close() {
-        queuesByTime.clear();
         partitionQueues.clear();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -51,7 +51,6 @@ public class ProcessorStateManager implements StateManager {
     private final TaskId taskId;
     private final String logPrefix;
     private final boolean isStandby;
-    private final StateDirectory stateDirectory;
     private final ChangelogReader changelogReader;
     private final Map<String, StateStore> stores;
     private final Map<String, StateStore> globalStores;
@@ -60,6 +59,7 @@ public class ProcessorStateManager implements StateManager {
     private final Map<TopicPartition, Long> checkpointedOffsets;
     private final Map<String, StateRestoreCallback> restoreCallbacks; // used for standby tasks, keyed by state topic name
     private final Map<String, String> storeToChangelogTopic;
+    private final List<TopicPartition> changelogPartitions = new ArrayList<>();
 
     // TODO: this map does not work with customized grouper where multiple partitions
     // of the same topic can be assigned to the same topic.
@@ -77,9 +77,8 @@ public class ProcessorStateManager implements StateManager {
                                  final StateDirectory stateDirectory,
                                  final Map<String, String> storeToChangelogTopic,
                                  final ChangelogReader changelogReader,
-                                 final boolean eosEnabled) throws LockException, IOException {
+                                 final boolean eosEnabled) throws IOException {
         this.taskId = taskId;
-        this.stateDirectory = stateDirectory;
         this.changelogReader = changelogReader;
         logPrefix = String.format("task [%s]", taskId);
 
@@ -95,10 +94,6 @@ public class ProcessorStateManager implements StateManager {
         restoreCallbacks = isStandby ? new HashMap<String, StateRestoreCallback>() : null;
         this.storeToChangelogTopic = storeToChangelogTopic;
 
-        if (!stateDirectory.lock(taskId, 5)) {
-            throw new LockException(String.format("%s Failed to lock the state directory for task %s",
-                logPrefix, taskId));
-        }
         // get a handle on the parent/base directory of the task directory
         // note that the parent directory could have been accidentally deleted here,
         // so catch that exception if that is the case
@@ -178,8 +173,10 @@ public class ProcessorStateManager implements StateManager {
                                                              offsetLimit(storePartition),
                                                              store.persistent(),
                                                              store.name());
+
             changelogReader.register(restorer);
         }
+        changelogPartitions.add(storePartition);
 
         stores.put(store.name(), store);
     }
@@ -279,38 +276,26 @@ public class ProcessorStateManager implements StateManager {
     @Override
     public void close(final Map<TopicPartition, Long> ackedOffsets) throws ProcessorStateException {
         RuntimeException firstException = null;
-        try {
-            // attempting to close the stores, just in case they
-            // are not closed by a ProcessorNode yet
-            if (!stores.isEmpty()) {
-                log.debug("{} Closing its state manager and all the registered state stores", logPrefix);
-                for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
-                    log.debug("{} Closing storage engine {}", logPrefix, entry.getKey());
-                    try {
-                        entry.getValue().close();
-                    } catch (final Exception e) {
-                        if (firstException == null) {
-                            firstException = new ProcessorStateException(String.format("%s Failed to close state store %s", logPrefix, entry.getKey()), e);
-                        }
-                        log.error("{} Failed to close state store {}: ", logPrefix, entry.getKey(), e);
+        // attempting to close the stores, just in case they
+        // are not closed by a ProcessorNode yet
+        if (!stores.isEmpty()) {
+            log.debug("{} Closing its state manager and all the registered state stores", logPrefix);
+            for (final Map.Entry<String, StateStore> entry : stores.entrySet()) {
+                log.debug("{} Closing storage engine {}", logPrefix, entry.getKey());
+                try {
+                    entry.getValue().close();
+                } catch (final Exception e) {
+                    if (firstException == null) {
+                        firstException = new ProcessorStateException(String.format("%s Failed to close state store %s", logPrefix, entry.getKey()), e);
                     }
+                    log.error("{} Failed to close state store {}: ", logPrefix, entry.getKey(), e);
                 }
-
-                if (ackedOffsets != null) {
-                    checkpoint(ackedOffsets);
-                }
-
             }
-        } finally {
-            // release the state directory directoryLock
-            try {
-                stateDirectory.unlock(taskId);
-            } catch (final IOException e) {
-                if (firstException == null) {
-                    firstException = new ProcessorStateException(String.format("%s Failed to release state dir lock", logPrefix), e);
-                }
-                log.error("{} Failed to release state dir lock: ", logPrefix, e);
+
+            if (ackedOffsets != null) {
+                checkpoint(ackedOffsets);
             }
+
         }
 
         if (firstException != null) {
@@ -372,5 +357,9 @@ public class ProcessorStateManager implements StateManager {
         }
 
         return new WrappedBatchingStateRestoreCallback(callback);
+    }
+
+    Collection<TopicPartition> changelogPartitions() {
+        return changelogPartitions;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -119,6 +119,9 @@ public class StandbyTask extends AbstractTask {
      */
     @Override
     public void close(final boolean clean) {
+        if (!taskInitialized) {
+            return;
+        }
         log.debug("{} Closing", logPrefix);
         boolean committedSuccessfully = false;
         try {
@@ -178,6 +181,7 @@ public class StandbyTask extends AbstractTask {
         initializeStateStores();
         checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
         processorContext.initialized();
+        taskInitialized = true;
         return true;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ import java.util.Map;
 public class StandbyTask extends AbstractTask {
 
     private static final Logger log = LoggerFactory.getLogger(StandbyTask.class);
-    private final Map<TopicPartition, Long> checkpointedOffsets;
+    private Map<TopicPartition, Long> checkpointedOffsets = new HashMap<>();
 
     /**
      * Create {@link StandbyTask} with its assigned partitions
@@ -63,11 +64,6 @@ public class StandbyTask extends AbstractTask {
 
         // initialize the topology with its own context
         processorContext = new StandbyContextImpl(id, applicationId, config, stateMgr, metrics);
-
-        log.debug("{} Initializing", logPrefix);
-        initializeStateStores();
-        processorContext.initialized();
-        checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
     }
 
     /**
@@ -135,7 +131,7 @@ public class StandbyTask extends AbstractTask {
 
     @Override
     public void closeSuspended(final boolean clean, final RuntimeException e) {
-        throw new UnsupportedOperationException("closeSuspended not supported by StandbyTask");
+        close(clean);
     }
 
     @Override
@@ -166,7 +162,7 @@ public class StandbyTask extends AbstractTask {
 
     @Override
     public int addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
-        throw new UnsupportedOperationException("addRecords not supported by StandbyTask");
+        throw new UnsupportedOperationException("add records not supported by StandbyTasks");
     }
 
     public Map<TopicPartition, Long> checkpointedOffsets() {
@@ -175,7 +171,14 @@ public class StandbyTask extends AbstractTask {
 
     @Override
     public boolean process() {
-        throw new UnsupportedOperationException("process not supported by StandbyTask");
+        throw new UnsupportedOperationException("process not supported by StandbyTasks");
+    }
+
+    public boolean initialize() {
+        initializeStateStores();
+        checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
+        processorContext.initialized();
+        return true;
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -112,4 +112,8 @@ public class StateRestorer {
     private Long readTo(final long endOffset) {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
     }
+
+    String storeName() {
+        return storeName;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -113,7 +113,4 @@ public class StateRestorer {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
     }
 
-    String storeName() {
-        return storeName;
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -30,10 +30,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -48,6 +48,9 @@ public class StoreChangelogReader implements ChangelogReader {
     private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
     private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
     private final StateRestoreListener stateRestoreListener;
+    private final Map<TopicPartition, StateRestorer> needsRestoring = new HashMap<>();
+    private final Map<TopicPartition, Long> endOffsets = new HashMap<>();
+    private boolean initialized = false;
 
     public StoreChangelogReader(final String threadId, final Consumer<byte[], byte[]> consumer, final Time time,
                                 final long partitionValidationTimeoutMs, final StateRestoreListener stateRestoreListener) {
@@ -98,72 +101,88 @@ public class StoreChangelogReader implements ChangelogReader {
 
     @Override
     public void register(final StateRestorer restorer) {
-        if (restorer.offsetLimit() > 0) {
-            restorer.setGlobalRestoreListener(stateRestoreListener);
-            stateRestorers.put(restorer.partition(), restorer);
-        }
+        restorer.setGlobalRestoreListener(stateRestoreListener);
+        stateRestorers.put(restorer.partition(), restorer);
     }
 
-    public void restore() {
-        final long start = time.milliseconds();
-        final Map<TopicPartition, StateRestorer> needsRestoring = new HashMap<>();
-        try {
-            if (!consumer.subscription().isEmpty()) {
-                throw new IllegalStateException(String.format("Restore consumer should have not subscribed to any partitions (%s) beforehand", consumer.subscription()));
-            }
-            final Map<TopicPartition, Long> endOffsets = consumer.endOffsets(stateRestorers.keySet());
 
-            // remove any partitions where we already have all of the data
-            for (final Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
-                TopicPartition topicPartition = entry.getKey();
-                Long offset = entry.getValue();
-                final StateRestorer restorer = stateRestorers.get(topicPartition);
-                if (restorer.checkpoint() >= offset) {
-                    restorer.setRestoredOffset(restorer.checkpoint());
-                } else {
-                    needsRestoring.put(topicPartition, restorer);
-                    final Long endOffset = endOffsets.get(topicPartition);
-                    restorer.restoreStarted(restorer.startingOffset(), endOffset);
-                }
-            }
-
-            log.debug("{} Starting restoring state stores from changelog topics {}", logPrefix, needsRestoring.keySet());
-
-            consumer.assign(needsRestoring.keySet());
-            final List<StateRestorer> needsPositionUpdate = new ArrayList<>();
-            for (final StateRestorer restorer : needsRestoring.values()) {
-                if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
-                    consumer.seek(restorer.partition(), restorer.checkpoint());
-                    logRestoreOffsets(restorer.partition(),
-                                      restorer.checkpoint(),
-                                      endOffsets.get(restorer.partition()));
-                    restorer.setStartingOffset(consumer.position(restorer.partition()));
-                } else {
-                    consumer.seekToBeginning(Collections.singletonList(restorer.partition()));
-                    needsPositionUpdate.add(restorer);
-                }
-            }
-
-            for (final StateRestorer restorer : needsPositionUpdate) {
-                final long position = consumer.position(restorer.partition());
-                restorer.setStartingOffset(position);
-                logRestoreOffsets(restorer.partition(),
-                                  position,
-                                  endOffsets.get(restorer.partition()));
-            }
-
-            final Set<TopicPartition> partitions = new HashSet<>(needsRestoring.keySet());
-            while (!partitions.isEmpty()) {
-                final ConsumerRecords<byte[], byte[]> allRecords = consumer.poll(10);
-                final Iterator<TopicPartition> partitionIterator = partitions.iterator();
-                while (partitionIterator.hasNext()) {
-                    restorePartition(endOffsets, allRecords, partitionIterator);
-                }
-            }
-        } finally {
-            consumer.assign(Collections.<TopicPartition>emptyList());
-            log.info("{} Completed restore all active states from changelog topics {} in {}ms ", logPrefix, needsRestoring.keySet(), time.milliseconds() - start);
+    public Collection<TopicPartition> restore() {
+        final List<TopicPartition> completed = new ArrayList<>();
+        if (!initialized) {
+            completed.addAll(initialize());
         }
+
+        if (needsRestoring.isEmpty()) {
+            consumer.assign(Collections.<TopicPartition>emptyList());
+            return completed;
+        }
+
+        final Set<TopicPartition> partitions = new HashSet<>(needsRestoring.keySet());
+        final ConsumerRecords<byte[], byte[]> allRecords = consumer.poll(10);
+        for (final TopicPartition partition : partitions) {
+            if (restorePartition(allRecords, partition)) {
+                completed.add(partition);
+            }
+        }
+
+        if (needsRestoring.isEmpty()) {
+            consumer.assign(Collections.<TopicPartition>emptyList());
+        }
+        return completed;
+    }
+
+    private Collection<TopicPartition> initialize() {
+        needsRestoring.clear();
+        if (!consumer.subscription().isEmpty()) {
+            throw new IllegalStateException(String.format("Restore consumer should have not subscribed to any partitions (%s) beforehand", consumer.subscription()));
+        }
+        endOffsets.putAll(consumer.endOffsets(stateRestorers.keySet()));
+
+        // remove any partitions where we already have all of the data
+        for (final Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
+            TopicPartition topicPartition = entry.getKey();
+            Long offset = entry.getValue();
+            final StateRestorer restorer = stateRestorers.get(topicPartition);
+            if (restorer.checkpoint() >= offset) {
+                restorer.setRestoredOffset(restorer.checkpoint());
+            } else if (restorer.offsetLimit() == 0) {
+                restorer.setRestoredOffset(0);
+            } else {
+                needsRestoring.put(topicPartition, restorer);
+                final Long endOffset = endOffsets.get(topicPartition);
+                restorer.restoreStarted(restorer.startingOffset(), endOffset);
+            }
+        }
+
+        log.debug("{} Starting restoring state stores from changelog topics {}", logPrefix, needsRestoring.keySet());
+
+        consumer.assign(needsRestoring.keySet());
+        final List<StateRestorer> needsPositionUpdate = new ArrayList<>();
+        for (final StateRestorer restorer : needsRestoring.values()) {
+            if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
+                consumer.seek(restorer.partition(), restorer.checkpoint());
+                logRestoreOffsets(restorer.partition(),
+                                  restorer.checkpoint(),
+                                  endOffsets.get(restorer.partition()));
+                restorer.setStartingOffset(consumer.position(restorer.partition()));
+            } else {
+                consumer.seekToBeginning(Collections.singletonList(restorer.partition()));
+                needsPositionUpdate.add(restorer);
+            }
+        }
+
+        for (final StateRestorer restorer : needsPositionUpdate) {
+            final long position = consumer.position(restorer.partition());
+            restorer.setStartingOffset(position);
+            logRestoreOffsets(restorer.partition(),
+                              position,
+                              endOffsets.get(restorer.partition()));
+        }
+
+        final Set<TopicPartition> completed = new HashSet<>(stateRestorers.keySet());
+        completed.removeAll(needsRestoring.keySet());
+        initialized = true;
+        return completed;
     }
 
     private void logRestoreOffsets(final TopicPartition partition, final long startingOffset, final Long endOffset) {
@@ -187,18 +206,20 @@ public class StoreChangelogReader implements ChangelogReader {
     }
 
     @Override
-    public void clear() {
+    public void reset() {
         partitionInfo.clear();
         stateRestorers.clear();
+        needsRestoring.clear();
+        endOffsets.clear();
+        initialized = false;
     }
 
-    private void restorePartition(final Map<TopicPartition, Long> endOffsets,
-                                  final ConsumerRecords<byte[], byte[]> allRecords,
-                                  final Iterator<TopicPartition> partitionIterator) {
-        final TopicPartition topicPartition = partitionIterator.next();
+    private boolean restorePartition(final ConsumerRecords<byte[], byte[]> allRecords,
+                                    final TopicPartition topicPartition) {
         final StateRestorer restorer = stateRestorers.get(topicPartition);
         final Long endOffset = endOffsets.get(topicPartition);
         final long pos = processNext(allRecords.records(topicPartition), restorer, endOffset);
+        restorer.setRestoredOffset(pos);
         if (restorer.hasCompleted(pos, endOffset)) {
             if (pos > endOffset + 1) {
                 throw new IllegalStateException(
@@ -208,19 +229,18 @@ public class StoreChangelogReader implements ChangelogReader {
                                       pos));
             }
 
-            restorer.setRestoredOffset(pos);
-
             log.debug("{} Completed restoring state from changelog {} with {} records ranging from offset {} to {}",
-                    logPrefix,
-                    topicPartition,
-                    restorer.restoredNumRecords(),
-                    restorer.startingOffset(),
-                    restorer.restoredOffset());
+                      logPrefix,
+                      topicPartition,
+                      restorer.restoredNumRecords(),
+                      restorer.startingOffset(),
+                      restorer.restoredOffset());
 
             restorer.restoreDone();
-
-            partitionIterator.remove();
+            needsRestoring.remove(topicPartition);
+            return true;
         }
+        return false;
     }
 
     private long processNext(final List<ConsumerRecord<byte[], byte[]>> records,

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -145,16 +145,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
         partitionGroup = new PartitionGroup(partitionQueues);
         this.time = time;
-        log.debug("{} Initializing", logPrefix);
-        initializeStateStores();
+
         stateMgr.registerGlobalStateStores(topology.globalStateStores());
         if (eosEnabled) {
             this.producer.initTransactions();
             this.producer.beginTransaction();
             transactionInFlight = true;
         }
-        initTopology();
-        processorContext.initialized();
     }
 
     /**
@@ -331,7 +328,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         }
     }
 
-    private void initTopology() {
+    void initTopology() {
         // initialize the task by initializing all its processor nodes in the topology
         log.trace("{} Initializing processor nodes of the topology", logPrefix);
         for (final ProcessorNode node : topology.processors()) {
@@ -590,6 +587,13 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     // visible for testing only
     RecordCollector createRecordCollector() {
         return new RecordCollectorImpl(producer, id.toString());
+    }
+
+    public boolean initialize() {
+        initializeStateStores();
+        initTopology();
+        processorContext.initialized();
+        return topology.stateStores().isEmpty();
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -381,14 +381,16 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         // close the processors
         // make sure close() is called for each node even when there is a RuntimeException
         RuntimeException exception = null;
-        for (final ProcessorNode node : topology.processors()) {
-            processorContext.setCurrentNode(node);
-            try {
-                node.close();
-            } catch (final RuntimeException e) {
-                exception = e;
-            } finally {
-                processorContext.setCurrentNode(null);
+        if (taskInitialized) {
+            for (final ProcessorNode node : topology.processors()) {
+                processorContext.setCurrentNode(node);
+                try {
+                    node.close();
+                } catch (final RuntimeException e) {
+                    exception = e;
+                } finally {
+                    processorContext.setCurrentNode(null);
+                }
             }
         }
 
@@ -593,6 +595,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         initializeStateStores();
         initTopology();
         processorContext.initialized();
+        taskInitialized = true;
         return topology.stateStores().isEmpty();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -592,6 +592,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     }
 
     public boolean initialize() {
+        log.debug("{} Initializing", logPrefix);
         initializeStateStores();
         initTopology();
         processorContext.initialized();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -1096,23 +1096,7 @@ public class StreamThread extends Thread implements ThreadDataProvider {
             .append(indent).append("\tStreamsThread clientId: ").append(clientId).append("\n")
             .append(indent).append("\tStreamsThread threadId: ").append(getName()).append("\n");
 
-        // iterate and print active tasks
-        final TaskAction printAction = new TaskAction() {
-            @Override
-            public String name() {
-                return "print";
-            }
-
-            @Override
-            public void apply(final Task task) {
-                sb.append(indent).append(task.toString(indent + "\t\t"));
-            }
-        };
-
-        sb.append(indent).append("\tActive tasks:\n");
-        taskManager.performOnActiveTasks(printAction, false);
-        sb.append(indent).append("\tStandby tasks:\n");
-        taskManager.performOnStandbyTasks(printAction, false);
+        sb.append(taskManager.toString(indent));
         return sb.toString();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Task.java
@@ -22,6 +22,7 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,4 +65,17 @@ public interface Task {
     String toString(String indent);
 
     int addRecords(TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records);
+
+    boolean hasStateStores();
+
+    /**
+     * initialize the task and return true if the task is ready to run, i.e, it has not state stores
+     * @return true if this task has no state stores that may need restoring.
+     */
+    boolean initialize();
+
+    /**
+     * @return any changelog partitions associated with this task
+     */
+    Collection<TopicPartition> changelogPartitions();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskAction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskAction.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+interface TaskAction {
+    String name();
+    void apply(final Task task);
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -254,10 +254,6 @@ class TaskManager {
         this.consumer = consumer;
     }
 
-    void closeProducer() {
-        taskCreator.close();
-    }
-
 
     boolean updateNewAndRestoringTasks() {
         active.initializeNewTasks();
@@ -306,5 +302,13 @@ class TaskManager {
     void commitAll() {
         active.commit();
         standby.commit();
+    }
+
+    long process() {
+        return active.process();
+    }
+
+    void maybeCommitActiveTasks() {
+        active.maybeCommit();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -16,26 +16,18 @@
  */
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.ProducerFencedException;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.singleton;
@@ -45,15 +37,9 @@ class TaskManager {
     // activeTasks needs to be concurrent as it can be accessed
     // by QueryableState
     private static final Logger log = LoggerFactory.getLogger(TaskManager.class);
-    private final Map<TaskId, Task> activeTasks = new ConcurrentHashMap<>();
-    private final Map<TaskId, Task> standbyTasks = new HashMap<>();
-    private final Map<TopicPartition, Task> activeTasksByPartition = new HashMap<>();
-    private final Map<TopicPartition, Task> standbyTasksByPartition = new HashMap<>();
-    private final Set<TaskId> prevActiveTasks = new TreeSet<>();
-    private final Map<TaskId, Task> suspendedTasks = new HashMap<>();
-    private final Map<TaskId, Task> suspendedStandbyTasks = new HashMap<>();
+    private final AssignedTasks active;
+    private final AssignedTasks standby;
     private final ChangelogReader changelogReader;
-    private final Time time;
     private final String logPrefix;
     private final Consumer<byte[], byte[]> restoreConsumer;
     private final StreamThread.AbstractTaskCreator taskCreator;
@@ -62,17 +48,19 @@ class TaskManager {
     private Consumer<byte[], byte[]> consumer;
 
     TaskManager(final ChangelogReader changelogReader,
-                final Time time,
                 final String logPrefix,
                 final Consumer<byte[], byte[]> restoreConsumer,
                 final StreamThread.AbstractTaskCreator taskCreator,
-                final StreamThread.AbstractTaskCreator standbyTaskCreator) {
+                final StreamThread.AbstractTaskCreator standbyTaskCreator,
+                final AssignedTasks active,
+                final AssignedTasks standby) {
         this.changelogReader = changelogReader;
-        this.time = time;
         this.logPrefix = logPrefix;
         this.restoreConsumer = restoreConsumer;
         this.taskCreator = taskCreator;
         this.standbyTaskCreator = standbyTaskCreator;
+        this.active = active;
+        this.standby = standby;
     }
 
     void createTasks(final Collection<TopicPartition> assignment) {
@@ -83,63 +71,28 @@ class TaskManager {
             throw new IllegalStateException(logPrefix + " consumer has not been initialized while adding stream tasks. This should not happen.");
         }
 
-        final long start = time.milliseconds();
-        changelogReader.clear();
+        changelogReader.reset();
         // do this first as we may have suspended standby tasks that
         // will become active or vice versa
-        closeNonAssignedSuspendedStandbyTasks();
+        standby.closeNonAssignedSuspendedTasks(threadMetadataProvider.standbyTasks());
         Map<TaskId, Set<TopicPartition>> assignedActiveTasks = threadMetadataProvider.activeTasks();
-        closeNonAssignedSuspendedTasks(assignedActiveTasks);
-        addStreamTasks(assignment, assignedActiveTasks, start);
-        changelogReader.restore();
-        addStandbyTasks(start);
+        active.closeNonAssignedSuspendedTasks(assignedActiveTasks);
+        addStreamTasks(assignment, assignedActiveTasks);
+        addStandbyTasks();
+        final Set<TopicPartition> partitions = active.uninitializedPartitions();
+        log.trace("{} pausing partitions: {}", logPrefix, partitions);
+        consumer.pause(partitions);
     }
 
     void setThreadMetadataProvider(final ThreadMetadataProvider threadMetadataProvider) {
         this.threadMetadataProvider = threadMetadataProvider;
     }
 
-    private void closeNonAssignedSuspendedStandbyTasks() {
-        final Set<TaskId> currentSuspendedTaskIds = threadMetadataProvider.standbyTasks().keySet();
-        final Iterator<Map.Entry<TaskId, Task>> standByTaskIterator = suspendedStandbyTasks.entrySet().iterator();
-        while (standByTaskIterator.hasNext()) {
-            final Map.Entry<TaskId, Task> suspendedTask = standByTaskIterator.next();
-            if (!currentSuspendedTaskIds.contains(suspendedTask.getKey())) {
-                final Task task = suspendedTask.getValue();
-                log.debug("{} Closing suspended and not re-assigned standby task {}", logPrefix, task.id());
-                try {
-                    task.close(true);
-                } catch (final Exception e) {
-                    log.error("{} Failed to remove suspended standby task {} due to the following error:", logPrefix, task.id(), e);
-                } finally {
-                    standByTaskIterator.remove();
-                }
-            }
-        }
-    }
-
-    private void closeNonAssignedSuspendedTasks(final Map<TaskId, Set<TopicPartition>> newTaskAssignment) {
-        final Iterator<Map.Entry<TaskId, Task>> suspendedTaskIterator = suspendedTasks.entrySet().iterator();
-        while (suspendedTaskIterator.hasNext()) {
-            final Map.Entry<TaskId, Task> next = suspendedTaskIterator.next();
-            final Task task = next.getValue();
-            final Set<TopicPartition> assignedPartitionsForTask = newTaskAssignment.get(next.getKey());
-            if (!task.partitions().equals(assignedPartitionsForTask)) {
-                log.debug("{} Closing suspended and not re-assigned task {}", logPrefix, task.id());
-                try {
-                    task.closeSuspended(true, null);
-                } catch (final Exception e) {
-                    log.error("{} Failed to close suspended task {} due to the following error:", logPrefix, next.getKey(), e);
-                } finally {
-                    suspendedTaskIterator.remove();
-                }
-            }
-        }
-    }
-
-    private void addStreamTasks(final Collection<TopicPartition> assignment, final Map<TaskId, Set<TopicPartition>> assignedTasks, final long start) {
+    private void addStreamTasks(final Collection<TopicPartition> assignment, final Map<TaskId, Set<TopicPartition>> assignedTasks) {
         final Map<TaskId, Set<TopicPartition>> newTasks = new HashMap<>();
-
+        if (assignedTasks.isEmpty()) {
+            return;
+        }
         // collect newly assigned tasks and reopen re-assigned tasks
         log.debug("{} Adding assigned tasks as active: {}", logPrefix, assignedTasks);
         for (final Map.Entry<TaskId, Set<TopicPartition>> entry : assignedTasks.entrySet()) {
@@ -148,17 +101,7 @@ class TaskManager {
 
             if (assignment.containsAll(partitions)) {
                 try {
-                    final Task task = findMatchingSuspendedTask(taskId, partitions);
-                    if (task != null) {
-                        suspendedTasks.remove(taskId);
-                        task.resume();
-
-                        activeTasks.put(taskId, task);
-
-                        for (final TopicPartition partition : partitions) {
-                            activeTasksByPartition.put(partition, task);
-                        }
-                    } else {
+                    if (!active.maybeResumeSuspendedTask(taskId, partitions)) {
                         newTasks.put(taskId, partitions);
                     }
                 } catch (final StreamsException e) {
@@ -170,135 +113,59 @@ class TaskManager {
             }
         }
 
+        if (newTasks.isEmpty()) {
+            return;
+        }
+
         // create all newly assigned tasks (guard against race condition with other thread via backoff and retry)
         // -> other thread will call removeSuspendedTasks(); eventually
         log.trace("{} New active tasks to be created: {}", logPrefix, newTasks);
 
-        if (!newTasks.isEmpty()) {
-            final Map<Task, Set<TopicPartition>> createdTasks = taskCreator.retryWithBackoff(consumer, newTasks, start);
-            for (final Map.Entry<Task, Set<TopicPartition>> entry : createdTasks.entrySet()) {
-                final Task task = entry.getKey();
-                activeTasks.put(task.id(), task);
-                for (final TopicPartition partition : entry.getValue()) {
-                    activeTasksByPartition.put(partition, task);
-                }
-            }
+        for (final Task task : taskCreator.createTasks(consumer, newTasks)) {
+            active.addNewTask(task);
         }
     }
 
-    private void addStandbyTasks(final long start) {
-        final Map<TopicPartition, Long> checkpointedOffsets = new HashMap<>();
-
-        final Map<TaskId, Set<TopicPartition>> newStandbyTasks = new HashMap<>();
-
-        Map<TaskId, Set<TopicPartition>> assignedStandbyTasks = threadMetadataProvider.standbyTasks();
+    private void addStandbyTasks() {
+        final Map<TaskId, Set<TopicPartition>> assignedStandbyTasks = threadMetadataProvider.standbyTasks();
+        if (assignedStandbyTasks.isEmpty()) {
+            return;
+        }
         log.debug("{} Adding assigned standby tasks {}", logPrefix, assignedStandbyTasks);
+        final Map<TaskId, Set<TopicPartition>> newStandbyTasks = new HashMap<>();
         // collect newly assigned standby tasks and reopen re-assigned standby tasks
         for (final Map.Entry<TaskId, Set<TopicPartition>> entry : assignedStandbyTasks.entrySet()) {
             final TaskId taskId = entry.getKey();
             final Set<TopicPartition> partitions = entry.getValue();
-            final Task task = findMatchingSuspendedStandbyTask(taskId, partitions);
-
-            if (task != null) {
-                suspendedStandbyTasks.remove(taskId);
-                task.resume();
-            } else {
+            if (!standby.maybeResumeSuspendedTask(taskId, partitions)) {
                 newStandbyTasks.put(taskId, partitions);
             }
 
-            updateStandByTasks(checkpointedOffsets, taskId, partitions, task);
+        }
+
+        if (newStandbyTasks.isEmpty()) {
+            return;
         }
 
         // create all newly assigned standby tasks (guard against race condition with other thread via backoff and retry)
         // -> other thread will call removeSuspendedStandbyTasks(); eventually
         log.trace("{} New standby tasks to be created: {}", logPrefix, newStandbyTasks);
-        if (!newStandbyTasks.isEmpty()) {
-            final Map<Task, Set<TopicPartition>> createdStandbyTasks = standbyTaskCreator.retryWithBackoff(consumer, newStandbyTasks, start);
-            for (Map.Entry<Task, Set<TopicPartition>> entry : createdStandbyTasks.entrySet()) {
-                final Task task = entry.getKey();
-                updateStandByTasks(checkpointedOffsets, task.id(), entry.getValue(), task);
-            }
+
+        for (final Task task : standbyTaskCreator.createTasks(consumer, newStandbyTasks)) {
+            standby.addNewTask(task);
         }
-
-        restoreConsumer.assign(checkpointedOffsets.keySet());
-
-        for (final Map.Entry<TopicPartition, Long> entry : checkpointedOffsets.entrySet()) {
-            final TopicPartition partition = entry.getKey();
-            final long offset = entry.getValue();
-            if (offset >= 0) {
-                restoreConsumer.seek(partition, offset);
-            } else {
-                restoreConsumer.seekToBeginning(singleton(partition));
-            }
-        }
-    }
-
-    private void updateStandByTasks(final Map<TopicPartition, Long> checkpointedOffsets,
-                                    final TaskId taskId,
-                                    final Set<TopicPartition> partitions,
-                                    final Task task) {
-        if (task != null) {
-            standbyTasks.put(taskId, task);
-            for (final TopicPartition partition : partitions) {
-                standbyTasksByPartition.put(partition, task);
-            }
-            // collect checked pointed offsets to position the restore consumer
-            // this include all partitions from which we restore states
-            for (final TopicPartition partition : task.checkpointedOffsets().keySet()) {
-                standbyTasksByPartition.put(partition, task);
-            }
-            checkpointedOffsets.putAll(task.checkpointedOffsets());
-        }
-    }
-
-    List<Task> allTasks() {
-        final List<Task> tasks = activeAndStandbytasks();
-        tasks.addAll(suspendedAndSuspendedStandbytasks());
-        return tasks;
-    }
-
-    private List<Task> activeAndStandbytasks() {
-        final List<Task> tasks = new ArrayList<>(activeTasks.values());
-        tasks.addAll(standbyTasks.values());
-        return tasks;
-    }
-
-    private List<Task> suspendedAndSuspendedStandbytasks() {
-        final List<Task> tasks = new ArrayList<>(suspendedTasks.values());
-        tasks.addAll(suspendedStandbyTasks.values());
-        return tasks;
-    }
-
-    private Task findMatchingSuspendedTask(final TaskId taskId, final Set<TopicPartition> partitions) {
-        if (suspendedTasks.containsKey(taskId)) {
-            final Task task = suspendedTasks.get(taskId);
-            if (task.partitions().equals(partitions)) {
-                return task;
-            }
-        }
-        return null;
-    }
-
-    private Task findMatchingSuspendedStandbyTask(final TaskId taskId, final Set<TopicPartition> partitions) {
-        if (suspendedStandbyTasks.containsKey(taskId)) {
-            final Task task = suspendedStandbyTasks.get(taskId);
-            if (task.partitions().equals(partitions)) {
-                return task;
-            }
-        }
-        return null;
     }
 
     Set<TaskId> activeTaskIds() {
-        return Collections.unmodifiableSet(activeTasks.keySet());
+        return active.allAssignedTaskIds();
     }
 
     Set<TaskId> standbyTaskIds() {
-        return Collections.unmodifiableSet(standbyTasks.keySet());
+        return standby.allAssignedTaskIds();
     }
 
     Set<TaskId> prevActiveTaskIds() {
-        return Collections.unmodifiableSet(prevActiveTasks);
+        return active.previousTaskIds();
     }
 
     /**
@@ -307,57 +174,14 @@ class TaskManager {
      */
     void suspendTasksAndState()  {
         log.debug("{} Suspending all active tasks {} and standby tasks {}",
-                  logPrefix, activeTasks.keySet(), standbyTasks.keySet());
+                  logPrefix, active.runningTaskIds(), standby.runningTaskIds());
 
         final AtomicReference<RuntimeException> firstException = new AtomicReference<>(null);
 
-        firstException.compareAndSet(null, performOnActiveTasks(new TaskAction() {
-            @Override
-            public String name() {
-                return "suspend";
-            }
-
-            @Override
-            public void apply(final Task task) {
-                try {
-                    task.suspend();
-                } catch (final CommitFailedException e) {
-                    // commit failed during suspension. Just log it.
-                    log.warn("{} Failed to commit task {} state when suspending due to CommitFailedException", logPrefix, task.id());
-                } catch (final Exception e) {
-                    log.error("{} Suspending task {} failed due to the following error:", logPrefix, task.id(), e);
-                    try {
-                        task.close(false);
-                    } catch (final Exception f) {
-                        log.error("{} After suspending failed, closing the same task {} failed again due to the following error:", logPrefix, task.id(), f);
-                    }
-                    throw e;
-                }
-            }
-        }));
-
-        for (final Task task : standbyTasks.values()) {
-            try {
-                try {
-                    task.suspend();
-                } catch (final Exception e) {
-                    log.error("{} Suspending standby task {} failed due to the following error:", logPrefix, task.id(), e);
-                    try {
-                        task.close(false);
-                    } catch (final Exception f) {
-                        log.error("{} After suspending failed, closing the same standby task {} failed again due to the following error:", logPrefix, task.id(), f);
-                    }
-                    throw e;
-                }
-            } catch (final RuntimeException e) {
-                firstException.compareAndSet(null, e);
-            }
-        }
-
+        firstException.compareAndSet(null, active.suspend());
+        firstException.compareAndSet(null, standby.suspend());
         // remove the changelog partitions from restore consumer
         firstException.compareAndSet(null, unAssignChangeLogPartitions());
-
-        updateSuspendedTasks();
 
         if (firstException.get() != null) {
             throw new StreamsException(logPrefix + " failed to suspend stream tasks", firstException.get());
@@ -375,88 +199,25 @@ class TaskManager {
         return null;
     }
 
-    private void updateSuspendedTasks() {
-        suspendedTasks.clear();
-        suspendedTasks.putAll(activeTasks);
-        suspendedStandbyTasks.putAll(standbyTasks);
+    RuntimeException performOnActiveTasks(final TaskAction action, final boolean throwException) {
+        return performOnTasks(action, active, throwException);
     }
 
-    private void removeStreamTasks() {
-        log.debug("{} Removing all active tasks {}", logPrefix, activeTasks.keySet());
-
-        try {
-            prevActiveTasks.clear();
-            prevActiveTasks.addAll(activeTasks.keySet());
-
-            activeTasks.clear();
-            activeTasksByPartition.clear();
-        } catch (final Exception e) {
-            log.error("{} Failed to remove stream tasks due to the following error:", logPrefix, e);
-        }
+    RuntimeException performOnStandbyTasks(final TaskAction action, final boolean throwException) {
+        return performOnTasks(action, standby, throwException);
     }
 
-    void closeZombieTask(final Task task) {
-        log.warn("{} Producer of task {} fenced; closing zombie task", logPrefix, task.id());
-        try {
-            task.close(false);
-        } catch (final Exception e) {
-            log.warn("{} Failed to close zombie task due to {}, ignore and proceed", logPrefix, e);
-        }
-        activeTasks.remove(task.id());
+    private RuntimeException performOnTasks(final TaskAction action, final AssignedTasks assignedTasks, final boolean throwException) {
+        return assignedTasks.applyToRunningTasks(action, throwException);
     }
-
-
-    RuntimeException performOnActiveTasks(final TaskAction action) {
-        return performOnTasks(action, activeTasks, "stream task");
-    }
-
-    RuntimeException performOnStandbyTasks(final TaskAction action) {
-        return performOnTasks(action, standbyTasks, "standby task");
-    }
-
-    private RuntimeException performOnTasks(final TaskAction action, final Map<TaskId, Task> tasks, final String taskType) {
-        RuntimeException firstException = null;
-        final Iterator<Map.Entry<TaskId, Task>> it = tasks.entrySet().iterator();
-        while (it.hasNext()) {
-            final Task task = it.next().getValue();
-            try {
-                action.apply(task);
-            } catch (final ProducerFencedException e) {
-                closeZombieTask(task);
-                it.remove();
-            } catch (final RuntimeException t) {
-                log.error("{} Failed to {} " + taskType + " {} due to the following error:",
-                          logPrefix,
-                          action.name(),
-                          task.id(),
-                          t);
-                if (firstException == null) {
-                    firstException = t;
-                }
-            }
-        }
-
-        return firstException;
-    }
-
-
 
     void shutdown(final boolean clean) {
         log.debug("{} Shutting down all active tasks {}, standby tasks {}, suspended tasks {}, and suspended standby tasks {}",
-                  logPrefix, activeTasks.keySet(), standbyTasks.keySet(),
-                  suspendedTasks.keySet(), suspendedStandbyTasks.keySet());
+                  logPrefix, active.runningTaskIds(), standby.runningTaskIds(),
+                  active.previousTaskIds(), standby.previousTaskIds());
 
-        for (final Task task : allTasks()) {
-            try {
-                task.close(clean);
-            } catch (final RuntimeException e) {
-                log.error("{} Failed while closing {} {} due to the following error:",
-                          logPrefix,
-                          task.getClass().getSimpleName(),
-                          task.id(),
-                          e);
-            }
-        }
+        active.close(clean);
+        standby.close(clean);
         try {
             threadMetadataProvider.close();
         } catch (final Throwable e) {
@@ -468,57 +229,76 @@ class TaskManager {
     }
 
     Set<TaskId> suspendedActiveTaskIds() {
-        return Collections.unmodifiableSet(suspendedTasks.keySet());
+        return active.previousTaskIds();
     }
 
     Set<TaskId> suspendedStandbyTaskIds() {
-        return Collections.unmodifiableSet(suspendedStandbyTasks.keySet());
-    }
-
-    void removeTasks() {
-        removeStreamTasks();
-        removeStandbyTasks();
-    }
-
-    private void removeStandbyTasks() {
-        log.debug("{} Removing all standby tasks {}", logPrefix, standbyTasks.keySet());
-        standbyTasks.clear();
-        standbyTasksByPartition.clear();
+        return standby.previousTaskIds();
     }
 
     Task activeTask(final TopicPartition partition) {
-        return activeTasksByPartition.get(partition);
+        return active.runningTaskFor(partition);
     }
 
-    boolean hasStandbyTasks() {
-        return !standbyTasks.isEmpty();
-    }
 
     Task standbyTask(final TopicPartition partition) {
-        return standbyTasksByPartition.get(partition);
+        return standby.runningTaskFor(partition);
     }
 
-    public Map<TaskId, Task> activeTasks() {
-        return activeTasks;
-    }
-
-    boolean hasActiveTasks() {
-        return !activeTasks.isEmpty();
+    Map<TaskId, Task> activeTasks() {
+        return active.runningTaskMap();
     }
 
     void setConsumer(final Consumer<byte[], byte[]> consumer) {
         this.consumer = consumer;
     }
 
-    public void closeProducer() {
+    void closeProducer() {
         taskCreator.close();
     }
 
 
+    boolean updateNewAndRestoringTasks() {
+        active.initializeNewTasks();
+        standby.initializeNewTasks();
 
+        final Collection<TopicPartition> restored = changelogReader.restore();
+        final Set<TopicPartition> resumed = active.updateRestored(restored);
 
-    interface TaskAction {
-        String name();
-        void apply(final Task task);
+        if (!resumed.isEmpty()) {
+            log.trace("{} resuming partitions {}", logPrefix, resumed);
+            consumer.resume(resumed);
+        }
+        if (active.allTasksRunning()) {
+            assignStandbyPartitions();
+        }
+        return true;
+    }
+
+    boolean hasActiveRunningTasks() {
+        return active.hasRunningTasks();
+    }
+
+    boolean readyToProcessStandbyTasks() {
+        return standby.hasRunningTasks();
+    }
+
+    private void assignStandbyPartitions() {
+        final Collection<Task> running = standby.running();
+        final Map<TopicPartition, Long> checkpointedOffsets = new HashMap<>();
+        for (final Task standbyTask : running) {
+            checkpointedOffsets.putAll(standbyTask.checkpointedOffsets());
+        }
+
+        restoreConsumer.assign(checkpointedOffsets.keySet());
+        for (final Map.Entry<TopicPartition, Long> entry : checkpointedOffsets.entrySet()) {
+            final TopicPartition partition = entry.getKey();
+            final long offset = entry.getValue();
+            if (offset >= 0) {
+                restoreConsumer.seek(partition, offset);
+            } else {
+                restoreConsumer.seekToBeginning(singleton(partition));
+            }
+        }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -225,6 +225,7 @@ class TaskManager {
         }
         // remove the changelog partitions from restore consumer
         unAssignChangeLogPartitions();
+        taskCreator.close();
 
     }
 
@@ -300,5 +301,10 @@ class TaskManager {
                 restoreConsumer.seekToBeginning(singleton(partition));
             }
         }
+    }
+
+    void commitAll() {
+        active.commit();
+        standby.commit();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -199,18 +199,6 @@ class TaskManager {
         return null;
     }
 
-    RuntimeException performOnActiveTasks(final TaskAction action, final boolean throwException) {
-        return performOnTasks(action, active, throwException);
-    }
-
-    RuntimeException performOnStandbyTasks(final TaskAction action, final boolean throwException) {
-        return performOnTasks(action, standby, throwException);
-    }
-
-    private RuntimeException performOnTasks(final TaskAction action, final AssignedTasks assignedTasks, final boolean throwException) {
-        return assignedTasks.applyToRunningTasks(action, throwException);
-    }
-
     void shutdown(final boolean clean) {
         log.debug("{} Shutting down all active tasks {}, standby tasks {}, suspended tasks {}, and suspended standby tasks {}",
                   logPrefix, active.runningTaskIds(), standby.runningTaskIds(),
@@ -314,5 +302,14 @@ class TaskManager {
 
     int maybeCommitActiveTasks() {
         return active.maybeCommit();
+    }
+
+    public String toString(final String indent) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(indent).append("\tActive tasks:\n");
+        builder.append(active.toString(indent + "\t\t"));
+        builder.append(indent).append("\tStandby tasks:\n");
+        builder.append(standby.toString(indent + "\t\t"));
+        return builder.toString();
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -299,16 +299,20 @@ class TaskManager {
         }
     }
 
-    void commitAll() {
-        active.commit();
-        standby.commit();
+    int commitAll() {
+        int committed = active.commit();
+        return committed + standby.commit();
     }
 
-    long process() {
+    int process() {
         return active.process();
     }
 
-    void maybeCommitActiveTasks() {
-        active.maybeCommit();
+    int punctuate() {
+        return active.punctuate();
+    }
+
+    int maybeCommitActiveTasks() {
+        return active.maybeCommit();
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -478,7 +478,7 @@ public class KafkaStreamsTest {
         CLUSTER.createTopic(topic);
         final StreamsBuilder builder = new StreamsBuilder();
 
-        builder.stream(Serdes.String(), Serdes.String(), topic);
+        builder.table(Serdes.String(), Serdes.String(), topic, topic);
 
         final KafkaStreams streams = new KafkaStreams(builder.build(), props);
         final CountDownLatch latch = new CountDownLatch(1);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -133,7 +133,7 @@ public class ResetIntegrationTest {
     public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
         CLUSTER.createTopic(INTERMEDIATE_USER_TOPIC);
 
-        final Properties streamsConfiguration = prepareTest();
+        final Properties streamsConfiguration = prepareTest(4);
         final Properties resultTopicConsumerConfig = TestUtils.consumerConfig(
             CLUSTER.bootstrapServers(),
             APP_ID + "-standard-consumer-" + OUTPUT_TOPIC,
@@ -199,7 +199,7 @@ public class ResetIntegrationTest {
 
     @Test
     public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
-        final Properties streamsConfiguration = prepareTest();
+        final Properties streamsConfiguration = prepareTest(1);
         final Properties resultTopicConsumerConfig = TestUtils.consumerConfig(
                 CLUSTER.bootstrapServers(),
                 APP_ID + "-standard-consumer-" + OUTPUT_TOPIC,
@@ -242,14 +242,14 @@ public class ResetIntegrationTest {
         cleanGlobal(null);
     }
 
-    private Properties prepareTest() throws Exception {
+    private Properties prepareTest(final int threads) throws Exception {
         final Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, APP_ID + testNo);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
         streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
         streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 4);
+        streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, threads);
         streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
         streamsConfiguration.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.integration;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
+
+@Category({IntegrationTest.class})
+public class RestoreIntegrationTest {
+    private static final int NUM_BROKERS = 1;
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER =
+            new EmbeddedKafkaCluster(NUM_BROKERS);
+    private final String inputStream = "input-stream";
+    private final int numberOfKeys = 10000;
+    private KafkaStreams kafkaStreams;
+    private String applicationId = "restore-test";
+
+
+    private void createTopics() throws InterruptedException {
+        CLUSTER.createTopic(inputStream, 2, 1);
+    }
+
+    @Before
+    public void before() throws IOException, InterruptedException {
+        createTopics();
+    }
+
+    private Properties props() {
+        Properties streamsConfiguration = new Properties();
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory(applicationId).getPath());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Integer().getClass());
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
+        return streamsConfiguration;
+    }
+
+    @After
+    public void shutdown() throws IOException {
+        if (kafkaStreams != null) {
+            kafkaStreams.close(30, TimeUnit.SECONDS);
+        }
+    }
+
+
+    @Test
+    public void shouldRestoreState() throws ExecutionException, InterruptedException {
+        final AtomicInteger numReceived = new AtomicInteger(0);
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        createStateForRestoration();
+
+        builder.table(Serdes.Integer(), Serdes.Integer(), inputStream, "store")
+                .toStream()
+                .foreach(new ForeachAction<Integer, Integer>() {
+                    @Override
+                    public void apply(final Integer key, final Integer value) {
+                        numReceived.incrementAndGet();
+                    }
+                });
+
+
+        final CountDownLatch startupLatch = new CountDownLatch(1);
+        kafkaStreams = new KafkaStreams(builder.build(), props());
+        kafkaStreams.setStateListener(new KafkaStreams.StateListener() {
+            @Override
+            public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
+                if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
+                    startupLatch.countDown();
+                }
+            }
+        });
+
+        final AtomicLong restored = new AtomicLong(0);
+        kafkaStreams.setGlobalStateRestoreListener(new StateRestoreListener() {
+            @Override
+            public void onRestoreStart(final TopicPartition topicPartition, final String storeName, final long startingOffset, final long endingOffset) {
+
+            }
+
+            @Override
+            public void onBatchRestored(final TopicPartition topicPartition, final String storeName, final long batchEndOffset, final long numRestored) {
+
+            }
+
+            @Override
+            public void onRestoreEnd(final TopicPartition topicPartition, final String storeName, final long totalRestored) {
+                restored.addAndGet(totalRestored);
+            }
+        });
+        kafkaStreams.start();
+
+        assertTrue(startupLatch.await(30, TimeUnit.SECONDS));
+        assertThat(restored.get(), equalTo((long)numberOfKeys));
+        assertThat(numReceived.get(), equalTo(0));
+    }
+
+
+    private void createStateForRestoration()
+            throws ExecutionException, InterruptedException {
+        final Properties producerConfig = new Properties();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+
+        try (final KafkaProducer<Integer, Integer> producer =
+                     new KafkaProducer<>(producerConfig, new IntegerSerializer(), new IntegerSerializer())) {
+
+            for (int i = 0; i < numberOfKeys; i++) {
+                producer.send(new ProducerRecord<>(inputStream, i, i));
+            }
+        }
+
+        final Properties consumerConfig = new Properties();
+        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, applicationId);
+        consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+
+        final Consumer consumer  = new KafkaConsumer(consumerConfig);
+        final List<TopicPartition> partitions = Arrays.asList(new TopicPartition(inputStream, 0),
+                                                        new TopicPartition(inputStream, 1));
+
+        consumer.assign(partitions);
+        consumer.seekToEnd(partitions);
+
+        final Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        for (TopicPartition partition : partitions) {
+            final long position = consumer.position(partition);
+            offsets.put(partition, new OffsetAndMetadata(position + 1));
+        }
+
+        consumer.commitSync(offsets);
+        consumer.close();
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -147,7 +147,7 @@ public class RestoreIntegrationTest {
         kafkaStreams.start();
 
         assertTrue(startupLatch.await(30, TimeUnit.SECONDS));
-        assertThat(restored.get(), equalTo((long)numberOfKeys));
+        assertThat(restored.get(), equalTo((long) numberOfKeys));
         assertThat(numReceived.get(), equalTo(0));
     }
 
@@ -171,9 +171,9 @@ public class RestoreIntegrationTest {
         consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
         consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
 
-        final Consumer consumer  = new KafkaConsumer(consumerConfig);
+        final Consumer consumer = new KafkaConsumer(consumerConfig);
         final List<TopicPartition> partitions = Arrays.asList(new TopicPartition(inputStream, 0),
-                                                        new TopicPartition(inputStream, 1));
+                                                              new TopicPartition(inputStream, 1));
 
         consumer.assign(partitions);
         consumer.seekToEnd(partitions);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -25,63 +25,106 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.TestUtils;
+import org.easymock.EasyMock;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.junit.Assert.fail;
+
 public class AbstractTaskTest {
+
+    private final TaskId id = new TaskId(0, 0);
+    private StateDirectory stateDirectory  = EasyMock.createMock(StateDirectory.class);
+
+    @Before
+    public void before() {
+        EasyMock.expect(stateDirectory.directoryForTask(id)).andReturn(TestUtils.tempDirectory());
+    }
 
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenAuthorizationException() throws Exception {
         final Consumer consumer = mockConsumer(new AuthorizationException("blah"));
-        final AbstractTask task = createTask(consumer);
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
         task.updateOffsetLimits();
     }
 
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateExceptionOnInitializeOffsetsWhenKafkaException() throws Exception {
         final Consumer consumer = mockConsumer(new KafkaException("blah"));
-        final AbstractTask task = createTask(consumer);
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
         task.updateOffsetLimits();
     }
 
     @Test(expected = WakeupException.class)
     public void shouldThrowWakeupExceptionOnInitializeOffsetsWhenWakeupException() throws Exception {
         final Consumer consumer = mockConsumer(new WakeupException());
-        final AbstractTask task = createTask(consumer);
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
         task.updateOffsetLimits();
     }
 
-    private AbstractTask createTask(final Consumer consumer) {
-        final MockTime time = new MockTime();
+    @Test
+    public void shouldThrowLockExceptionIfFailedToLockStateDirectoryWhenTopologyHasStores() throws IOException {
+        final Consumer consumer = EasyMock.createNiceMock(Consumer.class);
+        final StateStore store = EasyMock.createNiceMock(StateStore.class);
+        EasyMock.expect(stateDirectory.lock(id, 5)).andReturn(false);
+        EasyMock.replay(stateDirectory);
+
+        final AbstractTask task = createTask(consumer, Collections.singletonList(store));
+
+        try {
+            task.initializeStateStores();
+            fail("Should have thrown LockException");
+        } catch (final LockException e) {
+            // ok
+        }
+
+    }
+
+    @Test
+    public void shouldNotAttemptToLockIfNoStores() throws IOException {
+        final Consumer consumer = EasyMock.createNiceMock(Consumer.class);
+        EasyMock.replay(stateDirectory);
+
+        final AbstractTask task = createTask(consumer, Collections.<StateStore>emptyList());
+
+        task.initializeStateStores();
+
+        // should fail if lock is called
+        EasyMock.verify(stateDirectory);
+    }
+
+    private AbstractTask createTask(final Consumer consumer, final List<StateStore> stateStores) {
         final Properties properties = new Properties();
         properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "app-id");
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummyhost:9092");
         final StreamsConfig config = new StreamsConfig(properties);
-        return new AbstractTask(new TaskId(0, 0),
+        return new AbstractTask(id,
                                 "app",
                                 Collections.singletonList(new TopicPartition("t", 0)),
                                 new ProcessorTopology(Collections.<ProcessorNode>emptyList(),
                                                       Collections.<String, SourceNode>emptyMap(),
                                                       Collections.<String, SinkNode>emptyMap(),
-                                                      Collections.<StateStore>emptyList(),
+                                                      stateStores,
                                                       Collections.<String, String>emptyMap(),
                                                       Collections.<StateStore>emptyList()),
                                 consumer,
                                 new StoreChangelogReader(consumer, Time.SYSTEM, 5000, new MockStateRestoreListener()),
                                 false,
-                                new StateDirectory("app", TestUtils.tempDirectory().getPath(), time),
+                                stateDirectory,
                                 config) {
             @Override
             public void resume() {}
@@ -111,6 +154,11 @@ public class AbstractTaskTest {
             }
 
             @Override
+            public boolean commitNeeded() {
+                return false;
+            }
+
+            @Override
             public boolean maybePunctuateStreamTime() {
                 return false;
             }
@@ -131,7 +179,7 @@ public class AbstractTaskTest {
             }
 
             @Override
-            public boolean commitNeeded() {
+            public boolean initialize() {
                 return false;
             }
         };

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
@@ -20,6 +20,8 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.processor.TaskId;
 import org.easymock.EasyMock;
@@ -40,7 +42,7 @@ import static org.junit.Assert.fail;
 
 public class AssignedTasksTest {
 
-    private final AssignedTasks assignedTasks = new AssignedTasks("log", "task");
+    private final Metrics metrics = new Metrics();
     private final Task t1 = EasyMock.createMock(Task.class);
     private final Task t2 = EasyMock.createMock(Task.class);
     private final TopicPartition tp1 = new TopicPartition("t1", 0);
@@ -49,9 +51,16 @@ public class AssignedTasksTest {
     private final TopicPartition changeLog2 = new TopicPartition("cl2", 0);
     private final TaskId taskId1 = new TaskId(0, 0);
     private final TaskId taskId2 = new TaskId(1, 0);
+    private AssignedTasks assignedTasks;
 
     @Before
     public void before() {
+        assignedTasks = new AssignedTasks("log",
+                                          "task",
+                                          new MockTime(),
+                                          metrics.sensor("commit"),
+                                          metrics.sensor("process"),
+                                          metrics.sensor("punctuate"));
         EasyMock.expect(t1.id()).andReturn(taskId1).anyTimes();
         EasyMock.expect(t2.id()).andReturn(taskId2).anyTimes();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
@@ -235,77 +235,10 @@ public class AssignedTasksTest {
     }
 
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldApplyActionToRunningTasks() {
-        TaskAction taskAction = EasyMock.createMock(TaskAction.class);
-        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
-        EasyMock.expectLastCall();
-        mockTaskInitialization();
-
-        EasyMock.replay(t1, taskAction);
-
-        addAndInitTask();
-
-        assignedTasks.applyToRunningTasks(taskAction, false);
-
-        EasyMock.verify(taskAction);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldNotApplyActionToNotRunningTasks() {
-        final TaskAction taskAction = EasyMock.createMock(TaskAction.class);
-        EasyMock.expect(t1.initialize()).andReturn(false);
-
-        EasyMock.replay(t1, taskAction);
-
-        addAndInitTask();
-
-        assignedTasks.applyToRunningTasks(taskAction, false);
-
-        EasyMock.verify(taskAction);
-    }
-
-    @SuppressWarnings({"unchecked", "ThrowableNotThrown"})
-    @Test
-    public void shouldCloseTaskOnApplyToRunningIfProducerFencedException() {
-        final TaskAction taskAction = EasyMock.createMock(TaskAction.class);
-        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
-        EasyMock.expectLastCall().andThrow(new ProducerFencedException("BOOM!"));
-        mockTaskInitialization();
-        t1.close(false);
-        EasyMock.expectLastCall();
-        EasyMock.replay(t1, taskAction);
-
-        addAndInitTask();
-
-        assignedTasks.applyToRunningTasks(taskAction, false);
-        assertTrue(assignedTasks.running().isEmpty());
-        EasyMock.verify(t1, taskAction);
-    }
-
     private void mockTaskInitialization() {
         EasyMock.expect(t1.initialize()).andReturn(true);
         EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
         EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldReturnExceptionAndNotCloseTaskOnApplyToRunningWhenRuntimeException() {
-        final TaskAction taskAction = EasyMock.createMock(TaskAction.class);
-        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
-        EasyMock.expectLastCall().andThrow(new RuntimeException("KABOOM!"));
-        EasyMock.expect(taskAction.name()).andReturn("name");
-        mockTaskInitialization();
-        EasyMock.replay(t1, taskAction);
-
-        addAndInitTask();
-
-        assertThat(assignedTasks.applyToRunningTasks(taskAction, false), not(nullValue()));
-        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
-        EasyMock.verify(t1, taskAction);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AssignedTasksTest.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.processor.TaskId;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class AssignedTasksTest {
+
+    private final AssignedTasks assignedTasks = new AssignedTasks("log", "task");
+    private final Task t1 = EasyMock.createMock(Task.class);
+    private final Task t2 = EasyMock.createMock(Task.class);
+    private final TopicPartition tp1 = new TopicPartition("t1", 0);
+    private final TopicPartition tp2 = new TopicPartition("t2", 0);
+    private final TopicPartition changeLog1 = new TopicPartition("cl1", 0);
+    private final TopicPartition changeLog2 = new TopicPartition("cl2", 0);
+    private final TaskId taskId1 = new TaskId(0, 0);
+    private final TaskId taskId2 = new TaskId(1, 0);
+
+    @Before
+    public void before() {
+        EasyMock.expect(t1.id()).andReturn(taskId1).anyTimes();
+        EasyMock.expect(t2.id()).andReturn(taskId2).anyTimes();
+    }
+
+    @Test
+    public void shouldGetPartitionsFromNewTasksThatHaveStateStores() {
+        EasyMock.expect(t1.hasStateStores()).andReturn(true);
+        EasyMock.expect(t2.hasStateStores()).andReturn(true);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
+        EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
+        EasyMock.replay(t1, t2);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.addNewTask(t2);
+
+        final Set<TopicPartition> partitions = assignedTasks.uninitializedPartitions();
+        assertThat(partitions, equalTo(Utils.mkSet(tp1, tp2)));
+        EasyMock.verify(t1, t2);
+    }
+
+    @Test
+    public void shouldNotGetPartitionsFromNewTasksWithoutStateStores() {
+        EasyMock.expect(t1.hasStateStores()).andReturn(false);
+        EasyMock.expect(t2.hasStateStores()).andReturn(false);
+        EasyMock.replay(t1, t2);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.addNewTask(t2);
+
+        final Set<TopicPartition> partitions = assignedTasks.uninitializedPartitions();
+        assertTrue(partitions.isEmpty());
+        EasyMock.verify(t1, t2);
+    }
+
+    @Test
+    public void shouldInitializeNewTasks() {
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        EasyMock.replay(t1);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldMoveInitializedTasksNeedingRestoreToRestoring() {
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        EasyMock.expect(t2.initialize()).andReturn(true);
+        EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
+        EasyMock.expect(t2.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
+
+        EasyMock.replay(t1, t2);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.addNewTask(t2);
+
+        assignedTasks.initializeNewTasks();
+
+        Collection<Task> restoring = assignedTasks.restoringTasks();
+        assertThat(restoring.size(), equalTo(1));
+        assertSame(restoring.iterator().next(), t1);
+    }
+
+    @Test
+    public void shouldMoveInitializedTasksThatDontNeedRestoringToRunning() {
+        EasyMock.expect(t2.initialize()).andReturn(true);
+        EasyMock.expect(t2.partitions()).andReturn(Collections.singleton(tp2));
+        EasyMock.expect(t2.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
+
+        EasyMock.replay(t2);
+
+        assignedTasks.addNewTask(t2);
+        assignedTasks.initializeNewTasks();
+
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId2)));
+    }
+
+    @Test
+    public void shouldTransitionFullyRestoredTasksToRunning() {
+        final Set<TopicPartition> task1Partitions = Utils.mkSet(tp1);
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        EasyMock.expect(t1.partitions()).andReturn(task1Partitions).anyTimes();
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Utils.mkSet(changeLog1, changeLog2)).anyTimes();
+        EasyMock.replay(t1);
+
+        assignedTasks.addNewTask(t1);
+
+        assignedTasks.initializeNewTasks();
+
+        assertTrue(assignedTasks.updateRestored(Utils.mkSet(changeLog1)).isEmpty());
+        Set<TopicPartition> partitions = assignedTasks.updateRestored(Utils.mkSet(changeLog2));
+        assertThat(partitions, equalTo(task1Partitions));
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
+    }
+
+    @Test
+    public void shouldSuspendRunningTasks() {
+        mockRunningTaskSuspension();
+        EasyMock.replay(t1);
+
+        suspendTask();
+
+        assertThat(assignedTasks.previousTaskIds(), equalTo(Collections.singleton(taskId1)));
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldCloseRestoringTasks() {
+        EasyMock.expect(t1.initialize()).andReturn(false);
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        suspendTask();
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldClosedUnInitializedTasksOnSuspend() {
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.suspend();
+
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldNotSuspendSuspendedTasks() {
+        mockRunningTaskSuspension();
+        EasyMock.replay(t1);
+
+        suspendTask();
+        assignedTasks.suspend();
+        EasyMock.verify(t1);
+    }
+
+
+    @Test
+    public void shouldCloseTaskOnSuspendWhenRuntimeException() {
+        mockTaskInitialization();
+        t1.suspend();
+        EasyMock.expectLastCall().andThrow(new RuntimeException("KABOOM!"));
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        assertThat(suspendTask(), not(nullValue()));
+        assertThat(assignedTasks.previousTaskIds(), equalTo(Collections.singleton(taskId1)));
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldCloseTaskOnSuspendWhenProducerFencedException() {
+        mockTaskInitialization();
+        t1.suspend();
+        EasyMock.expectLastCall().andThrow(new ProducerFencedException("KABOOM!"));
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+
+        assertThat(suspendTask(), nullValue());
+        assertTrue(assignedTasks.previousTaskIds().isEmpty());
+        EasyMock.verify(t1);
+    }
+
+    @Test
+    public void shouldResumeMatchingSuspendedTasks() {
+        mockRunningTaskSuspension();
+        t1.resume();
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1);
+
+        suspendTask();
+
+        assertTrue(assignedTasks.maybeResumeSuspendedTask(taskId1, Collections.singleton(tp1)));
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
+        EasyMock.verify(t1);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldApplyActionToRunningTasks() {
+        TaskAction taskAction = EasyMock.createMock(TaskAction.class);
+        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
+        EasyMock.expectLastCall();
+        mockTaskInitialization();
+
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assignedTasks.applyToRunningTasks(taskAction, false);
+
+        EasyMock.verify(taskAction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldNotApplyActionToNotRunningTasks() {
+        final TaskAction taskAction = EasyMock.createMock(TaskAction.class);
+        EasyMock.expect(t1.initialize()).andReturn(false);
+
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assignedTasks.applyToRunningTasks(taskAction, false);
+
+        EasyMock.verify(taskAction);
+    }
+
+    @SuppressWarnings({"unchecked", "ThrowableNotThrown"})
+    @Test
+    public void shouldCloseTaskOnApplyToRunningIfProducerFencedException() {
+        final TaskAction taskAction = EasyMock.createMock(TaskAction.class);
+        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
+        EasyMock.expectLastCall().andThrow(new ProducerFencedException("BOOM!"));
+        mockTaskInitialization();
+        t1.close(false);
+        EasyMock.expectLastCall();
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assignedTasks.applyToRunningTasks(taskAction, false);
+        assertTrue(assignedTasks.running().isEmpty());
+        EasyMock.verify(t1, taskAction);
+    }
+
+    private void mockTaskInitialization() {
+        EasyMock.expect(t1.initialize()).andReturn(true);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1));
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldReturnExceptionAndNotCloseTaskOnApplyToRunningWhenRuntimeException() {
+        final TaskAction taskAction = EasyMock.createMock(TaskAction.class);
+        taskAction.apply(EasyMock.anyObject(AbstractTask.class));
+        EasyMock.expectLastCall().andThrow(new RuntimeException("KABOOM!"));
+        EasyMock.expect(taskAction.name()).andReturn("name");
+        mockTaskInitialization();
+        EasyMock.replay(t1, taskAction);
+
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+
+        assertThat(assignedTasks.applyToRunningTasks(taskAction, false), not(nullValue()));
+        assertThat(assignedTasks.runningTaskIds(), equalTo(Collections.singleton(taskId1)));
+        EasyMock.verify(t1, taskAction);
+    }
+
+    private RuntimeException suspendTask() {
+        assignedTasks.addNewTask(t1);
+        assignedTasks.initializeNewTasks();
+        return assignedTasks.suspend();
+    }
+
+    private void mockRunningTaskSuspension() {
+        EasyMock.expect(t1.initialize()).andReturn(true);
+        EasyMock.expect(t1.partitions()).andReturn(Collections.singleton(tp1)).anyTimes();
+        EasyMock.expect(t1.changelogPartitions()).andReturn(Collections.<TopicPartition>emptyList()).anyTimes();
+        t1.suspend();
+        EasyMock.expectLastCall();
+    }
+
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -420,7 +420,7 @@ public class StandbyTaskTest {
                 closedStateManager.set(true);
             }
         };
-
+        task.initialize();
         try {
             task.close(true);
             fail("should have thrown exception");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -165,7 +165,7 @@ public class StandbyTaskTest {
     public void testStorePartitions() throws Exception {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
-
+        task.initialize();
         assertEquals(Utils.mkSet(partition2), new HashSet<>(task.checkpointedOffsets().keySet()));
 
     }
@@ -188,7 +188,7 @@ public class StandbyTaskTest {
     public void testUpdate() throws Exception {
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, topicPartitions, topology, consumer, changelogReader, config, null, stateDirectory);
-
+        task.initialize();
         restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
@@ -245,7 +245,7 @@ public class StandbyTaskTest {
 
         StreamsConfig config = createConfig(baseDir);
         StandbyTask task = new StandbyTask(taskId, applicationId, ktablePartitions, ktableTopology, consumer, changelogReader, config, null, stateDirectory);
-
+        task.initialize();
         restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));
 
         for (ConsumerRecord<Integer, Integer> record : Arrays.asList(
@@ -367,6 +367,7 @@ public class StandbyTaskTest {
                                                  null,
                                                  stateDirectory
         );
+        task.initialize();
 
 
         restoreStateConsumer.assign(new ArrayList<>(task.checkpointedOffsets().keySet()));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -743,6 +743,7 @@ public class StreamTaskTest {
     public void shouldThrowExceptionIfAnyExceptionsRaisedDuringCloseButStillCloseAllProcessorNodesTopology() throws Exception {
         task.close(true);
         task = createTaskThatThrowsExceptionOnClose();
+        task.initialize();
         try {
             task.close(true);
             fail("should have thrown runtime exception");
@@ -959,7 +960,7 @@ public class StreamTaskTest {
         final StreamTask task = new StreamTask(taskId00, applicationId, Utils.mkSet(partition1), topology, consumer,
                                                changelogReader, eosConfig, streamsMetrics, stateDirectory, null, time, producer);
 
-
+        task.initialize();
         try {
             task.suspend();
             fail("should have thrown an exception");
@@ -994,6 +995,16 @@ public class StreamTaskTest {
             // all good
         }
         assertTrue(stateManagerCloseCalled.get());
+    }
+
+    @Test
+    public void shouldNotCloseTopologyProcessorNodesIfNotInitialized() {
+        final StreamTask task = createTaskThatThrowsExceptionOnClose();
+        try {
+            task.close(true);
+        } catch (Exception e) {
+            fail("should have not closed unitialized topology");
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -125,6 +125,7 @@ public class StreamTaskTest {
     private final MockTime time = new MockTime();
     private File baseDir = TestUtils.tempDirectory();
     private StateDirectory stateDirectory;
+    private final RecordCollectorImpl recordCollector = new RecordCollectorImpl(producer, "taskId");
     private StreamsConfig config;
     private StreamsConfig eosConfig;
     private StreamTask task;
@@ -164,6 +165,7 @@ public class StreamTaskTest {
         stateDirectory = new StateDirectory("applicationId", baseDir.getPath(), new MockTime());
         task = new StreamTask(taskId00, applicationId, partitions, topology, consumer,
                               changelogReader, config, streamsMetrics, stateDirectory, null, time, producer);
+        task.initialize();
     }
 
     @After
@@ -456,6 +458,7 @@ public class StreamTaskTest {
 
         task = new StreamTask(taskId00, applicationId, partitions, topology, consumer, changelogReader, config,
             streamsMetrics, stateDirectory, null, time, producer);
+        task.initialize();
         final int offset = 20;
         task.addRecords(partition1, Collections.singletonList(
                 new ConsumerRecord<>(partition1.topic(), partition1.partition(), offset, 0L, TimestampType.CREATE_TIME, 0L, 0, 0, recordKey, recordValue)));
@@ -613,6 +616,7 @@ public class StreamTaskTest {
                 };
             }
         };
+        streamTask.initialize();
 
         time.sleep(config.getLong(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -707,8 +707,7 @@ public class StreamThreadTest {
         final TaskManager taskManager = EasyMock.createMock(TaskManager.class);
         taskManager.setConsumer(EasyMock.anyObject(Consumer.class));
         EasyMock.expectLastCall();
-        taskManager.commitAll();
-        EasyMock.expectLastCall().times(numberOfCommits);
+        EasyMock.expect(taskManager.commitAll()).andReturn(1).times(numberOfCommits);
         EasyMock.replay(taskManager, consumer);
         return taskManager;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -293,7 +293,7 @@ public class StreamThreadTest {
         rebalanceListener.onPartitionsAssigned(assignedPartitions);
         thread.runOnce(-1);
         assertEquals(thread.state(), StreamThread.State.RUNNING);
-        Assert.assertEquals(5, stateListener.numChanges);
+        Assert.assertEquals(4, stateListener.numChanges);
         Assert.assertEquals(StreamThread.State.PARTITIONS_ASSIGNED, stateListener.oldState);
         assertTrue(thread.tasks().containsKey(task1));
         assertEquals(expectedGroup1, thread.tasks().get(task1).partitions());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -17,11 +17,8 @@
 
 package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.TaskId;
@@ -33,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -40,17 +38,14 @@ import java.util.Set;
 import static org.easymock.EasyMock.checkOrder;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
 public class TaskManagerTest {
 
-    private final Time time = new MockTime();
     private final TaskId taskId0 = new TaskId(0, 0);
     private final TopicPartition t1p0 = new TopicPartition("t1", 0);
-    private final TopicPartition t1p1 = new TopicPartition("t1", 1);
     private final Set<TopicPartition> taskId0Partitions = Utils.mkSet(t1p0);
     private final Map<TaskId, Set<TopicPartition>> taskId0Assignment = Collections.singletonMap(taskId0, taskId0Partitions);
 
@@ -68,173 +63,351 @@ public class TaskManagerTest {
     private ThreadMetadataProvider threadMetadataProvider;
     @Mock(type = MockType.NICE)
     private Task firstTask;
+    @Mock(type = MockType.NICE)
+    private AssignedTasks active;
+    @Mock(type = MockType.NICE)
+    private AssignedTasks standby;
 
     private TaskManager taskManager;
 
 
     @Before
     public void setUp() throws Exception {
-        taskManager = new TaskManager(changeLogReader, time, "", restoreConsumer, activeTaskCreator, standbyTaskCreator);
+        taskManager = new TaskManager(changeLogReader,
+                                      "",
+                                      restoreConsumer,
+                                      activeTaskCreator,
+                                      standbyTaskCreator,
+                                      active,
+                                      standby);
         taskManager.setThreadMetadataProvider(threadMetadataProvider);
         taskManager.setConsumer(consumer);
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldCloseActiveUnAssignedSuspendedTasksBeforeCreatingNewTasksWhenTaskPartitionAssignmentHasChanged() {
-        final Set<TopicPartition> secondPartitionAssignment = Utils.mkSet(t1p0, t1p1);
-        final Map<TaskId, Set<TopicPartition>> secondAssignment = Collections.singletonMap(taskId0, secondPartitionAssignment);
+    private void replay() {
+        EasyMock.replay(changeLogReader,
+                        restoreConsumer,
+                        consumer,
+                        activeTaskCreator,
+                        standbyTaskCreator,
+                        threadMetadataProvider,
+                        active,
+                        standby);
+    }
 
+    @Test
+    public void shouldCloseActiveUnAssignedSuspendedTasksWhenCreatingNewTasks() {
         mockSingleActiveTask();
-        expect(activeTaskCreator.retryWithBackoff(EasyMock.anyObject(Consumer.class),
-                                                           EasyMock.eq(secondAssignment),
-                                                           EasyMock.eq(time.milliseconds())))
-                .andReturn(Collections.singletonMap(firstTask, secondPartitionAssignment));
-
-        expect(threadMetadataProvider.activeTasks())
-                .andReturn(secondAssignment);
-
-        firstTask.closeSuspended(true, null);
+        active.closeNonAssignedSuspendedTasks(taskId0Assignment);
         expectLastCall();
-
-        replay(threadMetadataProvider, activeTaskCreator, standbyTaskCreator, firstTask);
-
-        taskManager.createTasks(taskId0Partitions);
-        taskManager.suspendTasksAndState();
-
-        taskManager.createTasks(secondPartitionAssignment);
-
-        verify(activeTaskCreator, firstTask);
-    }
-
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldCloseStandbyTaskIfFailureOnSuspend() {
-        checkOrder(firstTask, true);
-        mockStandbyTaskExpectations(Collections.<TopicPartition, Long>emptyMap());
-        verifyTaskIsClosedOnSuspendFailure(Collections.<TopicPartition>emptySet());
-    }
-
-    @Test
-    public void shouldCloseActiveTaskIfFailureOnSuspend() {
-        checkOrder(firstTask, true);
-        mockSingleActiveTask();
-        verifyTaskIsClosedOnSuspendFailure(taskId0Partitions);
-    }
-
-    @Test
-    public void shouldInitializeRestoreConsumerWithOffsetsFromStandbyTasks() {
-        mockStandbyTaskExpectations(Collections.singletonMap(t1p0, 0L));
-        restoreConsumer.assign(EasyMock.eq(taskId0Partitions));
-        expectLastCall();
-        replay(threadMetadataProvider, firstTask, activeTaskCreator, standbyTaskCreator, restoreConsumer);
-
-        taskManager.createTasks(Collections.<TopicPartition>emptySet());
-
-        EasyMock.verify(restoreConsumer);
-    }
-
-    @Test
-    public void shouldNotCloseSuspendedTasksTwice() {
-        mockSingleActiveTask();
-        expect(threadMetadataProvider.activeTasks())
-                .andReturn(Collections.<TaskId, Set<TopicPartition>>emptyMap());
-        firstTask.suspend();
-        expectLastCall();
-        firstTask.closeSuspended(true, null);
-        expectLastCall();
-
-        replay(threadMetadataProvider, activeTaskCreator, standbyTaskCreator, firstTask);
-
-        taskManager.createTasks(taskId0Partitions);
-        taskManager.suspendTasksAndState();
-
-        taskManager.createTasks(Collections.<TopicPartition>emptySet());
-
-        verify(firstTask);
-    }
-
-    @Test
-    public void shouldNotCloseActiveTaskOnCommitFailedExceptionDuringTaskSuspend() {
-        checkOrder(firstTask, true);
-        mockSingleActiveTask();
-        firstTask.suspend();
-        expectLastCall().andThrow(new CommitFailedException());
-
-        replay(threadMetadataProvider, firstTask, activeTaskCreator, standbyTaskCreator);
+        replay();
 
         taskManager.createTasks(taskId0Partitions);
 
+        verify(active);
+    }
+
+    @Test
+    public void shouldCloseStandbyUnAssignedSuspendedTasksWhenCreatingNewTasks() {
+        mockSingleActiveTask();
+        standby.closeNonAssignedSuspendedTasks(taskId0Assignment);
+        expectLastCall();
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+
+        verify(active);
+    }
+
+    @Test
+    public void shouldResetChangeLogReaderOnCreateTasks() {
+        mockSingleActiveTask();
+        changeLogReader.reset();
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+        verify(changeLogReader);
+    }
+
+    @Test
+    public void shouldAddNonResumedActiveTasks() {
+        mockSingleActiveTask();
+        EasyMock.expect(active.maybeResumeSuspendedTask(taskId0, taskId0Partitions)).andReturn(false);
+        active.addNewTask(EasyMock.same(firstTask));
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+
+        verify(activeTaskCreator, active);
+    }
+
+    @Test
+    public void shouldNotAddResumedActiveTasks() {
+        checkOrder(active, true);
+        mockThreadMetadataProvider(Collections.<TaskId, Set<TopicPartition>>emptyMap(), taskId0Assignment);
+        EasyMock.expect(active.maybeResumeSuspendedTask(taskId0, taskId0Partitions)).andReturn(true);
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+
+        // should be no calls to activeTaskCreator and no calls to active.addNewTasks(..)
+        verify(active, activeTaskCreator);
+    }
+
+    @Test
+    public void shouldAddNonResumedStandbyTasks() {
+        mockStandbyTaskExpectations();
+        EasyMock.expect(standby.maybeResumeSuspendedTask(taskId0, taskId0Partitions)).andReturn(false);
+        standby.addNewTask(EasyMock.same(firstTask));
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+
+        verify(standbyTaskCreator, active);
+    }
+
+    @Test
+    public void shouldNotAddResumedStandbyTasks() {
+        checkOrder(active, true);
+        mockThreadMetadataProvider(taskId0Assignment, Collections.<TaskId, Set<TopicPartition>>emptyMap());
+        EasyMock.expect(standby.maybeResumeSuspendedTask(taskId0, taskId0Partitions)).andReturn(true);
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+
+        // should be no calls to standbyTaskCreator and no calls to standby.addNewTasks(..)
+        verify(standby, standbyTaskCreator);
+    }
+
+
+    @Test
+    public void shouldPauseActiveUninitializedPartitions() {
+        mockSingleActiveTask();
+        EasyMock.expect(active.uninitializedPartitions()).andReturn(taskId0Partitions);
+        consumer.pause(taskId0Partitions);
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.createTasks(taskId0Partitions);
+        verify(consumer);
+    }
+
+    @Test
+    public void shouldSuspendActiveTasks() {
+        EasyMock.expect(active.suspend()).andReturn(null);
+        replay();
+
         taskManager.suspendTasksAndState();
-        verify(firstTask);
+        verify(active);
+    }
+
+    @Test
+    public void shouldSuspendStandbyTasks() {
+        EasyMock.expect(standby.suspend()).andReturn(null);
+        replay();
+
+        taskManager.suspendTasksAndState();
+        verify(standby);
+    }
+
+    @Test
+    public void shouldUnassignChangelogPartitionsOnSuspend() {
+        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.suspendTasksAndState();
+        verify(restoreConsumer);
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionAtEndIfExceptionDuringSuspend() {
+        EasyMock.expect(active.suspend()).andReturn(new RuntimeException(""));
+        EasyMock.expect(standby.suspend()).andReturn(new RuntimeException(""));
+        EasyMock.expectLastCall();
+        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
+
+        replay();
+        try {
+            taskManager.suspendTasksAndState();
+            fail("Should have thrown streams exception");
+        } catch (StreamsException e) {
+            // expected
+        }
+        verify(restoreConsumer, active, standby);
+    }
+
+    @Test
+    public void shouldCloseActiveTasksOnShutdown() {
+        active.close(true);
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.shutdown(true);
+        verify(active);
+    }
+
+    @Test
+    public void shouldCloseStandbyTasksOnShutdown() {
+        standby.close(false);
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.shutdown(false);
+        verify(standby);
+    }
+
+    @Test
+    public void shouldUnassignChangelogPartitionsOnShutdown() {
+        restoreConsumer.assign(Collections.<TopicPartition>emptyList());
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.shutdown(true);
+        verify(restoreConsumer);
+    }
+
+    @Test
+    public void shouldCloseThreadMetadataProviderOnShutdown() {
+        threadMetadataProvider.close();
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.shutdown(true);
+        verify(threadMetadataProvider);
+    }
+
+    @Test
+    public void shouldNotPropagateExceptionsOnShutdown() {
+        threadMetadataProvider.close();
+        EasyMock.expectLastCall().andThrow(new RuntimeException());
+        replay();
+
+        taskManager.shutdown(false);
+    }
+
+    @Test
+    public void shouldInitializeNewActiveTasks() {
+        active.initializeNewTasks();
+        EasyMock.expect(active.updateRestored(EasyMock.anyObject(Collection.class))).
+                andReturn(Collections.<TopicPartition>emptySet());
+        EasyMock.expectLastCall();
+        replay();
+        taskManager.updateNewAndRestoringTasks();
+        verify(active);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldInitializeNewStandbyTasks() {
+        standby.initializeNewTasks();
+        EasyMock.expect(active.updateRestored(EasyMock.anyObject(Collection.class))).
+                andReturn(Collections.<TopicPartition>emptySet());
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.updateNewAndRestoringTasks();
+        verify(standby);
+    }
+
+    @Test
+    public void shouldRestoreStateFromChangeLogReader() {
+        EasyMock.expect(changeLogReader.restore()).andReturn(taskId0Partitions);
+        EasyMock.expect(active.updateRestored(taskId0Partitions)).
+                andReturn(Collections.<TopicPartition>emptySet());
+
+        replay();
+        taskManager.updateNewAndRestoringTasks();
+        verify(changeLogReader, active);
+    }
+
+    @Test
+    public void shouldResumeRestoredPartitions() {
+        EasyMock.expect(changeLogReader.restore()).andReturn(taskId0Partitions);
+        EasyMock.expect(active.updateRestored(taskId0Partitions)).
+                andReturn(taskId0Partitions);
+
+        consumer.resume(taskId0Partitions);
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.updateNewAndRestoringTasks();
+        verify(consumer);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldAssignStandbyPartitionsWhenAllActiveTasksAreRunning() {
+        mockAssignStandbyPartitions(1L);
+        replay();
+
+        taskManager.updateNewAndRestoringTasks();
+        verify(restoreConsumer);
+    }
+
+    @Test
+    public void shouldSeekToCheckpointedOffsetOnStandbyPartitionsWhenOffsetGreaterThanEqualTo0() {
+        mockAssignStandbyPartitions(1L);
+        restoreConsumer.seek(t1p0, 1L);
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.updateNewAndRestoringTasks();
+        verify(restoreConsumer);
+    }
+
+    @Test
+    public void shouldSeekToBeginningIfOffsetIsLessThan0() {
+        mockAssignStandbyPartitions(-1L);
+        restoreConsumer.seekToBeginning(taskId0Partitions);
+        EasyMock.expectLastCall();
+        replay();
+
+        taskManager.updateNewAndRestoringTasks();
+        verify(restoreConsumer);
+    }
+
+    private void mockAssignStandbyPartitions(final long offset) {
+        final Task task = EasyMock.createNiceMock(Task.class);
+        EasyMock.expect(active.allTasksRunning()).andReturn(true);
+        EasyMock.expect(active.updateRestored(EasyMock.anyObject(Collection.class))).
+                andReturn(Collections.<TopicPartition>emptySet());
+        EasyMock.expect(standby.running()).andReturn(Collections.singletonList(task));
+        EasyMock.expect(task.checkpointedOffsets()).andReturn(Collections.singletonMap(t1p0, offset));
+        restoreConsumer.assign(taskId0Partitions);
+
+        EasyMock.expectLastCall();
+        EasyMock.replay(task);
     }
 
 
     @SuppressWarnings("unchecked")
-    private void mockStandbyTaskExpectations(final Map<TopicPartition, Long> checkpoint) {
-        expect(threadMetadataProvider.standbyTasks())
-                .andReturn(taskId0Assignment)
-                .anyTimes();
-        expect(threadMetadataProvider.activeTasks())
-                .andStubReturn(Collections.<TaskId, Set<TopicPartition>>emptyMap());
+    private void mockStandbyTaskExpectations() {
+        mockThreadMetadataProvider(taskId0Assignment, Collections.<TaskId, Set<TopicPartition>>emptyMap());
+        expect(standbyTaskCreator.createTasks(EasyMock.anyObject(Consumer.class),
+                                                   EasyMock.eq(taskId0Assignment)))
+                .andReturn(Collections.singletonList(firstTask));
 
-        expect(standbyTaskCreator.retryWithBackoff(EasyMock.anyObject(Consumer.class),
-                                                   EasyMock.eq(taskId0Assignment),
-                                                   EasyMock.eq(time.milliseconds())))
-                .andReturn(Collections.singletonMap(firstTask, taskId0Partitions));
-
-        stubTaskCreator(activeTaskCreator);
-
-        expect(firstTask.checkpointedOffsets())
-                .andReturn(checkpoint)
-                .anyTimes();
     }
 
     @SuppressWarnings("unchecked")
     private void mockSingleActiveTask() {
+        mockThreadMetadataProvider(Collections.<TaskId, Set<TopicPartition>>emptyMap(), taskId0Assignment);
+
+        expect(activeTaskCreator.createTasks(EasyMock.anyObject(Consumer.class),
+                                                  EasyMock.eq(taskId0Assignment)))
+                .andReturn(Collections.singletonList(firstTask));
+
+    }
+
+    private void mockThreadMetadataProvider(final Map<TaskId, Set<TopicPartition>> standbyAssignment,
+                                            final Map<TaskId, Set<TopicPartition>> activeAssignment) {
         expect(threadMetadataProvider.standbyTasks())
-                .andReturn(Collections.<TaskId, Set<TopicPartition>>emptyMap())
+                .andReturn(standbyAssignment)
                 .anyTimes();
         expect(threadMetadataProvider.activeTasks())
-                .andReturn(taskId0Assignment);
-
-        expect(activeTaskCreator.retryWithBackoff(EasyMock.anyObject(Consumer.class),
-                                                  EasyMock.eq(taskId0Assignment),
-                                                  EasyMock.eq(time.milliseconds())))
-                .andReturn(Collections.singletonMap(firstTask, taskId0Partitions));
-
-        stubTaskCreator(standbyTaskCreator);
-
-        expect(firstTask.id()).andStubReturn(taskId0);
-        expect(firstTask.partitions()).andStubReturn(taskId0Partitions);
-    }
-
-    private void verifyTaskIsClosedOnSuspendFailure(final Set<TopicPartition> assignment) {
-        firstTask.suspend();
-        expectLastCall().andThrow(new RuntimeException("KABOOM!"));
-        firstTask.close(false);
-        expectLastCall();
-        replay(threadMetadataProvider, firstTask, activeTaskCreator, standbyTaskCreator);
-
-        taskManager.createTasks(assignment);
-
-        try {
-            taskManager.suspendTasksAndState();
-            fail("should have thrown StreamsException");
-        } catch (final StreamsException e) {
-            // pass
-        }
-        verify(firstTask);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void stubTaskCreator(final StreamThread.AbstractTaskCreator taskCreator) {
-        expect(taskCreator.retryWithBackoff(EasyMock.anyObject(Consumer.class),
-                                                   EasyMock.anyObject(Map.class),
-                                                   EasyMock.anyLong()))
-                .andReturn(Collections.<Task, Set<TopicPartition>>emptyMap())
-                .anyTimes();
+                .andReturn(activeAssignment);
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -39,6 +39,8 @@ import static org.easymock.EasyMock.checkOrder;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.fail;
 
 @RunWith(EasyMockRunner.class)
@@ -370,13 +372,12 @@ public class TaskManagerTest {
 
     @Test
     public void shouldCommitActiveAndStandbyTasks() {
-        active.commit();
-        standby.commit();
-        EasyMock.expectLastCall();
+        EasyMock.expect(active.commit()).andReturn(1);
+        EasyMock.expect(standby.commit()).andReturn(2);
 
         replay();
-        taskManager.commitAll();
 
+        assertThat(taskManager.commitAll(), equalTo(3));
         verify(active, standby);
     }
 
@@ -399,8 +400,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldPropagateExceptionFromStandbyCommit() {
-        standby.commit();
-        EasyMock.expectLastCall().andThrow(new RuntimeException(""));
+        EasyMock.expect(standby.commit()).andThrow(new RuntimeException(""));
         replay();
 
         try {
@@ -410,6 +410,33 @@ public class TaskManagerTest {
             // ok
         }
         verify(standby);
+    }
+
+    @Test
+    public void shouldMaybeCommitActiveTasks() {
+        EasyMock.expect(active.maybeCommit()).andReturn(5);
+        replay();
+
+        assertThat(taskManager.maybeCommitActiveTasks(), equalTo(5));
+        verify(active);
+    }
+
+    @Test
+    public void shouldProcessActiveTasks() {
+        EasyMock.expect(active.process()).andReturn(10);
+        replay();
+
+        assertThat(taskManager.process(), equalTo(10));
+        verify(active);
+    }
+
+    @Test
+    public void shouldPunctuateActiveTasks() {
+        EasyMock.expect(active.punctuate()).andReturn(20);
+        replay();
+
+        assertThat(taskManager.punctuate(), equalTo(20));
+        verify(active);
     }
 
     private void mockAssignStandbyPartitions(final long offset) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -106,10 +106,12 @@ public class StreamThreadStateStoreProviderTest {
         stateDirectory = new StateDirectory(applicationId, stateConfigDir, new MockTime());
         taskOne = createStreamsTask(applicationId, streamsConfig, clientSupplier, topology,
                                     new TaskId(0, 0));
+        taskOne.initialize();
         tasks.put(new TaskId(0, 0),
                   taskOne);
         taskTwo = createStreamsTask(applicationId, streamsConfig, clientSupplier, topology,
                                     new TaskId(0, 1));
+        taskTwo.initialize();
         tasks.put(new TaskId(0, 1),
                   taskTwo);
 

--- a/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.processor.internals.ChangelogReader;
 import org.apache.kafka.streams.processor.internals.StateRestorer;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -39,8 +40,8 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
-    public void restore() {
-
+    public Collection<TopicPartition> restore() {
+        return registered;
     }
 
     @Override
@@ -49,7 +50,7 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
-    public void clear() {
+    public void reset() {
         registered.clear();
     }
 

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -230,6 +230,7 @@ public class ProcessorTopologyTestDriver {
                                   cache,
                                   new MockTime(),
                                   producer);
+            task.initialize();
         }
     }
 


### PR DESCRIPTION
In onPartitionsAssigned:

release all locks for non-assigned suspended tasks.
resume any suspended tasks.
Create new tasks, but don't attempt to take the state lock.
Pause partitions for any new tasks.
set the state to PARTITIONS_ASSIGNED
In StreamThread#runLoop

poll
if state is PARTITIONS_ASSIGNED
2.1 attempt to initialize any new tasks, i.e, take out the state locks and init state stores
2.2 restore some data for changelogs, i.e., poll once on the restore consumer and return the partitions that have been fully restored
2.3 update tasks with restored partitions and move any that have completed restoration to running
2.4 resume consumption for any tasks where all partitions have been restored.
2.5 if all active tasks are running, transition to RUNNING and assign standby partitions to the restoreConsumer.