### PR TITLE
MINOR: reduce logging to trace in NetworkClient when an old server API is being used

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -397,7 +397,7 @@ public class NetworkClient implements KafkaClient {
                 log.trace("Sending {} {} with correlation id {} to node {}", clientRequest.apiKey(), request,
                         clientRequest.correlationId(), nodeId);
             } else {
-                log.debug("Using older server API v{} to send {} {} with correlation id {} to node {}",
+                log.trace("Using older server API v{} to send {} {} with correlation id {} to node {}",
                         header.apiVersion(), clientRequest.apiKey(), request, clientRequest.correlationId(), nodeId);
             }
         }


### PR DESCRIPTION
logging in `NetworkClient#doSend` at debug level is spamming the logs when you have a producer that is sending many requests. It makes it extremely difficult to debug. Reducing to trace to remove the noise from the logs