### PR TITLE
KAFKA-6001: remove <Bytes, byte[]> from Materialized usages

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams;
 
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.KGroupedStream;
@@ -217,7 +216,7 @@ public class StreamsBuilder {
      */
     public synchronized <K, V> KTable<K, V> table(final String topic,
                                                   final Consumed<K, V> consumed,
-                                                  final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                                  final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
@@ -273,7 +272,7 @@ public class StreamsBuilder {
         return internalStreamsBuilder.table(topic,
                                             new ConsumedInternal<>(consumed),
                                             new MaterializedInternal<>(
-                                                    Materialized.<K, V, KeyValueStore<Bytes, byte[]>>as(
+                                                    Materialized.<K, V, KeyValueStore>as(
                                                             internalStreamsBuilder.newStoreName(topic))
                                                     .withKeySerde(consumed.keySerde)
                                                     .withValueSerde(consumed.valueSerde),
@@ -298,10 +297,10 @@ public class StreamsBuilder {
      * @return a {@link KTable} for the specified topic
      */
     public synchronized <K, V> KTable<K, V> table(final String topic,
-                                                  final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                                  final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
-        final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal = new MaterializedInternal<>(materialized);
+        final MaterializedInternal<K, V, KeyValueStore> materializedInternal = new MaterializedInternal<>(materialized);
         return internalStreamsBuilder.table(topic,
                                             new ConsumedInternal<>(Consumed.with(materializedInternal.keySerde(),
                                                                                  materializedInternal.valueSerde())),
@@ -328,8 +327,8 @@ public class StreamsBuilder {
                                                               final Consumed<K, V> consumed) {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
-        final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized =
-                new MaterializedInternal<>(Materialized.<K, V, KeyValueStore<Bytes, byte[]>>as(
+        final MaterializedInternal<K, V, KeyValueStore> materialized =
+                new MaterializedInternal<>(Materialized.<K, V, KeyValueStore>as(
                         internalStreamsBuilder.newStoreName(topic))
                                                    .withKeySerde(consumed.keySerde)
                                                    .withValueSerde(consumed.valueSerde),
@@ -391,7 +390,7 @@ public class StreamsBuilder {
      */
     public synchronized <K, V> GlobalKTable<K, V> globalTable(final String topic,
                                                               final Consumed<K, V> consumed,
-                                                              final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                                              final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(consumed, "consumed can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
@@ -428,10 +427,10 @@ public class StreamsBuilder {
      * @return a {@link GlobalKTable} for the specified topic
      */
     public synchronized <K, V> GlobalKTable<K, V> globalTable(final String topic,
-                                                              final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                                              final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
-        final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal = new MaterializedInternal<>(materialized);
+        final MaterializedInternal<K, V, KeyValueStore> materializedInternal = new MaterializedInternal<>(materialized);
         return internalStreamsBuilder.globalTable(topic,
                                                   new ConsumedInternal<>(Consumed.with(materializedInternal.keySerde(),
                                                                                        materializedInternal.valueSerde())),

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -182,7 +181,7 @@ public interface KGroupedStream<K, V> {
      * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
      * represent the latest (rolling) count (i.e., number of records) for each key
      */
-    KTable<K, Long> count(final Materialized<K, Long, KeyValueStore<Bytes, byte[]>> materialized);
+    KTable<K, Long> count(final Materialized<K, Long, KeyValueStore> materialized);
 
     /**
      * Count the number of records in this stream by the grouped key and the defined windows.
@@ -618,7 +617,7 @@ public interface KGroupedStream<K, V> {
      * latest (rolling) aggregate for each key
      */
     KTable<K, V> reduce(final Reducer<V> reducer,
-                        final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
+                        final Materialized<K, V, KeyValueStore> materialized);
 
     /**
      * Combine the number of records in this stream by the grouped key and the defined windows.
@@ -1072,16 +1071,16 @@ public interface KGroupedStream<K, V> {
      * provide {@code queryableStoreName}, and "-changelog" is a fixed suffix.
      * You can retrieve all generated internal topic names via {@link KafkaStreams#toString()}.
      *
+     * @param <VR>          the value type of the resulting {@link KTable}
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result
      * @param aggregator    an {@link Aggregator} that computes a new aggregate result
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
      * latest (rolling) aggregate for each key
      */
     <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                  final Aggregator<? super K, ? super V, VR> aggregator,
-                                 final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+                                 final Materialized<K, VR, KeyValueStore> materialized);
 
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedTable.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.StateStoreSupplier;
@@ -125,7 +124,7 @@ public interface KGroupedTable<K, V> {
      * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
      * represent the latest (rolling) count (i.e., number of records) for each key
      */
-    KTable<K, Long> count(final Materialized<K, Long, KeyValueStore<Bytes, byte[]>> materialized);
+    KTable<K, Long> count(final Materialized<K, Long, KeyValueStore> materialized);
 
     /**
      * Count number of records of the original {@link KTable} that got {@link KTable#groupBy(KeyValueMapper) mapped} to
@@ -340,7 +339,7 @@ public interface KGroupedTable<K, V> {
      */
     KTable<K, V> reduce(final Reducer<V> adder,
                         final Reducer<V> subtractor,
-                        final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
+                        final Materialized<K, V, KeyValueStore> materialized);
     /**
      * Combine the value of records of the original {@link KTable} that got {@link KTable#groupBy(KeyValueMapper)
      * mapped} to the same key into a new instance of {@link KTable}.
@@ -633,7 +632,7 @@ public interface KGroupedTable<K, V> {
     <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                  final Aggregator<? super K, ? super V, VR> adder,
                                  final Aggregator<? super K, ? super V, VR> subtractor,
-                                 final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+                                 final Materialized<K, VR, KeyValueStore> materialized);
 
     /**
      * Aggregate the value of records of the original {@link KTable} that got {@link KTable#groupBy(KeyValueMapper)

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.kstream;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -129,7 +128,7 @@ public interface KTable<K, V> {
      * @see #filterNot(Predicate, Materialized)
      */
     KTable<K, V> filter(final Predicate<? super K, ? super V> predicate,
-                        final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
+                        final Materialized<K, V, KeyValueStore> materialized);
 
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
@@ -265,7 +264,7 @@ public interface KTable<K, V> {
      * @see #filter(Predicate, Materialized)
      */
     KTable<K, V> filterNot(final Predicate<? super K, ? super V> predicate,
-                           final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized);
+                           final Materialized<K, V, KeyValueStore> materialized);
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
      * given predicate.
@@ -410,15 +409,15 @@ public interface KTable<K, V> {
      * Thus, for tombstones the provided value-mapper is not evaluated but the tombstone record is forwarded directly to
      * delete the corresponding record in the result {@code KTable}.
      *
+     * @param <VR>   the value type of the result {@code KTable}
+     *
      * @param mapper a {@link ValueMapper} that computes a new output value
      * @param materialized  a {@link Materialized} that describes how the {@link StateStore} for the resulting {@code KTable}
      *                      should be materialized. Cannot be {@code null}
-     * @param <VR>   the value type of the result {@code KTable}
-     *
      * @return a {@code KTable} that contains records with unmodified keys and new values (possibly of different type)
      */
     <VR> KTable<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper,
-                                 final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+                                 final Materialized<K, VR, KeyValueStore> materialized);
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
@@ -1386,12 +1385,12 @@ public interface KTable<K, V> {
      * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
      * partitions.
      *
+     * @param <VO>          the value type of the other {@code KTable}
+     * @param <VR>          the value type of the result {@code KTable}
      * @param other         the other {@code KTable} to be joined with this {@code KTable}
      * @param joiner        a {@link ValueJoiner} that computes the join result for a pair of matching records
      * @param materialized  an instance of {@link Materialized} used to describe how the state store should be materialized.
      *                      Cannot be {@code null}
-     * @param <VO>          the value type of the other {@code KTable}
-     * @param <VR>          the value type of the result {@code KTable}
      * @return a {@code KTable} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one for each matched record-pair with the same key
      * @see #leftJoin(KTable, ValueJoiner, Materialized)
@@ -1399,7 +1398,7 @@ public interface KTable<K, V> {
      */
     <VO, VR> KTable<K, VR> join(final KTable<K, VO> other,
                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+                                final Materialized<K, VR, KeyValueStore> materialized);
     /**
      * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
@@ -1713,12 +1712,12 @@ public interface KTable<K, V> {
      * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
      * partitions.
      *
+     * @param <VO>          the value type of the other {@code KTable}
+     * @param <VR>          the value type of the result {@code KTable}
      * @param other         the other {@code KTable} to be joined with this {@code KTable}
      * @param joiner        a {@link ValueJoiner} that computes the join result for a pair of matching records
      * @param materialized  an instance of {@link Materialized} used to describe how the state store should be materialized.
      *                      Cannot be {@code null}
-     * @param <VO>          the value type of the other {@code KTable}
-     * @param <VR>          the value type of the result {@code KTable}
      * @return a {@code KTable} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
      * left {@code KTable}
@@ -1727,7 +1726,7 @@ public interface KTable<K, V> {
      */
     <VO, VR> KTable<K, VR> leftJoin(final KTable<K, VO> other,
                                     final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                    final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+                                    final Materialized<K, VR, KeyValueStore> materialized);
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
      * non-windowed left equi join.
@@ -2055,12 +2054,12 @@ public interface KTable<K, V> {
      * Both input streams (or to be more precise, their underlying source topics) need to have the same number of
      * partitions.
      *
+     * @param <VO>          the value type of the other {@code KTable}
+     * @param <VR>          the value type of the result {@code KTable}
      * @param other         the other {@code KTable} to be joined with this {@code KTable}
      * @param joiner        a {@link ValueJoiner} that computes the join result for a pair of matching records
      * @param materialized  an instance of {@link Materialized} used to describe how the state store should be materialized.
      *                      Cannot be {@code null}
-     * @param <VO>          the value type of the other {@code KTable}
-     * @param <VR>          the value type of the result {@code KTable}
      * @return a {@code KTable} that contains join-records for each key and values computed by the given
      * {@link ValueJoiner}, one for each matched record-pair with the same key plus one for each non-matching record of
      * both {@code KTable}s
@@ -2069,7 +2068,7 @@ public interface KTable<K, V> {
      */
     <VO, VR> KTable<K, VR> outerJoin(final KTable<K, VO> other,
                                      final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                     final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized);
+                                     final Materialized<K, VR, KeyValueStore> materialized);
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -39,7 +38,7 @@ import java.util.Objects;
  * by providing just a store name.
  */
 public class Materialized<K, V, S extends StateStore> {
-    protected StoreSupplier<S> storeSupplier;
+    protected StoreSupplier storeSupplier;
     protected String storeName;
     protected Serde<V> valueSerde;
     protected Serde<K> keySerde;
@@ -47,7 +46,7 @@ public class Materialized<K, V, S extends StateStore> {
     protected boolean cachingEnabled = true;
     protected Map<String, String> topicConfig = new HashMap<>();
 
-    private Materialized(final StoreSupplier<S> storeSupplier) {
+    private Materialized(final StoreSupplier storeSupplier) {
         this.storeSupplier = storeSupplier;
     }
 
@@ -92,7 +91,7 @@ public class Materialized<K, V, S extends StateStore> {
      * @param <V>      value type of the store
      * @return a new {@link Materialized} instance with the given supplier
      */
-    public static <K, V> Materialized<K, V, WindowStore<Bytes, byte[]>> as(final WindowBytesStoreSupplier supplier) {
+    public static <K, V> Materialized<K, V, WindowStore> as(final WindowBytesStoreSupplier supplier) {
         Objects.requireNonNull(supplier, "supplier can't be null");
         return new Materialized<>(supplier);
     }
@@ -106,7 +105,7 @@ public class Materialized<K, V, S extends StateStore> {
      * @return a new {@link Materialized} instance with the given sup
      * plier
      */
-    public static <K, V> Materialized<K, V, SessionStore<Bytes, byte[]>> as(final SessionBytesStoreSupplier supplier) {
+    public static <K, V> Materialized<K, V, SessionStore> as(final SessionBytesStoreSupplier supplier) {
         Objects.requireNonNull(supplier, "supplier can't be null");
         return new Materialized<>(supplier);
     }
@@ -119,7 +118,7 @@ public class Materialized<K, V, S extends StateStore> {
      * @param <V>      value type of the store
      * @return a new {@link Materialized} instance with the given supplier
      */
-    public static <K, V> Materialized<K, V, KeyValueStore<Bytes, byte[]>> as(final KeyValueBytesStoreSupplier supplier) {
+    public static <K, V> Materialized<K, V, KeyValueStore> as(final KeyValueBytesStoreSupplier supplier) {
         Objects.requireNonNull(supplier, "supplier can't be null");
         return new Materialized<>(supplier);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -38,7 +38,7 @@ import java.util.Objects;
  * by providing just a store name.
  */
 public class Materialized<K, V, S extends StateStore> {
-    protected StoreSupplier storeSupplier;
+    protected StoreSupplier<S> storeSupplier;
     protected String storeName;
     protected Serde<V> valueSerde;
     protected Serde<K> keySerde;

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -96,7 +95,7 @@ public interface SessionWindowedKStream<K, V> {
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys and {@link Long} values
      * that represent the latest (rolling) count (i.e., number of records) for each key within a window
      */
-    KTable<Windowed<K>, Long> count(final Materialized<K, Long, SessionStore<Bytes, byte[]>> materialized);
+    KTable<Windowed<K>, Long> count(final Materialized<K, Long, SessionStore> materialized);
 
     /**
      * Aggregate the values of records in this stream by the grouped key and defined {@link SessionWindows}.
@@ -168,18 +167,18 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
+     * @param <VR>           the value type of the resulting {@link KTable}
      * @param initializer    the instance of {@link Initializer}
      * @param aggregator     the instance of {@link Aggregator}
      * @param sessionMerger  the instance of {@link Merger}
      * @param materialized   an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}
-     * @param <VR>           the value type of the resulting {@link KTable}
      * @return a windowed {@link KTable} that contains "update" records with unmodified keys, and values that represent
      * the latest (rolling) aggregate for each key within a window
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
                                            final Merger<? super K, VR> sessionMerger,
-                                           final Materialized<K, VR, SessionStore<Bytes, byte[]>> materialized);
+                                           final Materialized<K, VR, SessionStore> materialized);
 
     /**
      * Combine values of this stream by the grouped key into {@link SessionWindows}.
@@ -266,5 +265,5 @@ public interface SessionWindowedKStream<K, V> {
      * the latest (rolling) aggregate for each key within a window
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
-                                  final Materialized<K, V, SessionStore<Bytes, byte[]>> materializedAs);
+                                  final Materialized<K, V, SessionStore> materializedAs);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -105,7 +104,7 @@ public interface TimeWindowedKStream<K, V> {
      * @return a {@link KTable} that contains "update" records with unmodified keys and {@link Long} values that
      * represent the latest (rolling) count (i.e., number of records) for each key
      */
-    KTable<Windowed<K>, Long> count(final Materialized<K, Long, WindowStore<Bytes, byte[]>> materialized);
+    KTable<Windowed<K>, Long> count(final Materialized<K, Long, WindowStore> materialized);
 
     /**
      * Aggregate the values of records in this stream by the grouped key.
@@ -189,16 +188,16 @@ public interface TimeWindowedKStream<K, V> {
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
      *
+     * @param <VR>          the value type of the resulting {@link KTable}
      * @param initializer   an {@link Initializer} that computes an initial intermediate aggregation result
      * @param aggregator    an {@link Aggregator} that computes a new aggregate result
      * @param materialized  an instance of {@link Materialized} used to materialize a state store. Cannot be {@code null}.
-     * @param <VR>          the value type of the resulting {@link KTable}
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
      * latest (rolling) aggregate for each key
      */
     <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                            final Aggregator<? super K, ? super V, VR> aggregator,
-                                           final Materialized<K, VR, WindowStore<Bytes, byte[]>> materialized);
+                                           final Materialized<K, VR, WindowStore> materialized);
 
     /**
      * Combine the values of records in this stream by the grouped key.
@@ -270,9 +269,10 @@ public interface TimeWindowedKStream<K, V> {
      *
      *
      * @param reducer   a {@link Reducer} that computes a new aggregate result
+     * @param materialized
      * @return a {@link KTable} that contains "update" records with unmodified keys, and values that represent the
      * latest (rolling) aggregate for each key
      */
     KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
-                                  final Materialized<K, V, WindowStore<Bytes, byte[]>> materialized);
+                                  final Materialized<K, V, WindowStore> materialized);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -93,7 +92,7 @@ public class InternalStreamsBuilder {
     @SuppressWarnings("unchecked")
     public <K, V> KTable<K, V> table(final String topic,
                                      final ConsumedInternal<K, V> consumed,
-                                     final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                     final MaterializedInternal<K, V, KeyValueStore> materialized) {
         final StoreBuilder<KeyValueStore<K, V>> storeBuilder = new KeyValueStoreMaterializer<>(materialized).materialize();
 
         final String source = newName(KStreamImpl.SOURCE_NAME);
@@ -134,7 +133,7 @@ public class InternalStreamsBuilder {
 
     public <K, V> GlobalKTable<K, V> globalTable(final String topic,
                                                  final ConsumedInternal<K, V> consumed,
-                                                 final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                                 final MaterializedInternal<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(consumed, "consumed can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
         // explicitly disable logging for global stores

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImpl.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Reducer;
 import org.apache.kafka.streams.kstream.KTable;
@@ -179,7 +178,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K> implements KGroup
 
     private <T> KTable<K, T> doAggregate(final ProcessorSupplier<K, Change<V>> aggregateSupplier,
                                          final String functionName,
-                                         final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materialized) {
+                                         final MaterializedInternal<K, T, KeyValueStore> materialized) {
         final String sinkName = builder.newName(KStreamImpl.SINK_NAME);
         final String sourceName = builder.newName(KStreamImpl.SOURCE_NAME);
         final String funcName = builder.newName(functionName);
@@ -205,11 +204,11 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K> implements KGroup
     @Override
     public KTable<K, V> reduce(final Reducer<V> adder,
                                final Reducer<V> subtractor,
-                               final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                               final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(adder, "adder can't be null");
         Objects.requireNonNull(subtractor, "subtractor can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
-        final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal
+        final MaterializedInternal<K, V, KeyValueStore> materializedInternal
                 = new MaterializedInternal<>(materialized);
         final ProcessorSupplier<K, Change<V>> aggregateSupplier = new KTableReduce<>(materializedInternal.storeName(),
                                                                                      adder,
@@ -241,7 +240,7 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K> implements KGroup
     }
 
     @Override
-    public KTable<K, Long> count(final Materialized<K, Long, KeyValueStore<Bytes, byte[]>> materialized) {
+    public KTable<K, Long> count(final Materialized<K, Long, KeyValueStore> materialized) {
         return aggregate(countInitializer,
                          countAdder,
                          countSubtractor,
@@ -252,12 +251,12 @@ public class KGroupedTableImpl<K, V> extends AbstractStream<K> implements KGroup
     public <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                         final Aggregator<? super K, ? super V, VR> adder,
                                         final Aggregator<? super K, ? super V, VR> subtractor,
-                                        final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized) {
+                                        final Materialized<K, VR, KeyValueStore> materialized) {
         Objects.requireNonNull(initializer, "initializer can't be null");
         Objects.requireNonNull(adder, "adder can't be null");
         Objects.requireNonNull(subtractor, "subtractor can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
-        final MaterializedInternal<K, VR, KeyValueStore<Bytes, byte[]>> materializedInternal =
+        final MaterializedInternal<K, VR, KeyValueStore> materializedInternal =
                 new MaterializedInternal<>(materialized);
         final ProcessorSupplier<K, Change<V>> aggregateSupplier = new KTableAggregate<>(materializedInternal.storeName(),
                                                                                         initializer,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.TopologyException;
@@ -160,7 +159,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
     }
 
     private KTable<K, V> doFilter(final Predicate<? super K, ? super V> predicate,
-                                  final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized,
+                                  final MaterializedInternal<K, V, KeyValueStore> materialized,
                                   final boolean filterNot) {
         String name = builder.newName(FILTER_NAME);
 
@@ -190,7 +189,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
     @Override
     public KTable<K, V> filter(final Predicate<? super K, ? super V> predicate,
-                               final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                               final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(predicate, "predicate can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
         return doFilter(predicate, new MaterializedInternal<>(materialized), false);
@@ -220,7 +219,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
     @Override
     public KTable<K, V> filterNot(final Predicate<? super K, ? super V> predicate,
-                                  final Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+                                  final Materialized<K, V, KeyValueStore> materialized) {
         Objects.requireNonNull(predicate, "predicate can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
         return doFilter(predicate, new MaterializedInternal<>(materialized), true);
@@ -269,10 +268,10 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
     @Override
     public <VR> KTable<K, VR> mapValues(final ValueMapper<? super V, ? extends VR> mapper,
-                                        final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized) {
+                                        final Materialized<K, VR, KeyValueStore> materialized) {
         Objects.requireNonNull(mapper, "mapper can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
-        final MaterializedInternal<K, VR, KeyValueStore<Bytes, byte[]>> materializedInternal
+        final MaterializedInternal<K, VR, KeyValueStore> materializedInternal
                 = new MaterializedInternal<>(materialized);
         final String name = builder.newName(MAPVALUES_NAME);
         final KTableProcessorSupplier<K, V, VR> processorSupplier = new KTableMapValues<>(this,
@@ -402,7 +401,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
         return builder.table(topic,
                              new ConsumedInternal<>(keySerde, valSerde, new FailOnInvalidTimestamp(), null),
-                             new MaterializedInternal<>(Materialized.<K, V, KeyValueStore<Bytes, byte[]>>as(internalStoreName)
+                             new MaterializedInternal<>(Materialized.<K, V, KeyValueStore>as(internalStoreName)
                                      .withKeySerde(keySerde)
                                      .withValueSerde(valSerde),
                                      queryableStoreName != null));
@@ -545,7 +544,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
     @Override
     public <VO, VR> KTable<K, VR> join(final KTable<K, VO> other,
                                        final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                       final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized) {
+                                       final Materialized<K, VR, KeyValueStore> materialized) {
         Objects.requireNonNull(other, "other can't be null");
         Objects.requireNonNull(joiner, "joiner can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
@@ -577,7 +576,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
     @Override
     public <VO, VR> KTable<K, VR> outerJoin(final KTable<K, VO> other,
                                             final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                            final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized) {
+                                            final Materialized<K, VR, KeyValueStore> materialized) {
         return doJoin(other, joiner, new MaterializedInternal<>(materialized), true, true);
     }
 
@@ -606,7 +605,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
     @Override
     public <VO, VR> KTable<K, VR> leftJoin(final KTable<K, VO> other,
                                            final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                           final Materialized<K, VR, KeyValueStore<Bytes, byte[]>> materialized) {
+                                           final Materialized<K, VR, KeyValueStore> materialized) {
         return doJoin(other,
                       joiner,
                       new MaterializedInternal<>(materialized),
@@ -670,7 +669,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
     private <VO, VR> KTable<K, VR> doJoin(final KTable<K, VO> other,
                                           final ValueJoiner<? super V, ? super VO, ? extends VR> joiner,
-                                          final MaterializedInternal<K, VR, KeyValueStore<Bytes, byte[]>> materialized,
+                                          final MaterializedInternal<K, VR, KeyValueStore> materialized,
                                           final boolean leftOuter,
                                           final boolean rightOuter) {
         Objects.requireNonNull(other, "other can't be null");

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KeyValueStoreMaterializer.java
@@ -16,25 +16,25 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.StoreSupplier;
 import org.apache.kafka.streams.state.Stores;
 
 public class KeyValueStoreMaterializer<K, V> {
-    private final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized;
+    private final MaterializedInternal<K, V, KeyValueStore> materialized;
 
-    public KeyValueStoreMaterializer(final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materialized) {
+    public KeyValueStoreMaterializer(final MaterializedInternal<K, V, KeyValueStore> materialized) {
         this.materialized = materialized;
     }
 
     public StoreBuilder<KeyValueStore<K, V>> materialize() {
-        KeyValueBytesStoreSupplier supplier = (KeyValueBytesStoreSupplier) materialized.storeSupplier();
+        StoreSupplier supplier = materialized.storeSupplier();
         if (supplier == null) {
             supplier = Stores.persistentKeyValueStore(materialized.storeName());
         }
-        final StoreBuilder<KeyValueStore<K, V>> builder = Stores.keyValueStoreBuilder(supplier,
+        final StoreBuilder<KeyValueStore<K, V>> builder = Stores.keyValueStoreBuilder((KeyValueBytesStoreSupplier) supplier,
                                                                                       materialized.keySerde(),
                                                                                       materialized.valueSerde());
 

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.ForeachAction;
@@ -128,7 +127,7 @@ public class StreamsBuilderTest {
                 results.put(key, value);
             }
         };
-        builder.table(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store")
+        builder.table(topic, Materialized.<Long, String, KeyValueStore>as("store")
                 .withKeySerde(Serdes.Long())
                 .withValueSerde(Serdes.String()))
                 .toStream().foreach(action);
@@ -148,7 +147,7 @@ public class StreamsBuilderTest {
     @Test
     public void shouldUseSerdesDefinedInMaterializedToConsumeGlobalTable() {
         final String topic = "topic";
-        builder.globalTable(topic, Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as("store")
+        builder.globalTable(topic, Materialized.<Long, String, KeyValueStore>as("store")
                 .withKeySerde(Serdes.Long())
                 .withValueSerde(Serdes.String()));
         driver.setUp(builder, TestUtils.tempDirectory());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/GlobalKTableIntegrationTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
@@ -105,7 +104,7 @@ public class GlobalKTableIntegrationTest {
         streamsConfiguration.put(IntegrationTestUtils.INTERNAL_LEAVE_GROUP_ON_CLOSE, true);
         streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
         globalTable = builder.globalTable(globalOne, Consumed.with(Serdes.Long(), Serdes.String()),
-                                          Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>as(globalStore)
+                                          Materialized.<Long, String, KeyValueStore>as(globalStore)
                                                   .withKeySerde(Serdes.Long())
                                                   .withValueSerde(Serdes.String()));
         final Consumed<String, Long> stringLongConsumed = Consumed.with(Serdes.String(), Serdes.Long());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableJoinIntegrationTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -347,9 +346,9 @@ public class KTableKTableJoinIntegrationTest {
         final KTable<String, String> table2 = builder.table(TABLE_2);
         final KTable<String, String> table3 = builder.table(TABLE_3);
 
-        Materialized<String, String, KeyValueStore<Bytes, byte[]>> materialized = null;
+        Materialized<String, String, KeyValueStore> materialized = null;
         if (queryableName != null) {
-            materialized = Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(queryableName)
+            materialized = Materialized.<String, String, KeyValueStore>as(queryableName)
                     .withKeySerde(Serdes.String())
                     .withValueSerde(Serdes.String())
                     .withCachingDisabled();
@@ -363,7 +362,7 @@ public class KTableKTableJoinIntegrationTest {
     private KTable<String, String> join(final KTable<String, String> first,
                                         final KTable<String, String> second,
                                         final JoinType joinType,
-                                        final Materialized<String, String, KeyValueStore<Bytes, byte[]>> materialized) {
+                                        final Materialized<String, String, KeyValueStore> materialized) {
         final ValueJoiner<String, String, String> joiner = new ValueJoiner<String, String, String>() {
             @Override
             public String apply(final String value1, final String value2) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/QueryableStateIntegrationTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreamsTest;
@@ -449,8 +448,8 @@ public class QueryableStateIntegrationTest {
             }
         };
         final KTable<String, Long> t1 = builder.table(streamOne);
-        final KTable<String, Long> t2 = t1.filter(filterPredicate, Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("queryFilter"));
-        t1.filterNot(filterPredicate, Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("queryFilterNot"));
+        final KTable<String, Long> t2 = t1.filter(filterPredicate, Materialized.<String, Long, KeyValueStore>as("queryFilter"));
+        t1.filterNot(filterPredicate, Materialized.<String, Long, KeyValueStore>as("queryFilterNot"));
         t2.to(outputTopic);
 
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
@@ -512,7 +511,7 @@ public class QueryableStateIntegrationTest {
             public Long apply(final String value) {
                 return Long.valueOf(value);
             }
-        }, Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("queryMapValues").withValueSerde(Serdes.Long()));
+        }, Materialized.<String, Long, KeyValueStore>as("queryMapValues").withValueSerde(Serdes.Long()));
         t2.to(Serdes.String(), Serdes.Long(), outputTopic);
 
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);
@@ -562,13 +561,13 @@ public class QueryableStateIntegrationTest {
             }
         };
         final KTable<String, String> t1 = builder.table(streamOne);
-        final KTable<String, String> t2 = t1.filter(filterPredicate, Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("queryFilter"));
+        final KTable<String, String> t2 = t1.filter(filterPredicate, Materialized.<String, String, KeyValueStore>as("queryFilter"));
         final KTable<String, Long> t3 = t2.mapValues(new ValueMapper<String, Long>() {
             @Override
             public Long apply(final String value) {
                 return Long.valueOf(value);
             }
-        }, Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("queryMapValues").withValueSerde(Serdes.Long()));
+        }, Materialized.<String, Long, KeyValueStore>as("queryMapValues").withValueSerde(Serdes.Long()));
         t3.to(Serdes.String(), Serdes.Long(), outputTopic);
 
         kafkaStreams = new KafkaStreams(builder.build(), streamsConfiguration);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -165,7 +164,7 @@ public class RestoreIntegrationTest {
                     public Integer apply(final Integer value1, final Integer value2) {
                         return value1 + value2;
                     }
-                }, Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as("reduce-store").withLoggingDisabled());
+                }, Materialized.<Integer, Integer, KeyValueStore>as("reduce-store").withLoggingDisabled());
 
         final CountDownLatch startupLatch = new CountDownLatch(1);
         kafkaStreams = new KafkaStreams(builder.build(), props());

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilderTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.kstream.GlobalKTable;
@@ -61,8 +60,8 @@ public class InternalStreamsBuilderTest {
 
     private KStreamTestDriver driver = null;
     private final ConsumedInternal<String, String> consumed = new ConsumedInternal<>();
-    private MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-            = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("test-store"), false);
+    private MaterializedInternal<String, String, KeyValueStore> materialized
+            = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("test-store"), false);
 
     @Before
     public void setUp() {
@@ -141,7 +140,7 @@ public class InternalStreamsBuilderTest {
         KTable table1 = builder.table("topic2",
                                       consumed,
                                       new MaterializedInternal<>(
-                                              Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("topic2"),
+                                              Materialized.<String, String, KeyValueStore>as("topic2"),
                                               false));
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.build(null);
@@ -159,7 +158,7 @@ public class InternalStreamsBuilderTest {
         builder.globalTable("table",
                             consumed,
                             new MaterializedInternal<>(
-                                    Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("globalTable"),
+                                    Materialized.<String, String, KeyValueStore>as("globalTable"),
                                     false));
 
         final ProcessorTopology topology = builder.internalTopologyBuilder.buildGlobalStateTopology();
@@ -184,11 +183,11 @@ public class InternalStreamsBuilderTest {
         builder.globalTable("table",
                             consumed,
                             new MaterializedInternal<>(
-                                    Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("global1")));
+                                    Materialized.<String, String, KeyValueStore>as("global1")));
         builder.globalTable("table2",
                             consumed,
                             new MaterializedInternal<>(
-                                    Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("global2")));
+                                    Materialized.<String, String, KeyValueStore>as("global2")));
 
         doBuildGlobalTopologyWithAllGlobalTables();
     }
@@ -201,14 +200,14 @@ public class InternalStreamsBuilderTest {
         final GlobalKTable<String, String> globalTable = builder.globalTable("table",
                                                                              consumed,
                                                                              new MaterializedInternal<>(
-                                                                                     Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(one)));
+                                                                                     Materialized.<String, String, KeyValueStore>as(one)));
         final GlobalKTable<String, String> globalTable2 = builder.globalTable("table2",
                                                                               consumed,
                                                                               new MaterializedInternal<>(
-                                                                                      Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(two)));
+                                                                                      Materialized.<String, String, KeyValueStore>as(two)));
 
-        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("not-global"), false);
+        final MaterializedInternal<String, String, KeyValueStore> materialized
+                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("not-global"), false);
         builder.table("not-global", consumed, materialized);
 
         final KeyValueMapper<String, String, String> kvMapper = new KeyValueMapper<String, String, String>() {
@@ -242,8 +241,8 @@ public class InternalStreamsBuilderTest {
     public void shouldMapStateStoresToCorrectSourceTopics() throws Exception {
         final KStream<String, String> playEvents = builder.stream(Collections.singleton("events"), consumed);
 
-        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("table-store"), false);
+        final MaterializedInternal<String, String, KeyValueStore> materialized
+                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("table-store"), false);
         final KTable<String, String> table = builder.table("table-topic", consumed, materialized);
         assertEquals(Collections.singletonList("table-topic"), builder.internalTopologyBuilder.stateStoreNameToSourceTopics().get("table-store"));
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImplTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -508,7 +507,7 @@ public class KGroupedStreamImplTest {
     @SuppressWarnings("unchecked")
     @Test
     public void shouldCountAndMaterializeResults() {
-        groupedStream.count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("count")
+        groupedStream.count(Materialized.<String, Long, KeyValueStore>as("count")
                                     .withKeySerde(Serdes.String()));
 
         processData();
@@ -526,7 +525,7 @@ public class KGroupedStreamImplTest {
     @Test
     public void shouldReduceAndMaterializeResults() {
         groupedStream.reduce(MockReducer.STRING_ADDER,
-                             Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("reduce")
+                             Materialized.<String, String, KeyValueStore>as("reduce")
                                     .withKeySerde(Serdes.String())
                                     .withValueSerde(Serdes.String()));
 
@@ -544,7 +543,7 @@ public class KGroupedStreamImplTest {
     public void shouldAggregateAndMaterializeResults() {
         groupedStream.aggregate(MockInitializer.STRING_INIT,
                                 MockAggregator.TOSTRING_ADDER,
-                                Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("aggregate")
+                                Materialized.<String, String, KeyValueStore>as("aggregate")
                                         .withKeySerde(Serdes.String())
                                         .withValueSerde(Serdes.String()));
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KGroupedTableImplTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -160,7 +159,7 @@ public class KGroupedTableImplTest {
 
         final KTable<String, Integer> reduced = builder.table(topic,
                                                               Consumed.with(Serdes.String(), Serdes.Double()),
-                                                              Materialized.<String, Double, KeyValueStore<Bytes, byte[]>>as("store")
+                                                              Materialized.<String, Double, KeyValueStore>as("store")
                                                                       .withKeySerde(Serdes.String())
                                                                       .withValueSerde(Serdes.Double()))
             .groupBy(intProjection)
@@ -182,7 +181,7 @@ public class KGroupedTableImplTest {
 
         final KTable<String, Integer> reduced = builder.table(topic,
                                                               Consumed.with(Serdes.String(), Serdes.Double()),
-                                                              Materialized.<String, Double, KeyValueStore<Bytes, byte[]>>as("store")
+                                                              Materialized.<String, Double, KeyValueStore>as("store")
                                                                       .withKeySerde(Serdes.String())
                                                                       .withValueSerde(Serdes.Double()))
             .groupBy(intProjection)
@@ -207,7 +206,7 @@ public class KGroupedTableImplTest {
                 .groupBy(intProjection)
                 .reduce(MockReducer.INTEGER_ADDER,
                         MockReducer.INTEGER_SUBTRACTOR,
-                        Materialized.<String, Integer, KeyValueStore<Bytes, byte[]>>as("reduce")
+                        Materialized.<String, Integer, KeyValueStore>as("reduce")
                                 .withKeySerde(Serdes.String())
                                 .withValueSerde(Serdes.Integer()));
 
@@ -224,7 +223,7 @@ public class KGroupedTableImplTest {
         table.groupBy(MockKeyValueMapper.<String, String>SelectValueKeyValueMapper(),
                       Serialized.with(Serdes.String(),
                                       Serdes.String()))
-                .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("count")
+                .count(Materialized.<String, Long, KeyValueStore>as("count")
                                .withKeySerde(Serdes.String())
                                .withValueSerde(Serdes.Long()));
 
@@ -244,7 +243,7 @@ public class KGroupedTableImplTest {
                 .aggregate(MockInitializer.STRING_INIT,
                            MockAggregator.TOSTRING_ADDER,
                            MockAggregator.TOSTRING_REMOVER,
-                           Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("aggregate")
+                           Materialized.<String, String, KeyValueStore>as("aggregate")
                                    .withValueSerde(Serdes.String())
                                    .withKeySerde(Serdes.String()));
 
@@ -268,12 +267,12 @@ public class KGroupedTableImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnReduceWhenAdderIsNull() {
-        groupedTable.reduce(null, MockReducer.STRING_REMOVER, Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store"));
+        groupedTable.reduce(null, MockReducer.STRING_REMOVER, Materialized.<String, String, KeyValueStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnReduceWhenSubtractorIsNull() {
-        groupedTable.reduce(MockReducer.STRING_ADDER, null, Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store"));
+        groupedTable.reduce(MockReducer.STRING_ADDER, null, Materialized.<String, String, KeyValueStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -281,7 +280,7 @@ public class KGroupedTableImplTest {
         groupedTable.aggregate(null,
                                MockAggregator.TOSTRING_ADDER,
                                MockAggregator.TOSTRING_REMOVER,
-                               Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store"));
+                               Materialized.<String, String, KeyValueStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -289,7 +288,7 @@ public class KGroupedTableImplTest {
         groupedTable.aggregate(MockInitializer.STRING_INIT,
                                null,
                                MockAggregator.TOSTRING_REMOVER,
-                               Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store"));
+                               Materialized.<String, String, KeyValueStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -297,7 +296,7 @@ public class KGroupedTableImplTest {
         groupedTable.aggregate(MockInitializer.STRING_INIT,
                                MockAggregator.TOSTRING_ADDER,
                                null,
-                               Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store"));
+                               Materialized.<String, String, KeyValueStore>as("store"));
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KTable;
@@ -137,7 +136,7 @@ public class KTableFilterTest {
             public boolean test(String key, Integer value) {
                 return (value % 2) == 0;
             }
-        }, Materialized.<String, Integer, KeyValueStore<Bytes, byte[]>>as("anyStoreNameFilter"));
+        }, Materialized.<String, Integer, KeyValueStore>as("anyStoreNameFilter"));
         KTable<String, Integer> table3 = table1.filterNot(new Predicate<String, Integer>() {
             @Override
             public boolean test(String key, Integer value) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableForeachTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableForeachTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -85,7 +84,7 @@ public class KTableForeachTest {
         StreamsBuilder builder = new StreamsBuilder();
         KTable<Integer, String> table = builder.table(topicName,
                                                       Consumed.with(intSerde, stringSerde),
-                                                      new MaterializedInternal<>(Materialized.<Integer, String, KeyValueStore<Bytes, byte[]>>as(topicName)
+                                                      new MaterializedInternal<>(Materialized.<Integer, String, KeyValueStore>as(topicName)
                                                                                          .withKeySerde(intSerde)
                                                                                          .withValueSerde(stringSerde)));
         table.foreach(action);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -336,7 +335,7 @@ public class KTableImplTest {
         KTableImpl<String, String, String> table1 =
                 (KTableImpl<String, String, String>) builder.table(topic1,
                                                                    consumed,
-                                                                   Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(storeName1)
+                                                                   Materialized.<String, String, KeyValueStore>as(storeName1)
                                                                            .withKeySerde(stringSerde)
                                                                            .withValueSerde(stringSerde)
                 );
@@ -488,7 +487,7 @@ public class KTableImplTest {
             public boolean test(final String key, final String value) {
                 return false;
             }
-        }, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null);
+        }, (Materialized<String, String, KeyValueStore>) null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -498,7 +497,7 @@ public class KTableImplTest {
             public boolean test(final String key, final String value) {
                 return false;
             }
-        }, (Materialized<String, String, KeyValueStore<Bytes, byte[]>>) null);
+        }, (Materialized<String, String, KeyValueStore>) null);
     }
 
     @Test(expected = NullPointerException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -97,7 +96,7 @@ public class KTableMapValuesTest {
             public Integer apply(CharSequence value) {
                 return value.charAt(0) - 48;
             }
-        }, Materialized.<String, Integer, KeyValueStore<Bytes, byte[]>>as("anyName").withValueSerde(Serdes.Integer()));
+        }, Materialized.<String, Integer, KeyValueStore>as("anyName").withValueSerde(Serdes.Integer()));
 
         MockProcessorSupplier<String, Integer> proc2 = new MockProcessorSupplier<>();
         table2.toStream().process(proc2);
@@ -252,14 +251,14 @@ public class KTableMapValuesTest {
                 public Integer apply(String value) {
                     return new Integer(value);
                 }
-            }, Materialized.<String, Integer, KeyValueStore<Bytes, byte[]>>as("anyMapName").withValueSerde(Serdes.Integer()));
+            }, Materialized.<String, Integer, KeyValueStore>as("anyMapName").withValueSerde(Serdes.Integer()));
         KTableImpl<String, Integer, Integer> table3 = (KTableImpl<String, Integer, Integer>) table2.filter(
             new Predicate<String, Integer>() {
                 @Override
                 public boolean test(String key, Integer value) {
                     return (value % 2) == 0;
                 }
-            }, Materialized.<String, Integer, KeyValueStore<Bytes, byte[]>>as("anyFilterName").withValueSerde(Serdes.Integer()));
+            }, Materialized.<String, Integer, KeyValueStore>as("anyFilterName").withValueSerde(Serdes.Integer()));
         KTableImpl<String, String, String> table4 = (KTableImpl<String, String, String>)
             table1.through(stringSerde, stringSerde, topic2, storeName2);
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImplTest.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -129,7 +128,7 @@ public class SessionWindowedKStreamImplTest {
     @SuppressWarnings("unchecked")
     @Test
     public void shouldMaterializeCount() {
-        stream.count(Materialized.<String, Long, SessionStore<Bytes, byte[]>>as("count-store")
+        stream.count(Materialized.<String, Long, SessionStore>as("count-store")
                              .withKeySerde(Serdes.String()));
 
         processData();
@@ -145,7 +144,7 @@ public class SessionWindowedKStreamImplTest {
     @Test
     public void shouldMaterializeReduced() {
         stream.reduce(MockReducer.STRING_ADDER,
-                      Materialized.<String, String, SessionStore<Bytes, byte[]>>as("reduced")
+                      Materialized.<String, String, SessionStore>as("reduced")
                               .withKeySerde(Serdes.String())
                               .withValueSerde(Serdes.String()));
 
@@ -165,7 +164,7 @@ public class SessionWindowedKStreamImplTest {
         stream.aggregate(MockInitializer.STRING_INIT,
                          MockAggregator.TOSTRING_ADDER,
                          sessionMerger,
-                         Materialized.<String, String, SessionStore<Bytes, byte[]>>as("aggregated")
+                         Materialized.<String, String, SessionStore>as("aggregated")
                                  .withKeySerde(Serdes.String())
                                  .withValueSerde(Serdes.String()));
 
@@ -203,7 +202,7 @@ public class SessionWindowedKStreamImplTest {
         stream.aggregate(null,
                          MockAggregator.TOSTRING_ADDER,
                          sessionMerger,
-                         Materialized.<String, String, SessionStore<Bytes, byte[]>>as("store"));
+                         Materialized.<String, String, SessionStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -211,7 +210,7 @@ public class SessionWindowedKStreamImplTest {
         stream.aggregate(MockInitializer.STRING_INIT,
                          null,
                          sessionMerger,
-                         Materialized.<String, String, SessionStore<Bytes, byte[]>>as("store"));
+                         Materialized.<String, String, SessionStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -219,7 +218,7 @@ public class SessionWindowedKStreamImplTest {
         stream.aggregate(MockInitializer.STRING_INIT,
                          MockAggregator.TOSTRING_ADDER,
                          null,
-                         Materialized.<String, String, SessionStore<Bytes, byte[]>>as("store"));
+                         Materialized.<String, String, SessionStore>as("store"));
     }
 
     @SuppressWarnings("unchecked")
@@ -234,7 +233,7 @@ public class SessionWindowedKStreamImplTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull() {
         stream.reduce(null,
-                      Materialized.<String, String, SessionStore<Bytes, byte[]>>as("store"));
+                      Materialized.<String, String, SessionStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/TimeWindowedKStreamImplTest.java
@@ -18,7 +18,6 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -123,7 +122,7 @@ public class TimeWindowedKStreamImplTest {
     @SuppressWarnings("unchecked")
     @Test
     public void shouldMaterializeCount() {
-        windowedStream.count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("count-store")
+        windowedStream.count(Materialized.<String, Long, WindowStore>as("count-store")
                                      .withKeySerde(Serdes.String())
                                      .withValueSerde(Serdes.Long()));
 
@@ -140,7 +139,7 @@ public class TimeWindowedKStreamImplTest {
     @Test
     public void shouldMaterializeReduced() {
         windowedStream.reduce(MockReducer.STRING_ADDER,
-                              Materialized.<String, String, WindowStore<Bytes, byte[]>>as("reduced")
+                              Materialized.<String, String, WindowStore>as("reduced")
                                       .withKeySerde(Serdes.String())
                                       .withValueSerde(Serdes.String()));
 
@@ -159,7 +158,7 @@ public class TimeWindowedKStreamImplTest {
     public void shouldMaterializeAggregated() {
         windowedStream.aggregate(MockInitializer.STRING_INIT,
                                  MockAggregator.TOSTRING_ADDER,
-                                 Materialized.<String, String, WindowStore<Bytes, byte[]>>as("aggregated")
+                                 Materialized.<String, String, WindowStore>as("aggregated")
                                          .withKeySerde(Serdes.String())
                                          .withValueSerde(Serdes.String()));
 
@@ -191,14 +190,14 @@ public class TimeWindowedKStreamImplTest {
     public void shouldThrowNullPointerOnMaterializedAggregateIfInitializerIsNull() {
         windowedStream.aggregate(null,
                                  MockAggregator.TOSTRING_ADDER,
-                                 Materialized.<String, String, WindowStore<Bytes, byte[]>>as("store"));
+                                 Materialized.<String, String, WindowStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnMaterializedAggregateIfAggregatorIsNull() {
         windowedStream.aggregate(MockInitializer.STRING_INIT,
                                  null,
-                                 Materialized.<String, String, WindowStore<Bytes, byte[]>>as("store"));
+                                 Materialized.<String, String, WindowStore>as("store"));
     }
 
     @SuppressWarnings("unchecked")
@@ -212,7 +211,7 @@ public class TimeWindowedKStreamImplTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnMaterializedReduceIfReducerIsNull() {
         windowedStream.reduce(null,
-                              Materialized.<String, String, WindowStore<Bytes, byte[]>>as("store"));
+                              Materialized.<String, String, WindowStore>as("store"));
     }
 
     @Test(expected = NullPointerException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/KeyValueStoreMaterializerTest.java
@@ -44,8 +44,8 @@ public class KeyValueStoreMaterializerTest {
 
     @Test
     public void shouldCreateBuilderThatBuildsMeteredStoreWithCachingAndLoggingEnabled() {
-        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store"));
+        final MaterializedInternal<String, String, KeyValueStore> materialized
+                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("store"));
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
         final StoreBuilder<KeyValueStore<String, String>> builder = materializer.materialize();
         final KeyValueStore<String, String> store = builder.build();
@@ -58,8 +58,8 @@ public class KeyValueStoreMaterializerTest {
 
     @Test
     public void shouldCreateBuilderThatBuildsStoreWithCachingDisabled() {
-        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store")
+        final MaterializedInternal<String, String, KeyValueStore> materialized
+                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("store")
                                                      .withCachingDisabled());
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
         final StoreBuilder<KeyValueStore<String, String>> builder = materializer.materialize();
@@ -70,8 +70,8 @@ public class KeyValueStoreMaterializerTest {
 
     @Test
     public void shouldCreateBuilderThatBuildsStoreWithLoggingDisabled() {
-        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store")
+        final MaterializedInternal<String, String, KeyValueStore> materialized
+                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("store")
                                                      .withLoggingDisabled());
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
         final StoreBuilder<KeyValueStore<String, String>> builder = materializer.materialize();
@@ -83,8 +83,8 @@ public class KeyValueStoreMaterializerTest {
 
     @Test
     public void shouldCreateBuilderThatBuildsStoreWithCachingAndLoggingDisabled() {
-        final MaterializedInternal<String, String, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("store")
+        final MaterializedInternal<String, String, KeyValueStore> materialized
+                = new MaterializedInternal<>(Materialized.<String, String, KeyValueStore>as("store")
                                                      .withCachingDisabled()
                                                      .withLoggingDisabled());
         final KeyValueStoreMaterializer<String, String> materializer = new KeyValueStoreMaterializer<>(materialized);
@@ -103,9 +103,10 @@ public class KeyValueStoreMaterializerTest {
         EasyMock.expect(supplier.get()).andReturn(store);
         EasyMock.replay(supplier);
 
-        final MaterializedInternal<String, Integer, KeyValueStore<Bytes, byte[]>> materialized
-                = new MaterializedInternal<>(Materialized.<String, Integer>as(supplier));
-        final KeyValueStoreMaterializer<String, Integer> materializer = new KeyValueStoreMaterializer<>(materialized);
+        final Materialized<String, Integer, KeyValueStore> materialized = Materialized.as(supplier);
+        final MaterializedInternal<String, Integer, KeyValueStore> materializedInternal
+                = new MaterializedInternal<>(materialized);
+        final KeyValueStoreMaterializer<String, Integer> materializer = new KeyValueStoreMaterializer<>(materializedInternal);
         final StoreBuilder<KeyValueStore<String, Integer>> builder = materializer.materialize();
         final KeyValueStore<String, Integer> built = builder.build();
         final StateStore inner = ((WrappedStateStore) built).inner();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -792,7 +791,7 @@ public class StreamPartitionAssignorTest {
 
             // Task 2 (should get created):
             // create repartioning and changelog topic as task 1 exists
-            .count(Materialized.<Object, Long, KeyValueStore<Bytes, byte[]>>as("count"))
+            .count(Materialized.<Object, Long, KeyValueStore>as("count"))
 
             // force repartitioning for join, but second join input topic unknown
             // -> internal repartitioning topic should not get created

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -94,7 +93,7 @@ public class StreamsMetadataStateTest {
 
         builder.globalTable("global-topic",
                             Consumed.with(null, null),
-                            Materialized.<Object, Object, KeyValueStore<Bytes, byte[]>>as(globalTable));
+                            Materialized.<Object, Object, KeyValueStore>as(globalTable));
 
         StreamsBuilderTest.internalTopologyBuilder(builder).setApplicationId("appId");
 


### PR DESCRIPTION
Make the API simpler by removing `<Bytes, byte[]>` from usages of `Materialized`. This is already enforced when by `Materialized.as(KeyValueBytesStore)` etc.