### PR TITLE
KAFKA-5061:clientid should be set for Connect Producers and Consumers

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -83,6 +83,10 @@ public class ConnectorConfig extends AbstractConfig {
     private static final String TRANSFORMS_DOC = "Aliases for the transformations to be applied to records.";
     private static final String TRANSFORMS_DISPLAY = "Transforms";
 
+    private static final String CLIENT_ID = "client.id";
+    private static final String CLIENT_ID_DOC = "group ID + task ID as default value, if not set as connector config parameter.";
+    private static final String CLIENT_ID_DISPLAY = "Client.Id";
+
     private final EnrichedConnectorConfig enrichedConfig;
     private static class EnrichedConnectorConfig extends AbstractConfig {
         EnrichedConnectorConfig(ConfigDef configDef, Map<String, String> props) {
@@ -110,7 +114,8 @@ public class ConnectorConfig extends AbstractConfig {
                             throw new ConfigException(name, value, "Duplicate alias provided.");
                         }
                     }
-                }, Importance.LOW, TRANSFORMS_DOC, TRANSFORMS_GROUP, 6, Width.LONG, TRANSFORMS_DISPLAY);
+                }, Importance.LOW, TRANSFORMS_DOC, TRANSFORMS_GROUP, 6, Width.LONG, TRANSFORMS_DISPLAY)
+                .define(CLIENT_ID, Type.STRING, null, Importance.HIGH, CLIENT_ID_DOC, COMMON_GROUP, 7, Width.LONG, CLIENT_ID_DISPLAY);
     }
 
     public ConnectorConfig(Plugins plugins) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -31,6 +32,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.storage.Converter;
@@ -407,6 +409,14 @@ class WorkerSinkTask extends WorkerTask {
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        //Client.id worker group ID + task ID
+        if(workerConfig instanceof DistributedConfig) {
+            if (workerConfig.getString(ConsumerConfig.CLIENT_ID_CONFIG) == null) {
+                props.put(ConsumerConfig.CLIENT_ID_CONFIG, workerConfig.getString(DistributedConfig.GROUP_ID_CONFIG) + id);
+            } else {
+                props.put(ConsumerConfig.CLIENT_ID_CONFIG, workerConfig.getString(CommonClientConfigs.CLIENT_ID_CONFIG));
+            }
+        }
 
         props.putAll(workerConfig.originalsWithPrefix("consumer."));
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -162,14 +162,14 @@ public class AbstractHerderTest extends EasyMockSupport {
         assertEquals(TestSourceConnector.class.getName(), result.name());
         assertEquals(Arrays.asList(ConnectorConfig.COMMON_GROUP, ConnectorConfig.TRANSFORMS_GROUP), result.groups());
         assertEquals(2, result.errorCount());
-        // Base connector config has 6 fields, connector's configs add 2
-        assertEquals(8, result.values().size());
+        // Base connector config has 6 fields, connector's configs add 3(with client.id)
+        assertEquals(9, result.values().size());
         // Missing name should generate an error
         assertEquals(ConnectorConfig.NAME_CONFIG, result.values().get(0).configValue().name());
         assertEquals(1, result.values().get(0).configValue().errors().size());
         // "required" config from connector should generate an error
-        assertEquals("required", result.values().get(6).configValue().name());
-        assertEquals(1, result.values().get(6).configValue().errors().size());
+        assertEquals("required", result.values().get(7).configValue().name());
+        assertEquals(1, result.values().get(7).configValue().errors().size());
 
         verifyAll();
     }
@@ -208,15 +208,15 @@ public class AbstractHerderTest extends EasyMockSupport {
         );
         assertEquals(expectedGroups, result.groups());
         assertEquals(2, result.errorCount());
-        // Base connector config has 6 fields, connector's configs add 2, 2 type fields from the transforms, and
+        // Base connector config has 6 fields, connector's configs add 3(with client.id), 2 type fields from the transforms, and
         // 1 from the valid transformation's config
-        assertEquals(11, result.values().size());
+        assertEquals(12, result.values().size());
         // Should get 2 type fields from the transforms, first adds its own config since it has a valid class
-        assertEquals("transforms.xformA.type", result.values().get(6).configValue().name());
+         assertEquals("transforms.xformA.type", result.values().get(7).configValue().name());
         assertTrue(result.values().get(6).configValue().errors().isEmpty());
-        assertEquals("transforms.xformA.subconfig", result.values().get(7).configValue().name());
-        assertEquals("transforms.xformB.type", result.values().get(8).configValue().name());
-        assertFalse(result.values().get(8).configValue().errors().isEmpty());
+        assertEquals("transforms.xformA.subconfig", result.values().get(8).configValue().name());
+        assertEquals("transforms.xformB.type", result.values().get(9).configValue().name());
+        assertFalse(result.values().get(9).configValue().errors().isEmpty());
 
         verifyAll();
     }


### PR DESCRIPTION
Have added the new config in ConnectorConfig with priority "LOW", providing an option to override client.id on a per-connector basis.
And set client.id , using (worker group ID + task ID) by default, when client.id is not provided in connector configuration, for distributed mode.