### PR TITLE
KAFKA-5301 Improve exception handling on consumer path

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -592,8 +592,9 @@ public class AbstractCoordinatorTest {
         }
 
         @Override
-        protected void onJoinPrepare(int generation, String memberId) {
+        protected Exception onJoinPrepare(int generation, String memberId) {
             onJoinPrepareInvokes++;
+            return null;
         }
 
         @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -273,11 +273,12 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
     }
 
     @Override
-    protected void onJoinPrepare(int generation, String memberId) {
+    protected Exception onJoinPrepare(int generation, String memberId) {
         this.leaderState = null;
         log.debug("Revoking previous assignment {}", assignmentSnapshot);
         if (assignmentSnapshot != null && !assignmentSnapshot.failed())
             listener.onRevoked(assignmentSnapshot.leader(), assignmentSnapshot.connectors(), assignmentSnapshot.tasks());
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This is an improvised approach towards fixing @guozhangwang 's second issue. 
I have changed the method return type as well as override such that it returns exception.
If the exception returned is not null (the default value), than we skip the callback.
