### PR TITLE
KAFKA-5933: Move timeout and validate_only protocol fields into CommonFields class

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/CommonFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/CommonFields.java
@@ -26,6 +26,11 @@ public class CommonFields {
     public static final Field.Int32 PARTITION_ID = new Field.Int32("partition", "Topic partition id");
     public static final Field.Int16 ERROR_CODE = new Field.Int16("error_code", "Response error code");
     public static final Field.NullableStr ERROR_MESSAGE = new Field.NullableStr("error_message", "Response error message");
+    public static final Field.Boolean VALIDATE_ONLY = new Field.Boolean("validate_only",
+            "If this is true, the request will be validated, but the " +
+                     "topic won't be created.");
+    public static final Field.Int32 TIMEOUT = new Field.Int32("timeout",
+            "The maximum time to await a response in ms. Values <= 0 will trigger the request and return immediately");
 
     // Group APIs
     public static final Field.Str GROUP_ID = new Field.Str("group_id", "The unique group identifier");

--- a/clients/src/main/java/org/apache/kafka/common/protocol/CommonFields.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/CommonFields.java
@@ -27,8 +27,7 @@ public class CommonFields {
     public static final Field.Int16 ERROR_CODE = new Field.Int16("error_code", "Response error code");
     public static final Field.NullableStr ERROR_MESSAGE = new Field.NullableStr("error_message", "Response error message");
     public static final Field.Boolean VALIDATE_ONLY = new Field.Boolean("validate_only",
-            "If this is true, the request will be validated, but the " +
-                     "topic won't be created.");
+            "If this is true, the request will be only validated, but no action will be taken.");
     public static final Field.Int32 TIMEOUT = new Field.Int32("timeout",
             "The maximum time to await a response in ms. Values <= 0 will trigger the request and return immediately");
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Field.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Field.java
@@ -89,4 +89,10 @@ public class Field {
             super(name, Type.NULLABLE_STRING, docString, false, null);
         }
     }
+
+    public static class Boolean extends Field {
+        public Boolean(String name, String docString) {
+            super(name, Type.BOOLEAN, docString, false, null);
+        }
+    }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -127,6 +127,12 @@ public class Struct {
         return alternative;
     }
 
+    public Boolean getOrElse(Field.Boolean field, Boolean alternative) {
+        if (hasField(field.name))
+            return getBoolean(field.name);
+        return alternative;
+    }
+
     /**
      * Get the record value for the field with the given name by doing a hash table lookup (slower!)
      *

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -99,6 +99,10 @@ public class Struct {
         return getString(field.name);
     }
 
+    public Boolean get(Field.Boolean field) {
+        return getBoolean(field.name);
+    }
+
     public Long getOrElse(Field.Int64 field, long alternative) {
         if (hasField(field.name))
             return getLong(field.name);
@@ -285,6 +289,10 @@ public class Struct {
     }
 
     public Struct set(Field.Int16 def, short value) {
+        return set(def.name, value);
+    }
+
+    public Struct set(Field.Boolean def, Boolean value) {
         return set(def.name, value);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -75,19 +75,19 @@ public class Struct {
         return getFieldOrDefault(field);
     }
 
-    public Byte get(Field.Int8 field) {
+    public byte get(Field.Int8 field) {
         return getByte(field.name);
     }
 
-    public Integer get(Field.Int32 field) {
+    public int get(Field.Int32 field) {
         return getInt(field.name);
     }
 
-    public Long get(Field.Int64 field) {
+    public long get(Field.Int64 field) {
         return getLong(field.name);
     }
 
-    public Short get(Field.Int16 field) {
+    public short get(Field.Int16 field) {
         return getShort(field.name);
     }
 
@@ -103,13 +103,13 @@ public class Struct {
         return getBoolean(field.name);
     }
 
-    public Long getOrElse(Field.Int64 field, long alternative) {
+    public long getOrElse(Field.Int64 field, long alternative) {
         if (hasField(field.name))
             return getLong(field.name);
         return alternative;
     }
 
-    public Integer getOrElse(Field.Int32 field, int alternative) {
+    public int getOrElse(Field.Int32 field, int alternative) {
         if (hasField(field.name))
             return getInt(field.name);
         return alternative;
@@ -168,44 +168,44 @@ public class Struct {
         return (Struct) get(name);
     }
 
-    public Byte getByte(BoundField field) {
-        return (Byte) get(field);
+    public byte getByte(BoundField field) {
+        return (byte) get(field);
     }
 
     public byte getByte(String name) {
-        return (Byte) get(name);
+        return (byte) get(name);
     }
 
     public Records getRecords(String name) {
         return (Records) get(name);
     }
 
-    public Short getShort(BoundField field) {
-        return (Short) get(field);
+    public short getShort(BoundField field) {
+        return (short) get(field);
     }
 
-    public Short getShort(String name) {
-        return (Short) get(name);
+    public short getShort(String name) {
+        return (short) get(name);
     }
 
-    public Integer getInt(BoundField field) {
-        return (Integer) get(field);
+    public int getInt(BoundField field) {
+        return (int) get(field);
     }
 
-    public Integer getInt(String name) {
-        return (Integer) get(name);
+    public int getInt(String name) {
+        return (int) get(name);
     }
 
-    public Long getUnsignedInt(String name) {
-        return (Long) get(name);
+    public long getUnsignedInt(String name) {
+        return (long) get(name);
     }
 
-    public Long getLong(BoundField field) {
-        return (Long) get(field);
+    public long getLong(BoundField field) {
+        return (long) get(field);
     }
 
-    public Long getLong(String name) {
-        return (Long) get(name);
+    public long getLong(String name) {
+        return (long) get(name);
     }
 
     public Object[] getArray(BoundField field) {

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -127,7 +127,7 @@ public class Struct {
         return alternative;
     }
 
-    public Boolean getOrElse(Field.Boolean field, Boolean alternative) {
+    public Boolean getOrElse(Field.Boolean field, boolean alternative) {
         if (hasField(field.name))
             return getBoolean(field.name);
         return alternative;
@@ -298,7 +298,7 @@ public class Struct {
         return set(def.name, value);
     }
 
-    public Struct set(Field.Boolean def, Boolean value) {
+    public Struct set(Field.Boolean def, boolean value) {
         return set(def.name, value);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/types/Struct.java
@@ -99,7 +99,7 @@ public class Struct {
         return getString(field.name);
     }
 
-    public Boolean get(Field.Boolean field) {
+    public boolean get(Field.Boolean field) {
         return getBoolean(field.name);
     }
 
@@ -127,7 +127,7 @@ public class Struct {
         return alternative;
     }
 
-    public Boolean getOrElse(Field.Boolean field, boolean alternative) {
+    public boolean getOrElse(Field.Boolean field, boolean alternative) {
         if (hasField(field.name))
             return getBoolean(field.name);
         return alternative;
@@ -224,12 +224,12 @@ public class Struct {
         return (String) get(name);
     }
 
-    public Boolean getBoolean(BoundField field) {
-        return (Boolean) get(field);
+    public boolean getBoolean(BoundField field) {
+        return (boolean) get(field);
     }
 
-    public Boolean getBoolean(String name) {
-        return (Boolean) get(name);
+    public boolean getBoolean(String name) {
+        return (boolean) get(name);
     }
 
     public ByteBuffer getBytes(BoundField field) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterConfigsRequest.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
+import static org.apache.kafka.common.protocol.CommonFields.VALIDATE_ONLY;
 import static org.apache.kafka.common.protocol.types.Type.INT8;
 import static org.apache.kafka.common.protocol.types.Type.NULLABLE_STRING;
 import static org.apache.kafka.common.protocol.types.Type.STRING;
@@ -40,7 +40,6 @@ public class AlterConfigsRequest extends AbstractRequest {
     private static final String RESOURCES_KEY_NAME = "resources";
     private static final String RESOURCE_TYPE_KEY_NAME = "resource_type";
     private static final String RESOURCE_NAME_KEY_NAME = "resource_name";
-    private static final String VALIDATE_ONLY_KEY_NAME = "validate_only";
 
     private static final String CONFIG_ENTRIES_KEY_NAME = "config_entries";
     private static final String CONFIG_NAME = "config_name";
@@ -58,7 +57,7 @@ public class AlterConfigsRequest extends AbstractRequest {
     private static final Schema ALTER_CONFIGS_REQUEST_V0 = new Schema(
             new Field(RESOURCES_KEY_NAME, new ArrayOf(ALTER_CONFIGS_REQUEST_RESOURCE_V0),
                     "An array of resources to update with the provided configs."),
-            new Field(VALIDATE_ONLY_KEY_NAME, BOOLEAN));
+            VALIDATE_ONLY);
 
     public static Schema[] schemaVersions() {
         return new Schema[] {ALTER_CONFIGS_REQUEST_V0};
@@ -123,7 +122,7 @@ public class AlterConfigsRequest extends AbstractRequest {
 
     public AlterConfigsRequest(Struct struct, short version) {
         super(version);
-        validateOnly = struct.getBoolean(VALIDATE_ONLY_KEY_NAME);
+        validateOnly = struct.get(VALIDATE_ONLY);
         Object[] resourcesArray = struct.getArray(RESOURCES_KEY_NAME);
         configs = new HashMap<>(resourcesArray.length);
         for (Object resourcesObj : resourcesArray) {
@@ -157,7 +156,7 @@ public class AlterConfigsRequest extends AbstractRequest {
     @Override
     protected Struct toStruct() {
         Struct struct = new Struct(ApiKeys.ALTER_CONFIGS.requestSchema(version()));
-        struct.set(VALIDATE_ONLY_KEY_NAME, validateOnly);
+        struct.set(VALIDATE_ONLY, validateOnly);
         List<Struct> resourceStructs = new ArrayList<>(configs.size());
         for (Map.Entry<Resource, Config> entry : configs.entrySet()) {
             Struct resourceStruct = struct.instance(RESOURCES_KEY_NAME);

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
@@ -34,7 +34,8 @@ import java.util.Set;
 
 import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
 import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
-import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
+import static org.apache.kafka.common.protocol.CommonFields.VALIDATE_ONLY;
+import static org.apache.kafka.common.protocol.CommonFields.TIMEOUT;
 import static org.apache.kafka.common.protocol.types.Type.INT16;
 import static org.apache.kafka.common.protocol.types.Type.INT32;
 import static org.apache.kafka.common.protocol.types.Type.NULLABLE_STRING;
@@ -43,8 +44,6 @@ import static org.apache.kafka.common.protocol.types.Type.STRING;
 public class CreateTopicsRequest extends AbstractRequest {
     private static final String REQUESTS_KEY_NAME = "create_topic_requests";
 
-    private static final String TIMEOUT_KEY_NAME = "timeout";
-    private static final String VALIDATE_ONLY_KEY_NAME = "validate_only";
     private static final String NUM_PARTITIONS_KEY_NAME = "num_partitions";
     private static final String REPLICATION_FACTOR_KEY_NAME = "replication_factor";
     private static final String REPLICA_ASSIGNMENT_KEY_NAME = "replica_assignment";
@@ -77,16 +76,13 @@ public class CreateTopicsRequest extends AbstractRequest {
     private static final Schema CREATE_TOPICS_REQUEST_V0 = new Schema(
             new Field(REQUESTS_KEY_NAME, new ArrayOf(SINGLE_CREATE_TOPIC_REQUEST_V0),
                     "An array of single topic creation requests. Can not have multiple entries for the same topic."),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The time in ms to wait for a topic to be completely created on the " +
-                    "controller node. Values <= 0 will trigger topic creation and return immediately"));
+            TIMEOUT);
 
     private static final Schema CREATE_TOPICS_REQUEST_V1 = new Schema(
             new Field(REQUESTS_KEY_NAME, new ArrayOf(SINGLE_CREATE_TOPIC_REQUEST_V1), "An array of single " +
                     "topic creation requests. Can not have multiple entries for the same topic."),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The time in ms to wait for a topic to be completely created on the " +
-                    "controller node. Values <= 0 will trigger topic creation and return immediately"),
-            new Field(VALIDATE_ONLY_KEY_NAME, BOOLEAN, "If this is true, the request will be validated, but the " +
-                    "topic won't be created."));
+            TIMEOUT,
+            VALIDATE_ONLY);
 
     /* v2 request is the same as v1. Throttle time has been added to the response */
     private static final Schema CREATE_TOPICS_REQUEST_V2 = CREATE_TOPICS_REQUEST_V1;
@@ -249,9 +245,9 @@ public class CreateTopicsRequest extends AbstractRequest {
         }
 
         this.topics = topics;
-        this.timeout = struct.getInt(TIMEOUT_KEY_NAME);
-        if (struct.hasField(VALIDATE_ONLY_KEY_NAME))
-            this.validateOnly = struct.getBoolean(VALIDATE_ONLY_KEY_NAME);
+        this.timeout = struct.get(TIMEOUT);
+        if (struct.hasField(VALIDATE_ONLY))
+            this.validateOnly = struct.get(VALIDATE_ONLY);
         else
             this.validateOnly = false;
         this.duplicateTopics = duplicateTopics;
@@ -338,9 +334,9 @@ public class CreateTopicsRequest extends AbstractRequest {
             createTopicRequestStructs.add(singleRequestStruct);
         }
         struct.set(REQUESTS_KEY_NAME, createTopicRequestStructs.toArray());
-        struct.set(TIMEOUT_KEY_NAME, timeout);
+        struct.set(TIMEOUT, timeout);
         if (version >= 1)
-            struct.set(VALIDATE_ONLY_KEY_NAME, validateOnly);
+            struct.set(VALIDATE_ONLY, validateOnly);
         return struct;
 
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/CreateTopicsRequest.java
@@ -246,10 +246,7 @@ public class CreateTopicsRequest extends AbstractRequest {
 
         this.topics = topics;
         this.timeout = struct.get(TIMEOUT);
-        if (struct.hasField(VALIDATE_ONLY))
-            this.validateOnly = struct.get(VALIDATE_ONLY);
-        else
-            this.validateOnly = false;
+        this.validateOnly = struct.getOrElse(VALIDATE_ONLY, false);
         this.duplicateTopics = duplicateTopics;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsRequest.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
 import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
-import static org.apache.kafka.common.protocol.types.Type.INT32;
+import static org.apache.kafka.common.protocol.CommonFields.TIMEOUT;
 import static org.apache.kafka.common.protocol.types.Type.INT64;
 
 public class DeleteRecordsRequest extends AbstractRequest {
@@ -43,7 +43,6 @@ public class DeleteRecordsRequest extends AbstractRequest {
 
     // request level key names
     private static final String TOPICS_KEY_NAME = "topics";
-    private static final String TIMEOUT_KEY_NAME = "timeout";
 
     // topic level key names
     private static final String PARTITIONS_KEY_NAME = "partitions";
@@ -62,7 +61,7 @@ public class DeleteRecordsRequest extends AbstractRequest {
 
     private static final Schema DELETE_RECORDS_REQUEST_V0 = new Schema(
             new Field(TOPICS_KEY_NAME, new ArrayOf(DELETE_RECORDS_REQUEST_TOPIC_V0)),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The maximum time to await a response in ms."));
+            TIMEOUT);
 
     public static Schema[] schemaVersions() {
         return new Schema[]{DELETE_RECORDS_REQUEST_V0};
@@ -111,7 +110,7 @@ public class DeleteRecordsRequest extends AbstractRequest {
                 partitionOffsets.put(new TopicPartition(topic, partition), offset);
             }
         }
-        timeout = struct.getInt(TIMEOUT_KEY_NAME);
+        timeout = struct.get(TIMEOUT);
     }
 
     public DeleteRecordsRequest(int timeout, Map<TopicPartition, Long> partitionOffsets, short version) {
@@ -123,7 +122,7 @@ public class DeleteRecordsRequest extends AbstractRequest {
     protected Struct toStruct() {
         Struct struct = new Struct(ApiKeys.DELETE_RECORDS.requestSchema(version()));
         Map<String, Map<Integer, Long>> offsetsByTopic = CollectionUtils.groupDataByTopic(partitionOffsets);
-        struct.set(TIMEOUT_KEY_NAME, timeout);
+        struct.set(TIMEOUT, timeout);
         List<Struct> topicStructArray = new ArrayList<>();
         for (Map.Entry<String, Map<Integer, Long>> offsetsByTopicEntry : offsetsByTopic.entrySet()) {
             Struct topicStruct = struct.instance(TOPICS_KEY_NAME);

--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteTopicsRequest.java
@@ -30,18 +30,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.kafka.common.protocol.types.Type.INT32;
+import static org.apache.kafka.common.protocol.CommonFields.TIMEOUT;
 import static org.apache.kafka.common.protocol.types.Type.STRING;
 
 public class DeleteTopicsRequest extends AbstractRequest {
     private static final String TOPICS_KEY_NAME = "topics";
-    private static final String TIMEOUT_KEY_NAME = "timeout";
 
     /* DeleteTopic api */
     private static final Schema DELETE_TOPICS_REQUEST_V0 = new Schema(
             new Field(TOPICS_KEY_NAME, new ArrayOf(STRING), "An array of topics to be deleted."),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The time in ms to wait for a topic to be completely deleted on the " +
-                    "controller node. Values <= 0 will trigger topic deletion and return immediately"));
+            TIMEOUT);
 
     /* v1 request is the same as v0. Throttle time has been added to the response */
     private static final Schema DELETE_TOPICS_REQUEST_V1 = DELETE_TOPICS_REQUEST_V0;
@@ -93,14 +91,14 @@ public class DeleteTopicsRequest extends AbstractRequest {
             topics.add((String) topic);
 
         this.topics = topics;
-        this.timeout = struct.getInt(TIMEOUT_KEY_NAME);
+        this.timeout = struct.get(TIMEOUT);
     }
 
     @Override
     protected Struct toStruct() {
         Struct struct = new Struct(ApiKeys.DELETE_TOPICS.requestSchema(version()));
         struct.set(TOPICS_KEY_NAME, topics.toArray());
-        struct.set(TIMEOUT_KEY_NAME, timeout);
+        struct.set(TIMEOUT, timeout);
         return struct;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ProduceRequest.java
@@ -43,13 +43,12 @@ import java.util.Map;
 import static org.apache.kafka.common.protocol.CommonFields.NULLABLE_TRANSACTIONAL_ID;
 import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
 import static org.apache.kafka.common.protocol.CommonFields.TOPIC_NAME;
+import static org.apache.kafka.common.protocol.CommonFields.TIMEOUT;
 import static org.apache.kafka.common.protocol.types.Type.INT16;
-import static org.apache.kafka.common.protocol.types.Type.INT32;
 import static org.apache.kafka.common.protocol.types.Type.RECORDS;
 
 public class ProduceRequest extends AbstractRequest {
     private static final String ACKS_KEY_NAME = "acks";
-    private static final String TIMEOUT_KEY_NAME = "timeout";
     private static final String TOPIC_DATA_KEY_NAME = "topic_data";
 
     // topic level field names
@@ -69,7 +68,7 @@ public class ProduceRequest extends AbstractRequest {
             new Field(ACKS_KEY_NAME, INT16, "The number of acknowledgments the producer requires the leader to have " +
                     "received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for " +
                     "only the leader and -1 for the full ISR."),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The time to await a response in ms."),
+            TIMEOUT,
             new Field(TOPIC_DATA_KEY_NAME, new ArrayOf(TOPIC_PRODUCE_DATA_V0)));
 
     /**
@@ -91,7 +90,7 @@ public class ProduceRequest extends AbstractRequest {
             new Field(ACKS_KEY_NAME, INT16, "The number of acknowledgments the producer requires the leader to have " +
                     "received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 " +
                     "for only the leader and -1 for the full ISR."),
-            new Field(TIMEOUT_KEY_NAME, INT32, "The time to await a response in ms."),
+            TIMEOUT,
             new Field(TOPIC_DATA_KEY_NAME, new ArrayOf(TOPIC_PRODUCE_DATA_V0)));
 
     /**
@@ -227,7 +226,7 @@ public class ProduceRequest extends AbstractRequest {
         }
         partitionSizes = createPartitionSizes(partitionRecords);
         acks = struct.getShort(ACKS_KEY_NAME);
-        timeout = struct.getInt(TIMEOUT_KEY_NAME);
+        timeout = struct.get(TIMEOUT);
         transactionalId = struct.getOrElse(NULLABLE_TRANSACTIONAL_ID, null);
     }
 
@@ -266,7 +265,7 @@ public class ProduceRequest extends AbstractRequest {
         Struct struct = new Struct(ApiKeys.PRODUCE.requestSchema(version));
         Map<String, Map<Integer, MemoryRecords>> recordsByTopic = CollectionUtils.groupDataByTopic(partitionRecords);
         struct.set(ACKS_KEY_NAME, acks);
-        struct.set(TIMEOUT_KEY_NAME, timeout);
+        struct.set(TIMEOUT, timeout);
         struct.setIfExists(NULLABLE_TRANSACTIONAL_ID, transactionalId);
 
         List<Struct> topicDatas = new ArrayList<>(recordsByTopic.size());


### PR DESCRIPTION
Most of the fields which are shared by multiple protocol messages (requests ad responses) are in the CommonFields class. However there are still some fields used multiple times which are not there yet:
* `timeout`
* `validate_only`

It would be good to move also these two fields into the CommonFields class so that they can be easily shared by different messages.