### PR TITLE
KAFKA-5762; LogContext used to capture the clientId implicitly in the…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -344,7 +344,7 @@ public class KafkaAdminClient extends AdminClient {
                      Metrics metrics, KafkaClient client, TimeoutProcessorFactory timeoutProcessorFactory) {
         this.defaultTimeoutMs = config.getInt(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.clientId = clientId;
-        LogContext logContext = new LogContext("[Consumer clientId=" + clientId + "] ");
+        LogContext logContext = new LogContext("[AdminClient clientId=" + clientId + "] ");
         this.log = logContext.logger(KafkaAdminClient.class);
         this.time = time;
         this.metadata = metadata;


### PR DESCRIPTION
… logs.