### PR TITLE
KAFKA-5720: Fix AdminClientIntegrationTest#testCallInFlightTimeouts

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -465,6 +465,10 @@ public class KafkaAdminClient extends AdminClient {
          */
         final void fail(long now, Throwable throwable) {
             if (aborted) {
+                // If the call was aborted while in flight due to a timeout, deliver a
+                // TimeoutException.  In this case, we do not get any more retries-- the call has
+                // failed.  We increment tries anyway in order to display an accurate log message.
+                tries++;
                 if (log.isDebugEnabled()) {
                     log.debug("{} aborted at {} after {} attempt(s)", this, now, tries,
                         new Exception(prettyPrintException(throwable)));
@@ -472,7 +476,9 @@ public class KafkaAdminClient extends AdminClient {
                 handleFailure(new TimeoutException("Aborted due to timeout."));
                 return;
             }
-            // If this is an UnsupportedVersionException that we can retry, do so.
+            // If this is an UnsupportedVersionException that we can retry, do so.  Note that a
+            // protocol downgrade will not count against the total number of retries we get for
+            // this RPC.  That is why 'tries' is not incremented.
             if ((throwable instanceof UnsupportedVersionException) &&
                      handleUnsupportedVersionException((UnsupportedVersionException) throwable)) {
                 log.trace("{} attempting protocol downgrade.", this);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -372,6 +372,8 @@ public class KafkaAdminClientTest {
     public static class FailureInjectingTimeoutProcessorFactory extends KafkaAdminClient.TimeoutProcessorFactory {
 
         private int numTries = 0;
+
+        private int failuresInjected = 0;
         
         @Override
         public KafkaAdminClient.TimeoutProcessor create(long now) {
@@ -380,7 +382,15 @@ public class KafkaAdminClientTest {
 
         synchronized boolean shouldInjectFailure() {
             numTries++;
-            return numTries == 3;
+            if (numTries == 1) {
+                failuresInjected++;
+                return true;
+            }
+            return false;
+        }
+
+        public synchronized int failuresInjected() {
+            return failuresInjected;
         }
 
         public final class FailureInjectingTimeoutProcessor extends KafkaAdminClient.TimeoutProcessor {

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -392,12 +392,13 @@ class AdminClientIntegrationTest extends KafkaServerTestHarness with Logging {
     val factory = new KafkaAdminClientTest.FailureInjectingTimeoutProcessorFactory()
     val client = KafkaAdminClientTest.createInternal(new AdminClientConfig(config), factory)
     val future = client.createTopics(Seq("mytopic", "mytopic2").map(new NewTopic(_, 1, 1)).asJava,
-        new CreateTopicsOptions().validateOnly(true))
+        new CreateTopicsOptions().validateOnly(true)).all()
+    assertFutureExceptionTypeEquals(future, classOf[TimeoutException])
     val future2 = client.createTopics(Seq("mytopic3", "mytopic4").map(new NewTopic(_, 1, 1)).asJava,
-        new CreateTopicsOptions().validateOnly(true))
-    future.all().get
-    future2.all().get
+      new CreateTopicsOptions().validateOnly(true)).all()
+    future2.get
     client.close()
+    assertEquals(1, factory.failuresInjected)
   }
 }
 


### PR DESCRIPTION
* When a call is aborted, that should count as a "try" in the failure log message.
* FailureInjectingTimeoutProcessorFactory should fail the first request it is asked about.
* testCallTimeouts should expect the first request it makes to fail because of the timeout we injected.
* FailureInjectingTimeoutProcessorFactory should track how many failures it has injected, and the test should verify that one has been injected.