### PR TITLE
MINOR: Fix transient failure in SelectorTest.testCloseConnectionInClosingState

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -317,10 +317,11 @@ public class SelectorTest {
     public void testCloseConnectionInClosingState() throws Exception {
         KafkaChannel channel = createConnectionWithStagedReceives(5);
         String id = channel.id();
-        time.sleep(6000); // The max idle time is 5000ms
+        selector.mute(id); // Mute to allow channel to be expired even if more data is available for read
+        time.sleep(6000);  // The max idle time is 5000ms
         selector.poll(0);
-        assertEquals(channel, selector.closingChannel(id));
         assertNull("Channel not expired", selector.channel(id));
+        assertEquals(channel, selector.closingChannel(id));
         assertEquals(ChannelState.EXPIRED, channel.state());
         selector.close(id);
         assertNull("Channel not removed from channels", selector.channel(id));


### PR DESCRIPTION
`SelectorTest.testCloseConnectionInClosingState` creates a channel with some staging receives and moves time forward to expire the channel. To ensure that the channel will be expired on the next poll, the channel must be muted to avoid expiry time being updated if more data is available for read.