### PR TITLE
KAFKA-5818: KafkaStreams state transitions not correct

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -275,7 +275,8 @@ public class KafkaStreams {
     private boolean setRunningFromCreated() {
         synchronized (stateLock) {
             if (state != State.CREATED) {
-                return false;
+                log.error("{} Unexpected state transition from {} to {}", logPrefix, state, State.RUNNING);
+                throw new IllegalStateException(logPrefix + " Unexpected state transition from " + state + " to " + State.RUNNING);
             }
             state = State.RUNNING;
             stateLock.notifyAll();

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -673,9 +673,15 @@ public class KafkaStreams {
     public synchronized void start() throws IllegalStateException, StreamsException {
         log.debug("{} Starting Streams client", logPrefix);
 
+        final State oldState = state();
+        final State runningState = State.RUNNING;
+        // this is a mandatory check and not covered by regular state transition checks (cf. KAFKA-5818)
+        if (!(oldState == State.CREATED)) {
+            throw new IllegalStateException(logPrefix + " Unexpected state transition from " + oldState + " to " + runningState);
+        }
         // first set state to RUNNING before kicking off the threads,
         // making sure the state will always transit to RUNNING before REBALANCING
-        if (setState(State.RUNNING)) {
+        if (setState(runningState)) {
             checkBrokerVersionCompatibility();
 
             if (globalStreamThread != null) {

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -234,7 +234,8 @@ public class KafkaStreamsTest {
         streams.close();
         try {
             streams.start();
-        } catch (final IllegalStateException e) {
+            fail("Should have throw IllegalStateException");
+        } catch (final IllegalStateException expected) {
             // this is ok
         } finally {
             streams.close();
@@ -301,14 +302,18 @@ public class KafkaStreamsTest {
         assertEquals(metrics.size(), 16);
     }
 
-    @Test(expected = ConfigException.class)
+    @Test
     public void testIllegalMetricsConfig() {
         final Properties props = new Properties();
         props.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "appId");
         props.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         props.setProperty(StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG, "illegalConfig");
         final StreamsBuilder builder = new StreamsBuilder();
-        new KafkaStreams(builder.build(), props);
+
+        try {
+            new KafkaStreams(builder.build(), props);
+            fail("Should have throw ConfigException");
+        } catch (final ConfigException expected) { /* expected */ }
     }
 
     @Test
@@ -423,7 +428,7 @@ public class KafkaStreamsTest {
         streams.cleanUp();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testCannotCleanupWhileRunning() throws Exception {
         final Properties props = new Properties();
         props.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "testCannotCleanupWhileRunning");
@@ -441,9 +446,9 @@ public class KafkaStreamsTest {
         }, 10 * 1000, "Streams never started.");
         try {
             streams.cleanUp();
-        } catch (final IllegalStateException e) {
-            assertEquals("Cannot clean up while running.", e.getMessage());
-            throw e;
+            fail("Should have thrown IllegalStateException");
+        } catch (final IllegalStateException expected) {
+            assertEquals("Cannot clean up while running.", expected.getMessage());
         } finally {
             streams.close();
         }


### PR DESCRIPTION
- need to check that state is CRATED at startup
- some minor test cleanup