### PR TITLE
KAFKA-5692: Change PreferredReplicaLeaderElectionCommand to use Admin…

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -116,6 +116,7 @@
 
     <subpackage name="protocol">
       <allow pkg="org.apache.kafka.common.errors" />
+      <allow pkg="org.apache.kafka.common.message" />
       <allow pkg="org.apache.kafka.common.protocol.types" />
       <allow pkg="org.apache.kafka.common.record" />
       <allow pkg="org.apache.kafka.common.requests" />
@@ -140,6 +141,7 @@
     <subpackage name="requests">
       <allow pkg="org.apache.kafka.common.acl" />
       <allow pkg="org.apache.kafka.common.protocol" />
+      <allow pkg="org.apache.kafka.common.message" />
       <allow pkg="org.apache.kafka.common.network" />
       <allow pkg="org.apache.kafka.common.requests" />
       <allow pkg="org.apache.kafka.common.resource" />

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -676,7 +676,8 @@ public class NetworkClient implements KafkaClient {
 
     public static AbstractResponse parseResponse(ByteBuffer responseBuffer, RequestHeader requestHeader) {
         Struct responseStruct = parseStructMaybeUpdateThrottleTimeMetrics(responseBuffer, requestHeader, null, 0);
-        return AbstractResponse.parseResponse(requestHeader.apiKey(), responseStruct);
+        return AbstractResponse.parseResponse(requestHeader.apiKey(), responseStruct,
+                requestHeader.apiVersion());
     }
 
     private static Struct parseStructMaybeUpdateThrottleTimeMetrics(ByteBuffer responseBuffer, RequestHeader requestHeader,
@@ -811,7 +812,8 @@ public class NetworkClient implements KafkaClient {
                     req.header.apiKey(), req.header.correlationId(), responseStruct);
             }
             // If the received response includes a throttle delay, throttle the connection.
-            AbstractResponse body = AbstractResponse.parseResponse(req.header.apiKey(), responseStruct);
+            AbstractResponse body = AbstractResponse.
+                    parseResponse(req.header.apiKey(), responseStruct, req.header.apiVersion());
             maybeThrottle(body, req.header.apiVersion(), req.destination, now);
             if (req.isInternalRequest && body instanceof MetadataResponse)
                 metadataUpdater.handleCompletedMetadataResponse(req.header, now, (MetadataResponse) body);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -800,7 +800,7 @@ public abstract class AdminClient implements AutoCloseable {
      * with default options.
      * See the overload for more details.
      *
-     * @param partitions      The partitions for which the the preferred leader should be elected.
+     * @param partitions      The partitions for which the preferred leader should be elected.
      * @return                The ElectPreferredLeadersResult.
      */
     public ElectPreferredLeadersResult electPreferredLeaders(Collection<TopicPartition> partitions) {
@@ -837,7 +837,7 @@ public abstract class AdminClient implements AutoCloseable {
      *   if the preferred leader was not alive or not in the ISR.</li>
      * </ul>
      *
-     * @param partitions      The partitions for which the the preferred leader should be elected.
+     * @param partitions      The partitions for which the preferred leader should be elected.
      * @param options         The options to use when electing the preferred leaders.
      * @return                The ElectPreferredLeadersResult.
      */

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -818,7 +818,7 @@ public abstract class AdminClient implements AutoCloseable {
      * During this time, {@link AdminClient#describeTopics(Collection)}
      * may not return information about the partitions' new leaders.
      *
-     * This operation is supported by brokers with version 1.1.0 or higher.
+     * This operation is supported by brokers with version 2.2.0 or higher.
      *
      * <p>The following exceptions can be anticipated when calling {@code get()} on the futures obtained from
      * the returned {@code ElectPreferredLeadersResult}:</p>

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -793,7 +793,60 @@ public abstract class AdminClient implements AutoCloseable {
     }
 
     /**
+     * Elect the preferred broker of the given {@code partitions} as leader, or
+     * elect the preferred broker for all partitions as leader if the argument to {@code partitions} is null.
+     *
+     * This is a convenience method for {@link #electPreferredLeaders(Collection, ElectPreferredLeadersOptions)}
+     * with default options.
+     * See the overload for more details.
+     *
+     * @param partitions      The partitions for which the the preferred leader should be elected.
+     * @return                The ElectPreferredLeadersResult.
+     */
+    public ElectPreferredLeadersResult electPreferredLeaders(Collection<TopicPartition> partitions) {
+        return electPreferredLeaders(partitions, new ElectPreferredLeadersOptions());
+    }
+
+    /**
+     * Elect the preferred broker of the given {@code partitions} as leader, or
+     * elect the preferred broker for all partitions as leader if the argument to {@code partitions} is null.
+     *
+     * This operation is not transactional so it may succeed for some partitions while fail for others.
+     *
+     * It may take several seconds after this method returns
+     * success for all the brokers in the cluster to become aware that the partitions have new leaders.
+     * During this time, {@link AdminClient#describeTopics(Collection)}
+     * may not return information about the partitions' new leaders.
+     *
+     * This operation is supported by brokers with version 1.1.0 or higher.
+     *
+     * <p>The following exceptions can be anticipated when calling {@code get()} on the futures obtained from
+     * the returned {@code ElectPreferredLeadersResult}:</p>
+     * <ul>
+     *   <li>{@link org.apache.kafka.common.errors.ClusterAuthorizationException}
+     *   if the authenticated user didn't have alter access to the cluster.</li>
+     *   <li>{@link org.apache.kafka.common.errors.UnknownTopicOrPartitionException}
+     *   if the topic or partition did not exist within the cluster.</li>
+     *   <li>{@link org.apache.kafka.common.errors.InvalidTopicException}
+     *   if the topic was already queued for deletion.</li>
+     *   <li>{@link org.apache.kafka.common.errors.NotControllerException}
+     *   if the request was sent to a broker that was not the controller for the cluster.</li>
+     *   <li>{@link org.apache.kafka.common.errors.TimeoutException}
+     *   if the request timed out before the election was complete.</li>
+     *   <li>{@link org.apache.kafka.common.errors.LeaderNotAvailableException}
+     *   if the preferred leader was not alive or not in the ISR.</li>
+     * </ul>
+     *
+     * @param partitions      The partitions for which the the preferred leader should be elected.
+     * @param options         The options to use when electing the preferred leaders.
+     * @return                The ElectPreferredLeadersResult.
+     */
+    public abstract ElectPreferredLeadersResult electPreferredLeaders(Collection<TopicPartition> partitions,
+                                                                      ElectPreferredLeadersOptions options);
+
+    /**
      * Get the metrics kept by the adminClient
      */
     public abstract Map<MetricName, ? extends Metric> metrics();
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -848,5 +848,4 @@ public abstract class AdminClient implements AutoCloseable {
      * Get the metrics kept by the adminClient
      */
     public abstract Map<MetricName, ? extends Metric> metrics();
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ElectPreferredLeadersOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ElectPreferredLeadersOptions.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Collection;
+
+/**
+ * Options for {@link AdminClient#electPreferredLeaders(Collection, ElectPreferredLeadersOptions)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
+public class ElectPreferredLeadersOptions extends AbstractOptions<ElectPreferredLeadersOptions> {
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ElectPreferredLeadersResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ElectPreferredLeadersResult.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.requests.ApiError;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The result of {@link AdminClient#electPreferredLeaders(Collection, ElectPreferredLeadersOptions)}
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
+public class ElectPreferredLeadersResult {
+
+    private final KafkaFutureImpl<Map<TopicPartition, ApiError>> electionFuture;
+    private final Set<TopicPartition> partitions;
+
+    ElectPreferredLeadersResult(KafkaFutureImpl<Map<TopicPartition, ApiError>> electionFuture, Set<TopicPartition> partitions) {
+        this.electionFuture = electionFuture;
+        this.partitions = partitions;
+    }
+
+    /**
+     * Get the result of the election for the given {@code partition}.
+     * If there was not an election triggered for the given {@code partition}, the
+     * returned future will complete with an error.
+     */
+    public KafkaFuture<Void> partitionResult(final TopicPartition partition) {
+        final KafkaFutureImpl<Void> result = new KafkaFutureImpl<>();
+        electionFuture.whenComplete(new KafkaFuture.BiConsumer<Map<TopicPartition, ApiError>, Throwable>() {
+            @Override
+            public void accept(Map<TopicPartition, ApiError> topicPartitions, Throwable throwable) {
+                if (throwable != null) {
+                    result.completeExceptionally(throwable);
+                } else if (!topicPartitions.containsKey(partition)) {
+                    result.completeExceptionally(new UnknownTopicOrPartitionException(
+                            "Preferred leader election for partition \"" + partition +
+                                    "\" was not attempted"));
+                } else {
+                    ApiException exception = topicPartitions.get(partition).exception();
+                    if (exception == null) {
+                        result.complete(null);
+                    } else {
+                        result.completeExceptionally(exception);
+                    }
+                }
+            }
+        });
+        return result;
+    }
+
+    /**
+     * <p>Get a future for the topic partitions for which a leader election
+     * was attempted. A partition will be present in this result if
+     * an election was attempted even if the election was not successful.</p>
+     *
+     * <p>This method is provided to discover the partitions attempted when
+     * {@link AdminClient#electPreferredLeaders(Collection)} is called
+     * with a null {@code partitions} argument.</p>
+     */
+    public KafkaFuture<Set<TopicPartition>> partitions() {
+        if (partitions != null) {
+            return KafkaFutureImpl.completedFuture(this.partitions);
+        } else {
+            final KafkaFutureImpl<Set<TopicPartition>> result = new KafkaFutureImpl<>();
+            electionFuture.whenComplete(new KafkaFuture.BiConsumer<Map<TopicPartition, ApiError>, Throwable>() {
+                @Override
+                public void accept(Map<TopicPartition, ApiError> topicPartitions, Throwable throwable) {
+                    if (throwable != null) {
+                        result.completeExceptionally(throwable);
+                    } else {
+                        for (ApiError apiError : topicPartitions.values()) {
+                            if (apiError.isFailure()) {
+                                result.completeExceptionally(apiError.exception());
+                            }
+                        }
+                        result.complete(topicPartitions.keySet());
+                    }
+                }
+            });
+            return result;
+        }
+    }
+
+    /**
+     * Return a future which succeeds if all the topic elections succeed.
+     */
+    public KafkaFuture<Void> all() {
+        final KafkaFutureImpl<Void> result = new KafkaFutureImpl<>();
+        electionFuture.thenApply(new KafkaFuture.Function<Map<TopicPartition, ApiError>, Void>() {
+            @Override
+            public Void apply(Map<TopicPartition, ApiError> topicPartitions) {
+                for (ApiError apiError : topicPartitions.values()) {
+                    if (apiError.isFailure()) {
+                        result.completeExceptionally(apiError.exception());
+                        return null;
+                    }
+                }
+                result.complete(null);
+                return null;
+            }
+        });
+        return result;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -105,14 +105,14 @@ import org.apache.kafka.common.requests.DescribeGroupsRequest;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.DescribeLogDirsRequest;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
+import org.apache.kafka.common.requests.ElectPreferredLeadersRequest;
+import org.apache.kafka.common.requests.ElectPreferredLeadersResponse;
 import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
 import org.apache.kafka.common.requests.ExpireDelegationTokenResponse;
 import org.apache.kafka.common.requests.FindCoordinatorRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
-import org.apache.kafka.common.requests.ElectPreferredLeadersRequest;
-import org.apache.kafka.common.requests.ElectPreferredLeadersResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.OffsetFetchRequest;
@@ -2791,13 +2791,15 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             public AbstractRequest.Builder createRequest(int timeoutMs) {
-                return new ElectPreferredLeadersRequest.Builder(partitions, timeoutMs);
+                return new ElectPreferredLeadersRequest.Builder(
+                        ElectPreferredLeadersRequest.toRequestData(partitions, timeoutMs));
             }
 
             @Override
             public void handleResponse(AbstractResponse abstractResponse) {
                 ElectPreferredLeadersResponse response = (ElectPreferredLeadersResponse) abstractResponse;
-                electionFuture.complete(response.errors());
+                electionFuture.complete(
+                        ElectPreferredLeadersRequest.fromResponseData(response.data()));
             }
 
             @Override
@@ -2807,4 +2809,5 @@ public class KafkaAdminClient extends AdminClient {
         }, now);
         return new ElectPreferredLeadersResult(electionFuture, partitionSet);
     }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/PreferredLeaderNotAvailableException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PreferredLeaderNotAvailableException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.errors;
+
+public class PreferredLeaderNotAvailableException extends InvalidMetadataException {
+
+    public PreferredLeaderNotAvailableException(String message) {
+        super(message);
+    }
+
+    public PreferredLeaderNotAvailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -59,6 +59,8 @@ import org.apache.kafka.common.requests.DescribeLogDirsRequest;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
 import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
 import org.apache.kafka.common.requests.DescribeDelegationTokenResponse;
+import org.apache.kafka.common.requests.ElectPreferredLeadersRequest;
+import org.apache.kafka.common.requests.ElectPreferredLeadersResponse;
 import org.apache.kafka.common.requests.EndTxnRequest;
 import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
@@ -186,7 +188,9 @@ public enum ApiKeys {
     RENEW_DELEGATION_TOKEN(39, "RenewDelegationToken", RenewDelegationTokenRequest.schemaVersions(), RenewDelegationTokenResponse.schemaVersions()),
     EXPIRE_DELEGATION_TOKEN(40, "ExpireDelegationToken", ExpireDelegationTokenRequest.schemaVersions(), ExpireDelegationTokenResponse.schemaVersions()),
     DESCRIBE_DELEGATION_TOKEN(41, "DescribeDelegationToken", DescribeDelegationTokenRequest.schemaVersions(), DescribeDelegationTokenResponse.schemaVersions()),
-    DELETE_GROUPS(42, "DeleteGroups", DeleteGroupsRequest.schemaVersions(), DeleteGroupsResponse.schemaVersions());
+    DELETE_GROUPS(42, "DeleteGroups", DeleteGroupsRequest.schemaVersions(), DeleteGroupsResponse.schemaVersions()),
+    ELECT_PREFERRED_LEADERS(43, "ElectPreferredLeaders", ElectPreferredLeadersRequest.schemaVersions(),
+            ElectPreferredLeadersResponse.schemaVersions());
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.common.protocol;
 
+import org.apache.kafka.common.message.ElectPreferredLeadersRequestData;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.SchemaException;
 import org.apache.kafka.common.protocol.types.Struct;
@@ -35,10 +37,10 @@ import org.apache.kafka.common.requests.ControlledShutdownRequest;
 import org.apache.kafka.common.requests.ControlledShutdownResponse;
 import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreateAclsResponse;
-import org.apache.kafka.common.requests.CreatePartitionsRequest;
-import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.CreateDelegationTokenRequest;
 import org.apache.kafka.common.requests.CreateDelegationTokenResponse;
+import org.apache.kafka.common.requests.CreatePartitionsRequest;
+import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
@@ -53,14 +55,12 @@ import org.apache.kafka.common.requests.DescribeAclsRequest;
 import org.apache.kafka.common.requests.DescribeAclsResponse;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
+import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
+import org.apache.kafka.common.requests.DescribeDelegationTokenResponse;
 import org.apache.kafka.common.requests.DescribeGroupsRequest;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.DescribeLogDirsRequest;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
-import org.apache.kafka.common.requests.DescribeDelegationTokenRequest;
-import org.apache.kafka.common.requests.DescribeDelegationTokenResponse;
-import org.apache.kafka.common.requests.ElectPreferredLeadersRequest;
-import org.apache.kafka.common.requests.ElectPreferredLeadersResponse;
 import org.apache.kafka.common.requests.EndTxnRequest;
 import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.ExpireDelegationTokenRequest;
@@ -189,8 +189,8 @@ public enum ApiKeys {
     EXPIRE_DELEGATION_TOKEN(40, "ExpireDelegationToken", ExpireDelegationTokenRequest.schemaVersions(), ExpireDelegationTokenResponse.schemaVersions()),
     DESCRIBE_DELEGATION_TOKEN(41, "DescribeDelegationToken", DescribeDelegationTokenRequest.schemaVersions(), DescribeDelegationTokenResponse.schemaVersions()),
     DELETE_GROUPS(42, "DeleteGroups", DeleteGroupsRequest.schemaVersions(), DeleteGroupsResponse.schemaVersions()),
-    ELECT_PREFERRED_LEADERS(43, "ElectPreferredLeaders", ElectPreferredLeadersRequest.schemaVersions(),
-            ElectPreferredLeadersResponse.schemaVersions());
+    ELECT_PREFERRED_LEADERS(43, "ElectPreferredLeaders", ElectPreferredLeadersRequestData.SCHEMAS,
+            ElectPreferredLeadersResponseData.SCHEMAS);
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -72,6 +72,7 @@ import org.apache.kafka.common.errors.OffsetOutOfRangeException;
 import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.PolicyViolationException;
+import org.apache.kafka.common.errors.PreferredLeaderNotAvailableException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.ReassignmentInProgressException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
@@ -297,7 +298,9 @@ public enum Errors {
             "election so the offsets cannot be guaranteed to be monotonically increasing",
             OffsetNotAvailableException::new),
     MEMBER_ID_REQUIRED(79, "The group member needs to have a valid member id before actually entering a consumer group",
-            MemberIdRequiredException::new);
+            MemberIdRequiredException::new),
+    PREFERRED_LEADER_NOT_AVAILABLE(80, "The preferred leader was not available",
+            PreferredLeaderNotAvailableException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -227,6 +227,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
                 return new DescribeDelegationTokenRequest(struct, apiVersion);
             case DELETE_GROUPS:
                 return new DeleteGroupsRequest(struct, apiVersion);
+            case ELECT_PREFERRED_LEADERS:
+                return new ElectPreferredLeadersRequest(struct, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -156,6 +156,8 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
                 return new DescribeDelegationTokenResponse(struct);
             case DELETE_GROUPS:
                 return new DeleteGroupsResponse(struct);
+            case ELECT_PREFERRED_LEADERS:
+                return new ElectPreferredLeadersResponse(struct);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -68,7 +68,7 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
 
     protected abstract Struct toStruct(short version);
 
-    public static AbstractResponse parseResponse(ApiKeys apiKey, Struct struct) {
+    public static AbstractResponse parseResponse(ApiKeys apiKey, Struct struct, short version) {
         switch (apiKey) {
             case PRODUCE:
                 return new ProduceResponse(struct);
@@ -157,7 +157,7 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
             case DELETE_GROUPS:
                 return new DeleteGroupsResponse(struct);
             case ELECT_PREFERRED_LEADERS:
-                return new ElectPreferredLeadersResponse(struct);
+                return new ElectPreferredLeadersResponse(struct, version);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersRequest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.utils.CollectionUtils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
+import static org.apache.kafka.common.protocol.types.Type.INT32;
+
+public class ElectPreferredLeadersRequest extends AbstractRequest {
+
+    private static final String TIMEOUT_KEY_NAME = "timeout";
+    private static final String TOPIC_PARTITIONS_KEY_NAME = "topic_partitions";
+    private static final String PARTITIONS_KEY_NAME = "partitions";
+
+    public static final Schema ELECT_PREFERRED_LEADERS_REQUEST_V0 = new Schema(
+            new Field(TOPIC_PARTITIONS_KEY_NAME, ArrayOf.nullable(
+                    new Schema(
+                            TOPIC_NAME,
+                            new Field(PARTITIONS_KEY_NAME,
+                                    new ArrayOf(INT32),
+                                    "The partitions of this topic whose preferred leader should be elected")))),
+            new Field(TIMEOUT_KEY_NAME, INT32, "The time in ms to wait for the elections to be completed.")
+    );
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{ELECT_PREFERRED_LEADERS_REQUEST_V0};
+    }
+
+    public static class Builder extends AbstractRequest.Builder {
+
+        private final Set<TopicPartition> topicPartitions;
+        private final int timeout;
+
+        public Builder(Collection<TopicPartition> topicPartitions, int timeout) {
+            super(ApiKeys.ELECT_PREFERRED_LEADERS);
+            this.topicPartitions = topicPartitions != null ? new HashSet<>(topicPartitions) : null;
+            this.timeout = timeout;
+        }
+
+        @Override
+        public ElectPreferredLeadersRequest build(short version) {
+            return new ElectPreferredLeadersRequest(version, topicPartitions, timeout);
+        }
+    }
+
+    private final Set<TopicPartition> topicPartitions;
+    private final int timeout;
+
+    public ElectPreferredLeadersRequest(short version, Set<TopicPartition> topicPartitions, int timeout) {
+        super(ApiKeys.ELECT_PREFERRED_LEADERS, version);
+        this.topicPartitions = topicPartitions;
+        this.timeout = timeout;
+    }
+
+    public ElectPreferredLeadersRequest(Struct struct, short version) {
+        super(ApiKeys.ELECT_PREFERRED_LEADERS, version);
+        Object[] topicPartitionsArray = struct.getArray(TOPIC_PARTITIONS_KEY_NAME);
+        if (topicPartitionsArray != null) {
+            topicPartitions = new HashSet<>(topicPartitionsArray.length);
+            for (Object topicPartitionObj : topicPartitionsArray) {
+                Struct topicPartitionStruct = (Struct) topicPartitionObj;
+                String topicName = topicPartitionStruct.get(TOPIC_NAME);
+                Object[] partitionsArray = topicPartitionStruct.getArray(PARTITIONS_KEY_NAME);
+                if (partitionsArray != null) {
+                    for (Object partitionObj : partitionsArray) {
+                        Integer partition = (Integer) partitionObj;
+                        TopicPartition topicPartition = new TopicPartition(topicName, partition);
+                        topicPartitions.add(topicPartition);
+                    }
+                }
+            }
+        } else {
+            topicPartitions = null;
+        }
+        timeout = struct.getInt(TIMEOUT_KEY_NAME);
+    }
+
+    public Set<TopicPartition> topicPartitions() {
+        return topicPartitions;
+    }
+
+    public int timeout() {
+        return timeout;
+    }
+
+    @Override
+    protected Struct toStruct() {
+        Struct struct = new Struct(ApiKeys.ELECT_PREFERRED_LEADERS.requestSchema(version()));
+        Struct[] topicPartitionsArray;
+        if (topicPartitions != null) {
+            Map<String, List<Integer>> map = CollectionUtils.groupPartitionsByTopic(topicPartitions);
+            List<Struct> topicPartitionsList = new ArrayList<>(topicPartitions.size());
+            for (Map.Entry<String, List<Integer>> entry : map.entrySet()) {
+                Struct partitionStruct = struct.instance(TOPIC_PARTITIONS_KEY_NAME);
+                partitionStruct.set(TOPIC_NAME, entry.getKey());
+                partitionStruct.set(PARTITIONS_KEY_NAME, entry.getValue().toArray());
+                topicPartitionsList.add(partitionStruct);
+            }
+            topicPartitionsArray = topicPartitionsList.toArray(new Struct[topicPartitionsList.size()]);
+        } else {
+            topicPartitionsArray = null;
+        }
+        struct.set(TOPIC_PARTITIONS_KEY_NAME, topicPartitionsArray);
+        struct.set(TIMEOUT_KEY_NAME, timeout);
+        return struct;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        short version = version();
+        switch (version) {
+            case 0:
+                ApiError error = ApiError.fromThrowable(e);
+                Map<TopicPartition, ApiError> errors = new HashMap<>(topicPartitions.size());
+                for (TopicPartition partition : topicPartitions)
+                    errors.put(partition, error);
+                return new ElectPreferredLeadersResponse(throttleTimeMs, errors);
+            default:
+                throw new IllegalArgumentException(String.format(
+                        "Version %d is not valid. Valid versions for %s are 0 to %d",
+                        version, this.getClass().getSimpleName(), ApiKeys.ELECT_PREFERRED_LEADERS.latestVersion()));
+        }
+    }
+
+    public static ElectPreferredLeadersRequest parse(ByteBuffer buffer, short version) {
+        return new ElectPreferredLeadersRequest(ApiKeys.ELECT_PREFERRED_LEADERS.parseRequest(version, buffer), version);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersRequest.java
@@ -92,12 +92,10 @@ public class ElectPreferredLeadersRequest extends AbstractRequest {
                 Struct topicPartitionStruct = (Struct) topicPartitionObj;
                 String topicName = topicPartitionStruct.get(TOPIC_NAME);
                 Object[] partitionsArray = topicPartitionStruct.getArray(PARTITIONS_KEY_NAME);
-                if (partitionsArray != null) {
-                    for (Object partitionObj : partitionsArray) {
-                        Integer partition = (Integer) partitionObj;
-                        TopicPartition topicPartition = new TopicPartition(topicName, partition);
-                        topicPartitions.add(topicPartition);
-                    }
+                for (Object partitionObj : partitionsArray) {
+                    Integer partition = (Integer) partitionObj;
+                    TopicPartition topicPartition = new TopicPartition(topicName, partition);
+                    topicPartitions.add(topicPartition);
                 }
             }
         } else {

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersRequest.java
@@ -100,9 +100,7 @@ public class ElectPreferredLeadersRequest extends AbstractRequest {
     @Override
     public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
         ElectPreferredLeadersResponseData response = new ElectPreferredLeadersResponseData();
-        if (version() >= 2) {
-            response.setThrottleTimeMs(throttleTimeMs);
-        }
+        response.setThrottleTimeMs(throttleTimeMs);
         ApiError apiError = ApiError.fromThrowable(e);
         for (TopicPartitions topic : data.topicPartitions()) {
             ReplicaElectionResult electionResult = new ReplicaElectionResult().setTopic(topic.topic());
@@ -112,8 +110,7 @@ public class ElectPreferredLeadersRequest extends AbstractRequest {
                         .setErrorCode(apiError.error().code())
                         .setErrorMessage(apiError.message()));
             }
-            response.replicaElectionResults().add(
-                    electionResult);
+            response.replicaElectionResults().add(electionResult);
         }
         return new ElectPreferredLeadersResponse(response);
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ElectPreferredLeadersResponse.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.utils.CollectionUtils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_MESSAGE;
+import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
+import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
+import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
+
+public class ElectPreferredLeadersResponse extends AbstractResponse {
+
+    private static final String REPLICA_ELECTION_RESULT_KEY_NAME = "replica_election_result";
+    private static final String PARTITION_RESULTS_KEY_NAME = "partition_results";
+
+    public static final Schema ELECT_PREFERRED_LEADERS_RESPONSE_V0 = new Schema(
+            THROTTLE_TIME_MS,
+            new Field(REPLICA_ELECTION_RESULT_KEY_NAME, new ArrayOf(new Schema(
+                    TOPIC_NAME,
+                    new Field(PARTITION_RESULTS_KEY_NAME, new ArrayOf(
+                            new Schema(
+                                    PARTITION_ID,
+                                    ERROR_CODE,
+                                    ERROR_MESSAGE)),
+                            "The results for each partition")))));
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{ELECT_PREFERRED_LEADERS_RESPONSE_V0};
+    }
+
+    private final int throttleTimeMs;
+    private final Map<TopicPartition, ApiError> errors;
+
+    public ElectPreferredLeadersResponse(int throttleTimeMs, Map<TopicPartition, ApiError> errors) {
+        this.throttleTimeMs = throttleTimeMs;
+        this.errors = errors;
+    }
+
+    public ElectPreferredLeadersResponse(Struct struct) {
+        throttleTimeMs = struct.get(THROTTLE_TIME_MS);
+        Object[] resourcesArray = struct.getArray(REPLICA_ELECTION_RESULT_KEY_NAME);
+        errors = new HashMap<>(resourcesArray.length);
+        for (Object partitionObj : resourcesArray) {
+            Struct topicStruct = (Struct) partitionObj;
+            String topicName = topicStruct.get(TOPIC_NAME);
+            Object[] partitionResults = topicStruct.getArray(PARTITION_RESULTS_KEY_NAME);
+            for (Object partitionResult : partitionResults) {
+                Struct partitionStruct = (Struct) partitionResult;
+                int partitionId = partitionStruct.get(PARTITION_ID);
+                ApiError error = new ApiError(partitionStruct);
+                errors.put(new TopicPartition(topicName, partitionId), error);
+            }
+        }
+    }
+
+    public Map<TopicPartition, ApiError> errors() {
+        return errors;
+    }
+
+    public int throttleTimeMs() {
+        return throttleTimeMs;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return apiErrorCounts(errors);
+    }
+
+    @Override
+    protected Struct toStruct(short version) {
+        Struct struct = new Struct(ApiKeys.ELECT_PREFERRED_LEADERS.responseSchema(version));
+        struct.set(THROTTLE_TIME_MS, throttleTimeMs);
+        Map<String, Map<Integer, ApiError>> groupedErrors = CollectionUtils.groupPartitionDataByTopic(errors);
+        List<Struct> replicaElectionResultList = new ArrayList<>(errors.size());
+        for (Map.Entry<String, Map<Integer, ApiError>> topicToErrors : groupedErrors.entrySet()) {
+            Struct topicStruct = struct.instance(REPLICA_ELECTION_RESULT_KEY_NAME);
+            topicStruct.set(TOPIC_NAME, topicToErrors.getKey());
+            List<Struct> partitionResultList = new ArrayList<>(topicToErrors.getValue().size());
+            for (Map.Entry<Integer, ApiError> partitionToError : topicToErrors.getValue().entrySet()) {
+                Struct partitionResultStruct = topicStruct.instance(PARTITION_RESULTS_KEY_NAME);
+                partitionResultStruct.set(PARTITION_ID, partitionToError.getKey());
+                partitionToError.getValue().write(partitionResultStruct);
+                partitionResultList.add(partitionResultStruct);
+            }
+            topicStruct.set(PARTITION_RESULTS_KEY_NAME, partitionResultList.toArray());
+            replicaElectionResultList.add(topicStruct);
+        }
+        struct.set(REPLICA_ELECTION_RESULT_KEY_NAME, replicaElectionResultList.toArray(new Struct[0]));
+        return struct;
+    }
+
+    public static ElectPreferredLeadersResponse parse(ByteBuffer buffer, short version) {
+        return new ElectPreferredLeadersResponse(ApiKeys.ELECT_PREFERRED_LEADERS.parseResponse(version, buffer));
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
@@ -19,10 +19,10 @@ package org.apache.kafka.common.utils;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Collection;
 import java.util.stream.Collectors;
 
 public final class CollectionUtils {

--- a/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/CollectionUtils.java
@@ -19,10 +19,10 @@ package org.apache.kafka.common.utils;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 public final class CollectionUtils {

--- a/clients/src/main/resources/common/message/ElectPreferredLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectPreferredLeadersRequest.json
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 43,
+  "type": "request",
+  "name": "ElectPreferredLeadersRequest",
+  "validVersions": "0",
+  "fields": [
+    { "name": "TopicPartitions", "type": "[]TopicPartitions", "versions": "0+", "nullableVersions": "0+",
+      "about": "The topic partitions to elect the preferred leader of.",
+      "fields": [
+        { "name": "Topic", "type": "string", "versions": "0+",
+          "about": "The name of a topic." },
+        { "name": "PartitionId", "type": "[]int32", "versions": "0+",
+          "about": "The partitions of this topic whose preferred leader should be elected" }
+      ]},
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+      "about": "The time in ms to wait for the election to complete." }
+  ]
+}

--- a/clients/src/main/resources/common/message/ElectPreferredLeadersRequest.json
+++ b/clients/src/main/resources/common/message/ElectPreferredLeadersRequest.json
@@ -27,7 +27,7 @@
         { "name": "PartitionId", "type": "[]int32", "versions": "0+",
           "about": "The partitions of this topic whose preferred leader should be elected" }
       ]},
-    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
+    { "name": "TimeoutMs", "type": "int32", "versions": "0+", "default": "60000",
       "about": "The time in ms to wait for the election to complete." }
   ]
 }

--- a/clients/src/main/resources/common/message/ElectPreferredLeadersResponse.json
+++ b/clients/src/main/resources/common/message/ElectPreferredLeadersResponse.json
@@ -21,12 +21,12 @@
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
       "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
-    { "name": "ReplicaElectionResult", "type": "[]ReplicaElectionResult", "versions": "0+",
+    { "name": "ReplicaElectionResults", "type": "[]ReplicaElectionResult", "versions": "0+",
       "about": "The error code, or 0 if there was no error.", "fields": [
       { "name": "Topic", "type": "string", "versions": "0+",
         "about": "The topic name" },
       { "name": "PartitionResult", "type": "[]PartitionResult", "versions": "0+",
-        "about": "The topic name", "fields": [
+        "about": "The results for each partition", "fields": [
         { "name": "PartitionId", "type": "int32", "versions": "0+",
           "about": "The partition id" },
         { "name": "ErrorCode", "type": "int16", "versions": "0+",

--- a/clients/src/main/resources/common/message/ElectPreferredLeadersResponse.json
+++ b/clients/src/main/resources/common/message/ElectPreferredLeadersResponse.json
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{
+  "apiKey": 43,
+  "type": "response",
+  "name": "ElectPreferredLeadersResponse",
+  "validVersions": "0",
+  "fields": [
+    { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",
+      "about": "The duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota." },
+    { "name": "ReplicaElectionResult", "type": "[]ReplicaElectionResult", "versions": "0+",
+      "about": "The error code, or 0 if there was no error.", "fields": [
+      { "name": "Topic", "type": "string", "versions": "0+",
+        "about": "The topic name" },
+      { "name": "PartitionResult", "type": "[]PartitionResult", "versions": "0+",
+        "about": "The topic name", "fields": [
+        { "name": "PartitionId", "type": "int32", "versions": "0+",
+          "about": "The partition id" },
+        { "name": "ErrorCode", "type": "int16", "versions": "0+",
+          "about": "The result error, or zero if there was no error."},
+        { "name": "ErrorMessage", "type": "string", "versions": "0+", "nullableVersions": "0+",
+          "about": "The result message, or null if there was no error."}
+      ]}
+    ]}
+  ]
+}

--- a/clients/src/main/resources/common/message/README.md
+++ b/clients/src/main/resources/common/message/README.md
@@ -187,7 +187,7 @@ One very common pattern in Kafka is to load array elements from a message into
 a Map or Set for easier access.  The message protocol makes this easier with
 the "mapKey" concept.  
 
-If some of the elemements of an array are annotated with "mapKey": true, the
+If some of the elements of an array are annotated with "mapKey": true, the
 entire array will be treated as a linked hash set rather than a list.  Elements
 in this set will be accessible in O(1) time with an automatically generated
 "find" function.  The order of elements in the set will still be preserved,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -40,7 +40,6 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InvalidRequestException;
-import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.errors.NotLeaderForPartitionException;
@@ -71,7 +70,6 @@ import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
-import org.apache.kafka.common.requests.ElectPreferredLeadersResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
 import org.apache.kafka.common.resource.PatternType;
@@ -638,7 +636,7 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testElectPreferredLeaders()  throws Exception {
-        TopicPartition topic1 = new TopicPartition("topic", 0);
+        /*TopicPartition topic1 = new TopicPartition("topic", 0);
         TopicPartition topic2 = new TopicPartition("topic", 2);
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
@@ -657,7 +655,8 @@ public class KafkaAdminClientTest {
             // Test a call where there are no errors.
             map.put(topic1, ApiError.NONE);
             map.put(topic2, ApiError.NONE);
-            env.kafkaClient().prepareResponse(new ElectPreferredLeadersResponse(0,
+            env.kafkaClient().prepareResponse(new ElectPreferredLeadersResponse(
+                    ElectPreferredLeadersUtil.fromElectPreferredLeadersRequest()0,
                     map));
 
             results = env.adminClient().electPreferredLeaders(asList(topic1, topic2));
@@ -668,7 +667,7 @@ public class KafkaAdminClientTest {
             results = env.adminClient().electPreferredLeaders(asList(topic1, topic2), new ElectPreferredLeadersOptions().timeoutMs(100));
             TestUtils.assertFutureError(results.partitionResult(topic1), TimeoutException.class);
             TestUtils.assertFutureError(results.partitionResult(topic2), TimeoutException.class);
-        }
+        }*/
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -642,7 +642,6 @@ public class KafkaAdminClientTest {
         TopicPartition topic2 = new TopicPartition("topic", 2);
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            //env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
 
             // Test a call where one partition has an error.
             HashMap<TopicPartition, ApiError> map = new HashMap<>();

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -665,7 +665,7 @@ public class KafkaAdminClientTest {
             results.partitionResult(topic2).get();
 
             // Now try a timeout
-            results = env.adminClient().electPreferredLeaders(asList(topic1, topic2), new ElectPreferredLeadersOptions().timeoutMs(2000));
+            results = env.adminClient().electPreferredLeaders(asList(topic1, topic2), new ElectPreferredLeadersOptions().timeoutMs(100));
             TestUtils.assertFutureError(results.partitionResult(topic1), TimeoutException.class);
             TestUtils.assertFutureError(results.partitionResult(topic2), TimeoutException.class);
         }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.InvalidTopicException;
@@ -50,6 +51,9 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData.PartitionResult;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData.ReplicaElectionResult;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.CreateAclsResponse;
@@ -67,6 +71,7 @@ import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeAclsResponse;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
+import org.apache.kafka.common.requests.ElectPreferredLeadersResponse;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
@@ -636,28 +641,41 @@ public class KafkaAdminClientTest {
 
     @Test
     public void testElectPreferredLeaders()  throws Exception {
-        /*TopicPartition topic1 = new TopicPartition("topic", 0);
+        TopicPartition topic1 = new TopicPartition("topic", 0);
         TopicPartition topic2 = new TopicPartition("topic", 2);
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
 
             // Test a call where one partition has an error.
-            HashMap<TopicPartition, ApiError> map = new HashMap<>();
-            map.put(topic1, ApiError.NONE);
-            map.put(topic2, ApiError.fromThrowable(new ClusterAuthorizationException(null)));
-            env.kafkaClient().prepareResponse(new ElectPreferredLeadersResponse(0,
-                    map));
+            ApiError value = ApiError.fromThrowable(new ClusterAuthorizationException(null));
+            ElectPreferredLeadersResponseData responseData = new ElectPreferredLeadersResponseData();
+            ReplicaElectionResult r = new ReplicaElectionResult().setTopic(topic1.topic());
+            r.partitionResult().add(new PartitionResult()
+                    .setPartitionId(topic1.partition())
+                    .setErrorCode(ApiError.NONE.error().code())
+                    .setErrorMessage(ApiError.NONE.message()));
+            r.partitionResult().add(new PartitionResult()
+                    .setPartitionId(topic2.partition())
+                    .setErrorCode(value.error().code())
+                    .setErrorMessage(value.message()));
+            responseData.replicaElectionResults().add(r);
+            env.kafkaClient().prepareResponse(new ElectPreferredLeadersResponse(responseData));
             ElectPreferredLeadersResult results = env.adminClient().electPreferredLeaders(asList(topic1, topic2));
             results.partitionResult(topic1).get();
             TestUtils.assertFutureError(results.partitionResult(topic2), ClusterAuthorizationException.class);
             TestUtils.assertFutureError(results.all(), ClusterAuthorizationException.class);
 
             // Test a call where there are no errors.
-            map.put(topic1, ApiError.NONE);
-            map.put(topic2, ApiError.NONE);
-            env.kafkaClient().prepareResponse(new ElectPreferredLeadersResponse(
-                    ElectPreferredLeadersUtil.fromElectPreferredLeadersRequest()0,
-                    map));
+            r.partitionResult().clear();
+            r.partitionResult().add(new PartitionResult()
+                    .setPartitionId(topic1.partition())
+                    .setErrorCode(ApiError.NONE.error().code())
+                    .setErrorMessage(ApiError.NONE.message()));
+            r.partitionResult().add(new PartitionResult()
+                    .setPartitionId(topic2.partition())
+                    .setErrorCode(ApiError.NONE.error().code())
+                    .setErrorMessage(ApiError.NONE.message()));
+            env.kafkaClient().prepareResponse(new ElectPreferredLeadersResponse(responseData));
 
             results = env.adminClient().electPreferredLeaders(asList(topic1, topic2));
             results.partitionResult(topic1).get();
@@ -667,7 +685,7 @@ public class KafkaAdminClientTest {
             results = env.adminClient().electPreferredLeaders(asList(topic1, topic2), new ElectPreferredLeadersOptions().timeoutMs(100));
             TestUtils.assertFutureError(results.partitionResult(topic1), TimeoutException.class);
             TestUtils.assertFutureError(results.partitionResult(topic2), TimeoutException.class);
-        }*/
+        }
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -327,6 +327,10 @@ public class MockAdminClient extends AdminClient {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
+    public ElectPreferredLeadersResult electPreferredLeaders(Collection<TopicPartition> partitions, ElectPreferredLeadersOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
     @Override
     public CreateAclsResult createAcls(Collection<AclBinding> acls, CreateAclsOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -68,7 +68,8 @@ public class RequestContextTest {
         assertEquals(correlationId, responseHeader.correlationId());
 
         Struct struct = ApiKeys.API_VERSIONS.parseResponse((short) 0, responseBuffer);
-        ApiVersionsResponse response = (ApiVersionsResponse) AbstractResponse.parseResponse(ApiKeys.API_VERSIONS, struct);
+        ApiVersionsResponse response = (ApiVersionsResponse)
+                AbstractResponse.parseResponse(ApiKeys.API_VERSIONS, struct, (short) 0);
         assertEquals(Errors.UNSUPPORTED_VERSION, response.error());
         assertTrue(response.apiVersions().isEmpty());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -32,6 +32,11 @@ import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.message.ElectPreferredLeadersRequestData;
+import org.apache.kafka.common.message.ElectPreferredLeadersRequestData.TopicPartitions;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData.PartitionResult;
+import org.apache.kafka.common.message.ElectPreferredLeadersResponseData.ReplicaElectionResult;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -464,7 +469,7 @@ public class RequestResponseTest {
         Struct deserializedStruct = ApiKeys.PRODUCE.parseResponse(version, buffer);
 
         ProduceResponse v5FromBytes = (ProduceResponse) AbstractResponse.parseResponse(ApiKeys.PRODUCE,
-                deserializedStruct);
+                deserializedStruct, version);
 
         assertEquals(1, v5FromBytes.responses().size());
         assertTrue(v5FromBytes.responses().containsKey(tp0));
@@ -1328,20 +1333,34 @@ public class RequestResponseTest {
     }
 
     private ElectPreferredLeadersRequest createElectPreferredLeadersRequestNullPartitions() {
-        return new ElectPreferredLeadersRequest.Builder(null, 100).build((short) 0);
+        return new ElectPreferredLeadersRequest.Builder(
+                new ElectPreferredLeadersRequestData()
+                        .setTimeoutMs(100)
+                        .setTopicPartitions(null))
+                .build((short) 0);
     }
 
     private ElectPreferredLeadersRequest createElectPreferredLeadersRequest() {
-        return new ElectPreferredLeadersRequest.Builder(asList(
-                new TopicPartition("my_topic", 1),
-                new TopicPartition("my_topic", 2)), 100).build((short) 0);
+        ElectPreferredLeadersRequestData data = new ElectPreferredLeadersRequestData()
+                .setTimeoutMs(100);
+        data.topicPartitions().add(new TopicPartitions().setTopic("data").setPartitionId(asList(1, 2)));
+        return new ElectPreferredLeadersRequest.Builder(data).build((short) 0);
     }
 
     private ElectPreferredLeadersResponse createElectPreferredLeadersResponse() {
-        Map<TopicPartition, ApiError> errors = new HashMap<>();
-        errors.put(new TopicPartition("my_topic", 0), ApiError.NONE);
-        errors.put(new TopicPartition("my_topic", 1), ApiError.fromThrowable(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception("blah")));
-        return new ElectPreferredLeadersResponse(200, errors);
+        //Map<TopicPartition, ApiError> errors = new HashMap<>();
+        //errors.put(new TopicPartition("myTopic", 0), ApiError.NONE);
+        //errors.put(new TopicPartition("myTopic", 1), ApiError.fromThrowable(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception("blah")));
+        ElectPreferredLeadersResponseData data = new ElectPreferredLeadersResponseData().setThrottleTimeMs(200);
+        ReplicaElectionResult resultsByTopic = new ReplicaElectionResult().setTopic("myTopic");
+        resultsByTopic.partitionResult().add(new PartitionResult().setPartitionId(0)
+                .setErrorCode(Errors.NONE.code())
+                .setErrorMessage(Errors.NONE.message()));
+        resultsByTopic.partitionResult().add(new PartitionResult().setPartitionId(0)
+                .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
+                .setErrorMessage(Errors.UNKNOWN_TOPIC_OR_PARTITION.message()));
+        data.replicaElectionResults().add(resultsByTopic);
+        return new ElectPreferredLeadersResponse(data);
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -304,6 +304,10 @@ public class RequestResponseTest {
         checkRequest(createRenewTokenRequest());
         checkErrorResponse(createRenewTokenRequest(), new UnknownServerException());
         checkResponse(createRenewTokenResponse(), 0);
+        checkRequest(createElectPreferredLeadersRequest());
+        checkRequest(createElectPreferredLeadersRequestNullPartitions());
+        checkErrorResponse(createElectPreferredLeadersRequest(), new UnknownServerException());
+        checkResponse(createElectPreferredLeadersResponse(), 0);
     }
 
     @Test
@@ -1322,4 +1326,22 @@ public class RequestResponseTest {
 
         return new DescribeDelegationTokenResponse(20, Errors.NONE, tokenList);
     }
+
+    private ElectPreferredLeadersRequest createElectPreferredLeadersRequestNullPartitions() {
+        return new ElectPreferredLeadersRequest.Builder(null, 100).build((short) 0);
+    }
+
+    private ElectPreferredLeadersRequest createElectPreferredLeadersRequest() {
+        return new ElectPreferredLeadersRequest.Builder(asList(
+                new TopicPartition("my_topic", 1),
+                new TopicPartition("my_topic", 2)), 100).build((short) 0);
+    }
+
+    private ElectPreferredLeadersResponse createElectPreferredLeadersResponse() {
+        Map<TopicPartition, ApiError> errors = new HashMap<>();
+        errors.put(new TopicPartition("my_topic", 0), ApiError.NONE);
+        errors.put(new TopicPartition("my_topic", 1), ApiError.fromThrowable(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception("blah")));
+        return new ElectPreferredLeadersResponse(200, errors);
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1348,15 +1348,12 @@ public class RequestResponseTest {
     }
 
     private ElectPreferredLeadersResponse createElectPreferredLeadersResponse() {
-        //Map<TopicPartition, ApiError> errors = new HashMap<>();
-        //errors.put(new TopicPartition("myTopic", 0), ApiError.NONE);
-        //errors.put(new TopicPartition("myTopic", 1), ApiError.fromThrowable(Errors.UNKNOWN_TOPIC_OR_PARTITION.exception("blah")));
         ElectPreferredLeadersResponseData data = new ElectPreferredLeadersResponseData().setThrottleTimeMs(200);
         ReplicaElectionResult resultsByTopic = new ReplicaElectionResult().setTopic("myTopic");
         resultsByTopic.partitionResult().add(new PartitionResult().setPartitionId(0)
                 .setErrorCode(Errors.NONE.code())
                 .setErrorMessage(Errors.NONE.message()));
-        resultsByTopic.partitionResult().add(new PartitionResult().setPartitionId(0)
+        resultsByTopic.partitionResult().add(new PartitionResult().setPartitionId(1)
                 .setErrorCode(Errors.UNKNOWN_TOPIC_OR_PARTITION.code())
                 .setErrorMessage(Errors.UNKNOWN_TOPIC_OR_PARTITION.message()));
         data.replicaElectionResults().add(resultsByTopic);

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -49,7 +49,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
     if(args.length == 0)
       CommandLineUtils.printUsageAndDie(commandOpts.parser, "This tool causes leadership for each partition to be transferred back to the 'preferred replica'," +
                                                 " it can be used to balance leadership among the servers." +
-                                                " The preferred replica is the first one in the replica assignment (see kafka-reassign-partitions.sh)." +
+                                                " The preferred replica is the first one in the replica assignment (see the output from kafka-topics.sh with the --describe option)." +
                                                 " Using this command is not necessary when the broker is configured with \"auto.leader.rebalance.enable=true\".")
 
     CommandLineUtils.checkRequiredArgs(commandOpts.parser, commandOpts.options)
@@ -65,8 +65,8 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
       None
 
     val preferredReplicaElectionCommand = if (commandOpts.options.has(commandOpts.zkConnectOpt)) {
-      Console.err.println(s"$commandOpts.zkConnectOpt is deprecated and will be removed in a future version of Kafka.")
-      Console.err.println(s"Use $commandOpts.bootstrapServerOpt instead to specify a broker to connect to.")
+      println(s"Warning: $commandOpts.zkConnectOpt is deprecated and will be removed in a future version of Kafka.")
+      println(s"Use $commandOpts.bootstrapServerOpt instead to specify a broker to connect to.")
       new ZkCommand(commandOpts.options.valueOf(commandOpts.zkConnectOpt),
               JaasUtils.isZkSecurityEnabled,
               timeout)
@@ -153,7 +153,6 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
 
   class ZkCommand(zkConnect: String, isSecure: Boolean, timeout: Int)
     extends Command {
-    //val zkConnect = options.valueOf(zkConnectOpt)
     var zkClient: KafkaZkClient = null
 
     val time = Time.SYSTEM

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -75,7 +75,9 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
           Utils.loadProps(commandOpts.options.valueOf(commandOpts.adminClientConfigOpt))
         else
           new Properties()
-        adminProps.putAll(CommandLineUtils.parseKeyValueArgs(commandOpts.options.valuesOf(commandOpts.adminClientPropertyOpt).asScala).asInstanceOf[java.util.Map[_ <: Object, _ <: Object]])
+        for ((k, v) <- CommandLineUtils.parseKeyValueArgs(commandOpts.options.valuesOf(commandOpts.adminClientPropertyOpt).asScala).asScala) {
+            adminProps.setProperty(k, v)
+          }
         adminProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, commandOpts.options.valueOf(commandOpts.bootstrapServerOpt))
         adminProps.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, timeout.toString)
         new AdminClientCommand(adminProps)

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutionException
 import joptsimple.OptionSpecBuilder
 import kafka.common.AdminCommandFailedException
 import kafka.utils._
+import kafka.utils.Implicits._
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.common.errors.TimeoutException
@@ -75,9 +76,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
           Utils.loadProps(commandOpts.options.valueOf(commandOpts.adminClientConfigOpt))
         else
           new Properties()
-        for ((k, v) <- CommandLineUtils.parseKeyValueArgs(commandOpts.options.valuesOf(commandOpts.adminClientPropertyOpt).asScala).asScala) {
-            adminProps.setProperty(k, v)
-          }
+        adminProps ++= CommandLineUtils.parseKeyValueArgs(commandOpts.options.valuesOf(commandOpts.adminClientPropertyOpt).asScala)
         adminProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, commandOpts.options.valueOf(commandOpts.bootstrapServerOpt))
         adminProps.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, timeout.toString)
         new AdminClientCommand(adminProps)

--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -75,7 +75,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
           Utils.loadProps(commandOpts.options.valueOf(commandOpts.adminClientConfigOpt))
         else
           new Properties()
-        adminProps.putAll(CommandLineUtils.parseKeyValueArgs(commandOpts.options.valuesOf(commandOpts.adminClientPropertyOpt).asScala))
+        adminProps.putAll(CommandLineUtils.parseKeyValueArgs(commandOpts.options.valuesOf(commandOpts.adminClientPropertyOpt).asScala).asInstanceOf[java.util.Map[_ <: Object, _ <: Object]])
         adminProps.setProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, commandOpts.options.valueOf(commandOpts.bootstrapServerOpt))
         adminProps.setProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, timeout.toString)
         new AdminClientCommand(adminProps)

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -627,6 +627,7 @@ class Partition(val topicPartition: TopicPartition,
     replicaManager.tryCompleteDelayedFetch(requestKey)
     replicaManager.tryCompleteDelayedProduce(requestKey)
     replicaManager.tryCompleteDelayedDeleteRecords(requestKey)
+    replicaManager.tryCompleteElection(requestKey)
   }
 
   def maybeShrinkIsr(replicaMaxLagTimeMs: Long) {

--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -627,7 +627,6 @@ class Partition(val topicPartition: TopicPartition,
     replicaManager.tryCompleteDelayedFetch(requestKey)
     replicaManager.tryCompleteDelayedProduce(requestKey)
     replicaManager.tryCompleteDelayedDeleteRecords(requestKey)
-    replicaManager.tryCompleteElection(requestKey)
   }
 
   def maybeShrinkIsr(replicaMaxLagTimeMs: Long) {

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -28,6 +28,7 @@ import org.apache.kafka.common.errors.ControllerMovedException
 import org.apache.kafka.common.utils.Time
 
 import scala.collection._
+import scala.collection.JavaConverters._
 
 object ControllerEventManager {
   val ControllerEventThreadName = "controller-event-thread"
@@ -69,6 +70,11 @@ class ControllerEventManager(controllerId: Int, rateAndTimeMetrics: Map[Controll
   }
 
   def clearAndPut(event: ControllerEvent): Unit = inLock(putLock) {
+    queue.asScala.foreach(evt =>
+      if (evt.isInstanceOf[PreemptableControllerEvent]) {
+        evt.asInstanceOf[PreemptableControllerEvent].preempt()
+      }
+    )
     queue.clear()
     put(event)
   }

--- a/core/src/main/scala/kafka/controller/ControllerEventManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerEventManager.scala
@@ -71,9 +71,8 @@ class ControllerEventManager(controllerId: Int, rateAndTimeMetrics: Map[Controll
 
   def clearAndPut(event: ControllerEvent): Unit = inLock(putLock) {
     queue.asScala.foreach(evt =>
-      if (evt.isInstanceOf[PreemptableControllerEvent]) {
+      if (evt.isInstanceOf[PreemptableControllerEvent])
         evt.asInstanceOf[PreemptableControllerEvent].preempt()
-      }
     )
     queue.clear()
     put(event)

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -268,7 +268,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     maybeTriggerPartitionReassignment(controllerContext.partitionsBeingReassigned.keySet)
     topicDeletionManager.tryTopicDeletion()
     val pendingPreferredReplicaElections = fetchPendingPreferredReplicaElections()
-    onPreferredReplicaElection(pendingPreferredReplicaElections)
+    onPreferredReplicaElection(pendingPreferredReplicaElections, false, false)
     info("Starting the controller scheduler")
     kafkaScheduler.startup()
     if (config.autoLeaderRebalanceEnable) {
@@ -995,7 +995,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
           controllerContext.partitionsBeingReassigned.isEmpty &&
           !topicDeletionManager.isTopicQueuedUpForDeletion(tp.topic) &&
           controllerContext.allTopics.contains(tp.topic))
-        onPreferredReplicaElection(candidatePartitions.toSet, isTriggeredByAutoRebalance = true)
+        onPreferredReplicaElection(candidatePartitions.toSet, isTriggeredByAutoRebalance = true, newPath = false)
       }
     }
   }
@@ -1566,7 +1566,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
             currentLeader != preferredReplica
           }
 
-          val electionErrors = onPreferredReplicaElection(electablePartitions, newPath)
+          val electionErrors = onPreferredReplicaElection(electablePartitions, false, newPath)
           val successfulPartitions = electablePartitions -- electionErrors.keySet
           val results = electionErrors.map { case (partition, ex) =>
             val apiError = if (ex.isInstanceOf[StateChangeFailedException])

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -633,7 +633,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
                                          newPath: Boolean = false): Map[TopicPartition, Throwable] = {
     info(s"Starting preferred replica leader election for partitions ${partitions.mkString(",")}")
     try {
-      val results = partitionStateMachine.handleStateChangesWithResults(partitions.toSeq, OnlinePartition,
+      val results = partitionStateMachine.handleStateChanges(partitions.toSeq, OnlinePartition,
         Option(PreferredReplicaPartitionLeaderElectionStrategy))
       if (!newPath) {
         results.foreach(entry =>

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -125,9 +125,17 @@ class PartitionStateMachine(config: KafkaConfig,
     // It is important to trigger leader election for those partitions.
   }
 
+  /**
+    * Try to change the state of the given partitions to the given targetState, using the given
+    * partitionLeaderElectionStrategyOpt if a leader election is required.
+    * @param partitions The partitions
+    * @param targetState The state
+    * @param partitionLeaderElectionStrategyOpt The leader election strategy if a leader election is required.
+    * @return partitions and corresponding throwable for those partitions which could not transition to the given state
+    */
   def handleStateChanges(partitions: Seq[TopicPartition], targetState: PartitionState,
                          partitionLeaderElectionStrategyOpt: Option[PartitionLeaderElectionStrategy] = None): Map[TopicPartition, Throwable] = {
-    return if (partitions.nonEmpty) {
+    if (partitions.nonEmpty) {
       try {
         controllerBrokerRequestBatch.newBatch()
         val errors = doHandleStateChanges(partitions, targetState, partitionLeaderElectionStrategyOpt)

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -317,9 +317,11 @@ class PartitionStateMachine(config: KafkaConfig,
    * Repeatedly attempt to elect leaders for multiple partitions until there are no more remaining partitions to retry.
    * @param partitions The partitions that we're trying to elect leaders for.
    * @param partitionLeaderElectionStrategy The election strategy to use.
-   * @return The partitions that successfully had a leader elected.
+   * @return A pair with first element of which is the partitions that successfully had a leader elected
+    *        and the second element a map of failed partition to the corresponding thrown exception.
    */
-  private def electLeaderForPartitions(partitions: Seq[TopicPartition], partitionLeaderElectionStrategy: PartitionLeaderElectionStrategy): (Seq[TopicPartition], Map[TopicPartition, Throwable]) = {
+  private def electLeaderForPartitions(partitions: Seq[TopicPartition],
+                                       partitionLeaderElectionStrategy: PartitionLeaderElectionStrategy): (Seq[TopicPartition], Map[TopicPartition, Throwable]) = {
     val successfulElections = mutable.Buffer.empty[TopicPartition]
     var remaining = partitions
     var failures = Map.empty[TopicPartition, Throwable]

--- a/core/src/main/scala/kafka/server/DelayedElectPreferredLeader.scala
+++ b/core/src/main/scala/kafka/server/DelayedElectPreferredLeader.scala
@@ -17,7 +17,6 @@
 
 package kafka.server
 
-import kafka.controller.ControllerContext
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.Errors
 import org.apache.kafka.common.requests.ApiError

--- a/core/src/main/scala/kafka/server/DelayedElectPreferredLeader.scala
+++ b/core/src/main/scala/kafka/server/DelayedElectPreferredLeader.scala
@@ -1,0 +1,90 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import kafka.controller.ControllerContext
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.ApiError
+
+import scala.collection.{Map, Set, mutable}
+
+case class ElectPreferredLeaderMetadata(partition: TopicPartition, leader: Int)
+
+/** A delayed elect preferred leader operation that can be created by the replica manager and watched
+  * in the elect preferred leader purgatory
+  */
+class DelayedElectPreferredLeader(delayMs: Long,
+                                  expectedLeaders: Set[ElectPreferredLeaderMetadata],
+                                  results: Map[TopicPartition, ApiError],
+                                  replicaManager: ReplicaManager,
+                                  responseCallback: Map[TopicPartition, ApiError] => Unit)
+    extends DelayedOperation(delayMs) {
+
+  var waitingPartitions = expectedLeaders.to[mutable.Set]
+  val fullResults = results.to[mutable.Set]
+
+
+  /**
+    * Call-back to execute when a delayed operation gets expired and hence forced to complete.
+    */
+  override def onExpiration(): Unit = {}
+
+  /**
+    * Process for completing an operation; This function needs to be defined
+    * in subclasses and will be called exactly once in forceComplete()
+    */
+  override def onComplete(): Unit = {
+    // This could be called to force complete, so I need the full list of partitions, so I can time them all out.
+    updateWaiting()
+    val timedout = waitingPartitions.map(meta => meta.partition -> new ApiError(Errors.REQUEST_TIMED_OUT, null)).toMap
+    responseCallback(timedout ++ fullResults)
+  }
+
+  private def timeoutWaiting = {
+    waitingPartitions.map(partition => partition -> new ApiError(Errors.REQUEST_TIMED_OUT, null)).toMap
+  }
+
+  /**
+    * Try to complete the delayed operation by first checking if the operation
+    * can be completed by now. If yes execute the completion logic by calling
+    * forceComplete() and return true iff forceComplete returns true; otherwise return false
+    *
+    * This function needs to be defined in subclasses
+    */
+  override def tryComplete(): Boolean = {
+    updateWaiting()
+    debug(s"tryComplete() waitingPartitions: $waitingPartitions")
+    waitingPartitions.isEmpty && forceComplete()
+  }
+
+  private def updateWaiting() = {
+    waitingPartitions.foreach{m =>
+      val ps = replicaManager.metadataCache.getPartitionInfo(m.partition.topic, m.partition.partition)
+      ps match {
+        case Some(ps) =>
+          if (m.leader == ps.basePartitionState.leader) {
+            waitingPartitions -= m
+            fullResults += m.partition -> ApiError.NONE
+          }
+        case None =>
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -38,7 +38,6 @@ import kafka.security.auth.{Resource, _}
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.utils.{CoreUtils, Logging}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
-import org.apache.kafka.common
 import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors._

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -38,6 +38,7 @@ import kafka.security.auth.{Resource, _}
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.utils.{CoreUtils, Logging}
 import kafka.zk.{AdminZkClient, KafkaZkClient}
+import org.apache.kafka.common
 import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding}
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors._
@@ -2236,7 +2237,7 @@ class KafkaApis(val requestChannel: RequestChannel,
     val electionRequest = request.body[ElectPreferredLeadersRequest]
     val partitions =
       if (electionRequest.topicPartitions() == null) {
-        zkClient.getAllPartitions()
+        metadataCache.getAllPartitions()
       } else {
         electionRequest.topicPartitions().asScala
       }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -2250,7 +2250,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       val partitionErrors =
       if (electionRequest.topicPartitions() == null) {
         // Don't leak the set of partitions if the client lack authz
-        Map(new TopicPartition(null, -1) -> error)
+        Map.empty[TopicPartition, ApiError]
       } else {
         partitions.map(partition => partition -> error).toMap
       }

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -138,12 +138,9 @@ class MetadataCache(brokerId: Int) extends Logging {
   }
 
   def getAllPartitions(): Set[TopicPartition] = {
-    metadataSnapshot.partitionStates.foldLeft(Set.empty[TopicPartition]) { case (result, namePartitionsAndStates) => {
-        val topicName = namePartitionsAndStates._1
-        val partitionsAndStates = namePartitionsAndStates._2
-        result ++ partitionsAndStates.keys.map(partitionId => new TopicPartition(topicName, partitionId.toInt))
-      }
-    }
+    metadataSnapshot.partitionStates.flatMap { case (topicName, partitionsAndStates) =>
+      partitionsAndStates.keys.map(partitionId => new TopicPartition(topicName, partitionId.toInt))
+    }.toSet
   }
 
   private def getAllTopics(snapshot: MetadataSnapshot): Set[String] = {

--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -137,6 +137,15 @@ class MetadataCache(brokerId: Int) extends Logging {
     getAllTopics(metadataSnapshot)
   }
 
+  def getAllPartitions(): Set[TopicPartition] = {
+    metadataSnapshot.partitionStates.foldLeft(Set.empty[TopicPartition]) { case (result, namePartitionsAndStates) => {
+        val topicName = namePartitionsAndStates._1
+        val partitionsAndStates = namePartitionsAndStates._2
+        result ++ partitionsAndStates.keys.map(partitionId => new TopicPartition(topicName, partitionId.toInt))
+      }
+    }
+  }
+
   private def getAllTopics(snapshot: MetadataSnapshot): Set[String] = {
     snapshot.partitionStates.keySet
   }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1521,16 +1521,16 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   def electPreferredLeaders(controller: KafkaController,
-                                  partitions: Set[TopicPartition],
-                                  responseCallback: Map[TopicPartition, ApiError] => Unit,
-                                  requestTimeout: Long): Unit = {
+                            partitions: Set[TopicPartition],
+                            responseCallback: Map[TopicPartition, ApiError] => Unit,
+                            requestTimeout: Long): Unit = {
 
     val (validPartitions, invalidPartitions) = partitions.partition(tp => metadataCache.contains(tp))
 
     val invalidPartitionsResults = invalidPartitions.map { p =>
       val msg = s"Skipping preferred replica leader election for partition ${p} since it doesn't exist."
       logger.info(msg)
-      p -> new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, s"The partition '$p' does not exist.")
+      p -> new ApiError(Errors.UNKNOWN_TOPIC_OR_PARTITION, s"The partition does not exist.")
     }.toMap
 
     def electionCallback(waiting: Set[TopicPartition], results: Map[TopicPartition, ApiError]) = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1527,11 +1527,10 @@ class ReplicaManager(val config: KafkaConfig,
 
     val deadline = time.milliseconds() + requestTimeout
 
-    def electionCallback(waiting: Set[TopicPartition], results: Map[TopicPartition, ApiError]): Unit = {
+    def electionCallback(waiting: Set[TopicPartition],
+                         expectedLeaders: Set[ElectPreferredLeaderMetadata],
+                         results: Map[TopicPartition, ApiError]): Unit = {
       if (waiting.nonEmpty) {
-        val expectedLeaders = waiting.map(
-          tp => ElectPreferredLeaderMetadata(tp, controller.controllerContext.partitionReplicaAssignment(tp).head))
-
         val watchKeys = waiting.map(p => new TopicPartitionOperationKey(p.topic, p.partition)).toSeq
         delayedElectPreferredLeaderPurgatory.tryCompleteElseWatch(
           new DelayedElectPreferredLeader(deadline - time.milliseconds(), expectedLeaders, results,

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1527,11 +1527,12 @@ class ReplicaManager(val config: KafkaConfig,
 
     val deadline = time.milliseconds() + requestTimeout
 
-    def electionCallback(waiting: Set[TopicPartition],
-                         expectedLeaders: Set[ElectPreferredLeaderMetadata],
+    def electionCallback(expectedLeaders: Map[TopicPartition, Int],
                          results: Map[TopicPartition, ApiError]): Unit = {
-      if (waiting.nonEmpty) {
-        val watchKeys = waiting.map(p => new TopicPartitionOperationKey(p.topic, p.partition)).toSeq
+      if (expectedLeaders.nonEmpty) {
+        val watchKeys = expectedLeaders.map{
+          case (tp, leader) => new TopicPartitionOperationKey(tp.topic, tp.partition)
+        }.toSeq
         delayedElectPreferredLeaderPurgatory.tryCompleteElseWatch(
           new DelayedElectPreferredLeader(deadline - time.milliseconds(), expectedLeaders, results,
             this, responseCallback),

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -47,12 +47,13 @@ import org.junit.Assert._
 
 import scala.util.Random
 import scala.collection.JavaConverters._
-import java.lang.{Long => JLong}
 
 import kafka.zk.KafkaZkClient
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
+
+import java.lang.{Long => JLong}
 
 /**
  * An integration test of the KafkaAdminClient.
@@ -1198,6 +1199,194 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     }
   }
 
+  @Test
+  def testElectPreferredLeaders(): Unit = {
+    client = AdminClient.create(createConfig)
+
+    val prefer0 = Seq(0, 1, 2)
+    val prefer1 = Seq(1, 2, 0)
+    val prefer2 = Seq(2, 0, 1)
+
+    val partition1 = new TopicPartition("elect-preferred-leaders-topic-1", 0)
+    TestUtils.createTopic(zkClient, partition1.topic, Map[Int, Seq[Int]](partition1.partition -> prefer0), servers)
+
+    val partition2 = new TopicPartition("elect-preferred-leaders-topic-2", 0)
+    TestUtils.createTopic(zkClient, partition2.topic, Map[Int, Seq[Int]](partition2.partition -> prefer0), servers)
+
+    def currentLeader(topicPartition: TopicPartition) =
+      client.describeTopics(asList(topicPartition.topic)).values.get(topicPartition.topic).
+        get.partitions.get(topicPartition.partition).leader.id
+
+    def preferredLeader(topicPartition: TopicPartition) =
+      client.describeTopics(asList(topicPartition.topic)).values.get(topicPartition.topic).
+        get.partitions.get(topicPartition.partition).replicas.get(0).id
+
+    def waitForLeaderToBecome(topicPartition: TopicPartition, leader: Int) =
+      TestUtils.waitUntilTrue(() => currentLeader(topicPartition) == leader, s"Expected leader to become $leader", 10000)
+
+    /** Changes the <i>preferred</i> leader without changing the <i>current</i> leader. */
+    def changePreferredLeader(newAssignment: Seq[Int]) = {
+      val preferred = newAssignment.head
+      val prior1 = currentLeader(partition1)
+      val prior2 = currentLeader(partition2)
+
+      var m = Map.empty[TopicPartition, Seq[Int]]
+
+      if (prior1 != preferred)
+        m += partition1 -> newAssignment
+      if (prior2 != preferred)
+        m += partition2 -> newAssignment
+
+      zkClient.createPartitionReassignment(m)
+      TestUtils.waitUntilTrue(
+        () => preferredLeader(partition1) == preferred && preferredLeader(partition2) == preferred,
+        s"Expected preferred leader to become $preferred, but is ${preferredLeader(partition1)} and ${preferredLeader(partition2)}", 10000)
+      // Check the leader hasn't moved
+      assertEquals(prior1, currentLeader(partition1))
+      assertEquals(prior2, currentLeader(partition2))
+    }
+
+    // Check current leaders are 0
+    assertEquals(0, currentLeader(partition1))
+    assertEquals(0, currentLeader(partition2))
+
+    // Noop election
+    var electResult = client.electPreferredLeaders(asList(partition1))
+    electResult.partitionResult(partition1).get()
+    assertEquals(0, currentLeader(partition1))
+
+    // Noop election with null partitions
+    electResult = client.electPreferredLeaders(null)
+    electResult.partitionResult(partition1).get()
+    assertEquals(0, currentLeader(partition1))
+    electResult.partitionResult(partition2).get()
+    assertEquals(0, currentLeader(partition2))
+
+    // Now change the preferred leader to 1
+    changePreferredLeader(prefer1)
+
+    // meaningful election
+    electResult = client.electPreferredLeaders(asList(partition1))
+    assertEquals(Set(partition1).asJava, electResult.partitions.get)
+    electResult.partitionResult(partition1).get()
+    waitForLeaderToBecome(partition1, 1)
+
+    // topic 2 unchanged
+    try {
+      electResult.partitionResult(partition2).get()
+      fail("topic 2 wasn't requested")
+    } catch {
+      case e: ExecutionException =>
+        val cause = e.getCause
+        assertTrue(cause.getClass.getName, cause.isInstanceOf[UnknownTopicOrPartitionException])
+        assertEquals("Preferred leader election for partition \"elect-preferred-leaders-topic-2-0\" was not attempted",
+          cause.getMessage)
+        assertEquals(0, currentLeader(partition2))
+    }
+
+    // meaningful election with null partitions
+    electResult = client.electPreferredLeaders(null)
+    assertEquals(Set(partition1, partition2), electResult.partitions.get.asScala.filterNot(_.topic == "__consumer_offsets"))
+    electResult.partitionResult(partition1).get()
+    waitForLeaderToBecome(partition1, 1)
+    electResult.partitionResult(partition2).get()
+    waitForLeaderToBecome(partition2, 1)
+
+    // unknown topic
+    val unknownPartition = new TopicPartition("topic-does-not-exist", 0)
+    electResult = client.electPreferredLeaders(asList(unknownPartition))
+    assertEquals(Set(unknownPartition).asJava, electResult.partitions.get)
+    try {
+      electResult.partitionResult(unknownPartition).get()
+    } catch {
+      case e: Exception =>
+        val cause = e.getCause
+        assertTrue(cause.isInstanceOf[UnknownTopicOrPartitionException])
+        assertEquals("The partition 'topic-does-not-exist-0' does not exist.",
+          cause.getMessage)
+        assertEquals(1, currentLeader(partition1))
+        assertEquals(1, currentLeader(partition2))
+    }
+
+    // Now change the preferred leader to 2
+    changePreferredLeader(prefer2)
+
+    // mixed results
+    electResult = client.electPreferredLeaders(asList(unknownPartition, partition1))
+    assertEquals(Set(unknownPartition, partition1).asJava, electResult.partitions.get)
+    waitForLeaderToBecome(partition1, 2)
+    assertEquals(1, currentLeader(partition2))
+    try {
+      electResult.partitionResult(unknownPartition).get()
+    } catch {
+      case e: Exception =>
+        val cause = e.getCause
+        assertTrue(cause.isInstanceOf[UnknownTopicOrPartitionException])
+        assertEquals("The partition 'topic-does-not-exist-0' does not exist.",
+          cause.getMessage)
+    }
+
+    // dupe partitions
+    electResult = client.electPreferredLeaders(asList(partition2, partition2))
+    assertEquals(Set(partition2).asJava, electResult.partitions.get)
+    electResult.partitionResult(partition2).get()
+    waitForLeaderToBecome(partition2, 2)
+
+    // Now change the preferred leader to 1
+    changePreferredLeader(prefer1)
+    // but shut it down...
+    servers(1).shutdown()
+
+    // ... now what happens if we try to elect the preferred leader and it's down?
+    val shortTimeout = new ElectPreferredLeadersOptions().timeoutMs(10000)
+    electResult = client.electPreferredLeaders(asList(partition1), shortTimeout)
+    assertEquals(Set(partition1).asJava, electResult.partitions.get)
+    try {
+      electResult.partitionResult(partition1).get()
+      fail()
+    } catch {
+      case e: Exception =>
+        val cause = e.getCause
+        assertTrue(cause.getClass.getName, cause.isInstanceOf[LeaderNotAvailableException])
+        assertTrue(s"Wrong message ${cause.getMessage}", cause.getMessage.contains(
+          "Failed to elect leader for partition elect-preferred-leaders-topic-1-0 under strategy PreferredReplicaPartitionLeaderElectionStrategy"))
+    }
+    assertEquals(2, currentLeader(partition1))
+
+    // preferred leader unavailable with null argument
+    electResult = client.electPreferredLeaders(null, shortTimeout)
+    try {
+      electResult.partitions.get()
+      fail()
+    } catch {
+      case e: Exception =>
+        val cause = e.getCause
+        assertTrue(cause.getClass.getName, cause.isInstanceOf[LeaderNotAvailableException])
+    }
+    try {
+      electResult.partitionResult(partition1).get()
+      fail()
+    } catch {
+      case e: Exception =>
+        val cause = e.getCause
+        assertTrue(cause.getClass.getName, cause.isInstanceOf[LeaderNotAvailableException])
+        assertTrue(s"Wrong message ${cause.getMessage}", cause.getMessage.contains(
+          "Failed to elect leader for partition elect-preferred-leaders-topic-1-0 under strategy PreferredReplicaPartitionLeaderElectionStrategy"))
+    }
+    try {
+      electResult.partitionResult(partition2).get()
+      fail()
+    } catch {
+      case e: Exception =>
+        val cause = e.getCause
+        assertTrue(cause.getClass.getName, cause.isInstanceOf[LeaderNotAvailableException])
+        assertTrue(s"Wrong message ${cause.getMessage}", cause.getMessage.contains(
+          "Failed to elect leader for partition elect-preferred-leaders-topic-2-0 under strategy PreferredReplicaPartitionLeaderElectionStrategy"))
+    }
+
+    assertEquals(2, currentLeader(partition1))
+    assertEquals(2, currentLeader(partition2))
+  }
 }
 
 object AdminClientIntegrationTest {

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -1302,7 +1302,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       case e: Exception =>
         val cause = e.getCause
         assertTrue(cause.isInstanceOf[UnknownTopicOrPartitionException])
-        assertEquals("The partition 'topic-does-not-exist-0' does not exist.",
+        assertEquals("The partition does not exist.",
           cause.getMessage)
         assertEquals(1, currentLeader(partition1))
         assertEquals(1, currentLeader(partition2))
@@ -1322,7 +1322,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       case e: Exception =>
         val cause = e.getCause
         assertTrue(cause.isInstanceOf[UnknownTopicOrPartitionException])
-        assertEquals("The partition 'topic-does-not-exist-0' does not exist.",
+        assertEquals("The partition does not exist.",
           cause.getMessage)
     }
 

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -146,7 +146,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       ApiKeys.DESCRIBE_ACLS -> classOf[DescribeAclsResponse],
       ApiKeys.ALTER_REPLICA_LOG_DIRS -> classOf[AlterReplicaLogDirsResponse],
       ApiKeys.DESCRIBE_LOG_DIRS -> classOf[DescribeLogDirsResponse],
-      ApiKeys.CREATE_PARTITIONS -> classOf[CreatePartitionsResponse]
+      ApiKeys.CREATE_PARTITIONS -> classOf[CreatePartitionsResponse],
+      ApiKeys.ELECT_PREFERRED_LEADERS -> classOf[ElectPreferredLeadersResponse]
   )
 
   val requestKeyToError = Map[ApiKeys, Nothing => Errors](
@@ -187,7 +188,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     ApiKeys.ALTER_REPLICA_LOG_DIRS -> ((resp: AlterReplicaLogDirsResponse) => resp.responses.get(tp)),
     ApiKeys.DESCRIBE_LOG_DIRS -> ((resp: DescribeLogDirsResponse) =>
       if (resp.logDirInfos.size() > 0) resp.logDirInfos.asScala.head._2.error else Errors.CLUSTER_AUTHORIZATION_FAILED),
-    ApiKeys.CREATE_PARTITIONS -> ((resp: CreatePartitionsResponse) => resp.errors.asScala.find(_._1 == topic).get._2.error)
+    ApiKeys.CREATE_PARTITIONS -> ((resp: CreatePartitionsResponse) => resp.errors.asScala.find(_._1 == topic).get._2.error),
+    ApiKeys.ELECT_PREFERRED_LEADERS -> ((resp: ElectPreferredLeadersResponse) => resp.errors.get(tp).error)
   )
 
   val requestKeysToAcls = Map[ApiKeys, Map[Resource, Set[Acl]]](
@@ -225,7 +227,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     ApiKeys.DELETE_ACLS -> clusterAlterAcl,
     ApiKeys.ALTER_REPLICA_LOG_DIRS -> clusterAlterAcl,
     ApiKeys.DESCRIBE_LOG_DIRS -> clusterDescribeAcl,
-    ApiKeys.CREATE_PARTITIONS -> topicAlterAcl
+    ApiKeys.CREATE_PARTITIONS -> topicAlterAcl,
+    ApiKeys.CREATE_PARTITIONS -> topicAlterAcl,
+    ApiKeys.ELECT_PREFERRED_LEADERS -> clusterAlterAcl
   )
 
   @Before
@@ -382,6 +386,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
 
   private def addOffsetsToTxnRequest = new AddOffsetsToTxnRequest.Builder(transactionalId, 1, 1, group).build()
 
+  private def electPreferredLeadersRequest = new ElectPreferredLeadersRequest.Builder(Collections.singleton(tp), 10000).build()
+
   @Test
   def testAuthorizationWithTopicExisting() {
     val requestKeyToRequest = mutable.LinkedHashMap[ApiKeys, AbstractRequest](
@@ -414,9 +420,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       ApiKeys.CREATE_PARTITIONS -> createPartitionsRequest,
       ApiKeys.ADD_PARTITIONS_TO_TXN -> addPartitionsToTxnRequest,
       ApiKeys.ADD_OFFSETS_TO_TXN -> addOffsetsToTxnRequest,
-
       // Check StopReplica last since some APIs depend on replica availability
-      ApiKeys.STOP_REPLICA -> stopReplicaRequest
+      ApiKeys.STOP_REPLICA -> stopReplicaRequest,
+      ApiKeys.ELECT_PREFERRED_LEADERS -> electPreferredLeadersRequest
     )
 
     for ((key, request) <- requestKeyToRequest) {
@@ -462,7 +468,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       ApiKeys.ADD_OFFSETS_TO_TXN -> addOffsetsToTxnRequest,
       ApiKeys.CREATE_PARTITIONS -> createPartitionsRequest,
       ApiKeys.DELETE_GROUPS -> deleteGroupsRequest,
-      ApiKeys.OFFSET_FOR_LEADER_EPOCH -> offsetsForLeaderEpochRequest
+      ApiKeys.OFFSET_FOR_LEADER_EPOCH -> offsetsForLeaderEpochRequest,
+      ApiKeys.ELECT_PREFERRED_LEADERS -> electPreferredLeadersRequest
     )
 
     for ((key, request) <- requestKeyToRequest) {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -189,7 +189,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     ApiKeys.DESCRIBE_LOG_DIRS -> ((resp: DescribeLogDirsResponse) =>
       if (resp.logDirInfos.size() > 0) resp.logDirInfos.asScala.head._2.error else Errors.CLUSTER_AUTHORIZATION_FAILED),
     ApiKeys.CREATE_PARTITIONS -> ((resp: CreatePartitionsResponse) => resp.errors.asScala.find(_._1 == topic).get._2.error),
-    ApiKeys.ELECT_PREFERRED_LEADERS -> ((resp: ElectPreferredLeadersResponse) => resp.errors.get(tp).error)
+    ApiKeys.ELECT_PREFERRED_LEADERS -> ((resp: ElectPreferredLeadersResponse) =>
+      ElectPreferredLeadersRequest.fromResponseData(resp.data()).get(tp).error())
   )
 
   val requestKeysToAcls = Map[ApiKeys, Map[Resource, Set[Acl]]](
@@ -386,7 +387,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
 
   private def addOffsetsToTxnRequest = new AddOffsetsToTxnRequest.Builder(transactionalId, 1, 1, group).build()
 
-  private def electPreferredLeadersRequest = new ElectPreferredLeadersRequest.Builder(Collections.singleton(tp), 10000).build()
+  private def electPreferredLeadersRequest = new ElectPreferredLeadersRequest.Builder(
+    ElectPreferredLeadersRequest.toRequestData(Collections.singleton(tp), 10000)).build()
 
   @Test
   def testAuthorizationWithTopicExisting() {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -229,7 +229,6 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     ApiKeys.ALTER_REPLICA_LOG_DIRS -> clusterAlterAcl,
     ApiKeys.DESCRIBE_LOG_DIRS -> clusterDescribeAcl,
     ApiKeys.CREATE_PARTITIONS -> topicAlterAcl,
-    ApiKeys.CREATE_PARTITIONS -> topicAlterAcl,
     ApiKeys.ELECT_PREFERRED_LEADERS -> clusterAlterAcl
   )
 

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -29,7 +29,7 @@ import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{Logging, TestUtils, ZkUtils}
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{ClusterAuthorizationException, LeaderNotAvailableException, TimeoutException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.errors.{ClusterAuthorizationException, PreferredLeaderNotAvailableException, TimeoutException, UnknownTopicOrPartitionException}
 import org.apache.kafka.common.network.ListenerName
 import org.junit.Assert._
 import org.junit.{After, Test}
@@ -264,7 +264,7 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
       case e: AdminCommandFailedException =>
         assertEquals("1 preferred replica(s) could not be elected", e.getMessage)
         val suppressed = e.getSuppressed()(0)
-        assertTrue(suppressed.isInstanceOf[LeaderNotAvailableException])
+        assertTrue(suppressed.isInstanceOf[PreferredLeaderNotAvailableException])
         assertTrue(suppressed.getMessage, suppressed.getMessage.contains("Failed to elect leader for partition test-0 under strategy PreferredReplicaPartitionLeaderElectionStrategy"))
         // Check we still have the same leader
         assertEquals(leader, getLeader(testPartition))

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -62,11 +62,6 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
     // create brokers
     servers = brokerConfigs.map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))
     // create the topic
-    //zkClient.createPartitionReassignment(partitionsAndAssignments)
-//    partitionsAndAssignments.foreach { partitionAndAssignment =>
-//      zkClient.createPartitionReassignment()OrUpdateTopicPartitionAssignmentPathInZK(partitionAndAssignment._1.topic(),
-//        Map(partitionAndAssignment._1.partition -> partitionAndAssignment._2))
-//    }
     partitionsAndAssignments.foreach { partitionAndAssignment =>
       zkClient.createTopicAssignment(partitionAndAssignment._1.topic(),
       Map(partitionAndAssignment._1 -> partitionAndAssignment._2))

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -288,7 +288,7 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
       PreferredReplicaLeaderElectionCommand.run(Array(
         "--bootstrap-server", bootstrapServer(),
         "--path-to-json-file", jsonFile.getAbsolutePath),
-        timeout = 10000)
+        timeout = 2000)
       fail();
     } catch {
       case e: AdminCommandFailedException =>

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -1,0 +1,341 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package unit.kafka.admin
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+import java.util.Properties
+
+import kafka.admin.{PreferredReplicaLeaderElectionCommand}
+import kafka.common.{AdminCommandFailedException, TopicAndPartition}
+import kafka.network.RequestChannel
+import kafka.security.auth._
+import kafka.server.{KafkaConfig, KafkaServer}
+import kafka.utils.{Logging, TestUtils, ZkUtils}
+import kafka.zk.ZooKeeperTestHarness
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.{LeaderNotAvailableException, TimeoutException, UnknownTopicOrPartitionException}
+import org.apache.kafka.common.network.ListenerName
+import org.junit.Assert._
+import org.junit.{After, Test}
+
+class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness with Logging /*with RackAwareTest*/ {
+
+  var servers: Seq[KafkaServer] = Seq()
+
+  @After
+  override def tearDown() {
+    TestUtils.shutdownServers(servers)
+    super.tearDown()
+  }
+
+  private def createTestTopicAndCluster(topicPartition: Map[TopicPartition, List[Int]],
+                                        authorizer: Option[String] = None) {
+
+    val brokerConfigs = TestUtils.createBrokerConfigs(3, zkConnect, false)
+    brokerConfigs.foreach(p => p.setProperty("auto.leader.rebalance.enable", "false"))
+    authorizer match {
+      case Some(className) =>
+        brokerConfigs.foreach(p => p.setProperty("authorizer.class.name", className))
+      case None =>
+    }
+    createTestTopicAndCluster(topicPartition,brokerConfigs)
+  }
+
+  private def createTestTopicAndCluster(partitionsAndAssignments: Map[TopicPartition, List[Int]],
+                                        brokerConfigs: Seq[Properties]) {
+    // create brokers
+    servers = brokerConfigs.map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))
+    // create the topic
+//    partitionsAndAssignments.foreach { partitionAndAssignment =>
+//      zkClient.createPartitionReassignment()OrUpdateTopicPartitionAssignmentPathInZK(partitionAndAssignment._1.topic(),
+//        Map(partitionAndAssignment._1.partition -> partitionAndAssignment._2))
+//    }
+    // wait until replica log is created on every broker
+    TestUtils.waitUntilTrue(() => servers.forall(server => partitionsAndAssignments.forall(partitionAndAssignment => server.getLogManager().getLog(partitionAndAssignment._1).isDefined)),
+      "Replicas for topic test not created")
+  }
+
+  /** Bounce the given server and wait for all servers to get metadata for the given partition */
+  private def bounceServer(server: Int, partition: TopicPartition) {
+    info(s"Shutting down server $server so a non-preferred replica becomes leader")
+    servers(server).shutdown()
+    info(s"Starting server $server now that a non-preferred replica is leader")
+    servers(server).startup()
+    TestUtils.waitUntilTrue(() => servers.forall(server => server.metadataCache.getPartitionInfo(partition.topic(), partition.partition()).isDefined),
+      s"Replicas for partition $partition not created")
+  }
+
+  private def getController() = {
+    servers.find(p => p.kafkaController.isActive)
+  }
+
+  private def getLeader(topicPartition: TopicPartition) = {
+    servers(0).metadataCache.getPartitionInfo(topicPartition.topic(), topicPartition.partition()).get.basePartitionState.leader
+  }
+
+  private def bootstrapServer(broker: Int = 0): String = {
+    val port = servers(broker).socketServer.boundPort(ListenerName.normalised("PLAINTEXT"))
+    info("Server bound to port "+port)
+    s"localhost:$port"
+  }
+
+  val testPartition = new TopicPartition("test", 0)
+  val testPartitionAssignment = List(1, 2, 0)
+  val testPartitionPreferredLeader = testPartitionAssignment.head
+  val testPartitionAndAssignment = Map(testPartition -> testPartitionAssignment)
+
+  /** Test the case multiple values are given for --bootstrap-broker */
+  @Test
+  def testMultipleBrokersGiven() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    PreferredReplicaLeaderElectionCommand.run(Array(
+      "--bootstrap-server", s"${bootstrapServer(1)},${bootstrapServer(0)}"))
+    // Check the leader for the partition IS the preferred one
+    assertEquals(testPartitionPreferredLeader, getLeader(testPartition))
+  }
+
+  /** Test the case when an invalid broker is given for --bootstrap-broker */
+  @Test
+  def testInvalidBrokerGiven() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", "example.com:1234"),
+        timeout = 10000)
+    } catch {
+      case e: AdminCommandFailedException =>
+        if (e.getCause.isInstanceOf[TimeoutException]) {
+          // Check the leader for the partition is STILL not the preferred one
+          assertNotEquals(testPartitionPreferredLeader, getLeader(testPartition))
+        } else {
+          throw e
+        }
+    }
+
+  }
+
+  /** Test the case where no partitions are given (=> elect all partitions) */
+  @Test
+  def testNoPartitionsGiven() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    PreferredReplicaLeaderElectionCommand.run(Array(
+      "--bootstrap-server", bootstrapServer()))
+    // Check the leader for the partition IS the preferred one
+    assertEquals(testPartitionPreferredLeader, getLeader(testPartition))
+  }
+
+  private def toJsonFile(partitions: scala.collection.Set[TopicPartition]): File = {
+    val jsonFile = File.createTempFile("preferredreplicaelection", ".js")
+    jsonFile.deleteOnExit()
+    val jsonString = ZkUtils.preferredReplicaLeaderElectionZkData(partitions.map(new TopicAndPartition(_)))
+    info("Using json: "+jsonString)
+    Files.write(Paths.get(jsonFile.getAbsolutePath), jsonString.getBytes(StandardCharsets.UTF_8))
+    jsonFile
+  }
+
+  /** Test the case where a list of partitions is given */
+  @Test
+  def testSingletonPartitionGiven() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath))
+    } finally {
+      jsonFile.delete()
+    }
+    // Check the leader for the partition IS the preferred one
+    assertEquals(testPartitionPreferredLeader, getLeader(testPartition))
+  }
+
+  /** Test the case where a topic does not exist */
+  @Test
+  def testTopicDoesNotExist() {
+    val nonExistentPartition = new TopicPartition("does.not.exist", 0)
+    val nonExistentPartitionAssignment = List(1, 2, 0)
+    val nonExistentPartitionAndAssignment = Map(nonExistentPartition -> nonExistentPartitionAssignment)
+
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    val jsonFile = toJsonFile(nonExistentPartitionAndAssignment.keySet)
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath))
+    } catch {
+      case e: AdminCommandFailedException =>
+        val suppressed = e.getSuppressed()(0)
+        assertTrue(suppressed.isInstanceOf[UnknownTopicOrPartitionException])
+      case e: Throwable =>
+        e.printStackTrace()
+        throw e
+    } finally {
+      jsonFile.delete()
+    }
+  }
+
+  /** Test the case where several partitions are given */
+  @Test
+  def testMultiplePartitionsSameAssignment() {
+    val testPartitionA = new TopicPartition("testA", 0)
+    val testPartitionB = new TopicPartition("testB", 0)
+    val testPartitionAssignment = List(1, 2, 0)
+    val testPartitionPreferredLeader = testPartitionAssignment.head
+    val testPartitionAndAssignment = Map(testPartitionA -> testPartitionAssignment, testPartitionB -> testPartitionAssignment)
+
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartitionA)
+    // Check the leader for the partition is not the preferred one
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartitionA))
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartitionB))
+    val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath))
+    } finally {
+      jsonFile.delete()
+    }
+    // Check the leader for the partition IS the preferred one
+    assertEquals(testPartitionPreferredLeader, getLeader(testPartitionA))
+    assertEquals(testPartitionPreferredLeader, getLeader(testPartitionB))
+  }
+
+  /** What happens when the preferred replica is already the leader? */
+  @Test
+  def testNoopElection() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    // Don't bounce the server. Doublec heck the leader for the partition is the preferred one
+    assertEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
+    try {
+      // Now do the election, even though the preferred replica is *already* the leader
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath))
+      // Check the leader for the partition still is the preferred one
+      assertEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    } finally {
+      jsonFile.delete()
+    }
+  }
+
+  /** What happens if the preferred replica is offline? */
+  @Test
+  def testWithOfflinePreferredReplica() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    val leader = getLeader(testPartition)
+    assertNotEquals(testPartitionPreferredLeader, leader)
+    // Now kill the preferred one
+    servers(testPartitionPreferredLeader).shutdown()
+    // Now try to elect the preferred one
+    val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath))
+      fail();
+    } catch {
+      case e: AdminCommandFailedException =>
+        assertEquals("1 preferred replica(s) could not be elected", e.getMessage)
+        val suppressed = e.getSuppressed()(0)
+        assertTrue(suppressed.isInstanceOf[LeaderNotAvailableException])
+        assertTrue(suppressed.getMessage, suppressed.getMessage.contains("Failed to elect leader for partition test-0 under strategy PreferredReplicaPartitionLeaderElectionStrategy"))
+        // Check we still have the same leader
+        assertEquals(leader, getLeader(testPartition))
+    } finally {
+      jsonFile.delete()
+    }
+  }
+
+  /** What happens if the controller gets killed just before an election? */
+  @Test
+  def testTimeout() {
+    createTestTopicAndCluster(testPartitionAndAssignment)
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    val leader = getLeader(testPartition)
+    assertNotEquals(testPartitionPreferredLeader, leader)
+    // Now kill the controller just before we trigger the election
+    servers(getController().get.config.brokerId).shutdown()
+    val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath),
+        timeout = 10000)
+      fail();
+    } catch {
+      case e: AdminCommandFailedException =>
+        assertEquals("1 preferred replica(s) could not be elected", e.getMessage)
+        assertTrue(e.getSuppressed()(0).getMessage.contains("Timed out waiting for a node assignment"))
+        // Check we still have the same leader
+        assertEquals(leader, getLeader(testPartition))
+    } finally {
+      jsonFile.delete()
+    }
+  }
+
+  /** Test the case where a list of partitions is given */
+  @Test
+  def testAuthzFailure() {
+    createTestTopicAndCluster(testPartitionAndAssignment, Some(classOf[PreferredReplicaLeaderElectionCommandTestAuthorizer].getName))
+    bounceServer(testPartitionPreferredLeader, testPartition)
+    // Check the leader for the partition is not the preferred one
+    val leader = getLeader(testPartition)
+    assertNotEquals(testPartitionPreferredLeader, leader)
+    // Check the leader for the partition is not the preferred one
+    assertNotEquals(testPartitionPreferredLeader, getLeader(testPartition))
+    val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
+    try {
+      PreferredReplicaLeaderElectionCommand.run(Array(
+        "--bootstrap-server", bootstrapServer(),
+        "--path-to-json-file", jsonFile.getAbsolutePath))
+      fail();
+    } catch {
+      case e: AdminCommandFailedException =>
+        assertEquals("1 preferred replica(s) could not be elected", e.getMessage)
+        assertTrue(e.getSuppressed()(0).getMessage.contains("Cluster authorization failed"))
+        // Check we still have the same leader
+        assertEquals(leader, getLeader(testPartition))
+    } finally {
+      jsonFile.delete()
+    }
+  }
+
+}
+
+class PreferredReplicaLeaderElectionCommandTestAuthorizer extends SimpleAclAuthorizer {
+  override def authorize(session: RequestChannel.Session, operation: Operation, resource: Resource): Boolean =
+    operation != Alter || resource.resourceType != Cluster
+}

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -62,10 +62,15 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
     // create brokers
     servers = brokerConfigs.map(b => TestUtils.createServer(KafkaConfig.fromProps(b)))
     // create the topic
+    //zkClient.createPartitionReassignment(partitionsAndAssignments)
 //    partitionsAndAssignments.foreach { partitionAndAssignment =>
 //      zkClient.createPartitionReassignment()OrUpdateTopicPartitionAssignmentPathInZK(partitionAndAssignment._1.topic(),
 //        Map(partitionAndAssignment._1.partition -> partitionAndAssignment._2))
 //    }
+    partitionsAndAssignments.foreach { partitionAndAssignment =>
+      zkClient.createTopicAssignment(partitionAndAssignment._1.topic(),
+      Map(partitionAndAssignment._1 -> partitionAndAssignment._2))
+    }
     // wait until replica log is created on every broker
     TestUtils.waitUntilTrue(() => servers.forall(server => partitionsAndAssignments.forall(partitionAndAssignment => server.getLogManager().getLog(partitionAndAssignment._1).isDefined)),
       "Replicas for topic test not created")

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package unit.kafka.admin
+package kafka.admin
 
 import java.io.File
 import java.nio.charset.StandardCharsets

--- a/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/PreferredReplicaLeaderElectionCommandTest.scala
@@ -282,11 +282,12 @@ class PreferredReplicaLeaderElectionCommandTest extends ZooKeeperTestHarness wit
     val leader = getLeader(testPartition)
     assertNotEquals(testPartitionPreferredLeader, leader)
     // Now kill the controller just before we trigger the election
-    servers(getController().get.config.brokerId).shutdown()
+    val controller = getController().get.config.brokerId
+    servers(controller).shutdown()
     val jsonFile = toJsonFile(testPartitionAndAssignment.keySet)
     try {
       PreferredReplicaLeaderElectionCommand.run(Array(
-        "--bootstrap-server", bootstrapServer(),
+        "--bootstrap-server", bootstrapServer(controller),
         "--path-to-json-file", jsonFile.getAbsolutePath),
         timeout = 2000)
       fail();

--- a/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/AbstractCoordinatorConcurrencyTest.scala
@@ -158,7 +158,7 @@ object AbstractCoordinatorConcurrencyTest {
   }
 
   class TestReplicaManager extends ReplicaManager(
-    null, null, null, null, null, null, null, null, null, null, null, null, null, null, None) {
+    null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, None) {
 
     var producePurgatory: DelayedOperationPurgatory[DelayedProduce] = _
     var watchKeys: mutable.Set[TopicPartitionOperationKey] = _

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -524,7 +524,7 @@ class KafkaApisTest {
     channel.buffer.getInt() // read the size
     ResponseHeader.parse(channel.buffer)
     val struct = api.responseSchema(request.version).read(channel.buffer)
-    AbstractResponse.parseResponse(api, struct)
+    AbstractResponse.parseResponse(api, struct, request.version)
   }
 
   private def expectNoThrottling(): Capture[RequestChannel.Response] = {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -657,6 +657,8 @@ class ReplicaManagerTest {
       purgatoryName = "Fetch", timer, reaperEnabled = false)
     val mockDeleteRecordsPurgatory = new DelayedOperationPurgatory[DelayedDeleteRecords](
       purgatoryName = "DeleteRecords", timer, reaperEnabled = false)
+    val mockElectPreferredLeaderPurgatory = new DelayedOperationPurgatory[DelayedElectPreferredLeader](
+      purgatoryName = "ElectPreferredLeader", timer, reaperEnabled = false)
 
     // Mock network client to show leader offset of 5
     val quota = QuotaFactory.instantiate(config, metrics, time, "")
@@ -665,7 +667,7 @@ class ReplicaManagerTest {
     val replicaManager = new ReplicaManager(config, metrics, time, kafkaZkClient, mockScheduler, mockLogMgr,
       new AtomicBoolean(false), quota, mockBrokerTopicStats,
       metadataCache, mockLogDirFailureChannel, mockProducePurgatory, mockFetchPurgatory,
-      mockDeleteRecordsPurgatory, Option(this.getClass.getName)) {
+      mockDeleteRecordsPurgatory, mockElectPreferredLeaderPurgatory, Option(this.getClass.getName)) {
 
       override protected def createReplicaFetcherManager(metrics: Metrics,
                                                      time: Time,
@@ -815,11 +817,13 @@ class ReplicaManagerTest {
       purgatoryName = "Fetch", timer, reaperEnabled = false)
     val mockDeleteRecordsPurgatory = new DelayedOperationPurgatory[DelayedDeleteRecords](
       purgatoryName = "DeleteRecords", timer, reaperEnabled = false)
+    val mockDelayedElectPreferredLeaderPurgatory = new DelayedOperationPurgatory[DelayedElectPreferredLeader](
+      purgatoryName = "DelayedElectPreferredLeader", timer, reaperEnabled = false)
 
     new ReplicaManager(config, metrics, time, kafkaZkClient, new MockScheduler(time), mockLogMgr,
       new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
       metadataCache, new LogDirFailureChannel(config.logDirs.size), mockProducePurgatory, mockFetchPurgatory,
-      mockDeleteRecordsPurgatory, Option(this.getClass.getName))
+      mockDeleteRecordsPurgatory, mockDelayedElectPreferredLeaderPurgatory, Option(this.getClass.getName))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -24,6 +24,7 @@ import kafka.security.auth._
 import kafka.utils.TestUtils
 import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
 import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.message.ElectPreferredLeadersRequestData
 import org.apache.kafka.common.resource.{PatternType, ResourcePattern, ResourcePatternFilter, ResourceType => AdminResourceType}
 import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.metrics.{KafkaMetric, Quota, Sensor}
@@ -360,7 +361,13 @@ class RequestQuotaTest extends BaseRequestTest {
           new DeleteGroupsRequest.Builder(Collections.singleton("test-group"))
 
         case ApiKeys.ELECT_PREFERRED_LEADERS =>
-          new ElectPreferredLeadersRequest.Builder(Collections.singleton(new TopicPartition("my_topic", 0)), 0)
+          val partition = new ElectPreferredLeadersRequestData.TopicPartitions()
+            .setPartitionId(Collections.singletonList(0))
+            .setTopic("my_topic")
+          new ElectPreferredLeadersRequest.Builder(
+            new ElectPreferredLeadersRequestData()
+                .setTimeoutMs(0)
+                .setTopicPartitions(Collections.singletonList(partition)))
 
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
@@ -453,7 +460,7 @@ class RequestQuotaTest extends BaseRequestTest {
       case ApiKeys.RENEW_DELEGATION_TOKEN => new RenewDelegationTokenResponse(response).throttleTimeMs
       case ApiKeys.DELETE_GROUPS => new DeleteGroupsResponse(response).throttleTimeMs
       case ApiKeys.OFFSET_FOR_LEADER_EPOCH => new OffsetsForLeaderEpochResponse(response).throttleTimeMs
-      case ApiKeys.ELECT_PREFERRED_LEADERS => new ElectPreferredLeadersResponse(response).throttleTimeMs
+      case ApiKeys.ELECT_PREFERRED_LEADERS => new ElectPreferredLeadersResponse(response, 0).throttleTimeMs
       case requestId => throw new IllegalArgumentException(s"No throttle time for $requestId")
     }
   }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -359,6 +359,9 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.DELETE_GROUPS =>
           new DeleteGroupsRequest.Builder(Collections.singleton("test-group"))
 
+        case ApiKeys.ELECT_PREFERRED_LEADERS =>
+          new ElectPreferredLeadersRequest.Builder(Collections.singleton(new TopicPartition("my_topic", 0)), 0)
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }
@@ -450,6 +453,7 @@ class RequestQuotaTest extends BaseRequestTest {
       case ApiKeys.RENEW_DELEGATION_TOKEN => new RenewDelegationTokenResponse(response).throttleTimeMs
       case ApiKeys.DELETE_GROUPS => new DeleteGroupsResponse(response).throttleTimeMs
       case ApiKeys.OFFSET_FOR_LEADER_EPOCH => new OffsetsForLeaderEpochResponse(response).throttleTimeMs
+      case ApiKeys.ELECT_PREFERRED_LEADERS => new ElectPreferredLeadersResponse(response).throttleTimeMs
       case requestId => throw new IllegalArgumentException(s"No throttle time for $requestId")
     }
   }


### PR DESCRIPTION
…Client

See also KIP-183.

The contribution is my original work and I license the work to the project under the project's open source license.

This implements the following algorithm:

1. AdminClient sends ElectPreferredLeadersRequest.
2. KafakApis receives ElectPreferredLeadersRequest and delegates to
   ReplicaManager.electPreferredLeaders()
3. ReplicaManager delegates to KafkaController.electPreferredLeaders()
4. KafkaController adds a PreferredReplicaLeaderElection to the EventManager,
5. ReplicaManager.electPreferredLeaders()'s callback uses the
   delayedElectPreferredReplicasPurgatory to wait for the results of the
   election to appear in the metadata cache. If there are no results
   because of errors, or because the preferred leaders are already leading
   the partitions then a response is returned immediately.

In the EventManager work thread the preferred leader is elected as follows:

1. The EventManager runs PreferredReplicaLeaderElection.process()
2. process() calls KafkaController.onPreferredReplicaElectionWithResults()
3. KafkaController.onPreferredReplicaElectionWithResults()
   calls the PartitionStateMachine.handleStateChangesWithResults() to
   perform the election (asynchronously the PSM will send LeaderAndIsrRequest
   to the new and old leaders and UpdateMetadataRequest to all brokers)
   then invokes the callback.

Note: the change in parameter type for CollectionUtils.groupDataByTopic().
This makes sense because the AdminClient APIs use Collection consistently,
rather than List or Set. If binary compatiblity is a consideration the old
version should be kept, delegating to the new version.

I had to add PartitionStateMachine.handleStateChangesWithResults()
in order to be able to process a set of state changes in the
PartitionStateMachine *and get back individual results*.
At the same time I noticed that all callers of existing handleStateChange()
were destructuring a TopicAndPartition that they already had in order
to call handleStateChange(), and that handleStateChange() immediately
instantiated a new TopicAndPartition. Since TopicAndPartition is immutable
this is pointless, so I refactored it. handleStateChange() also now returns
any exception it caught, which is necessary for handleStateChangesWithResults()