### PR TITLE
MINOR: Fix error message in exception when records have schemas in Connect's Flatten transformation

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/Flatten.java
@@ -190,7 +190,7 @@ public abstract class Flatten<R extends ConnectRecord<R>> implements Transformat
                     break;
                 default:
                     throw new DataException("Flatten transformation does not support " + field.schema().type()
-                            + " for record without schemas (for field " + fieldName + ").");
+                            + " for record with schemas (for field " + fieldName + ").");
             }
         }
     }
@@ -235,7 +235,7 @@ public abstract class Flatten<R extends ConnectRecord<R>> implements Transformat
                     break;
                 default:
                     throw new DataException("Flatten transformation does not support " + field.schema().type()
-                            + " for record without schemas (for field " + fieldName + ").");
+                            + " for record with schemas (for field " + fieldName + ").");
             }
         }
     }


### PR DESCRIPTION
In case of an error while flattening a record with schema, the Flatten transform was reporting an error about a record without schema, as follows: 

```
org.apache.kafka.connect.errors.DataException: Flatten transformation does not support ARRAY for record without schemas (for field ...)
```

The expected behaviour would be an error message specifying "with schemas". 

This looks like a simple copy/paste typo from the schemaless equivalent methods, in the same file 