### PR TITLE
KAFKA-5797: Delay checking of partition existence in StoreChangelogReader

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -124,7 +124,7 @@ class AssignedTasks {
                 it.remove();
             } catch (final LockException e) {
                 // made this trace as it will spam the logs in the poll loop.
-                log.debug("{} Could not create {} {} due to {}; will retry in the next run loop", logPrefix, taskTypeName, entry.getKey(), e.getMessage());
+                log.trace("{} Could not create {} {} due to {}; will retry in the next run loop", logPrefix, taskTypeName, entry.getKey(), e.getMessage());
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -124,7 +124,7 @@ class AssignedTasks {
                 it.remove();
             } catch (final LockException e) {
                 // made this trace as it will spam the logs in the poll loop.
-                log.trace("{} Could not create {} {} due to {}; will retry", logPrefix, taskTypeName, entry.getKey(), e.getMessage());
+                log.debug("{} Could not create {} {} due to {}; will retry in the next run loop", logPrefix, taskTypeName, entry.getKey(), e.getMessage());
             }
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -28,18 +28,10 @@ import java.util.Map;
  */
 public interface ChangelogReader {
     /**
-     * Validate that the partition exists on the cluster.
-     * @param topicPartition    partition to validate.
-     * @param storeName         name of the store the partition is for.
-     * @throws org.apache.kafka.streams.errors.StreamsException if partition doesn't exist
-     */
-    void validatePartitionExists(final TopicPartition topicPartition, final String storeName);
-
-    /**
      * Register a state store and it's partition for later restoration.
-     * @param restorationInfo
+     * @param restorer the state restorer to register
      */
-    void register(final StateRestorer restorationInfo);
+    void register(final StateRestorer restorer);
 
     /**
      * Restore all registered state stores by reading from their changelogs.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -28,11 +28,6 @@ import java.util.Map;
  */
 public interface ChangelogReader {
     /**
-     * Refresh the changelog information for all the registered restorer
-     */
-    void refreshChangelogInfo();
-
-    /**
      * Register a state store and it's partition for later restoration.
      * @param restorer the state restorer to register
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ChangelogReader.java
@@ -28,6 +28,11 @@ import java.util.Map;
  */
 public interface ChangelogReader {
     /**
+     * Refresh the changelog information for all the registered restorer
+     */
+    void refreshChangelogInfo();
+
+    /**
      * Register a state store and it's partition for later restoration.
      * @param restorer the state restorer to register
      */

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -157,7 +157,6 @@ public class ProcessorStateManager implements StateManager {
         }
 
         final TopicPartition storePartition = new TopicPartition(topic, getPartition(topic));
-        changelogReader.validatePartitionExists(storePartition, store.name());
 
         if (isStandby) {
             if (store.persistent()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -29,11 +29,13 @@ public class StateRestorer {
     private final Long checkpoint;
     private final long offsetLimit;
     private final boolean persistent;
-    private final TopicPartition partition;
     private final String storeName;
+    private final TopicPartition partition;
     private final CompositeRestoreListener compositeRestoreListener;
+
     private long restoredOffset;
     private long startingOffset;
+    private long endingOffset;
 
     StateRestorer(final TopicPartition partition,
                   final CompositeRestoreListener compositeRestoreListener,
@@ -57,7 +59,7 @@ public class StateRestorer {
         return checkpoint == null ? NO_CHECKPOINT : checkpoint;
     }
 
-    void restoreStarted(long startingOffset, long endingOffset) {
+    void restoreStarted() {
         compositeRestoreListener.onRestoreStart(partition, storeName, startingOffset, endingOffset);
     }
 
@@ -87,6 +89,10 @@ public class StateRestorer {
 
     void setStartingOffset(final long startingOffset) {
         this.startingOffset = Math.min(offsetLimit, startingOffset);
+    }
+
+    void setEndingOffset(final long endingOffset) {
+        this.endingOffset = Math.min(offsetLimit, endingOffset);
     }
 
     long startingOffset() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -22,9 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,62 +39,27 @@ import java.util.Set;
 public class StoreChangelogReader implements ChangelogReader {
     private static final Logger log = LoggerFactory.getLogger(StoreChangelogReader.class);
 
-    private final Consumer<byte[], byte[]> consumer;
     private final String logPrefix;
-    private final Time time;
-    private final long partitionValidationTimeoutMs;
-    private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
+    private final Consumer<byte[], byte[]> consumer;
     private final StateRestoreListener stateRestoreListener;
+    private final Map<TopicPartition, Long> endOffsets = new HashMap<>();
+    private final Map<String, List<PartitionInfo>> partitionInfo = new HashMap<>();
     private final Map<TopicPartition, StateRestorer> stateRestorers = new HashMap<>();
     private final Map<TopicPartition, StateRestorer> needsRestoring = new HashMap<>();
     private final Map<TopicPartition, StateRestorer> needsInitializing = new HashMap<>();
-    private final Map<TopicPartition, Long> endOffsets = new HashMap<>();
 
-    public StoreChangelogReader(final String threadId, final Consumer<byte[], byte[]> consumer, final Time time,
-                                final long partitionValidationTimeoutMs, final StateRestoreListener stateRestoreListener) {
-        this.time = time;
+    public StoreChangelogReader(final String threadId,
+                                final Consumer<byte[], byte[]> consumer,
+                                final StateRestoreListener stateRestoreListener) {
         this.consumer = consumer;
-        this.partitionValidationTimeoutMs = partitionValidationTimeoutMs;
 
         this.logPrefix = String.format("stream-thread [%s]", threadId);
         this.stateRestoreListener = stateRestoreListener;
     }
 
-    public StoreChangelogReader(final Consumer<byte[], byte[]> consumer, final Time time,
-                                long partitionValidationTimeoutMs, final StateRestoreListener stateRestoreListener) {
-        this("", consumer, time, partitionValidationTimeoutMs, stateRestoreListener);
-    }
-
-    @Override
-    public void validatePartitionExists(final TopicPartition topicPartition, final String storeName) {
-        final long start = time.milliseconds();
-        // fetch all info on all topics to avoid multiple remote calls
-        if (partitionInfo.isEmpty()) {
-            try {
-                partitionInfo.putAll(consumer.listTopics());
-            } catch (final TimeoutException e) {
-                log.warn("{} Could not list topics so will fall back to partition by partition fetching", logPrefix);
-            }
-        }
-
-        final long endTime = time.milliseconds() + partitionValidationTimeoutMs;
-        while (!hasPartition(topicPartition) && time.milliseconds() < endTime) {
-            try {
-                final List<PartitionInfo> partitions = consumer.partitionsFor(topicPartition.topic());
-                if (partitions != null) {
-                    partitionInfo.put(topicPartition.topic(), partitions);
-                }
-            } catch (final TimeoutException e) {
-                throw new StreamsException(String.format("Could not fetch partition info for topic: %s before expiration of the configured request timeout",
-                                                         topicPartition.topic()));
-            }
-        }
-
-        if (!hasPartition(topicPartition)) {
-            throw new StreamsException(String.format("Store %s's change log (%s) does not contain partition %s",
-                                                     storeName, topicPartition.topic(), topicPartition.partition()));
-        }
-        log.debug("{} Took {}ms to validate that partition {} exists", logPrefix, time.milliseconds() - start, topicPartition);
+    public StoreChangelogReader(final Consumer<byte[], byte[]> consumer,
+                                final StateRestoreListener stateRestoreListener) {
+        this("", consumer, stateRestoreListener);
     }
 
     @Override
@@ -131,45 +94,79 @@ public class StoreChangelogReader implements ChangelogReader {
     }
 
     private void initialize() {
-        final Map<TopicPartition, StateRestorer> newTasksNeedingRestoration = new HashMap<>();
-
         if (!consumer.subscription().isEmpty()) {
-            throw new IllegalStateException(String.format("Restore consumer should have not subscribed to any partitions (%s) beforehand", consumer.subscription()));
+            throw new IllegalStateException("Restore consumer should not subscribed to any topics (" + consumer.subscription() + ")");
         }
-        endOffsets.putAll(consumer.endOffsets(needsInitializing.keySet()));
 
-        // remove any partitions where we already have all of the data
-        for (final Map.Entry<TopicPartition, Long> entry : endOffsets.entrySet()) {
-            TopicPartition topicPartition = entry.getKey();
-            Long offset = entry.getValue();
-            final StateRestorer restorer = needsInitializing.get(topicPartition);
-            // might be null as has was initialized in a previous invocation.
-            if (restorer != null) {
-                if (restorer.checkpoint() >= offset) {
-                    restorer.setRestoredOffset(restorer.checkpoint());
-                } else if (restorer.offsetLimit() == 0 || endOffsets.get(topicPartition) == 0) {
-                    restorer.setRestoredOffset(0);
+        Map<TopicPartition, StateRestorer> initializable = new HashMap<>();
+        for (Map.Entry<TopicPartition, StateRestorer> entry : needsInitializing.entrySet()) {
+            final TopicPartition topicPartition = entry.getKey();
+            if (hasPartition(topicPartition)) {
+                initializable.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // try to fetch end offsets for the initializable restorers and remove any partitions
+        // where we already have all of the data
+        try {
+            endOffsets.putAll(consumer.endOffsets(initializable.keySet()));
+        } catch (final TimeoutException e) {
+            // if timeout exception gets thrown we just give up this time and retry in the next run loop
+            log.debug("{} Could not fetch end offset for {}; will fall back to partition by partition fetching", logPrefix, initializable);
+            initializable.clear();
+        }
+
+        if (!initializable.isEmpty()) {
+            for (final TopicPartition topicPartition : initializable.keySet()) {
+                final Long offset = endOffsets.get(topicPartition);
+
+                // offset should not be null; but since the consumer API does not guarantee it
+                // we add this check just in case
+                if (offset != null) {
+                    // do not need to check restorer since it will never by null
+                    final StateRestorer restorer = needsInitializing.get(topicPartition);
+                    if (restorer.checkpoint() >= offset) {
+                        restorer.setRestoredOffset(restorer.checkpoint());
+                        initializable.remove(topicPartition);
+                    } else if (restorer.offsetLimit() == 0 || endOffsets.get(topicPartition) == 0) {
+                        restorer.setRestoredOffset(0);
+                        initializable.remove(topicPartition);
+                    } else {
+                        restorer.setEndingOffset(offset);
+                    }
+                    needsInitializing.remove(topicPartition);
                 } else {
-                    newTasksNeedingRestoration.put(topicPartition, restorer);
-                    final Long endOffset = endOffsets.get(topicPartition);
-                    restorer.restoreStarted(restorer.startingOffset(), endOffset);
+                    initializable.remove(topicPartition);
                 }
             }
         }
 
-        log.debug("{} Starting restoring state stores from changelog topics {}", logPrefix, newTasksNeedingRestoration.keySet());
+        // set up restorer for those initializable
+        if (!initializable.isEmpty()) {
+            maybeSetupRestoration(initializable);
+        }
+
+        // if there are still some restorers whose changelog partitions are not known yet,
+        // try to fetch all metadata info once and in the next run loop we will retry again
+        maybeRefreshPartitionInfo();
+    }
+
+    private void maybeSetupRestoration(final Map<TopicPartition, StateRestorer> initializable) {
+        log.debug("{} Starting restoring state stores from changelog topics {}", logPrefix, initializable.keySet());
 
         final Set<TopicPartition> assignment = new HashSet<>(consumer.assignment());
-        assignment.addAll(newTasksNeedingRestoration.keySet());
+        assignment.addAll(initializable.keySet());
         consumer.assign(assignment);
+
         final List<StateRestorer> needsPositionUpdate = new ArrayList<>();
-        for (final StateRestorer restorer : newTasksNeedingRestoration.values()) {
+        for (final StateRestorer restorer : initializable.values()) {
             if (restorer.checkpoint() != StateRestorer.NO_CHECKPOINT) {
                 consumer.seek(restorer.partition(), restorer.checkpoint());
                 logRestoreOffsets(restorer.partition(),
-                                  restorer.checkpoint(),
-                                  endOffsets.get(restorer.partition()));
+                        restorer.checkpoint(),
+                        endOffsets.get(restorer.partition()));
                 restorer.setStartingOffset(consumer.position(restorer.partition()));
+                restorer.restoreStarted();
             } else {
                 consumer.seekToBeginning(Collections.singletonList(restorer.partition()));
                 needsPositionUpdate.add(restorer);
@@ -178,14 +175,26 @@ public class StoreChangelogReader implements ChangelogReader {
 
         for (final StateRestorer restorer : needsPositionUpdate) {
             final long position = consumer.position(restorer.partition());
-            restorer.setStartingOffset(position);
             logRestoreOffsets(restorer.partition(),
-                              position,
-                              endOffsets.get(restorer.partition()));
+                    position,
+                    endOffsets.get(restorer.partition()));
+            restorer.setStartingOffset(position);
+            restorer.restoreStarted();
         }
 
-        needsRestoring.putAll(newTasksNeedingRestoration);
-        needsInitializing.clear();
+        needsRestoring.putAll(initializable);
+    }
+
+    private void maybeRefreshPartitionInfo() {
+        if (!needsInitializing.isEmpty()) {
+            log.debug("{} Changelog partitions {} metadata are unknown so they cannot be used for restoration;" +
+                    "will retry in the next run loop", logPrefix, needsInitializing.keySet());
+            try {
+                partitionInfo.putAll(consumer.listTopics());
+            } catch (final TimeoutException e) {
+                log.debug("{} Could not fetch topic metadata; will fall back to partition by partition fetching", logPrefix);
+            }
+        }
     }
 
     private void logRestoreOffsets(final TopicPartition partition, final long startingOffset, final Long endOffset) {
@@ -294,6 +303,5 @@ public class StoreChangelogReader implements ChangelogReader {
         }
 
         return false;
-
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -557,8 +557,6 @@ public class StreamThread extends Thread implements ThreadDataProvider {
         final Consumer<byte[], byte[]> restoreConsumer = clientSupplier.getRestoreConsumer(consumerConfigs);
         final StoreChangelogReader changelogReader = new StoreChangelogReader(threadClientId,
                                                                               restoreConsumer,
-                                                                              time,
-                                                                              config.getInt(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG),
                                                                               stateRestoreListener);
 
         Producer<byte[], byte[]> threadProducer = null;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -79,6 +79,7 @@ class TaskManager {
         active.closeNonAssignedSuspendedTasks(assignedActiveTasks);
         addStreamTasks(assignment);
         addStandbyTasks();
+        changelogReader.refreshChangelogInfo();
         final Set<TopicPartition> partitions = active.uninitializedPartitions();
         log.trace("{} pausing partitions: {}", logPrefix, partitions);
         consumer.pause(partitions);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -79,7 +79,6 @@ class TaskManager {
         active.closeNonAssignedSuspendedTasks(assignedActiveTasks);
         addStreamTasks(assignment);
         addStandbyTasks();
-        changelogReader.refreshChangelogInfo();
         final Set<TopicPartition> partitions = active.uninitializedPartitions();
         log.trace("{} pausing partitions: {}", logPrefix, partitions);
         consumer.pause(partitions);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
@@ -122,7 +121,7 @@ public class AbstractTaskTest {
                                                       Collections.<String, String>emptyMap(),
                                                       Collections.<StateStore>emptyList()),
                                 consumer,
-                                new StoreChangelogReader(consumer, Time.SYSTEM, 5000, new MockStateRestoreListener()),
+                                new StoreChangelogReader(consumer, new MockStateRestoreListener()),
                                 false,
                                 stateDirectory,
                                 config) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StandbyTaskTest.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.ProcessorStateException;
@@ -133,7 +132,7 @@ public class StandbyTaskTest {
 
     private final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     private final MockRestoreConsumer restoreStateConsumer = new MockRestoreConsumer();
-    private final StoreChangelogReader changelogReader = new StoreChangelogReader(restoreStateConsumer, Time.SYSTEM, 5000, stateRestoreListener);
+    private final StoreChangelogReader changelogReader = new StoreChangelogReader(restoreStateConsumer, stateRestoreListener);
 
     private final byte[] recordValue = intSerializer.serialize(null, 10);
     private final byte[] recordKey = intSerializer.serialize(null, 1);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -94,7 +94,6 @@ public class StoreChangelogReaderTest {
         setupConsumer(messages, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
-        changelogReader.refreshChangelogInfo();
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(messages));
     }
@@ -105,7 +104,6 @@ public class StoreChangelogReaderTest {
         setupConsumer(messages, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, 5L, Long.MAX_VALUE, true,
                                                    "storeName"));
-        changelogReader.refreshChangelogInfo();
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(5));
@@ -128,8 +126,6 @@ public class StoreChangelogReaderTest {
         final StateRestorer restorer = new StateRestorer(topicPartition, restoreListener, null, 3, true,
                                                          "storeName");
         changelogReader.register(restorer);
-        changelogReader.refreshChangelogInfo();
-
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(3));
         assertThat(restorer.restoredOffset(), equalTo(3L));
@@ -151,7 +147,6 @@ public class StoreChangelogReaderTest {
             .register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName1"));
         changelogReader.register(new StateRestorer(one, restoreListener1, null, Long.MAX_VALUE, true, "storeName2"));
         changelogReader.register(new StateRestorer(two, restoreListener2, null, Long.MAX_VALUE, true, "storeName3"));
-        changelogReader.refreshChangelogInfo();
 
         changelogReader.restore();
 
@@ -176,7 +171,6 @@ public class StoreChangelogReaderTest {
             .register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName1"));
         changelogReader.register(new StateRestorer(one, restoreListener1, null, Long.MAX_VALUE, true, "storeName2"));
         changelogReader.register(new StateRestorer(two, restoreListener2, null, Long.MAX_VALUE, true, "storeName3"));
-        changelogReader.refreshChangelogInfo();
 
         changelogReader.restore();
 
@@ -218,7 +212,6 @@ public class StoreChangelogReaderTest {
             new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName");
         setupConsumer(0, topicPartition);
         changelogReader.register(restorer);
-        changelogReader.refreshChangelogInfo();
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(0));
@@ -234,7 +227,6 @@ public class StoreChangelogReaderTest {
             new StateRestorer(topicPartition, restoreListener, endOffset, Long.MAX_VALUE, true, "storeName");
 
         changelogReader.register(restorer);
-        changelogReader.refreshChangelogInfo();
 
         changelogReader.restore();
         assertThat(callback.restored.size(), equalTo(0));
@@ -246,7 +238,6 @@ public class StoreChangelogReaderTest {
         setupConsumer(10, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
-        changelogReader.refreshChangelogInfo();
         changelogReader.restore();
         final Map<TopicPartition, Long> restoredOffsets = changelogReader.restoredOffsets();
         assertThat(restoredOffsets, equalTo(Collections.singletonMap(topicPartition, 10L)));
@@ -257,7 +248,6 @@ public class StoreChangelogReaderTest {
         setupConsumer(10, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false,
                                                    "storeName"));
-        changelogReader.refreshChangelogInfo();
         changelogReader.restore();
         final Map<TopicPartition, Long> restoredOffsets = changelogReader.restoredOffsets();
         assertThat(restoredOffsets, equalTo(Collections.<TopicPartition, Long>emptyMap()));
@@ -273,7 +263,6 @@ public class StoreChangelogReaderTest {
         consumer.assign(Collections.singletonList(topicPartition));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false,
                                                    "storeName"));
-        changelogReader.refreshChangelogInfo();
         changelogReader.restore();
 
         assertThat(callback.restored, CoreMatchers.equalTo(Utils.mkList(KeyValue.pair(bytes, bytes), KeyValue.pair(bytes, bytes))));
@@ -284,7 +273,6 @@ public class StoreChangelogReaderTest {
         final Collection<TopicPartition> expected = Collections.singleton(topicPartition);
         setupConsumer(0, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "store"));
-        changelogReader.refreshChangelogInfo();
         final Collection<TopicPartition> restored = changelogReader.restore();
         assertThat(restored, equalTo(expected));
     }
@@ -297,7 +285,6 @@ public class StoreChangelogReaderTest {
         setupConsumer(1, topicPartition);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 10L));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false, "storeName"));
-        changelogReader.refreshChangelogInfo();
 
         assertTrue(changelogReader.restore().isEmpty());
 
@@ -309,7 +296,6 @@ public class StoreChangelogReaderTest {
         consumer.updateEndOffsets(Collections.singletonMap(postInitialization, 3L));
 
         changelogReader.register(new StateRestorer(postInitialization, restoreListener2, null, Long.MAX_VALUE, false, "otherStore"));
-        changelogReader.refreshChangelogInfo();
 
         final Collection<TopicPartition> expected = Utils.mkSet(topicPartition, postInitialization);
         consumer.assign(expected);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -34,7 +34,6 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
@@ -115,7 +114,7 @@ public class StreamTaskTest {
     private final MockProducer<byte[], byte[]> producer = new MockProducer<>(false, bytesSerializer, bytesSerializer);
     private final MockConsumer<byte[], byte[]> restoreStateConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     private final StateRestoreListener stateRestoreListener = new MockStateRestoreListener();
-    private final StoreChangelogReader changelogReader = new StoreChangelogReader(restoreStateConsumer, Time.SYSTEM, 5000, stateRestoreListener);
+    private final StoreChangelogReader changelogReader = new StoreChangelogReader(restoreStateConsumer, stateRestoreListener);
     private final byte[] recordValue = intSerializer.serialize(null, 10);
     private final byte[] recordKey = intSerializer.serialize(null, 1);
     private final String applicationId = "applicationId";

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProviderTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.MockTime;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
@@ -188,7 +187,7 @@ public class StreamThreadStateStoreProviderTest {
             Collections.singletonList(new TopicPartition(topicName, taskId.partition)),
             topology,
             clientSupplier.consumer,
-            new StoreChangelogReader(clientSupplier.restoreConsumer, Time.SYSTEM, 5000, new MockStateRestoreListener()),
+            new StoreChangelogReader(clientSupplier.restoreConsumer, new MockStateRestoreListener()),
             streamsConfig,
             new MockStreamsMetrics(new Metrics()),
             stateDirectory,

--- a/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
@@ -30,13 +30,8 @@ public class MockChangelogReader implements ChangelogReader {
     private final Set<TopicPartition> registered = new HashSet<>();
 
     @Override
-    public void validatePartitionExists(final TopicPartition topicPartition, final String storeName) {
-
-    }
-
-    @Override
-    public void register(final StateRestorer restorationInfo) {
-        registered.add(restorationInfo.partition());
+    public void register(final StateRestorer restorer) {
+        registered.add(restorer.partition());
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
@@ -45,9 +45,6 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
-    public void refreshChangelogInfo() {}
-
-    @Override
     public void reset() {
         registered.clear();
     }

--- a/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockChangelogReader.java
@@ -45,6 +45,9 @@ public class MockChangelogReader implements ChangelogReader {
     }
 
     @Override
+    public void refreshChangelogInfo() {}
+
+    @Override
     public void reset() {
         registered.clear();
     }

--- a/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/ProcessorTopologyTestDriver.java
@@ -222,8 +222,6 @@ public class ProcessorTopologyTestDriver {
                                   consumer,
                                   new StoreChangelogReader(
                                       createRestoreConsumer(topology.storeToChangelogTopic()),
-                                      Time.SYSTEM,
-                                      5000,
                                       stateRestoreListener),
                                   config,
                                   streamsMetrics, stateDirectory,


### PR DESCRIPTION
1. Remove timeout-based validatePartitionExists from StoreChangelogReader; instead only try to refresh metadata once after all tasks have been created and their topology initialized (hence all stores have been registered).
2. Add the logic to refresh partition metadata at the end of initialization if some restorers needing initialization cannot find their changelogs, hoping that in the next run loop these stores can find their changelogs.

As a result, after `initialize` is called we may not be able to start initializing all the `needsInitializing` ones.

As an optimization, we would not call `consumer#partitionsFor` any more, but only `consumer#listTopics` fetching all the topic metadata; so the only blocking calls left are `listTopics` and `endOffsets`, and we always capture timeout exceptions around these two calls, and delay to retry in the next run loop after refreshing the metadata. By doing this we can also reduce the number of request round trips between consumer and brokers.