### PR TITLE
KAFKA-5668: fetch across stores in CompositeReadOnlyWindowStore & CompositeReadOnlySessionStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeKeyValueIterator.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeKeyValueIterator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+class CompositeKeyValueIterator<K, V, StoreType> implements KeyValueIterator<K, V> {
+
+    private final Iterator<StoreType> storeIterator;
+    private final NextIteratorFunction<K, V, StoreType> nextIteratorFunction;
+
+    private KeyValueIterator<K, V> current;
+
+    CompositeKeyValueIterator(final Iterator<StoreType> underlying,
+                              final NextIteratorFunction<K, V, StoreType> nextIteratorFunction) {
+        this.storeIterator = underlying;
+        this.nextIteratorFunction = nextIteratorFunction;
+    }
+
+    @Override
+    public void close() {
+        if (current != null) {
+            current.close();
+            current = null;
+        }
+    }
+
+    @Override
+    public K peekNextKey() {
+        throw new UnsupportedOperationException("peekNextKey not supported");
+    }
+
+    @Override
+    public boolean hasNext() {
+        while ((current == null || !current.hasNext())
+                && storeIterator.hasNext()) {
+            close();
+            current = nextIteratorFunction.apply(storeIterator.next());
+        }
+        return current != null && current.hasNext();
+    }
+
+
+    @Override
+    public KeyValue<K, V> next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return current.next();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("Remove not supported");
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyKeyValueStore.java
@@ -16,15 +16,12 @@
  */
 package org.apache.kafka.streams.state.internals;
 
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.QueryableStoreType;
 import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
@@ -71,7 +68,7 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
     public KeyValueIterator<K, V> range(final K from, final K to) {
         Objects.requireNonNull(from);
         Objects.requireNonNull(to);
-        final NextIteratorFunction<K, V> nextIteratorFunction = new NextIteratorFunction<K, V>() {
+        final NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>> nextIteratorFunction = new NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>>() {
             @Override
             public KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store) {
                 try {
@@ -82,12 +79,12 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
             }
         };
         final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
-        return new DelegatingPeekingKeyValueIterator<>(storeName, new CompositeKeyValueIterator(stores.iterator(), nextIteratorFunction));
+        return new DelegatingPeekingKeyValueIterator<>(storeName, new CompositeKeyValueIterator<>(stores.iterator(), nextIteratorFunction));
     }
 
     @Override
     public KeyValueIterator<K, V> all() {
-        final NextIteratorFunction<K, V> nextIteratorFunction = new NextIteratorFunction<K, V>() {
+        final NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>> nextIteratorFunction = new NextIteratorFunction<K, V, ReadOnlyKeyValueStore<K, V>>() {
             @Override
             public KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store) {
                 try {
@@ -98,7 +95,7 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
             }
         };
         final List<ReadOnlyKeyValueStore<K, V>> stores = storeProvider.stores(storeName, storeType);
-        return new DelegatingPeekingKeyValueIterator<>(storeName, new CompositeKeyValueIterator(stores.iterator(), nextIteratorFunction));
+        return new DelegatingPeekingKeyValueIterator<>(storeName, new CompositeKeyValueIterator<>(stores.iterator(), nextIteratorFunction));
     }
 
     @Override
@@ -111,61 +108,6 @@ public class CompositeReadOnlyKeyValueStore<K, V> implements ReadOnlyKeyValueSto
         return total < 0 ? Long.MAX_VALUE : total;
     }
 
-    interface NextIteratorFunction<K, V> {
 
-        KeyValueIterator<K, V> apply(final ReadOnlyKeyValueStore<K, V> store);
-    }
-
-
-    private class CompositeKeyValueIterator implements KeyValueIterator<K, V> {
-
-        private final Iterator<ReadOnlyKeyValueStore<K, V>> storeIterator;
-        private final NextIteratorFunction<K, V> nextIteratorFunction;
-
-        private KeyValueIterator<K, V> current;
-
-        CompositeKeyValueIterator(final Iterator<ReadOnlyKeyValueStore<K, V>> underlying,
-                                  final NextIteratorFunction<K, V> nextIteratorFunction) {
-            this.storeIterator = underlying;
-            this.nextIteratorFunction = nextIteratorFunction;
-        }
-
-        @Override
-        public void close() {
-            if (current != null) {
-                current.close();
-                current = null;
-            }
-        }
-
-        @Override
-        public K peekNextKey() {
-            throw new UnsupportedOperationException("peekNextKey not supported");
-        }
-
-        @Override
-        public boolean hasNext() {
-            while ((current == null || !current.hasNext())
-                    && storeIterator.hasNext()) {
-                close();
-                current = nextIteratorFunction.apply(storeIterator.next());
-            }
-            return current != null && current.hasNext();
-        }
-
-
-        @Override
-        public KeyValue<K, V> next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            return current.next();
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("Remove not supported");
-        }
-    }
 }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/CompositeReadOnlyWindowStore.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Wrapper over the underlying {@link ReadOnlyWindowStore}s found in a {@link
@@ -43,16 +44,13 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
         this.storeName = storeName;
     }
 
-    private interface Fetcher<K, V, IteratorType extends KeyValueIterator<?, V>> {
-        IteratorType fetch(ReadOnlyWindowStore<K, V> store);
-        IteratorType empty();
-    }
-
-    public <IteratorType extends KeyValueIterator<?, V>> IteratorType fetch(Fetcher<K, V, IteratorType> fetcher) {
+    @Override
+    public WindowStoreIterator<V> fetch(final K key, final long timeFrom, final long timeTo) {
+        Objects.requireNonNull(key, "key can't be null");
         final List<ReadOnlyWindowStore<K, V>> stores = provider.stores(storeName, windowStoreType);
         for (ReadOnlyWindowStore<K, V> windowStore : stores) {
             try {
-                final IteratorType result = fetcher.fetch(windowStore);
+                final WindowStoreIterator<V> result = windowStore.fetch(key, timeFrom, timeTo);
                 if (!result.hasNext()) {
                     result.close();
                 } else {
@@ -60,41 +58,26 @@ public class CompositeReadOnlyWindowStore<K, V> implements ReadOnlyWindowStore<K
                 }
             } catch (InvalidStateStoreException e) {
                 throw new InvalidStateStoreException(
-                    "State store is not available anymore and may have been migrated to another instance; " +
-                    "please re-discover its location from the state metadata.");
+                        "State store is not available anymore and may have been migrated to another instance; " +
+                                "please re-discover its location from the state metadata.");
             }
         }
-
-        return fetcher.empty();
-    }
-
-    @Override
-    public WindowStoreIterator<V> fetch(final K key, final long timeFrom, final long timeTo) {
-        return fetch(new Fetcher<K, V, WindowStoreIterator<V>>() {
-            @Override
-            public WindowStoreIterator<V> fetch(ReadOnlyWindowStore<K, V> store) {
-                return store.fetch(key, timeFrom, timeTo);
-            }
-
-            @Override
-            public WindowStoreIterator<V> empty() {
-                return KeyValueIterators.emptyWindowStoreIterator();
-            }
-        });
+        return KeyValueIterators.emptyWindowStoreIterator();
     }
 
     @Override
     public KeyValueIterator<Windowed<K>, V> fetch(final K from, final K to, final long timeFrom, final long timeTo) {
-        return fetch(new Fetcher<K, V, KeyValueIterator<Windowed<K>, V>>() {
+        Objects.requireNonNull(from, "from can't be null");
+        Objects.requireNonNull(to, "to can't be null");
+        final NextIteratorFunction<Windowed<K>, V, ReadOnlyWindowStore<K, V>> nextIteratorFunction = new NextIteratorFunction<Windowed<K>, V, ReadOnlyWindowStore<K, V>>() {
             @Override
-            public KeyValueIterator<Windowed<K>, V> fetch(ReadOnlyWindowStore<K, V> store) {
-                return store.fetch(from, to, timeFrom, timeTo);
+            public KeyValueIterator<Windowed<K>, V> apply(final ReadOnlyWindowStore<K, V> store) {
+                return store.fetch(from, to, timeFrom, timeFrom);
             }
-
-            @Override
-            public KeyValueIterator<Windowed<K>, V> empty() {
-                return KeyValueIterators.emptyIterator();
-            }
-        });
+        };
+        return new DelegatingPeekingKeyValueIterator<>(storeName,
+                                                       new CompositeKeyValueIterator<>(
+                                                               provider.stores(storeName, windowStoreType).iterator(),
+                                                               nextIteratorFunction));
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NextIteratorFunction.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NextIteratorFunction.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+interface NextIteratorFunction<K, V, StoreType> {
+
+    KeyValueIterator<K, V> apply(final StoreType store);
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -233,12 +233,7 @@ public class RocksDBSessionStoreTest {
     public void shouldThrowNullPointerExceptionOnPutNullKey() throws Exception {
         sessionStore.put(null, 1L);
     }
-
-    @Test
-    public void should() {
-        
-    }
-
+    
     static List<KeyValue<Windowed<String>, Long>> toList(final KeyValueIterator<Windowed<String>, Long> iterator) {
         final List<KeyValue<Windowed<String>, Long>> results = new ArrayList<>();
         while (iterator.hasNext()) {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -234,6 +234,11 @@ public class RocksDBSessionStoreTest {
         sessionStore.put(null, 1L);
     }
 
+    @Test
+    public void should() {
+        
+    }
+
     static List<KeyValue<Windowed<String>, Long>> toList(final KeyValueIterator<Windowed<String>, Long> iterator) {
         final List<KeyValue<Windowed<String>, Long>> results = new ArrayList<>();
         while (iterator.hasNext()) {

--- a/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
+++ b/streams/src/test/java/org/apache/kafka/test/ReadOnlySessionStoreStub.java
@@ -58,10 +58,10 @@ public class ReadOnlySessionStoreStub<K, V> implements ReadOnlySessionStore<K, V
         if (!open) {
             throw new InvalidStateStoreException("not open");
         }
-        if (!sessions.subMap(from, to).isEmpty()) {
+        if (sessions.subMap(from, true, to, true).isEmpty()) {
             return new KeyValueIteratorStub<>(Collections.<KeyValue<Windowed<K>, V>>emptyIterator());
         }
-        final Iterator<List<KeyValue<Windowed<K>, V>>> keysIterator = sessions.subMap(from, to).values().iterator();
+        final Iterator<List<KeyValue<Windowed<K>, V>>> keysIterator = sessions.subMap(from, true,  to, true).values().iterator();
         return new KeyValueIteratorStub<>(
             new Iterator<KeyValue<Windowed<K>, V>>() {
 


### PR DESCRIPTION
Fix range queries in `CompositeReadOnlyWindowStore` and `CompositeReadOnlySessionStore` to fetch across all stores (was previously just looking in the first store)