### PR TITLE
KAFKA-4320: Clarify the log compaction config property per-topic and per-broker

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -524,8 +524,9 @@
 
     The log cleaner is enabled by default. This will start the pool of cleaner threads. 
     To enable log cleaning on a particular topic you can add the log-specific property
+    <pre class="brush: text;">  cleanup.policy=compact</pre>
+    This can be done either at topic creation time or using the alter topic command. To enable log cleaning as default policy you can add the log-specific property to the broker configuration:
     <pre class="brush: text;">  log.cleanup.policy=compact</pre>
-    This can be done either at topic creation time or using the alter topic command.
     <p>
     The log cleaner can be configured to retain a minimum amount of the uncompacted "head" of the log. This is enabled by setting the compaction time lag.
     <pre class="brush: text;">  log.cleaner.min.compaction.lag.ms</pre>


### PR DESCRIPTION
The per-topic config property is different from the per-broker. This PR makes it a bit more clear.