### PR TITLE
MINOR: Java 9 version handling improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.2"
+  gradleVersion = "4.2.1"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -177,7 +177,7 @@ public class SaslChannelBuilder implements ChannelBuilder {
         Class<?> classRef;
         Method getInstanceMethod;
         Method getDefaultRealmMethod;
-        if (Java.isIBMJdk()) {
+        if (Java.isIbmJdk()) {
             classRef = Class.forName("com.ibm.security.krb5.internal.Config");
         } else {
             classRef = Class.forName("sun.security.krb5.Config");

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -20,32 +20,53 @@ import java.util.StringTokenizer;
 
 public final class Java {
 
-    private Java() {
+    private Java() { }
+
+    public static final Version VERSION = parseVersion(System.getProperty("java.specification.version"));
+
+    // Package private for testing
+    static Version parseVersion(String versionString) {
+        final StringTokenizer st = new StringTokenizer(versionString, ".");
+        int majorVersion = Integer.parseInt(st.nextToken());
+        int minorVersion;
+        if (st.hasMoreTokens())
+            minorVersion = Integer.parseInt(st.nextToken());
+        else
+            minorVersion = 0;
+        return new Version(majorVersion, minorVersion);
     }
 
-    public static final String JVM_SPEC_VERSION = System.getProperty("java.specification.version");
-
-    private static final int JVM_MAJOR_VERSION;
-    private static final int JVM_MINOR_VERSION;
-
-    static {
-        final StringTokenizer st = new StringTokenizer(JVM_SPEC_VERSION, ".");
-        JVM_MAJOR_VERSION = Integer.parseInt(st.nextToken());
-        if (st.hasMoreTokens()) {
-            JVM_MINOR_VERSION = Integer.parseInt(st.nextToken());
-        } else {
-            JVM_MINOR_VERSION = 0;
-        }
+    static boolean isJava9Compatible(Version v) {
+        return v.majorVersion >= 9;
     }
 
-    public static final boolean IS_JAVA9_COMPATIBLE = JVM_MAJOR_VERSION > 1 ||
-            (JVM_MAJOR_VERSION == 1 && JVM_MINOR_VERSION >= 9);
+    static boolean isJava8Compatible(Version v) {
+        return v.majorVersion > 1 || (v.majorVersion == 1 && v.minorVersion >= 8);
+    }
 
-    public static final boolean IS_JAVA8_COMPATIBLE = JVM_MAJOR_VERSION > 1 ||
-            (JVM_MAJOR_VERSION == 1 && JVM_MINOR_VERSION >= 8);
+    // Having these as static final provides the best opportunity for compilar optimization
+    public static final boolean IS_JAVA9_COMPATIBLE = isJava9Compatible(VERSION);
+    public static final boolean IS_JAVA8_COMPATIBLE = isJava8Compatible(VERSION);
 
     public static boolean isIBMJdk() {
         return System.getProperty("java.vendor").contains("IBM");
+    }
+
+    // Package private for testing
+    static class Version {
+        public final int majorVersion;
+        public final int minorVersion;
+
+        private Version(int majorVersion, int minorVersion) {
+            this.majorVersion = majorVersion;
+            this.minorVersion = minorVersion;
+        }
+
+        @Override
+        public String toString() {
+            return "Version(majorVersion=" + majorVersion +
+                    ", minorVersion=" + minorVersion + ")";
+        }
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -36,17 +36,9 @@ public final class Java {
         return new Version(majorVersion, minorVersion);
     }
 
-    static boolean isJava9Compatible(Version v) {
-        return v.majorVersion >= 9;
-    }
-
-    static boolean isJava8Compatible(Version v) {
-        return v.majorVersion > 1 || (v.majorVersion == 1 && v.minorVersion >= 8);
-    }
-
     // Having these as static final provides the best opportunity for compilar optimization
-    public static final boolean IS_JAVA9_COMPATIBLE = isJava9Compatible(VERSION);
-    public static final boolean IS_JAVA8_COMPATIBLE = isJava8Compatible(VERSION);
+    public static final boolean IS_JAVA9_COMPATIBLE = VERSION.isJava9Compatible();
+    public static final boolean IS_JAVA8_COMPATIBLE = VERSION.isJava8Compatible();
 
     public static boolean isIbmJdk() {
         return System.getProperty("java.vendor").contains("IBM");
@@ -66,6 +58,16 @@ public final class Java {
         public String toString() {
             return "Version(majorVersion=" + majorVersion +
                     ", minorVersion=" + minorVersion + ")";
+        }
+
+        // Package private for testing
+        boolean isJava9Compatible() {
+            return majorVersion >= 9;
+        }
+
+        // Package private for testing
+        boolean isJava8Compatible() {
+            return majorVersion > 1 || (majorVersion == 1 && minorVersion >= 8);
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -22,7 +22,7 @@ public final class Java {
 
     private Java() { }
 
-    public static final Version VERSION = parseVersion(System.getProperty("java.specification.version"));
+    private static final Version VERSION = parseVersion(System.getProperty("java.specification.version"));
 
     // Package private for testing
     static Version parseVersion(String versionString) {

--- a/clients/src/main/java/org/apache/kafka/common/utils/Java.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Java.java
@@ -48,7 +48,7 @@ public final class Java {
     public static final boolean IS_JAVA9_COMPATIBLE = isJava9Compatible(VERSION);
     public static final boolean IS_JAVA8_COMPATIBLE = isJava8Compatible(VERSION);
 
-    public static boolean isIBMJdk() {
+    public static boolean isIbmJdk() {
         return System.getProperty("java.vendor").contains("IBM");
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -53,4 +54,43 @@ public class JavaTest {
         Class.forName(clazz);
     }
 
+    @Test
+    public void testJavaVersion() {
+        Java.Version v = Java.parseVersion("9");
+        assertEquals(9, v.majorVersion);
+        assertEquals(0, v.minorVersion);
+        assertTrue(Java.isJava9Compatible(v));
+        assertTrue(Java.isJava8Compatible(v));
+
+        v = Java.parseVersion("9.0.1");
+        assertEquals(9, v.majorVersion);
+        assertEquals(0, v.minorVersion);
+        assertTrue(Java.isJava9Compatible(v));
+        assertTrue(Java.isJava8Compatible(v));
+
+        v = Java.parseVersion("9.0.0.15"); // Azul Zulu
+        assertEquals(9, v.majorVersion);
+        assertEquals(0, v.minorVersion);
+        assertTrue(Java.isJava9Compatible(v));
+        assertTrue(Java.isJava8Compatible(v));
+
+        v = Java.parseVersion("9.1");
+        assertEquals(9, v.majorVersion);
+        assertEquals(1, v.minorVersion);
+        assertTrue(Java.isJava9Compatible(v));
+        assertTrue(Java.isJava8Compatible(v));
+
+        v = Java.parseVersion("1.8.0_152");
+        assertEquals(1, v.majorVersion);
+        assertEquals(8, v.minorVersion);
+        assertFalse(Java.isJava9Compatible(v));
+        assertTrue(Java.isJava8Compatible(v));
+
+        v = Java.parseVersion("1.7.0_80");
+        assertEquals(1, v.majorVersion);
+        assertEquals(7, v.minorVersion);
+        assertFalse(Java.isJava9Compatible(v));
+        assertFalse(Java.isJava8Compatible(v));
+
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -59,38 +59,38 @@ public class JavaTest {
         Java.Version v = Java.parseVersion("9");
         assertEquals(9, v.majorVersion);
         assertEquals(0, v.minorVersion);
-        assertTrue(Java.isJava9Compatible(v));
-        assertTrue(Java.isJava8Compatible(v));
+        assertTrue(v.isJava9Compatible());
+        assertTrue(v.isJava8Compatible());
 
         v = Java.parseVersion("9.0.1");
         assertEquals(9, v.majorVersion);
         assertEquals(0, v.minorVersion);
-        assertTrue(Java.isJava9Compatible(v));
-        assertTrue(Java.isJava8Compatible(v));
+        assertTrue(v.isJava9Compatible());
+        assertTrue(v.isJava8Compatible());
 
         v = Java.parseVersion("9.0.0.15"); // Azul Zulu
         assertEquals(9, v.majorVersion);
         assertEquals(0, v.minorVersion);
-        assertTrue(Java.isJava9Compatible(v));
-        assertTrue(Java.isJava8Compatible(v));
+        assertTrue(v.isJava9Compatible());
+        assertTrue(v.isJava8Compatible());
 
         v = Java.parseVersion("9.1");
         assertEquals(9, v.majorVersion);
         assertEquals(1, v.minorVersion);
-        assertTrue(Java.isJava9Compatible(v));
-        assertTrue(Java.isJava8Compatible(v));
+        assertTrue(v.isJava9Compatible());
+        assertTrue(v.isJava8Compatible());
 
         v = Java.parseVersion("1.8.0_152");
         assertEquals(1, v.majorVersion);
         assertEquals(8, v.minorVersion);
-        assertFalse(Java.isJava9Compatible(v));
-        assertTrue(Java.isJava8Compatible(v));
+        assertFalse(v.isJava9Compatible());
+        assertTrue(v.isJava8Compatible());
 
         v = Java.parseVersion("1.7.0_80");
         assertEquals(1, v.majorVersion);
         assertEquals(7, v.minorVersion);
-        assertFalse(Java.isJava9Compatible(v));
-        assertFalse(Java.isJava8Compatible(v));
+        assertFalse(v.isJava9Compatible());
+        assertFalse(v.isJava8Compatible());
 
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/JavaTest.java
@@ -41,14 +41,14 @@ public class JavaTest {
     @Test
     public void testIsIBMJdk() {
         System.setProperty("java.vendor", "Oracle Corporation");
-        assertFalse(Java.isIBMJdk());
+        assertFalse(Java.isIbmJdk());
         System.setProperty("java.vendor", "IBM Corporation");
-        assertTrue(Java.isIBMJdk());
+        assertTrue(Java.isIbmJdk());
     }
 
     @Test
     public void testLoadKerberosLoginModule() throws ClassNotFoundException {
-        String clazz = Java.isIBMJdk()
+        String clazz = Java.isIbmJdk()
                 ? "com.ibm.security.auth.module.Krb5LoginModule"
                 : "com.sun.security.auth.module.Krb5LoginModule";
         Class.forName(clazz);

--- a/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
+++ b/core/src/test/scala/kafka/security/minikdc/MiniKdc.scala
@@ -261,7 +261,7 @@ class MiniKdc(config: Properties, workDir: File) extends Logging {
 
   private def refreshJvmKerberosConfig(): Unit = {
     val klass =
-      if (Java.isIBMJdk)
+      if (Java.isIbmJdk)
         Class.forName("com.ibm.security.krb5.internal.Config")
       else
         Class.forName("sun.security.krb5.Config")

--- a/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/JaasTestUtils.scala
@@ -31,13 +31,13 @@ object JaasTestUtils {
                              serviceName: Option[String]) extends JaasModule {
 
     def name =
-      if (Java.isIBMJdk)
+      if (Java.isIbmJdk)
         "com.ibm.security.auth.module.Krb5LoginModule"
       else
         "com.sun.security.auth.module.Krb5LoginModule"
 
     def entries: Map[String, String] =
-      if (Java.isIBMJdk)
+      if (Java.isIbmJdk)
         Map(
           "principal" -> principal,
           "credsType" -> "both"
@@ -142,7 +142,7 @@ object JaasTestUtils {
     }
     // IBM Kerberos module doesn't support the serviceName JAAS property, hence it needs to be
     // passed as a Kafka property
-    if (Java.isIBMJdk && !result.contains(KafkaConfig.SaslKerberosServiceNameProp))
+    if (Java.isIbmJdk && !result.contains(KafkaConfig.SaslKerberosServiceNameProp))
       result.put(KafkaConfig.SaslKerberosServiceNameProp, serviceName)
     result
   }


### PR DESCRIPTION
- Upgrade Gradle to 4.2.1, which handles Azul Zulu 9's version
correctly.
- Add tests to our Java version handling code
- Refactor the code to make it possible to add tests
- Rename `isIBMJdk` method to use consistent naming
convention.