### PR TITLE
KAFKA-5947: Handle authentication failure in admin client, txn producer

### DIFF
--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -41,6 +41,7 @@
   <!-- anyone can use public classes -->
   <allow pkg="org.apache.kafka.common" exact-match="true" />
   <allow pkg="org.apache.kafka.common.security" />
+  <allow pkg="org.apache.kafka.common.serialization" />
   <allow pkg="org.apache.kafka.common.utils" />
   <allow pkg="org.apache.kafka.common.errors" exact-match="true" />
   <allow pkg="org.apache.kafka.common.memory" />

--- a/clients/src/main/java/org/apache/kafka/clients/Metadata.java
+++ b/clients/src/main/java/org/apache/kafka/clients/Metadata.java
@@ -149,14 +149,15 @@ public final class Metadata {
 
     /**
      * If any non-retriable authentication exceptions were encountered during
-     * metadata update, clear and throw the exception.
+     * metadata update, clear and return the exception.
      */
-    public synchronized void maybeThrowAuthenticationException() {
+    public synchronized AuthenticationException getAndClearAuthenticationException() {
         if (authenticationException != null) {
             AuthenticationException exception = authenticationException;
             authenticationException = null;
-            throw exception;
-        }
+            return exception;
+        } else
+            return null;
     }
 
     /**
@@ -169,7 +170,9 @@ public final class Metadata {
         long begin = System.currentTimeMillis();
         long remainingWaitMs = maxWaitMs;
         while (this.version <= lastVersion) {
-            maybeThrowAuthenticationException();
+            AuthenticationException ex = getAndClearAuthenticationException();
+            if (ex != null)
+                throw ex;
             if (remainingWaitMs != 0)
                 wait(remainingWaitMs);
             long elapsed = System.currentTimeMillis() - begin;

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
@@ -47,7 +47,7 @@ public class NetworkClientUtils {
      * It returns `true` if the call completes normally or `false` if the timeoutMs expires. If the connection fails,
      * an `IOException` is thrown instead. Note that if the `NetworkClient` has been configured with a positive
      * connection timeoutMs, it is possible for this method to raise an `IOException` for a previous connection which
-     * has recently disconnected.
+     * has recently disconnected. If authentication to the node fails, an `AuthenticationException` is thrown.
      *
      * This method is useful for implementing blocking behaviour on top of the non-blocking `NetworkClient`, use it with
      * care.
@@ -69,6 +69,8 @@ public class NetworkClientUtils {
             }
             long pollTimeout = expiryTime - attemptStartTime;
             client.poll(pollTimeout, attemptStartTime);
+            if (client.authenticationException(node) != null)
+                throw client.authenticationException(node);
             attemptStartTime = time.milliseconds();
         }
         return client.isReady(node, attemptStartTime);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerNetworkClient.java
@@ -135,7 +135,9 @@ public class ConsumerNetworkClient implements Closeable {
         int version = this.metadata.requestUpdate();
         do {
             poll(timeout);
-            this.metadata.maybeThrowAuthenticationException();
+            AuthenticationException ex = this.metadata.getAndClearAuthenticationException();
+            if (ex != null)
+                throw ex;
         } while (this.metadata.version() == version && time.milliseconds() - startMs < timeout);
         return this.metadata.version() > version;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.InvalidMetadataException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
@@ -200,32 +201,38 @@ public class Sender implements Runnable {
      */
     void run(long now) {
         if (transactionManager != null) {
-            if (transactionManager.shouldResetProducerStateAfterResolvingSequences())
-                // Check if the previous run expired batches which requires a reset of the producer state.
-                transactionManager.resetProducerId();
+            try {
+                if (transactionManager.shouldResetProducerStateAfterResolvingSequences())
+                    // Check if the previous run expired batches which requires a reset of the producer state.
+                    transactionManager.resetProducerId();
 
-            if (!transactionManager.isTransactional()) {
-                // this is an idempotent producer, so make sure we have a producer id
-                maybeWaitForProducerId();
-            } else if (transactionManager.hasUnresolvedSequences() && !transactionManager.hasFatalError()) {
-                transactionManager.transitionToFatalError(new KafkaException("The client hasn't received acknowledgment for " +
-                        "some previously sent messages and can no longer retry them. It isn't safe to continue."));
-            } else if (transactionManager.hasInFlightTransactionalRequest() || maybeSendTransactionalRequest(now)) {
-                // as long as there are outstanding transactional requests, we simply wait for them to return
-                client.poll(retryBackoffMs, now);
-                return;
-            }
+                if (!transactionManager.isTransactional()) {
+                    // this is an idempotent producer, so make sure we have a producer id
+                    maybeWaitForProducerId();
+                } else if (transactionManager.hasUnresolvedSequences() && !transactionManager.hasFatalError()) {
+                    transactionManager.transitionToFatalError(new KafkaException("The client hasn't received acknowledgment for " +
+                            "some previously sent messages and can no longer retry them. It isn't safe to continue."));
+                } else if (transactionManager.hasInFlightTransactionalRequest() || maybeSendTransactionalRequest(now)) {
+                    // as long as there are outstanding transactional requests, we simply wait for them to return
+                    client.poll(retryBackoffMs, now);
+                    return;
+                }
 
-            // do not continue sending if the transaction manager is in a failed state or if there
-            // is no producer id (for the idempotent case).
-            if (transactionManager.hasFatalError() || !transactionManager.hasProducerId()) {
-                RuntimeException lastError = transactionManager.lastError();
-                if (lastError != null)
-                    maybeAbortBatches(lastError);
-                client.poll(retryBackoffMs, now);
-                return;
-            } else if (transactionManager.hasAbortableError()) {
-                accumulator.abortUndrainedBatches(transactionManager.lastError());
+                // do not continue sending if the transaction manager is in a failed state or if there
+                // is no producer id (for the idempotent case).
+                if (transactionManager.hasFatalError() || !transactionManager.hasProducerId()) {
+                    RuntimeException lastError = transactionManager.lastError();
+                    if (lastError != null)
+                        maybeAbortBatches(lastError);
+                    client.poll(retryBackoffMs, now);
+                    return;
+                } else if (transactionManager.hasAbortableError()) {
+                    accumulator.abortUndrainedBatches(transactionManager.lastError());
+                }
+            } catch (AuthenticationException e) {
+                // This is already logged as error, but propagated here to perform any clean ups.
+                log.trace("Authentication exception while processing transactional request");
+                transactionManager.authenticationFailed(e);
             }
         }
 
@@ -406,7 +413,7 @@ public class Sender implements Runnable {
 
     private Node awaitLeastLoadedNodeReady(long remainingTimeMs) throws IOException {
         Node node = client.leastLoadedNode(time.milliseconds());
-        if (NetworkClientUtils.awaitReady(client, node, time, remainingTimeMs)) {
+        if (node != null && NetworkClientUtils.awaitReady(client, node, time, remainingTimeMs)) {
             return node;
         }
         return null;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -231,7 +231,7 @@ public class Sender implements Runnable {
                 }
             } catch (AuthenticationException e) {
                 // This is already logged as error, but propagated here to perform any clean ups.
-                log.trace("Authentication exception while processing transactional request");
+                log.trace("Authentication exception while processing transactional request: {}", e);
                 transactionManager.authenticationFailed(e);
             }
         }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/TransactionManager.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.protocol.Errors;
@@ -577,6 +578,11 @@ public class TransactionManager {
     synchronized void retry(TxnRequestHandler request) {
         request.setRetry();
         enqueueRequest(request);
+    }
+
+    synchronized void authenticationFailed(AuthenticationException e) {
+        for (TxnRequestHandler request : pendingRequests)
+            request.fatalError(e);
     }
 
     Node coordinator(FindCoordinatorRequest.CoordinatorType type) {

--- a/clients/src/main/java/org/apache/kafka/common/errors/AuthenticationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/AuthenticationException.java
@@ -16,6 +16,21 @@
  */
 package org.apache.kafka.common.errors;
 
+import javax.net.ssl.SSLException;
+
+/**
+ * This exception indicates that SSL handshake or SASL authentication has failed.
+ * On authentication failure, clients abort the operation requested and raise one
+ * of the subclasses of this exception:
+ * <ul>
+ *   </li>{@link AuthenticationFailedException} if SSL handshake fails with an
+ *   {@link SSLException} or SASL handshake fails with invalid credentials.</li>
+ *   <li>{@link UnsupportedSaslMechanismException} if the SASL mechanism requested by the client
+ *   is not supported on the broker.</li>
+ *   <li>{@link IllegalSaslStateException} if an unexpected request is received on during SASL
+ *   handshake. This could be due to misconfigured security protocol.
+ * </ul>
+ */
 public class AuthenticationException extends ApiException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/AuthenticationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/AuthenticationException.java
@@ -16,19 +16,17 @@
  */
 package org.apache.kafka.common.errors;
 
-import javax.net.ssl.SSLException;
-
 /**
- * This exception indicates that SSL handshake or SASL authentication has failed.
+ * This exception indicates that SASL authentication has failed.
  * On authentication failure, clients abort the operation requested and raise one
  * of the subclasses of this exception:
  * <ul>
- *   </li>{@link AuthenticationFailedException} if SSL handshake fails with an
- *   {@link SSLException} or SASL handshake fails with invalid credentials.</li>
+ *   </li>{@link SaslAuthenticationException} if SASL handshake fails with invalid credentials
+ *   or any other failure specific to the SASL mechanism used for authentication</li>
  *   <li>{@link UnsupportedSaslMechanismException} if the SASL mechanism requested by the client
  *   is not supported on the broker.</li>
  *   <li>{@link IllegalSaslStateException} if an unexpected request is received on during SASL
- *   handshake. This could be due to misconfigured security protocol.
+ *   handshake. This could be due to misconfigured security protocol.</li>
  * </ul>
  */
 public class AuthenticationException extends ApiException {

--- a/clients/src/main/java/org/apache/kafka/common/errors/AuthenticationFailedException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/AuthenticationFailedException.java
@@ -16,6 +16,19 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that SSL handshake or SASL authentication has
+ * failed.
+ * <p>
+ * SSL handshake failures in clients may indicate client authentication
+ * failure due to untrusted certificates if server is configured to request
+ * client certificates. Handshake failures could also indicate misconfigured
+ * security including protocol/cipher suite mismatch, server certificate
+ * authentication failure or server host name verification failure.
+ * </p><p>
+ * SASL authentication failures typically indicate invalid credentials.
+ * <p>
+ */
 public class AuthenticationFailedException extends AuthenticationException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/IllegalSaslStateException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/IllegalSaslStateException.java
@@ -20,7 +20,6 @@ package org.apache.kafka.common.errors;
  * This exception indicates unexpected requests prior to SASL authentication.
  * This could be due to misconfigured security, e.g. if PLAINTEXT protocol
  * is used to connect to a SASL endpoint.
- *
  */
 public class IllegalSaslStateException extends AuthenticationException {
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/IllegalSaslStateException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/IllegalSaslStateException.java
@@ -16,6 +16,12 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates unexpected requests prior to SASL authentication.
+ * This could be due to misconfigured security, e.g. if PLAINTEXT protocol
+ * is used to connect to a SASL endpoint.
+ *
+ */
 public class IllegalSaslStateException extends AuthenticationException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/errors/SaslAuthenticationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/SaslAuthenticationException.java
@@ -17,27 +17,23 @@
 package org.apache.kafka.common.errors;
 
 /**
- * This exception indicates that SSL handshake or SASL authentication has
- * failed.
+ * This exception indicates that SASL authentication has failed. The error message
+ * in the exception indicates the actual cause of failure.
  * <p>
- * SSL handshake failures in clients may indicate client authentication
- * failure due to untrusted certificates if server is configured to request
- * client certificates. Handshake failures could also indicate misconfigured
- * security including protocol/cipher suite mismatch, server certificate
- * authentication failure or server host name verification failure.
- * </p><p>
- * SASL authentication failures typically indicate invalid credentials.
- * <p>
+ * SASL authentication failures typically indicate invalid credentials, but
+ * could also include other failures specific to the SASL mechanism used
+ * for authentication.
+ * </p>
  */
-public class AuthenticationFailedException extends AuthenticationException {
+public class SaslAuthenticationException extends AuthenticationException {
 
     private static final long serialVersionUID = 1L;
 
-    public AuthenticationFailedException(String message) {
+    public SaslAuthenticationException(String message) {
         super(message);
     }
 
-    public AuthenticationFailedException(String message, Throwable cause) {
+    public SaslAuthenticationException(String message, Throwable cause) {
         super(message, cause);
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedSaslMechanismException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedSaslMechanismException.java
@@ -19,7 +19,6 @@ package org.apache.kafka.common.errors;
 /**
  * This exception indicates that the SASL mechanism requested by the client
  * is not enabled on the broker.
- *
  */
 public class UnsupportedSaslMechanismException extends AuthenticationException {
 

--- a/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedSaslMechanismException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/UnsupportedSaslMechanismException.java
@@ -16,6 +16,11 @@
  */
 package org.apache.kafka.common.errors;
 
+/**
+ * This exception indicates that the SASL mechanism requested by the client
+ * is not enabled on the broker.
+ *
+ */
 public class UnsupportedSaslMechanismException extends AuthenticationException {
 
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -79,7 +79,7 @@ public class KafkaChannel {
                 authenticator.authenticate();
             } catch (AuthenticationException e) {
                 switch (authenticator.error()) {
-                    case AUTHENTICATION_FAILED:
+                    case SASL_AUTHENTICATION_FAILED:
                     case ILLEGAL_SASL_STATE:
                     case UNSUPPORTED_SASL_MECHANISM:
                         state = new ChannelState(ChannelState.State.AUTHENTICATION_FAILED, e);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -17,7 +17,7 @@
 package org.apache.kafka.common.protocol;
 
 import org.apache.kafka.common.errors.ApiException;
-import org.apache.kafka.common.errors.AuthenticationFailedException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.ConcurrentTransactionsException;
@@ -518,11 +518,11 @@ public enum Errors {
                 return new LogDirNotFoundException(message);
             }
     }),
-    AUTHENTICATION_FAILED(58, "Authentication failed.",
+    SASL_AUTHENTICATION_FAILED(58, "SASL Authentication failed.",
         new ApiExceptionBuilder() {
             @Override
             public ApiException build(String message) {
-                return new AuthenticationFailedException(message);
+                return new SaslAuthenticationException(message);
             }
         });
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SaslAuthenticateResponse.java
@@ -51,7 +51,7 @@ public class SaslAuthenticateResponse extends AbstractResponse {
 
     /**
      * Possible error codes:
-     *   AUTHENTICATION_FAILED(57) : Authentication failed
+     *   SASL_AUTHENTICATION_FAILED(57) : Authentication failed
      */
     private final Errors error;
     private final String errorMessage;

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -104,7 +104,8 @@ public class SaslClientAuthenticator implements Authenticator {
     private RequestHeader currentRequestHeader;
     // Version of SaslAuthenticate request/responses
     private short saslAuthenticateVersion;
-    // Sasl authentication error which may be one of NONE, UNSUPPORTED_SASL_MECHANISM, ILLEGAL_SASL_STATE, AUTHENTICATION_FAILED or NETWORK_EXCEPTION
+    // Sasl authentication error which may be one of NONE, UNSUPPORTED_SASL_MECHANISM, ILLEGAL_SASL_STATE,
+    // SASL_AUTHENTICATION_FAILED or NETWORK_EXCEPTION
     private Errors error;
 
     public SaslClientAuthenticator(Map<String, ?> configs,

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -385,7 +385,7 @@ public class SaslServerAuthenticator implements Authenticator {
                 ByteBuffer responseBuf = responseToken == null ? EMPTY_BUFFER : ByteBuffer.wrap(responseToken);
                 sendKafkaResponse(requestContext, new SaslAuthenticateResponse(Errors.NONE, null, responseBuf));
             } catch (SaslException e) {
-                this.error = Errors.AUTHENTICATION_FAILED;
+                this.error = Errors.SASL_AUTHENTICATION_FAILED;
                 sendKafkaResponse(requestContext, new SaslAuthenticateResponse(this.error,
                         "Authentication failed due to invalid credentials with SASL mechanism " + saslMechanism));
                 throw e;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/ClientAuthenticationFailureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/ClientAuthenticationFailureTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
-import org.apache.kafka.common.errors.AuthenticationFailedException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.NetworkTestUtils;
 import org.apache.kafka.common.network.NioEchoServer;
@@ -84,7 +84,7 @@ public class ClientAuthenticationFailureTest {
             consumer.subscribe(Arrays.asList(topic));
             consumer.poll(100);
             fail("Expected an authentication error!");
-        } catch (AuthenticationFailedException e) {
+        } catch (SaslAuthenticationException e) {
             // OK
         } catch (Exception e) {
             fail("Expected only an authentication error, but another error occurred: " + e.getMessage());
@@ -102,7 +102,8 @@ public class ClientAuthenticationFailureTest {
             producer.send(record).get();
             fail("Expected an authentication error!");
         } catch (Exception e) {
-            assertTrue("Expected an exception of type AuthenticationFailedException", e.getCause() instanceof AuthenticationFailedException);
+            assertTrue("Expected SaslAuthenticationException, got " + e.getCause().getClass(),
+                    e.getCause() instanceof SaslAuthenticationException);
         }
     }
 
@@ -115,7 +116,8 @@ public class ClientAuthenticationFailureTest {
             result.all().get();
             fail("Expected an authentication error!");
         } catch (Exception e) {
-            assertTrue("Expected AuthenticationFailedException, got " + e.getClass(), e.getCause() instanceof AuthenticationFailedException);
+            assertTrue("Expected SaslAuthenticationException, got " + e.getCause().getClass(),
+                    e.getCause() instanceof SaslAuthenticationException);
         }
     }
 
@@ -126,14 +128,12 @@ public class ClientAuthenticationFailureTest {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
         props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "txclient-1");
-        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
-        props.put(ProducerConfig.BATCH_SIZE_CONFIG, "16384");
 
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
             producer.initTransactions();
             fail("Expected an authentication error!");
-        } catch (AuthenticationFailedException e) {
+        } catch (SaslAuthenticationException e) {
             // expected exception
         }
     }

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -13,12 +13,14 @@
 package kafka.api
 
 import java.io.FileOutputStream
+import java.util.Collections
 import java.util.concurrent.{ExecutionException, Future, TimeUnit}
-import scala.collection.JavaConverters.seqAsJavaListConverter
+import scala.collection.JavaConverters._
 
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig}
 import org.apache.kafka.clients.consumer.{KafkaConsumer, ConsumerConfig}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord, RecordMetadata}
-import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.AuthenticationFailedException
 import org.apache.kafka.common.protocol.SecurityProtocol
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
@@ -39,9 +41,13 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
   val producerCount = 1
   val serverCount = 1
 
+  this.serverConfig.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp, "1")
+  this.serverConfig.setProperty(KafkaConfig.TransactionsTopicReplicationFactorProp, "1")
+  this.serverConfig.setProperty(KafkaConfig.TransactionsTopicMinISRProp, "1")
   this.consumerConfig.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
   val topic = "topic"
+  val numPartitions = 1
   val tp = new TopicPartition(topic, 0)
 
   override def configureSecurityBeforeServersStart() {
@@ -56,7 +62,7 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     startSasl(jaasSections(kafkaServerSaslMechanisms, Some(kafkaClientSaslMechanism), Both,
       JaasTestUtils.KafkaServerContextName))
     super.setUp()
-    TestUtils.createTopic(this.zkUtils, topic, 1, serverCount, this.servers)
+    TestUtils.createTopic(this.zkUtils, topic, numPartitions, serverCount, this.servers)
   }
 
   @After
@@ -68,9 +74,24 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
   @Test
   def testProducerWithAuthenticationFailure() {
     verifyAuthenticationException(() => sendOneRecord(10000))
+    verifyAuthenticationException(() => producers.head.partitionsFor(topic))
 
     createClientCredential()
     verifyWithRetry(() => sendOneRecord())
+  }
+
+  @Test
+  def testTransactionalProducerWithAuthenticationFailure() {
+    val txProducer = createTransactionalProducer()
+    verifyAuthenticationException(() => txProducer.initTransactions())
+
+    createClientCredential()
+    try {
+      txProducer.initTransactions()
+      fail("Transaction initialization should fail after authentication failure")
+    } catch {
+      case _: KafkaException => // expected exception
+    }
   }
 
   @Test
@@ -100,10 +121,39 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
 
   private def verifyConsumerWithAuthenticationFailure(consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {
     verifyAuthenticationException(() => consumer.poll(10000))
+    verifyAuthenticationException(() => consumer.partitionsFor(topic))
 
     createClientCredential()
     verifyWithRetry(() => sendOneRecord())
     verifyWithRetry(() => assertEquals(1, consumer.poll(1000).count))
+  }
+
+  @Test
+  def testKafkaAdminClientWithAuthenticationFailure() {
+    val props = TestUtils.adminClientSecurityConfigs(securityProtocol, trustStoreFile, clientSaslProperties)
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    val adminClient = AdminClient.create(props)
+
+    def describeTopic(): Unit = {
+      try {
+        val response = adminClient.describeTopics(Collections.singleton(topic)).all.get
+        assertEquals(1, response.size)
+        response.asScala.foreach { case (topic, description) =>
+          assertEquals(numPartitions, description.partitions.size)
+        }
+      } catch {
+        case e: ExecutionException => throw e.getCause
+      }
+    }
+
+    try {
+      verifyAuthenticationException(() => describeTopic())
+
+      createClientCredential()
+      verifyWithRetry(() => describeTopic())
+    } finally {
+      adminClient.close
+    }
   }
 
   @Test
@@ -172,5 +222,20 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
         case _: AuthenticationFailedException => false
       }
     }, s"Operation did not succeed within timeout after $attempts")
+  }
+
+  private def createTransactionalProducer(): KafkaProducer[Array[Byte], Array[Byte]] = {
+    producerConfig.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "txclient-1")
+    producerConfig.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5")
+    producerConfig.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
+    producerConfig.put(ProducerConfig.BATCH_SIZE_CONFIG, "16384")
+    val txProducer = TestUtils.createNewProducer(brokerList,
+                                  securityProtocol = this.securityProtocol,
+                                  saslProperties = this.clientSaslProperties,
+                                  retries = 1000,
+                                  acks = -1,
+                                  props = Some(producerConfig))
+    producers += txProducer
+    txProducer
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -73,17 +73,17 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
 
   @Test
   def testProducerWithAuthenticationFailure() {
-    verifyAuthenticationException(() => sendOneRecord(10000))
-    verifyAuthenticationException(() => producers.head.partitionsFor(topic))
+    verifyAuthenticationException(sendOneRecord(10000))
+    verifyAuthenticationException(producers.head.partitionsFor(topic))
 
     createClientCredential()
-    verifyWithRetry(() => sendOneRecord())
+    verifyWithRetry(sendOneRecord())
   }
 
   @Test
   def testTransactionalProducerWithAuthenticationFailure() {
     val txProducer = createTransactionalProducer()
-    verifyAuthenticationException(() => txProducer.initTransactions())
+    verifyAuthenticationException(txProducer.initTransactions())
 
     createClientCredential()
     try {
@@ -120,12 +120,12 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
   }
 
   private def verifyConsumerWithAuthenticationFailure(consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {
-    verifyAuthenticationException(() => consumer.poll(10000))
-    verifyAuthenticationException(() => consumer.partitionsFor(topic))
+    verifyAuthenticationException(consumer.poll(10000))
+    verifyAuthenticationException(consumer.partitionsFor(topic))
 
     createClientCredential()
-    verifyWithRetry(() => sendOneRecord())
-    verifyWithRetry(() => assertEquals(1, consumer.poll(1000).count))
+    verifyWithRetry(sendOneRecord())
+    verifyWithRetry(assertEquals(1, consumer.poll(1000).count))
   }
 
   @Test
@@ -147,10 +147,10 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     }
 
     try {
-      verifyAuthenticationException(() => describeTopic())
+      verifyAuthenticationException(describeTopic())
 
       createClientCredential()
-      verifyWithRetry(() => describeTopic())
+      verifyWithRetry(describeTopic())
     } finally {
       adminClient.close
     }
@@ -174,9 +174,9 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     val consumer = consumers.head
     consumer.subscribe(List(topic).asJava)
 
-    verifyAuthenticationException(() => consumerGroupService.listGroups)
+    verifyAuthenticationException(consumerGroupService.listGroups)
     createClientCredential()
-    verifyWithRetry(() => consumer.poll(1000))
+    verifyWithRetry(consumer.poll(1000))
     assertEquals(1, consumerGroupService.listGroups.size)
   }
 
@@ -197,10 +197,10 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     }
   }
 
-  private def verifyAuthenticationException(f: () => Unit): Unit = {
+  private def verifyAuthenticationException(action: => Unit): Unit = {
     val startMs = System.currentTimeMillis
     try {
-      f()
+      action
       fail("Expected an authentication exception")
     } catch {
       case e: SaslAuthenticationException =>
@@ -211,12 +211,12 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     }
   }
 
-  private def verifyWithRetry(f: () => Unit): Unit = {
+  private def verifyWithRetry(action: => Unit): Unit = {
     var attempts = 0
     TestUtils.waitUntilTrue(() => {
       try {
         attempts += 1
-        f()
+        action
         true
       } catch {
         case _: SaslAuthenticationException => false


### PR DESCRIPTION
1. Raise AuthenticationException for authentication failures in admin client
2. Handle AuthenticationException as a fatal error for transactional producer
3. Add comments to authentication exceptions