### PR TITLE
HOTFIX: Cherrypicking state deadlock fix from 0.11

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -695,6 +695,7 @@ public class KafkaStreams {
 
     private void closeGlobalStreamThread() {
         if (globalStreamThread != null) {
+            globalStreamThread.setStateListener(null);
             globalStreamThread.close();
             if (!globalStreamThread.stillRunning()) {
                 try {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -80,6 +80,7 @@ import static org.apache.kafka.common.utils.Utils.getPort;
 import static org.apache.kafka.streams.KafkaStreams.State.CREATED;
 import static org.apache.kafka.streams.KafkaStreams.State.ERROR;
 import static org.apache.kafka.streams.KafkaStreams.State.NOT_RUNNING;
+import static org.apache.kafka.streams.KafkaStreams.State.RUNNING;
 import static org.apache.kafka.streams.KafkaStreams.State.PENDING_SHUTDOWN;
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
 import static org.apache.kafka.streams.StreamsConfig.PROCESSING_GUARANTEE_CONFIG;
@@ -194,23 +195,23 @@ public class KafkaStreams {
      *         |             |
      *         |             v
      *         |       +-----+--------+
-     *         +-----> | Pending      |
-     *         |       | Shutdown     |
-     *         |       +-----+--------+
-     *         |             |
-     *         |             v
-     *         |       +-----+--------+
-     *         +-----> | Not Running  |
-     *         |       +--------------+
-     *         |
-     *         |       +--------------+
-     *         +-----> | Error        |
+     *         +-----> | Pending      |<----+
+     *         |       | Shutdown     |     |
+     *         |       +-----+--------+     |
+     *         |             |              |
+     *         |             v              |
+     *         |       +-----+--------+     |
+     *         |       | Not Running  |     |
+     *         |       +--------------+     |
+     *         |                            |
+     *         |       +--------------+     |
+     *         +-----> | Error        |-----+
      *                 +--------------+
      *
      *
      * </pre>
      * Note the following:
-     * - Any state can go to PENDING_SHUTDOWN (during clean shutdown) or NOT_RUNNING (e.g., during an exception).
+     * - Any state can go to PENDING_SHUTDOWN and subsequently NOT_RUNNING.
      * - It is theoretically possible for a thread to always be in the PARTITION_REVOKED state
      * (see {@code StreamThread} state diagram) and hence it is possible that this instance is always
      * on a REBALANCING state.
@@ -218,7 +219,7 @@ public class KafkaStreams {
      * the instance will be in the ERROR state. The user will need to close it.
      */
     public enum State {
-        CREATED(1, 2, 3, 5), REBALANCING(1, 2, 3, 4, 5), RUNNING(1, 3, 4, 5), PENDING_SHUTDOWN(4), NOT_RUNNING, ERROR;
+        CREATED(1, 2, 3, 5), REBALANCING(1, 2, 3, 5), RUNNING(1, 3, 5), PENDING_SHUTDOWN(4), NOT_RUNNING, ERROR(3);
 
         private final Set<Integer> validTransitions = new HashSet<>();
 
@@ -274,21 +275,28 @@ public class KafkaStreams {
     /**
      * Sets the state
      * @param newState New state
+     * @return true if state is set, false otherwise
+     * @throws StreamsException when there is an unexpected transition.
      */
-    private void setState(final State newState) {
-
+    private boolean setState(final State newState) {
+        State oldState;
         synchronized (stateLock) {
-
             // there are cases when we shouldn't check if a transition is valid, e.g.,
             // when, for testing, Kafka Streams is closed multiple times. We could either
             // check here and immediately return for those cases, or add them to the transition
             // diagram (but then the diagram would be confusing and have transitions like
-            // NOT_RUNNING->NOT_RUNNING).
-            if (newState != NOT_RUNNING && (state == State.NOT_RUNNING || state == PENDING_SHUTDOWN)) {
-                return;
+            // NOT_RUNNING->NOT_RUNNING). These cases include:
+            // - calling close() multiple times. Would mean going from NOT_RUNNING -> PENDING_SHUTDOWN
+            // - calling start() after close(). Would mean going from PENDING_SHUTDOWN (or NOT_RUNNING) -> RUNNING
+
+            // note we could be going from PENDING_SHUTDOWN to NOT_RUNNING, and we obviously want to allow that
+            // transition, hence the check newState != NOT_RUNNING.
+            if (newState != NOT_RUNNING &&
+                    (state == State.NOT_RUNNING || state == PENDING_SHUTDOWN)) {
+                return false;
             }
 
-            final State oldState = state;
+            oldState = state;
             if (!state.isValidTransition(newState)) {
                 log.warn("{} Unexpected state transition from {} to {}.", logPrefix, oldState, newState);
                 throw new StreamsException(logPrefix + " Unexpected state transition from " + oldState + " to " + newState);
@@ -296,16 +304,18 @@ public class KafkaStreams {
                 log.info("{} State transition from {} to {}.", logPrefix, oldState, newState);
             }
             state = newState;
-            if (stateListener != null) {
-                stateListener.onChange(state, oldState);
-            }
         }
+        if (stateListener != null) {
+            stateListener.onChange(state, oldState);
+        }
+
+        return true;
     }
 
     /**
      * Return the current {@link State} of this {@code KafkaStreams} instance.
      *
-     * @return the currnt state of this Kafka Streams instance
+     * @return the current state of this Kafka Streams instance
      */
     public State state() {
         synchronized (stateLock) {
@@ -622,13 +632,14 @@ public class KafkaStreams {
     }
 
     private void validateStartOnce() {
-        synchronized (stateLock) {
-            if (state == State.CREATED) {
-                state = State.RUNNING;
-            } else {
-                throw new IllegalStateException("Cannot start again.");
+        try {
+            if (setState(RUNNING)) {
+                return;
             }
+        } catch (StreamsException e) {
+            // do nothing, will throw
         }
+        throw new IllegalStateException("Cannot start again.");
     }
 
     /**
@@ -679,13 +690,7 @@ public class KafkaStreams {
 
 
     private boolean checkFirstTimeClosing() {
-        synchronized (stateLock) {
-            if (state.isCreatedOrRunning() || state == ERROR) {
-                state = PENDING_SHUTDOWN;
-                return true;
-            }
-            return false;
-        }
+        return setState(PENDING_SHUTDOWN);
     }
 
     private void closeGlobalStreamThread() {
@@ -711,6 +716,7 @@ public class KafkaStreams {
      * @param timeUnit unit of time used for timeout
      * @return {@code true} if all threads were successfully stopped&mdash;{@code false} if the timeout was reached
      * before all threads stopped
+     * Note that this method must not be called in the {@code onChange} callback of {@link StateListener}.
      */
     public synchronized boolean close(final long timeout, final TimeUnit timeUnit) {
         log.debug("{} Stopping Kafka Stream process.", logPrefix);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -101,25 +101,23 @@ public class StreamThread extends Thread implements ThreadDataProvider {
      *          |           v
      *          |     +-----+-------+
      *          +---> | Pending     |
-     *          |     | Shutdown    |
-     *          |     +-----+-------+
-     *          |           |
-     *          |           v
-     *          |     +-----+-------+
-     *          +---> | Dead        |
+     *                | Shutdown    |
+     *                +-----+-------+
+     *                      |
+     *                      v
+     *                +-----+-------+
+     *                | Dead        |
      *                +-------------+
      * </pre>
      *
      * Note the following:
-     * - Any state can go to PENDING_SHUTDOWN. That is because streams can be closed at any time.
-     * - Any state can go to DEAD. That is because exceptions can happen at any other state,
-     *   leading to the stream thread terminating.
+     * - Any state can go to PENDING_SHUTDOWN followed by a subsequent transition to DEAD.
      * - A streams thread can stay in PARTITIONS_REVOKED indefinitely, in the corner case when
      *   the coordinator repeatedly fails in-between revoking partitions and assigning new partitions.
      *
      */
     public enum State implements ThreadStateTransitionValidator {
-        CREATED(1, 4, 5), RUNNING(2, 4, 5), PARTITIONS_REVOKED(2, 3, 4, 5), ASSIGNING_PARTITIONS(1, 4, 5), PENDING_SHUTDOWN(5), DEAD;
+        CREATED(1, 4), RUNNING(2, 4), PARTITIONS_REVOKED(2, 3, 4), ASSIGNING_PARTITIONS(1, 4), PENDING_SHUTDOWN(5), DEAD;
 
         private final Set<Integer> validTransitions = new HashSet<>();
 
@@ -1093,13 +1091,13 @@ public class StreamThread extends Thread implements ThreadDataProvider {
         setState(State.PENDING_SHUTDOWN);
     }
 
-    public synchronized boolean isInitialized() {
+    public boolean isInitialized() {
         synchronized (stateLock) {
             return state == State.RUNNING;
         }
     }
 
-    public synchronized boolean stillRunning() {
+    public boolean stillRunning() {
         synchronized (stateLock) {
             return state.isRunning();
         }
@@ -1183,9 +1181,7 @@ public class StreamThread extends Thread implements ThreadDataProvider {
      * @return The state this instance is in
      */
     public State state() {
-        synchronized (stateLock) {
-            return state;
-        }
+        return state;
     }
 
 
@@ -1194,29 +1190,35 @@ public class StreamThread extends Thread implements ThreadDataProvider {
      * @param newState New state
      */
     void setState(final State newState) {
+        State oldState;
         synchronized (stateLock) {
-            final State oldState = state;
+            oldState = state;
 
             // there are cases when we shouldn't check if a transition is valid, e.g.,
             // when, for testing, a thread is closed multiple times. We could either
             // check here and immediately return for those cases, or add them to the transition
             // diagram (but then the diagram would be confusing and have transitions like
-            // PENDING_SHUTDOWN->PENDING_SHUTDOWN).
-            if (newState != State.DEAD && (state == State.PENDING_SHUTDOWN || state == State.DEAD)) {
+            // PENDING_SHUTDOWN->PENDING_SHUTDOWN). These cases include:
+            // - normal close() sequence. State is set to PENDING_SHUTDOWN in close() as well as in shutdown().
+            // - calling close() on the thread after an exception within the thread has already called shutdown().
+
+            // note we could be going from PENDING_SHUTDOWN to DEAD, and we obviously want to allow that
+            // transition, hence the check newState != DEAD.
+            if (newState != State.DEAD &&
+                    (state == State.PENDING_SHUTDOWN || state == State.DEAD)) {
                 return;
             }
-
             if (!state.isValidTransition(newState)) {
-                log.warn("{} Unexpected state transition from {} to {}", logPrefix, oldState, newState);
+                log.warn("{} Unexpected state transition from {} to {}.", logPrefix, oldState, newState);
                 throw new StreamsException(logPrefix + " Unexpected state transition from " + oldState + " to " + newState);
             } else {
                 log.info("{} State transition from {} to {}.", logPrefix, oldState, newState);
             }
 
             state = newState;
-            if (stateListener != null) {
-                stateListener.onChange(this, state, oldState);
-            }
+        }
+        if (stateListener != null) {
+            stateListener.onChange(this, state, oldState);
         }
     }
 
@@ -1273,6 +1275,7 @@ public class StreamThread extends Thread implements ThreadDataProvider {
 
     private void shutdown(final boolean cleanRun) {
         log.info("{} Shutting down", logPrefix);
+        setState(State.PENDING_SHUTDOWN);
         taskManager.shutdown(cleanRun);
 
         // close all embedded clients


### PR DESCRIPTION
Cherrypicking additional changes made as part of this PR https://github.com/apache/kafka/pull/3622, back to trunk.