### PR TITLE
MINOR: Fix unresolvable address in `testUnresolvableConnectString`

### DIFF
--- a/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ZookeeperClientTest.scala
@@ -41,7 +41,7 @@ class ZookeeperClientTest extends ZooKeeperTestHarness {
 
   @Test(expected = classOf[UnknownHostException])
   def testUnresolvableConnectString(): Unit = {
-    new ZookeeperClient("-1", -1, -1, null)
+    new ZookeeperClient("some.invalid.hostname.foo.bar.local", -1, -1, null)
   }
 
   @Test(expected = classOf[ZookeeperClientTimeoutException])


### PR DESCRIPTION
Before this change, the test always failed on my MacBook Pro.