### PR TITLE
KAFKA-5899: Added Connect metrics for connectors

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The Connect metrics with JMX reporter.
@@ -48,7 +47,6 @@ public class ConnectMetrics {
     public static final String WORKER_ID_TAG_NAME = "worker-id";
 
     private static final Logger LOG = LoggerFactory.getLogger(ConnectMetrics.class);
-    private static final AtomicInteger CONNECT_WORKER_ID_SEQUENCE = new AtomicInteger(1);
 
     private final Metrics metrics;
     private final Time time;
@@ -58,12 +56,12 @@ public class ConnectMetrics {
     /**
      * Create an instance.
      *
-     * @param workerId the worker identifier; may be null
+     * @param workerId the worker identifier; may not be null
      * @param config   the worker configuration; may not be null
      * @param time     the time; may not be null
      */
     public ConnectMetrics(String workerId, WorkerConfig config, Time time) {
-        this.workerId = workerId != null ? makeValidName(workerId) : "worker-" + CONNECT_WORKER_ID_SEQUENCE.getAndIncrement();
+        this.workerId = makeValidName(workerId);
         this.time = time;
 
         MetricConfig metricConfig = new MetricConfig().samples(config.getInt(CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG))
@@ -258,7 +256,7 @@ public class ConnectMetrics {
         Objects.requireNonNull(name);
         name = name.trim();
         if (!name.isEmpty()) {
-            name = name.replaceAll("[:/\\\\*?,;\\[\\]\\\\=]+", "-");
+            name = name.replaceAll("[.:/\\\\*?,;\\[\\]\\\\=]+", "-");
         }
         return name;
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -122,7 +122,7 @@ public class ConnectMetrics {
      * @param tagKeyValues    pairs of tag name and values
      * @return the {@link MetricGroup} that can be used to create metrics; never null
      */
-    public synchronized MetricGroup group(String groupName, boolean includeWorkerId, String... tagKeyValues) {
+    public MetricGroup group(String groupName, boolean includeWorkerId, String... tagKeyValues) {
         MetricGroup group = groupsByName.get(groupName);
         if (group == null) {
             Map<String, String> tags = tags(includeWorkerId ? workerId : null, tagKeyValues);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.runtime.distributed.WorkerGroupMember;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The Connect metrics with JMX reporter.
+ */
+public class ConnectMetrics {
+
+    public static final String JMX_PREFIX = "kafka.connect";
+    public static final String WORKER_ID_TAG_NAME = "worker-id";
+    private static final AtomicInteger CONNECT_WORKER_ID_SEQUENCE = new AtomicInteger(1);
+
+    /**
+     * Utility to ensure the supplied name contains valid characters, replacing sequences of 1 or more
+     * ':', '/', '\', '*', '?', '[', ']', '=', or comma characters with a single '-'.
+     *
+     * @param name the name; may not be null
+     * @return the validated name; never null
+     */
+    static String makeValidName(String name) {
+        Objects.requireNonNull(name);
+        name = name.trim();
+        if (!name.isEmpty()) {
+            name = name.replaceAll("[:/\\\\*?,;\\[\\]\\\\=]+", "-");
+        }
+        return name;
+    }
+
+    private final Logger log;
+    private final Metrics metrics;
+    private final Time time;
+    private final String workerId;
+    private final Map<String, MetricGroup> groupsByName = new HashMap<>();
+
+    public ConnectMetrics(String workerId, WorkerConfig config, Time time) {
+        this.log = LoggerFactory.getLogger(WorkerGroupMember.class);
+        this.workerId = workerId != null ? makeValidName(workerId) : "worker-" + CONNECT_WORKER_ID_SEQUENCE.getAndIncrement();
+        this.time = time;
+
+        Map<String, String> metricsTags = new LinkedHashMap<>(); // currently empty
+        MetricConfig metricConfig = new MetricConfig().samples(config.getInt(CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG))
+                                            .timeWindow(config.getLong(CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
+                                            .recordLevel(Sensor.RecordingLevel.forName(config.getString(CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG)))
+                                            .tags(metricsTags);
+        List<MetricsReporter> reporters = config.getConfiguredInstances(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, MetricsReporter.class);
+        reporters.add(new JmxReporter(JMX_PREFIX));
+        this.metrics = new Metrics(metricConfig, reporters, time);
+        log.debug("Registering Connect metrics with JMX for worker '{}'", workerId);
+        AppInfoParser.registerAppInfo(JMX_PREFIX, workerId);
+    }
+
+    /**
+     * Get the worker identifier.
+     * @return the worker ID; never null
+     */
+    public String workerId() {
+        return workerId;
+    }
+
+    /**
+     * Get the {@link Metrics Kafka Metrics} that are managed by this object and that should be used to
+     * add sensors and individual metrics.
+     *
+     * @return the Kafka Metrics instance; never null
+     */
+    public Metrics metrics() {
+        return metrics;
+    }
+
+    /**
+     * Get or create a {@link MetricGroup} with the specified group name.
+     *
+     * @param groupName the name of the metric group; may not be null
+     * @return the {@link MetricGroup} that can be used to create metrics; never null
+     */
+    public synchronized MetricGroup group(String groupName) {
+        return group(groupName, false);
+    }
+
+    /**
+     * Get or create a {@link MetricGroup} with the specified group name and the given tags.
+     *
+     * @param groupName    the name of the metric group; may not be null
+     * @param tagKeyValues pairs of tag name and values
+     * @return the {@link MetricGroup} that can be used to create metrics; never null
+     */
+    public synchronized MetricGroup group(String groupName, String... tagKeyValues) {
+        return group(groupName, false, tagKeyValues);
+    }
+
+    /**
+     * Get or create a {@link MetricGroup} with the specified group name and the given tags.
+     *
+     * @param groupName       the name of the metric group; may not be null
+     * @param includeWorkerId true if the tags should include the worker ID
+     * @param tagKeyValues    pairs of tag name and values
+     * @return the {@link MetricGroup} that can be used to create metrics; never null
+     */
+    public synchronized MetricGroup group(String groupName, boolean includeWorkerId, String... tagKeyValues) {
+        MetricGroup group = groupsByName.get(groupName);
+        if (group == null) {
+            Map<String, String> tags = tags(includeWorkerId ? workerId : null, tagKeyValues);
+            group = new MetricGroup(groupName, tags);
+            groupsByName.put(groupName, group);
+        }
+        return group;
+    }
+
+    /**
+     * Create a set of tags using the supplied key and value pairs.
+     *
+     * @param workerId the worker ID that should be included first in the tags; may be null if not to be included
+     * @param keyValue the key and value pairs for the tags; must be an even number
+     * @return the map of tags that can be supplied to the {@link Metrics} methods; never null
+     */
+    static Map<String, String> tags(String workerId, String... keyValue) {
+        if ((keyValue.length % 2) != 0)
+            throw new IllegalArgumentException("keyValue needs to be specified in pairs");
+        Map<String, String> tags = new HashMap<>();
+        if (workerId != null && !workerId.trim().isEmpty()) {
+            tags.put(WORKER_ID_TAG_NAME, workerId);
+        }
+        for (int i = 0; i < keyValue.length; i += 2) {
+            tags.put(keyValue[i], keyValue[i + 1]);
+        }
+        return tags;
+    }
+
+    /**
+     * Get the time.
+     *
+     * @return the time; never null
+     */
+    public Time time() {
+        return time;
+    }
+
+    /**
+     * Stop and unregister the metrics from any reporters.
+     */
+    public void stop() {
+        metrics.close();
+        log.debug("Unregistering Connect metrics with JMX for worker '{}'", workerId);
+        AppInfoParser.unregisterAppInfo(JMX_PREFIX, workerId);
+    }
+
+    /**
+     * A group of metrics. Each group maps to a JMX MBean and each metric maps to an MBean attribute.
+     */
+    public class MetricGroup {
+        private final String groupName;
+        private final Map<String, String> tags;
+
+        protected MetricGroup(String groupName, Map<String, String> tags) {
+            this.groupName = groupName;
+            this.tags = tags;
+        }
+
+        /**
+         * Create the name of a metric that belongs to this group and has the group's tags.
+         *
+         * @param name the name of the metric/attribute; may not be null
+         * @param desc the description for the metric/attribute; may not be null
+         * @return the metric name; never null
+         */
+        public MetricName metricName(String name, String desc) {
+            return metrics.metricName(name, groupName, desc, tags);
+        }
+
+        /**
+         * The {@link Metrics} that this group belongs to.
+         *
+         * @return the metrics; never null
+         */
+        public Metrics metrics() {
+            return metrics;
+        }
+
+        Map<String, String> tags() {
+            return Collections.unmodifiableMap(tags);
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -100,7 +100,7 @@ public class ConnectMetrics {
      * @param groupName the name of the metric group; may not be null
      * @return the {@link MetricGroup} that can be used to create metrics; never null
      */
-    public synchronized MetricGroup group(String groupName) {
+    public MetricGroup group(String groupName) {
         return group(groupName, false);
     }
 
@@ -111,7 +111,7 @@ public class ConnectMetrics {
      * @param tagKeyValues pairs of tag name and values
      * @return the {@link MetricGroup} that can be used to create metrics; never null
      */
-    public synchronized MetricGroup group(String groupName, String... tagKeyValues) {
+    public MetricGroup group(String groupName, String... tagKeyValues) {
         return group(groupName, false, tagKeyValues);
     }
 
@@ -128,7 +128,8 @@ public class ConnectMetrics {
         if (group == null) {
             Map<String, String> tags = tags(includeWorkerId ? workerId : null, tagKeyValues);
             group = new MetricGroup(groupName, tags);
-            groupsByName.putIfAbsent(groupName, group);
+            MetricGroup previous = groupsByName.putIfAbsent(groupName, group);
+            if (previous != null) group = previous;
         }
         return group;
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -49,22 +49,6 @@ public class ConnectMetrics {
     private static final Logger LOG = LoggerFactory.getLogger(ConnectMetrics.class);
     private static final AtomicInteger CONNECT_WORKER_ID_SEQUENCE = new AtomicInteger(1);
 
-    /**
-     * Utility to ensure the supplied name contains valid characters, replacing sequences of 1 or more
-     * ':', '/', '\', '*', '?', '[', ']', '=', or comma characters with a single '-'.
-     *
-     * @param name the name; may not be null
-     * @return the validated name; never null
-     */
-    static String makeValidName(String name) {
-        Objects.requireNonNull(name);
-        name = name.trim();
-        if (!name.isEmpty()) {
-            name = name.replaceAll("[:/\\\\*?,;\\[\\]\\\\=]+", "-");
-        }
-        return name;
-    }
-
     private final Metrics metrics;
     private final Time time;
     private final String workerId;
@@ -150,26 +134,6 @@ public class ConnectMetrics {
     }
 
     /**
-     * Create a set of tags using the supplied key and value pairs.
-     *
-     * @param workerId the worker ID that should be included first in the tags; may be null if not to be included
-     * @param keyValue the key and value pairs for the tags; must be an even number
-     * @return the map of tags that can be supplied to the {@link Metrics} methods; never null
-     */
-    static Map<String, String> tags(String workerId, String... keyValue) {
-        if ((keyValue.length % 2) != 0)
-            throw new IllegalArgumentException("keyValue needs to be specified in pairs");
-        Map<String, String> tags = new HashMap<>();
-        if (workerId != null && !workerId.trim().isEmpty()) {
-            tags.put(WORKER_ID_TAG_NAME, workerId);
-        }
-        for (int i = 0; i < keyValue.length; i += 2) {
-            tags.put(keyValue[i], keyValue[i + 1]);
-        }
-        return tags;
-    }
-
-    /**
      * Get the time.
      *
      * @return the time; never null
@@ -222,5 +186,41 @@ public class ConnectMetrics {
         Map<String, String> tags() {
             return Collections.unmodifiableMap(tags);
         }
+    }
+
+    /**
+     * Create a set of tags using the supplied key and value pairs.
+     *
+     * @param workerId the worker ID that should be included first in the tags; may be null if not to be included
+     * @param keyValue the key and value pairs for the tags; must be an even number
+     * @return the map of tags that can be supplied to the {@link Metrics} methods; never null
+     */
+    static Map<String, String> tags(String workerId, String... keyValue) {
+        if ((keyValue.length % 2) != 0)
+            throw new IllegalArgumentException("keyValue needs to be specified in pairs");
+        Map<String, String> tags = new HashMap<>();
+        if (workerId != null && !workerId.trim().isEmpty()) {
+            tags.put(WORKER_ID_TAG_NAME, workerId);
+        }
+        for (int i = 0; i < keyValue.length; i += 2) {
+            tags.put(keyValue[i], keyValue[i + 1]);
+        }
+        return tags;
+    }
+
+    /**
+     * Utility to ensure the supplied name contains valid characters, replacing sequences of 1 or more
+     * ':', '/', '\', '*', '?', '[', ']', '=', or comma characters with a single '-'.
+     *
+     * @param name the name; may not be null
+     * @return the validated name; never null
+     */
+    static String makeValidName(String name) {
+        Objects.requireNonNull(name);
+        name = name.trim();
+        if (!name.isEmpty()) {
+            name = name.replaceAll("[:/\\\\*?,;\\[\\]\\\\=]+", "-");
+        }
+        return name;
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -67,6 +67,7 @@ public class Worker {
     private final Time time;
     private final String workerId;
     private final Plugins plugins;
+    private final ConnectMetrics metrics;
     private final WorkerConfig config;
     private final Converter defaultKeyConverter;
     private final Converter defaultValueConverter;
@@ -86,6 +87,7 @@ public class Worker {
             WorkerConfig config,
             OffsetBackingStore offsetBackingStore
     ) {
+        this.metrics = new ConnectMetrics(workerId, config, time);
         this.executor = Executors.newCachedThreadPool();
         this.workerId = workerId;
         this.time = time;
@@ -172,6 +174,7 @@ public class Worker {
         sourceTaskOffsetCommitter.close(timeoutMs);
 
         offsetBackingStore.stop();
+        metrics.stop();
 
         log.info("Worker stopped");
     }
@@ -203,7 +206,7 @@ public class Worker {
             final String connClass = connConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
             log.info("Creating connector {} of type {}", connName, connClass);
             final Connector connector = plugins.newConnector(connClass);
-            workerConnector = new WorkerConnector(connName, connector, ctx, statusListener);
+            workerConnector = new WorkerConnector(connName, connector, ctx, metrics,  statusListener);
             log.info("Instantiated connector {} with version {} of type {}", connName, connector.version(), connector.getClass());
             savedLoader = plugins.compareAndSwapLoaders(connector);
             workerConnector.initialize(connConfig);
@@ -535,6 +538,14 @@ public class Worker {
 
     public String workerId() {
         return workerId;
+    }
+
+    /**
+     * Get the {@link ConnectMetrics} that uses Kafka Metrics and manages the JMX reporter.
+     * @return the Connect-specific metrics; never null
+     */
+    public ConnectMetrics metrics() {
+        return metrics;
     }
 
     public void setTargetState(String connName, TargetState state) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -21,11 +21,15 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.metrics.Sensor;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 
 /**
  * Common base class providing configuration for Kafka Connect workers, whether standalone or distributed.
@@ -138,6 +142,11 @@ public class WorkerConfig extends AbstractConfig {
             + "Examples: plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,"
             + "/opt/connectors";
 
+    public static final String METRICS_SAMPLE_WINDOW_MS_CONFIG = CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG;
+    public static final String METRICS_NUM_SAMPLES_CONFIG = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
+    public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
+    public static final String METRIC_REPORTER_CLASSES_CONFIG = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG;
+
     /**
      * Get a basic ConfigDef for a WorkerConfig. This includes all the common settings. Subclasses can use this to
      * bootstrap their own ConfigDef.
@@ -172,13 +181,25 @@ public class WorkerConfig extends AbstractConfig {
                 .define(ACCESS_CONTROL_ALLOW_METHODS_CONFIG, Type.STRING,
                         ACCESS_CONTROL_ALLOW_METHODS_DEFAULT, Importance.LOW,
                         ACCESS_CONTROL_ALLOW_METHODS_DOC)
-                .define(
-                        PLUGIN_PATH_CONFIG,
+                .define(PLUGIN_PATH_CONFIG,
                         Type.LIST,
                         null,
                         Importance.LOW,
-                        PLUGIN_PATH_DOC
-                );
+                        PLUGIN_PATH_DOC)
+                .define(METRICS_SAMPLE_WINDOW_MS_CONFIG, Type.LONG,
+                        30000, atLeast(0), Importance.LOW,
+                        CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_DOC)
+                .define(METRICS_NUM_SAMPLES_CONFIG, Type.INT,
+                        2, atLeast(1), Importance.LOW,
+                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC)
+                .define(METRICS_RECORDING_LEVEL_CONFIG, Type.STRING,
+                        Sensor.RecordingLevel.INFO.toString(),
+                        in(Sensor.RecordingLevel.INFO.toString(), Sensor.RecordingLevel.DEBUG.toString()),
+                        Importance.LOW,
+                        CommonClientConfigs.METRICS_RECORDING_LEVEL_DOC)
+                .define(METRIC_REPORTER_CLASSES_CONFIG, Type.LIST,
+                        "", Importance.LOW,
+                        CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -42,7 +42,7 @@ import java.util.Map;
  */
 public class WorkerConnector {
     private static final Logger log = LoggerFactory.getLogger(WorkerConnector.class);
-    private static double EPSILON = 0.000001d;
+    private static final double EPSILON = 0.000001d;
 
     private enum State {
         INIT,    // initial state before startup

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -42,6 +42,7 @@ import java.util.Map;
  */
 public class WorkerConnector {
     private static final Logger log = LoggerFactory.getLogger(WorkerConnector.class);
+    private static double EPSILON = 0.000001d;
 
     private enum State {
         INIT,    // initial state before startup
@@ -293,7 +294,7 @@ public class WorkerConnector {
 
         private boolean asBoolean(MetricName metric) {
             double value = this.metricGroup.metrics().metric(metric).value();
-            return value > 0.00001d || value < -0.000001d;
+            return value > EPSILON || value < -EPSILON;
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/DistributedConfig.java
@@ -194,23 +194,6 @@ public class DistributedConfig extends WorkerConfig {
                         atLeast(0L),
                         ConfigDef.Importance.LOW,
                         CommonClientConfigs.RETRY_BACKOFF_MS_DOC)
-                .define(CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG,
-                        ConfigDef.Type.LONG,
-                        30000,
-                        atLeast(0),
-                        ConfigDef.Importance.LOW,
-                        CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_DOC)
-                .define(CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG,
-                        ConfigDef.Type.INT,
-                        2,
-                        atLeast(1),
-                        ConfigDef.Importance.LOW,
-                        CommonClientConfigs.METRICS_NUM_SAMPLES_DOC)
-                .define(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
-                        ConfigDef.Type.LIST,
-                        "",
-                        ConfigDef.Importance.LOW,
-                        CommonClientConfigs.METRIC_REPORTER_CLASSES_DOC)
                 .define(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG,
                         ConfigDef.Type.INT,
                         40 * 1000,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -45,7 +45,7 @@ public class ConnectMetricsTest {
 
     @Before
     public void setUp() {
-        metrics = new ConnectMetrics(null, new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
+        metrics = new ConnectMetrics("worker1", new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
     }
 
     @After

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -55,8 +55,8 @@ public class ConnectMetricsTest {
 
     @Test
     public void testValidatingNameWithAllValidCharacters() {
-        String name = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-";
-        assertSame(name, ConnectMetrics.makeValidName(name));
+        String name = "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ-0123456789";
+        assertEquals(name, ConnectMetrics.makeValidName(name));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class ConnectMetricsTest {
 
     @Test
     public void testValidatingNameWithInvalidCharacters() {
-        assertEquals("a-b-c-d-e-f-g-h-i-j-k", ConnectMetrics.makeValidName("a:b;c/d\\e,f*g?h[i]j=k"));
+        assertEquals("a-b-c-d-e-f-g-h-i-j-k", ConnectMetrics.makeValidName("a:b;c/d\\e,f*.--..;;g?h[i]j=k"));
         assertEquals("-a-b-c-d-e-f-g-h-", ConnectMetrics.makeValidName(":a:b;c/d\\e,f*g?[]=h:"));
         assertEquals("a-f-h", ConnectMetrics.makeValidName("a:;/\\,f*?h"));
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.util.MockTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class ConnectMetricsTest {
+
+    private static final Map<String, String> DEFAULT_WORKER_CONFIG = new HashMap<>();
+
+    static {
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+    }
+
+    private ConnectMetrics metrics;
+
+    @Before
+    public void beforeEach() {
+        metrics = new ConnectMetrics(null, new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
+    }
+
+    @Test
+    public void testValidatingNameWithAllValidCharacters() {
+        String name = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-";
+        assertSame(name, ConnectMetrics.makeValidName(name));
+    }
+
+    @Test
+    public void testValidatingEmptyName() {
+        String name = "";
+        assertSame(name, ConnectMetrics.makeValidName(name));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testValidatingNullName() {
+        ConnectMetrics.makeValidName(null);
+    }
+
+    @Test
+    public void testValidatingNameWithInvalidCharacters() {
+        assertEquals("a-b-c-d-e-f-g-h-i-j-k", ConnectMetrics.makeValidName("a:b;c/d\\e,f*g?h[i]j=k"));
+        assertEquals("-a-b-c-d-e-f-g-h-", ConnectMetrics.makeValidName(":a:b;c/d\\e,f*g?[]=h:"));
+        assertEquals("a-f-h", ConnectMetrics.makeValidName("a:;/\\,f*?h"));
+    }
+
+    @Test
+    public void testKafkaMetricsNotNull() {
+        assertNotNull(metrics.metrics());
+    }
+
+    @Test
+    public void testCreatingTagsWithNonNullWorkerId() {
+        Map<String, String> tags = ConnectMetrics.tags("name", "k1", "v1", "k2", "v2");
+        assertEquals("v1", tags.get("k1"));
+        assertEquals("v2", tags.get("k2"));
+        assertEquals("name", tags.get(ConnectMetrics.WORKER_ID_TAG_NAME));
+    }
+
+    @Test
+    public void testCreatingTagsWithNullWorkerId() {
+        Map<String, String> tags = ConnectMetrics.tags(null, "k1", "v1", "k2", "v2");
+        assertEquals("v1", tags.get("k1"));
+        assertEquals("v2", tags.get("k2"));
+        assertEquals(null, tags.get(ConnectMetrics.WORKER_ID_TAG_NAME));
+    }
+
+    @Test
+    public void testCreatingTagsWithEmptyWorkerId() {
+        Map<String, String> tags = ConnectMetrics.tags("", "k1", "v1", "k2", "v2");
+        assertEquals("v1", tags.get("k1"));
+        assertEquals("v2", tags.get("k2"));
+        assertEquals(null, tags.get(ConnectMetrics.WORKER_ID_TAG_NAME));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreatingTagsWithOddNumberOfTags() {
+        ConnectMetrics.tags("name", "k1", "v1", "k2", "v2", "extra");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGettingGroupWithOddNumberOfTags() {
+        metrics.group("name", false, "k1", "v1", "k2", "v2", "extra");
+    }
+
+    @Test
+    public void testGettingGroupWithTags() {
+        MetricGroup group1 = metrics.group("name", false, "k1", "v1", "k2", "v2");
+        assertEquals("v1", group1.tags().get("k1"));
+        assertEquals("v2", group1.tags().get("k2"));
+        assertEquals(null, group1.tags().get(ConnectMetrics.WORKER_ID_TAG_NAME));
+    }
+
+    @Test
+    public void testGettingGroupWithWorkerIdAndTags() {
+        MetricGroup group1 = metrics.group("name", true, "k1", "v1", "k2", "v2");
+        assertEquals("v1", group1.tags().get("k1"));
+        assertEquals("v2", group1.tags().get("k2"));
+        assertEquals(metrics.workerId(), group1.tags().get(ConnectMetrics.WORKER_ID_TAG_NAME));
+    }
+
+    @Test
+    public void testGettingGroupMultipleTimes() {
+        MetricGroup group1 = metrics.group("name");
+        MetricGroup group2 = metrics.group("name");
+        assertNotNull(group1);
+        assertSame(group1, group2);
+        MetricGroup group3 = metrics.group("other");
+        assertNotNull(group3);
+        assertNotSame(group1, group3);
+    }
+
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/ConnectMetricsTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.util.MockTime;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,8 +44,13 @@ public class ConnectMetricsTest {
     private ConnectMetrics metrics;
 
     @Before
-    public void beforeEach() {
+    public void setUp() {
         metrics = new ConnectMetrics(null, new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
+    }
+
+    @After
+    public void tearDown() {
+        if (metrics != null) metrics.stop();
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectorMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectorMetrics.java
@@ -32,7 +32,7 @@ public class MockConnectorMetrics extends ConnectMetrics {
     }
 
     public MockConnectorMetrics() {
-        super(null, new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
+        super("mock", new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectorMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectorMetrics.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime;
+
+import org.apache.kafka.connect.util.MockTime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MockConnectorMetrics extends ConnectMetrics {
+
+    private static final Map<String, String> DEFAULT_WORKER_CONFIG = new HashMap<>();
+    static {
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        DEFAULT_WORKER_CONFIG.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+    }
+
+    public MockConnectorMetrics() {
+        super(null, new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
+    }
+
+    @Override
+    public MockTime time() {
+        return (MockTime) super.time();
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConnectorTest.java
@@ -23,6 +23,7 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,6 +56,11 @@ public class WorkerConnectorTest extends EasyMockSupport {
     public void setup() {
         connectorConfig = new ConnectorConfig(plugins, CONFIG);
         metrics = new MockConnectorMetrics();
+    }
+
+    @After
+    public void tearDown() {
+        if (metrics != null) metrics.stop();
     }
 
     @Test
@@ -101,7 +107,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertFailedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -133,7 +138,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -168,7 +172,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -205,7 +208,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.PAUSED);
@@ -235,7 +237,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.PAUSED);
@@ -266,7 +267,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -293,14 +293,13 @@ public class WorkerConnectorTest extends EasyMockSupport {
         connector.stop();
         expectLastCall().andThrow(exception);
 
-        listener.onShutdown(CONNECTOR);
+        listener.onFailure(CONNECTOR, exception);
         expectLastCall();
 
         replayAll();
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -333,7 +332,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -370,7 +368,6 @@ public class WorkerConnectorTest extends EasyMockSupport {
 
         WorkerConnector workerConnector = new WorkerConnector(CONNECTOR, connector, ctx, metrics, listener);
 
-        assertStoppedMetric(workerConnector);
         workerConnector.initialize(connectorConfig);
         assertInitializedMetric(workerConnector);
         workerConnector.transitionTo(TargetState.STARTED);
@@ -386,30 +383,35 @@ public class WorkerConnectorTest extends EasyMockSupport {
     }
 
     protected void assertFailedMetric(WorkerConnector workerConnector) {
+        assertFalse(workerConnector.metrics().isUnassigned());
         assertTrue(workerConnector.metrics().isFailed());
         assertFalse(workerConnector.metrics().isPaused());
         assertFalse(workerConnector.metrics().isRunning());
     }
 
     protected void assertPausedMetric(WorkerConnector workerConnector) {
+        assertFalse(workerConnector.metrics().isUnassigned());
         assertFalse(workerConnector.metrics().isFailed());
         assertTrue(workerConnector.metrics().isPaused());
         assertFalse(workerConnector.metrics().isRunning());
     }
 
     protected void assertRunningMetric(WorkerConnector workerConnector) {
+        assertFalse(workerConnector.metrics().isUnassigned());
         assertFalse(workerConnector.metrics().isFailed());
         assertFalse(workerConnector.metrics().isPaused());
         assertTrue(workerConnector.metrics().isRunning());
     }
 
     protected void assertStoppedMetric(WorkerConnector workerConnector) {
+        assertTrue(workerConnector.metrics().isUnassigned());
         assertFalse(workerConnector.metrics().isFailed());
         assertFalse(workerConnector.metrics().isPaused());
         assertFalse(workerConnector.metrics().isRunning());
     }
 
     protected void assertInitializedMetric(WorkerConnector workerConnector) {
+        assertTrue(workerConnector.metrics().isUnassigned());
         assertFalse(workerConnector.metrics().isFailed());
         assertFalse(workerConnector.metrics().isPaused());
         assertFalse(workerConnector.metrics().isRunning());


### PR DESCRIPTION
This PR is the first of several subtasks for [KAFKA-2376](https://issues.apache.org/jira/browse/KAFKA-2376) to add metrics to Connect worker processes. See that issue and [KIP-196 for details](https://cwiki.apache.org/confluence/display/KAFKA/KIP-196%3A+Add+metrics+to+Kafka+Connect+framework).

This PR adds metrics for each connector using Kafka’s existing `Metrics` framework. This is the first of several changes to add several groups of metrics, this change starts by adding a very simple `ConnectMetrics` object that is owned by each worker and that makes it easy to define multiple groups of metrics, called `ConnectMetricGroup` objects. Each metric group maps to a JMX MBean, and each metric within the group maps to an MBean attribute.

Future PRs will build upon this simple pattern to add metrics for source and sink tasks, workers, and worker rebalances.