### PR TITLE
KAFKA-5986: Streams State Restoration never completes when logging is disabled

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -158,7 +158,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         initTopology();
         processorContext.initialized();
         taskInitialized = true;
-        return topology.stateStores().isEmpty();
+        return changelogPartitions().isEmpty();
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -27,17 +27,22 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Reducer;
 import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -65,19 +70,15 @@ public class RestoreIntegrationTest {
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER =
             new EmbeddedKafkaCluster(NUM_BROKERS);
-    private final String inputStream = "input-stream";
+    private static final String INPUT_STREAM = "input-stream";
     private final int numberOfKeys = 10000;
     private KafkaStreams kafkaStreams;
     private String applicationId = "restore-test";
 
 
-    private void createTopics() throws InterruptedException {
-        CLUSTER.createTopic(inputStream, 2, 1);
-    }
-
-    @Before
-    public void before() throws IOException, InterruptedException {
-        createTopics();
+    @BeforeClass
+    public static void createTopics() throws InterruptedException {
+        CLUSTER.createTopic(INPUT_STREAM, 2, 1);
     }
 
     private Properties props() {
@@ -107,7 +108,7 @@ public class RestoreIntegrationTest {
 
         createStateForRestoration();
 
-        builder.table(inputStream, Consumed.with(Serdes.Integer(), Serdes.Integer()))
+        builder.table(INPUT_STREAM, Consumed.with(Serdes.Integer(), Serdes.Integer()))
                 .toStream()
                 .foreach(new ForeachAction<Integer, Integer>() {
                     @Override
@@ -153,6 +154,36 @@ public class RestoreIntegrationTest {
     }
 
 
+    @Test
+    public void shouldSuccessfullyStartWhenLoggingDisabled() throws InterruptedException {
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<Integer, Integer> stream = builder.stream(INPUT_STREAM);
+        stream.groupByKey()
+                .reduce(new Reducer<Integer>() {
+                    @Override
+                    public Integer apply(final Integer value1, final Integer value2) {
+                        return value1 + value2;
+                    }
+                }, Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as("reduce-store").withLoggingDisabled());
+
+        final CountDownLatch startupLatch = new CountDownLatch(1);
+        kafkaStreams = new KafkaStreams(builder.build(), props());
+        kafkaStreams.setStateListener(new KafkaStreams.StateListener() {
+            @Override
+            public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
+                if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
+                    startupLatch.countDown();
+                }
+            }
+        });
+
+        kafkaStreams.start();
+
+        assertTrue(startupLatch.await(30, TimeUnit.SECONDS));
+
+
+    }
     private void createStateForRestoration()
             throws ExecutionException, InterruptedException {
         final Properties producerConfig = new Properties();
@@ -162,7 +193,7 @@ public class RestoreIntegrationTest {
                      new KafkaProducer<>(producerConfig, new IntegerSerializer(), new IntegerSerializer())) {
 
             for (int i = 0; i < numberOfKeys; i++) {
-                producer.send(new ProducerRecord<>(inputStream, i, i));
+                producer.send(new ProducerRecord<>(INPUT_STREAM, i, i));
             }
         }
 
@@ -173,8 +204,8 @@ public class RestoreIntegrationTest {
         consumerConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
 
         final Consumer consumer = new KafkaConsumer(consumerConfig);
-        final List<TopicPartition> partitions = Arrays.asList(new TopicPartition(inputStream, 0),
-                                                              new TopicPartition(inputStream, 1));
+        final List<TopicPartition> partitions = Arrays.asList(new TopicPartition(INPUT_STREAM, 0),
+                                                              new TopicPartition(INPUT_STREAM, 1));
 
         consumer.assign(partitions);
         consumer.seekToEnd(partitions);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -181,9 +181,8 @@ public class RestoreIntegrationTest {
         kafkaStreams.start();
 
         assertTrue(startupLatch.await(30, TimeUnit.SECONDS));
-
-
     }
+    
     private void createStateForRestoration()
             throws ExecutionException, InterruptedException {
         final Properties producerConfig = new Properties();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -214,7 +214,7 @@ public class GlobalStateManagerImplTest {
         stateManager.initialize(context);
 
         final TheStateRestoreCallback stateRestoreCallback = new TheStateRestoreCallback();
-        stateManager.register(store1, false, stateRestoreCallback);
+        stateManager.register(store1, stateRestoreCallback);
 
         assertThat(stateRestoreListener.restoreStartOffset, equalTo(1L));
         assertThat(stateRestoreListener.restoreEndOffset, equalTo(5L));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -53,6 +53,7 @@ import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
 import org.apache.kafka.test.MockProcessorNode;
 import org.apache.kafka.test.MockSourceNode;
 import org.apache.kafka.test.MockStateRestoreListener;
+import org.apache.kafka.test.MockStateStoreSupplier;
 import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.NoOpProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
@@ -125,7 +126,6 @@ public class StreamTaskTest {
     private final MockTime time = new MockTime();
     private File baseDir = TestUtils.tempDirectory();
     private StateDirectory stateDirectory;
-    private final RecordCollectorImpl recordCollector = new RecordCollectorImpl(producer, "taskId", new LogContext("taskId "));
     private StreamsConfig config;
     private StreamsConfig eosConfig;
     private StreamTask task;
@@ -1016,6 +1016,62 @@ public class StreamTaskTest {
         } catch (Exception e) {
             fail("should have not closed unitialized topology");
         }
+    }
+
+    @Test
+    public void shouldBeInitializedIfChangelogPartitionsIsEmpty() {
+        final ProcessorTopology topology = new ProcessorTopology(Collections.<ProcessorNode>singletonList(source1),
+                                                                 Collections.<String, SourceNode>singletonMap(topic1[0], source1),
+                                                                 Collections.<String, SinkNode>emptyMap(),
+                                                                 Collections.<StateStore>singletonList(
+                                                                         new MockStateStoreSupplier.MockStateStore("store",
+                                                                                                                   false)),
+                                                                 Collections.<String, String>emptyMap(),
+                                                                 Collections.<StateStore>emptyList());
+
+
+        final StreamTask task = new StreamTask(taskId00,
+                                               applicationId,
+                                               Utils.mkSet(partition1),
+                                               topology,
+                                               consumer,
+                                               changelogReader,
+                                               config,
+                                               streamsMetrics,
+                                               stateDirectory,
+                                               null,
+                                               time,
+                                               producer);
+
+        assertTrue(task.initialize());
+    }
+
+    @Test
+    public void shouldNotBeInitializedIfChangelogPartitionsIsNonEmpty() {
+        final ProcessorTopology topology = new ProcessorTopology(Collections.<ProcessorNode>singletonList(source1),
+                                                                 Collections.<String, SourceNode>singletonMap(topic1[0], source1),
+                                                                 Collections.<String, SinkNode>emptyMap(),
+                                                                 Collections.<StateStore>singletonList(
+                                                                         new MockStateStoreSupplier.MockStateStore("store",
+                                                                                                                   false)),
+                                                                 Collections.singletonMap("store", "changelog"),
+                                                                 Collections.<StateStore>emptyList());
+
+
+        final StreamTask task = new StreamTask(taskId00,
+                                               applicationId,
+                                               Utils.mkSet(partition1),
+                                               topology,
+                                               consumer,
+                                               changelogReader,
+                                               config,
+                                               streamsMetrics,
+                                               stateDirectory,
+                                               null,
+                                               time,
+                                               producer);
+
+        assertFalse(task.initialize());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
When logging is disabled and there are state stores the task never transitions from restoring to running. This is because we only ever check if the task has state stores and return false on initialization if it does. The check should be if we have changelog partitions, i.e., we need to restore.