### PR TITLE
KAFKA-5856: Add AdminClient.createPartitions()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -87,7 +87,7 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Create a batch of new topics with the default options.
      *
-     * This operation is supported by brokers with version 0.10.1.0 or higher.
+     * This is a convenience method for #{@link #createTopics(Collection, CreateTopicsOptions)} with default options. See the overload for more details.
      *
      * @param newTopics         The new topics to create.
      * @return                  The CreateTopicsResult.
@@ -99,9 +99,11 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Create a batch of new topics.
      *
-     * It may take several seconds after AdminClient#createTopics returns
+     * This operation is not transactional so it may succeed for some topics while fail for others.
+     *
+     * It may take several seconds after this method returns
      * success for all the brokers to become aware that the topics have been created.
-     * During this time, AdminClient#listTopics and AdminClient#describeTopics
+     * During this time, {@link AdminClient#listTopics()} and {@link AdminClient#describeTopics(Collection)}
      * may not return information about the new topics.
      *
      * This operation is supported by brokers with version 0.10.1.0 or higher. The validateOnly option is supported
@@ -422,7 +424,7 @@ public abstract class AdminClient implements AutoCloseable {
      * Increase the number of partitions of the topics given as the keys of {@code newPartitions}
      * according to the corresponding values.
      *
-     * This operation is supported by brokers with version 1.0.0 or higher.
+     * This is a convenience method for {@link #createPartitions(Map, CreatePartitionsOptions)} with default options. See the overload for more details.
      *
      * @param newPartitions The topics which should have new partitions created, and corresponding parameters
      *                      for the created partitions.
@@ -435,6 +437,13 @@ public abstract class AdminClient implements AutoCloseable {
     /**
      * Increase the number of partitions of the topics given as the keys of {@code newPartitions}
      * according to the corresponding values.
+     *
+     * This operation is not transactional so it may succeed for some topics while fail for others.
+     *
+     * It may take several seconds after this method returns
+     * success for all the brokers to become aware that the partitions have been created.
+     * During this time, {@link AdminClient#describeTopics(Collection)}
+     * may not return information about the new partitions.
      *
      * This operation is supported by brokers with version 1.0.0 or higher.
      *

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -417,4 +417,33 @@ public abstract class AdminClient implements AutoCloseable {
      * @return              The DescribeReplicaLogDirResult
      */
     public abstract DescribeReplicaLogDirResult describeReplicaLogDir(Collection<TopicPartitionReplica> replicas, DescribeReplicaLogDirOptions options);
+
+    /**
+     * Increase the number of partitions of the topics given as the keys of {@code newPartitions}
+     * according to the corresponding values.
+     *
+     * This operation is supported by brokers with version 1.0.0 or higher.
+     *
+     * @param newPartitions The topics which should have new partitions created, and corresponding parameters
+     *                      for the created partitions.
+     * @return              The CreatePartitionsResult.
+     */
+    public CreatePartitionsResult createPartitions(Map<String, NewPartitions> newPartitions) {
+        return createPartitions(newPartitions, new CreatePartitionsOptions());
+    }
+
+    /**
+     * Increase the number of partitions of the topics given as the keys of {@code newPartitions}
+     * according to the corresponding values.
+     *
+     * This operation is supported by brokers with version 1.0.0 or higher.
+     *
+     * @param newPartitions The topics which should have new partitions created, and corresponding parameters
+     *                      for the created partitions.
+     * @param options       The options to use when creating the new paritions.
+     * @return              The CreatePartitionsResult.
+     */
+    public abstract CreatePartitionsResult createPartitions(Map<String, NewPartitions> newPartitions,
+                                                            CreatePartitionsOptions options);
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -424,7 +424,8 @@ public abstract class AdminClient implements AutoCloseable {
      * Increase the number of partitions of the topics given as the keys of {@code newPartitions}
      * according to the corresponding values.
      *
-     * This is a convenience method for {@link #createPartitions(Map, CreatePartitionsOptions)} with default options. See the overload for more details.
+     * This is a convenience method for {@link #createPartitions(Map, CreatePartitionsOptions)} with default options.
+     * See the overload for more details.
      *
      * @param newPartitions The topics which should have new partitions created, and corresponding parameters
      *                      for the created partitions.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Map;
+
+/**
+ * Options for {@link AdminClient#createPartitions(Map)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
+public class CreatePartitionsOptions extends AbstractOptions<CreatePartitionsOptions> {
+
+    private boolean validateOnly = false;
+
+    public CreatePartitionsOptions() {
+    }
+
+    /**
+     * Return true if the request should be validated without creating new partitions.
+     */
+    public boolean validateOnly() {
+        return validateOnly;
+    }
+
+    /**
+     * Set to true if the request should be validated without creating new partitions.
+     */
+    public CreatePartitionsOptions validateOnly(boolean validateOnly) {
+        this.validateOnly = validateOnly;
+        return this;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsResult.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.Map;
+
+/**
+ * The result of the {@link AdminClient#createPartitions(Map)} call.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
+public class CreatePartitionsResult {
+
+    private final Map<String, KafkaFuture<Void>> values;
+
+    CreatePartitionsResult(Map<String, KafkaFuture<Void>> values) {
+        this.values = values;
+    }
+
+    /**
+     * Return a map from topic names to futures, which can be used to check the status of individual
+     * partition creations.
+     */
+    public Map<String, KafkaFuture<Void>> values() {
+        return values;
+    }
+
+    /**
+     * Return a future which succeeds if all the partition creations succeed.
+     */
+    public KafkaFuture<Void> all() {
+        return KafkaFuture.allOf(values.values().toArray(new KafkaFuture[values.size()]));
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreatePartitionsResult.java
@@ -48,6 +48,6 @@ public class CreatePartitionsResult {
      * Return a future which succeeds if all the partition creations succeed.
      */
     public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(values.values().toArray(new KafkaFuture[values.size()]));
+        return KafkaFuture.allOf(values.values().toArray(new KafkaFuture[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1804,7 +1804,7 @@ public class KafkaAdminClient extends AdminClient {
 
     public CreatePartitionsResult createPartitions(Map<String, NewPartitions> newPartitions, final CreatePartitionsOptions options) {
         final Map<String, KafkaFutureImpl<Void>> futures = new HashMap<>(newPartitions.size());
-        for (String topic: newPartitions.keySet()) {
+        for (String topic : newPartitions.keySet()) {
             futures.put(topic, new KafkaFutureImpl<Void>());
         }
         final Map<String, NewPartitions> requestMap = new HashMap<>(newPartitions);
@@ -1836,7 +1836,7 @@ public class KafkaAdminClient extends AdminClient {
                 completeAllExceptionally(futures.values(), throwable);
             }
         }, now);
-        return new CreatePartitionsResult(new HashMap<String, KafkaFuture<Void>>(futures));
+        return new CreatePartitionsResult((Map) futures);
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -64,6 +64,9 @@ import org.apache.kafka.common.requests.AlterConfigsRequest;
 import org.apache.kafka.common.requests.AlterConfigsResponse;
 import org.apache.kafka.common.requests.AlterReplicaDirRequest;
 import org.apache.kafka.common.requests.AlterReplicaDirResponse;
+import org.apache.kafka.common.requests.CreatePartitionsRequest;
+import org.apache.kafka.common.requests.CreatePartitionsResponse;
+import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreateAclsRequest.AclCreation;
 import org.apache.kafka.common.requests.CreateAclsResponse;
@@ -78,7 +81,6 @@ import org.apache.kafka.common.requests.DeleteTopicsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeAclsRequest;
 import org.apache.kafka.common.requests.DescribeAclsResponse;
-import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.DescribeLogDirsRequest;
@@ -1799,4 +1801,42 @@ public class KafkaAdminClient extends AdminClient {
 
         return new DescribeReplicaLogDirResult(new HashMap<TopicPartitionReplica, KafkaFuture<ReplicaLogDirInfo>>(futures));
     }
+
+    public CreatePartitionsResult createPartitions(Map<String, NewPartitions> newPartitions, final CreatePartitionsOptions options) {
+        final Map<String, KafkaFutureImpl<Void>> futures = new HashMap<>(newPartitions.size());
+        for (String topic: newPartitions.keySet()) {
+            futures.put(topic, new KafkaFutureImpl<Void>());
+        }
+        final Map<String, NewPartitions> requestMap = new HashMap<>(newPartitions);
+
+        final long now = time.milliseconds();
+        runnable.call(new Call("createPartitions", calcDeadlineMs(now, options.timeoutMs()),
+                new ControllerNodeProvider()) {
+
+            @Override
+            public AbstractRequest.Builder createRequest(int timeoutMs) {
+                return new CreatePartitionsRequest.Builder(requestMap, timeoutMs, options.validateOnly());
+            }
+
+            @Override
+            public void handleResponse(AbstractResponse abstractResponse) {
+                CreatePartitionsResponse response = (CreatePartitionsResponse) abstractResponse;
+                for (Map.Entry<String, ApiError> result : response.errors().entrySet()) {
+                    KafkaFutureImpl<Void> future = futures.get(result.getKey());
+                    if (result.getValue().isSuccess()) {
+                        future.complete(null);
+                    } else {
+                        future.completeExceptionally(result.getValue().exception());
+                    }
+                }
+            }
+
+            @Override
+            void handleFailure(Throwable throwable) {
+                completeAllExceptionally(futures.values(), throwable);
+            }
+        }, now);
+        return new CreatePartitionsResult(new HashMap<String, KafkaFuture<Void>>(futures));
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java
@@ -43,7 +43,7 @@ public class NewPartitions {
      * Increase the partition count for a topic to the given {@code totalCount}.
      * The assignment of new replicas to brokers will be decided by the broker.
      *
-     * @param totalCount       The new total partition count (not the number of new partitions).
+     * @param totalCount The total partitions count after the operation succeeds.
      */
     public static NewPartitions increaseTo(int totalCount) {
         return new NewPartitions(totalCount, null);
@@ -59,14 +59,19 @@ public class NewPartitions {
      * The first broker id in each inner list is the "preferred replica".</p>
      *
      * <p>For example, suppose a topic currently has a replication factor of 2, and
-     * has 3 partitions. The number of partitions can be increased to 4
-     * (with broker 1 being the preferred replica for the new partition) using a
+     * has 3 partitions. The number of partitions can be increased to 6 using a
      * {@code NewPartition} constructed like this:</p>
      *
-     * <pre><code>NewPartitions.increaseTo(4, Arrays.asList(Arrays.asList(1, 2))</code></pre>
+     * <pre><code>
+     * NewPartitions.increaseTo(6, asList(asList(1, 2),
+     *                                    asList(2, 3),
+     *                                    asList(3, 1)))
+     * </code></pre>
+     * <p>In this example partition 3's preferred leader will be broker 1, partition 4's preferred leader will be
+     * broker 2 and partition 5's preferred leader will be broker 3.</p>
      *
-     * @param totalCount       The new total partition count (not the number of new partitions).
-     * @param newAssignments   The replica assignments for the new partitions.
+     * @param totalCount The total partitions count after the operation succeeds.
+     * @param newAssignments The replica assignments for the new partitions.
      */
     public static NewPartitions increaseTo(int totalCount, List<List<Integer>> newAssignments) {
         return new NewPartitions(totalCount, newAssignments);
@@ -89,11 +94,7 @@ public class NewPartitions {
 
     @Override
     public String toString() {
-        StringBuilder bld = new StringBuilder();
-        bld.append("(totalCount=").append(totalCount()).
-        append(", newAssignments=").append(assignments()).
-        append(")");
-        return bld.toString();
+        return "(totalCount=" + totalCount() + ", newAssignments=" + assignments() + ")";
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/NewPartitions.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Describes new partitions for a particular topic in a call to {@link AdminClient#createPartitions(Map)}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
+public class NewPartitions {
+
+    private int totalCount;
+
+    private List<List<Integer>> newAssignments;
+
+    private NewPartitions(int totalCount, List<List<Integer>> newAssignments) {
+        this.totalCount = totalCount;
+        this.newAssignments = newAssignments;
+    }
+
+    /**
+     * Increase the partition count for a topic to the given {@code totalCount}.
+     * The assignment of new replicas to brokers will be decided by the broker.
+     *
+     * @param totalCount       The new total partition count (not the number of new partitions).
+     */
+    public static NewPartitions increaseTo(int totalCount) {
+        return new NewPartitions(totalCount, null);
+    }
+
+    /**
+     * <p>Increase the partition count for a topic to the given {@code totalCount}
+     * assigning the new partitions according to the given {@code newAssignments}.
+     * The length of the given {@code newAssignments} should equal {@code totalCount - oldCount}, since
+     * the assignment of existing partitions are not changed.
+     * Each inner list of {@code newAssignments} should have a length equal to
+     * the topic's replication factor.
+     * The first broker id in each inner list is the "preferred replica".</p>
+     *
+     * <p>For example, suppose a topic currently has a replication factor of 2, and
+     * has 3 partitions. The number of partitions can be increased to 4
+     * (with broker 1 being the preferred replica for the new partition) using a
+     * {@code NewPartition} constructed like this:</p>
+     *
+     * <pre><code>NewPartitions.increaseTo(4, Arrays.asList(Arrays.asList(1, 2))</code></pre>
+     *
+     * @param totalCount       The new total partition count (not the number of new partitions).
+     * @param newAssignments   The replica assignments for the new partitions.
+     */
+    public static NewPartitions increaseTo(int totalCount, List<List<Integer>> newAssignments) {
+        return new NewPartitions(totalCount, newAssignments);
+    }
+
+    /**
+     * The new total partition count (not the number of new partitions).
+     */
+    public int totalCount() {
+        return totalCount;
+    }
+
+    /**
+     * The replica assignments for the new partitions, or null if the assignment of
+     * replicas to brokers will be done by the controller.
+     */
+    public List<List<Integer>> assignments() {
+        return newAssignments;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder bld = new StringBuilder();
+        bld.append("(totalCount=").append(totalCount()).
+        append(", newAssignments=").append(assignments()).
+        append(")");
+        return bld.toString();
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.errors;
+
+/**
+ * Thrown if a request cannot be completed because a partition reassignment is in progress.
+ */
+public class ReassignmentInProgressException extends ApiException {
+
+    public ReassignmentInProgressException(String msg) {
+        super(msg);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/ReassignmentInProgressException.java
@@ -25,4 +25,8 @@ public class ReassignmentInProgressException extends ApiException {
     public ReassignmentInProgressException(String msg) {
         super(msg);
     }
+
+    public ReassignmentInProgressException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -35,6 +35,8 @@ import org.apache.kafka.common.requests.ControlledShutdownRequest;
 import org.apache.kafka.common.requests.ControlledShutdownResponse;
 import org.apache.kafka.common.requests.CreateAclsRequest;
 import org.apache.kafka.common.requests.CreateAclsResponse;
+import org.apache.kafka.common.requests.CreatePartitionsRequest;
+import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteAclsRequest;
@@ -167,8 +169,9 @@ public enum ApiKeys {
     DESCRIBE_LOG_DIRS(35, "DescribeLogDirs", DescribeLogDirsRequest.schemaVersions(),
             DescribeLogDirsResponse.schemaVersions()),
     SASL_AUTHENTICATE(36, "SaslAuthenticate", SaslAuthenticateRequest.schemaVersions(),
-            SaslAuthenticateResponse.schemaVersions());
-
+            SaslAuthenticateResponse.schemaVersions()),
+    CREATE_PARTITIONS(37, "CreatePartitions", CreatePartitionsRequest.schemaVersions(),
+            CreatePartitionsResponse.schemaVersions());
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -60,6 +60,7 @@ import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.ReassignmentInProgressException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
 import org.apache.kafka.common.errors.RecordBatchTooLargeException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
@@ -524,7 +525,14 @@ public enum Errors {
             public ApiException build(String message) {
                 return new AuthenticationFailedException(message);
             }
-        });
+    }),
+    REASSIGNMENT_IN_PROGRESS(59, "A partition reassignment is in progress",
+        new ApiExceptionBuilder() {
+            @Override
+            public ApiException build(String message) {
+                return new ReassignmentInProgressException(message);
+            }
+    });
 
     private interface ApiExceptionBuilder {
         ApiException build(String message);

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -183,6 +183,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
                 return new DescribeLogDirsRequest(struct, apiVersion);
             case SASL_AUTHENTICATE:
                 return new SaslAuthenticateRequest(struct, apiVersion);
+            case CREATE_PARTITIONS:
+                return new CreatePartitionsRequest(struct, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -115,6 +115,8 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
                 return new DescribeLogDirsResponse(struct);
             case SASL_AUTHENTICATE:
                 return new SaslAuthenticateResponse(struct);
+            case CREATE_PARTITIONS:
+                return new CreatePartitionsResponse(struct);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
@@ -46,17 +46,17 @@ public class CreatePartitionsRequest extends AbstractRequest {
     private static final String TIMEOUT_KEY_NAME = "timeout";
     private static final String VALIDATE_ONLY_KEY_NAME = "validate_only";
 
-    public static final Schema CREATE_PARTITIONS_REQUEST_V0 = new Schema(
-            new Field("topic_partition_count", new ArrayOf(
+    private static final Schema CREATE_PARTITIONS_REQUEST_V0 = new Schema(
+            new Field(TOPIC_PARTITION_COUNT_KEY_NAME, new ArrayOf(
                     new Schema(
                             TOPIC_NAME,
-                            new Field("new_partitions", new Schema(
-                                    new Field("count", INT32, "The new partition count."),
-                                    new Field("assignment", ArrayOf.nullable(new ArrayOf(INT32)), "The assigned brokers")
+                            new Field(NEW_PARTITIONS_KEY_NAME, new Schema(
+                                    new Field(COUNT_KEY_NAME, INT32, "The new partition count."),
+                                    new Field(ASSIGNMENT_KEY_NAME, ArrayOf.nullable(new ArrayOf(INT32)), "The assigned brokers")
                             )))),
                     "List of topic and the corresponding partition count"),
-            new Field("timeout", INT32, "The time in ms to wait for a topic to be altered."),
-            new Field("validate_only", BOOLEAN, "If true then validate the request, but don't actually increase the partition count."));
+            new Field(TIMEOUT_KEY_NAME, INT32, "The time in ms to wait for a topic to be altered."),
+            new Field(VALIDATE_ONLY_KEY_NAME, BOOLEAN, "If true then validate the request, but don't actually increase the partition count."));
 
     public static Schema[] schemaVersions() {
         return new Schema[]{CREATE_PARTITIONS_REQUEST_V0};
@@ -66,8 +66,6 @@ public class CreatePartitionsRequest extends AbstractRequest {
     private final Map<String, NewPartitions> newPartitions;
     private final int timeout;
     private final boolean validateOnly;
-
-
 
     public static class Builder extends AbstractRequest.Builder<CreatePartitionsRequest> {
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsRequest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.clients.admin.NewPartitions;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
+import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
+import static org.apache.kafka.common.protocol.types.Type.INT32;
+
+public class CreatePartitionsRequest extends AbstractRequest {
+
+    private static final String TOPIC_PARTITION_COUNT_KEY_NAME = "topic_partition_count";
+    private static final String NEW_PARTITIONS_KEY_NAME = "new_partitions";
+    private static final String COUNT_KEY_NAME = "count";
+    private static final String ASSIGNMENT_KEY_NAME = "assignment";
+    private static final String TIMEOUT_KEY_NAME = "timeout";
+    private static final String VALIDATE_ONLY_KEY_NAME = "validate_only";
+
+    public static final Schema CREATE_PARTITIONS_REQUEST_V0 = new Schema(
+            new Field("topic_partition_count", new ArrayOf(
+                    new Schema(
+                            TOPIC_NAME,
+                            new Field("new_partitions", new Schema(
+                                    new Field("count", INT32, "The new partition count."),
+                                    new Field("assignment", ArrayOf.nullable(new ArrayOf(INT32)), "The assigned brokers")
+                            )))),
+                    "List of topic and the corresponding partition count"),
+            new Field("timeout", INT32, "The time in ms to wait for a topic to be altered."),
+            new Field("validate_only", BOOLEAN, "If true then validate the request, but don't actually increase the partition count."));
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{CREATE_PARTITIONS_REQUEST_V0};
+    }
+
+    private final Set<String> duplicates;
+    private final Map<String, NewPartitions> newPartitions;
+    private final int timeout;
+    private final boolean validateOnly;
+
+
+
+    public static class Builder extends AbstractRequest.Builder<CreatePartitionsRequest> {
+
+        private final Map<String, NewPartitions> newPartitions;
+        private final int timeout;
+        private final boolean validateOnly;
+
+        public Builder(Map<String, NewPartitions> newPartitions, int timeout, boolean validateOnly) {
+            super(ApiKeys.CREATE_PARTITIONS);
+            this.newPartitions = newPartitions;
+            this.timeout = timeout;
+            this.validateOnly = validateOnly;
+        }
+
+        @Override
+        public CreatePartitionsRequest build(short version) {
+            return new CreatePartitionsRequest(newPartitions, timeout, validateOnly, version);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder bld = new StringBuilder();
+            bld.append("(type=CreatePartitionsRequest").
+                    append(", newPartitions=").append(newPartitions).
+                    append(", timeout=").append(timeout).
+                    append(", validateOnly=").append(validateOnly).
+                    append(")");
+            return bld.toString();
+        }
+    }
+
+    CreatePartitionsRequest(Map<String, NewPartitions> newPartitions, int timeout, boolean validateOnly, short apiVersion) {
+        super(apiVersion);
+        this.newPartitions = newPartitions;
+        this.duplicates = Collections.emptySet();
+        this.timeout = timeout;
+        this.validateOnly = validateOnly;
+    }
+
+    public CreatePartitionsRequest(Struct struct, short apiVersion) {
+        super(apiVersion);
+        Object[] topicCountArray = struct.getArray(TOPIC_PARTITION_COUNT_KEY_NAME);
+        Map<String, NewPartitions> counts = new HashMap<>(topicCountArray.length);
+        Set<String> dupes = Collections.emptySet();
+        for (Object topicPartitionCountObj : topicCountArray) {
+            Struct topicPartitionCountStruct = (Struct) topicPartitionCountObj;
+            String topic = topicPartitionCountStruct.get(TOPIC_NAME);
+            Struct partitionCountStruct = topicPartitionCountStruct.getStruct(NEW_PARTITIONS_KEY_NAME);
+            int count = partitionCountStruct.getInt(COUNT_KEY_NAME);
+            Object[] outerArray = partitionCountStruct.getArray(ASSIGNMENT_KEY_NAME);
+            NewPartitions newPartition;
+            if (outerArray != null) {
+                List<List<Integer>> assignments = new ArrayList(outerArray.length);
+                for (Object inner : outerArray) {
+                    Object[] innerArray = (Object[]) inner;
+                    List<Integer> innerList = new ArrayList<>(innerArray.length);
+                    assignments.add(innerList);
+                    for (Object broker : innerArray) {
+                        innerList.add((Integer) broker);
+                    }
+                }
+                newPartition = NewPartitions.increaseTo(count, assignments);
+            } else {
+                newPartition = NewPartitions.increaseTo(count);
+            }
+            NewPartitions dupe = counts.put(topic, newPartition);
+            if (dupe != null) {
+                if (dupes.isEmpty()) {
+                    dupes = new HashSet<>();
+                }
+                dupes.add(topic);
+            }
+        }
+        this.newPartitions = counts;
+        this.duplicates = dupes;
+        this.timeout = struct.getInt(TIMEOUT_KEY_NAME);
+        this.validateOnly = struct.getBoolean(VALIDATE_ONLY_KEY_NAME);
+    }
+
+    public Set<String> duplicates() {
+        return duplicates;
+    }
+
+    public Map<String, NewPartitions> newPartitions() {
+        return newPartitions;
+    }
+
+    public int timeout() {
+        return timeout;
+    }
+
+    public boolean validateOnly() {
+        return validateOnly;
+    }
+
+    @Override
+    protected Struct toStruct() {
+        Struct struct = new Struct(ApiKeys.CREATE_PARTITIONS.requestSchema(version()));
+        List<Struct> topicPartitionsList = new ArrayList<>();
+        for (Map.Entry<String, NewPartitions> topicPartitionCount : this.newPartitions.entrySet()) {
+            Struct topicPartitionCountStruct = struct.instance(TOPIC_PARTITION_COUNT_KEY_NAME);
+            topicPartitionCountStruct.set(TOPIC_NAME, topicPartitionCount.getKey());
+            NewPartitions count = topicPartitionCount.getValue();
+            Struct partitionCountStruct = topicPartitionCountStruct.instance(NEW_PARTITIONS_KEY_NAME);
+            partitionCountStruct.set(COUNT_KEY_NAME, count.totalCount());
+            Object[][] x;
+            if (count.assignments() != null) {
+                x = new Object[count.assignments().size()][];
+                int i = 0;
+                for (List<Integer> partitionAssignment : count.assignments()) {
+                    x[i] = partitionAssignment.toArray(new Object[partitionAssignment.size()]);
+                    i++;
+                }
+            } else {
+                x = null;
+            }
+            partitionCountStruct.set(ASSIGNMENT_KEY_NAME, x);
+            topicPartitionCountStruct.set(NEW_PARTITIONS_KEY_NAME, partitionCountStruct);
+            topicPartitionsList.add(topicPartitionCountStruct);
+        }
+        struct.set(TOPIC_PARTITION_COUNT_KEY_NAME, topicPartitionsList.toArray(new Object[topicPartitionsList.size()]));
+        struct.set(TIMEOUT_KEY_NAME, this.timeout);
+        struct.set(VALIDATE_ONLY_KEY_NAME, this.validateOnly);
+        return struct;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        Map<String, ApiError> topicErrors = new HashMap<>();
+        for (String topic : newPartitions.keySet()) {
+            topicErrors.put(topic, ApiError.fromThrowable(e));
+        }
+
+        short versionId = version();
+        switch (versionId) {
+            case 0:
+                return new CreatePartitionsResponse(throttleTimeMs, topicErrors);
+            default:
+                throw new IllegalArgumentException(String.format("Version %d is not valid. Valid versions for %s are 0 to %d",
+                        versionId, this.getClass().getSimpleName(), ApiKeys.CREATE_PARTITIONS.latestVersion()));
+        }
+    }
+
+    public static CreatePartitionsRequest parse(ByteBuffer buffer, short version) {
+        return new CreatePartitionsRequest(ApiKeys.CREATE_PARTITIONS.parseRequest(version, buffer), version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_MESSAGE;
+import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
+import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
+
+
+public class CreatePartitionsResponse extends AbstractResponse {
+
+    private static final String TOPIC_ERRORS_KEY_NAME = "topic_partition_count_error";
+
+    public static final Schema CREATE_PARTITIONS_RESPONSE_V0 = new Schema(
+            THROTTLE_TIME_MS,
+            new Field("topic_partition_count_error", new ArrayOf(
+                    new Schema(
+                            TOPIC_NAME,
+                            ERROR_CODE,
+                            ERROR_MESSAGE
+                    )), "Topic partition count results")
+    );
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{CREATE_PARTITIONS_RESPONSE_V0};
+    }
+
+    private final int throttleTimeMs;
+    private final Map<String, ApiError> errors;
+
+    public CreatePartitionsResponse(int throttleTimeMs, Map<String, ApiError> errors) {
+        this.throttleTimeMs = throttleTimeMs;
+        this.errors = errors;
+    }
+
+    public CreatePartitionsResponse(Struct struct) {
+        super();
+        Object[] topicErrorsArray = struct.getArray(TOPIC_ERRORS_KEY_NAME);
+        Map<String, ApiError> errors = new HashMap<>(topicErrorsArray.length);
+        for (Object topicErrorObj : topicErrorsArray) {
+            Struct topicErrorStruct = (Struct) topicErrorObj;
+            String topic = topicErrorStruct.get(TOPIC_NAME);
+            ApiError error = new ApiError(topicErrorStruct);
+            errors.put(topic, error);
+        }
+        this.throttleTimeMs = struct.get(THROTTLE_TIME_MS);
+        this.errors = errors;
+    }
+
+    @Override
+    protected Struct toStruct(short version) {
+        Struct struct = new Struct(ApiKeys.CREATE_PARTITIONS.responseSchema(version));
+        List<Struct> topicErrors = new ArrayList<>(errors.size());
+        for (Map.Entry<String, ApiError> error : errors.entrySet()) {
+            Struct errorStruct = struct.instance(TOPIC_ERRORS_KEY_NAME);
+            errorStruct.set(TOPIC_NAME, error.getKey());
+            error.getValue().write(errorStruct);
+            topicErrors.add(errorStruct);
+        }
+        struct.set(THROTTLE_TIME_MS, throttleTimeMs);
+        struct.set(TOPIC_ERRORS_KEY_NAME, topicErrors.toArray(new Object[topicErrors.size()]));
+        return struct;
+    }
+
+    public Map<String, ApiError> errors() {
+        return errors;
+    }
+
+    public int throttleTimeMs() {
+        return throttleTimeMs;
+    }
+
+    public static CreatePartitionsResponse parse(ByteBuffer buffer, short version) {
+        return new CreatePartitionsResponse(ApiKeys.CREATE_PARTITIONS.parseResponse(version, buffer));
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -37,7 +37,7 @@ import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
 
 public class CreatePartitionsResponse extends AbstractResponse {
 
-    private static final String TOPIC_ERRORS_KEY_NAME = "topic_partition_count_error";
+    private static final String TOPIC_ERRORS_KEY_NAME = "topic_errors";
 
     private static final Schema CREATE_PARTITIONS_RESPONSE_V0 = new Schema(
             THROTTLE_TIME_MS,
@@ -46,7 +46,7 @@ public class CreatePartitionsResponse extends AbstractResponse {
                             TOPIC_NAME,
                             ERROR_CODE,
                             ERROR_MESSAGE
-                    )), "Topic partition count results")
+                    )), "Per topic results for the create partitions request")
     );
 
     public static Schema[] schemaVersions() {

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreatePartitionsResponse.java
@@ -39,9 +39,9 @@ public class CreatePartitionsResponse extends AbstractResponse {
 
     private static final String TOPIC_ERRORS_KEY_NAME = "topic_partition_count_error";
 
-    public static final Schema CREATE_PARTITIONS_RESPONSE_V0 = new Schema(
+    private static final Schema CREATE_PARTITIONS_RESPONSE_V0 = new Schema(
             THROTTLE_TIME_MS,
-            new Field("topic_partition_count_error", new ArrayOf(
+            new Field(TOPIC_ERRORS_KEY_NAME, new ArrayOf(
                     new Schema(
                             TOPIC_NAME,
                             ERROR_CODE,

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -381,7 +381,7 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testAlterPartitionCounts() throws Exception {
+    public void testCreatePartitions() throws Exception {
         try (MockKafkaAdminClientEnv env = mockClientEnv()) {
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
             env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -29,9 +29,11 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.requests.CreateAclsResponse;
 import org.apache.kafka.common.requests.CreateAclsResponse.AclCreationResponse;
@@ -375,6 +377,40 @@ public class KafkaAdminClientTest {
             DescribeConfigsResult result2 = env.adminClient().describeConfigs(Collections.singleton(
                 new ConfigResource(ConfigResource.Type.BROKER, "0")));
             result2.all().get();
+        }
+    }
+
+    @Test
+    public void testAlterPartitionCounts() throws Exception {
+        try (MockKafkaAdminClientEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(env.cluster().controller());
+
+            Map<String, ApiError> m = new HashMap<>();
+            m.put("my_topic", ApiError.NONE);
+            m.put("other_topic", ApiError.fromThrowable(new InvalidTopicException("some detailed reason")));
+
+            // Test a call where one filter has an error.
+            env.kafkaClient().prepareResponse(new CreatePartitionsResponse(0, m));
+
+            Map<String, NewPartitions> counts = new HashMap<>();
+            counts.put("my_topic", NewPartitions.increaseTo(3));
+            counts.put("other_topic", NewPartitions.increaseTo(3, asList(asList(2), asList(3))));
+
+            CreatePartitionsResult results = env.adminClient().createPartitions(counts);
+            Map<String, KafkaFuture<Void>> values = results.values();
+            KafkaFuture<Void> myTopicResult = values.get("my_topic");
+            assertEquals(null, myTopicResult.get());
+            KafkaFuture<Void> otherTopicResult = values.get("other_topic");
+            try {
+                otherTopicResult.get();
+                fail("get() should throw ExecutionException");
+            } catch (ExecutionException e0) {
+                assertTrue(e0.getCause() instanceof InvalidTopicException);
+                InvalidTopicException e = (InvalidTopicException) e0.getCause();
+                assertEquals("some detailed reason", e.getMessage());
+            }
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -401,7 +401,7 @@ public class KafkaAdminClientTest {
             CreatePartitionsResult results = env.adminClient().createPartitions(counts);
             Map<String, KafkaFuture<Void>> values = results.values();
             KafkaFuture<Void> myTopicResult = values.get("my_topic");
-            assertEquals(null, myTopicResult.get());
+            myTopicResult.get();
             KafkaFuture<Void> otherTopicResult = values.get("other_topic");
             try {
                 otherTopicResult.get();

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -71,7 +71,6 @@ import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
 import static org.apache.kafka.test.TestUtils.toBuffer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1085,19 +1084,24 @@ public class RequestResponseTest {
     }
 
     private CreatePartitionsRequest createCreatePartitionsRequest() {
-        Map<String, NewPartitions> assignments = singletonMap("my_topic", NewPartitions.increaseTo(3));
+        Map<String, NewPartitions> assignments = new HashMap<>();
+        assignments.put("my_topic", NewPartitions.increaseTo(3));
+        assignments.put("my_other_topic", NewPartitions.increaseTo(3));
         return new CreatePartitionsRequest(assignments, 0, false, (short) 0);
     }
 
     private CreatePartitionsRequest createCreatePartitionsRequestWithAssignments() {
-        Map<String, NewPartitions> assignments = singletonMap("my_topic", NewPartitions.increaseTo(3, asList(asList(2))));
+        Map<String, NewPartitions> assignments = new HashMap<>();
+        assignments.put("my_topic", NewPartitions.increaseTo(3, asList(asList(2))));
+        assignments.put("my_other_topic", NewPartitions.increaseTo(3, asList(asList(2, 3), asList(3, 1))));
         return new CreatePartitionsRequest(assignments, 0, false, (short) 0);
     }
 
     private CreatePartitionsResponse createCreatePartitionsErrorResponse() {
-        Map<String, ApiError> results = singletonMap(
-                "my_topic", ApiError.fromThrowable(new InvalidReplicaAssignmentException("The assigned brokers included an unknown broker"))
-        );
+        Map<String, ApiError> results = new HashMap<>();
+        results.put("my_topic", ApiError.fromThrowable(
+                new InvalidReplicaAssignmentException("The assigned brokers included an unknown broker")));
+        results.put("my_topic", ApiError.NONE);
         return new CreatePartitionsResponse(42, results);
     }
 

--- a/core/src/main/scala/kafka/admin/AdminUtils.scala
+++ b/core/src/main/scala/kafka/admin/AdminUtils.scala
@@ -274,7 +274,7 @@ object AdminUtils extends Logging with AdminUtilities {
                     replicaAssignment: Option[Map[Int, Seq[Int]]] = None,
                     checkBrokerAvailable: Boolean = true,
                     rackAwareMode: RackAwareMode = RackAwareMode.Enforced,
-                    validateOnly: Boolean = false) {
+                    validateOnly: Boolean = false): Map[Int, Seq[Int]] = {
     if (zkUtils.pathExists(ZkUtils.ReassignPartitionsPath)) {
       // We prevent addition partitions while a reassignment is in progress, since
       // during reassignment there is no meaningful notion of replication factor
@@ -311,6 +311,7 @@ object AdminUtils extends Logging with AdminUtilities {
       // add the combined new list
       AdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(zkUtils, topic, partitionReplicaList ++ newPartitionReplicaList, update = true)
     }
+    newPartitionReplicaList
   }
 
   /**

--- a/core/src/main/scala/kafka/admin/AdminUtils.scala
+++ b/core/src/main/scala/kafka/admin/AdminUtils.scala
@@ -323,16 +323,16 @@ object AdminUtils extends Logging with AdminUtilities {
     var partitionId = startPartitionId
     partitionList = partitionList.takeRight(partitionList.size - partitionId)
     for (i <- partitionList.indices) {
-      val brokerList = partitionList(i).split(":").map(s => s.trim().toInt)
+      val brokerList = partitionList(i).split(":").map(s => s.trim().toInt).toList
       if (brokerList.isEmpty)
         throw new InvalidReplicaAssignmentException("Replication factor must be larger than 0.")
       if (brokerList.size != brokerList.toSet.size)
-        throw new InvalidReplicaAssignmentException(s"Duplicate brokers in replica assignment: $brokerList.")
+        throw new InvalidReplicaAssignmentException(s"Duplicate brokers in replica assignment: ${brokerList.mkString(", ")}.")
       if (checkBrokerAvailable && !brokerList.toSet.subsetOf(availableBrokerList))
-        throw new AdminOperationException(s"Some specified brokers not available. Specified brokers: $brokerList, available brokers: $availableBrokerList.")
-      ret.put(partitionId, brokerList.toList)
-      if (ret(partitionId).size != ret(startPartitionId).size)
-        throw new AdminOperationException(s"Partition $i has different replication factor: $brokerList.")
+        throw new AdminOperationException(s"Some specified brokers not available. Specified brokers: ${brokerList.mkString(", ")}, available brokers: ${availableBrokerList.mkString(", ")}.")
+      ret.put(partitionId, brokerList)
+      if (brokerList.size != ret(startPartitionId).size)
+        throw new InvalidReplicaAssignmentException(s"Partition ${i+startPartitionId} has different replication factor: ${brokerList.mkString(", ")}.")
       partitionId = partitionId + 1
     }
     ret.toMap

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -223,7 +223,7 @@ class AdminManager(val config: KafkaConfig,
           // check each broker exists
           val unknownBrokers = assignments.flatten.toSet -- zkUtils.getAllBrokersInCluster.map(broker => broker.id)
           if (unknownBrokers.nonEmpty) {
-            throw new InvalidPartitionsException(s"Unknown broker(s): $unknownBrokers.")
+            throw new InvalidReplicaAssignmentException(s"Unknown broker(s) in replica assignment: ${unknownBrokers.mkString(", ")}.")
           }
           if (assignments.size != numPartitionsIncrement) {
             throw new InvalidRequestException(s"Increasing the number of partitions by $numPartitionsIncrement but ${assignments.size} assignments provided.")

--- a/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
+++ b/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
@@ -83,11 +83,6 @@ class DelayedCreatePartitions(delayMs: Long,
     }
     if (isTraceEnabled)
       trace(s"DelayedCreatePartitions.tryComplete(): waitedResults: $waitedResults, waitingFor: $waitingFor")
-    if (waitingFor.isEmpty) {
-      return forceComplete()
-    } else {
-      false
-    }
-
+    waitingFor.isEmpty && forceComplete()
   }
 }

--- a/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
+++ b/core/src/main/scala/kafka/server/DelayedCreatePartitions.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server
+
+import kafka.common.TopicAndPartition
+import org.apache.kafka.clients.admin.NewPartitions
+import org.apache.kafka.common.network.ListenerName
+import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.ApiError
+
+import scala.collection.{Map, Seq, mutable}
+
+/**
+  * A delayed create partitions operation that can be created by the admin manager and watched
+  * in the topic purgatory
+  */
+class DelayedCreatePartitions(delayMs: Long,
+                              done: Map[String, ApiError],
+                              waiting: Map[String, NewPartitions],
+                              adminManager: AdminManager,
+                              listenerName: ListenerName,
+                              responseCallback: Map[String, ApiError] => Unit)
+  extends DelayedOperation(delayMs) {
+
+  // the results of topics we were waiting for
+  val waitedResults = mutable.Map.empty[String, ApiError]
+
+  // the topics we're still waiting for
+  val waitingFor = mutable.Map.empty[String, NewPartitions] ++= waiting
+
+  /**
+    * Call-back to execute when a delayed operation gets expired and hence forced to complete.
+    */
+  override def onExpiration(): Unit = {
+    (waitingFor.keySet--waitedResults.keySet).foreach{
+      case topic => waitedResults += topic -> new ApiError(Errors.REQUEST_TIMED_OUT, Errors.REQUEST_TIMED_OUT.message())
+    }
+    onComplete()
+  }
+
+  /**
+    * Process for completing an operation; This function needs to be defined
+    * in subclasses and will be called exactly once in forceComplete()
+    */
+  override def onComplete(): Unit = {
+    responseCallback(waitedResults ++ done)
+  }
+
+  /**
+    * Try to complete the delayed operation by first checking if the operation
+    * can be completed by now. If yes execute the completion logic by calling
+    * forceComplete() and return true iff forceComplete returns true; otherwise return false
+    *
+    * This function needs to be defined in subclasses
+    */
+  override def tryComplete(): Boolean = {
+    for (topicMeta <- adminManager.metadataCache.getTopicMetadata(waitingFor.keySet, listenerName)) {
+      if (isTraceEnabled)
+        trace(s"DelayedCreatePartitions.tryComplete(): topicMeta: $topicMeta")
+      val requiredCount = waitingFor(topicMeta.topic).totalCount()
+      val currentCount = topicMeta.partitionMetadata.size()
+      if (isTraceEnabled)
+        trace(s"DelayedCreatePartitions.tryComplete(): topic: ${topicMeta.topic}, currentCount: $currentCount, requiredCount: $requiredCount")
+      if (currentCount == requiredCount) {
+        waitedResults += topicMeta.topic -> ApiError.NONE
+        waitingFor -= topicMeta.topic
+      }
+    }
+    if (isTraceEnabled)
+      trace(s"DelayedCreatePartitions.tryComplete(): waitedResults: $waitedResults, waitingFor: $waitingFor")
+    if (waitingFor.isEmpty) {
+      return forceComplete()
+    } else {
+      false
+    }
+
+  }
+}

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -55,6 +55,7 @@ import org.apache.kafka.common.requests.{SaslAuthenticateResponse, SaslHandshake
 import org.apache.kafka.common.resource.{Resource => AdminResource}
 import org.apache.kafka.common.acl.{AccessControlEntry, AclBinding}
 import DescribeLogDirsResponse.LogDirInfo
+import org.apache.kafka.clients.admin.NewPartitions
 
 import scala.collection.{mutable, _}
 import scala.collection.JavaConverters._
@@ -133,6 +134,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.ALTER_REPLICA_DIR => handleAlterReplicaDirRequest(request)
         case ApiKeys.DESCRIBE_LOG_DIRS => handleDescribeLogDirsRequest(request)
         case ApiKeys.SASL_AUTHENTICATE => handleSaslAuthenticateRequest(request)
+        case ApiKeys.CREATE_PARTITIONS => handleCreatePartitionsRequest(request)
       }
     } catch {
       case e: FatalExitError => throw e
@@ -219,7 +221,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
       if (adminManager.hasDelayedTopicOperations) {
         updateMetadataRequest.partitionStates.keySet.asScala.map(_.topic).foreach { topic =>
-        adminManager.tryCompleteDelayedTopicOperations(topic)
+          adminManager.tryCompleteDelayedTopicOperations(topic)
         }
       }
       sendResponseExemptThrottle(request, new UpdateMetadataResponse(Errors.NONE))
@@ -1331,6 +1333,40 @@ class KafkaApis(val requestChannel: RequestChannel,
         sendResponseWithDuplicatesCallback
       )
     }
+  }
+
+  def handleCreatePartitionsRequest(request: RequestChannel.Request): Unit = {
+    val alterPartitionCountsRequest = request.body[CreatePartitionsRequest]
+    var valid: Map[String, NewPartitions] = null
+    var errors: Map[String, ApiError] = null
+    if (!controller.isActive) {
+      valid = Map[String, NewPartitions]()
+      errors = alterPartitionCountsRequest.newPartitions.asScala.map { case (topic, _) =>
+        (topic, new ApiError(Errors.NOT_CONTROLLER, null))
+      }
+    } else {
+      // Special handling to add duplicate topics to the response
+      val dupes = alterPartitionCountsRequest.duplicates.asScala
+      val notDuped = alterPartitionCountsRequest.newPartitions.asScala.retain((topic, count) => !dupes.contains(topic))
+      val (authorized, unauthorized) = notDuped.partition { case (topic, _) =>
+        authorize(request.session, Alter, new Resource(Topic, topic))
+      }
+      val (queuedForDeletion, live) = authorized.partition{ case (topic, _) => controller.topicDeletionManager.isTopicQueuedUpForDeletion(topic) }
+      valid = live
+      errors = dupes.map(_ -> new ApiError(Errors.INVALID_REQUEST, "Duplicate topic in request")).toMap ++
+        unauthorized.map(_._1 -> new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED, Errors.TOPIC_AUTHORIZATION_FAILED.message())) ++
+        queuedForDeletion.map(_._1 -> new ApiError(Errors.INVALID_TOPIC_EXCEPTION, "The topic is queued for deletion."))
+    }
+
+    def sendResponseCallback(results: Map[String, ApiError]): Unit = {
+      def createResponse(requestThrottleMs: Int): AbstractResponse = {
+        val responseBody = new CreatePartitionsResponse(requestThrottleMs, (results ++ errors).asJava)
+        trace(s"Sending alter partition counts response $responseBody for correlation id ${request.header.correlationId} to client ${request.header.clientId}.")
+        responseBody
+      }
+      sendResponseMaybeThrottle(request, createResponse)
+    }
+    adminManager.createPartitions(alterPartitionCountsRequest.timeout(), valid, alterPartitionCountsRequest.validateOnly, request.context.listenerName, sendResponseCallback)
   }
 
   def handleDeleteTopicsRequest(request: RequestChannel.Request) {

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -448,7 +448,8 @@ class AdminClientIntegrationTest extends KafkaServerTestHarness with Logging {
     } catch {
       case e: ExecutionException =>
         assertTrue(e.getCause.isInstanceOf[InvalidPartitionsException])
-        assertEquals("Topic currently has 3 partitions, which is higher than the requested -22.", e.getCause.getMessage)
+        assertEquals("Topic currently has 3 partitions, which is higher than the requested -22.",
+          e.getCause.getMessage)
     }
 
     // try assignments where the number of brokers != replication factor
@@ -460,7 +461,8 @@ class AdminClientIntegrationTest extends KafkaServerTestHarness with Logging {
     } catch {
       case e: ExecutionException =>
         assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException])
-        assertEquals("Existing topic replication factor of 1, but manual replication assignment would imply replication factor(s) of 2.",
+        assertEquals("Inconsistent replication factor between partitions, partition 0 has 1 " +
+          "while partitions [3] have replication factors [2], respectively",
           e.getCause.getMessage)
     }
 
@@ -485,7 +487,8 @@ class AdminClientIntegrationTest extends KafkaServerTestHarness with Logging {
     } catch {
       case e: ExecutionException =>
         assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException])
-        assertEquals("Duplicate brokers in replica assignment: 1, 1.", e.getCause.getMessage)
+        assertEquals("Duplicate brokers not allowed in replica assignment: 1, 1 for partition id 3.",
+          e.getCause.getMessage)
     }
 
     // try assignments with differently sized inner lists
@@ -498,7 +501,8 @@ class AdminClientIntegrationTest extends KafkaServerTestHarness with Logging {
       case e: ExecutionException =>
         e.printStackTrace()
         assertTrue(e.getCause.isInstanceOf[InvalidReplicaAssignmentException])
-        assertEquals("Partition 4 has different replication factor: 1, 0.", e.getCause.getMessage)
+        assertEquals("Inconsistent replication factor between partitions, partition 0 has 1 " +
+          "while partitions [4] have replication factors [2], respectively", e.getCause.getMessage)
     }
 
     // try assignments with unknown brokers

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -372,7 +372,10 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
       case _: KafkaException => // this is ok
     }
 
-    AdminUtils.addPartitions(zkUtils, topic, 2)
+    val existingAssignment = zkUtils.getReplicaAssignmentForTopics(List(topic)).map {
+      case (topicPartition, replicas) => topicPartition.partition -> replicas
+    }
+    AdminUtils.addPartitions(zkUtils, topic, existingAssignment, 2)
     // read metadata from a broker and verify the new topic partitions exist
     TestUtils.waitUntilMetadataIsPropagated(servers, topic, 0)
     TestUtils.waitUntilMetadataIsPropagated(servers, topic, 1)

--- a/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
@@ -46,6 +46,8 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
   val topic3Assignment = Map(0->Seq(2,3,0,1))
   val topic4 = "new-topic4"
   val topic4Assignment = Map(0->Seq(0,3))
+  val topic5 = "new-topic5"
+  val topic5Assignment = Map(1->Seq(0,1))
 
   @Before
   override def setUp() {
@@ -76,6 +78,17 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
       fail("Add partitions should fail")
     } catch {
       case _: InvalidReplicaAssignmentException => //this is good
+    }
+  }
+
+  @Test
+  def testMissingPartition0(): Unit = {
+    try {
+      AdminUtils.addPartitions(zkUtils, topic5, topic5Assignment, 2, Some(Map(1 -> Seq(0, 1), 2 -> Seq(0, 1, 2))))
+      fail("Add partitions should fail")
+    } catch {
+      case e: AdminOperationException => //this is good
+        assertTrue(e.getMessage.contains("Unexpected existing replica assignment for topic 'new-topic5', partition id 0 is missing"))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
@@ -25,6 +25,7 @@ import kafka.utils.TestUtils._
 import kafka.utils.TestUtils
 import kafka.cluster.Broker
 import kafka.client.ClientUtils
+import kafka.common.TopicAndPartition
 import kafka.server.{KafkaConfig, KafkaServer}
 import org.apache.kafka.common.errors.{InvalidReplicaAssignmentException, InvalidTopicException}
 import org.apache.kafka.common.network.ListenerName
@@ -38,9 +39,13 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
   val partitionId = 0
 
   val topic1 = "new-topic1"
+  val topic1Assignment = Map(0->Seq(0,1))
   val topic2 = "new-topic2"
+  val topic2Assignment = Map(0->Seq(1,2))
   val topic3 = "new-topic3"
+  val topic3Assignment = Map(0->Seq(2,3,0,1))
   val topic4 = "new-topic4"
+  val topic4Assignment = Map(0->Seq(0,3))
 
   @Before
   override def setUp() {
@@ -52,10 +57,10 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
     brokers = servers.map(s => TestUtils.createBroker(s.config.brokerId, s.config.hostName, TestUtils.boundPort(s)))
 
     // create topics first
-    createTopic(zkUtils, topic1, partitionReplicaAssignment = Map(0->Seq(0,1)), servers = servers)
-    createTopic(zkUtils, topic2, partitionReplicaAssignment = Map(0->Seq(1,2)), servers = servers)
-    createTopic(zkUtils, topic3, partitionReplicaAssignment = Map(0->Seq(2,3,0,1)), servers = servers)
-    createTopic(zkUtils, topic4, partitionReplicaAssignment = Map(0->Seq(0,3)), servers = servers)
+    createTopic(zkUtils, topic1, partitionReplicaAssignment = topic1Assignment, servers = servers)
+    createTopic(zkUtils, topic2, partitionReplicaAssignment = topic2Assignment, servers = servers)
+    createTopic(zkUtils, topic3, partitionReplicaAssignment = topic3Assignment, servers = servers)
+    createTopic(zkUtils, topic4, partitionReplicaAssignment = topic4Assignment, servers = servers)
   }
 
   @After
@@ -65,19 +70,9 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
   }
 
   @Test
-  def testTopicDoesNotExist(): Unit = {
-    try {
-      AdminUtils.addPartitions(zkUtils, "Blah", 1)
-      fail("Topic should not exist")
-    } catch {
-      case _: InvalidTopicException => //this is good
-    }
-  }
-
-  @Test
   def testWrongReplicaCount(): Unit = {
     try {
-      AdminUtils.addPartitions(zkUtils, topic1, 2, "0:1,0:1:2")
+      AdminUtils.addPartitions(zkUtils, topic1, topic1Assignment, 2, Some(Map(1 -> Seq(0, 1), 2 -> Seq(0, 1, 2))))
       fail("Add partitions should fail")
     } catch {
       case _: InvalidReplicaAssignmentException => //this is good
@@ -86,7 +81,7 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
 
   @Test
   def testIncrementPartitions(): Unit = {
-    AdminUtils.addPartitions(zkUtils, topic1, 3)
+    AdminUtils.addPartitions(zkUtils, topic1, topic1Assignment, 3)
     // wait until leader is elected
     val leader1 = waitUntilLeaderIsElectedOrChanged(zkUtils, topic1, 1)
     val leader2 = waitUntilLeaderIsElectedOrChanged(zkUtils, topic1, 2)
@@ -113,7 +108,8 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
 
   @Test
   def testManualAssignmentOfReplicas(): Unit = {
-    AdminUtils.addPartitions(zkUtils, topic2, 3, "1:2,0:1,2:3")
+    AdminUtils.addPartitions(zkUtils, topic2, topic2Assignment, 3,
+      Some(Map(0 -> Seq(1, 2), 1 -> Seq(0, 1), 2 -> Seq(2, 3))))
     // wait until leader is elected
     val leader1 = waitUntilLeaderIsElectedOrChanged(zkUtils, topic2, 1)
     val leader2 = waitUntilLeaderIsElectedOrChanged(zkUtils, topic2, 2)
@@ -141,7 +137,7 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
 
   @Test
   def testReplicaPlacementAllServers(): Unit = {
-    AdminUtils.addPartitions(zkUtils, topic3, 7)
+    AdminUtils.addPartitions(zkUtils, topic3, topic3Assignment, 7)
 
     // read metadata from a broker and verify the new topic partitions exist
     TestUtils.waitUntilMetadataIsPropagated(servers, topic3, 1)
@@ -168,7 +164,7 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
 
   @Test
   def testReplicaPlacementPartialServers(): Unit = {
-    AdminUtils.addPartitions(zkUtils, topic2, 3)
+    AdminUtils.addPartitions(zkUtils, topic2, topic2Assignment, 3)
 
     // read metadata from a broker and verify the new topic partitions exist
     TestUtils.waitUntilMetadataIsPropagated(servers, topic2, 1)

--- a/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
@@ -26,6 +26,7 @@ import kafka.utils.TestUtils
 import kafka.cluster.Broker
 import kafka.client.ClientUtils
 import kafka.server.{KafkaConfig, KafkaServer}
+import org.apache.kafka.common.errors.{InvalidReplicaAssignmentException, InvalidTopicException}
 import org.apache.kafka.common.network.ListenerName
 import org.junit.{After, Before, Test}
 
@@ -69,7 +70,7 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
       AdminUtils.addPartitions(zkUtils, "Blah", 1)
       fail("Topic should not exist")
     } catch {
-      case _: AdminOperationException => //this is good
+      case _: InvalidTopicException => //this is good
     }
   }
 
@@ -79,7 +80,7 @@ class AddPartitionsTest extends ZooKeeperTestHarness {
       AdminUtils.addPartitions(zkUtils, topic1, 2, "0:1,0:1:2")
       fail("Add partitions should fail")
     } catch {
-      case _: AdminOperationException => //this is good
+      case _: InvalidReplicaAssignmentException => //this is good
     }
   }
 

--- a/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/CreateTopicsRequestWithPolicyTest.scala
@@ -96,11 +96,11 @@ class CreateTopicsRequestWithPolicyTest extends AbstractCreateTopicsRequestTest 
     validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
       Map("error-replication" -> new CreateTopicsRequest.TopicDetails(10, (numBrokers + 1).toShort)).asJava, timeout, true).build(),
       Map("error-replication" -> error(Errors.INVALID_REPLICATION_FACTOR,
-        Some("replication factor: 4 larger than available brokers: 3"))))
+        Some("Replication factor: 4 larger than available brokers: 3."))))
 
     validateErrorCreateTopicsRequests(new CreateTopicsRequest.Builder(
       Map("error-replication2" -> new CreateTopicsRequest.TopicDetails(10, -1: Short)).asJava, timeout, true).build(),
-      Map("error-replication2" -> error(Errors.INVALID_REPLICATION_FACTOR, Some("replication factor must be larger than 0"))))
+      Map("error-replication2" -> error(Errors.INVALID_REPLICATION_FACTOR, Some("Replication factor must be larger than 0."))))
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -24,6 +24,7 @@ import kafka.log.LogConfig
 import kafka.network.RequestChannel.Session
 import kafka.security.auth._
 import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin.NewPartitions
 import org.apache.kafka.common.acl.{AccessControlEntry, AccessControlEntryFilter, AclBinding, AclBindingFilter, AclOperation, AclPermissionType}
 import org.apache.kafka.common.resource.{ResourceFilter, Resource => AdminResource, ResourceType => AdminResourceType}
 import org.apache.kafka.common.{Node, TopicPartition}
@@ -299,6 +300,11 @@ class RequestQuotaTest extends BaseRequestTest {
         case ApiKeys.DESCRIBE_LOG_DIRS =>
           new DescribeLogDirsRequest.Builder(Collections.singleton(tp))
 
+        case ApiKeys.CREATE_PARTITIONS =>
+          new CreatePartitionsRequest.Builder(
+            Collections.singletonMap("topic-2", NewPartitions.increaseTo(1)), 0, false
+          )
+
         case _ =>
           throw new IllegalArgumentException("Unsupported API key " + apiKey)
     }
@@ -392,6 +398,7 @@ class RequestQuotaTest extends BaseRequestTest {
       case ApiKeys.ALTER_CONFIGS => new AlterConfigsResponse(response).throttleTimeMs
       case ApiKeys.ALTER_REPLICA_DIR => new AlterReplicaDirResponse(response).throttleTimeMs
       case ApiKeys.DESCRIBE_LOG_DIRS => new DescribeLogDirsResponse(response).throttleTimeMs
+      case ApiKeys.CREATE_PARTITIONS => new CreatePartitionsResponse(response).throttleTimeMs
       case requestId => throw new IllegalArgumentException(s"No throttle time for $requestId")
     }
   }


### PR DESCRIPTION
See KIP-195.

The contribution is my original work and I license the work to the project under the project's open source license.

This patch adds AdminClient.createPartitions() and the network protocol is
uses. The broker-side algorithm is as follows:

1. KafkaApis makes some initial checks on the request, then delegates to the
   new AdminManager.createPartitions() method.
2. AdminManager.createPartitions() performs some validation then delegates to
   AdminUtils.addPartitions().

Aside: I felt it was safer to add the extra validation in
AdminManager.createPartitions() than in AdminUtils.addPartitions() since the
latter is used on other code paths which might fail differently with the
introduction of extra checks.

3. AdminUtils.addPartitions() does its own checks and adds the partitions.
4. AdminManager then uses the existing topic purgatory to wait for the
   PartitionInfo available from the metadata cache to become consistent with
   the new total number of partitions.

The messages of exceptions thrown in AdminUtils affecting this new API have
been made consistent with initial capital letter and terminating period.
A few have been reworded for clarity. I've also standardized on using
String.format().

cc @ijuma