### PR TITLE
KAFKA-5746; Return 0.0 from Metric.value() instead of throwing exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Metric.java
+++ b/clients/src/main/java/org/apache/kafka/common/Metric.java
@@ -24,19 +24,19 @@ public interface Metric {
     /**
      * A name for this metric
      */
-    public MetricName metricName();
+    MetricName metricName();
 
     /**
-     * The value of the metric as double if the metric is measurable
-     * @throws IllegalStateException if this metric does not have a measurable double value
+     * The value of the metric as double if the metric is measurable and `0.0` otherwise.
+     *
      * @deprecated As of 1.0.0, use {@link #metricValue()} instead. This will be removed in a future major release.
      */
     @Deprecated
-    public double value();
+    double value();
 
     /**
      * The value of the metric, which may be measurable or a non-measurable gauge
      */
-    public Object metricValue();
+    Object metricValue();
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/KafkaMetric.java
@@ -83,7 +83,7 @@ public final class KafkaMetric implements Metric {
         if (this.metricValueProvider instanceof Measurable)
             return ((Measurable) metricValueProvider).measure(config, timeMs);
         else
-            throw new IllegalStateException("Not a measurable metric");
+            return 0;
     }
 
     public void config(MetricConfig config) {

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -71,7 +71,7 @@
     <li>The <code>app-info</code> mbean registered with JMX to provide version and commit id will be deprecated and replaced with
         metrics providing these attributes.</li>
     <li>Kafka metrics may now contain non-numeric values. <code>org.apache.kafka.common.Metric#value()</code> has been deprecated and
-        may throw an <code>IllegalStateException</code> when iterating over metrics of <code>KafkaProducer/KafkaConsumer/KafkaAdminClient</code>.
+        will return <code>0.0</code> when iterating over metrics of <code>KafkaProducer/KafkaConsumer/KafkaAdminClient</code>.
         <code>org.apache.kafka.common.Metric#metricValue()</code> can be used to safely iterate over any metric value.</code>
 
 </ul>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -71,9 +71,9 @@
     <li>The <code>app-info</code> mbean registered with JMX to provide version and commit id will be deprecated and replaced with
         metrics providing these attributes.</li>
     <li>Kafka metrics may now contain non-numeric values. <code>org.apache.kafka.common.Metric#value()</code> has been deprecated and
-        will return <code>0.0</code> when iterating over metrics of <code>KafkaProducer/KafkaConsumer/KafkaAdminClient</code>.
-        <code>org.apache.kafka.common.Metric#metricValue()</code> can be used to safely iterate over any metric value.</code>
-
+        will return <code>0.0</code> in such cases to minimise the probability of breaking users who read the value of every client
+        metric (via a <code>MetricsReporter</code> implementation or by calling the <code>metrics()</code> method).
+        <code>org.apache.kafka.common.Metric#metricValue()</code> can be used to retrieve numeric and non-numeric metric values.</li>
 </ul>
 
 <h5><a id="upgrade_100_new_protocols" href="#upgrade_100_new_protocols">New Protocol Versions</a></h5>


### PR DESCRIPTION
This is less likely to break custom metric reporters and since the method
is deprecated, people will be warned about this potential issue.