### PR TITLE
[KAFKA-4468] Correctly calculate the window end timestamp after read from state stores

### DIFF
--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/temperature/TemperatureDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/temperature/TemperatureDemo.java
@@ -114,7 +114,7 @@ public class TemperatureDemo {
                 });
 
         WindowedSerializer<String> windowedSerializer = new WindowedSerializer<>(Serdes.String().serializer());
-        WindowedDeserializer<String> windowedDeserializer = new WindowedDeserializer<>(Serdes.String().deserializer());
+        WindowedDeserializer<String> windowedDeserializer = new WindowedDeserializer<>(Serdes.String().deserializer(), TEMPERATURE_WINDOW_SIZE);
         Serde<Windowed<String>> windowedSerde = Serdes.serdeFrom(windowedSerializer, windowedDeserializer);
 
         // need to override key serde to Windowed<String> type

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedDeserializer.java
@@ -48,7 +48,7 @@ public class WindowedDeserializer<T> implements Deserializer<Windowed<T>> {
     }
 
     public WindowedDeserializer(final Deserializer<T> inner,
-            final long windowSize) {
+                                final long windowSize) {
         this.inner = inner;
         this.windowSize = windowSize;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedDeserializer.java
@@ -40,15 +40,15 @@ public class WindowedDeserializer<T> implements Deserializer<Windowed<T>> {
     
     // Default constructor needed by Kafka
     public WindowedDeserializer() {
-        this.windowSize = Long.MAX_VALUE;
+        this(null, Long.MAX_VALUE);
     }
 
     public WindowedDeserializer(Deserializer<T> inner) {
-        this.inner = inner;
-        this.windowSize = Long.MAX_VALUE;
+        this(inner, Long.MAX_VALUE);
     }
 
-    public WindowedDeserializer(Deserializer<T> inner, final long windowSize) {
+    public WindowedDeserializer(final Deserializer<T> inner,
+            final long windowSize) {
         this.inner = inner;
         this.windowSize = windowSize;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowedDeserializer.java
@@ -19,6 +19,7 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.internals.WindowStoreUtils;
 
@@ -42,8 +43,12 @@ public class WindowedDeserializer<T> implements Deserializer<Windowed<T>> {
     public WindowedDeserializer() {
         this(null, Long.MAX_VALUE);
     }
-
-    public WindowedDeserializer(Deserializer<T> inner) {
+    
+    public WindowedDeserializer(final Long windowSize) {
+       this(null, windowSize);
+    }
+    
+    public WindowedDeserializer(final Deserializer<T> inner) {
         this(inner, Long.MAX_VALUE);
     }
 
@@ -80,7 +85,7 @@ public class WindowedDeserializer<T> implements Deserializer<Windowed<T>> {
         
         long start = ByteBuffer.wrap(data).getLong(data.length - TIMESTAMP_SIZE);
         
-        TimeWindow timeWindow = (TimeWindow) (windowSize != Long.MAX_VALUE ? WindowStoreUtils.timeWindowForSize(start, windowSize) : new UnlimitedWindow(start));
+        Window timeWindow = windowSize != Long.MAX_VALUE ? WindowStoreUtils.timeWindowForSize(start, windowSize) : new UnlimitedWindow(start);
         return new Windowed<T>(inner.deserialize(topic, bytes), timeWindow);
     }
 
@@ -89,9 +94,13 @@ public class WindowedDeserializer<T> implements Deserializer<Windowed<T>> {
     public void close() {
         inner.close();
     }
-
+    
     // Only for testing
     public Deserializer<T> innerDeserializer() {
         return inner;
+    }
+    
+    public Long getWindowSize() {
+        return this.windowSize;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreUtils.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreUtils.java
@@ -79,7 +79,7 @@ public class WindowStoreUtils {
      * Safely construct a time window of the given size,
      * taking care of bounding endMs to Long.MAX_VALUE if necessary
      */
-    static TimeWindow timeWindowForSize(final long startMs, final long windowSize) {
+    public static TimeWindow timeWindowForSize(final long startMs, final long windowSize) {
         final long endMs = startMs + windowSize;
         return new TimeWindow(startMs, endMs < 0 ? Long.MAX_VALUE : endMs);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -147,27 +147,27 @@ public class WindowedStreamPartitionerTest {
     
     @Test
     public void testWindowedDeserializerWindowSize() {
-        Map<String, String> props = new HashMap<>();
+        final Map<String, String> props = new HashMap<>();
         // test key[value].deserializer.inner.class takes precedence over serializer.inner.class
-        WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
+        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         windowedDeserializer.configure(props, true);
-        Deserializer<?> inner = windowedDeserializer.innerDeserializer();
+        final Deserializer<?> inner = windowedDeserializer.innerDeserializer();
         assertNotNull("Inner deserializer should be not null", inner);
         assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         //test for deserializer expected window end time
-        long randomLong = 5000000;
-        byte[] byteValues = stringSerializer.serialize(topicName, "dummy string");
-        WindowedDeserializer<StringSerializer> windowedDeserializer1 = 
+        final long randomLong = 5000000;
+        byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose
+        final WindowedDeserializer<StringSerializer> windowedDeserializer1 = 
             new WindowedDeserializer<>(windowedDeserializer.innerDeserializer(), randomLong);
         windowedDeserializer1.configure(props, false);
         Windowed<?> windowed = windowedDeserializer1.deserialize(topicName, byteValues);
-        long actualSize = windowed.window().end() - windowed.window().start();
-        assertEquals(randomLong, actualSize);
+        final long actualSize = windowed.window().end() - windowed.window().start(); //find actual window time
+        assertEquals(randomLong, actualSize); //testing if window size matches up with expected one
         windowedDeserializer.close();
         windowedDeserializer1.close();
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -92,6 +92,7 @@ public class WindowedStreamPartitionerTest {
 
         defaultPartitioner.close();
     }
+    
     @Test
     public void testWindowedSerializerNoArgConstructors() {
         Map<String, String> props = new HashMap<>();
@@ -143,32 +144,27 @@ public class WindowedStreamPartitionerTest {
         windowedDeserializer.close();
         windowedDeserializer1.close();
     }
+    
     @Test
     public void testWindowSerializeConfig() {
         final Map<String, String> props = new HashMap<>();
         // test key[value].serializer.inner.class takes precedence over serializer.inner.class
         final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         windowedDeserializer.configure(props, true);
         final Deserializer<?> inner = windowedDeserializer.innerDeserializer();
-        assertNotNull("Inner deserializer should be not null", inner);
         assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArraySerializer");
     }
+    
     @Test
     public void testWindowSerializeWithWindowSize() {
         final Map<String, String> props = new HashMap<>();
         // test key[value].serializer.inner.class takes precedence over serializer.inner.class
         final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         windowedDeserializer.configure(props, true);
-        final Deserializer<?> inner = windowedDeserializer.innerDeserializer();
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArraySerializer");
         props.remove("key.serializer.inner.class");
         props.remove("value.serializer.inner.class");
@@ -184,6 +180,7 @@ public class WindowedStreamPartitionerTest {
         windowedDeserializer.close();
         windowedDeserializer1.close();
     }
+    
     @Test
     public void testWindowDeserializeConfig() {
         final Map<String, String> props = new HashMap<>();
@@ -198,6 +195,7 @@ public class WindowedStreamPartitionerTest {
         assertNotNull("Inner deserializer should be not null", inner);
         assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
     }
+    
     @Test
     public void testWindowDeserializeWithWindowSize() {
         final Map<String, String> props = new HashMap<>();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -138,7 +138,7 @@ public class WindowedStreamPartitionerTest {
         props.remove("value.deserializer.inner.class");
         WindowedDeserializer<?> windowedDeserializer1 = new WindowedDeserializer<>();
         windowedDeserializer1.configure(props, false);
-        Deserializer<?> inner1 = windowedDeserializer1.innerDeserializer();
+        final Deserializer<?> inner1 = windowedDeserializer1.innerDeserializer();
         assertNotNull("Inner deserializer should be not null", inner1);
         assertTrue("Inner deserializer type should be ByteArrayDeserializer", inner1 instanceof ByteArrayDeserializer);
         windowedDeserializer.close();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -92,7 +92,6 @@ public class WindowedStreamPartitionerTest {
 
         defaultPartitioner.close();
     }
-
     @Test
     public void testWindowedSerializerNoArgConstructors() {
         Map<String, String> props = new HashMap<>();
@@ -118,33 +117,6 @@ public class WindowedStreamPartitionerTest {
         windowedSerializer.close();
         windowedSerializer1.close();
     }
-
-    @Test
-    public void testWindowedDeserializerNoArgConstructors() {
-        Map<String, String> props = new HashMap<>();
-        // test key[value].deserializer.inner.class takes precedence over serializer.inner.class
-        WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
-        props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        windowedDeserializer.configure(props, true);
-        Deserializer<?> inner = windowedDeserializer.innerDeserializer();
-        assertNotNull("Inner deserializer should be not null", inner);
-        assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
-        // test deserializer.inner.class
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-        props.remove("key.deserializer.inner.class");
-        props.remove("value.deserializer.inner.class");
-        WindowedDeserializer<?> windowedDeserializer1 = new WindowedDeserializer<>();
-        windowedDeserializer1.configure(props, false);
-        final Deserializer<?> inner1 = windowedDeserializer1.innerDeserializer();
-        assertNotNull("Inner deserializer should be not null", inner1);
-        assertTrue("Inner deserializer type should be ByteArrayDeserializer", inner1 instanceof ByteArrayDeserializer);
-        windowedDeserializer.close();
-        windowedDeserializer1.close();
-    }
-    
     @Test
     public void testWindowedDeserializerWindowSize() {
         final Map<String, String> props = new HashMap<>();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -145,28 +145,11 @@ public class WindowedStreamPartitionerTest {
     }
     
     @Test
-    public void testWindowSerializeExpectedWindowSize() {
-        final long randomLong = 5000000;
-        final Map<String, String> props = new HashMap<>();
-        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>(randomLong);
-        props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        windowedDeserializer.configure(props, true);
-        //test for serializer expected window end time
-        final byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose
-        final Windowed<?> windowed = windowedDeserializer.deserialize(topicName, byteValues);
-        final long actualSize = windowed.window().end() - windowed.window().start(); //find actual window time
-        assertEquals(randomLong, actualSize); //testing if window size matches up with expected one
-        windowedDeserializer.close();
-    }
-    
-    @Test
     public void testWindowDeserializeExpectedWindowSize() {
         final long randomLong = 5000000;
         final Map<String, String> props = new HashMap<>();
         final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>(randomLong);
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         windowedDeserializer.configure(props, true);
         //test for deserializer expected window end time
         final byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -144,4 +144,31 @@ public class WindowedStreamPartitionerTest {
         windowedDeserializer.close();
         windowedDeserializer1.close();
     }
+    
+    @Test
+    public void testWindowedDeserializerWindowSize() {
+        Map<String, String> props = new HashMap<>();
+        // test key[value].deserializer.inner.class takes precedence over serializer.inner.class
+        WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
+        props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
+        windowedDeserializer.configure(props, true);
+        Deserializer<?> inner = windowedDeserializer.innerDeserializer();
+        assertNotNull("Inner deserializer should be not null", inner);
+        assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
+        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        //test for deserializer expected window end time
+        long randomLong = 5000000;
+        byte[] byteValues = stringSerializer.serialize(topicName, "dummy string");
+        WindowedDeserializer<StringSerializer> windowedDeserializer1 = 
+            new WindowedDeserializer<>(windowedDeserializer.innerDeserializer(), randomLong);
+        windowedDeserializer1.configure(props, false);
+        Windowed<?> windowed = windowedDeserializer1.deserialize(topicName, byteValues);
+        long actualSize = windowed.window().end() - windowed.window().start();
+        assertEquals(randomLong, actualSize);
+        windowedDeserializer.close();
+        windowedDeserializer1.close();
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -146,21 +146,8 @@ public class WindowedStreamPartitionerTest {
     }
     
     @Test
-    public void testWindowSerializeConfig() {
+    public void testWindowSerializeExpectedWindowSize() {
         final Map<String, String> props = new HashMap<>();
-        // test key[value].serializer.inner.class takes precedence over serializer.inner.class
-        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
-        props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        windowedDeserializer.configure(props, true);
-        final Deserializer<?> inner = windowedDeserializer.innerDeserializer();
-        assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
-    }
-    
-    @Test
-    public void testWindowSerializeWithWindowSize() {
-        final Map<String, String> props = new HashMap<>();
-        // test key[value].serializer.inner.class takes precedence over serializer.inner.class
         final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
@@ -182,24 +169,8 @@ public class WindowedStreamPartitionerTest {
     }
     
     @Test
-    public void testWindowDeserializeConfig() {
+    public void testWindowDeserializeExpectedWindowSize() {
         final Map<String, String> props = new HashMap<>();
-        // test key[value].deserializer.inner.class takes precedence over serializer.inner.class
-        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
-        props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
-        windowedDeserializer.configure(props, true);
-        final Deserializer<?> inner = windowedDeserializer.innerDeserializer();
-        assertNotNull("Inner deserializer should be not null", inner);
-        assertTrue("Inner deserializer type should be StringDeserializer", inner instanceof StringDeserializer);
-    }
-    
-    @Test
-    public void testWindowDeserializeWithWindowSize() {
-        final Map<String, String> props = new HashMap<>();
-        // test key[value].deserializer.inner.class takes precedence over serializer.inner.class
         final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -161,11 +161,11 @@ public class WindowedStreamPartitionerTest {
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         //test for deserializer expected window end time
         final long randomLong = 5000000;
-        byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose
+        final byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose
         final WindowedDeserializer<StringSerializer> windowedDeserializer1 = 
             new WindowedDeserializer<>(windowedDeserializer.innerDeserializer(), randomLong);
         windowedDeserializer1.configure(props, false);
-        Windowed<?> windowed = windowedDeserializer1.deserialize(topicName, byteValues);
+        final Windowed<?> windowed = windowedDeserializer1.deserialize(topicName, byteValues);
         final long actualSize = windowed.window().end() - windowed.window().start(); //find actual window time
         assertEquals(randomLong, actualSize); //testing if window size matches up with expected one
         windowedDeserializer.close();

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/WindowedStreamPartitionerTest.java
@@ -122,7 +122,6 @@ public class WindowedStreamPartitionerTest {
     @Test
     public void testWindowedDeserializerNoArgConstructors() {
         Map<String, String> props = new HashMap<>();
-        // test key[value].deserializer.inner.class takes precedence over serializer.inner.class
         WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
         props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
@@ -147,50 +146,33 @@ public class WindowedStreamPartitionerTest {
     
     @Test
     public void testWindowSerializeExpectedWindowSize() {
+        final long randomLong = 5000000;
         final Map<String, String> props = new HashMap<>();
-        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
+        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>(randomLong);
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         windowedDeserializer.configure(props, true);
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArraySerializer");
-        props.remove("key.serializer.inner.class");
-        props.remove("value.serializer.inner.class");
         //test for serializer expected window end time
-        final long randomLong = 5000000;
         final byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose
-        final WindowedDeserializer<StringSerializer> windowedDeserializer1 = 
-            new WindowedDeserializer<>(windowedDeserializer.innerDeserializer(), randomLong);
-        windowedDeserializer1.configure(props, false);
-        final Windowed<?> windowed = windowedDeserializer1.deserialize(topicName, byteValues);
+        final Windowed<?> windowed = windowedDeserializer.deserialize(topicName, byteValues);
         final long actualSize = windowed.window().end() - windowed.window().start(); //find actual window time
         assertEquals(randomLong, actualSize); //testing if window size matches up with expected one
         windowedDeserializer.close();
-        windowedDeserializer1.close();
     }
     
     @Test
     public void testWindowDeserializeExpectedWindowSize() {
+        final long randomLong = 5000000;
         final Map<String, String> props = new HashMap<>();
-        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>();
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "host:1");
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
+        final WindowedDeserializer<StringSerializer> windowedDeserializer = new WindowedDeserializer<>(randomLong);
         props.put("key.deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.StringDeserializer");
         windowedDeserializer.configure(props, true);
-        final Deserializer<?> inner = windowedDeserializer.innerDeserializer();
-        props.put("deserializer.inner.class", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-        props.remove("key.serializer.inner.class");
-        props.remove("value.serializer.inner.class");
         //test for deserializer expected window end time
-        final long randomLong = 5000000;
         final byte[] byteValues = stringSerializer.serialize(topicName, "dummy string"); //dummy string, serves no real purpose
-        final WindowedDeserializer<StringSerializer> windowedDeserializer1 = 
-            new WindowedDeserializer<>(windowedDeserializer.innerDeserializer(), randomLong);
-        windowedDeserializer1.configure(props, false);
-        final Windowed<?> windowed = windowedDeserializer1.deserialize(topicName, byteValues);
+        final Windowed<?> windowed = windowedDeserializer.deserialize(topicName, byteValues);
         final long actualSize = windowed.window().end() - windowed.window().start(); //find actual window time
         assertEquals(randomLong, actualSize); //testing if window size matches up with expected one
         windowedDeserializer.close();
-        windowedDeserializer1.close();
     }
 }


### PR DESCRIPTION
I have decided to use the following approach to fixing this bug:

1) Since the Window Size in WindowedDeserializer was originally unknown, I have initialized
a field _windowSize_ and created a constructor to allow it to be instantiated

2) The default size for __windowSize__ is _Long.MAX_VALUE_. If that is the case, then the 
deserialize method will return an Unlimited Window, or else will return Timed one.

3) Temperature Demo was modified to demonstrate how to use this new constructor, given
that the window size is known.
