### PR TITLE
MINOR: Update powermock and enable its tests when running with Java 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,20 +193,6 @@ subprojects {
   def testShowStandardStreams = false
   def testExceptionFormat = 'full'
 
-  // Exclude PowerMock tests when running with Java 9 until a version of PowerMock that supports Java 9 is released
-  // The relevant issue is https://github.com/powermock/powermock/issues/783
-  String[] testsToExclude = []
-  if (JavaVersion.current().isJava9Compatible()) {
-    testsToExclude = [
-      "**/KafkaProducerTest.*", "**/BufferPoolTest.*",
-      "**/SourceTaskOffsetCommitterTest.*", "**/WorkerSinkTaskTest.*", "**/WorkerSinkTaskThreadedTest.*",
-      "**/WorkerSourceTaskTest.*", "**/WorkerTest.*", "**/DistributedHerderTest.*", "**/WorkerCoordinatorTest.*",
-      "**/RestServerTest.*", "**/ConnectorPluginsResourceTest.*", "**/ConnectorsResourceTest.*",
-      "**/StandaloneHerderTest.*", "**/FileOffsetBakingStoreTest.*", "**/KafkaConfigBackingStoreTest.*",
-      "**/KafkaOffsetBackingStoreTest.*", "**/OffsetStorageWriterTest.*", "**/KafkaBasedLogTest.*"
-    ]
-  }
-
   test {
     maxParallelForks = userMaxForks ?: Runtime.runtime.availableProcessors()
 
@@ -220,7 +206,6 @@ subprojects {
       exceptionFormat = testExceptionFormat
     }
 
-    exclude(testsToExclude)
   }
 
   task integrationTest(type: Test, dependsOn: compileJava) {
@@ -240,8 +225,6 @@ subprojects {
       includeCategories 'org.apache.kafka.test.IntegrationTest'
     }
 
-    exclude(testsToExclude)
-
   }
 
   task unitTest(type: Test, dependsOn: compileJava) {
@@ -260,8 +243,7 @@ subprojects {
     useJUnit {
       excludeCategories 'org.apache.kafka.test.IntegrationTest'
     }
-
-    exclude(testsToExclude)
+    
   }
 
   jar {
@@ -788,7 +770,7 @@ project(':clients') {
     testCompile libs.bcpkix
     testCompile libs.junit
     testCompile libs.easymock
-    testCompile libs.powermock
+    testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
     testRuntime libs.slf4jlog4j
@@ -1076,7 +1058,7 @@ project(':connect:transforms') {
 
     testCompile libs.easymock
     testCompile libs.junit
-    testCompile libs.powermock
+    testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
     testRuntime libs.slf4jlog4j
@@ -1114,7 +1096,7 @@ project(':connect:json') {
 
     testCompile libs.easymock
     testCompile libs.junit
-    testCompile libs.powermock
+    testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
     testRuntime libs.slf4jlog4j
@@ -1163,7 +1145,7 @@ project(':connect:runtime') {
     testCompile project(':clients').sourceSets.test.output
     testCompile libs.easymock
     testCompile libs.junit
-    testCompile libs.powermock
+    testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
     testCompile project(":connect:json")
@@ -1216,7 +1198,7 @@ project(':connect:file') {
 
     testCompile libs.easymock
     testCompile libs.junit
-    testCompile libs.powermock
+    testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
     testRuntime libs.slf4jlog4j

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -43,11 +43,12 @@ import org.apache.kafka.connect.util.MockTime;
 import org.apache.kafka.connect.util.ThreadedTest;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.api.easymock.annotation.MockStrict;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -76,15 +77,17 @@ public class WorkerTest extends ThreadedTest {
     private Worker worker;
 
     @Mock
-    private Plugins plugins = PowerMock.createMock(Plugins.class);
+    private Plugins plugins;
     @Mock
-    private PluginClassLoader pluginLoader = PowerMock.createMock(PluginClassLoader.class);
+    private PluginClassLoader pluginLoader;
     @Mock
-    private DelegatingClassLoader delegatingLoader =
-            PowerMock.createMock(DelegatingClassLoader.class);
-    private OffsetBackingStore offsetBackingStore = PowerMock.createMock(OffsetBackingStore.class);
-    private TaskStatus.Listener taskStatusListener = PowerMock.createStrictMock(TaskStatus.Listener.class);
-    private ConnectorStatus.Listener connectorStatusListener = PowerMock.createStrictMock(ConnectorStatus.Listener.class);
+    private DelegatingClassLoader delegatingLoader;
+    @Mock
+    private OffsetBackingStore offsetBackingStore;
+    @MockStrict
+    private TaskStatus.Listener taskStatusListener;
+    @MockStrict
+    private ConnectorStatus.Listener connectorStatusListener;
 
     @Before
     public void setup() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -61,9 +61,8 @@ versions += [
   junit: "4.12",
   lz4: "1.4",
   metrics: "2.2.0",
-  // A few connect tests fail with powermock 1.6.5 due to https://github.com/powermock/powermock/issues/828, which
-  // is easy to workaround. However, WorkerTest also fails and it seems to be for a different reason.
-  powermock: "1.6.4",
+  // PowerMock 1.x doesn't support Java 9, so use PowerMock 2.0.0 beta
+  powermock: "2.0.0-beta.5",
   reflections: "0.9.11",
   rocksDB: "5.3.6",
   scalatest: "3.0.4",
@@ -103,7 +102,7 @@ libs += [
   joptSimple: "net.sf.jopt-simple:jopt-simple:$versions.jopt",
   lz4: "org.lz4:lz4-java:$versions.lz4",
   metrics: "com.yammer.metrics:metrics-core:$versions.metrics",
-  powermock: "org.powermock:powermock-module-junit4:$versions.powermock",
+  powermockJunit4: "org.powermock:powermock-module-junit4:$versions.powermock",
   powermockEasymock: "org.powermock:powermock-api-easymock:$versions.powermock",
   reflections: "org.reflections:reflections:$versions.reflections",
   rocksDBJni: "org.rocksdb:rocksdbjni:$versions.rocksDB",


### PR DESCRIPTION
Also:
1. Fix WorkerTest to use the correct `Mock` annotations. `org.easymock.Mock`
is not supported by PowerMock 2.x.
2. Rename `powermock` to `powermockJunit4` in `dependencies.gradle` for
clarity.