### PR TITLE
[WIP input needed] MINOR: Further code cleanup involving log statements

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -355,7 +355,7 @@ public class StickyAssignor extends AbstractPartitionAssignor {
                     String otherConsumer = allPartitions.get(topicPartition);
                     int otherConsumerPartitionCount = currentAssignment.get(otherConsumer).size();
                     if (consumerPartitionCount < otherConsumerPartitionCount) {
-                        log.debug(topicPartition + " can be moved from consumer " + otherConsumer + " to consumer " + consumer + " for a more balanced assignment.");
+                        log.debug("{} can be moved from consumer {} to consumer {} for a more balanced assignment.", topicPartition, otherConsumer, consumer);
                         return false;
                     }
                 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -558,7 +558,7 @@ public abstract class AbstractCoordinator implements Closeable {
                     future.raise(error);
                 } else if (error == Errors.COORDINATOR_NOT_AVAILABLE
                         || error == Errors.NOT_COORDINATOR) {
-                    log.debug("SyncGroup failed:", error.message());
+                    log.debug("SyncGroup failed: {}", error.message());
                     coordinatorDead();
                     future.raise(error);
                 } else {

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -426,7 +426,7 @@ public class Sender implements Runnable {
                         transactionManager.setProducerIdAndEpoch(producerIdAndEpoch);
                         return;
                     } else if (error.exception() instanceof RetriableException) {
-                        log.debug("Retriable error from InitProducerId response", error.message());
+                        log.debug("Retriable error from InitProducerId response {}", error.message());
                     } else {
                         transactionManager.transitionToFatalError(error.exception());
                         break;
@@ -439,6 +439,7 @@ public class Sender implements Runnable {
                 transactionManager.transitionToFatalError(e);
                 break;
             } catch (IOException e) {
+                // TODO: Exception being passed into the placeholder???
                 log.debug("Broker {} disconnected while awaiting InitProducerId response", e);
             }
             log.trace("Retry InitProducerIdRequest in {}ms.", retryBackoffMs);

--- a/clients/src/main/java/org/apache/kafka/common/security/JaasContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasContext.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 public class JaasContext {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JaasUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JaasContext.class);
 
     private static final String GLOBAL_CONTEXT_NAME_SERVER = "KafkaServer";
     private static final String GLOBAL_CONTEXT_NAME_CLIENT = "KafkaClient";

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -219,8 +219,8 @@ public class KerberosLogin extends AbstractLogin {
                                     }
                                 } else {
                                     log.warn("[Principal={}]: Could not renew TGT due to problem running shell command: '{} {}'; " +
-                                            "exception was: %s. Exiting refresh thread.", 
-                                            principal, kinitCmd, kinitArgs, e, e);
+                                            "exception was: %s. Exiting refresh thread.",
+                                            principal, kinitCmd, kinitArgs, e);
                                     return;
                                 }
                             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -432,6 +432,7 @@ public class Worker {
             return new WorkerSinkTask(id, (SinkTask) task, statusListener, initialState, config, keyConverter,
                     valueConverter, transformationChain, loader, time);
         } else {
+            // TODO: Does this need a placeholder or is this code correct?
             log.error("Tasks must be a subclass of either SourceTask or SinkTask", task);
             throw new ConnectException("Tasks must be a subclass of either SourceTask or SinkTask");
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -164,7 +164,7 @@ class WorkerSourceTask extends WorkerTask {
                 }
                 if (toSend == null)
                     continue;
-                log.debug("{} About to send " + toSend.size() + " records to Kafka", this);
+                log.debug("{} About to send {} records to Kafka", this, toSend.size());
                 if (!sendRecords())
                     stopRequestedLatch.await(SEND_FAILED_BACKOFF_MS, TimeUnit.MILLISECONDS);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -358,7 +358,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
             Struct connectConfig = new Struct(TASK_CONFIGURATION_V0);
             connectConfig.put("properties", taskConfig);
             byte[] serializedConfig = converter.fromConnectData(topic, TASK_CONFIGURATION_V0, connectConfig);
-            log.debug("Writing configuration for task " + index + " configuration: " + taskConfig);
+            log.debug("Writing configuration for task {} configuration: {}", index, taskConfig);
             ConnectorTaskId connectorTaskId = new ConnectorTaskId(connector, index);
             configLog.send(TASK_KEY(connectorTaskId), serializedConfig);
             index++;
@@ -375,7 +375,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
             Struct connectConfig = new Struct(CONNECTOR_TASKS_COMMIT_V0);
             connectConfig.put("tasks", taskCount);
             byte[] serializedConfig = converter.fromConnectData(topic, CONNECTOR_TASKS_COMMIT_V0, connectConfig);
-            log.debug("Writing commit for connector " + connector + " with " + taskCount + " tasks.");
+            log.debug("Writing commit for connector {} with {} tasks.", connector, taskCount);
             configLog.send(COMMIT_TASKS_KEY(connector), serializedConfig);
 
             // Read to end to ensure all the commit messages have been written
@@ -525,7 +525,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                                     newConnectorConfig == null ? null : newConnectorConfig.getClass());
                             return;
                         }
-                        log.debug("Updating configuration for connector " + connectorName + " configuration: " + newConnectorConfig);
+                        log.debug("Updating configuration for connector {} configuration: {}", connectorName, newConnectorConfig);
                         connectorConfigs.put(connectorName, (Map<String, String>) newConnectorConfig);
 
                         // Set the initial state of the connector to STARTED, which ensures that any connectors
@@ -563,7 +563,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                         deferred = new HashMap<>();
                         deferredTaskUpdates.put(taskId.connector(), deferred);
                     }
-                    log.debug("Storing new config for task " + taskId + " this will wait for a commit message before the new config will take effect. New config: " + newTaskConfig);
+                    log.debug("Storing new config for task {} this will wait for a commit message before the new config will take effect. New config: {}", taskId, newTaskConfig);
                     deferred.put(taskId, (Map<String, String>) newTaskConfig);
                 }
             } else if (record.key().startsWith(COMMIT_TASKS_PREFIX)) {
@@ -607,7 +607,7 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
                         // historical data, in which case we would not have applied any updates yet and there will be no
                         // task config data already committed for the connector, so we shouldn't have to clear any data
                         // out. All we need to do is add the flag marking it inconsistent.
-                        log.debug("We have an incomplete set of task configs for connector " + connectorName + " probably due to compaction. So we are not doing anything with the new configuration.");
+                        log.debug("We have an incomplete set of task configs for connector {} probably due to compaction. So we are not doing anything with the new configuration.", connectorName);
                         inconsistent.add(connectorName);
                     } else {
                         if (deferred != null) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -154,7 +154,7 @@ public final class Agent {
                     }
                     for (Fault fault: toStart) {
                         try {
-                            log.debug("Activating fault " + fault);
+                            log.debug("Activating fault {}", fault);
                             fault.activate(now, platform);
                             started.add(fault);
                         } catch (Throwable e) {
@@ -164,7 +164,7 @@ public final class Agent {
                     }
                     for (Fault fault: toEnd) {
                         try {
-                            log.debug("Deactivating fault " + fault);
+                            log.debug("Deactivating fault {}", fault);
                             fault.deactivate(now, platform);
                         } catch (Throwable e) {
                             log.error("Error deactivating fault " + fault.id(), e);


### PR DESCRIPTION
First of all, terribly sorry for not having included this in the previous PR, that one only focused on the streams folder, this one is on the entire project. I realized my mistake too late.

I do need some input for this one, I left 2 TODO statements in the code that I'll point out.

This commit largely replaces string concatenation with placeholders in debug and trace log statements. Other things I'll point out with comments.

For historical purposes, on why replacing string concatenation with placeholders: When running an application on a certain log level, one wants to avoid log statements of more detailed levels actually being evaluated, both due to potential size issues and time spent doing it, since they're not actually going to be printed. If the message being passed to the log method utilizes string concatenation directly in the passed argument, that means the string will be fully evaluated before being passed along to the log method, to then potentially not even be shown, if the application is running on a different log level.

Using placeholders prevents this from happening.

EDIT: Ran the tests: 
BUILD SUCCESSFUL in 30m 59s
90 actionable tasks: 90 executed