### PR TITLE
KAFKA-5976: RequestChannel.sendResponse should record correct size for NetworkSend.

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -247,7 +247,7 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
     if (isTraceEnabled) {
       val requestHeader = response.request.header
       trace(s"Sending ${requestHeader.apiKey} response to client ${requestHeader.clientId} of " +
-        s"${response.responseSend.size} bytes.")
+        s"${response.responseSend.get.size} bytes.")
     }
 
     responseQueues(response.processor).put(response)

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -23,8 +23,7 @@ import java.util.concurrent._
 
 import com.yammer.metrics.core.Gauge
 import kafka.metrics.KafkaMetricsGroup
-import kafka.network.RequestChannel._
-import kafka.server.QuotaId
+import kafka.network.RequestChannel.{BaseRequest, SendAction, ShutdownRequest, NoOpAction, CloseConnectionAction}
 import kafka.utils.{Logging, NotNothing}
 import org.apache.kafka.common.memory.MemoryPool
 import org.apache.kafka.common.metrics.Sanitizer
@@ -204,7 +203,7 @@ object RequestChannel extends Logging {
       s"Response(request=$request, responseSend=$responseSend, responseAction=$responseAction), responseAsString=$responseAsString"
   }
 
-  trait ResponseAction
+  sealed trait ResponseAction
   case object SendAction extends ResponseAction
   case object NoOpAction extends ResponseAction
   case object CloseConnectionAction extends ResponseAction
@@ -245,17 +244,17 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
   /** Send a response back to the socket server to be sent over the network */
   def sendResponse(response: RequestChannel.Response) {
     if (isTraceEnabled) {
-      response.responseAction match {
+      val message = response.responseAction match {
         case SendAction =>
           val requestHeader = response.request.header
-          trace(s"Sending ${requestHeader.apiKey} response to client ${requestHeader.clientId} of ${response.responseSend.get.size} bytes.")
+          s"Sending ${requestHeader.apiKey} response to client ${requestHeader.clientId} of ${response.responseSend.get.size} bytes."
         case NoOpAction =>
           val requestHeader = response.request.header
-          trace(s"No need to send ${requestHeader.apiKey} response to client ${requestHeader.clientId}.")
+          s"No need to send ${requestHeader.apiKey} response to client ${requestHeader.clientId}."
         case CloseConnectionAction =>
-          trace("The connection is being closed since request handler encountered an error.")
-        case _ => // it should not happen
+          "The connection is being closed since request handler encountered an error."
       }
+      trace(message)
     }
 
     responseQueues(response.processor).put(response)

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -246,8 +246,11 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
   def sendResponse(response: RequestChannel.Response) {
     if (isTraceEnabled) {
       val requestHeader = response.request.header
-      trace(s"Sending ${requestHeader.apiKey} response to client ${requestHeader.clientId} of " +
-        s"${response.responseSend.get.size} bytes.")
+      val size = response.responseSend match {
+        case Some(send) => send.size
+        case None => 0
+      }
+      trace(s"Sending ${requestHeader.apiKey} response[action=${response.responseAction}, size=$size] to client")
     }
 
     responseQueues(response.processor).put(response)


### PR DESCRIPTION
When TRACE logging is enabled, RequestChannel.sendResponse records incorrect size for `Send` due to the fact that `response.responseSend` is of scala.Option type.