### PR TITLE
[MINOR] Added equals() method to Stamped

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/PunctuationSchedule.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/PunctuationSchedule.java
@@ -85,4 +85,40 @@ public class PunctuationSchedule extends Stamped<ProcessorNode> {
             schedule.markCancelled();
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        PunctuationSchedule that = (PunctuationSchedule) o;
+
+        if (interval != that.interval) {
+            return false;
+        }
+        if (isCancelled != that.isCancelled) {
+            return false;
+        }
+        if (punctuator != null ? !punctuator.equals(that.punctuator) : that.punctuator != null) {
+            return false;
+        }
+        return cancellable != null ? cancellable.equals(that.cancellable) : that.cancellable == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (int) (interval ^ (interval >>> 32));
+        result = 31 * result + (punctuator != null ? punctuator.hashCode() : 0);
+        result = 31 * result + (isCancelled ? 1 : 0);
+        result = 31 * result + (cancellable != null ? cancellable.hashCode() : 0);
+        return result;
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/Stamped.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/Stamped.java
@@ -34,4 +34,31 @@ public class Stamped<V> implements Comparable {
         else if (timestamp > otherTimestamp) return 1;
         return 0;
     }
+
+    /*
+     * public classes implementing Comparable should always implement both compareTo() and equals().
+     * This is because an end-user can at some point add objects of that class to java.util.SortedSet.
+     * If the compareTo() and equals() implementations are not consistent, that would violate the contract of java.util.Set, which is defined in terms of equals().
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Stamped<?> stamped = (Stamped<?>) o;
+
+        if (timestamp != stamped.timestamp) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (timestamp ^ (timestamp >>> 32));
+    }
 }


### PR DESCRIPTION
Please don't let analyzing this PR take away from actual working time. I did this in my spare time, it's not intended to take away from your working hours. It may well be that this is a non-issue.

As the title states: I added equals() method to Stamped.java because a class that implements Comparable should always have this.

This was pointed out to me by Intellij's code analysis, which warned that classes implementing Comparable should always implement both compareTo() and equals(). This is because an end-user can at some point add objects of that class to java.util.SortedSet. If the compareTo() and equals() implementations are not consistent, that would violate the contract of java.util.Set, which is defined in terms of equals().

findBugs also complained about PunctuationScheduler, a subclass of Stamped, nothing having equals, so I also implemented that.

The equals() in Stamped.java is written to be consistent with how the already-existing compareTo() works in that class. The hashCode() is autogenerated, with only the timestamp field, as that is the only one used by compareTo() and equals().

findBugs complained about PunctuationSchedule.java, a subclass of Stamped.java, also needing these methods if Stamped.java had them. So I had equals() and hashCode() auto-generated for them.

./gradlew test ran fine.