### PR TITLE
MINOR: Increase timeout of Zookeeper service in system tests

### DIFF
--- a/tests/kafkatest/services/zookeeper.py
+++ b/tests/kafkatest/services/zookeeper.py
@@ -82,7 +82,7 @@ class ZookeeperService(KafkaPathResolverMixin, Service):
         start_cmd += "%s/zookeeper.properties &>> %s &" % (ZookeeperService.ROOT, self.logs["zk_log"]["path"])
         node.account.ssh(start_cmd)
 
-        wait_until(lambda: self.listening(node), timeout_sec=10, err_msg="Zookeeper node failed to start")
+        wait_until(lambda: self.listening(node), timeout_sec=30, err_msg="Zookeeper node failed to start")
 
     def listening(self, node):
         try:


### PR DESCRIPTION
The previous timeout was 10 seconds, but system test failures have occurred when Zookeeper has started after about 11 seconds. Increasing the timeout to 30 seconds, since most of the time this extra time will not be required, and when it is it will prevent a failed system test.

In addition to merging to `trunk`, please backport to the `0.11.x` and `0.10.2.x` branches.