### PR TITLE
KAFKA-5514 KafkaConsumer ignores default values in Properties object because of incorrect use of Properties object.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1799,14 +1799,15 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     }
     
     /**
-     * Returns a flattened Properties object
-     */
-    private Properties getFlattenedProperties(Properties properties) {
+      * Returns a flattened Properties object
+      * @param properties - Java Properties object
+      */
+     private Properties getFlattenedProperties(Properties properties) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
                 properties.put(name, properties.getProperty(name));
             }
         }
-    }
-     
+     }
+    
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -614,6 +614,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param properties The consumer configuration properties
      */
     public KafkaConsumer(Properties properties) {
+        for (final String name: properties.stringPropertyNames()) {
+            if (properties.get(name) == null) {
+                map.put(name, properties.getProperty(name));
+            }
+        }
         this(properties, null, null);
     }
 
@@ -632,6 +637,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     public KafkaConsumer(Properties properties,
                          Deserializer<K> keyDeserializer,
                          Deserializer<V> valueDeserializer) {
+        for (final String name: properties.stringPropertyNames()) {
+            if (properties.get(name) == null) {
+                map.put(name, properties.getProperty(name));
+            }
+        }
         this(new ConsumerConfig(ConsumerConfig.addDeserializerToConfig(properties, keyDeserializer, valueDeserializer)),
              keyDeserializer,
              valueDeserializer);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1808,6 +1808,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                 properties.put(name, properties.getProperty(name));
             }
         }
+        return properties;         
      }
     
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1798,7 +1798,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             currentThread.set(NO_CURRENT_THREAD);
     }
     
-    /**
+     /**
       * Returns a flattened Properties object
       * @param properties - Java Properties object
       */

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -614,12 +614,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @param properties The consumer configuration properties
      */
     public KafkaConsumer(Properties properties) {
-        for (final String name: properties.stringPropertyNames()) {
-            if (properties.get(name) == null) {
-                properties.put(name, properties.getProperty(name));
-            }
-        }
-        this(properties, null, null);
+        this(getFlattenedProperties(properties), null, null);
     }
 
     /**
@@ -637,12 +632,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     public KafkaConsumer(Properties properties,
                          Deserializer<K> keyDeserializer,
                          Deserializer<V> valueDeserializer) {
-        for (final String name: properties.stringPropertyNames()) {
-            if (properties.get(name) == null) {
-                properties.put(name, properties.getProperty(name));
-            }
-        }
-        this(new ConsumerConfig(ConsumerConfig.addDeserializerToConfig(properties, keyDeserializer, valueDeserializer)),
+        this(new ConsumerConfig(ConsumerConfig.addDeserializerToConfig(getFlattenedProperties(properties), keyDeserializer, valueDeserializer)),
              keyDeserializer,
              valueDeserializer);
     }
@@ -1807,4 +1797,16 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         if (refcount.decrementAndGet() == 0)
             currentThread.set(NO_CURRENT_THREAD);
     }
+    
+    /**
+     * Returns a flattened Properties object
+     */
+    private Properties getFlattenedProperties(Properties properties) {
+        for (final String name: properties.stringPropertyNames()) {
+            if (properties.get(name) == null) {
+                properties.put(name, properties.getProperty(name));
+            }
+        }
+    }
+     
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -616,7 +616,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     public KafkaConsumer(Properties properties) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
-                map.put(name, properties.getProperty(name));
+                properties.put(name, properties.getProperty(name));
             }
         }
         this(properties, null, null);
@@ -639,7 +639,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                          Deserializer<V> valueDeserializer) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
-                map.put(name, properties.getProperty(name));
+                properties.put(name, properties.getProperty(name));
             }
         }
         this(new ConsumerConfig(ConsumerConfig.addDeserializerToConfig(properties, keyDeserializer, valueDeserializer)),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1802,7 +1802,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
       * Returns a flattened Properties object
       * @param properties - Java Properties object
       */
-     private Properties getFlattenedProperties(Properties properties) {
+     private static Properties getFlattenedProperties(Properties properties) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
                 properties.put(name, properties.getProperty(name));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -311,7 +311,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * Returns a flattened Properties object
      * @param properties - Java Properties object
      */
-    private Properties getFlattenedProperties(Properties properties) {
+    private static Properties getFlattenedProperties(Properties properties) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
                 properties.put(name, properties.getProperty(name));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -292,7 +292,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     public KafkaProducer(Properties properties) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
-                map.put(name, properties.getProperty(name));
+                properties.put(name, properties.getProperty(name));
             }
         }
         this(new ProducerConfig(properties), null, null);
@@ -310,7 +310,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
     public KafkaProducer(Properties properties, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
-                map.put(name, properties.getProperty(name));
+                properties.put(name, properties.getProperty(name));
             }
         }
         this(new ProducerConfig(ProducerConfig.addSerializerToConfig(properties, keySerializer, valueSerializer)),

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -317,6 +317,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
                 properties.put(name, properties.getProperty(name));
             }
         }
+        return properties;
     }
 
     @SuppressWarnings("unchecked")

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -290,6 +290,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * @param properties   The producer configs
      */
     public KafkaProducer(Properties properties) {
+        for (final String name: properties.stringPropertyNames()) {            
+            map.put(name, properties.getProperty(name));
+        }
         this(new ProducerConfig(properties), null, null);
     }
 
@@ -303,6 +306,9 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *                         be called in the producer when the serializer is passed in directly.
      */
     public KafkaProducer(Properties properties, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+        for (final String name: properties.stringPropertyNames()) {            
+            map.put(name, properties.getProperty(name));
+        }
         this(new ProducerConfig(ProducerConfig.addSerializerToConfig(properties, keySerializer, valueSerializer)),
                 keySerializer, valueSerializer);
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -290,8 +290,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * @param properties   The producer configs
      */
     public KafkaProducer(Properties properties) {
-        for (final String name: properties.stringPropertyNames()) {            
-            map.put(name, properties.getProperty(name));
+        for (final String name: properties.stringPropertyNames()) {
+            if (properties.get(name) == null) {
+                map.put(name, properties.getProperty(name));
+            }
         }
         this(new ProducerConfig(properties), null, null);
     }
@@ -306,8 +308,10 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *                         be called in the producer when the serializer is passed in directly.
      */
     public KafkaProducer(Properties properties, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
-        for (final String name: properties.stringPropertyNames()) {            
-            map.put(name, properties.getProperty(name));
+        for (final String name: properties.stringPropertyNames()) {
+            if (properties.get(name) == null) {
+                map.put(name, properties.getProperty(name));
+            }
         }
         this(new ProducerConfig(ProducerConfig.addSerializerToConfig(properties, keySerializer, valueSerializer)),
                 keySerializer, valueSerializer);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -290,12 +290,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      * @param properties   The producer configs
      */
     public KafkaProducer(Properties properties) {
-        for (final String name: properties.stringPropertyNames()) {
-            if (properties.get(name) == null) {
-                properties.put(name, properties.getProperty(name));
-            }
-        }
-        this(new ProducerConfig(properties), null, null);
+        this(new ProducerConfig(getFlattenedProperties(properties)), null, null);
     }
 
     /**
@@ -308,13 +303,20 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      *                         be called in the producer when the serializer is passed in directly.
      */
     public KafkaProducer(Properties properties, Serializer<K> keySerializer, Serializer<V> valueSerializer) {
+        this(new ProducerConfig(ProducerConfig.addSerializerToConfig(getFlattenedProperties(properties), keySerializer, valueSerializer)),
+                keySerializer, valueSerializer);
+    }
+    
+    /**
+     * Returns a flattened Properties object
+     * @param properties - Java Properties object
+     */
+    private Properties getFlattenedProperties(Properties properties) {
         for (final String name: properties.stringPropertyNames()) {
             if (properties.get(name) == null) {
                 properties.put(name, properties.getProperty(name));
             }
         }
-        this(new ProducerConfig(ProducerConfig.addSerializerToConfig(properties, keySerializer, valueSerializer)),
-                keySerializer, valueSerializer);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This problem plagues anywhere Properties are being misused. I have this issue with KafkaProducer(Properties properties) constructor. I bet this problem spans across more classes just like this KafkaConsumer(Properties properties).

Clarification:

putAll is implemented in Hashtable.java and at that point we are already too late.
When we cast to Map/Hashtable we lose  Properties's 'defaults member which is another Properties object. Whenever you use Properties's getProperty() method, if the Property object does not explicity contain the property, it will refer to it's internal defaults Properties object which can be set as so:
Properties myProps = new Properties(oldProperties)
if oldProperties has a key:value of foo:bar
calling myProps.get(foo) will not return bar
whereas, calling myProps.getProperty(foo) will return bar

Reference:


```
public
class Properties extends Hashtable<Object,Object> {
...
    /**
     * A property list that contains default values for any keys not
     * found in this property list.
     *
     * @serial
     */
    protected Properties defaults;

    /**
     * Creates an empty property list with the specified defaults.
     *
     * @param   defaults   the defaults.
     */
    public Properties(Properties defaults) {
        this.defaults = defaults;
    }
...
    public String getProperty(String key) {
        Object oval = super.get(key);
        String sval = (oval instanceof String) ? (String)oval : null;
        return ((sval == null) && (defaults != null)) ? defaults.getProperty(key) : sval;
    }
...
```



Here is the fix:

```
        for (final String name: properties.stringPropertyNames()) {
            if (properties.get(name) == null) {
                properties.put(name, properties.getProperty(name));
            }
        }
```


This pulls all the 'default' inner Properties object's entries up into the outer level Properties object.
This should be applied to all the public methods that are being passed in a Properties object
See https://github.com/Galus/kafka/commit/8af611dfd9c8f3cb37f1d2b400890525c5a646d3 and https://github.com/Galus/kafka/commit/130b4cde2da4d9ede7aa6d6a99997af32d1a00fc


Similar Issues addressing this issue: KAFKA-2184, KAFKA-3049, KAFKA-3161
@Kamal15 

This contribution is my original work and I hereby license it for use by the apache kafka project's open source license.