### PR TITLE
KAFKA-5733: RocksDB bulk load with lower number of levels.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -532,8 +532,8 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         }
     }
 
-    private boolean hasSstFiles(File dbDir) {
-        String[] sstFileNames = dbDir.list(new FilenameFilter() {
+    private boolean hasSstFiles(final File dbDir) {
+        final String[] sstFileNames = dbDir.list(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
                 return name.matches(".*\\.sst");

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -179,6 +179,8 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         } catch (IOException e) {
             throw new ProcessorStateException(e);
         }
+
+        open = true;
     }
 
     public void init(ProcessorContext context, StateStore root) {
@@ -190,8 +192,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         // value getter should always read directly from rocksDB
         // since it is only for values that are already flushed
         context.register(root, false, this.batchingStateRestoreCallback);
-
-        open = true;
     }
 
     private RocksDB openDB(File dir, Options options, int ttl) throws IOException {
@@ -270,7 +270,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             if (sstFileNames != null && sstFileNames.length > 0) {
                 try {
                     this.db.compactRange(true, 1, 0);
-
                 } catch (RocksDBException e) {
                     throw new ProcessorStateException("Error while range compacting during restoring  store " + this.name, e);
                 }
@@ -285,7 +284,6 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         close();
         this.prepareForBulkload = prepareForBulkload;
         openDB(internalProcessorContext);
-        open = true;
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -40,8 +40,6 @@ class Segment extends RocksDBStore<Bytes, byte[]> {
         super.openDB(context);
 
         // skip the registering step
-
-        open = true;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -158,12 +158,10 @@ public class RocksDBStoreTest {
 
         restoreListener.onRestoreEnd(null, null, 0);
         assertFalse("Should have set bulk loading to false", subject.isPrepareForBulkload());
-
-        assertTrue("Should have been re-opened", restoreListener.isWasReOpenedAfterRestore());
     }
 
     @Test
-    public void shouldNotTogglePrepareForBulkloadSettingWhenPrexistingSstFiles() throws Exception {
+    public void shouldTogglePrepareForBulkloadSettingWhenPrexistingSstFiles() throws Exception {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
 
         subject.init(context, subject);
@@ -173,14 +171,10 @@ public class RocksDBStoreTest {
             (RocksDBStore.RocksDBBatchingRestoreCallback) subject.batchingStateRestoreCallback;
 
         restoreListener.onRestoreStart(null, null, 0, 0);
-
-        // since pre-existing sst files, should not have called the toggleForBulkload method, hence,
-        // prepareForBulkLoad is never set to true;
-        assertFalse("Should have not set bulk loading to true", subject.isPrepareForBulkload());
+        assertTrue("Should have not set bulk loading to true", subject.isPrepareForBulkload());
 
         restoreListener.onRestoreEnd(null, null, 0);
-
-        assertFalse("Should not have have been re-opened", restoreListener.isWasReOpenedAfterRestore());
+        assertFalse("Should have set bulk loading to false", subject.isPrepareForBulkload());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -76,17 +76,19 @@ public class RocksDBStoreTest {
     }
 
     @Test
-    public void shouldNotThrowExceptionOnRestoreWithBulkLoad() throws Exception {
-        String message = "how can a 4 ounce bird carry a 2lb coconut";
+    public void shouldNotThrowExceptionOnRestoreWhenThereIsPreExistingRocksDbFiles() throws Exception {
         subject.init(context, subject);
+
+        final String message = "how can a 4 ounce bird carry a 2lb coconut";
         int intKey = 1;
         for (int i = 0; i < 2000000; i++) {
             subject.put("theKeyIs" + intKey++, message);
         }
 
-        List<KeyValue<byte[], byte[]>> restoreBytes = new ArrayList<>();
-        byte[] restoredKey = "restoredKey".getBytes("UTF-8");
-        byte[] restoredValue = "restoredValue".getBytes("UTF-8");
+        final List<KeyValue<byte[], byte[]>> restoreBytes = new ArrayList<>();
+
+        final byte[] restoredKey = "restoredKey".getBytes("UTF-8");
+        final byte[] restoredValue = "restoredValue".getBytes("UTF-8");
         restoreBytes.add(KeyValue.pair(restoredKey, restoredValue));
 
         context.restore("test", restoreBytes);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -76,6 +76,25 @@ public class RocksDBStoreTest {
     }
 
     @Test
+    public void shouldNotThrowExceptionOnRestoreWithBulkLoad() throws Exception {
+        String message = "how can a 4 ounce bird carry a 2lb coconut";
+        subject.init(context, subject);
+        int intKey = 1;
+        for (int i = 0; i < 2000000; i++) {
+            subject.put("theKeyIs" + intKey++, message);
+        }
+
+        List<KeyValue<byte[], byte[]>> restoreBytes = new ArrayList<>();
+        byte[] restoredKey = "restoredKey".getBytes("UTF-8");
+        byte[] restoredValue = "restoredValue".getBytes("UTF-8");
+        restoreBytes.add(KeyValue.pair(restoredKey, restoredValue));
+
+        context.restore("test", restoreBytes);
+
+        assertThat(subject.get("restoredKey"), equalTo("restoredValue"));
+    }
+
+    @Test
     public void canSpecifyConfigSetterAsClass() throws Exception {
         final Map<String, Object> configs = new HashMap<>();
         configs.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);


### PR DESCRIPTION
This is to complete Bill's PR #3664 on KAFKA-5733, incorporating the suggestion in https://github.com/facebook/rocksdb/issues/2734.

Some minor changes: move `open = true` in `openDB`.