### PR TITLE
KAFKA-5830: kafka-configs.sh should allow deletion of all configs for…

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -54,7 +54,7 @@ object ConfigCommand extends Config {
 
     val opts = new ConfigCommandOptions(args)
 
-    if(args.length == 0)
+    if (args.isEmpty)
       CommandLineUtils.printUsageAndDie(opts.parser, "Add/Remove entity config for a topic, client, user or broker")
 
     opts.checkArgs()
@@ -81,6 +81,7 @@ object ConfigCommand extends Config {
   private[admin] def alterConfig(zkUtils: ZkUtils, opts: ConfigCommandOptions, utils: AdminUtilities = AdminUtils) {
     val configsToBeAdded = parseConfigsToBeAdded(opts)
     val configsToBeDeleted = parseConfigsToBeDeleted(opts)
+    val deleteAllConfigs = opts.options.has(opts.deleteAllConfigs)
     val entity = parseEntity(opts)
     val entityType = entity.root.entityType
     val entityName = entity.fullSanitizedName
@@ -98,6 +99,9 @@ object ConfigCommand extends Config {
 
     configs ++= configsToBeAdded
     configsToBeDeleted.foreach(configs.remove(_))
+
+    if (deleteAllConfigs)
+      configs.clear()
 
     utils.changeConfigs(zkUtils, entityType, entityName, configs)
 
@@ -285,12 +289,12 @@ object ConfigCommand extends Config {
             .withRequiredArg
             .describedAs("urls")
             .ofType(classOf[String])
-    val alterOpt = parser.accepts("alter", "Alter the configuration for the entity.")
-    val describeOpt = parser.accepts("describe", "List configs for the given entity.")
-    val entityType = parser.accepts("entity-type", "Type of entity (topics/clients/users/brokers)")
+    val alterOpt = parser.accepts("alter", "Alter the configuration for the given entity.")
+    val describeOpt = parser.accepts("describe", "List configurations for the given entity.")
+    val entityType = parser.accepts("entity-type", "Type of entity (topics/clients/users/brokers).")
             .withRequiredArg
             .ofType(classOf[String])
-    val entityName = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id)")
+    val entityName = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id).")
             .withRequiredArg
             .ofType(classOf[String])
     val entityDefault = parser.accepts("entity-default", "Default entity name for clients/users (applies to corresponding entity type in command line)")
@@ -304,28 +308,29 @@ object ConfigCommand extends Config {
             s"Entity types '${ConfigType.User}' and '${ConfigType.Client}' may be specified together to update config for clients of a specific user.")
             .withRequiredArg
             .ofType(classOf[String])
-    val deleteConfig = parser.accepts("delete-config", "config keys to remove 'k1,k2'")
+    val deleteConfig = parser.accepts("delete-config", "Configuration keys to remove for the given entity: 'k1,k2'.")
             .withRequiredArg
             .ofType(classOf[String])
             .withValuesSeparatedBy(',')
+    val deleteAllConfigs = parser.accepts("delete-all-configs", "Delete all configurations for the given entity.")
     val helpOpt = parser.accepts("help", "Print usage information.")
-    val forceOpt = parser.accepts("force", "Suppress console prompts")
+    val forceOpt = parser.accepts("force", "Suppress console prompts.")
     val options = parser.parse(args : _*)
 
-    val allOpts: Set[OptionSpec[_]] = Set(alterOpt, describeOpt, entityType, entityName, addConfig, deleteConfig, helpOpt)
+    val allOpts: Set[OptionSpec[_]] = Set(alterOpt, describeOpt, entityType, entityName, addConfig, deleteConfig, helpOpt, deleteAllConfigs)
 
     def checkArgs() {
       // should have exactly one action
       val actions = Seq(alterOpt, describeOpt).count(options.has _)
-      if(actions != 1)
+      if (actions != 1)
         CommandLineUtils.printUsageAndDie(parser, "Command must include exactly one action: --describe, --alter")
 
       // check required args
       CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt, entityType)
       CommandLineUtils.checkInvalidArgs(parser, options, alterOpt, Set(describeOpt))
-      CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set(alterOpt, addConfig, deleteConfig))
+      CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set(alterOpt, addConfig, deleteConfig, deleteAllConfigs))
       val entityTypeVals = options.valuesOf(entityType).asScala
-      if(options.has(alterOpt)) {
+      if (options.has(alterOpt)) {
         if (entityTypeVals.contains(ConfigType.User) || entityTypeVals.contains(ConfigType.Client)) {
           if (!options.has(entityName) && !options.has(entityDefault))
             throw new IllegalArgumentException("--entity-name or --entity-default must be specified with --alter of users/clients")
@@ -334,8 +339,9 @@ object ConfigCommand extends Config {
 
         val isAddConfigPresent: Boolean = options.has(addConfig)
         val isDeleteConfigPresent: Boolean = options.has(deleteConfig)
-        if(! isAddConfigPresent && ! isDeleteConfigPresent)
-          throw new IllegalArgumentException("At least one of --add-config or --delete-config must be specified with --alter")
+        val isDeleteAllConfigsPresent: Boolean = options.has(deleteAllConfigs)
+        if (! isAddConfigPresent && ! isDeleteConfigPresent && ! isDeleteAllConfigsPresent)
+          throw new IllegalArgumentException("At least one of --add-config, --delete-config or --delete-all-configs must be specified with --alter")
       }
       entityTypeVals.foreach(entityTypeVal =>
         if (!ConfigType.all.contains(entityTypeVal))

--- a/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConfigCommandTest.scala
@@ -457,4 +457,28 @@ class ConfigCommandTest extends ZooKeeperTestHarness with Logging {
         Map("users" -> Seq("<default>", sanitizedPrincipal)) ++ defaultUserMap ++ userMap,
         Seq("<default>/clients/client-3", sanitizedPrincipal + "/clients/client-2"))
   }
+
+  @Test
+  def shouldDeleteAllConfigs(): Unit = {
+    val deleteOpts = new ConfigCommandOptions(Array("--zookeeper", zkConnect,
+      "--entity-name", "1",
+      "--entity-type", "brokers",
+      "--alter",
+      "--delete-all-configs"))
+
+    val configChange = new TestAdminUtils {
+      override def fetchEntityConfig(zkUtils: ZkUtils, entityType: String, entityName: String): Properties = {
+        val properties: Properties = new Properties
+        properties.put("a", "b")
+        properties.put("c", "d")
+        properties.put("e", "f")
+        properties
+      }
+
+      override def changeBrokerConfig(zkUtils: ZkUtils, brokerIds: Seq[Int], configChange: Properties): Unit = {
+        assertEquals(0, configChange.size())
+      }
+    }
+    ConfigCommand.alterConfig(null, deleteOpts, configChange)
+  }
 }


### PR DESCRIPTION
… an entity

Added a --delete-all-configs flag to delete all configurations for a given entity