### PR TITLE
Minor: Fix testUniqueErrorCodes unit test failure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -538,7 +538,7 @@ public enum Errors {
                 return new UnknownProducerIdException(message);
             }
     }),
-    REASSIGNMENT_IN_PROGRESS(59, "A partition reassignment is in progress",
+    REASSIGNMENT_IN_PROGRESS(60, "A partition reassignment is in progress",
         new ApiExceptionBuilder() {
             @Override
             public ApiException build(String message) {


### PR DESCRIPTION
I'm not really sure if I'm doing the right thing here, but I thought I'd give it a shot and try to fix the unit test breakage. Running ```./gradlew :clients:unitTest``` now passes.

Fix error code collision accidentally introduced when merging in https://github.com/apache/kafka/commit/5f6393f9b17cce17ded7a00e439599dfa77deb2d#diff-b119227df7efa3ffeb7fe69e49ff1afeR541

There were two Error 59's

Requesting review by @tombentley and @ijuma 