### PR TITLE
KAFKA-5896: Force Connect tasks to stop via thread interruption

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -491,11 +491,11 @@ public class Worker {
 
     private void awaitStopTask(ConnectorTaskId taskId, long timeout) {
         WorkerTask task;
-        Future<?> handle;
+        Future<?> future;
 
         synchronized (taskAndThreadLock) {
             task = tasks.remove(taskId);
-            handle = threads.remove(taskId);
+            future = threads.remove(taskId);
         }
 
         if (task == null) {
@@ -507,7 +507,7 @@ public class Worker {
             log.error("Graceful stop of task {} failed. Cancelling and forcibly interrupting.", task.id());
             task.cancel();
 
-            if (handle == null) {
+            if (future == null) {
                 log.warn("No associated Future found for task {}", taskId);
                 return;
             }
@@ -515,7 +515,7 @@ public class Worker {
             // Interrupt the thread that the task is running in since it hasn't stopped on its
             // own by this point. This prevents scenarios where a task runs indefinitely because
             // it's blocked on something (lock, network I/O, etc.).
-            handle.cancel(true);
+            future.cancel(true);
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -790,7 +790,7 @@ public class WorkerTest extends ThreadedTest {
 
     @Test
     public void testStopHungConnectorTask() throws Exception {
-        expectConverters();
+        expectConverters(true);
         expectStartStorage();
 
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -34,6 +34,8 @@ import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -57,14 +59,18 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(PowerMockRunner.class)
@@ -782,6 +788,71 @@ public class WorkerTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
+    @Test
+    public void testStopHungConnectorTask() throws Exception {
+        expectConverters();
+        expectStartStorage();
+
+        EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
+
+        Map<String, String> taskProps = new HashMap<>();
+        taskProps.put(TaskConfig.TASK_CLASS_CONFIG, TestHangSinkTask.class.getName());
+        taskProps.put(SinkTask.TOPICS_CONFIG, "foo,bar");
+
+        Map<String, String> connectorProps = new HashMap<>();
+        connectorProps.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_ID);
+        connectorProps.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerHangTestConnector.class.getName());
+        connectorProps.put(ConnectorConfig.TASKS_MAX_CONFIG, "1");
+
+        CountDownLatch started = new CountDownLatch(1);
+        SinkTask task = new TestHangSinkTask(started);
+        EasyMock.expect(plugins.newTask(TestHangSinkTask.class)).andReturn(task);
+
+        EasyMock.expect(plugins.delegatingLoader()).andReturn(delegatingLoader);
+        EasyMock.expect(delegatingLoader.connectorLoader(WorkerHangTestConnector.class.getName()))
+                .andReturn(pluginLoader);
+
+        EasyMock.expect(Plugins.compareAndSwapLoaders(pluginLoader)).andReturn(delegatingLoader)
+                .times(3);
+
+        EasyMock.expect(Plugins.compareAndSwapLoaders(delegatingLoader)).andReturn(pluginLoader)
+                .times(3);
+
+        taskStatusListener.onStartup(TASK_ID);
+        EasyMock.expectLastCall();
+
+        taskStatusListener.onShutdown(TASK_ID);
+        EasyMock.expectLastCall();
+
+        expectStopStorage();
+
+        PowerMock.replayAll();
+
+        worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
+        worker.start();
+
+        assertEquals(Collections.emptySet(), worker.taskIds());
+        assertFalse(worker.isTaskThreadRunning(TASK_ID));
+
+        // Start running the task in an executor and attempt to wait a little while until
+        // it starts to block indefinitely. This ensures that our call to .stopAndAwaitTask()
+        // will have to force the task to stop by interrupting the thread.
+        worker.startTask(TASK_ID, connectorProps, taskProps, taskStatusListener, TargetState.STARTED);
+        started.await(10, TimeUnit.SECONDS);
+
+        assertEquals(Collections.singleton(TASK_ID), worker.taskIds());
+        assertTrue(worker.isTaskThreadRunning(TASK_ID));
+
+        worker.stopAndAwaitTask(TASK_ID);
+
+        assertEquals(Collections.emptySet(), worker.taskIds());
+        assertFalse(worker.isTaskThreadRunning(TASK_ID));
+
+        worker.stop();
+
+        PowerMock.verifyAll();
+    }
+
     private void assertStatistics(Worker worker, int connectors, int tasks) {
         MetricGroup workerMetrics = worker.workerMetricsGroup().metricGroup();
         assertEquals(connectors, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-count"), 0.0001d);
@@ -966,6 +1037,70 @@ public class WorkerTest extends ThreadedTest {
         @Override
         public SchemaAndValue toConnectData(String topic, byte[] value) {
             return null;
+        }
+    }
+
+    static class WorkerHangTestConnector extends SinkConnector {
+
+        @Override
+        public String version() {
+            return "1.0";
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+        }
+
+        @Override
+        public Class<? extends Task> taskClass() {
+            return TestHangSinkTask.class;
+        }
+
+        @Override
+        public List<Map<String, String>> taskConfigs(int maxTasks) {
+            return null;
+        }
+
+        @Override
+        public void stop() {
+        }
+
+        @Override
+        public ConfigDef config() {
+            return new ConfigDef();
+        }
+    }
+
+    static class TestHangSinkTask extends SinkTask {
+        private CountDownLatch hung;
+        private CountDownLatch started;
+
+        TestHangSinkTask(CountDownLatch started) {
+            this.started = started;
+        }
+
+        @Override
+        public String version() {
+            return "1.0";
+        }
+
+        @Override
+        public void start(Map<String, String> props) {
+            this.hung = new CountDownLatch(1);
+        }
+
+        @Override
+        public void put(Collection<SinkRecord> records) {
+            try {
+                started.countDown();
+                hung.await();
+            } catch (InterruptedException e) {
+                // nothing
+            }
+        }
+
+        @Override
+        public void stop() {
         }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -832,7 +832,7 @@ public class WorkerTest extends ThreadedTest {
         worker.start();
 
         assertEquals(Collections.emptySet(), worker.taskIds());
-        assertFalse(worker.isTaskThreadRunning(TASK_ID));
+        assertFalse(worker.isTaskFutureRunning(TASK_ID));
 
         // Start running the task in an executor and attempt to wait a little while until
         // it starts to block indefinitely. This ensures that our call to .stopAndAwaitTask()
@@ -841,12 +841,12 @@ public class WorkerTest extends ThreadedTest {
         started.await(10, TimeUnit.SECONDS);
 
         assertEquals(Collections.singleton(TASK_ID), worker.taskIds());
-        assertTrue(worker.isTaskThreadRunning(TASK_ID));
+        assertTrue(worker.isTaskFutureRunning(TASK_ID));
 
         worker.stopAndAwaitTask(TASK_ID);
 
         assertEquals(Collections.emptySet(), worker.taskIds());
-        assertFalse(worker.isTaskThreadRunning(TASK_ID));
+        assertFalse(worker.isTaskFutureRunning(TASK_ID));
 
         worker.stop();
 


### PR DESCRIPTION
Interrupt the thread of Kafka Connect tasks that do not stop within
the timeout via `Worker::stopAndAwaitTasks()`. Previously tasks would
be asked to stop via setting a `stopping` flag. It was possible for
tasks to ignore this flag if they were, for example, waiting for
a lock or blocked on I/O.

This prevents issues where tasks may end up with multiple threads
all running and attempting to make progress when there should only
be a single thread running for that task at a time.

Fixes KAFKA-5896

/cc @rhauch @tedyu 