### PR TITLE
KAFKA-5787: StoreChangelogReader needs to restore partitions that were added post initialization

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -116,6 +116,7 @@ class AssignedTasks {
             final Map.Entry<TaskId, Task> entry = it.next();
             try {
                 if (!entry.getValue().initialize()) {
+                    log.debug("{} transitioning {} {} to restoring", logPrefix, taskTypeName, entry.getKey());
                     restoring.put(entry.getKey(), entry.getValue());
                 } else {
                     transitionToRunning(entry.getValue());
@@ -142,6 +143,16 @@ class AssignedTasks {
                 transitionToRunning(task);
                 resume.addAll(task.partitions());
                 it.remove();
+            } else {
+                if (log.isTraceEnabled()) {
+                    final HashSet<TopicPartition> outstandingPartitions = new HashSet<>(task.changelogPartitions());
+                    outstandingPartitions.removeAll(restoredPartitions);
+                    log.trace("{} partition restoration not complete for {} {} partitions:",
+                              logPrefix,
+                              taskTypeName,
+                              task.id(),
+                              task.changelogPartitions());
+                }
             }
         }
         if (allTasksRunning()) {
@@ -252,6 +263,7 @@ class AssignedTasks {
     }
 
     private void transitionToRunning(final Task task) {
+        log.debug("{} transitioning {} {} to running", logPrefix, taskTypeName, task.id());
         running.put(task.id(), task);
         for (TopicPartition topicPartition : task.partitions()) {
             runningByPartition.put(topicPartition, task);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -147,7 +147,7 @@ class AssignedTasks {
                 if (log.isTraceEnabled()) {
                     final HashSet<TopicPartition> outstandingPartitions = new HashSet<>(task.changelogPartitions());
                     outstandingPartitions.removeAll(restoredPartitions);
-                    log.trace("{} partition restoration not complete for {} {} partitions:",
+                    log.trace("{} partition restoration not complete for {} {} partitions: {}",
                               logPrefix,
                               taskTypeName,
                               task.id(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -34,6 +34,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_END;
 import static org.apache.kafka.test.MockStateRestoreListener.RESTORE_START;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class StoreChangelogReaderTest {
@@ -332,13 +334,54 @@ public class StoreChangelogReaderTest {
         assertThat(callback.restored, CoreMatchers.equalTo(Utils.mkList(KeyValue.pair(bytes, bytes), KeyValue.pair(bytes, bytes))));
     }
 
+    @Test
+    public void shouldCompleteImmediatelyWhenEndOffsetIs0() {
+        final Collection<TopicPartition> expected = Collections.singleton(topicPartition);
+        setupConsumer(0, topicPartition);
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "store"));
+        final Collection<TopicPartition> restored = changelogReader.restore();
+        assertThat(restored, equalTo(expected));
+    }
+
+    @Test
+    public void shouldRestorePartitionsRegisteredPostInitialization() {
+        final MockRestoreCallback callbackTwo = new MockRestoreCallback();
+        final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
+
+        setupConsumer(1, topicPartition);
+        consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 10L));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false,
+                                                   "storeName"));
+
+        assertTrue(changelogReader.restore().isEmpty());
+
+        final TopicPartition postInitialization = new TopicPartition("other", 0);
+        consumer.updateBeginningOffsets(Collections.singletonMap(postInitialization, 0L));
+        consumer.updateEndOffsets(Collections.singletonMap(postInitialization, 3L));
+
+        changelogReader.register(new StateRestorer(postInitialization, restoreListener2, null, Long.MAX_VALUE, false, "otherStore"));
+
+        addRecords(9, topicPartition, 1);
+
+        final Collection<TopicPartition> expected = Utils.mkSet(topicPartition, postInitialization);
+
+        consumer.assign(expected);
+        addRecords(3, postInitialization, 0);
+        assertThat(changelogReader.restore(), equalTo(expected));
+        assertThat(callback.restored.size(), equalTo(10));
+        assertThat(callbackTwo.restored.size(), equalTo(3));
+    }
+
     private void setupConsumer(final long messages, final TopicPartition topicPartition) {
         assignPartition(messages, topicPartition);
-
-        for (int i = 0; i < messages; i++) {
-            consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), i, new byte[0], new byte[0]));
-        }
+        addRecords(messages, topicPartition, 0);
         consumer.assign(Collections.<TopicPartition>emptyList());
+    }
+
+    private void addRecords(final long messages, final TopicPartition topicPartition, final int startingOffset) {
+        for (int i = 0; i < messages; i++) {
+            consumer.addRecord(new ConsumerRecord<>(topicPartition.topic(), topicPartition.partition(), startingOffset + i, new byte[0], new byte[0]));
+        }
     }
 
     private void assignPartition(final long messages, final TopicPartition topicPartition) {


### PR DESCRIPTION
If a task fails during initialization due to a LockException, its changelog partitions are not immediately added to the StoreChangelogReader as the thread doesn't hold the lock. However StoreChangelogReader#restore will be called and it sets the initialized flag. On a subsequent successfull call to initialize the new tasks the partitions are added to the StoreChangelogReader, however as it is already initialized these new partitions will never be restored. So the task would remain in a non-running state forever.