### PR TITLE
KAFKA-5915: Support unmapping of mapped/direct buffers in Java 9

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/MappedByteBuffers.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/MappedByteBuffers.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+
+import static java.lang.invoke.MethodHandles.constant;
+import static java.lang.invoke.MethodHandles.dropArguments;
+import static java.lang.invoke.MethodHandles.filterReturnValue;
+import static java.lang.invoke.MethodHandles.guardWithTest;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
+
+/**
+ * Utility methods for MappedByteBuffer implementations.
+ *
+ * The unmap implementation was inspired by the one in Lucene's MMapDirectory.
+ */
+public final class MappedByteBuffers {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MappedByteBuffers.class);
+
+    // null if unmap is not supported
+    private static final MethodHandle UNMAP;
+
+    // null if unmap is supported
+    private static final String UNMAP_NOT_SUPPORTED_REASON;
+
+    static {
+        Object unmap = lookupUnmapMethodHandle();
+        if (unmap instanceof MethodHandle) {
+            UNMAP = (MethodHandle) unmap;
+            UNMAP_NOT_SUPPORTED_REASON = null;
+        } else {
+            UNMAP = null;
+            UNMAP_NOT_SUPPORTED_REASON = (String) unmap;
+        }
+    }
+
+    private MappedByteBuffers() {}
+
+    public static void unmap(String resourceDescription, MappedByteBuffer buffer) throws IOException {
+        if (!buffer.isDirect())
+            throw new IllegalArgumentException("Unmapping only works with direct buffers");
+        if (UNMAP == null)
+            throw new UnsupportedOperationException(UNMAP_NOT_SUPPORTED_REASON);
+
+        try {
+            UNMAP.invokeExact((ByteBuffer) buffer);
+        } catch (Throwable throwable) {
+            throw new IOException("Unable to unmap the mapped buffer: " + resourceDescription, throwable);
+        }
+    }
+
+    /**
+     * Return an unmap MethodHandle or a String with the reason why unmap is not supported.
+     */
+    private static Object lookupUnmapMethodHandle() {
+        final MethodHandles.Lookup lookup = lookup();
+        try {
+            try {
+                return unmapJava9(lookup);
+            } catch (SecurityException e) {
+                return e.getMessage();
+            } catch (ReflectiveOperationException | RuntimeException e) {
+                LOGGER.debug("Falling back to unmap implementation for Java 7/Java 8 due to " + e.getMessage());
+                return unmapJava7Or8(lookup);
+            }
+        } catch (SecurityException se) {
+            return se.getMessage();
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            return "Unmapping is not supported on this platform, because internal Java APIs are not compatible with " +
+                    "this Kafka version: " + e;
+        }
+    }
+
+    private static Object unmapJava7Or8(MethodHandles.Lookup lookup) throws ReflectiveOperationException {
+        /* "Compile" a MethodHandle that is roughly equivalent to the following lambda:
+         *
+         * (ByteBuffer buffer) -> {
+         *   sun.misc.Cleaner cleaner = ((java.nio.DirectByteBuffer) byteBuffer).cleaner();
+         *   if (nonNull(cleaner))
+         *     cleaner.clean();
+         *   else
+         *     noop(cleaner); // the noop is needed because MethodHandles#guardWithTest always needs both if and else
+         * }
+         */
+        Class<?> directBufferClass = Class.forName("java.nio.DirectByteBuffer");
+        Method m = directBufferClass.getMethod("cleaner");
+        m.setAccessible(true);
+        MethodHandle directBufferCleanerMethod = lookup.unreflect(m);
+        Class<?> cleanerClass = directBufferCleanerMethod.type().returnType();
+        MethodHandle cleanMethod = lookup.findVirtual(cleanerClass, "clean", methodType(void.class));
+        MethodHandle nonNullTest = lookup.findStatic(MappedByteBuffers.class, "nonNull",
+                methodType(boolean.class, Object.class)).asType(methodType(boolean.class, cleanerClass));
+        MethodHandle noop = dropArguments(constant(Void.class, null).asType(methodType(void.class)), 0, cleanerClass);
+        MethodHandle unmapper = filterReturnValue(directBufferCleanerMethod, guardWithTest(nonNullTest, cleanMethod, noop))
+                .asType(methodType(void.class, ByteBuffer.class));
+        return unmapper;
+    }
+
+    private static Object unmapJava9(MethodHandles.Lookup lookup) throws ReflectiveOperationException {
+        Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+        MethodHandle unmapper = lookup.findVirtual(unsafeClass, "invokeCleaner",
+                methodType(void.class, ByteBuffer.class));
+        Field f = unsafeClass.getDeclaredField("theUnsafe");
+        f.setAccessible(true);
+        Object theUnsafe = f.get(null);
+        return unmapper.bindTo(theUnsafe);
+    }
+
+    private static boolean nonNull(Object o) {
+        return o != null;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/MappedByteBuffersTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/MappedByteBuffersTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.utils;
+
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+public class MappedByteBuffersTest {
+
+    /**
+     * Checks that unmap doesn't throw exceptions.
+     */
+    @Test
+    public void testUnmap() throws Exception {
+        File file = TestUtils.tempFile();
+        try (FileChannel channel = FileChannel.open(file.toPath())) {
+            MappedByteBuffer map = channel.map(FileChannel.MapMode.READ_ONLY, 0, 0);
+            MappedByteBuffers.unmap(file.getAbsolutePath(), map);
+        }
+    }
+
+}

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -18,6 +18,7 @@
 package kafka.log
 
 import java.io._
+import java.nio.file.Files
 
 import org.junit.Assert._
 import java.util.{Arrays, Collections}
@@ -37,7 +38,7 @@ class OffsetIndexTest extends JUnitSuite {
   
   @Before
   def setup() {
-    this.idx = new OffsetIndex(nonExistantTempFile(), baseOffset = 45L, maxIndexSize = 30 * 8)
+    this.idx = new OffsetIndex(nonExistentTempFile(), baseOffset = 45L, maxIndexSize = 30 * 8)
   }
   
   @After
@@ -138,7 +139,7 @@ class OffsetIndexTest extends JUnitSuite {
   
   @Test
   def truncate() {
-	val idx = new OffsetIndex(nonExistantTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
+	val idx = new OffsetIndex(nonExistentTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
 	idx.truncate()
     for(i <- 1 until 10)
       idx.append(i, i)
@@ -171,7 +172,7 @@ class OffsetIndexTest extends JUnitSuite {
 
   @Test
   def forceUnmapTest(): Unit = {
-    val idx = new OffsetIndex(nonExistantTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
+    val idx = new OffsetIndex(nonExistentTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
     idx.forceUnmap()
     // mmap should be null after unmap causing lookup to throw a NPE
     intercept[NullPointerException](idx.lookup(1))
@@ -197,9 +198,9 @@ class OffsetIndexTest extends JUnitSuite {
     vals
   }
   
-  def nonExistantTempFile(): File = {
+  def nonExistentTempFile(): File = {
     val file = TestUtils.tempFile()
-    file.delete()
+    Files.delete(file.toPath)
     file
   }
 

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -18,10 +18,13 @@
 package kafka.log
 
 import java.io._
+
 import org.junit.Assert._
-import java.util.{Collections, Arrays}
+import java.util.{Arrays, Collections}
+
 import org.junit._
 import org.scalatest.junit.JUnitSuite
+
 import scala.collection._
 import scala.util.Random
 import kafka.utils.TestUtils
@@ -165,6 +168,14 @@ class OffsetIndexTest extends JUnitSuite {
     assertEquals("Full truncation should leave no entries", 0, idx.entries)
     idx.append(0, 0)
   }
+
+  @Test
+  def forceUnmapTest(): Unit = {
+    val idx = new OffsetIndex(nonExistantTempFile(), baseOffset = 0L, maxIndexSize = 10 * 8)
+    idx.forceUnmap()
+    // mmap should be null after unmap causing lookup to throw a NPE
+    intercept[NullPointerException](idx.lookup(1))
+  }
   
   def assertWriteFails[T](message: String, idx: OffsetIndex, offset: Int, klass: Class[T]) {
     try {
@@ -191,4 +202,5 @@ class OffsetIndexTest extends JUnitSuite {
     file.delete()
     file
   }
+
 }


### PR DESCRIPTION
As mentioned in MappedByteBuffers' class documentation, its
implementation was inspired by Lucene's MMapDirectory:

https://github.com/apache/lucene-solr/blob/releases/lucene-solr/6.6.1/lucene/core/src/java/org/apache/lucene/store/MMapDirectory.java#L315

Without this change, unmapping fails with the following message:

> java.lang.IllegalAccessError: class kafka.log.AbstractIndex (in unnamed module @0x45103d6b) cannot access class jdk.internal.ref.Cleaner (in module java.base) because module java.base does not export jdk.internal.ref to unnamed module @0x45103d6b