### PR TITLE
KAFKA-5918: Fix minor typos and errors in the Kafka Streams turotial

### DIFF
--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -461,7 +461,7 @@
         source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
                     @Override
                     public Iterable&lt;String&gt; apply(String value) {
-                        return Arrays.asList(value.toLowerCase(Locale.getDefault()));
+                        return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
                     }
                 });
     </pre>
@@ -476,7 +476,7 @@
         source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
                     @Override
                     public Iterable&lt;String&gt; apply(String value) {
-                        return Arrays.asList(value.toLowerCase(Locale.getDefault()));
+                        return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
                     }
                 })
               .groupBy(new KeyValueMapper&lt;String, String, String&gt;() {
@@ -513,7 +513,7 @@
 
     <pre class="brush: java;">
         KStream&lt;String, String&gt; source = builder.stream("streams-plaintext-input");
-        source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault())))
+        source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
               .groupBy((key, value) -> value)
               .count("Counts")
               .to(Serdes.String(), Serdes.Long(), "streams-wordcount-output");
@@ -586,7 +586,7 @@
                 final StreamsBuilder builder = new StreamsBuilder();
 
                 KStream&lt;String, String&gt; source = builder.stream("streams-plaintext-input");
-                source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault())))
+                source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
                       .groupBy((key, value) -> value)
                       .count("Counts")
                       .to(Serdes.String(), Serdes.Long(), "streams-wordcount-output");

--- a/docs/streams/tutorial.html
+++ b/docs/streams/tutorial.html
@@ -186,7 +186,7 @@
     </pre>
 
     <p>
-        As shown above, it illustrate that the constructed topology has two processor nodes, a source node <code>KSTREAM-SOURCE-0000000000</code> and a sink node <code>KSTREAM-SINK-0000000001</code>.
+        As shown above, it illustrates that the constructed topology has two processor nodes, a source node <code>KSTREAM-SOURCE-0000000000</code> and a sink node <code>KSTREAM-SINK-0000000001</code>.
         <code>KSTREAM-SOURCE-0000000000</code> continuously read records from Kafka topic <code>streams-plaintext-input</code> and pipe them to its downstream node <code>KSTREAM-SINK-0000000001</code>;
         <code>KSTREAM-SINK-0000000001</code> will write each of its received record in order to another Kafka topic <code>streams-pipe-output</code>
         (the <code>--&gt;</code> and <code>&lt;--</code> arrows dictates the downstream and upstream processor nodes of this node, i.e. "children" and "parents" within the topology graph).
@@ -320,7 +320,7 @@
     </p>
 
     <pre class="brush: java;">
-        public class Pipe {
+        public class LineSplit {
 
             public static void main(String[] args) throws Exception {
                 Properties props = new Properties();
@@ -405,6 +405,7 @@
         import org.apache.kafka.streams.StreamsBuilder;
         import org.apache.kafka.streams.StreamsConfig;
         import org.apache.kafka.streams.Topology;
+        import org.apache.kafka.streams.kstream.KStream;
 
         import java.util.Arrays;
         import java.util.Properties;
@@ -429,7 +430,7 @@
                 final KafkaStreams streams = new KafkaStreams(topology, props);
                 final CountDownLatch latch = new CountDownLatch(1);
 
-                // ... same as Pipe.java below
+                // ... same as Pipe.java above
             }
         }
     </pre>
@@ -460,7 +461,7 @@
         source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
                     @Override
                     public Iterable&lt;String&gt; apply(String value) {
-                        return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
+                        return Arrays.asList(value.toLowerCase(Locale.getDefault()));
                     }
                 });
     </pre>
@@ -475,7 +476,7 @@
         source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
                     @Override
                     public Iterable&lt;String&gt; apply(String value) {
-                        return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
+                        return Arrays.asList(value.toLowerCase(Locale.getDefault()));
                     }
                 })
               .groupBy(new KeyValueMapper&lt;String, String, String&gt;() {
@@ -512,7 +513,7 @@
 
     <pre class="brush: java;">
         KStream&lt;String, String&gt; source = builder.stream("streams-plaintext-input");
-        source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
+        source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault())))
               .groupBy((key, value) -> value)
               .count("Counts")
               .to(Serdes.String(), Serdes.Long(), "streams-wordcount-output");
@@ -566,6 +567,7 @@
         import org.apache.kafka.streams.StreamsBuilder;
         import org.apache.kafka.streams.StreamsConfig;
         import org.apache.kafka.streams.Topology;
+        import org.apache.kafka.streams.kstream.KStream;
 
         import java.util.Arrays;
         import java.util.Locale;
@@ -584,7 +586,7 @@
                 final StreamsBuilder builder = new StreamsBuilder();
 
                 KStream&lt;String, String&gt; source = builder.stream("streams-plaintext-input");
-                source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+")))
+                source.flatMapValues(value -> Arrays.asList(value.toLowerCase(Locale.getDefault())))
                       .groupBy((key, value) -> value)
                       .count("Counts")
                       .to(Serdes.String(), Serdes.Long(), "streams-wordcount-output");
@@ -593,7 +595,7 @@
                 final KafkaStreams streams = new KafkaStreams(topology, props);
                 final CountDownLatch latch = new CountDownLatch(1);
 
-                // ... same as Pipe.java below
+                // ... same as Pipe.java above
             }
         }
     </pre>


### PR DESCRIPTION
I found several minor issues with the Kafka Streams tutorial:
* Some typos
  * "As shown above, it illustrate that the constructed ..." instead of "As shown above, it illustrate_s_ that the constructed ..."
  * "same as Pipe.java below" instead of "same as Pipe.java _above_"
  * Wrong class name in the `LineSplit` example
* Incorrect imports for the code examples
  * Missing `import org.apache.kafka.streams.kstream.KStream;` in `LineSplit` and `WordCount` example
* Unnecessary (and potentially confusing) split by whitespaces in the `WorkCount` class (the split into words happened already in `LineSplit`)
