### PR TITLE
KAFKA-5914: add message format version and message max bytes to metadata response

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/MetadataRequest.java
@@ -62,9 +62,11 @@ public class MetadataRequest extends AbstractRequest {
     /* The v5 metadata request is the same as v4. An additional field for offline_replicas has been added to the v5 metadata response */
     private static final Schema METADATA_REQUEST_V5 = METADATA_REQUEST_V4;
 
+    private static final Schema METADATA_REQUEST_V6 = METADATA_REQUEST_V5;
+
     public static Schema[] schemaVersions() {
         return new Schema[] {METADATA_REQUEST_V0, METADATA_REQUEST_V1, METADATA_REQUEST_V2, METADATA_REQUEST_V3,
-            METADATA_REQUEST_V4, METADATA_REQUEST_V5};
+            METADATA_REQUEST_V4, METADATA_REQUEST_V5, METADATA_REQUEST_V6};
     }
 
     public static class Builder extends AbstractRequest.Builder<MetadataRequest> {
@@ -158,7 +160,9 @@ public class MetadataRequest extends AbstractRequest {
 
         if (topics != null) {
             for (String topic : topics)
-                topicMetadatas.add(new MetadataResponse.TopicMetadata(error, topic, false, partitions));
+                topicMetadatas.add(new MetadataResponse.TopicMetadata(error, topic, false,
+                        MetadataResponse.UNKNOWN_TOPIC_MESSAGE_FORMAT_VERSION,
+                        MetadataResponse.UNKNOWN_TOPIC_MESSAGE_MAX_BYTES, partitions));
         }
 
         short versionId = version();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -2045,7 +2045,8 @@ public class FetcherTest {
             }
         }
 
-        MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(error, topic, false, partitionsMetadata);
+        MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(error, topic, false,
+                MetadataResponse.UNKNOWN_TOPIC_MESSAGE_FORMAT_VERSION, MetadataResponse.UNKNOWN_TOPIC_MESSAGE_MAX_BYTES, partitionsMetadata);
         return new MetadataResponse(cluster.nodes(), null, MetadataResponse.NO_CONTROLLER_ID, Arrays.asList(topicMetadata));
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -121,6 +121,7 @@ public class RequestResponseTest {
         checkResponse(createMetadataResponse(), 3);
         checkErrorResponse(createMetadataRequest(3, singletonList("topic1")), new UnknownServerException());
         checkResponse(createMetadataResponse(), 4);
+        checkResponse(createMetadataResponse(), 6);
         checkErrorResponse(createMetadataRequest(4, singletonList("topic1")), new UnknownServerException());
         checkRequest(createOffsetCommitRequest(2));
         checkErrorResponse(createOffsetCommitRequest(2), new UnknownServerException());
@@ -695,8 +696,9 @@ public class RequestResponseTest {
 
         List<MetadataResponse.TopicMetadata> allTopicMetadata = new ArrayList<>();
         allTopicMetadata.add(new MetadataResponse.TopicMetadata(Errors.NONE, "__consumer_offsets", true,
-                asList(new MetadataResponse.PartitionMetadata(Errors.NONE, 1, node, replicas, isr, offlineReplicas))));
+                RecordBatch.MAGIC_VALUE_V2, 16384, asList(new MetadataResponse.PartitionMetadata(Errors.NONE, 1, node, replicas, isr, offlineReplicas))));
         allTopicMetadata.add(new MetadataResponse.TopicMetadata(Errors.LEADER_NOT_AVAILABLE, "topic2", false,
+                MetadataResponse.UNKNOWN_TOPIC_MESSAGE_FORMAT_VERSION, MetadataResponse.UNKNOWN_TOPIC_MESSAGE_MAX_BYTES,
                 Collections.<MetadataResponse.PartitionMetadata>emptyList()));
 
         return new MetadataResponse(asList(node), null, MetadataResponse.NO_CONTROLLER_ID, allTopicMetadata);

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -587,7 +587,6 @@ class LogManager(logDirs: Array[File],
               config.originals.asScala.mkString(", ")))
           // Remove the preferred log dir since it has already been satisfied
           preferredLogDirs.remove(topicPartition)
-
           log
         } catch {
           case e: IOException =>

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -222,7 +222,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         logManager = LogManager(config, initialOfflineDirs, zkUtils, brokerState, kafkaScheduler, time, brokerTopicStats, logDirFailureChannel)
         logManager.startup()
 
-        metadataCache = new MetadataCache(config.brokerId)
+        metadataCache = new MetadataCache(config.brokerId, logManager.topicConfigs)
         credentialProvider = new CredentialProvider(config.saslEnabledMechanisms)
 
         socketServer = new SocketServer(config, metrics, time, credentialProvider)
@@ -266,7 +266,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         Mx4jLoader.maybeLoad()
 
         /* start dynamic config manager */
-        dynamicConfigHandlers = Map[String, ConfigHandler](ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers),
+        dynamicConfigHandlers = Map[String, ConfigHandler](ConfigType.Topic -> new TopicConfigHandler(logManager, config, quotaManagers, metadataCache),
                                                            ConfigType.Client -> new ClientIdConfigHandler(quotaManagers),
                                                            ConfigType.User -> new UserConfigHandler(quotaManagers, credentialProvider),
                                                            ConfigType.Broker -> new BrokerConfigHandler(config, quotaManagers))

--- a/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DynamicConfigChangeTest.scala
@@ -230,7 +230,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @Test
   def shouldParseReplicationQuotaProperties(): Unit = {
-    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null)
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null, null)
     val props: Properties = new Properties()
 
     //Given
@@ -243,7 +243,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @Test
   def shouldParseWildcardReplicationQuotaProperties(): Unit = {
-    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null)
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null, null)
     val props: Properties = new Properties()
 
     //Given
@@ -258,7 +258,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @Test
   def shouldParseReplicationQuotaReset(): Unit = {
-    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null)
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null, null)
     val props: Properties = new Properties()
 
     //Given
@@ -273,7 +273,7 @@ class DynamicConfigChangeTest extends KafkaServerTestHarness {
 
   @Test
   def shouldParseRegardlessOfWhitespaceAroundValues() {
-    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null)
+    val configHandler: TopicConfigHandler = new TopicConfigHandler(null, null, null, null)
     assertEquals(AllReplicas, parse(configHandler, "* "))
     assertEquals(Seq(), parse(configHandler, " "))
     assertEquals(Seq(6), parse(configHandler, "6:102"))

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -64,7 +64,7 @@ class HighwatermarkPersistenceTest {
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, zkUtils, scheduler,
       logManagers.head, new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time).follower,
-      new BrokerTopicStats, new MetadataCache(configs.head.brokerId), logDirFailureChannels.head)
+      new BrokerTopicStats, new MetadataCache(configs.head.brokerId, logManagers.head.topicConfigs), logDirFailureChannels.head)
     replicaManager.startup()
     try {
       replicaManager.checkpointHighWatermarks()
@@ -109,7 +109,7 @@ class HighwatermarkPersistenceTest {
     // create replica manager
     val replicaManager = new ReplicaManager(configs.head, metrics, time, zkUtils,
       scheduler, logManagers.head, new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time).follower,
-      new BrokerTopicStats, new MetadataCache(configs.head.brokerId), logDirFailureChannels.head)
+      new BrokerTopicStats, new MetadataCache(configs.head.brokerId, logManagers.head.topicConfigs), logDirFailureChannels.head)
     replicaManager.startup()
     try {
       replicaManager.checkpointHighWatermarks()

--- a/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ISRExpirationTest.scala
@@ -21,7 +21,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.cluster.{Partition, Replica}
-import kafka.log.Log
+import kafka.log.{Log, LogConfig}
 import kafka.server.epoch.LeaderEpochCache
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
@@ -56,10 +56,11 @@ class IsrExpirationTest {
   def setUp() {
     val logManager = EasyMock.createMock(classOf[kafka.log.LogManager])
     EasyMock.expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
+    EasyMock.expect(logManager.topicConfigs).andReturn(Map.empty[String, LogConfig]).anyTimes()
     EasyMock.replay(logManager)
 
     replicaManager = new ReplicaManager(configs.head, metrics, time, null, null, logManager, new AtomicBoolean(false),
-      QuotaFactory.instantiate(configs.head, metrics, time).follower, new BrokerTopicStats, new MetadataCache(configs.head.brokerId),
+      QuotaFactory.instantiate(configs.head, metrics, time).follower, new BrokerTopicStats, new MetadataCache(configs.head.brokerId, logManager.topicConfigs),
       new LogDirFailureChannel(configs.head.logDirs.size))
   }
 

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -20,6 +20,7 @@ import java.util
 import util.Arrays.asList
 
 import kafka.common.BrokerEndPointNotAvailableException
+import kafka.log.LogConfig
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.protocol.{ApiKeys, Errors, SecurityProtocol}
@@ -29,13 +30,14 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 class MetadataCacheTest {
 
   @Test
   def getTopicMetadataNonExistingTopics() {
     val topic = "topic"
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, Map.empty[String, LogConfig])
     val topicMetadata = cache.getTopicMetadata(Set(topic), ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))
     assertTrue(topicMetadata.isEmpty)
   }
@@ -45,8 +47,7 @@ class MetadataCacheTest {
     val topic0 = "topic-0"
     val topic1 = "topic-1"
 
-
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, createLogConfigs(Seq(topic0, topic1), "0.11.0", 110))
 
     val zkVersion = 3
     val controllerId = 2
@@ -84,6 +85,8 @@ class MetadataCacheTest {
         val topicMetadata = topicMetadatas.head
         assertEquals(Errors.NONE, topicMetadata.error)
         assertEquals(topic, topicMetadata.topic)
+        assertEquals(2, topicMetadata.messageFormatVersion())
+        assertEquals(110, topicMetadata.messageMaxBytes())
 
         val topicPartitionStates = partitionStates.filter { case (tp, _) => tp.topic ==  topic }
         val partitionMetadatas = topicMetadata.partitionMetadata.asScala.sortBy(_.partition)
@@ -113,7 +116,7 @@ class MetadataCacheTest {
   def getTopicMetadataPartitionLeaderNotAvailable() {
     val topic = "topic"
 
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, createLogConfigs(Seq(topic)))
 
     val zkVersion = 3
     val controllerId = 2
@@ -153,7 +156,7 @@ class MetadataCacheTest {
   def getTopicMetadataReplicaNotAvailable() {
     val topic = "topic"
 
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, createLogConfigs(Seq(topic)))
 
     val zkVersion = 3
     val controllerId = 2
@@ -213,7 +216,7 @@ class MetadataCacheTest {
   def getTopicMetadataIsrNotAvailable() {
     val topic = "topic"
 
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, createLogConfigs(Seq(topic)))
 
     val zkVersion = 3
     val controllerId = 2
@@ -272,7 +275,7 @@ class MetadataCacheTest {
   @Test
   def getTopicMetadataWithNonSupportedSecurityProtocol() {
     val topic = "topic"
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, createLogConfigs(Seq(topic)))
     val securityProtocol = SecurityProtocol.PLAINTEXT
     val brokers = Set(new Broker(0,
       Seq(new EndPoint("foo", 9092, securityProtocol, ListenerName.forSecurityProtocol(securityProtocol))).asJava, ""))
@@ -301,7 +304,7 @@ class MetadataCacheTest {
   @Test
   def getAliveBrokersShouldNotBeMutatedByUpdateCache() {
     val topic = "topic"
-    val cache = new MetadataCache(1)
+    val cache = new MetadataCache(1, createLogConfigs(Seq(topic)))
 
     def updateCache(brokerIds: Set[Int]) {
       val brokers = brokerIds.map { brokerId =>
@@ -330,4 +333,59 @@ class MetadataCacheTest {
     assertEquals(initialBrokerIds, aliveBrokersFromCache.map(_.id).toSet)
   }
 
+  @Test
+  def testPropagationOfTopicConfigs(): Unit = {
+    val existingTopic : String = "existing"
+    val newTopic = "newtopic"
+    val zkVersion = 3
+    val controllerId = 2
+    val controllerEpoch = 1
+
+    def endPoints(brokerId: Int): Seq[EndPoint] = {
+      val host = s"foo-$brokerId"
+      Seq(
+        new EndPoint(host, 9092, SecurityProtocol.PLAINTEXT, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))
+      )
+    }
+
+    val brokers = (0 to 4).map { brokerId =>
+      new Broker(brokerId, endPoints(brokerId).asJava, "rack1")
+    }.toSet
+
+    val partitionStates = Map(
+      new TopicPartition(newTopic, 0) -> new UpdateMetadataRequest.PartitionState(controllerEpoch, 0, 0, asList(0, 1, 3), zkVersion, asList(0, 1, 3), asList()),
+      new TopicPartition(existingTopic, 0) -> new UpdateMetadataRequest.PartitionState(controllerEpoch, 0, 0, asList(0, 1, 3), zkVersion, asList(0, 1, 3), asList()))
+
+    val version = ApiKeys.UPDATE_METADATA_KEY.latestVersion
+    val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
+      partitionStates.asJava, brokers.asJava).build()
+
+    val cache = new MetadataCache(1, createLogConfigs(Seq(existingTopic), "0.10.2"))
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+    cache.updateCache(15, updateMetadataRequest)
+
+    val retrievedMetadata = cache.getTopicMetadata(Set(existingTopic), listenerName, true)
+    assertEquals(1, retrievedMetadata.size)
+    assertEquals(1, retrievedMetadata.head.messageFormatVersion())
+
+    val updatedConfig = createLogConfigs(Seq(existingTopic), "0.11.0")
+    cache.updateTopicMetadata(existingTopic, updatedConfig(existingTopic))
+
+    val newConfig = createLogConfigs(Seq(newTopic), "0.9.0")
+    cache.updateTopicMetadata(newTopic, newConfig(newTopic))
+
+    val updatedMetadata = cache.getTopicMetadata(Set(existingTopic, newTopic), listenerName)
+    assertEquals(2, updatedMetadata.size)
+    assertEquals(2, updatedMetadata.head.messageFormatVersion())
+    assertEquals(0, updatedMetadata.tail.head.messageFormatVersion())
+  }
+
+  private def createLogConfigs(topics: Seq[String], messageFormatVersion: String = "0.11.0", messageMaxBytes: Int = 1000000) : Map[String, LogConfig] = {
+    val configs = mutable.Map[String, Object]()
+    configs.put(LogConfig.MessageFormatVersionProp, messageFormatVersion)
+    configs.put(LogConfig.MaxMessageBytesProp, messageMaxBytes.toString)
+    topics.map { case topic =>
+      (topic, LogConfig(configs.asJava))
+    }.toMap
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -356,7 +356,7 @@ class MetadataCacheTest {
       new TopicPartition(newTopic, 0) -> new UpdateMetadataRequest.PartitionState(controllerEpoch, 0, 0, asList(0, 1, 3), zkVersion, asList(0, 1, 3), asList()),
       new TopicPartition(existingTopic, 0) -> new UpdateMetadataRequest.PartitionState(controllerEpoch, 0, 0, asList(0, 1, 3), zkVersion, asList(0, 1, 3), asList()))
 
-    val version = ApiKeys.UPDATE_METADATA_KEY.latestVersion
+    val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
 

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -21,7 +21,7 @@ import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.cluster.Replica
-import kafka.log.Log
+import kafka.log.{Log, LogConfig}
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.metrics.Metrics
@@ -180,11 +180,12 @@ class ReplicaManagerQuotasTest {
     //Return the same log for each partition as it doesn't matter
     expect(logManager.getLog(anyObject())).andReturn(Some(log)).anyTimes()
     expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
+    expect(logManager.topicConfigs).andReturn(Map.empty[String, LogConfig]).anyTimes()
     replay(logManager)
 
     replicaManager = new ReplicaManager(configs.head, metrics, time, zkUtils, scheduler, logManager,
       new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time).follower,
-      new BrokerTopicStats, new MetadataCache(configs.head.brokerId), new LogDirFailureChannel(configs.head.logDirs.size))
+      new BrokerTopicStats, new MetadataCache(configs.head.brokerId, logManager.topicConfigs), new LogDirFailureChannel(configs.head.logDirs.size))
 
     //create the two replicas
     for ((p, _) <- fetchInfo) {

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -67,7 +67,7 @@ class ReplicaManagerTest {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)).toArray)
     val rm = new ReplicaManager(config, metrics, time, zkUtils, new MockScheduler(time), mockLogMgr,
       new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time).follower, new BrokerTopicStats,
-      new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size))
+      new MetadataCache(config.brokerId, mockLogMgr.topicConfigs), new LogDirFailureChannel(config.logDirs.size))
     try {
       val partition = rm.getOrCreatePartition(new TopicPartition(topic, 1))
       partition.getOrCreateReplica(1)
@@ -86,7 +86,7 @@ class ReplicaManagerTest {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)).toArray)
     val rm = new ReplicaManager(config, metrics, time, zkUtils, new MockScheduler(time), mockLogMgr,
       new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time).follower, new BrokerTopicStats,
-      new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size))
+      new MetadataCache(config.brokerId, mockLogMgr.topicConfigs), new LogDirFailureChannel(config.logDirs.size))
     try {
       val partition = rm.getOrCreatePartition(new TopicPartition(topic, 1))
       partition.getOrCreateReplica(1)
@@ -104,7 +104,7 @@ class ReplicaManagerTest {
     val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)).toArray)
     val rm = new ReplicaManager(config, metrics, time, zkUtils, new MockScheduler(time), mockLogMgr,
       new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time).follower, new BrokerTopicStats,
-      new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size), Option(this.getClass.getName))
+      new MetadataCache(config.brokerId, mockLogMgr.topicConfigs), new LogDirFailureChannel(config.logDirs.size), Option(this.getClass.getName))
     try {
       def callback(responseStatus: Map[TopicPartition, PartitionResponse]) = {
         assert(responseStatus.values.head.error == Errors.INVALID_REQUIRED_ACKS)

--- a/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/SimpleFetchTest.scala
@@ -21,7 +21,7 @@ import java.io.File
 import kafka.api._
 import kafka.utils._
 import kafka.cluster.Replica
-import kafka.log.Log
+import kafka.log.{Log, LogConfig}
 import kafka.server.QuotaFactory.UnboundedQuota
 import org.apache.kafka.common.metrics.Metrics
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
@@ -108,12 +108,13 @@ class SimpleFetchTest {
     val logManager = EasyMock.createMock(classOf[kafka.log.LogManager])
     EasyMock.expect(logManager.getLog(topicPartition)).andReturn(Some(log)).anyTimes()
     EasyMock.expect(logManager.liveLogDirs).andReturn(Array.empty[File]).anyTimes()
+    EasyMock.expect(logManager.topicConfigs).andReturn(Map.empty[String, LogConfig]).anyTimes()
     EasyMock.replay(logManager)
 
     // create the replica manager
     replicaManager = new ReplicaManager(configs.head, metrics, time, zkUtils, scheduler, logManager,
       new AtomicBoolean(false), QuotaFactory.instantiate(configs.head, metrics, time).follower, new BrokerTopicStats,
-      new MetadataCache(configs.head.brokerId), new LogDirFailureChannel(configs.head.logDirs.size))
+      new MetadataCache(configs.head.brokerId, logManager.topicConfigs), new LogDirFailureChannel(configs.head.logDirs.size))
 
     // add the partition with two replicas, both in ISR
     val partition = replicaManager.getOrCreatePartition(new TopicPartition(topic, partitionId))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -837,8 +837,8 @@ object TestUtils extends Logging {
         return
       } catch {
         case e: AssertionError =>
-          val ellapsed = System.currentTimeMillis - startTime
-          if(ellapsed > maxWaitMs) {
+          val elapsed = System.currentTimeMillis - startTime
+          if(elapsed > maxWaitMs) {
             throw e
           } else {
             info("Attempt failed, sleeping for " + wait + ", and then retrying.")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopicManagerTest.java
@@ -134,7 +134,9 @@ public class InternalTopicManagerTest {
         public MetadataResponse fetchMetadata() {
             Node node = new Node(1, "host1", 1001);
             MetadataResponse.PartitionMetadata partitionMetadata = new MetadataResponse.PartitionMetadata(Errors.NONE, 1, node, new ArrayList<Node>(), new ArrayList<Node>(), new ArrayList<Node>());
-            MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(Errors.NONE, topic, true, Collections.singletonList(partitionMetadata));
+            MetadataResponse.TopicMetadata topicMetadata = new MetadataResponse.TopicMetadata(Errors.NONE, topic, true,
+                    MetadataResponse.UNKNOWN_TOPIC_MESSAGE_FORMAT_VERSION, MetadataResponse.UNKNOWN_TOPIC_MESSAGE_MAX_BYTES,
+                    Collections.singletonList(partitionMetadata));
             MetadataResponse response = new MetadataResponse(Collections.<Node>singletonList(node), null, MetadataResponse.NO_CONTROLLER_ID,
                 Collections.singletonList(topicMetadata));
             return response;


### PR DESCRIPTION
Updated the `TopicResponse` part of the `MetadataResponse` to include the message format version and the message max bytes.

One problem here is that we use the `TopicConfigHandler` to listen for topic changes. However this is not invoked for topic _creates_ since the change notification path is not updated during creates. I am not sure what the right solution is here. Intuitively, we should update the the change notification path for topic creates, but not sure if that has compatibility (or other) implications.

TODO:
1. Add a more complete integration test where the client sends a real `MetadataRequest` and receives the proper `MetadataResponse`.
2. Update the code to pull the global topic config during startup. The present patch only contains configs for the topics present on each broker.
3. Update `AdminUtils.createTopic` to update the change notification path so that each broker gets notified of topic creations and can update its topic config cache.