### PR TITLE
KAFKA-5771: org.apache.kafka.streams.state.internals.Segments#segments method returns incorrect results when segments were added out of order

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segments.java
@@ -85,9 +85,7 @@ class Segments {
             if (previousSegment == null) {
                 newSegment.openDB(context);
                 maxSegmentId = segmentId > maxSegmentId ? segmentId : maxSegmentId;
-                if (minSegmentId == Long.MAX_VALUE) {
-                    minSegmentId = maxSegmentId;
-                }
+                minSegmentId = segmentId < minSegmentId ? segmentId : minSegmentId;
             }
             return previousSegment == null ? newSegment : previousSegment;
         } else {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
@@ -167,6 +167,21 @@ public class SegmentsTest {
     }
 
     @Test
+    public void shouldGetSegmentsWithinTimeRangeOutOfOrder() throws Exception {
+        segments.getOrCreateSegment(4, context);
+        segments.getOrCreateSegment(2, context);
+        segments.getOrCreateSegment(0, context);
+        segments.getOrCreateSegment(1, context);
+        segments.getOrCreateSegment(3, context);
+
+        final List<Segment> segments = this.segments.segments(0, 2 * 60 * 1000);
+        assertEquals(3, segments.size());
+        assertEquals(0, segments.get(0).id);
+        assertEquals(1, segments.get(1).id);
+        assertEquals(2, segments.get(2).id);
+    }
+
+    @Test
     public void shouldRollSegments() throws Exception {
         segments.getOrCreateSegment(0, context);
         verifyCorrectSegments(0, 1);


### PR DESCRIPTION
Suggested fix for the bug