### PR TITLE
MINOR: Allow schedule and commit in MockProcessorContext

### DIFF
--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorContext.java
@@ -164,14 +164,10 @@ public class MockProcessorContext extends AbstractProcessorContext implements Re
     }
 
     @Override
-    public void schedule(final long interval) {
-        throw new UnsupportedOperationException("schedule() not supported.");
-    }
+    public void schedule(final long interval) { }
 
     @Override
-    public void commit() {
-        throw new UnsupportedOperationException("commit() not supported.");
-    }
+    public void commit() { }
 
     @Override
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This change allows for testing custom Processors and Transformers that call `schedule` and `commit` using KStreamTestDriver, by _not_ throwing `UnsupportedOperationException`. 

This PR is my original work. 