### PR TITLE
KAFKA-5934 Cross build for Scala 2.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,10 +218,14 @@ project(':core') {
     testCompile project(':clients')
     if (scalaVersion.startsWith('2.10')) {
       testCompile 'org.scalatest:scalatest_2.10:1.9.1'
-    } else if (scalaVersion.startsWith('2.11') || scalaVersion.startsWith('2.12')) {
+    } else if (scalaVersion.startsWith('2.11')) {
       compile 'org.scala-lang.modules:scala-xml_2.11:1.0.6'
       compile 'org.scala-lang.modules:scala-parser-combinators_2.11:1.0.6'
       testCompile "org.scalatest:scalatest_2.11:2.2.0"
+    } else if (scalaVersion.startsWith('2.12')) {
+      compile 'org.scala-lang.modules:scala-xml_2.12:1.0.6'
+      compile 'org.scala-lang.modules:scala-parser-combinators_2.12:1.0.6'
+      testCompile "org.scalatest:scalatest_2.12:3.0.4"
     } else {
       testCompile "org.scalatest:scalatest_$scalaVersion:1.8"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,10 @@ subprojects {
   }
 
   tasks.withType(ScalaCompile) {
-    scalaCompileOptions.useAnt = false
+    scalaCompileOptions.metaClass.daemonServer = true
+    scalaCompileOptions.metaClass.fork = true
+    scalaCompileOptions.metaClass.useAnt = false
+    scalaCompileOptions.metaClass.useCompileDaemon = false
 
     configure(scalaCompileOptions.forkOptions) {
       memoryMaximumSize = '1g'
@@ -137,7 +140,7 @@ subprojects {
   }
 }
 
-for ( sv in ['2_9_1', '2_9_2', '2_10_4', '2_11_5'] ) {
+for ( sv in ['2_9_1', '2_9_2', '2_10_4', '2_11_5', '2_12_3'] ) {
   String svInDot = sv.replaceAll( "_", ".")
 
   tasks.create(name: "jar_core_${sv}", type: GradleBuild) {
@@ -177,20 +180,20 @@ for ( sv in ['2_9_1', '2_9_2', '2_10_4', '2_11_5'] ) {
   }
 }
 
-tasks.create(name: "jarAll", dependsOn: ['jar_core_2_9_1', 'jar_core_2_9_2', 'jar_core_2_10_4', 'jar_core_2_11_5', 'clients:jar', 'examples:jar', 'contrib:hadoop-consumer:jar', 'contrib:hadoop-producer:jar']) {
+tasks.create(name: "jarAll", dependsOn: ['jar_core_2_9_1', 'jar_core_2_9_2', 'jar_core_2_10_4', 'jar_core_2_11_5', 'jar_core_2_12_3', 'clients:jar', 'examples:jar', 'contrib:hadoop-consumer:jar', 'contrib:hadoop-producer:jar']) {
 }
 
-tasks.create(name: "srcJarAll", dependsOn: ['srcJar_2_9_1', 'srcJar_2_9_2', 'srcJar_2_10_4', 'srcJar_2_11_5', 'clients:srcJar', 'examples:srcJar', 'contrib:hadoop-consumer:srcJar', 'contrib:hadoop-producer:srcJar']) { }
+tasks.create(name: "srcJarAll", dependsOn: ['srcJar_2_9_1', 'srcJar_2_9_2', 'srcJar_2_10_4', 'srcJar_2_11_5', 'srcJar_2_12_3', 'clients:srcJar', 'examples:srcJar', 'contrib:hadoop-consumer:srcJar', 'contrib:hadoop-producer:srcJar']) { }
 
-tasks.create(name: "docsJarAll", dependsOn: ['docsJar_2_9_1', 'docsJar_2_9_2', 'docsJar_2_10_4', 'docsJar_2_11_5', 'clients:docsJar', 'examples:docsJar', 'contrib:hadoop-consumer:docsJar', 'contrib:hadoop-producer:docsJar']) { }
+tasks.create(name: "docsJarAll", dependsOn: ['docsJar_2_9_1', 'docsJar_2_9_2', 'docsJar_2_10_4', 'docsJar_2_11_5', 'docsJar_2_12_3', 'clients:docsJar', 'examples:docsJar', 'contrib:hadoop-consumer:docsJar', 'contrib:hadoop-producer:docsJar']) { }
 
-tasks.create(name: "testAll", dependsOn: ['test_core_2_9_1', 'test_core_2_9_2', 'test_core_2_10_4', 'test_core_2_11_5', 'clients:test']) {
+tasks.create(name: "testAll", dependsOn: ['test_core_2_9_1', 'test_core_2_9_2', 'test_core_2_10_4', 'test_core_2_11_5', 'test_core_2_12_3', 'clients:test']) {
 }
 
-tasks.create(name: "releaseTarGzAll", dependsOn: ['releaseTarGz_2_9_1', 'releaseTarGz_2_9_2', 'releaseTarGz_2_10_4', 'releaseTarGz_2_11_5']) {
+tasks.create(name: "releaseTarGzAll", dependsOn: ['releaseTarGz_2_9_1', 'releaseTarGz_2_9_2', 'releaseTarGz_2_10_4', 'releaseTarGz_2_11_5', 'releaseTarGz_2_12_3']) {
 }
 
-tasks.create(name: "uploadArchivesAll", dependsOn: ['uploadCoreArchives_2_9_1', 'uploadCoreArchives_2_9_2', 'uploadCoreArchives_2_10_4', 'uploadCoreArchives_2_11_5', 'clients:uploadArchives', 'examples:uploadArchives', 'contrib:hadoop-consumer:uploadArchives', 'contrib:hadoop-producer:uploadArchives']) {
+tasks.create(name: "uploadArchivesAll", dependsOn: ['uploadCoreArchives_2_9_1', 'uploadCoreArchives_2_9_2', 'uploadCoreArchives_2_10_4', 'uploadCoreArchives_2_11_5', 'uploadCoreArchives_2_12_3', 'clients:uploadArchives', 'examples:uploadArchives', 'contrib:hadoop-consumer:uploadArchives', 'contrib:hadoop-producer:uploadArchives']) {
 }
 
 project(':core') {
@@ -215,9 +218,9 @@ project(':core') {
     testCompile project(':clients')
     if (scalaVersion.startsWith('2.10')) {
       testCompile 'org.scalatest:scalatest_2.10:1.9.1'
-    } else if (scalaVersion.startsWith('2.11')) {
-      compile 'org.scala-lang.modules:scala-xml_2.11:1.0.2'
-      compile 'org.scala-lang.modules:scala-parser-combinators_2.11:1.0.2'
+    } else if (scalaVersion.startsWith('2.11') || scalaVersion.startsWith('2.12')) {
+      compile 'org.scala-lang.modules:scala-xml_2.11:1.0.6'
+      compile 'org.scala-lang.modules:scala-parser-combinators_2.11:1.0.6'
       testCompile "org.scalatest:scalatest_2.11:2.2.0"
     } else {
       testCompile "org.scalatest:scalatest_$scalaVersion:1.8"

--- a/core/src/main/scala/kafka/utils/IteratorTemplate.scala
+++ b/core/src/main/scala/kafka/utils/IteratorTemplate.scala
@@ -76,8 +76,8 @@ abstract class IteratorTemplate[T] extends Iterator[T] with java.util.Iterator[T
     state = DONE
     null.asInstanceOf[T]
   }
-  
-  def remove = 
+
+  override def remove =
     throw new UnsupportedOperationException("Removal not supported")
 
   protected def resetState() {

--- a/core/src/test/scala/unit/kafka/producer/ProducerTest.scala
+++ b/core/src/test/scala/unit/kafka/producer/ProducerTest.scala
@@ -18,7 +18,7 @@
 package kafka.producer
 
 import org.apache.kafka.common.config.ConfigException
-import org.scalatest.TestFailedException
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.junit.JUnit3Suite
 import kafka.consumer.SimpleConsumer
 import kafka.message.Message

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 
 group=org.apache.kafka
 version=0.8.2.2
-scalaVersion=2.10.4
+scalaVersion=2.12.3
 task=build
 org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 
 group=org.apache.kafka
 version=0.8.2.2
-scalaVersion=2.12.3
+scalaVersion=2.12.4
 task=build
 org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m
 

--- a/scala.gradle
+++ b/scala.gradle
@@ -6,6 +6,8 @@ if (scalaVersion.startsWith('2.10')) {
     ext.baseScalaVersion = '2.10'
 } else if (scalaVersion.startsWith('2.11')) {
     ext.baseScalaVersion = '2.11'
+} else if (scalaVersion.startsWith('2.12')) {
+    ext.baseScalaVersion = '2.12'
 } else {
     ext.baseScalaVersion = scalaVersion
 }


### PR DESCRIPTION
Tried to do some simple refactorings to publish Kafka 0.8.x for Scala 2.12 as it's still used quite a lot in the industry. Let me know if more needs to be done, I don't use gradle day to day plus there probably was a change in gradle 4 which required a change to  build.gradle and I bumped the scala modules from 1.0.2 to 1.0.6.