### PR TITLE
KAFKA-5874: TopicCommand should check at least one parameter is given...

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -122,6 +122,7 @@ object TopicCommand extends Logging {
       throw new IllegalArgumentException("Topic %s does not exist on ZK path %s".format(opts.options.valueOf(opts.topicOpt),
           opts.options.valueOf(opts.zkConnectOpt)))
     }
+    CommandLineUtils.checkAtLeastRequiredArg(opts.parser, opts.options, opts.configOpt, opts.deleteConfigOpt, opts.partitionsOpt)
     topics.foreach { topic =>
       val configs = AdminUtils.fetchEntityConfig(zkUtils, ConfigType.Topic, topic)
       if(opts.options.has(opts.configOpt) || opts.options.has(opts.deleteConfigOpt)) {

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -122,7 +122,7 @@ object TopicCommand extends Logging {
       throw new IllegalArgumentException("Topic %s does not exist on ZK path %s".format(opts.options.valueOf(opts.topicOpt),
           opts.options.valueOf(opts.zkConnectOpt)))
     }
-    CommandLineUtils.checkAtLeastRequiredArg(opts.parser, opts.options, opts.configOpt, opts.deleteConfigOpt, opts.partitionsOpt)
+    CommandLineUtils.checkRequiredArgNotMissing(opts.parser, opts.options, opts.configOpt, opts.deleteConfigOpt, opts.partitionsOpt)
     topics.foreach { topic =>
       val configs = AdminUtils.fetchEntityConfig(zkUtils, ConfigType.Topic, topic)
       if(opts.options.has(opts.configOpt) || opts.options.has(opts.deleteConfigOpt)) {

--- a/core/src/main/scala/kafka/utils/CommandLineUtils.scala
+++ b/core/src/main/scala/kafka/utils/CommandLineUtils.scala
@@ -35,6 +35,19 @@ object CommandLineUtils extends Logging {
     }
   }
 
+   /**
+     * Check that at least one option is present
+     */
+   def checkAtLeastRequiredArg(parser: OptionParser, options: OptionSet, required: OptionSpec[_]*) {
+     var areAllArgsMissed = true
+     for (arg <- required) {
+       if (options.has(arg))
+         areAllArgsMissed = false
+     }
+     if (areAllArgsMissed)
+       printUsageAndDie(parser, s"Must specify at least one parameter in ${required.mkString(",")}")
+   }
+
   /**
    * Check that none of the listed options are present
    */

--- a/core/src/main/scala/kafka/utils/CommandLineUtils.scala
+++ b/core/src/main/scala/kafka/utils/CommandLineUtils.scala
@@ -38,13 +38,13 @@ object CommandLineUtils extends Logging {
    /**
      * Check that at least one option is present
      */
-   def checkAtLeastRequiredArg(parser: OptionParser, options: OptionSet, required: OptionSpec[_]*) {
-     var areAllArgsMissed = true
+   def checkRequiredArgNotMissing(parser: OptionParser, options: OptionSet, required: OptionSpec[_]*) {
+     var areAllArgsMissing = true
      for (arg <- required) {
        if (options.has(arg))
-         areAllArgsMissed = false
+         areAllArgsMissing = false
      }
-     if (areAllArgsMissed)
+     if (areAllArgsMissing)
        printUsageAndDie(parser, s"Must specify at least one parameter in ${required.mkString(",")}")
    }
 


### PR DESCRIPTION
When altering topics, TopicCommand should ensure that at least one of parameters in `partitions`, `config` or `delete-config` must be specified.