### PR TITLE
KAFKA-4915: do not use word "error" while logging with non-error level

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -677,7 +677,7 @@ public class NetworkClient implements KafkaClient {
         final String node = req.destination;
         if (apiVersionsResponse.error() != Errors.NONE) {
             if (req.request.version() == 0 || apiVersionsResponse.error() != Errors.UNSUPPORTED_VERSION) {
-                log.warn("Received error {} from node {} when making an ApiVersionsRequest with correlation id {}. Disconnecting.",
+                log.warn("Received response {} from node {} when making an ApiVersionsRequest with correlation id {}. Disconnecting.",
                         apiVersionsResponse.error(), node, req.header.correlationId());
                 this.selector.close(node);
                 processDisconnection(responses, node, now, ChannelState.LOCAL_CLOSE);
@@ -772,7 +772,7 @@ public class NetworkClient implements KafkaClient {
             connectionStates.disconnected(nodeConnectionId, now);
             /* maybe the problem is our metadata, update it */
             metadataUpdater.requestUpdate();
-            log.debug("Error connecting to node {}", node, e);
+            log.debug("Unable to connect to node {}", node, e);
         }
     }
 
@@ -845,7 +845,7 @@ public class NetworkClient implements KafkaClient {
             // check if any topics metadata failed to get updated
             Map<String, Errors> errors = response.errors();
             if (!errors.isEmpty())
-                log.warn("Error while fetching metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
+                log.warn("Unable to fetch metadata with correlation id {} : {}", requestHeader.correlationId(), errors);
 
             // don't update the cluster if there are no valid nodes...the topic we want may still be in the process of being
             // created which means we will get errors and no nodes until it exists

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -735,7 +735,7 @@ public abstract class AbstractCoordinator implements Closeable {
                 log.debug("LeaveGroup request returned successfully");
                 future.complete(null);
             } else {
-                log.debug("LeaveGroup request failed with error: {}", error.message());
+                log.debug("LeaveGroup request failed: {}", error.message());
                 future.raise(error);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerInterceptors.java
@@ -61,7 +61,7 @@ public class ConsumerInterceptors<K, V> implements Closeable {
                 interceptRecords = interceptor.onConsume(interceptRecords);
             } catch (Exception e) {
                 // do not propagate interceptor exception, log and continue calling other interceptors
-                log.warn("Error executing interceptor onConsume callback", e);
+                log.warn("Unable to execute interceptor onConsume callback", e);
             }
         }
         return interceptRecords;
@@ -82,7 +82,7 @@ public class ConsumerInterceptors<K, V> implements Closeable {
                 interceptor.onCommit(offsets);
             } catch (Exception e) {
                 // do not propagate interceptor exception, just log
-                log.warn("Error executing interceptor onCommit callback", e);
+                log.warn("Unable to execute interceptor onCommit callback", e);
             }
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -738,7 +738,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 future.raise(error);
                 return;
             } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
-                log.warn("Received unknown topic or partition error in ListOffset request for partition {}. The topic/partition " +
+                log.warn("Received 'unknown topic or partition' in ListOffset request for partition {}. The topic/partition " +
                         "may not exist or the user may not have Describe access to it.", topicPartition);
                 future.raise(error);
                 return;
@@ -866,10 +866,10 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 }
             } else if (error == Errors.NOT_LEADER_FOR_PARTITION ||
                        error == Errors.KAFKA_STORAGE_ERROR) {
-                log.debug("Error in fetch for partition {}: {}", tp, error.exceptionName());
+                log.debug("Failure in fetch for partition {}: {}", tp, error.exceptionName());
                 this.metadata.requestUpdate();
             } else if (error == Errors.UNKNOWN_TOPIC_OR_PARTITION) {
-                log.warn("Received unknown topic or partition error in fetch for partition {}. The topic/partition " +
+                log.warn("Received 'unknown topic or partition' in fetch for partition {}. The topic/partition " +
                         "may not exist or the user may not have Describe access to it", tp);
                 this.metadata.requestUpdate();
             } else if (error == Errors.OFFSET_OUT_OF_RANGE) {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/ProducerInterceptors.java
@@ -63,9 +63,9 @@ public class ProducerInterceptors<K, V> implements Closeable {
                 // do not propagate interceptor exception, log and continue calling other interceptors
                 // be careful not to throw exception from here
                 if (record != null)
-                    log.warn("Error executing interceptor onSend callback for topic: {}, partition: {}", record.topic(), record.partition(), e);
+                    log.warn("Unable to execute interceptor onSend callback for topic: {}, partition: {}", record.topic(), record.partition(), e);
                 else
-                    log.warn("Error executing interceptor onSend callback", e);
+                    log.warn("Unable to execute interceptor onSend callback", e);
             }
         }
         return interceptRecord;
@@ -88,7 +88,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                 interceptor.onAcknowledgement(metadata, exception);
             } catch (Exception e) {
                 // do not propagate interceptor exceptions, just log
-                log.warn("Error executing interceptor onAcknowledgement callback", e);
+                log.warn("Unable to execute interceptor onAcknowledgement callback", e);
             }
         }
     }
@@ -118,7 +118,7 @@ public class ProducerInterceptors<K, V> implements Closeable {
                 }
             } catch (Exception e) {
                 // do not propagate interceptor exceptions, just log
-                log.warn("Error executing interceptor onAcknowledgement callback", e);
+                log.warn("Unable to execute interceptor onAcknowledgement callback", e);
             }
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -466,7 +466,7 @@ public class Selector implements Selectable, AutoCloseable {
                 if (e instanceof IOException)
                     log.debug("Connection with {} disconnected", desc, e);
                 else
-                    log.warn("Unexpected error from {}; closing connection", desc, e);
+                    log.warn("Unexpected failure from {}; closing connection", desc, e);
                 close(channel, true);
             } finally {
                 maybeRecordTimePerConnection(channel, channelStartTimeNanos);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -600,7 +600,7 @@ public enum Errors {
         if (error != null) {
             return error;
         } else {
-            log.warn("Unexpected error code: {}.", code);
+            log.warn("Unknown code: {}.", code);
             return UNKNOWN_SERVER_ERROR;
         }
     }

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -265,7 +265,7 @@ public class KerberosLogin extends AbstractLogin {
             try {
                 t.join();
             } catch (InterruptedException e) {
-                log.warn("[Principal={}]: Error while waiting for Login thread to shutdown.", principal, e);
+                log.warn("[Principal={}]: Unable to wait for Login thread to shutdown.", principal, e);
                 Thread.currentThread().interrupt();
             }
         }

--- a/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/AppInfoParser.java
@@ -37,7 +37,7 @@ public class AppInfoParser {
         try (InputStream resourceStream = AppInfoParser.class.getResourceAsStream("/kafka/kafka-version.properties")) {
             props.load(resourceStream);
         } catch (Exception e) {
-            log.warn("Error while loading kafka-version.properties :" + e.getMessage());
+            log.warn("Unable to load kafka-version.properties :" + e.getMessage());
         }
         VERSION = props.getProperty("version", "unknown").trim();
         COMMIT_ID = props.getProperty("commitId", "unknown").trim();
@@ -57,7 +57,7 @@ public class AppInfoParser {
             AppInfo mBean = new AppInfo();
             ManagementFactory.getPlatformMBeanServer().registerMBean(mBean, name);
         } catch (JMException e) {
-            log.warn("Error registering AppInfo mbean", e);
+            log.warn("Unable to register AppInfo mbean", e);
         }
     }
 
@@ -68,7 +68,7 @@ public class AppInfoParser {
             if (server.isRegistered(name))
                 server.unregisterMBean(name);
         } catch (JMException e) {
-            log.warn("Error unregistering AppInfo mbean", e);
+            log.warn("Unable to unregister AppInfo mbean", e);
         }
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/NodeManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/NodeManager.java
@@ -178,7 +178,7 @@ class NodeManager {
         try {
             client.putFault(new CreateAgentFaultRequest(fault.id(), fault.spec()));
         } catch (Exception e) {
-            log.warn("{}: error sending fault to {}.", node.name(), client.target(), e);
+            log.warn("{}: unable to send fault to {}.", node.name(), client.target(), e);
             return false;
         }
         lock.lock();
@@ -195,7 +195,7 @@ class NodeManager {
         try {
             status = client.getStatus();
         } catch (Exception e) {
-            log.warn("{}: error sending heartbeat to {}.", node.name(), client.target(), e);
+            log.warn("{}: unable to send heartbeat to {}.", node.name(), client.target(), e);
             return;
         }
         lock.lock();


### PR DESCRIPTION
Normally if logging event is an error, then it should have log level "ERROR". If it's not an error, it should not have "Error" in the log message.

So I changed wordings a bit.

Also I've deliberately skipped several places, where error is the actual entity name received/sent.