### PR TITLE
[KAFKA-4793] Restart tasks for connector endpoint

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -154,11 +154,10 @@ public class ConnectorsResource {
     @POST
     @Path("/{connector}/restart")
     public void restartConnector(final @PathParam("connector") String connector,
-                                 final @QueryParam("forward") Boolean forward,
-                                 final @QueryParam("tasks") Boolean tasks) throws Throwable {
+                                 final @QueryParam("forward") Boolean forward) throws Throwable {
         FutureCallback<Void> cb = new FutureCallback<>();
-        herder.restartConnector(connector, tasks, cb);
-        completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", null, forward, tasks);
+        herder.restartConnector(connector, cb);
+        completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", null, forward);
     }
 
     @PUT
@@ -200,6 +199,24 @@ public class ConnectorsResource {
     public ConnectorStateInfo.TaskState getTaskStatus(final @PathParam("connector") String connector,
                                                       final @PathParam("task") Integer task) throws Throwable {
         return herder.taskStatus(new ConnectorTaskId(connector, task));
+    }
+
+    @POST
+    @Path("/{connector}/tasks/restart")
+    public void restartTasks(final @PathParam("connector") String connector,
+                             final @QueryParam("forward") Boolean forward) throws Throwable {
+        FutureCallback<List<TaskInfo>> cb = new FutureCallback<>();
+        herder.taskConfigs(connector, cb);
+        List<TaskInfo> tasks = completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "GET", null, new TypeReference<List<TaskInfo>>() {
+        }, forward);
+
+        for (TaskInfo: tasks) {
+            FutureCallback<Void> cb = new FutureCallback<>();
+            ConnectorTaskId taskId = task.id();
+            Integer taskNum = task.id().task()
+            herder.restartTask(taskId, cb);
+            completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks/" + taskNum + "/restart", "POST", null, forward);
+        }
     }
 
     @POST

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -154,10 +154,11 @@ public class ConnectorsResource {
     @POST
     @Path("/{connector}/restart")
     public void restartConnector(final @PathParam("connector") String connector,
-                                 final @QueryParam("forward") Boolean forward) throws Throwable {
+                                 final @QueryParam("forward") Boolean forward,
+                                 final @QueryParam("tasks") Boolean tasks) throws Throwable {
         FutureCallback<Void> cb = new FutureCallback<>();
-        herder.restartConnector(connector, cb);
-        completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", null, forward);
+        herder.restartConnector(connector, tasks, cb);
+        completeOrForwardRequest(cb, "/connectors/" + connector + "/restart", "POST", null, forward, tasks);
     }
 
     @PUT

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -211,11 +211,11 @@ public class ConnectorsResource {
         }, forward);
 
         for (TaskInfo task: tasks) {
-            FutureCallback<Void> restart_cb = new FutureCallback<>();
+            FutureCallback<Void> restartCb = new FutureCallback<>();
             ConnectorTaskId taskId = task.id();
             Integer taskNum = task.id().task();
-            herder.restartTask(taskId, restart_cb);
-            completeOrForwardRequest(restart_cb, "/connectors/" + connector + "/tasks/" + taskNum + "/restart", "POST", null, forward);
+            herder.restartTask(taskId, restartCb);
+            completeOrForwardRequest(restartCb, "/connectors/" + connector + "/tasks/" + taskNum + "/restart", "POST", null, forward);
         }
     }
 
@@ -282,9 +282,11 @@ public class ConnectorsResource {
         } catch (TimeoutException e) {
             // This timeout is for the operation itself. None of the timeout error codes are relevant, so internal server
             // error is the best option
-            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request timed out");
+            throw new ConnectRestException(
+              Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request timed out");
         } catch (InterruptedException e) {
-            throw new ConnectRestException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request interrupted");
+            throw new ConnectRestException(
+              Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "Request interrupted");
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -210,12 +210,12 @@ public class ConnectorsResource {
         List<TaskInfo> tasks = completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "GET", null, new TypeReference<List<TaskInfo>>() {
         }, forward);
 
-        for (TaskInfo: tasks) {
-            FutureCallback<Void> cb = new FutureCallback<>();
+        for (TaskInfo task: tasks) {
+            FutureCallback<Void> restart_cb = new FutureCallback<>();
             ConnectorTaskId taskId = task.id();
-            Integer taskNum = task.id().task()
-            herder.restartTask(taskId, cb);
-            completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks/" + taskNum + "/restart", "POST", null, forward);
+            Integer taskNum = task.id().task();
+            herder.restartTask(taskId, restart_cb);
+            completeOrForwardRequest(restart_cb, "/connectors/" + connector + "/tasks/" + taskNum + "/restart", "POST", null, forward);
         }
     }
 


### PR DESCRIPTION
As suggested in KAFKA-4793 users may sometimes want to restart all of the tasks associated with a given connection. This proposed change adds a new endpoint to ConnectorsResource to allow one to restart all of the tasks associated with a given connector. This is slightly different than the original request of KAFKA-4793 with the comments of Ewen Cheslack-Postava  in mind that the migration of modifying the existing endpoint might have some challenges.

Note: this is one of my early contributions to Kafka, so if I'm still learning the code base -- if I've done something silly please let me know :) (I mean as always but especially so here :))