### PR TITLE
MINOR: Fix JavaDoc for StreamsConfig.PROCESSING_GUARANTEE_CONFIG

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -230,7 +230,7 @@ public class StreamsConfig extends AbstractConfig {
     public static final String POLL_MS_CONFIG = "poll.ms";
     private static final String POLL_MS_DOC = "The amount of time in milliseconds to block waiting for input.";
 
-    /** {@code cache.max.bytes.buffering} */
+    /** {@code processing.guarantee} */
     public static final String PROCESSING_GUARANTEE_CONFIG = "processing.guarantee";
     private static final String PROCESSING_GUARANTEE_DOC = "The processing guarantee that should be used. Possible values are <code>" + AT_LEAST_ONCE + "</code> (default) and <code>" + EXACTLY_ONCE + "</code>.";
 


### PR DESCRIPTION
The contribution is my original work and I license the work to the project under the project's open source licence.