### PR TITLE
KAFKA-5973 Exit when ShutdownableThread encounters uncaught exception

### DIFF
--- a/core/src/main/scala/kafka/utils/ShutdownableThread.scala
+++ b/core/src/main/scala/kafka/utils/ShutdownableThread.scala
@@ -25,6 +25,12 @@ import org.apache.kafka.common.internals.FatalExitError
 abstract class ShutdownableThread(val name: String, val isInterruptible: Boolean = true)
         extends Thread(name) with Logging {
   this.setDaemon(false)
+  setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+      override def uncaughtException(thread: Thread, exception: Throwable) {
+        error("Exiting due to uncaught exception", exception)
+        Exit.exit(-2)
+      }
+  })
   this.logIdent = "[" + name + "]: "
   val isRunning: AtomicBoolean = new AtomicBoolean(true)
   private val shutdownLatch = new CountDownLatch(1)


### PR DESCRIPTION
This PR installs UncaughtExceptionHandler which calls Exit.exit() .

According to discussion on KAFKA-5973, exiting seems to be the consensus in this scenario.