### PR TITLE
KAFKA-4950: Fix ConcurrentModificationException on assigned-partitions metric

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -942,7 +942,8 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
             Measurable numParts =
                 new Measurable() {
                     public double measure(MetricConfig config, long now) {
-                        return subscriptions.assignedPartitions().size();
+                        // Get the number of assigned partitions in a thread safe manner
+                        return subscriptions.assignedPartitionsSize();
                     }
                 };
             metrics.addMetric(metrics.metricName("assigned-partitions",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -943,7 +943,7 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                 new Measurable() {
                     public double measure(MetricConfig config, long now) {
                         // Get the number of assigned partitions in a thread safe manner
-                        return subscriptions.assignedPartitionsSize();
+                        return subscriptions.numAssignedPartitions();
                     }
                 };
             metrics.addMetric(metrics.metricName("assigned-partitions",

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -71,7 +71,7 @@ public class SubscriptionState {
     private final Set<String> groupSubscription;
 
     /* the partitions that are currently assigned, note that the order of partition matters (see FetchBuilder for more details) */
-    private final Assignment<TopicPartitionState> assignment;
+    private final PartitionStates<TopicPartitionState> assignment;
 
     /* Default offset reset strategy */
     private final OffsetResetStrategy defaultResetStrategy;
@@ -85,7 +85,7 @@ public class SubscriptionState {
     public SubscriptionState(OffsetResetStrategy defaultResetStrategy) {
         this.defaultResetStrategy = defaultResetStrategy;
         this.subscription = Collections.emptySet();
-        this.assignment = new Assignment<>();
+        this.assignment = new PartitionStates<>();
         this.groupSubscription = new HashSet<>();
         this.subscribedPattern = null;
         this.subscriptionType = SubscriptionType.NONE;
@@ -539,60 +539,4 @@ public class SubscriptionState {
         void onAssignment(Set<TopicPartition> assignment);
     }
 
-
-    /**
-     * Wrapper to manipulate assignment while exporting the number of partitions in a thread safe manner.
-     */
-    private static class Assignment<S> {
-        /* the partitions that are currently assigned, note that the order of partition matters (see FetchBuilder for more details) */
-        private final PartitionStates<S> assignment;
-
-        /* the number of partitions that are currently assigned available in a thread safe manner */
-        private volatile int size;
-
-        private Assignment() {
-            this.assignment = new PartitionStates<>();
-            this.size = 0;
-        }
-
-        private void moveToEnd(TopicPartition topicPartition) {
-            assignment.moveToEnd(topicPartition);
-        }
-
-        /**
-         * Returns the partitions in random order.
-         */
-        private Set<TopicPartition> partitionSet() {
-            return assignment.partitionSet();
-        }
-
-        private boolean contains(TopicPartition topicPartition) {
-            return assignment.contains(topicPartition);
-        }
-
-        private void clear() {
-            this.assignment.clear();
-            this.size = 0;
-        }
-
-        /**
-         * Returns the partition states in order.
-         */
-        private List<PartitionStates.PartitionState<S>> partitionStates() {
-            return assignment.partitionStates();
-        }
-
-        private S stateValue(TopicPartition topicPartition) {
-            return assignment.stateValue(topicPartition);
-        }
-
-        private void set(Map<TopicPartition, S> partitionToState) {
-            this.assignment.set(partitionToState);
-            this.size = assignment.size();
-        }
-
-        private int size() {
-            return size;
-        }
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -272,7 +272,7 @@ public class SubscriptionState {
      * Provides the number of assigned partitions in a thread safe manner.
      * @return the number of assigned partitions.
      */
-    public int assignedPartitionsSize() {
+    public int numAssignedPartitions() {
         return this.assignment.size();
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -71,7 +71,7 @@ public class SubscriptionState {
     private final Set<String> groupSubscription;
 
     /* the partitions that are currently assigned, note that the order of partition matters (see FetchBuilder for more details) */
-    private final PartitionStates<TopicPartitionState> assignment;
+    private final Assignment<TopicPartitionState> assignment;
 
     /* Default offset reset strategy */
     private final OffsetResetStrategy defaultResetStrategy;
@@ -85,7 +85,7 @@ public class SubscriptionState {
     public SubscriptionState(OffsetResetStrategy defaultResetStrategy) {
         this.defaultResetStrategy = defaultResetStrategy;
         this.subscription = Collections.emptySet();
-        this.assignment = new PartitionStates<>();
+        this.assignment = new Assignment<>();
         this.groupSubscription = new HashSet<>();
         this.subscribedPattern = null;
         this.subscriptionType = SubscriptionType.NONE;
@@ -266,6 +266,14 @@ public class SubscriptionState {
 
     public Set<TopicPartition> assignedPartitions() {
         return this.assignment.partitionSet();
+    }
+
+    /**
+     * Provides the number of assigned partitions in a thread safe manner.
+     * @return the number of assigned partitions.
+     */
+    public int assignedPartitionsSize() {
+        return this.assignment.size();
     }
 
     public List<TopicPartition> fetchablePartitions() {
@@ -531,4 +539,60 @@ public class SubscriptionState {
         void onAssignment(Set<TopicPartition> assignment);
     }
 
+
+    /**
+     * Wrapper to manipulate assignment while exporting the number of partitions in a thread safe manner.
+     */
+    private static class Assignment<S> {
+        /* the partitions that are currently assigned, note that the order of partition matters (see FetchBuilder for more details) */
+        private final PartitionStates<S> assignment;
+
+        /* the number of partitions that are currently assigned available in a thread safe manner */
+        private volatile int size;
+
+        private Assignment() {
+            this.assignment = new PartitionStates<>();
+            this.size = 0;
+        }
+
+        private void moveToEnd(TopicPartition topicPartition) {
+            assignment.moveToEnd(topicPartition);
+        }
+
+        /**
+         * Returns the partitions in random order.
+         */
+        private Set<TopicPartition> partitionSet() {
+            return assignment.partitionSet();
+        }
+
+        private boolean contains(TopicPartition topicPartition) {
+            return assignment.contains(topicPartition);
+        }
+
+        private void clear() {
+            this.assignment.clear();
+            this.size = 0;
+        }
+
+        /**
+         * Returns the partition states in order.
+         */
+        private List<PartitionStates.PartitionState<S>> partitionStates() {
+            return assignment.partitionStates();
+        }
+
+        private S stateValue(TopicPartition topicPartition) {
+            return assignment.stateValue(topicPartition);
+        }
+
+        private void set(Map<TopicPartition, S> partitionToState) {
+            this.assignment.set(partitionToState);
+            this.size = assignment.size();
+        }
+
+        private int size() {
+            return size;
+        }
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -47,7 +47,6 @@ public class PartitionStates<S> {
     /* the number of partitions that are currently assigned available in a thread safe manner */
     private volatile int size = 0;
 
-
     public PartitionStates() {}
 
     public void moveToEnd(TopicPartition topicPartition) {

--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -58,12 +58,12 @@ public class PartitionStates<S> {
     public void updateAndMoveToEnd(TopicPartition topicPartition, S state) {
         map.remove(topicPartition);
         map.put(topicPartition, state);
-        size = map.size();
+        updateSize();
     }
 
     public void remove(TopicPartition topicPartition) {
         map.remove(topicPartition);
-        size = map.size();
+        updateSize();
     }
 
     /**
@@ -75,7 +75,7 @@ public class PartitionStates<S> {
 
     public void clear() {
         map.clear();
-        size = 0;
+        updateSize();
     }
 
     public boolean contains(TopicPartition topicPartition) {
@@ -120,6 +120,10 @@ public class PartitionStates<S> {
     public void set(Map<TopicPartition, S> partitionToState) {
         map.clear();
         update(partitionToState);
+        updateSize();
+    }
+
+    private void updateSize() {
         size = map.size();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/PartitionStates.java
@@ -36,10 +36,17 @@ import java.util.Set;
  * topic would "wrap around" and appear twice. However, as partitions are fetched in different orders and partition
  * leadership changes, we will deviate from the optimal. If this turns out to be an issue in practice, we can improve
  * it by tracking the partitions per node or calling `set` every so often.
+ *
+ * Note that this class is not thread-safe with the exception of {@link #size()} which returns the number of
+ * partitions currently tracked.
  */
 public class PartitionStates<S> {
 
     private final LinkedHashMap<TopicPartition, S> map = new LinkedHashMap<>();
+
+    /* the number of partitions that are currently assigned available in a thread safe manner */
+    private volatile int size = 0;
+
 
     public PartitionStates() {}
 
@@ -52,10 +59,12 @@ public class PartitionStates<S> {
     public void updateAndMoveToEnd(TopicPartition topicPartition, S state) {
         map.remove(topicPartition);
         map.put(topicPartition, state);
+        size = map.size();
     }
 
     public void remove(TopicPartition topicPartition) {
         map.remove(topicPartition);
+        size = map.size();
     }
 
     /**
@@ -67,6 +76,7 @@ public class PartitionStates<S> {
 
     public void clear() {
         map.clear();
+        size = 0;
     }
 
     public boolean contains(TopicPartition topicPartition) {
@@ -95,8 +105,11 @@ public class PartitionStates<S> {
         return map.get(topicPartition);
     }
 
+    /**
+     * Get the number of partitions that are currently being tracked. This is thread-safe.
+     */
     public int size() {
-        return map.size();
+        return size;
     }
 
     /**
@@ -108,6 +121,7 @@ public class PartitionStates<S> {
     public void set(Map<TopicPartition, S> partitionToState) {
         map.clear();
         update(partitionToState);
+        size = map.size();
     }
 
     private void update(Map<TopicPartition, S> partitionToState) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -30,6 +30,8 @@ import org.apache.kafka.clients.consumer.RetriableCommitFailedException;
 import org.apache.kafka.clients.consumer.RoundRobinAssignor;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ApiException;
@@ -77,6 +79,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.singleton;
@@ -440,7 +443,7 @@ public class ConsumerCoordinatorTest {
         coordinator.poll(time.timer(Long.MAX_VALUE));
 
         assertFalse(coordinator.rejoinNeededOrPending());
-        assertEquals(2, subscriptions.assignedPartitions().size());
+        assertEquals(2, subscriptions.assignedPartitionsSize());
         assertEquals(2, subscriptions.groupSubscription().size());
         assertEquals(2, subscriptions.subscription().size());
         assertEquals(1, rebalanceListener.revokedCount);
@@ -685,7 +688,7 @@ public class ConsumerCoordinatorTest {
         coordinator.joinGroupIfNeeded(time.timer(Long.MAX_VALUE));
 
         assertFalse(coordinator.rejoinNeededOrPending());
-        assertEquals(2, subscriptions.assignedPartitions().size());
+        assertEquals(2, subscriptions.assignedPartitionsSize());
         assertEquals(2, subscriptions.subscription().size());
         assertEquals(1, rebalanceListener.revokedCount);
         assertEquals(1, rebalanceListener.assignedCount);
@@ -1738,6 +1741,43 @@ public class ConsumerCoordinatorTest {
             assertEquals(range.name(), metadata.get(0).name());
             assertEquals(roundRobin.name(), metadata.get(1).name());
         }
+    }
+
+    @Test
+    public void testThreadSafeAssignedPartitionsMetric() throws Exception {
+        // Get the assigned-partitions metric
+        final Metric metric = metrics.metric(new MetricName("assigned-partitions", "consumer" + groupId + "-coordinator-metrics",
+                "", Collections.<String, String>emptyMap()));
+
+        // Start polling the metric in the background
+        final AtomicBoolean doStop = new AtomicBoolean();
+        final AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+        Thread poller = new Thread() {
+            @Override
+            public void run() {
+                // Poll as fast as possible to reproduce ConcurrentModificationException
+                while (!doStop.get()) {
+                    try {
+                        metric.value();
+                    } catch (Exception e) {
+                        exceptionHolder.set(e);
+                        doStop.set(true);
+                    }
+                }
+            }
+        };
+        poller.start();
+
+        // Assign two partitions to trigger a metric change that can lead to ConcurrentModificationException
+        client.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        coordinator.ensureCoordinatorReady(time.timer(Long.MAX_VALUE));
+        subscriptions.assignFromUser(new HashSet<>(Arrays.asList(t1p, t2p)));
+        // Wait just a bit for the poller to see the metric value transition from 0.0 to 2.0
+        Thread.sleep(50);
+        // Stop and wait for the poller
+        doStop.set(true);
+        poller.join();
+        assertNull("Failed fetching the metric at least once", exceptionHolder.get());
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -49,14 +49,14 @@ public class SubscriptionStateTest {
     public void partitionAssignment() {
         state.assignFromUser(singleton(tp0));
         assertEquals(singleton(tp0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
         assertFalse(state.hasAllFetchPositions());
         state.seek(tp0, 1);
         assertTrue(state.isFetchable(tp0));
         assertEquals(1L, state.position(tp0).longValue());
         state.assignFromUser(Collections.<TopicPartition>emptySet());
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
         assertFalse(state.isAssigned(tp0));
         assertFalse(state.isFetchable(tp0));
     }
@@ -66,34 +66,34 @@ public class SubscriptionStateTest {
         state.assignFromUser(new HashSet<>(Arrays.asList(tp0, tp1)));
         // assigned partitions should immediately change
         assertEquals(2, state.assignedPartitions().size());
-        assertEquals(2, state.assignedPartitionsSize());
+        assertEquals(2, state.numAssignedPartitions());
         assertTrue(state.assignedPartitions().contains(tp0));
         assertTrue(state.assignedPartitions().contains(tp1));
 
         state.unsubscribe();
         // assigned partitions should immediately change
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
 
         state.subscribe(singleton(topic1), rebalanceListener);
         // assigned partitions should remain unchanged
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
 
         state.assignFromSubscribed(singleton(t1p0));
         // assigned partitions should immediately change
         assertEquals(singleton(t1p0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
 
         state.subscribe(singleton(topic), rebalanceListener);
         // assigned partitions should remain unchanged
         assertEquals(singleton(t1p0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
 
         state.unsubscribe();
         // assigned partitions should immediately change
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
     }
 
     @Test
@@ -101,45 +101,45 @@ public class SubscriptionStateTest {
         state.subscribe(Pattern.compile(".*"), rebalanceListener);
         // assigned partitions should remain unchanged
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
 
         state.subscribeFromPattern(new HashSet<>(Collections.singletonList(topic)));
         // assigned partitions should remain unchanged
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
 
         state.assignFromSubscribed(singleton(tp1));
         // assigned partitions should immediately change
         assertEquals(singleton(tp1), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
         assertEquals(singleton(topic), state.subscription());
 
         state.assignFromSubscribed(Collections.singletonList(t1p0));
         // assigned partitions should immediately change
         assertEquals(singleton(t1p0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
         assertEquals(singleton(topic), state.subscription());
 
         state.subscribe(Pattern.compile(".*t"), rebalanceListener);
         // assigned partitions should remain unchanged
         assertEquals(singleton(t1p0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
 
         state.subscribeFromPattern(singleton(topic));
         // assigned partitions should remain unchanged
         assertEquals(singleton(t1p0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
 
         state.assignFromSubscribed(Collections.singletonList(tp0));
         // assigned partitions should immediately change
         assertEquals(singleton(tp0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
         assertEquals(singleton(topic), state.subscription());
 
         state.unsubscribe();
         // assigned partitions should immediately change
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
     }
 
     @Test
@@ -185,7 +185,7 @@ public class SubscriptionStateTest {
         state.subscribe(singleton(topic), rebalanceListener);
         assertEquals(1, state.subscription().size());
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
         assertTrue(state.partitionsAutoAssigned());
         state.assignFromSubscribed(singleton(tp0));
         state.seek(tp0, 1);
@@ -195,7 +195,7 @@ public class SubscriptionStateTest {
         assertFalse(state.isAssigned(tp0));
         assertFalse(state.isFetchable(tp1));
         assertEquals(singleton(tp1), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
     }
 
     @Test
@@ -279,7 +279,7 @@ public class SubscriptionStateTest {
         state.unsubscribe();
         state.assignFromUser(singleton(tp0));
         assertEquals(singleton(tp0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
     }
 
     @Test
@@ -288,21 +288,21 @@ public class SubscriptionStateTest {
         state.subscribeFromPattern(new HashSet<>(Arrays.asList(topic, topic1)));
         state.assignFromSubscribed(singleton(tp1));
         assertEquals(singleton(tp1), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
 
         state.unsubscribe();
         assertEquals(0, state.subscription().size());
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
 
         state.assignFromUser(singleton(tp0));
         assertEquals(singleton(tp0), state.assignedPartitions());
-        assertEquals(1, state.assignedPartitionsSize());
+        assertEquals(1, state.numAssignedPartitions());
 
         state.unsubscribe();
         assertEquals(0, state.subscription().size());
         assertTrue(state.assignedPartitions().isEmpty());
-        assertEquals(0, state.assignedPartitionsSize());
+        assertEquals(0, state.numAssignedPartitions());
     }
 
     private static class MockRebalanceListener implements ConsumerRebalanceListener {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/SubscriptionStateTest.java
@@ -49,12 +49,14 @@ public class SubscriptionStateTest {
     public void partitionAssignment() {
         state.assignFromUser(singleton(tp0));
         assertEquals(singleton(tp0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
         assertFalse(state.hasAllFetchPositions());
         state.seek(tp0, 1);
         assertTrue(state.isFetchable(tp0));
         assertEquals(1L, state.position(tp0).longValue());
         state.assignFromUser(Collections.<TopicPartition>emptySet());
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
         assertFalse(state.isAssigned(tp0));
         assertFalse(state.isFetchable(tp0));
     }
@@ -64,28 +66,34 @@ public class SubscriptionStateTest {
         state.assignFromUser(new HashSet<>(Arrays.asList(tp0, tp1)));
         // assigned partitions should immediately change
         assertEquals(2, state.assignedPartitions().size());
+        assertEquals(2, state.assignedPartitionsSize());
         assertTrue(state.assignedPartitions().contains(tp0));
         assertTrue(state.assignedPartitions().contains(tp1));
 
         state.unsubscribe();
         // assigned partitions should immediately change
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
 
         state.subscribe(singleton(topic1), rebalanceListener);
         // assigned partitions should remain unchanged
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
 
         state.assignFromSubscribed(singleton(t1p0));
         // assigned partitions should immediately change
         assertEquals(singleton(t1p0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
 
         state.subscribe(singleton(topic), rebalanceListener);
         // assigned partitions should remain unchanged
         assertEquals(singleton(t1p0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
 
         state.unsubscribe();
         // assigned partitions should immediately change
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
     }
 
     @Test
@@ -93,37 +101,45 @@ public class SubscriptionStateTest {
         state.subscribe(Pattern.compile(".*"), rebalanceListener);
         // assigned partitions should remain unchanged
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
 
         state.subscribeFromPattern(new HashSet<>(Collections.singletonList(topic)));
         // assigned partitions should remain unchanged
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
 
         state.assignFromSubscribed(singleton(tp1));
         // assigned partitions should immediately change
         assertEquals(singleton(tp1), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
         assertEquals(singleton(topic), state.subscription());
 
         state.assignFromSubscribed(Collections.singletonList(t1p0));
         // assigned partitions should immediately change
         assertEquals(singleton(t1p0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
         assertEquals(singleton(topic), state.subscription());
 
         state.subscribe(Pattern.compile(".*t"), rebalanceListener);
         // assigned partitions should remain unchanged
         assertEquals(singleton(t1p0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
 
         state.subscribeFromPattern(singleton(topic));
         // assigned partitions should remain unchanged
         assertEquals(singleton(t1p0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
 
         state.assignFromSubscribed(Collections.singletonList(tp0));
         // assigned partitions should immediately change
         assertEquals(singleton(tp0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
         assertEquals(singleton(topic), state.subscription());
 
         state.unsubscribe();
         // assigned partitions should immediately change
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
     }
 
     @Test
@@ -169,6 +185,7 @@ public class SubscriptionStateTest {
         state.subscribe(singleton(topic), rebalanceListener);
         assertEquals(1, state.subscription().size());
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
         assertTrue(state.partitionsAutoAssigned());
         state.assignFromSubscribed(singleton(tp0));
         state.seek(tp0, 1);
@@ -178,6 +195,7 @@ public class SubscriptionStateTest {
         assertFalse(state.isAssigned(tp0));
         assertFalse(state.isFetchable(tp1));
         assertEquals(singleton(tp1), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
     }
 
     @Test
@@ -261,6 +279,7 @@ public class SubscriptionStateTest {
         state.unsubscribe();
         state.assignFromUser(singleton(tp0));
         assertEquals(singleton(tp0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
     }
 
     @Test
@@ -269,17 +288,21 @@ public class SubscriptionStateTest {
         state.subscribeFromPattern(new HashSet<>(Arrays.asList(topic, topic1)));
         state.assignFromSubscribed(singleton(tp1));
         assertEquals(singleton(tp1), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
 
         state.unsubscribe();
         assertEquals(0, state.subscription().size());
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
 
         state.assignFromUser(singleton(tp0));
         assertEquals(singleton(tp0), state.assignedPartitions());
+        assertEquals(1, state.assignedPartitionsSize());
 
         state.unsubscribe();
         assertEquals(0, state.subscription().size());
         assertTrue(state.assignedPartitions().isEmpty());
+        assertEquals(0, state.assignedPartitionsSize());
     }
 
     private static class MockRebalanceListener implements ConsumerRebalanceListener {


### PR DESCRIPTION
Code change:
- prevent `java.util.ConcurrentModificationException` being thrown when fetching the consumer coordinator assigned-partitions metric value from a `MetricsReporter` (e.g. a reporter exporting metrics periodically running in a separate thread) because of a race condition by using a volatile field for storing the number of assigned partitions:
```
java.util.ConcurrentModificationException: null
        at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719)
        at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:742)
        at java.util.AbstractCollection.addAll(AbstractCollection.java:343)
        at java.util.HashSet.<init>(HashSet.java:119)
        at org.apache.kafka.common.internals.PartitionStates.partitionSet(PartitionStates.java:66)
        at org.apache.kafka.clients.consumer.internals.SubscriptionState.assignedPartitions(SubscriptionState.java:293)
        at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator$ConsumerCoordinatorMetrics$1.measure(ConsumerCoordinator.java:880)
        ...
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
- new unit test to reproduce the issue and detect potential future regression

I am using a volatile field on `SubscriptionState` rather than changing the `PartitionStates.map` field to some thread safe `LinkedHashMap` alternative to avoid bringing an unnecessary concurrent structure to other components relying on `PartitionStates`.