### PR TITLE
MINOR: Disable KafkaAdminClientTest.testHandleTimeout

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -310,6 +311,7 @@ public class KafkaAdminClientTest {
     /**
      * Test handling timeouts.
      */
+    @Ignore // The test is flaky. Should be renabled when this JIRA is fixed: https://issues.apache.org/jira/browse/KAFKA-5792
     @Test
     public void testHandleTimeout() throws Exception {
         HashMap<Integer, Node> nodes = new HashMap<>();


### PR DESCRIPTION
This test is super flaky in the PR builder. https://issues.apache.org/jira/browse/KAFKA-5792 tracks the fix.