### PR TITLE
KAFKA-5806. Fix transient unit test failure in trogdor coordinator shutdown

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -130,16 +130,19 @@ public final class Coordinator {
                     List<Fault> toStart = new ArrayList<>();
                     lock.lock();
                     try {
+                        if (shutdown) {
+                            break;
+                        }
                         if (nextWakeMs > now) {
                             if (cond.await(nextWakeMs - now, TimeUnit.MILLISECONDS)) {
                                 log.trace("CoordinatorRunnable woke up early.");
                             }
+                            now = time.milliseconds();
+                            if (shutdown) {
+                                break;
+                            }
                         }
                         nextWakeMs = now + (60L * 60L * 1000L);
-                        if (shutdown) {
-                            log.info("CoordinatorRunnable shutting down.");
-                            return;
-                        }
                         Iterator<Fault> iter = pendingFaults.iterateByStart();
                         while (iter.hasNext()) {
                             Fault fault = iter.next();


### PR DESCRIPTION
In the coordinator, we should check that 'shutdown' is not true before going to sleep waiting for the condition.