### PR TITLE
KAFKA-5952 Refactor Consumer Fetcher metrics

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -699,12 +699,12 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(config.getList(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
             this.metadata.update(Cluster.bootstrap(addresses), Collections.<String>emptySet(), 0);
             String metricGrpPrefix = "consumer";
-            ConsumerMetrics metricsRegistry = new ConsumerMetrics(metricsTags.keySet(), "consumer");
+            ConsumerMetrics metricsRegistry = new ConsumerMetrics(this.metrics);
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config);
 
             IsolationLevel isolationLevel = IsolationLevel.valueOf(
                     config.getString(ConsumerConfig.ISOLATION_LEVEL_CONFIG).toUpperCase(Locale.ROOT));
-            Sensor throttleTimeSensor = Fetcher.throttleTimeSensor(metrics, metricsRegistry.fetcherMetrics);
+            Sensor throttleTimeSensor = Fetcher.throttleTimeSensor(metricsRegistry.fetcherMetrics);
 
             NetworkClient netClient = new NetworkClient(
                     new Selector(config.getLong(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
@@ -764,7 +764,6 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     this.valueDeserializer,
                     this.metadata,
                     this.subscriptions,
-                    metrics,
                     metricsRegistry.fetcherMetrics,
                     this.time,
                     this.retryBackoffMs,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetrics.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerMetrics.java
@@ -17,35 +17,36 @@
 package org.apache.kafka.clients.consumer.internals;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 
 public class ConsumerMetrics {
     
-    public FetcherMetricsRegistry fetcherMetrics;
+    private final Metrics metrics;
+    public final FetcherMetricsRegistry fetcherMetrics;
     
-    public ConsumerMetrics(Set<String> metricsTags, String metricGrpPrefix) {
-        this.fetcherMetrics = new FetcherMetricsRegistry(metricsTags, metricGrpPrefix);
+    public ConsumerMetrics(Metrics metrics) {
+        this.metrics = metrics;
+        this.fetcherMetrics = new FetcherMetricsRegistry(this.metrics);
     }
-
-    public ConsumerMetrics(String metricGroupPrefix) {
-        this(new HashSet<String>(), metricGroupPrefix);
-    }
-
-    private List<MetricNameTemplate> getAllTemplates() {
+    
+    private List<MetricNameTemplate> allTemplates() {
         List<MetricNameTemplate> l = new ArrayList<>();
-        l.addAll(this.fetcherMetrics.getAllTemplates());
+        l.addAll(this.fetcherMetrics.allTemplates());
         return l;
     }
 
     public static void main(String[] args) {
-        Set<String> tags = new HashSet<>();
-        tags.add("client-id");
-        ConsumerMetrics metrics = new ConsumerMetrics(tags, "consumer");
-        System.out.println(Metrics.toHtmlTable("kafka.consumer", metrics.getAllTemplates()));
+        Map<String, String> metricTags = Collections.singletonMap("client-id", "client-id");
+        MetricConfig metricConfig = new MetricConfig().tags(metricTags);
+        Metrics metrics = new Metrics(metricConfig);
+
+        ConsumerMetrics metricsRegistry = new ConsumerMetrics(metrics);
+        System.out.println(Metrics.toHtmlTable("kafka.consumer", metricsRegistry.allTemplates()));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -38,7 +38,6 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Count;
@@ -125,7 +124,6 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                    Deserializer<V> valueDeserializer,
                    Metadata metadata,
                    SubscriptionState subscriptions,
-                   Metrics metrics,
                    FetcherMetricsRegistry metricsRegistry,
                    Time time,
                    long retryBackoffMs,
@@ -144,7 +142,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
         this.keyDeserializer = ensureExtended(keyDeserializer);
         this.valueDeserializer = ensureExtended(valueDeserializer);
         this.completedFetches = new ConcurrentLinkedQueue<>();
-        this.sensors = new FetchManagerMetrics(metrics, metricsRegistry);
+        this.sensors = new FetchManagerMetrics(metricsRegistry);
         this.retryBackoffMs = retryBackoffMs;
         this.isolationLevel = isolationLevel;
 
@@ -937,11 +935,11 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
         sensors.updatePartitionLagSensors(assignment);
     }
 
-    public static Sensor throttleTimeSensor(Metrics metrics, FetcherMetricsRegistry metricsRegistry) {
+    public static Sensor throttleTimeSensor(FetcherMetricsRegistry metrics) {
         Sensor fetchThrottleTimeSensor = metrics.sensor("fetch-throttle-time");
-        fetchThrottleTimeSensor.add(metrics.metricInstance(metricsRegistry.fetchThrottleTimeAvg), new Avg());
+        fetchThrottleTimeSensor.add(metrics.fetchThrottleTimeAvg, new Avg());
 
-        fetchThrottleTimeSensor.add(metrics.metricInstance(metricsRegistry.fetchThrottleTimeMax), new Max());
+        fetchThrottleTimeSensor.add(metrics.fetchThrottleTimeMax, new Max());
 
         return fetchThrottleTimeSensor;
     }
@@ -1244,8 +1242,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
     }
 
     private static class FetchManagerMetrics {
-        private final Metrics metrics;
-        private FetcherMetricsRegistry metricsRegistry;
+        private FetcherMetricsRegistry metrics;
         private final Sensor bytesFetched;
         private final Sensor recordsFetched;
         private final Sensor fetchLatency;
@@ -1253,29 +1250,28 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
 
         private Set<TopicPartition> assignedPartitions;
 
-        private FetchManagerMetrics(Metrics metrics, FetcherMetricsRegistry metricsRegistry) {
+        private FetchManagerMetrics(FetcherMetricsRegistry metrics) {
             this.metrics = metrics;
-            this.metricsRegistry = metricsRegistry;
 
             this.bytesFetched = metrics.sensor("bytes-fetched");
-            this.bytesFetched.add(metrics.metricInstance(metricsRegistry.fetchSizeAvg), new Avg());
-            this.bytesFetched.add(metrics.metricInstance(metricsRegistry.fetchSizeMax), new Max());
-            this.bytesFetched.add(new Meter(metrics.metricInstance(metricsRegistry.bytesConsumedRate),
-                    metrics.metricInstance(metricsRegistry.bytesConsumedTotal)));
+            this.bytesFetched.add(metrics.fetchSizeAvg, new Avg());
+            this.bytesFetched.add(metrics.fetchSizeMax, new Max());
+            this.bytesFetched.add(new Meter(metrics.bytesConsumedRate,
+                    metrics.bytesConsumedTotal));
 
             this.recordsFetched = metrics.sensor("records-fetched");
-            this.recordsFetched.add(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg), new Avg());
-            this.recordsFetched.add(new Meter(metrics.metricInstance(metricsRegistry.recordsConsumedRate),
-                    metrics.metricInstance(metricsRegistry.recordsConsumedTotal)));
+            this.recordsFetched.add(metrics.recordsPerRequestAvg, new Avg());
+            this.recordsFetched.add(new Meter(metrics.recordsConsumedRate,
+                    metrics.recordsConsumedTotal));
 
             this.fetchLatency = metrics.sensor("fetch-latency");
-            this.fetchLatency.add(metrics.metricInstance(metricsRegistry.fetchLatencyAvg), new Avg());
-            this.fetchLatency.add(metrics.metricInstance(metricsRegistry.fetchLatencyMax), new Max());
-            this.fetchLatency.add(new Meter(new Count(), metrics.metricInstance(metricsRegistry.fetchRequestRate),
-                    metrics.metricInstance(metricsRegistry.fetchRequestTotal)));
+            this.fetchLatency.add(metrics.fetchLatencyAvg, new Avg());
+            this.fetchLatency.add(metrics.fetchLatencyMax, new Max());
+            this.fetchLatency.add(new Meter(new Count(), metrics.fetchRequestRate,
+                    metrics.fetchRequestTotal));
 
             this.recordsFetchLag = metrics.sensor("records-lag");
-            this.recordsFetchLag.add(metrics.metricInstance(metricsRegistry.recordsLagMax), new Max());
+            this.recordsFetchLag.add(metrics.recordsLagMax, new Max());
         }
 
         private void recordTopicFetchMetrics(String topic, int bytes, int records) {
@@ -1286,12 +1282,10 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 Map<String, String> metricTags = Collections.singletonMap("topic", topic.replace('.', '_'));
 
                 bytesFetched = this.metrics.sensor(name);
-                bytesFetched.add(this.metrics.metricInstance(metricsRegistry.topicFetchSizeAvg,
-                        metricTags), new Avg());
-                bytesFetched.add(this.metrics.metricInstance(metricsRegistry.topicFetchSizeMax,
-                        metricTags), new Max());
-                bytesFetched.add(new Meter(this.metrics.metricInstance(metricsRegistry.topicBytesConsumedRate, metricTags),
-                        this.metrics.metricInstance(metricsRegistry.topicBytesConsumedTotal, metricTags)));
+                bytesFetched.add(metrics.getTopicFetchSizeAvg(metricTags), new Avg());
+                bytesFetched.add(metrics.getTopicFetchSizeMax(metricTags), new Max());
+                bytesFetched.add(new Meter(metrics.getTopicBytesConsumedRate(metricTags),
+                        metrics.getTopicBytesConsumedTotal(metricTags)));
             }
             bytesFetched.record(bytes);
 
@@ -1303,10 +1297,9 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 metricTags.put("topic", topic.replace('.', '_'));
 
                 recordsFetched = this.metrics.sensor(name);
-                recordsFetched.add(this.metrics.metricInstance(metricsRegistry.topicRecordsPerRequestAvg,
-                        metricTags), new Avg());
-                recordsFetched.add(new Meter(this.metrics.metricInstance(metricsRegistry.topicRecordsConsumedRate, metricTags),
-                        this.metrics.metricInstance(metricsRegistry.topicRecordsConsumedTotal, metricTags)));
+                recordsFetched.add(metrics.getTopicRecordsPerRequestAvg(metricTags), new Avg());
+                recordsFetched.add(new Meter(metrics.getTopicRecordsConsumedRate(metricTags),
+                        metrics.getTopicRecordsConsumedTotal(metricTags)));
             }
             recordsFetched.record(records);
         }
@@ -1328,15 +1321,9 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             Sensor recordsLag = this.metrics.getSensor(name);
             if (recordsLag == null) {
                 recordsLag = this.metrics.sensor(name);
-                recordsLag.add(this.metrics.metricName(name,
-                        metricsRegistry.partitionRecordsLag.group(),
-                        metricsRegistry.partitionRecordsLag.description()), new Value());
-                recordsLag.add(this.metrics.metricName(name + "-max",
-                        metricsRegistry.partitionRecordsLagMax.group(),
-                        metricsRegistry.partitionRecordsLagMax.description()), new Max());
-                recordsLag.add(this.metrics.metricName(name + "-avg",
-                        metricsRegistry.partitionRecordsLagAvg.group(),
-                        metricsRegistry.partitionRecordsLagAvg.description()), new Avg());
+                recordsLag.add(metrics.getPartitionRecordsLag(name), new Value());
+                recordsLag.add(metrics.getPartitionRecordsLagMax(name), new Max());
+                recordsLag.add(metrics.getPartitionRecordsLagAvg(name), new Avg());
             }
             recordsLag.record(lag);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -1282,10 +1282,10 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 Map<String, String> metricTags = Collections.singletonMap("topic", topic.replace('.', '_'));
 
                 bytesFetched = this.metrics.sensor(name);
-                bytesFetched.add(metrics.getTopicFetchSizeAvg(metricTags), new Avg());
-                bytesFetched.add(metrics.getTopicFetchSizeMax(metricTags), new Max());
-                bytesFetched.add(new Meter(metrics.getTopicBytesConsumedRate(metricTags),
-                        metrics.getTopicBytesConsumedTotal(metricTags)));
+                bytesFetched.add(metrics.topicFetchSizeAvg(metricTags), new Avg());
+                bytesFetched.add(metrics.topicFetchSizeMax(metricTags), new Max());
+                bytesFetched.add(new Meter(metrics.topicBytesConsumedRate(metricTags),
+                        metrics.topicBytesConsumedTotal(metricTags)));
             }
             bytesFetched.record(bytes);
 
@@ -1297,9 +1297,9 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 metricTags.put("topic", topic.replace('.', '_'));
 
                 recordsFetched = this.metrics.sensor(name);
-                recordsFetched.add(metrics.getTopicRecordsPerRequestAvg(metricTags), new Avg());
-                recordsFetched.add(new Meter(metrics.getTopicRecordsConsumedRate(metricTags),
-                        metrics.getTopicRecordsConsumedTotal(metricTags)));
+                recordsFetched.add(metrics.topicRecordsPerRequestAvg(metricTags), new Avg());
+                recordsFetched.add(new Meter(metrics.topicRecordsConsumedRate(metricTags),
+                        metrics.topicRecordsConsumedTotal(metricTags)));
             }
             recordsFetched.record(records);
         }
@@ -1321,9 +1321,9 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             Sensor recordsLag = this.metrics.getSensor(name);
             if (recordsLag == null) {
                 recordsLag = this.metrics.sensor(name);
-                recordsLag.add(metrics.getPartitionRecordsLag(name), new Value());
-                recordsLag.add(metrics.getPartitionRecordsLagMax(name), new Max());
-                recordsLag.add(metrics.getPartitionRecordsLagAvg(name), new Avg());
+                recordsLag.add(metrics.partitionRecordsLag(name), new Value());
+                recordsLag.add(metrics.partitionRecordsLagMax(name), new Max());
+                recordsLag.add(metrics.partitionRecordsLagAvg(name), new Avg());
             }
             recordsLag.record(lag);
         }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
@@ -48,20 +48,20 @@ public class FetcherMetricsRegistry {
     public final MetricName fetchThrottleTimeAvg;
     public final MetricName fetchThrottleTimeMax;
 
-    private MetricNameTemplate topicFetchSizeAvg;
-    private MetricNameTemplate topicFetchSizeMax;
-    private MetricNameTemplate topicBytesConsumedRate;
-    private MetricNameTemplate topicBytesConsumedTotal;
-    private MetricNameTemplate topicRecordsPerRequestAvg;
-    private MetricNameTemplate topicRecordsConsumedRate;
-    private MetricNameTemplate topicRecordsConsumedTotal;
-    private MetricNameTemplate partitionRecordsLag;
-    private MetricNameTemplate partitionRecordsLagMax;
-    private MetricNameTemplate partitionRecordsLagAvg;
+    private final MetricNameTemplate topicFetchSizeAvg;
+    private final MetricNameTemplate topicFetchSizeMax;
+    private final MetricNameTemplate topicBytesConsumedRate;
+    private final MetricNameTemplate topicBytesConsumedTotal;
+    private final MetricNameTemplate topicRecordsPerRequestAvg;
+    private final MetricNameTemplate topicRecordsConsumedRate;
+    private final MetricNameTemplate topicRecordsConsumedTotal;
+    private final MetricNameTemplate partitionRecordsLag;
+    private final MetricNameTemplate partitionRecordsLagMax;
+    private final MetricNameTemplate partitionRecordsLagAvg;
 
-    private Metrics metrics;
-    private Set<String> tags;
-    private HashSet<String> topicTags;
+    private final Metrics metrics;
+    private final Set<String> tags;
+    private final HashSet<String> topicTags;
 
     public FetcherMetricsRegistry(Metrics metrics) {
         this.metrics = metrics;
@@ -129,47 +129,47 @@ public class FetcherMetricsRegistry {
         
     }
     
-    public MetricName getTopicFetchSizeAvg(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicFetchSizeAvg, metricTags);
+    public MetricName topicFetchSizeAvg(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicFetchSizeAvg, tags);
     }
 
-    public MetricName getTopicFetchSizeMax(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicFetchSizeMax, metricTags);
+    public MetricName topicFetchSizeMax(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicFetchSizeMax, tags);
     }
 
-    public MetricName getTopicBytesConsumedRate(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicBytesConsumedRate, metricTags);
+    public MetricName topicBytesConsumedRate(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicBytesConsumedRate, tags);
     }
 
-    public MetricName getTopicBytesConsumedTotal(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicBytesConsumedTotal, metricTags);
+    public MetricName topicBytesConsumedTotal(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicBytesConsumedTotal, tags);
     }
 
-    public MetricName getTopicRecordsPerRequestAvg(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicRecordsPerRequestAvg, metricTags);
+    public MetricName topicRecordsPerRequestAvg(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicRecordsPerRequestAvg, tags);
     }
 
-    public MetricName getTopicRecordsConsumedRate(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicRecordsConsumedRate, metricTags);
+    public MetricName topicRecordsConsumedRate(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicRecordsConsumedRate, tags);
     }
 
-    public MetricName getTopicRecordsConsumedTotal(Map<String, String> metricTags) {
-        return metrics.metricInstance(this.topicRecordsConsumedTotal, metricTags);
+    public MetricName topicRecordsConsumedTotal(Map<String, String> tags) {
+        return metrics.metricInstance(this.topicRecordsConsumedTotal, tags);
     }
 
-    public MetricName getPartitionRecordsLag(String partitionLagMetricName) {
+    public MetricName partitionRecordsLag(String partitionLagMetricName) {
         return metrics.metricName(partitionLagMetricName,
                 partitionRecordsLag.group(),
                 partitionRecordsLag.description());
     }
 
-    public MetricName getPartitionRecordsLagMax(String partitionLagMetricName) {
+    public MetricName partitionRecordsLagMax(String partitionLagMetricName) {
         return metrics.metricName(partitionLagMetricName + "-max",
                 partitionRecordsLagMax.group(),
                 partitionRecordsLagMax.description());
     }
 
-    public MetricName getPartitionRecordsLagAvg(String partitionLagMetricName) {
+    public MetricName partitionRecordsLagAvg(String partitionLagMetricName) {
         return metrics.metricName(partitionLagMetricName + "-avg",
                 partitionRecordsLagAvg.group(),
                 partitionRecordsLagAvg.description());

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/FetcherMetricsRegistry.java
@@ -16,145 +16,194 @@
  */
 package org.apache.kafka.clients.consumer.internals;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
 
 public class FetcherMetricsRegistry {
 
-    public MetricNameTemplate fetchSizeAvg;
-    public MetricNameTemplate fetchSizeMax;
-    public MetricNameTemplate bytesConsumedRate;
-    public MetricNameTemplate bytesConsumedTotal;
-    public MetricNameTemplate recordsPerRequestAvg;
-    public MetricNameTemplate recordsConsumedRate;
-    public MetricNameTemplate recordsConsumedTotal;
-    public MetricNameTemplate fetchLatencyAvg;
-    public MetricNameTemplate fetchLatencyMax;
-    public MetricNameTemplate fetchRequestRate;
-    public MetricNameTemplate fetchRequestTotal;
-    public MetricNameTemplate recordsLagMax;
-    public MetricNameTemplate fetchThrottleTimeAvg;
-    public MetricNameTemplate fetchThrottleTimeMax;
-    public MetricNameTemplate topicFetchSizeAvg;
-    public MetricNameTemplate topicFetchSizeMax;
-    public MetricNameTemplate topicBytesConsumedRate;
-    public MetricNameTemplate topicBytesConsumedTotal;
-    public MetricNameTemplate topicRecordsPerRequestAvg;
-    public MetricNameTemplate topicRecordsConsumedRate;
-    public MetricNameTemplate topicRecordsConsumedTotal;
-    public MetricNameTemplate partitionRecordsLag;
-    public MetricNameTemplate partitionRecordsLagMax;
-    public MetricNameTemplate partitionRecordsLagAvg;
+    final static String METRIC_GROUP_NAME = "consumer-fetch-manager-metrics";
+    
+    private final List<MetricNameTemplate> allTemplates;
 
-    public FetcherMetricsRegistry() {
-        this(new HashSet<String>(), "");
-    }
+    public final MetricName fetchSizeAvg;
+    public final MetricName fetchSizeMax;
+    public final MetricName bytesConsumedRate;
+    public final MetricName bytesConsumedTotal;
+    public final MetricName recordsPerRequestAvg;
+    public final MetricName recordsConsumedRate;
+    public final MetricName recordsConsumedTotal;
+    public final MetricName fetchLatencyAvg;
+    public final MetricName fetchLatencyMax;
+    public final MetricName fetchRequestRate;
+    public final MetricName fetchRequestTotal;
+    public final MetricName recordsLagMax;
+    public final MetricName fetchThrottleTimeAvg;
+    public final MetricName fetchThrottleTimeMax;
 
-    public FetcherMetricsRegistry(String metricGrpPrefix) {
-        this(new HashSet<String>(), metricGrpPrefix);
-    }
+    private MetricNameTemplate topicFetchSizeAvg;
+    private MetricNameTemplate topicFetchSizeMax;
+    private MetricNameTemplate topicBytesConsumedRate;
+    private MetricNameTemplate topicBytesConsumedTotal;
+    private MetricNameTemplate topicRecordsPerRequestAvg;
+    private MetricNameTemplate topicRecordsConsumedRate;
+    private MetricNameTemplate topicRecordsConsumedTotal;
+    private MetricNameTemplate partitionRecordsLag;
+    private MetricNameTemplate partitionRecordsLagMax;
+    private MetricNameTemplate partitionRecordsLagAvg;
 
-    public FetcherMetricsRegistry(Set<String> tags, String metricGrpPrefix) {
-        
+    private Metrics metrics;
+    private Set<String> tags;
+    private HashSet<String> topicTags;
+
+    public FetcherMetricsRegistry(Metrics metrics) {
+        this.metrics = metrics;
+        this.tags = this.metrics.config().tags().keySet();
+        this.allTemplates = new ArrayList<MetricNameTemplate>();
+
         /***** Client level *****/
-        String groupName = metricGrpPrefix + "-fetch-manager-metrics";
-                
-        this.fetchSizeAvg = new MetricNameTemplate("fetch-size-avg", groupName, 
-                "The average number of bytes fetched per request", tags);
-
-        this.fetchSizeMax = new MetricNameTemplate("fetch-size-max", groupName, 
-                "The maximum number of bytes fetched per request", tags);
-        this.bytesConsumedRate = new MetricNameTemplate("bytes-consumed-rate", groupName, 
-                "The average number of bytes consumed per second", tags);
-        this.bytesConsumedTotal = new MetricNameTemplate("bytes-consumed-total", groupName,
-                "The total number of bytes consumed", tags);
-
-        this.recordsPerRequestAvg = new MetricNameTemplate("records-per-request-avg", groupName, 
-                "The average number of records in each request", tags);
-        this.recordsConsumedRate = new MetricNameTemplate("records-consumed-rate", groupName, 
-                "The average number of records consumed per second", tags);
-        this.recordsConsumedTotal = new MetricNameTemplate("records-consumed-total", groupName,
-                "The total number of records consumed", tags);
-
-        this.fetchLatencyAvg = new MetricNameTemplate("fetch-latency-avg", groupName, 
-                "The average time taken for a fetch request.", tags);
-        this.fetchLatencyMax = new MetricNameTemplate("fetch-latency-max", groupName, 
-                "The max time taken for any fetch request.", tags);
-        this.fetchRequestRate = new MetricNameTemplate("fetch-rate", groupName, 
-                "The number of fetch requests per second.", tags);
-        this.fetchRequestTotal = new MetricNameTemplate("fetch-total", groupName,
-                "The total number of fetch requests.", tags);
-
-        this.recordsLagMax = new MetricNameTemplate("records-lag-max", groupName, 
-                "The maximum lag in terms of number of records for any partition in this window", tags);
-
-        this.fetchThrottleTimeAvg = new MetricNameTemplate("fetch-throttle-time-avg", groupName, 
-                "The average throttle time in ms", tags);
-        this.fetchThrottleTimeMax = new MetricNameTemplate("fetch-throttle-time-max", groupName, 
-                "The maximum throttle time in ms", tags);
+        this.fetchSizeAvg = createMetricName("fetch-size-avg",
+                "The average number of bytes fetched per request");
+        this.fetchSizeMax = createMetricName("fetch-size-max",
+                "The maximum number of bytes fetched per request");
+        this.bytesConsumedRate = createMetricName("bytes-consumed-rate",
+                "The average number of bytes consumed per second");
+        this.bytesConsumedTotal = createMetricName("bytes-consumed-total",
+                "The total number of bytes consumed");
+        this.recordsPerRequestAvg = createMetricName("records-per-request-avg",
+                "The average number of records in each request");
+        this.recordsConsumedRate = createMetricName("records-consumed-rate",
+                "The average number of records consumed per second");
+        this.recordsConsumedTotal = createMetricName("records-consumed-total",
+                "The total number of records consumed");
+        this.fetchLatencyAvg = createMetricName("fetch-latency-avg",
+                "The average time taken for a fetch request.");
+        this.fetchLatencyMax = createMetricName("fetch-latency-max",
+                "The max time taken for any fetch request.");
+        this.fetchRequestRate = createMetricName("fetch-rate",
+                "The number of fetch requests per second.");
+        this.fetchRequestTotal = createMetricName("fetch-total",
+                "The total number of fetch requests.");
+        this.recordsLagMax = createMetricName("records-lag-max",
+                "The maximum lag in terms of number of records for any partition in this window");
+        this.fetchThrottleTimeAvg = createMetricName("fetch-throttle-time-avg", 
+                "The average throttle time in ms");
+        this.fetchThrottleTimeMax = createMetricName("fetch-throttle-time-max", 
+                "The maximum throttle time in ms");
 
         /***** Topic level *****/
-        Set<String> topicTags = new HashSet<>(tags);
-        topicTags.add("topic");
+        this.topicTags = new HashSet<>(tags);
+        this.topicTags.add("topic");
 
-        this.topicFetchSizeAvg = new MetricNameTemplate("fetch-size-avg", groupName, 
-                "The average number of bytes fetched per request for a topic", topicTags);
-        this.topicFetchSizeMax = new MetricNameTemplate("fetch-size-max", groupName, 
-                "The maximum number of bytes fetched per request for a topic", topicTags);
-        this.topicBytesConsumedRate = new MetricNameTemplate("bytes-consumed-rate", groupName, 
-                "The average number of bytes consumed per second for a topic", topicTags);
-        this.topicBytesConsumedTotal = new MetricNameTemplate("bytes-consumed-total", groupName,
-                "The total number of bytes consumed for a topic", topicTags);
-
-        this.topicRecordsPerRequestAvg = new MetricNameTemplate("records-per-request-avg", groupName, 
-                "The average number of records in each request for a topic", topicTags);
-        this.topicRecordsConsumedRate = new MetricNameTemplate("records-consumed-rate", groupName, 
-                "The average number of records consumed per second for a topic", topicTags);
-        this.topicRecordsConsumedTotal = new MetricNameTemplate("records-consumed-total", groupName,
-                "The total number of records consumed for a topic", topicTags);
+        // We can't create the MetricName up front for these, because we don't know the topic name yet.
+        this.topicFetchSizeAvg = createTopicTemplate("fetch-size-avg",
+                "The average number of bytes fetched per request for a topic");
+        this.topicFetchSizeMax = createTopicTemplate("fetch-size-max",
+                "The maximum number of bytes fetched per request for a topic");
+        this.topicBytesConsumedRate = createTopicTemplate("bytes-consumed-rate",
+                "The average number of bytes consumed per second for a topic");
+        this.topicBytesConsumedTotal = createTopicTemplate("bytes-consumed-total",
+                "The total number of bytes consumed for a topic");
+        this.topicRecordsPerRequestAvg = createTopicTemplate("records-per-request-avg",
+                "The average number of records in each request for a topic");
+        this.topicRecordsConsumedRate = createTopicTemplate("records-consumed-rate",
+                "The average number of records consumed per second for a topic");
+        this.topicRecordsConsumedTotal = createTopicTemplate("records-consumed-total",
+                "The total number of records consumed for a topic");
         
         /***** Partition level *****/
-        this.partitionRecordsLag = new MetricNameTemplate("{topic}-{partition}.records-lag", groupName, 
-                "The latest lag of the partition", tags);
-        this.partitionRecordsLagMax = new MetricNameTemplate("{topic}-{partition}.records-lag-max", groupName, 
-                "The max lag of the partition", tags);
-        this.partitionRecordsLagAvg = new MetricNameTemplate("{topic}-{partition}.records-lag-avg", groupName, 
-                "The average lag of the partition", tags);
+        // We can't create the MetricName up front for these, because we don't know the topic and partition name.
+        this.partitionRecordsLag = createTemplate("{topic}-{partition}.records-lag", "The latest lag of the partition", 
+                tags);
+        this.partitionRecordsLagMax = createTemplate("{topic}-{partition}.records-lag-max", "The max lag of the partition", 
+                tags);
+        this.partitionRecordsLagAvg = createTemplate("{topic}-{partition}.records-lag-avg", "The average lag of the partition", 
+                tags);
         
-    
     }
     
-    public List<MetricNameTemplate> getAllTemplates() {
-        return Arrays.asList(
-            fetchSizeAvg,
-            fetchSizeMax,
-            bytesConsumedRate,
-            bytesConsumedTotal,
-            recordsPerRequestAvg,
-            recordsConsumedRate,
-            recordsConsumedTotal,
-            fetchLatencyAvg,
-            fetchLatencyMax,
-            fetchRequestRate,
-            fetchRequestTotal,
-            recordsLagMax,
-            fetchThrottleTimeAvg,
-            fetchThrottleTimeMax,
-            topicFetchSizeAvg,
-            topicFetchSizeMax,
-            topicBytesConsumedRate,
-            topicBytesConsumedTotal,
-            topicRecordsPerRequestAvg,
-            topicRecordsConsumedRate,
-            topicRecordsConsumedTotal,
-            partitionRecordsLag,
-            partitionRecordsLagAvg,
-            partitionRecordsLagMax
-        );
+    public MetricName getTopicFetchSizeAvg(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicFetchSizeAvg, metricTags);
+    }
+
+    public MetricName getTopicFetchSizeMax(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicFetchSizeMax, metricTags);
+    }
+
+    public MetricName getTopicBytesConsumedRate(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicBytesConsumedRate, metricTags);
+    }
+
+    public MetricName getTopicBytesConsumedTotal(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicBytesConsumedTotal, metricTags);
+    }
+
+    public MetricName getTopicRecordsPerRequestAvg(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicRecordsPerRequestAvg, metricTags);
+    }
+
+    public MetricName getTopicRecordsConsumedRate(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicRecordsConsumedRate, metricTags);
+    }
+
+    public MetricName getTopicRecordsConsumedTotal(Map<String, String> metricTags) {
+        return metrics.metricInstance(this.topicRecordsConsumedTotal, metricTags);
+    }
+
+    public MetricName getPartitionRecordsLag(String partitionLagMetricName) {
+        return metrics.metricName(partitionLagMetricName,
+                partitionRecordsLag.group(),
+                partitionRecordsLag.description());
+    }
+
+    public MetricName getPartitionRecordsLagMax(String partitionLagMetricName) {
+        return metrics.metricName(partitionLagMetricName + "-max",
+                partitionRecordsLagMax.group(),
+                partitionRecordsLagMax.description());
+    }
+
+    public MetricName getPartitionRecordsLagAvg(String partitionLagMetricName) {
+        return metrics.metricName(partitionLagMetricName + "-avg",
+                partitionRecordsLagAvg.group(),
+                partitionRecordsLagAvg.description());
+    }
+
+    public List<MetricNameTemplate> allTemplates() {
+        return allTemplates;
+    }
+    
+    public Sensor sensor(String name) {
+        return this.metrics.sensor(name);
+    }
+
+    public Sensor getSensor(String name) {
+        return this.metrics.getSensor(name);
+    }
+
+    public void removeSensor(String name) {
+        this.metrics.removeSensor(name);
+    }
+
+    private MetricName createMetricName(String name, String description) {
+        return this.metrics.metricInstance(createTemplate(name, description, this.tags));
+    }
+
+    private MetricNameTemplate createTopicTemplate(String name, String description) {
+        return createTemplate(name, description, this.topicTags);
+    }
+
+    
+    private MetricNameTemplate createTemplate(String name, String description, Set<String> tags) {
+        MetricNameTemplate template = new MetricNameTemplate(name, METRIC_GROUP_NAME, description, tags);
+        this.allTemplates.add(template);
+        return template;
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1619,7 +1619,7 @@ public class KafkaConsumerTest {
         ConsumerInterceptors<String, String> interceptors = null;
 
         Metrics metrics = new Metrics();
-        ConsumerMetrics metricsRegistry = new ConsumerMetrics(metricGroupPrefix);
+        ConsumerMetrics metricsRegistry = new ConsumerMetrics(metrics);
 
         SubscriptionState subscriptions = new SubscriptionState(autoResetStrategy);
         LogContext loggerFactory = new LogContext();
@@ -1658,7 +1658,6 @@ public class KafkaConsumerTest {
                 valueDeserializer,
                 metadata,
                 subscriptions,
-                metrics,
                 metricsRegistry.fetcherMetrics,
                 time,
                 retryBackoffMs,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -112,8 +112,6 @@ import static org.junit.Assert.fail;
 public class FetcherTest {
     private ConsumerRebalanceListener listener = new NoOpConsumerRebalanceListener();
     private String topicName = "test";
-    private String groupId = "test-group";
-    private final String metricGroup = "consumer" + groupId + "-fetch-manager-metrics";
     private TopicPartition tp0 = new TopicPartition(topicName, 0);
     private TopicPartition tp1 = new TopicPartition(topicName, 1);
     private int minBytes = 1;
@@ -127,7 +125,7 @@ public class FetcherTest {
     private Cluster cluster = TestUtils.singletonCluster(topicName, 2);
     private Node node = cluster.nodes().get(0);
     private Metrics metrics = new Metrics(time);
-    FetcherMetricsRegistry metricsRegistry = new FetcherMetricsRegistry("consumer" + groupId);
+    private FetcherMetricsRegistry metricsRegistry = new FetcherMetricsRegistry(metrics);
 
     private SubscriptionState subscriptions = new SubscriptionState(OffsetResetStrategy.EARLIEST);
     private SubscriptionState subscriptionsNoAutoReset = new SubscriptionState(OffsetResetStrategy.NONE);
@@ -1126,7 +1124,7 @@ public class FetcherTest {
     @Test
     public void testQuotaMetrics() throws Exception {
         MockSelector selector = new MockSelector(time);
-        Sensor throttleTimeSensor = Fetcher.throttleTimeSensor(metrics, metricsRegistry);
+        Sensor throttleTimeSensor = Fetcher.throttleTimeSensor(metricsRegistry);
         Cluster cluster = TestUtils.singletonCluster("test", 1);
         Node node = cluster.nodes().get(0);
         NetworkClient client = new NetworkClient(selector, metadata, "mock", Integer.MAX_VALUE,
@@ -1153,8 +1151,8 @@ public class FetcherTest {
             selector.clear();
         }
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
-        KafkaMetric avgMetric = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchThrottleTimeAvg));
-        KafkaMetric maxMetric = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchThrottleTimeMax));
+        KafkaMetric avgMetric = allMetrics.get(metricsRegistry.fetchThrottleTimeAvg);
+        KafkaMetric maxMetric = allMetrics.get(metricsRegistry.fetchThrottleTimeMax);
         // Throttle times are ApiVersions=400, Fetch=(100, 200, 300)
         assertEquals(250, avgMetric.value(), EPSILON);
         assertEquals(400, maxMetric.value(), EPSILON);
@@ -1169,8 +1167,8 @@ public class FetcherTest {
         subscriptions.assignFromUser(singleton(tp0));
         subscriptions.seek(tp0, 0);
 
-        MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
-        MetricName partitionLagMetric = metrics.metricName(tp0 + ".records-lag", metricGroup);
+        MetricName maxLagMetric = metricsRegistry.recordsLagMax;
+        MetricName partitionLagMetric = metricsRegistry.getPartitionRecordsLag(tp0 + ".records-lag");
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
@@ -1208,8 +1206,8 @@ public class FetcherTest {
         subscriptions.assignFromUser(singleton(tp0));
         subscriptions.seek(tp0, 0);
 
-        MetricName maxLagMetric = metrics.metricInstance(metricsRegistry.recordsLagMax);
-        MetricName partitionLagMetric = metrics.metricName(tp0 + ".records-lag", metricGroup);
+        MetricName maxLagMetric = metricsRegistry.recordsLagMax;
+        MetricName partitionLagMetric = metricsRegistry.getPartitionRecordsLag(tp0 + ".records-lag");
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
@@ -1244,8 +1242,8 @@ public class FetcherTest {
         subscriptions.seek(tp0, 0);
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
-        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
-        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+        KafkaMetric fetchSizeAverage = allMetrics.get(metricsRegistry.fetchSizeAvg);
+        KafkaMetric recordsCountAverage = allMetrics.get(metricsRegistry.recordsPerRequestAvg);
 
         MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
                 TimestampType.CREATE_TIME, 0L);
@@ -1268,8 +1266,8 @@ public class FetcherTest {
         subscriptions.seek(tp0, 1);
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
-        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
-        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+        KafkaMetric fetchSizeAverage = allMetrics.get(metricsRegistry.fetchSizeAvg);
+        KafkaMetric recordsCountAverage = allMetrics.get(metricsRegistry.recordsPerRequestAvg);
 
         MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
                 TimestampType.CREATE_TIME, 0L);
@@ -1295,8 +1293,8 @@ public class FetcherTest {
         subscriptions.seek(tp1, 0);
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
-        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
-        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+        KafkaMetric fetchSizeAverage = allMetrics.get(metricsRegistry.fetchSizeAvg);
+        KafkaMetric recordsCountAverage = allMetrics.get(metricsRegistry.recordsPerRequestAvg);
 
         MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), CompressionType.NONE,
                 TimestampType.CREATE_TIME, 0L);
@@ -1330,8 +1328,8 @@ public class FetcherTest {
         subscriptions.seek(tp1, 0);
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
-        KafkaMetric fetchSizeAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.fetchSizeAvg));
-        KafkaMetric recordsCountAverage = allMetrics.get(metrics.metricInstance(metricsRegistry.recordsPerRequestAvg));
+        KafkaMetric fetchSizeAverage = allMetrics.get(metricsRegistry.fetchSizeAvg);
+        KafkaMetric recordsCountAverage = allMetrics.get(metricsRegistry.recordsPerRequestAvg);
 
         // send the fetch and then seek to a new offset
         assertEquals(1, fetcher.sendFetches());
@@ -1368,7 +1366,7 @@ public class FetcherTest {
         metrics.close();
         Map<String, String> clientTags = Collections.singletonMap("client-id", "clientA");
         metrics = new Metrics(new MetricConfig().tags(clientTags));
-        metricsRegistry = new FetcherMetricsRegistry(clientTags.keySet(), "consumer" + groupId);
+        metricsRegistry = new FetcherMetricsRegistry(metrics);
         fetcher.close();
         fetcher = createFetcher(subscriptions, metrics);
 
@@ -1383,7 +1381,7 @@ public class FetcherTest {
         assertTrue(partitionRecords.containsKey(tp0));
 
         // Create throttle metrics
-        Fetcher.throttleTimeSensor(metrics, metricsRegistry);
+        Fetcher.throttleTimeSensor(metricsRegistry);
 
         // Verify that all metrics except metrics-count have registered templates
         Set<MetricNameTemplate> allMetrics = new HashSet<>();
@@ -1392,7 +1390,7 @@ public class FetcherTest {
             if (!n.group().equals("kafka-metrics-count"))
                 allMetrics.add(new MetricNameTemplate(name, n.group(), "", n.tags().keySet()));
         }
-        TestUtils.checkEquals(allMetrics, new HashSet<>(metricsRegistry.getAllTemplates()), "metrics", "templates");
+        TestUtils.checkEquals(allMetrics, new HashSet<>(metricsRegistry.allTemplates()), "metrics", "templates");
     }
 
     private Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> fetchRecords(
@@ -2087,8 +2085,7 @@ public class FetcherTest {
                 valueDeserializer,
                 metadata,
                 subscriptions,
-                metrics,
-                metricsRegistry,
+                new FetcherMetricsRegistry(metrics),
                 time,
                 retryBackoffMs,
                 isolationLevel);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/FetcherTest.java
@@ -1168,7 +1168,7 @@ public class FetcherTest {
         subscriptions.seek(tp0, 0);
 
         MetricName maxLagMetric = metricsRegistry.recordsLagMax;
-        MetricName partitionLagMetric = metricsRegistry.getPartitionRecordsLag(tp0 + ".records-lag");
+        MetricName partitionLagMetric = metricsRegistry.partitionRecordsLag(tp0 + ".records-lag");
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);
@@ -1207,7 +1207,7 @@ public class FetcherTest {
         subscriptions.seek(tp0, 0);
 
         MetricName maxLagMetric = metricsRegistry.recordsLagMax;
-        MetricName partitionLagMetric = metricsRegistry.getPartitionRecordsLag(tp0 + ".records-lag");
+        MetricName partitionLagMetric = metricsRegistry.partitionRecordsLag(tp0 + ".records-lag");
 
         Map<MetricName, KafkaMetric> allMetrics = metrics.metrics();
         KafkaMetric recordsFetchLagMax = allMetrics.get(maxLagMetric);


### PR DESCRIPTION
This is ready for review. This does not have to be merged into 1.0.0, it can simply go to trunk.