### PR TITLE
KAFKA-5902: Added sink task metrics

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/StateTracker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/StateTracker.java
@@ -167,7 +167,7 @@ public class StateTracker {
             }
             long total = durationCurrent + unassignedTotalTimeMs + runningTotalTimeMs + pausedTotalTimeMs +
                                  failedTotalTimeMs + destroyedTotalTimeMs;
-            return (double) durationDesired / total;
+            return total == 0.0d ? 0.0d : (double) durationDesired / total;
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -726,10 +726,10 @@ class WorkerSinkTask extends WorkerTask {
                     long consumedOffset = consumedOffsetMeta.offset();
                     long committedOffset = committedOffsetMeta.offset();
                     long diff = consumedOffset - committedOffset;
-                    activeRecords += diff;
+                    // Connector tasks can return offsets, so make sure nothing wonky happens
+                    activeRecords += Math.max(diff, 0L);
                 }
             }
-            activeRecords = Math.max(activeRecords, 0L);
             sinkRecordActiveCount.record(activeRecords);
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
+import org.apache.kafka.common.metrics.stats.Value;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
@@ -205,10 +206,12 @@ class WorkerSourceTask extends WorkerTask {
     private boolean sendRecords() {
         int processed = 0;
         recordBatch(toSend.size());
+        final SourceRecordWriteCounter counter = new SourceRecordWriteCounter(toSend.size(), sourceTaskMetricsGroup);
         for (final SourceRecord preTransformRecord : toSend) {
             final SourceRecord record = transformationChain.apply(preTransformRecord);
 
             if (record == null) {
+                counter.skipRecord();
                 commitTaskRecord(preTransformRecord);
                 continue;
             }
@@ -256,6 +259,7 @@ class WorkerSourceTask extends WorkerTask {
                                     commitTaskRecord(preTransformRecord);
                                 }
                                 recordSent(producerRecord);
+                                counter.completeRecord();
                             }
                         });
                 lastSendFailed = false;
@@ -263,6 +267,7 @@ class WorkerSourceTask extends WorkerTask {
                 log.warn("{} Failed to send {}, backing off before retrying:", this, producerRecord, e);
                 toSend = toSend.subList(processed, toSend.size());
                 lastSendFailed = true;
+                counter.retryRemaining();
                 return false;
             } catch (KafkaException e) {
                 throw new ConnectException("Unrecoverable exception trying to send", e);
@@ -282,7 +287,6 @@ class WorkerSourceTask extends WorkerTask {
     }
 
     private synchronized void recordSent(final ProducerRecord<byte[], byte[]> record) {
-        recordWriteCompleted(1);
         ProducerRecord<byte[], byte[]> removed = outstandingMessages.remove(record);
         // While flushing, we may also see callbacks for items in the backlog
         if (removed == null && flushing)
@@ -440,19 +444,50 @@ class WorkerSourceTask extends WorkerTask {
         sourceTaskMetricsGroup.recordPoll(numRecordsInBatch, duration);
     }
 
-    protected void recordWriteCompleted(int numRecords) {
-        sourceTaskMetricsGroup.recordWrite(numRecords);
-    }
-
     SourceTaskMetricsGroup sourceTaskMetricsGroup() {
         return sourceTaskMetricsGroup;
+    }
+
+    static class SourceRecordWriteCounter {
+        private final SourceTaskMetricsGroup metricsGroup;
+        private final int batchSize;
+        private boolean completed = false;
+        private int counter;
+        public SourceRecordWriteCounter(int batchSize, SourceTaskMetricsGroup metricsGroup) {
+            assert batchSize > 0;
+            assert metricsGroup != null;
+            this.batchSize = batchSize;
+            counter = batchSize;
+            this.metricsGroup = metricsGroup;
+        }
+        public void skipRecord() {
+            if (counter > 0 && --counter == 0) {
+                finishedAllWrites();
+            }
+        }
+        public void completeRecord() {
+            if (counter > 0 && --counter == 0) {
+                finishedAllWrites();
+            }
+        }
+        public void retryRemaining() {
+            finishedAllWrites();
+        }
+        private void finishedAllWrites() {
+            if (!completed) {
+                metricsGroup.recordWrite(batchSize - counter);
+                completed = true;
+            }
+        }
     }
 
     static class SourceTaskMetricsGroup {
         private final MetricGroup metricGroup;
         private final Sensor sourceRecordPoll;
         private final Sensor sourceRecordWrite;
+        private final Sensor sourceRecordActiveCount;
         private final Sensor pollTime;
+        private int activeRecordCount;
 
         public SourceTaskMetricsGroup(ConnectorTaskId id, ConnectMetrics connectMetrics) {
             metricGroup = connectMetrics.group("source-task-metrics",
@@ -490,27 +525,16 @@ class WorkerSourceTask extends WorkerTask {
                     "The average time in milliseconds taken by this task to poll for a batch of source records"),
                     new Avg());
 
-//            int buckets = 100;
-//            MetricName p99 = metricGroup.metricName("poll-batch-99p-time-ms",
-//                    "The 99th percentile time in milliseconds spent by this task to poll for a batch of source records");
-//            MetricName p95 = metricGroup.metricName("poll-batch-95p-time-ms",
-//                    "The 95th percentile time in milliseconds spent by this task to poll for a batch of source records");
-//            MetricName p90 = metricGroup.metricName("poll-batch-90p-time-ms",
-//                    "The 90th percentile time in milliseconds spent by this task to poll for a batch of source records");
-//            MetricName p75 = metricGroup.metricName("poll-batch-75p-time-ms",
-//                    "The 75th percentile time in milliseconds spent by this task to poll for a batch of source records");
-//            MetricName p50 = metricGroup.metricName("poll-batch-50p-time-ms",
-//                    "The 50th percentile (median) time in milliseconds spent by this task to poll for a batch of source records");
-//            Percentiles pollTimePercentiles = new Percentiles(4 * buckets,
-//                                                            0.0,
-//                                                            10*1000.0,
-//                                                            BucketSizing.LINEAR,
-//                                                            new Percentile(p50, 50),
-//                                                            new Percentile(p75, 75),
-//                                                            new Percentile(p90, 90),
-//                                                            new Percentile(p95, 95),
-//                                                            new Percentile(p99, 99));
-//            pollTime.add(pollTimePercentiles);
+            sourceRecordActiveCount = metricGroup.metrics().sensor("source-record-active-count");
+            sourceRecordActiveCount.add(metricGroup.metricName("source-record-active-count",
+                    "The number of records that have been produced by this task but not yet completely written to Kafka."),
+                    new Value());
+            sourceRecordActiveCount.add(metricGroup.metricName("source-record-active-count-max",
+                    "The maximum number of records that have been produced by this task but not yet completely written to Kafka."),
+                    new Max());
+            sourceRecordActiveCount.add(metricGroup.metricName("source-record-active-count-avg",
+                    "The average number of records that have been produced by this task but not yet completely written to Kafka."),
+                    new Avg());
         }
 
         void close() {
@@ -520,10 +544,15 @@ class WorkerSourceTask extends WorkerTask {
         void recordPoll(int batchSize, long duration) {
             sourceRecordPoll.record(batchSize);
             pollTime.record(duration);
+            activeRecordCount += batchSize;
+            sourceRecordActiveCount.record(activeRecordCount);
         }
 
         void recordWrite(int recordCount) {
             sourceRecordWrite.record(recordCount);
+            activeRecordCount -= recordCount;
+            activeRecordCount = Math.max(0, activeRecordCount);
+            sourceRecordActiveCount.record(activeRecordCount);
         }
 
         protected MetricGroup metricGroup() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
@@ -53,7 +53,11 @@ public class MockConnectMetrics extends ConnectMetrics {
     }
 
     public MockConnectMetrics() {
-        super("mock", new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), new MockTime());
+        this(new MockTime());
+    }
+
+    public MockConnectMetrics(MockTime time) {
+        super("mock", new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), time);
     }
 
     @Override
@@ -133,7 +137,8 @@ public class MockConnectMetrics extends ConnectMetrics {
          * @return the current value of the metric
          */
         public double currentMetricValue(MetricName metricName) {
-            return metricsByName.get(metricName).value();
+            KafkaMetric metric = metricsByName.get(metricName);
+            return metric != null ? metric.value() : Double.NaN;
         }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -245,7 +245,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count", 1.0);
+        assertSinkMetricValue("sink-record-active-count-max", 1.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.333333);
         assertSinkMetricValue("offset-commit-seq-no", 0.0);
         assertSinkMetricValue("offset-commit-completion-rate", 0.0);
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
@@ -323,7 +325,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 0.0);
         assertSinkMetricValue("sink-record-send-total", 0.0);
-        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count", 0.0);
+        assertSinkMetricValue("sink-record-active-count-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.0);
         assertSinkMetricValue("offset-commit-seq-no", 0.0);
         assertSinkMetricValue("offset-commit-completion-rate", 0.0);
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
@@ -345,7 +349,9 @@ public class WorkerSinkTaskTest {
 
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count", 1.0);
+        assertSinkMetricValue("sink-record-active-count-max", 1.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.5);
         assertTaskMetricValue("status-running", 1.0);
         assertTaskMetricValue("status-paused", 0.0);
         assertTaskMetricValue("running-ratio", 1.0);
@@ -480,7 +486,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count", 0.0);
+        assertSinkMetricValue("sink-record-active-count-max", 1.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.33333);
         assertSinkMetricValue("offset-commit-seq-no", 1.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
@@ -546,7 +554,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count", 1.0);
+        assertSinkMetricValue("sink-record-active-count-max", 1.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.333333);
         assertSinkMetricValue("offset-commit-seq-no", 0.0);
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
@@ -572,7 +582,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("sink-record-active-count", 0.0);
+        assertSinkMetricValue("sink-record-active-count-max", 1.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.2);
         assertSinkMetricValue("offset-commit-seq-no", 1.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
@@ -973,7 +985,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 3);
         assertSinkMetricValue("sink-record-read-total", 3.0);
         assertSinkMetricValue("sink-record-send-total", 3.0);
-        assertSinkMetricValue("sink-record-lag-max", 2.0);
+        assertSinkMetricValue("sink-record-active-count", 4.0);
+        assertSinkMetricValue("sink-record-active-count-max", 4.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.71429);
         assertSinkMetricValue("offset-commit-seq-no", 2.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 1.0);
@@ -1006,7 +1020,9 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 3);
         assertSinkMetricValue("sink-record-read-total", 4.0);
         assertSinkMetricValue("sink-record-send-total", 4.0);
-        assertSinkMetricValue("sink-record-lag-max", 2.0);
+        assertSinkMetricValue("sink-record-active-count", 0.0);
+        assertSinkMetricValue("sink-record-active-count-max", 4.0);
+        assertSinkMetricValue("sink-record-active-count-avg", 0.5555555);
         assertSinkMetricValue("offset-commit-seq-no", 3.0);
         assertSinkMetricValue("offset-commit-completion-total", 2.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 1.0);
@@ -1286,7 +1302,9 @@ public class WorkerSinkTaskTest {
         sinkMetricValue("sink-record-read-total");
         sinkMetricValue("sink-record-send-rate");
         sinkMetricValue("sink-record-send-total");
-        sinkMetricValue("sink-record-lag-max");
+        sinkMetricValue("sink-record-active-count");
+        sinkMetricValue("sink-record-active-count-max");
+        sinkMetricValue("sink-record-active-count-avg");
         sinkMetricValue("partition-count");
         sinkMetricValue("offset-commit-seq-no");
         sinkMetricValue("offset-commit-completion-rate");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -26,10 +26,10 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.sink.SinkConnector;
@@ -107,7 +107,7 @@ public class WorkerSinkTaskTest {
 
     private ConnectorTaskId taskId = new ConnectorTaskId("job", 0);
     private TargetState initialState = TargetState.STARTED;
-    private Time time;
+    private MockTime time;
     private WorkerSinkTask workerTask;
     @Mock
     private SinkTask sinkTask;
@@ -144,7 +144,7 @@ public class WorkerSinkTaskTest {
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
         workerConfig = new StandaloneConfig(workerProps);
         pluginLoader = PowerMock.createMock(PluginClassLoader.class);
-        metrics = new MockConnectMetrics();
+        metrics = new MockConnectMetrics(time);
         recordsReturnedTp1 = 0;
         recordsReturnedTp3 = 0;
     }
@@ -177,6 +177,14 @@ public class WorkerSinkTaskTest {
         workerTask.initialize(TASK_CONFIG);
         workerTask.initializeAndStart();
         workerTask.iteration();
+        time.sleep(10000L);
+
+        assertSinkMetricValue("partition-count", 2);
+        assertTaskMetricValue("status-running", 0.0);
+        assertTaskMetricValue("status-paused", 1.0);
+        assertTaskMetricValue("running-ratio", 0.0);
+        assertTaskMetricValue("pause-ratio", 1.0);
+        assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
 
         PowerMock.verifyAll();
     }
@@ -232,11 +240,45 @@ public class WorkerSinkTaskTest {
         workerTask.iteration(); // initial assignment
         workerTask.iteration(); // fetch some data
         workerTask.transitionTo(TargetState.PAUSED);
+        time.sleep(10000L);
+
+        assertSinkMetricValue("partition-count", 2);
+        assertSinkMetricValue("sink-record-read-total", 1.0);
+        assertSinkMetricValue("sink-record-send-total", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("offset-commit-seq-no", 0.0);
+        assertSinkMetricValue("offset-commit-completion-rate", 0.0);
+        assertSinkMetricValue("offset-commit-completion-total", 0.0);
+        assertSinkMetricValue("offset-commit-completion-skip-rate", 0.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 1.0);
+        assertTaskMetricValue("batch-size-avg", 0.5);
+        assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 0.0);
+
         workerTask.iteration(); // wakeup
         workerTask.iteration(); // now paused
+        time.sleep(30000L);
+
+        assertSinkMetricValue("offset-commit-seq-no", 1.0);
+        assertSinkMetricValue("offset-commit-completion-rate", 0.0333);
+        assertSinkMetricValue("offset-commit-completion-total", 1.0);
+        assertSinkMetricValue("offset-commit-completion-skip-rate", 0.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
+        assertTaskMetricValue("status-running", 0.0);
+        assertTaskMetricValue("status-paused", 1.0);
+        assertTaskMetricValue("running-ratio", 0.25);
+        assertTaskMetricValue("pause-ratio", 0.75);
+
         workerTask.transitionTo(TargetState.STARTED);
         workerTask.iteration(); // wakeup
         workerTask.iteration(); // now unpaused
+        //printMetrics();
 
         PowerMock.verifyAll();
     }
@@ -276,8 +318,39 @@ public class WorkerSinkTaskTest {
         workerTask.initialize(TASK_CONFIG);
         workerTask.initializeAndStart();
         workerTask.iteration();
+        time.sleep(10000L);
+
+        assertSinkMetricValue("partition-count", 2);
+        assertSinkMetricValue("sink-record-read-total", 0.0);
+        assertSinkMetricValue("sink-record-send-total", 0.0);
+        assertSinkMetricValue("sink-record-lag-max", 0.0);
+        assertSinkMetricValue("offset-commit-seq-no", 0.0);
+        assertSinkMetricValue("offset-commit-completion-rate", 0.0);
+        assertSinkMetricValue("offset-commit-completion-total", 0.0);
+        assertSinkMetricValue("offset-commit-completion-skip-rate", 0.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 0.0);
+        assertTaskMetricValue("batch-size-avg", 0.0);
+        assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 0.0);
+
         workerTask.iteration();
         workerTask.iteration();
+        time.sleep(30000L);
+
+        assertSinkMetricValue("sink-record-read-total", 1.0);
+        assertSinkMetricValue("sink-record-send-total", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("batch-size-max", 1.0);
+        assertTaskMetricValue("batch-size-avg", 0.5);
 
         PowerMock.verifyAll();
     }
@@ -394,10 +467,33 @@ public class WorkerSinkTaskTest {
         PowerMock.replayAll();
 
         workerTask.initialize(TASK_CONFIG);
+        time.sleep(30000L);
         workerTask.initializeAndStart();
+        time.sleep(30000L);
+
         workerTask.iteration(); // poll for initial assignment
+        time.sleep(30000L);
         workerTask.iteration(); // first record delivered
         workerTask.iteration(); // now rebalance with the wakeup triggered
+        time.sleep(30000L);
+
+        assertSinkMetricValue("partition-count", 2);
+        assertSinkMetricValue("sink-record-read-total", 1.0);
+        assertSinkMetricValue("sink-record-send-total", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("offset-commit-seq-no", 1.0);
+        assertSinkMetricValue("offset-commit-completion-total", 1.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 1.0);
+        assertTaskMetricValue("batch-size-avg", 1.0);
+        assertTaskMetricValue("offset-commit-max-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-avg-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 1.0);
 
         PowerMock.verifyAll();
     }
@@ -440,17 +536,56 @@ public class WorkerSinkTaskTest {
         workerTask.initialize(TASK_CONFIG);
         workerTask.initializeAndStart();
 
-        workerTask.iteration(); // initial assignment
+        // Initial assignment
+        time.sleep(30000L);
+        workerTask.iteration();
+        assertSinkMetricValue("partition-count", 2);
 
-        workerTask.iteration(); // first record delivered
+        // First record delivered
+        workerTask.iteration();
+        assertSinkMetricValue("partition-count", 2);
+        assertSinkMetricValue("sink-record-read-total", 1.0);
+        assertSinkMetricValue("sink-record-send-total", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("offset-commit-seq-no", 0.0);
+        assertSinkMetricValue("offset-commit-completion-total", 0.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 1.0);
+        assertTaskMetricValue("batch-size-avg", 0.5);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 0.0);
 
         sinkTaskContext.getValue().requestCommit();
         assertTrue(sinkTaskContext.getValue().isCommitRequested());
         assertNotEquals(offsets, Whitebox.<Map<TopicPartition, OffsetAndMetadata>>getInternalState(workerTask, "lastCommittedOffsets"));
+        time.sleep(10000L);
         workerTask.iteration(); // triggers the commit
+        time.sleep(10000L);
         assertFalse(sinkTaskContext.getValue().isCommitRequested()); // should have been cleared
         assertEquals(offsets, Whitebox.<Map<TopicPartition, OffsetAndMetadata>>getInternalState(workerTask, "lastCommittedOffsets"));
         assertEquals(0, workerTask.commitFailures());
+
+        assertSinkMetricValue("partition-count", 2);
+        assertSinkMetricValue("sink-record-read-total", 1.0);
+        assertSinkMetricValue("sink-record-send-total", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("offset-commit-seq-no", 1.0);
+        assertSinkMetricValue("offset-commit-completion-total", 1.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 1.0);
+        assertTaskMetricValue("batch-size-avg", 0.33333);
+        assertTaskMetricValue("offset-commit-max-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-avg-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 1.0);
 
         PowerMock.verifyAll();
     }
@@ -1094,6 +1229,74 @@ public class WorkerSinkTaskTest {
                                : origRecord;
                     }
                 }).times(numMessages);
+    }
+
+
+    private void assertSinkMetricValue(String name, double expected) {
+        MetricGroup sinkTaskGroup = workerTask.sinkTaskMetricsGroup().metricGroup();
+        double measured = metrics.currentMetricValue(sinkTaskGroup, name);
+        assertEquals(expected, measured, 0.001d);
+    }
+
+    private void assertTaskMetricValue(String name, double expected) {
+        MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
+        double measured = metrics.currentMetricValue(taskGroup, name);
+        assertEquals(expected, measured, 0.001d);
+    }
+
+    private void printMetrics() {
+        System.out.println("");
+        sinkMetricValue("sink-record-read-rate");
+        sinkMetricValue("sink-record-read-total");
+        sinkMetricValue("sink-record-send-rate");
+        sinkMetricValue("sink-record-send-total");
+        sinkMetricValue("sink-record-lag-max");
+        sinkMetricValue("partition-count");
+        sinkMetricValue("offset-commit-seq-no");
+        sinkMetricValue("offset-commit-completion-rate");
+        sinkMetricValue("offset-commit-completion-total");
+        sinkMetricValue("offset-commit-completion-skip-rate");
+        sinkMetricValue("offset-commit-completion-skip-total");
+        sinkMetricValue("put-batch-max-time-ms");
+        sinkMetricValue("put-batch-avg-time-ms");
+
+        taskMetricValue("status-unassigned");
+        taskMetricValue("status-running");
+        taskMetricValue("status-paused");
+        taskMetricValue("status-failed");
+        taskMetricValue("status-destroyed");
+        taskMetricValue("running-ratio");
+        taskMetricValue("pause-ratio");
+        taskMetricValue("offset-commit-max-time-ms");
+        taskMetricValue("offset-commit-avg-time-ms");
+        taskMetricValue("batch-size-max");
+        taskMetricValue("batch-size-avg");
+        taskMetricValue("offset-commit-failure-percentage");
+        taskMetricValue("offset-commit-success-percentage");
+    }
+
+    private double sinkMetricValue(String metricName) {
+        MetricGroup sinkTaskGroup = workerTask.sinkTaskMetricsGroup().metricGroup();
+        double value = metrics.currentMetricValue(sinkTaskGroup, metricName);
+        System.out.println("** " + metricName + "=" + value);
+        return value;
+    }
+
+    private double taskMetricValue(String metricName) {
+        MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
+        double value = metrics.currentMetricValue(taskGroup, metricName);
+        System.out.println("** " + metricName + "=" + value);
+        return value;
+    }
+
+
+    private void assertMetrics(int minimumPollCountExpected) {
+        MetricGroup sinkTaskGroup = workerTask.sinkTaskMetricsGroup().metricGroup();
+        MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
+        double readRate = metrics.currentMetricValue(sinkTaskGroup, "sink-record-read-rate");
+        double readTotal = metrics.currentMetricValue(sinkTaskGroup, "sink-record-read-total");
+        double sendRate = metrics.currentMetricValue(sinkTaskGroup, "sink-record-send-rate");
+        double sendTotal = metrics.currentMetricValue(sinkTaskGroup, "sink-record-send-total");
     }
 
     private abstract static class TestSinkTask extends SinkTask  {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -245,7 +245,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 0.0);
         assertSinkMetricValue("offset-commit-seq-no", 0.0);
         assertSinkMetricValue("offset-commit-completion-rate", 0.0);
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
@@ -345,7 +345,7 @@ public class WorkerSinkTaskTest {
 
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 0.0);
         assertTaskMetricValue("status-running", 1.0);
         assertTaskMetricValue("status-paused", 0.0);
         assertTaskMetricValue("running-ratio", 1.0);
@@ -480,7 +480,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 0.0);
         assertSinkMetricValue("offset-commit-seq-no", 1.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
@@ -546,7 +546,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 0.0);
         assertSinkMetricValue("offset-commit-seq-no", 0.0);
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
@@ -572,7 +572,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("partition-count", 2);
         assertSinkMetricValue("sink-record-read-total", 1.0);
         assertSinkMetricValue("sink-record-send-total", 1.0);
-        assertSinkMetricValue("sink-record-lag-max", 1.0);
+        assertSinkMetricValue("sink-record-lag-max", 0.0);
         assertSinkMetricValue("offset-commit-seq-no", 1.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-completion-skip-total", 0.0);
@@ -970,6 +970,24 @@ public class WorkerSinkTaskTest {
         sinkTaskContext.getValue().requestCommit();
         workerTask.iteration(); // iter 3 -- commit in progress
 
+        assertSinkMetricValue("partition-count", 3);
+        assertSinkMetricValue("sink-record-read-total", 3.0);
+        assertSinkMetricValue("sink-record-send-total", 3.0);
+        assertSinkMetricValue("sink-record-lag-max", 2.0);
+        assertSinkMetricValue("offset-commit-seq-no", 2.0);
+        assertSinkMetricValue("offset-commit-completion-total", 1.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 1.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 2.0);
+        assertTaskMetricValue("batch-size-avg", 1.0);
+        assertTaskMetricValue("offset-commit-max-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-avg-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 1.0);
+
         assertTrue(asyncCallbackRan.get());
         assertTrue(rebalanced.get());
 
@@ -984,6 +1002,24 @@ public class WorkerSinkTaskTest {
         // Check that the offsets were not reset by the out-of-order async commit callback
         assertEquals(postRebalanceCurrentOffsets, Whitebox.getInternalState(workerTask, "currentOffsets"));
         assertEquals(postRebalanceCurrentOffsets, Whitebox.getInternalState(workerTask, "lastCommittedOffsets"));
+
+        assertSinkMetricValue("partition-count", 3);
+        assertSinkMetricValue("sink-record-read-total", 4.0);
+        assertSinkMetricValue("sink-record-send-total", 4.0);
+        assertSinkMetricValue("sink-record-lag-max", 2.0);
+        assertSinkMetricValue("offset-commit-seq-no", 3.0);
+        assertSinkMetricValue("offset-commit-completion-total", 2.0);
+        assertSinkMetricValue("offset-commit-completion-skip-total", 1.0);
+        assertTaskMetricValue("status-running", 1.0);
+        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("running-ratio", 1.0);
+        assertTaskMetricValue("pause-ratio", 0.0);
+        assertTaskMetricValue("batch-size-max", 2.0);
+        assertTaskMetricValue("batch-size-avg", 1.0);
+        assertTaskMetricValue("offset-commit-max-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-avg-time-ms", 0.0);
+        assertTaskMetricValue("offset-commit-failure-percentage", 0.0);
+        assertTaskMetricValue("offset-commit-success-percentage", 1.0);
 
         PowerMock.verifyAll();
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -820,6 +820,12 @@ public class WorkerSourceTaskTest extends ThreadedTest {
             assertTrue(pollBatchTimeMax >= 0.0d);
         }
         assertTrue(pollBatchTimeAvg >= 0.0d);
+        double activeCount = metrics.currentMetricValue(sourceTaskGroup, "source-record-active-count");
+        double activeCountMax = metrics.currentMetricValue(sourceTaskGroup, "source-record-active-count-max");
+        assertEquals(0, activeCount, 0.000001d);
+        if (minimumPollCountExpected > 0) {
+            assertEquals(RECORDS.size(), activeCountMax, 0.000001d);
+        }
     }
 
     private abstract static class TestSourceTask extends SourceTask {


### PR DESCRIPTION
Added Connect metrics specific to source tasks, and builds upon #3864 and #3911 that have already been merged into `trunk`, and #3959 that has yet to be merged.

I'll rebase this PR when the latter is merged.