### PR TITLE
MINOR: Code cleanup, subject: log statements.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -502,7 +502,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable,
             states.put(entry.getKey(), entry.getValue().state);
         }
 
-        log.debug("Assigning tasks {} to clients {} with number of replicas {}",
+        log.debug("{} Assigning tasks {} to clients {} with number of replicas {}",
                 logPrefix, partitionsForTask.keySet(), states, numStandbyReplicas);
 
         final StickyTaskAssignor<UUID> taskAssignor = new StickyTaskAssignor<>(states, partitionsForTask.keySet());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -963,7 +963,7 @@ public class StreamThread extends Thread implements ThreadDataProvider {
                 streamsMetrics.commitTimeSensor.record(computeLatency() / (double) committed, timerStartedMs);
             }
             if (log.isDebugEnabled()) {
-                log.info("Committed all active tasks {} and standby tasks {} in {}ms",
+                log.debug("Committed all active tasks {} and standby tasks {} in {}ms",
                         taskManager.activeTaskIds(), taskManager.standbyTaskIds(), timerStartedMs - now);
             }
 


### PR DESCRIPTION
I'm doing this in my spare time, so don't let reviewing this PR take away actual work time. This is just me going over the code with the Intellij analyzer and implementing the most easily implementable fixes.

This PR is focused only on seemingly erronous log statements.

1: A log statement that has 4 arguments supplied but only 3 `{}` statements

2: A log statement that checks is debug is enabled, but then logs on `info` level.