### PR TITLE
KAFKA-5969: Use correct error message when the JSON file is invalid

### DIFF
--- a/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
+++ b/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala
@@ -94,7 +94,7 @@ object PreferredReplicaLeaderElectionCommand extends Logging {
             partitions.toSet
           case None => throw new AdminOperationException("Preferred replica election data is empty")
         }
-      case None => throw new AdminOperationException("Preferred replica election data is empty")
+      case None => throw new AdminOperationException("The JSON file with the list of partitions is empty or invalid")
     }
   }
 


### PR DESCRIPTION
When invalid JSON file is passed to the bin/kafka-preferred-replica-election.sh / PreferredReplicaLeaderElectionCommand tool it gives a misleading error `Preferred replica election data is empty`. This PR replaces it with the correct error message.