### PR TITLE
HOTFIX: reduce streams benchmark input records to 10 million

### DIFF
--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -30,7 +30,7 @@ class StreamsSimpleBenchmarkTest(Test):
 
     def __init__(self, test_context):
         super(StreamsSimpleBenchmarkTest, self).__init__(test_context)
-        self.num_records = 20000000L
+        self.num_records = 10000000L
         self.replication = 1
         self.num_threads = 1
 


### PR DESCRIPTION
We are occasionally hitting some timeouts due to processing not finishing. So rather than failing the build for these reasons it would be better to reduce the runtime.