### PR TITLE
MINOR: Add attributes `processedKeys` and `processedValues` to MockProcessorSupplier

### DIFF
--- a/streams/src/test/java/org/apache/kafka/test/MockProcessorSupplier.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockProcessorSupplier.java
@@ -31,6 +31,9 @@ import static org.junit.Assert.assertEquals;
 public class MockProcessorSupplier<K, V> implements ProcessorSupplier<K, V> {
 
     public final ArrayList<String> processed = new ArrayList<>();
+    public final ArrayList<K> processedKeys = new ArrayList<>();
+    public final ArrayList<V> processedValues = new ArrayList<>();
+
     public final ArrayList<Long> punctuatedStreamTime = new ArrayList<>();
     public final ArrayList<Long> punctuatedSystemTime = new ArrayList<>();
 
@@ -86,6 +89,8 @@ public class MockProcessorSupplier<K, V> implements ProcessorSupplier<K, V> {
 
         @Override
         public void process(K key, V value) {
+            processedKeys.add(key);
+            processedValues.add(value);
             processed.add((key == null ? "null" : key) + ":" +
                     (value == null ? "null" : value));
 


### PR DESCRIPTION
This would allow for easier testing of topologies using the following pattern:
```Scala
// in Scala
val builder = new KStreamBuilder
val stream: KStream[K, V] = builder.stream(KSerde, VSerde, topic)

val processedStream: KStream[K, VR] = createTopology(stream, builder)

val processorSupplier = new MyMockProcessorSupplier[K, VR]
processedStream.process(processorSupplier)

val streamDriver = new MyKStreamTestDriver(builder, TestUtils.tempDirectory())
streamDriver.setTime(0L)

streamDriver.process(topic, somethingK, somethingV)
streamDriver.flushState()

val results = (processorSupplier.processedKeys zip processorSupplier.processedValues).toMap
results(expectedK) should be(expectedVR)
```
Without breaking any existing tests that rely on the `processed` `ArrayList`. Of course it's not as elegant as rewriting the logic here, as we're (almost) duplicating the information in the `processed` array.

@guozhangwang any thoughts?