### PR TITLE
MINOR: Fix replica_verification_tool.py to handle slight change in output format

### DIFF
--- a/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
+++ b/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
@@ -53,6 +53,7 @@ class ReplicaVerificationToolTest {
     replicaBuffer.verifyCheckSum(line => sb.append(s"$line\n"))
     val output = sb.toString.trim
 
+    // If you change this assertion, you should verify that the replica_verification_tool.py system test still passes
     assertTrue(s"Max lag information should be in output: `$output`",
       output.endsWith(": max lag is 10 for partition a-0 at offset 10 among 3 partitions"))
   }

--- a/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
+++ b/core/src/test/scala/kafka/tools/ReplicaVerificationToolTest.scala
@@ -53,7 +53,7 @@ class ReplicaVerificationToolTest {
     replicaBuffer.verifyCheckSum(line => sb.append(s"$line\n"))
     val output = sb.toString.trim
 
-    // If you change this assertion, you should verify that the replica_verification_tool.py system test still passes
+    // If you change this assertion, you should verify that the replica_verification_test.py system test still passes
     assertTrue(s"Max lag information should be in output: `$output`",
       output.endsWith(": max lag is 10 for partition a-0 at offset 10 among 3 partitions"))
   }

--- a/tests/kafkatest/services/replica_verification_tool.py
+++ b/tests/kafkatest/services/replica_verification_tool.py
@@ -62,7 +62,7 @@ class ReplicaVerificationTool(KafkaPathResolverMixin, BackgroundThreadService):
             topic:          a topic
             partition:      a partition of the topic
         """
-        topic_partition = topic + ',' + str(partition)
+        topic_partition = topic + '-' + str(partition)
         lag = self.partition_lag.get(topic_partition, -1)
         self.logger.debug("Returning lag for {} as {}".format(topic_partition, lag))
 

--- a/tests/kafkatest/services/replica_verification_tool.py
+++ b/tests/kafkatest/services/replica_verification_tool.py
@@ -47,7 +47,7 @@ class ReplicaVerificationTool(KafkaPathResolverMixin, BackgroundThreadService):
         for line in node.account.ssh_capture(cmd):
             self.logger.debug("Parsing line:{}".format(line))
 
-            parsed = re.search('.*max lag is (.+?) for partition \[(.+?)\] at', line)
+            parsed = re.search('.*max lag is (.+?) for partition ([a-zA-Z0-9._-]+-[0-9]+) at', line)
             if parsed:
                 lag = int(parsed.group(1))
                 topic_partition = parsed.group(2)
@@ -64,7 +64,7 @@ class ReplicaVerificationTool(KafkaPathResolverMixin, BackgroundThreadService):
         """
         topic_partition = topic + ',' + str(partition)
         lag = self.partition_lag.get(topic_partition, -1)
-        self.logger.debug("Retuning lag for {} as {}".format(topic_partition, lag))
+        self.logger.debug("Returning lag for {} as {}".format(topic_partition, lag))
 
         return lag
 


### PR DESCRIPTION
The string representation of TopicPartition was changed to be
{topic}-{partitition} consistently in the following commit:

f6f56a645bb1c5ec6810c024ba517e43bf77056c