### PR TITLE
KAFKA-5903: Added Connect metrics to the worker and distributed herder

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -306,7 +306,7 @@ public class ConnectMetrics {
                 metrics().addMetric(metricName, new Gauge<T>() {
                     @Override
                     public T value(MetricConfig config, long now) {
-                        return supplier.metricValue();
+                        return supplier.metricValue(now);
                     }
                 });
             }
@@ -421,9 +421,10 @@ public class ConnectMetrics {
         /**
          * Return the literal value for the metric.
          *
+         * @param now the current time in milliseconds
          * @return the literal metric value; may not be null
          */
-        T metricValue();
+        T metricValue(long now);
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetrics.java
@@ -19,8 +19,8 @@ package org.apache.kafka.connect.runtime;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.JmxReporter;
-import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.MetricsReporter;
@@ -68,9 +68,11 @@ public class ConnectMetrics {
         this.time = time;
 
         MetricConfig metricConfig = new MetricConfig().samples(config.getInt(CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG))
-                                            .timeWindow(config.getLong(CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG), TimeUnit.MILLISECONDS)
-                                            .recordLevel(Sensor.RecordingLevel.forName(config.getString(CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG)));
-        List<MetricsReporter> reporters = config.getConfiguredInstances(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, MetricsReporter.class);
+                                                      .timeWindow(config.getLong(CommonClientConfigs.METRICS_SAMPLE_WINDOW_MS_CONFIG),
+                                                                  TimeUnit.MILLISECONDS).recordLevel(
+                        Sensor.RecordingLevel.forName(config.getString(CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG)));
+        List<MetricsReporter> reporters = config.getConfiguredInstances(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG,
+                                                                        MetricsReporter.class);
         reporters.add(new JmxReporter(JMX_PREFIX));
         this.metrics = new Metrics(metricConfig, reporters, time);
         LOG.debug("Registering Connect metrics with JMX for worker '{}'", workerId);
@@ -121,7 +123,8 @@ public class ConnectMetrics {
         if (group == null) {
             group = new MetricGroup(groupId);
             MetricGroup previous = groupsByName.putIfAbsent(groupId, group);
-            if (previous != null) group = previous;
+            if (previous != null)
+                group = previous;
         }
         return group;
     }
@@ -204,7 +207,8 @@ public class ConnectMetrics {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj == this) return true;
+            if (obj == this)
+                return true;
             if (obj instanceof MetricGroupId) {
                 MetricGroupId that = (MetricGroupId) obj;
                 return this.groupName.equals(that.groupName) && this.tags.equals(that.tags);
@@ -290,19 +294,38 @@ public class ConnectMetrics {
         }
 
         /**
-         * Add to this group an indicator metric with a function that will be used to obtain the indicator state.
+         * Add to this group an indicator metric with a function that returns the current value.
          *
          * @param nameTemplate the name template for the metric; may not be null
-         * @param predicate    the predicate function used to determine the indicator state; may not be null
+         * @param supplier     the function used to determine the literal value of the metric; may not be null
          * @throws IllegalArgumentException if the name is not valid
          */
-        public void addIndicatorMetric(MetricNameTemplate nameTemplate, final IndicatorPredicate predicate) {
+        public <T> void addValueMetric(MetricNameTemplate nameTemplate, final LiteralSupplier<T> supplier) {
             MetricName metricName = metricName(nameTemplate);
             if (metrics().metric(metricName) == null) {
-                metrics().addMetric(metricName, new Measurable() {
+                metrics().addMetric(metricName, new Gauge<T>() {
                     @Override
-                    public double measure(MetricConfig config, long now) {
-                        return predicate.matches() ? 1.0d : 0.0d;
+                    public T value(MetricConfig config, long now) {
+                        return supplier.metricValue();
+                    }
+                });
+            }
+        }
+
+        /**
+         * Add to this group an indicator metric that always returns the specified value.
+         *
+         * @param nameTemplate the name template for the metric; may not be null
+         * @param value        the value; may not be null
+         * @throws IllegalArgumentException if the name is not valid
+         */
+        public <T> void addImmutableValueMetric(MetricNameTemplate nameTemplate, final T value) {
+            MetricName metricName = metricName(nameTemplate);
+            if (metrics().metric(metricName) == null) {
+                metrics().addMetric(metricName, new Gauge<T>() {
+                    @Override
+                    public T value(MetricConfig config, long now) {
+                        return value;
                     }
                 });
             }
@@ -369,7 +392,8 @@ public class ConnectMetrics {
         public synchronized Sensor sensor(String name, MetricConfig config, Sensor.RecordingLevel recordingLevel, Sensor... parents) {
             // We need to make sure that all sensor names are unique across all groups, so use the sensor prefix
             Sensor result = metrics.sensor(sensorPrefix + name, config, Long.MAX_VALUE, recordingLevel, parents);
-            if (result != null) sensorNames.add(result.name());
+            if (result != null)
+                sensorNames.add(result.name());
             return result;
         }
 
@@ -390,16 +414,16 @@ public class ConnectMetrics {
     }
 
     /**
-     * A simple functional interface that determines whether an indicator metric is true.
+     * A simple functional interface that returns a literal value.
      */
-    public interface IndicatorPredicate {
+    public interface LiteralSupplier<T> {
 
         /**
-         * Return whether the indicator metric is true.
+         * Return the literal value for the metric.
          *
-         * @return true if the indicator metric is satisfied, or false otherwise
+         * @return the literal metric value; may not be null
          */
-        boolean matches();
+        T metricValue();
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -32,6 +32,8 @@ public class ConnectMetricsRegistry {
     public static final String TASK_GROUP_NAME = "connector-task-metrics";
     public static final String SOURCE_TASK_GROUP_NAME = "source-task-metrics";
     public static final String SINK_TASK_GROUP_NAME = "sink-task-metrics";
+    public static final String WORKER_GROUP_NAME = "connect-worker-metrics";
+    public static final String WORKER_REBALANCE_GROUP_NAME = "connect-worker-rebalance-metrics";
 
     private final List<MetricNameTemplate> allTemplates = new ArrayList<>();
     public final MetricNameTemplate connectorStatus;
@@ -72,6 +74,19 @@ public class ConnectMetricsRegistry {
     public final MetricNameTemplate sinkRecordActiveCount;
     public final MetricNameTemplate sinkRecordActiveCountMax;
     public final MetricNameTemplate sinkRecordActiveCountAvg;
+    public final MetricNameTemplate connectorCount;
+    public final MetricNameTemplate taskCount;
+    public final MetricNameTemplate connectorStartupAttemptsTotal;
+    public final MetricNameTemplate connectorStartupSuccessTotal;
+    public final MetricNameTemplate connectorStartupSuccessPercentage;
+    public final MetricNameTemplate connectorStartupFailureTotal;
+    public final MetricNameTemplate connectorStartupFailurePercentage;
+    public final MetricNameTemplate taskStartupAttemptsTotal;
+    public final MetricNameTemplate taskStartupSuccessTotal;
+    public final MetricNameTemplate taskStartupSuccessPercentage;
+    public final MetricNameTemplate taskStartupFailureTotal;
+    public final MetricNameTemplate taskStartupFailurePercentage;
+    public final MetricNameTemplate workerStatus;
 
     public ConnectMetricsRegistry() {
         this(new LinkedHashSet<String>());
@@ -82,20 +97,25 @@ public class ConnectMetricsRegistry {
         Set<String> connectorTags = new LinkedHashSet<>(tags);
         connectorTags.add(CONNECTOR_TAG_NAME);
 
-        connectorStatus = createTemplate("status", CONNECTOR_GROUP_NAME, "The status of the connector. One of 'unassigned', " +
-                                                                         "'running', 'paused', 'failed', or 'destroyed'.", connectorTags);
-        connectorType = createTemplate("connector-type", CONNECTOR_GROUP_NAME, "The type of the connector. One of 'source' or " +
-                                                                               "'sink'.", connectorTags);
+        connectorStatus = createTemplate("status", CONNECTOR_GROUP_NAME,
+                                         "The status of the connector. One of 'unassigned', 'running', 'paused', 'failed', or " +
+                                         "'destroyed'.",
+                                         connectorTags);
+        connectorType = createTemplate("connector-type", CONNECTOR_GROUP_NAME, "The type of the connector. One of 'source' or 'sink'.",
+                                       connectorTags);
         connectorClass = createTemplate("connector-class", CONNECTOR_GROUP_NAME, "The name of the connector class.", connectorTags);
-        connectorVersion = createTemplate("connector-version", CONNECTOR_GROUP_NAME, "The version of the connector class, as reported by the connector.", connectorTags);
+        connectorVersion = createTemplate("connector-version", CONNECTOR_GROUP_NAME,
+                                          "The version of the connector class, as reported by the connector.", connectorTags);
 
         /***** Worker task level *****/
         Set<String> workerTaskTags = new LinkedHashSet<>(tags);
         workerTaskTags.add(CONNECTOR_TAG_NAME);
         workerTaskTags.add(TASK_TAG_NAME);
 
-        taskStatus = createTemplate("status", TASK_GROUP_NAME, "The status of the connector task. One of 'unassigned', " +
-                                                               "'running', 'paused', 'failed', or 'destroyed'.", workerTaskTags);
+        taskStatus = createTemplate("status", TASK_GROUP_NAME,
+                                    "The status of the connector task. One of 'unassigned', 'running', 'paused', 'failed', or " +
+                                    "'destroyed'.",
+                                    workerTaskTags);
         taskRunningRatio = createTemplate("running-ratio", TASK_GROUP_NAME,
                                           "The fraction of time this task has spent in the running state.", workerTaskTags);
         taskPauseRatio = createTemplate("pause-ratio", TASK_GROUP_NAME, "The fraction of time this task has spent in the pause state.",
@@ -219,13 +239,41 @@ public class ConnectMetricsRegistry {
                                                "committed/flushed/acknowledged by the sink task.",
                                                sinkTaskTags);
         sinkRecordActiveCountMax = createTemplate("sink-record-active-count-max", SINK_TASK_GROUP_NAME,
-                                                  "The maximum number of records that have been read from Kafka but not yet completely " +
-                                                  "committed/flushed/acknowledged by the sink task.",
+                                                  "The maximum number of records that have been read from Kafka but not yet completely "
+                                                  + "committed/flushed/acknowledged by the sink task.",
                                                   sinkTaskTags);
         sinkRecordActiveCountAvg = createTemplate("sink-record-active-count-avg", SINK_TASK_GROUP_NAME,
-                                                  "The average number of records that have been read from Kafka but not yet completely " +
-                                                  "committed/flushed/acknowledged by the sink task.",
+                                                  "The average number of records that have been read from Kafka but not yet completely "
+                                                  + "committed/flushed/acknowledged by the sink task.",
                                                   sinkTaskTags);
+
+        /***** Worker level *****/
+        Set<String> workerTags = new LinkedHashSet<>(tags);
+
+        connectorCount = createTemplate("connector-count", WORKER_GROUP_NAME, "The number of connectors run in this worker.", workerTags);
+        taskCount = createTemplate("task-count", WORKER_GROUP_NAME, "The number of tasks run in this worker.", workerTags);
+        workerStatus = createTemplate("status", WORKER_GROUP_NAME, "The state of this worker. One of: 'running', 'stopping', or 'stopped'.",
+                                      workerTags);
+        connectorStartupAttemptsTotal = createTemplate("connector-startup-attempts-total", WORKER_GROUP_NAME,
+                                                  "The total number of connector startups that this worker has attempted.", workerTags);
+        connectorStartupSuccessTotal = createTemplate("connector-startup-success-total", WORKER_GROUP_NAME,
+                                                 "The total number of connector starts that succeeded.", workerTags);
+        connectorStartupSuccessPercentage = createTemplate("connector-startup-success-percentage", WORKER_GROUP_NAME,
+                                                      "The average percentage of this worker's connectors starts that succeeded.", workerTags);
+        connectorStartupFailureTotal = createTemplate("connector-startup-failure-total", WORKER_GROUP_NAME,
+                                                 "The total number of connector starts that failed.", workerTags);
+        connectorStartupFailurePercentage = createTemplate("connector-startup-failure-percentage", WORKER_GROUP_NAME,
+                                                      "The average percentage of this worker's connectors starts that failed.", workerTags);
+        taskStartupAttemptsTotal = createTemplate("task-startup-attempts-total", WORKER_GROUP_NAME,
+                                                  "The total number of task startups that this worker has attempted.", workerTags);
+        taskStartupSuccessTotal = createTemplate("task-startup-success-total", WORKER_GROUP_NAME,
+                                                 "The total number of task starts that succeeded.", workerTags);
+        taskStartupSuccessPercentage = createTemplate("task-startup-success-percentage", WORKER_GROUP_NAME,
+                                                      "The average percentage of this worker's tasks starts that succeeded.", workerTags);
+        taskStartupFailureTotal = createTemplate("task-startup-failure-total", WORKER_GROUP_NAME,
+                                                 "The total number of task starts that failed.", workerTags);
+        taskStartupFailurePercentage = createTemplate("task-startup-failure-percentage", WORKER_GROUP_NAME,
+                                                      "The average percentage of this worker's tasks starts that failed.", workerTags);
     }
 
     private MetricNameTemplate createTemplate(String name, String group, String doc, Set<String> tags) {
@@ -260,5 +308,13 @@ public class ConnectMetricsRegistry {
 
     public String sourceTaskGroupName() {
         return SOURCE_TASK_GROUP_NAME;
+    }
+
+    public String workerGroupName() {
+        return WORKER_GROUP_NAME;
+    }
+
+    public String workerRebalanceGroupName() {
+        return WORKER_REBALANCE_GROUP_NAME;
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -86,7 +86,6 @@ public class ConnectMetricsRegistry {
     public final MetricNameTemplate taskStartupSuccessPercentage;
     public final MetricNameTemplate taskStartupFailureTotal;
     public final MetricNameTemplate taskStartupFailurePercentage;
-    public final MetricNameTemplate workerStatus;
     public final MetricNameTemplate leaderName;
     public final MetricNameTemplate epoch;
     public final MetricNameTemplate rebalanceCompletedTotal;
@@ -259,8 +258,6 @@ public class ConnectMetricsRegistry {
 
         connectorCount = createTemplate("connector-count", WORKER_GROUP_NAME, "The number of connectors run in this worker.", workerTags);
         taskCount = createTemplate("task-count", WORKER_GROUP_NAME, "The number of tasks run in this worker.", workerTags);
-        workerStatus = createTemplate("status", WORKER_GROUP_NAME, "The state of this worker. One of: 'running', 'stopping', or 'stopped'.",
-                                      workerTags);
         connectorStartupAttemptsTotal = createTemplate("connector-startup-attempts-total", WORKER_GROUP_NAME,
                                                   "The total number of connector startups that this worker has attempted.", workerTags);
         connectorStartupSuccessTotal = createTemplate("connector-startup-success-total", WORKER_GROUP_NAME,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -34,14 +34,11 @@ public class ConnectMetricsRegistry {
     public static final String SINK_TASK_GROUP_NAME = "sink-task-metrics";
 
     private final List<MetricNameTemplate> allTemplates = new ArrayList<>();
-    public final MetricNameTemplate connectorStatusRunning;
-    public final MetricNameTemplate connectorStatusPaused;
-    public final MetricNameTemplate connectorStatusFailed;
-    public final MetricNameTemplate taskStatusUnassigned;
-    public final MetricNameTemplate taskStatusRunning;
-    public final MetricNameTemplate taskStatusPaused;
-    public final MetricNameTemplate taskStatusFailed;
-    public final MetricNameTemplate taskStatusDestroyed;
+    public final MetricNameTemplate connectorStatus;
+    public final MetricNameTemplate connectorType;
+    public final MetricNameTemplate connectorClass;
+    public final MetricNameTemplate connectorVersion;
+    public final MetricNameTemplate taskStatus;
     public final MetricNameTemplate taskRunningRatio;
     public final MetricNameTemplate taskPauseRatio;
     public final MetricNameTemplate taskCommitTimeMax;
@@ -85,28 +82,20 @@ public class ConnectMetricsRegistry {
         Set<String> connectorTags = new LinkedHashSet<>(tags);
         connectorTags.add(CONNECTOR_TAG_NAME);
 
-        connectorStatusRunning = createTemplate("status-running", CONNECTOR_GROUP_NAME,
-                                                "Signals whether the connector is in the running state.", connectorTags);
-        connectorStatusPaused = createTemplate("status-paused", CONNECTOR_GROUP_NAME,
-                                               "Signals whether the connector is in the paused state.", connectorTags);
-        connectorStatusFailed = createTemplate("status-failed", CONNECTOR_GROUP_NAME,
-                                               "Signals whether the connector is in the failed state.", connectorTags);
+        connectorStatus = createTemplate("status", CONNECTOR_GROUP_NAME, "The status of the connector. One of 'unassigned', " +
+                                                                         "'running', 'paused', 'failed', or 'destroyed'.", connectorTags);
+        connectorType = createTemplate("connector-type", CONNECTOR_GROUP_NAME, "The type of the connector. One of 'source' or " +
+                                                                               "'sink'.", connectorTags);
+        connectorClass = createTemplate("connector-class", CONNECTOR_GROUP_NAME, "The name of the connector class.", connectorTags);
+        connectorVersion = createTemplate("connector-version", CONNECTOR_GROUP_NAME, "The version of the connector class, as reported by the connector.", connectorTags);
 
         /***** Worker task level *****/
         Set<String> workerTaskTags = new LinkedHashSet<>(tags);
         workerTaskTags.add(CONNECTOR_TAG_NAME);
         workerTaskTags.add(TASK_TAG_NAME);
 
-        taskStatusUnassigned = createTemplate("status-unassigned", TASK_GROUP_NAME, "Signals whether this task is in the unassigned state.",
-                                              workerTaskTags);
-        taskStatusRunning = createTemplate("status-running", TASK_GROUP_NAME, "Signals whether this task is in the running state.",
-                                           workerTaskTags);
-        taskStatusPaused = createTemplate("status-paused", TASK_GROUP_NAME, "Signals whether this task is in the paused state.",
-                                          workerTaskTags);
-        taskStatusFailed = createTemplate("status-failed", TASK_GROUP_NAME, "Signals whether this task is in the failed state.",
-                                          workerTaskTags);
-        taskStatusDestroyed = createTemplate("status-destroyed", TASK_GROUP_NAME, "Signals whether this task is in the destroyed state.",
-                                             workerTaskTags);
+        taskStatus = createTemplate("status", TASK_GROUP_NAME, "The status of the connector task. One of 'unassigned', " +
+                                                               "'running', 'paused', 'failed', or 'destroyed'.", workerTaskTags);
         taskRunningRatio = createTemplate("running-ratio", TASK_GROUP_NAME,
                                           "The fraction of time this task has spent in the running state.", workerTaskTags);
         taskPauseRatio = createTemplate("pause-ratio", TASK_GROUP_NAME, "The fraction of time this task has spent in the pause state.",

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectMetricsRegistry.java
@@ -87,6 +87,13 @@ public class ConnectMetricsRegistry {
     public final MetricNameTemplate taskStartupFailureTotal;
     public final MetricNameTemplate taskStartupFailurePercentage;
     public final MetricNameTemplate workerStatus;
+    public final MetricNameTemplate leaderName;
+    public final MetricNameTemplate epoch;
+    public final MetricNameTemplate rebalanceCompletedTotal;
+    public final MetricNameTemplate rebalanceMode;
+    public final MetricNameTemplate rebalanceTimeMax;
+    public final MetricNameTemplate rebalanceTimeAvg;
+    public final MetricNameTemplate rebalanceTimeSinceLast;
 
     public ConnectMetricsRegistry() {
         this(new LinkedHashSet<String>());
@@ -274,6 +281,22 @@ public class ConnectMetricsRegistry {
                                                  "The total number of task starts that failed.", workerTags);
         taskStartupFailurePercentage = createTemplate("task-startup-failure-percentage", WORKER_GROUP_NAME,
                                                       "The average percentage of this worker's tasks starts that failed.", workerTags);
+
+        /***** Worker rebalance level *****/
+        Set<String> rebalanceTags = new LinkedHashSet<>(tags);
+
+        leaderName = createTemplate("leader-name", WORKER_REBALANCE_GROUP_NAME, "The name of the group leader.", rebalanceTags);
+        epoch = createTemplate("epoch", WORKER_REBALANCE_GROUP_NAME, "The epoch or generation number of this worker.", rebalanceTags);
+        rebalanceCompletedTotal = createTemplate("completed-rebalances-total", WORKER_REBALANCE_GROUP_NAME,
+                                                "The total number of rebalances completed by this worker.", rebalanceTags);
+        rebalanceMode = createTemplate("rebalancing", WORKER_REBALANCE_GROUP_NAME,
+                                               "Whether this worker is currently rebalancing.", rebalanceTags);
+        rebalanceTimeMax = createTemplate("rebalance-max-time-ms", WORKER_REBALANCE_GROUP_NAME,
+                                          "The maximum time in milliseconds spent by this worker to rebalance.", rebalanceTags);
+        rebalanceTimeAvg = createTemplate("rebalance-avg-time-ms", WORKER_REBALANCE_GROUP_NAME,
+                                          "The average time in milliseconds spent by this worker to rebalance.", rebalanceTags);
+        rebalanceTimeSinceLast = createTemplate("time-since-last-rebalance-ms", WORKER_REBALANCE_GROUP_NAME,
+                                                "The time in milliseconds since this worker completed the most recent rebalance.", rebalanceTags);
     }
 
     private MetricNameTemplate createTemplate(String name, String group, String doc, Set<String> tags) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -18,12 +18,18 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Frequencies;
+import org.apache.kafka.common.metrics.stats.Total;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.ConnectMetrics.LiteralSupplier;
+import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
@@ -43,6 +49,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -63,11 +70,16 @@ import java.util.concurrent.Executors;
 public class Worker {
     private static final Logger log = LoggerFactory.getLogger(Worker.class);
 
+    public enum State {
+        RUNNING, STOPPING, STOPPED;
+    }
+
     private final ExecutorService executor;
     private final Time time;
     private final String workerId;
     private final Plugins plugins;
     private final ConnectMetrics metrics;
+    private final WorkerMetricsGroup workerMetricsGroup;
     private final WorkerConfig config;
     private final Converter internalKeyConverter;
     private final Converter internalValueConverter;
@@ -91,6 +103,8 @@ public class Worker {
         this.time = time;
         this.plugins = plugins;
         this.config = config;
+        this.workerMetricsGroup = new WorkerMetricsGroup(metrics);
+
         // Internal converters are required properties, thus getClass won't return null.
         this.internalKeyConverter = plugins.newConverter(
                 config.getClass(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG).getName(),
@@ -135,6 +149,7 @@ public class Worker {
         offsetBackingStore.start();
         sourceTaskOffsetCommitter = new SourceTaskOffsetCommitter(config);
 
+        workerMetricsGroup.recordState(State.RUNNING);
         log.info("Worker started");
     }
 
@@ -143,6 +158,7 @@ public class Worker {
      */
     public void stop() {
         log.info("Worker stopping");
+        workerMetricsGroup.recordState(State.STOPPING);
 
         long started = time.milliseconds();
         long limit = started + config.getLong(WorkerConfig.TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG);
@@ -163,7 +179,10 @@ public class Worker {
         offsetBackingStore.stop();
         metrics.stop();
 
+        workerMetricsGroup.recordState(State.STOPPED);
         log.info("Worker stopped");
+
+        workerMetricsGroup.close();
     }
 
     /**
@@ -204,6 +223,7 @@ public class Worker {
             // Can't be put in a finally block because it needs to be swapped before the call on
             // statusListener
             Plugins.compareAndSwapLoaders(savedLoader);
+            workerMetricsGroup.recordConnectorStartupFailure();
             statusListener.onFailure(connName, t);
             return false;
         }
@@ -213,6 +233,7 @@ public class Worker {
             throw new ConnectException("Connector with name " + connName + " already exists");
 
         log.info("Finished creating connector {}", connName);
+        workerMetricsGroup.recordConnectorStartupSuccess();
         return true;
     }
 
@@ -396,6 +417,7 @@ public class Worker {
             // Can't be put in a finally block because it needs to be swapped before the call on
             // statusListener
             Plugins.compareAndSwapLoaders(savedLoader);
+            workerMetricsGroup.recordTaskFailure();
             statusListener.onFailure(id, t);
             return false;
         }
@@ -408,6 +430,7 @@ public class Worker {
         if (workerTask instanceof WorkerSourceTask) {
             sourceTaskOffsetCommitter.schedule(id, (WorkerSourceTask) workerTask);
         }
+        workerMetricsGroup.recordTaskSuccess();
         return true;
     }
 
@@ -581,6 +604,117 @@ public class Worker {
             }
         } finally {
             Plugins.compareAndSwapLoaders(savedLoader);
+        }
+    }
+
+    WorkerMetricsGroup workerMetricsGroup() {
+        return workerMetricsGroup;
+    }
+
+    class WorkerMetricsGroup {
+        private final MetricGroup metricGroup;
+        private final Sensor connectorStartupAttempts;
+        private final Sensor connectorStartupSuccesses;
+        private final Sensor connectorStartupFailures;
+        private final Sensor connectorStartupResults;
+        private final Sensor taskStartupAttempts;
+        private final Sensor taskStartupSuccesses;
+        private final Sensor taskStartupFailures;
+        private final Sensor taskStartupResults;
+        private State state;
+
+        public WorkerMetricsGroup(ConnectMetrics connectMetrics) {
+            ConnectMetricsRegistry registry = connectMetrics.registry();
+            metricGroup = connectMetrics.group(registry.workerGroupName());
+
+            metricGroup.addValueMetric(registry.connectorCount, new LiteralSupplier<Double>() {
+                @Override
+                public Double metricValue() {
+                    return (double) connectors.size();
+                }
+            });
+            metricGroup.addValueMetric(registry.taskCount, new LiteralSupplier<Double>() {
+                @Override
+                public Double metricValue() {
+                    return (double) tasks.size();
+                }
+            });
+            metricGroup.addValueMetric(registry.workerStatus, new LiteralSupplier<String>() {
+                @Override
+                public String metricValue() {
+                    return state.toString().toLowerCase(Locale.getDefault());
+                }
+            });
+
+            MetricName connectorFailurePct = metricGroup.metricName(registry.connectorStartupFailurePercentage);
+            MetricName connectorSuccessPct = metricGroup.metricName(registry.connectorStartupSuccessPercentage);
+            Frequencies connectorStartupResultFrequencies = Frequencies.forBooleanValues(connectorFailurePct, connectorSuccessPct);
+            connectorStartupResults = metricGroup.sensor("connector-startup-results");
+            connectorStartupResults.add(connectorStartupResultFrequencies);
+
+            connectorStartupAttempts = metricGroup.sensor("connector-startup-attempts");
+            connectorStartupAttempts.add(metricGroup.metricName(registry.connectorStartupAttemptsTotal), new Total());
+
+            connectorStartupSuccesses = metricGroup.sensor("connector-startup-successes");
+            connectorStartupSuccesses.add(metricGroup.metricName(registry.connectorStartupSuccessTotal), new Total());
+
+            connectorStartupFailures = metricGroup.sensor("connector-startup-failures");
+            connectorStartupFailures.add(metricGroup.metricName(registry.connectorStartupFailureTotal), new Total());
+
+            MetricName taskFailurePct = metricGroup.metricName(registry.taskStartupFailurePercentage);
+            MetricName taskSuccessPct = metricGroup.metricName(registry.taskStartupSuccessPercentage);
+            Frequencies taskStartupResultFrequencies = Frequencies.forBooleanValues(taskFailurePct, taskSuccessPct);
+            taskStartupResults = metricGroup.sensor("task-startup-results");
+            taskStartupResults.add(taskStartupResultFrequencies);
+
+            taskStartupAttempts = metricGroup.sensor("task-startup-attempts");
+            taskStartupAttempts.add(metricGroup.metricName(registry.taskStartupAttemptsTotal), new Total());
+
+            taskStartupSuccesses = metricGroup.sensor("task-startup-successes");
+            taskStartupSuccesses.add(metricGroup.metricName(registry.taskStartupSuccessTotal), new Total());
+
+            taskStartupFailures = metricGroup.sensor("task-startup-failures");
+            taskStartupFailures.add(metricGroup.metricName(registry.taskStartupFailureTotal), new Total());
+        }
+
+        void close() {
+            metricGroup.close();
+        }
+
+        void recordState(State state) {
+            this.state = state;
+        }
+
+        void recordConnectorStartupFailure() {
+            connectorStartupAttempts.record(1.0);
+            connectorStartupFailures.record(1.0);
+            connectorStartupResults.record(0.0);
+        }
+
+        void recordConnectorStartupSuccess() {
+            connectorStartupAttempts.record(1.0);
+            connectorStartupSuccesses.record(1.0);
+            connectorStartupResults.record(1.0);
+        }
+
+        void recordTaskFailure() {
+            taskStartupAttempts.record(1.0);
+            taskStartupFailures.record(1.0);
+            taskStartupResults.record(0.0);
+        }
+
+        void recordTaskSuccess() {
+            taskStartupAttempts.record(1.0);
+            taskStartupSuccesses.record(1.0);
+            taskStartupResults.record(1.0);
+        }
+
+        public State state() {
+            return state;
+        }
+
+        protected MetricGroup metricGroup() {
+            return metricGroup;
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -629,19 +629,19 @@ public class Worker {
 
             metricGroup.addValueMetric(registry.connectorCount, new LiteralSupplier<Double>() {
                 @Override
-                public Double metricValue() {
+                public Double metricValue(long now) {
                     return (double) connectors.size();
                 }
             });
             metricGroup.addValueMetric(registry.taskCount, new LiteralSupplier<Double>() {
                 @Override
-                public Double metricValue() {
+                public Double metricValue(long now) {
                     return (double) tasks.size();
                 }
             });
             metricGroup.addValueMetric(registry.workerStatus, new LiteralSupplier<String>() {
                 @Override
-                public String metricValue() {
+                public String metricValue(long now) {
                     return state.toString().toLowerCase(Locale.getDefault());
                 }
             });

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -253,7 +253,7 @@ public class WorkerConnector {
             metricGroup.addImmutableValueMetric(registry.connectorVersion, connector.version());
             metricGroup.addValueMetric(registry.connectorStatus, new LiteralSupplier<String>() {
                 @Override
-                public String metricValue() {
+                public String metricValue(long now) {
                     return state.toString().toLowerCase(Locale.getDefault());
                 }
             });

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConnector.java
@@ -16,16 +16,18 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.ConnectorContext;
-import org.apache.kafka.connect.runtime.ConnectMetrics.IndicatorPredicate;
+import org.apache.kafka.connect.runtime.ConnectMetrics.LiteralSupplier;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.sink.SinkConnector;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Container for connectors which is responsible for managing their lifecycle (e.g. handling startup,
@@ -199,6 +201,18 @@ public class WorkerConnector {
         return SinkConnector.class.isAssignableFrom(connector.getClass());
     }
 
+    public boolean isSourceConnector() {
+        return SourceConnector.class.isAssignableFrom(connector.getClass());
+    }
+
+    protected String connectorType() {
+        if (isSinkConnector())
+            return "sink";
+        if (isSourceConnector())
+            return "source";
+        return "unknown";
+    }
+
     public Connector connector() {
         return connector;
     }
@@ -224,22 +238,23 @@ public class WorkerConnector {
         private final ConnectorStatus.Listener delegate;
 
         public ConnectorMetricsGroup(ConnectMetrics connectMetrics, AbstractStatus.State initialState, ConnectorStatus.Listener delegate) {
+            Objects.requireNonNull(connectMetrics);
+            Objects.requireNonNull(connector);
+            Objects.requireNonNull(initialState);
+            Objects.requireNonNull(delegate);
             this.delegate = delegate;
             this.state = initialState;
             ConnectMetricsRegistry registry = connectMetrics.registry();
             this.metricGroup = connectMetrics.group(registry.connectorGroupName(),
                     registry.connectorTagName(), connName);
 
-            addStateMetric(AbstractStatus.State.RUNNING, registry.connectorStatusRunning);
-            addStateMetric(AbstractStatus.State.PAUSED, registry.connectorStatusPaused);
-            addStateMetric(AbstractStatus.State.FAILED, registry.connectorStatusFailed);
-        }
-
-        private void addStateMetric(final AbstractStatus.State matchingState, MetricNameTemplate nameTemplate) {
-            metricGroup.addIndicatorMetric(nameTemplate, new IndicatorPredicate() {
+            metricGroup.addImmutableValueMetric(registry.connectorType, connectorType());
+            metricGroup.addImmutableValueMetric(registry.connectorClass, connector.getClass().getName());
+            metricGroup.addImmutableValueMetric(registry.connectorVersion, connector.version());
+            metricGroup.addValueMetric(registry.connectorStatus, new LiteralSupplier<String>() {
                 @Override
-                public boolean matches() {
-                    return state == matchingState;
+                public String metricValue() {
+                    return state.toString().toLowerCase(Locale.getDefault());
                 }
             });
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -316,7 +316,7 @@ abstract class WorkerTask implements Runnable {
 
             metricGroup.addValueMetric(registry.taskStatus, new LiteralSupplier<String>() {
                 @Override
-                public String metricValue() {
+                public String metricValue(long now) {
                     return taskStateTimer.currentState().toString().toLowerCase(Locale.getDefault());
                 }
             });

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -26,13 +26,14 @@ import org.apache.kafka.common.metrics.stats.Frequencies;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.AbstractStatus.State;
-import org.apache.kafka.connect.runtime.ConnectMetrics.IndicatorPredicate;
+import org.apache.kafka.connect.runtime.ConnectMetrics.LiteralSupplier;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -313,11 +314,12 @@ abstract class WorkerTask implements Runnable {
                     registry.connectorTagName(), id.connector(),
                     registry.taskTagName(), Integer.toString(id.task()));
 
-            addTaskStateMetric(State.UNASSIGNED, registry.taskStatusUnassigned);
-            addTaskStateMetric(State.RUNNING, registry.taskStatusRunning);
-            addTaskStateMetric(State.PAUSED, registry.taskStatusPaused);
-            addTaskStateMetric(State.FAILED, registry.taskStatusDestroyed);
-            addTaskStateMetric(State.DESTROYED, registry.taskStatusDestroyed);
+            metricGroup.addValueMetric(registry.taskStatus, new LiteralSupplier<String>() {
+                @Override
+                public String metricValue() {
+                    return taskStateTimer.currentState().toString().toLowerCase(Locale.getDefault());
+                }
+            });
 
             addRatioMetric(State.RUNNING, registry.taskRunningRatio);
             addRatioMetric(State.PAUSED, registry.taskPauseRatio);
@@ -335,15 +337,6 @@ abstract class WorkerTask implements Runnable {
             Frequencies commitFrequencies = Frequencies.forBooleanValues(offsetCommitFailures, offsetCommitSucceeds);
             commitAttempts = metricGroup.sensor("offset-commit-completion");
             commitAttempts.add(commitFrequencies);
-        }
-
-        private void addTaskStateMetric(final State matchingState, MetricNameTemplate template) {
-            metricGroup.addIndicatorMetric(template, new IndicatorPredicate() {
-                @Override
-                public boolean matches() {
-                    return matchingState == taskStateTimer.currentState();
-                }
-            });
         }
 
         private void addRatioMetric(final State matchingState, MetricNameTemplate template) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
@@ -74,13 +74,7 @@ public class MockConnectMetrics extends ConnectMetrics {
      * @return the current value of the metric
      */
     public Object currentMetricValue(MetricGroup metricGroup, String name) {
-        MetricName metricName = metricGroup.metricName(name);
-        for (MetricsReporter reporter : metrics().reporters()) {
-            if (reporter instanceof MockMetricsReporter) {
-                return ((MockMetricsReporter) reporter).currentMetricValue(metricName);
-            }
-        }
-        return null;
+        return currentMetricValue(this, metricGroup, name);
     }
 
     /**
@@ -110,17 +104,50 @@ public class MockConnectMetrics extends ConnectMetrics {
     }
 
     /**
-     * Determine if the {@link KafkaMetric} with the specified name exists within the
-     * {@link org.apache.kafka.common.metrics.Metrics} instance.
+     * Get the current value of the named metric, which may have already been removed from the
+     * {@link org.apache.kafka.common.metrics.Metrics} but will have been captured before it was removed.
      *
+     * @param metrics the {@link ConnectMetrics} instance
      * @param metricGroup the metric metricGroup that contained the metric
      * @param name        the name of the metric
-     * @return true if the metric is still register, or false if it has been removed
+     * @return the current value of the metric
      */
-    public boolean metricExists(MetricGroup metricGroup, String name) {
+    public static Object currentMetricValue(ConnectMetrics metrics, MetricGroup metricGroup, String name) {
         MetricName metricName = metricGroup.metricName(name);
-        KafkaMetric metric = metricGroup.metrics().metric(metricName);
-        return metric != null;
+        for (MetricsReporter reporter : metrics.metrics().reporters()) {
+            if (reporter instanceof MockMetricsReporter) {
+                return ((MockMetricsReporter) reporter).currentMetricValue(metricName);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the current value of the named metric, which may have already been removed from the
+     * {@link org.apache.kafka.common.metrics.Metrics} but will have been captured before it was removed.
+     *
+     * @param metrics the {@link ConnectMetrics} instance
+     * @param metricGroup the metric metricGroup that contained the metric
+     * @param name        the name of the metric
+     * @return the current value of the metric
+     */
+    public static double currentMetricValueAsDouble(ConnectMetrics metrics, MetricGroup metricGroup, String name) {
+        Object value = currentMetricValue(metrics, metricGroup, name);
+        return value instanceof Double ? ((Double) value).doubleValue() : Double.NaN;
+    }
+
+    /**
+     * Get the current value of the named metric, which may have already been removed from the
+     * {@link org.apache.kafka.common.metrics.Metrics} but will have been captured before it was removed.
+     *
+     * @param metrics the {@link ConnectMetrics} instance
+     * @param metricGroup the metric metricGroup that contained the metric
+     * @param name        the name of the metric
+     * @return the current value of the metric
+     */
+    public static String currentMetricValueAsString(ConnectMetrics metrics, MetricGroup metricGroup, String name) {
+        Object value = currentMetricValue(metrics, metricGroup, name);
+        return value instanceof String ? (String) value : null;
     }
 
     public static class MockMetricsReporter implements MetricsReporter {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
@@ -73,14 +73,40 @@ public class MockConnectMetrics extends ConnectMetrics {
      * @param name        the name of the metric
      * @return the current value of the metric
      */
-    public double currentMetricValue(MetricGroup metricGroup, String name) {
+    public Object currentMetricValue(MetricGroup metricGroup, String name) {
         MetricName metricName = metricGroup.metricName(name);
         for (MetricsReporter reporter : metrics().reporters()) {
             if (reporter instanceof MockMetricsReporter) {
                 return ((MockMetricsReporter) reporter).currentMetricValue(metricName);
             }
         }
-        return Double.NEGATIVE_INFINITY;
+        return null;
+    }
+
+    /**
+     * Get the current value of the named metric, which may have already been removed from the
+     * {@link org.apache.kafka.common.metrics.Metrics} but will have been captured before it was removed.
+     *
+     * @param metricGroup the metric metricGroup that contained the metric
+     * @param name        the name of the metric
+     * @return the current value of the metric
+     */
+    public double currentMetricValueAsDouble(MetricGroup metricGroup, String name) {
+        Object value = currentMetricValue(metricGroup, name);
+        return value instanceof Double ? ((Double) value).doubleValue() : Double.NaN;
+    }
+
+    /**
+     * Get the current value of the named metric, which may have already been removed from the
+     * {@link org.apache.kafka.common.metrics.Metrics} but will have been captured before it was removed.
+     *
+     * @param metricGroup the metric metricGroup that contained the metric
+     * @param name        the name of the metric
+     * @return the current value of the metric
+     */
+    public String currentMetricValueAsString(MetricGroup metricGroup, String name) {
+        Object value = currentMetricValue(metricGroup, name);
+        return value instanceof String ? (String) value : null;
     }
 
     /**
@@ -136,10 +162,9 @@ public class MockConnectMetrics extends ConnectMetrics {
          * @param metricName the name of the metric that was registered most recently
          * @return the current value of the metric
          */
-        @SuppressWarnings("deprecation")
-        public double currentMetricValue(MetricName metricName) {
+        public Object currentMetricValue(MetricName metricName) {
             KafkaMetric metric = metricsByName.get(metricName);
-            return metric != null ? metric.value() : Double.NaN;
+            return metric != null ? metric.metricValue() : null;
         }
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
@@ -56,6 +56,10 @@ public class MockConnectMetrics extends ConnectMetrics {
         this(new MockTime());
     }
 
+    public MockConnectMetrics(org.apache.kafka.common.utils.MockTime time) {
+        super("mock", new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), time);
+    }
+
     public MockConnectMetrics(MockTime time) {
         super("mock", new WorkerConfig(WorkerConfig.baseConfigDef(), DEFAULT_WORKER_CONFIG), time);
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -180,8 +180,7 @@ public class WorkerSinkTaskTest {
         time.sleep(10000L);
 
         assertSinkMetricValue("partition-count", 2);
-        assertTaskMetricValue("status-running", 0.0);
-        assertTaskMetricValue("status-paused", 1.0);
+        assertTaskMetricValue("status", "paused");
         assertTaskMetricValue("running-ratio", 0.0);
         assertTaskMetricValue("pause-ratio", 1.0);
         assertTaskMetricValue("offset-commit-max-time-ms", Double.NEGATIVE_INFINITY);
@@ -253,8 +252,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
         assertSinkMetricValue("offset-commit-skip-rate", 0.0);
         assertSinkMetricValue("offset-commit-skip-total", 0.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 1.0);
@@ -272,8 +270,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-skip-rate", 0.0);
         assertSinkMetricValue("offset-commit-skip-total", 0.0);
-        assertTaskMetricValue("status-running", 0.0);
-        assertTaskMetricValue("status-paused", 1.0);
+        assertTaskMetricValue("status", "paused");
         assertTaskMetricValue("running-ratio", 0.25);
         assertTaskMetricValue("pause-ratio", 0.75);
 
@@ -333,8 +330,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
         assertSinkMetricValue("offset-commit-skip-rate", 0.0);
         assertSinkMetricValue("offset-commit-skip-total", 0.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 0.0);
@@ -352,8 +348,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("sink-record-active-count", 1.0);
         assertSinkMetricValue("sink-record-active-count-max", 1.0);
         assertSinkMetricValue("sink-record-active-count-avg", 0.5);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("batch-size-max", 1.0);
         assertTaskMetricValue("batch-size-avg", 0.5);
@@ -492,8 +487,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-seq-no", 1.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-skip-total", 0.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 1.0);
@@ -560,8 +554,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-seq-no", 0.0);
         assertSinkMetricValue("offset-commit-completion-total", 0.0);
         assertSinkMetricValue("offset-commit-skip-total", 0.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 1.0);
@@ -588,8 +581,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-seq-no", 1.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-skip-total", 0.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 1.0);
@@ -991,8 +983,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-seq-no", 2.0);
         assertSinkMetricValue("offset-commit-completion-total", 1.0);
         assertSinkMetricValue("offset-commit-skip-total", 1.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 2.0);
@@ -1026,8 +1017,7 @@ public class WorkerSinkTaskTest {
         assertSinkMetricValue("offset-commit-seq-no", 3.0);
         assertSinkMetricValue("offset-commit-completion-total", 2.0);
         assertSinkMetricValue("offset-commit-skip-total", 1.0);
-        assertTaskMetricValue("status-running", 1.0);
-        assertTaskMetricValue("status-paused", 0.0);
+        assertTaskMetricValue("status", "running");
         assertTaskMetricValue("running-ratio", 1.0);
         assertTaskMetricValue("pause-ratio", 0.0);
         assertTaskMetricValue("batch-size-max", 2.0);
@@ -1089,7 +1079,7 @@ public class WorkerSinkTaskTest {
         assertFalse(sinkTaskContext.getValue().isCommitRequested()); // should have been cleared
         assertEquals(offsets, Whitebox.<Map<TopicPartition, OffsetAndMetadata>>getInternalState(workerTask, "lastCommittedOffsets"));
         assertEquals(0, workerTask.commitFailures());
-        assertEquals(1.0, metrics.currentMetricValue(workerTask.taskMetricsGroup().metricGroup(), "batch-size-max"), 0.0001);
+        assertEquals(1.0, metrics.currentMetricValueAsDouble(workerTask.taskMetricsGroup().metricGroup(), "batch-size-max"), 0.0001);
 
         PowerMock.verifyAll();
     }
@@ -1289,14 +1279,20 @@ public class WorkerSinkTaskTest {
 
     private void assertSinkMetricValue(String name, double expected) {
         MetricGroup sinkTaskGroup = workerTask.sinkTaskMetricsGroup().metricGroup();
-        double measured = metrics.currentMetricValue(sinkTaskGroup, name);
+        double measured = metrics.currentMetricValueAsDouble(sinkTaskGroup, name);
         assertEquals(expected, measured, 0.001d);
     }
 
     private void assertTaskMetricValue(String name, double expected) {
         MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
-        double measured = metrics.currentMetricValue(taskGroup, name);
+        double measured = metrics.currentMetricValueAsDouble(taskGroup, name);
         assertEquals(expected, measured, 0.001d);
+    }
+
+    private void assertTaskMetricValue(String name, String expected) {
+        MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
+        String measured = metrics.currentMetricValueAsString(taskGroup, name);
+        assertEquals(expected, measured);
     }
 
     private void printMetrics() {
@@ -1334,14 +1330,14 @@ public class WorkerSinkTaskTest {
 
     private double sinkMetricValue(String metricName) {
         MetricGroup sinkTaskGroup = workerTask.sinkTaskMetricsGroup().metricGroup();
-        double value = metrics.currentMetricValue(sinkTaskGroup, metricName);
+        double value = metrics.currentMetricValueAsDouble(sinkTaskGroup, metricName);
         System.out.println("** " + metricName + "=" + value);
         return value;
     }
 
     private double taskMetricValue(String metricName) {
         MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
-        double value = metrics.currentMetricValue(taskGroup, metricName);
+        double value = metrics.currentMetricValueAsDouble(taskGroup, metricName);
         System.out.println("** " + metricName + "=" + value);
         return value;
     }
@@ -1350,10 +1346,10 @@ public class WorkerSinkTaskTest {
     private void assertMetrics(int minimumPollCountExpected) {
         MetricGroup sinkTaskGroup = workerTask.sinkTaskMetricsGroup().metricGroup();
         MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
-        double readRate = metrics.currentMetricValue(sinkTaskGroup, "sink-record-read-rate");
-        double readTotal = metrics.currentMetricValue(sinkTaskGroup, "sink-record-read-total");
-        double sendRate = metrics.currentMetricValue(sinkTaskGroup, "sink-record-send-rate");
-        double sendTotal = metrics.currentMetricValue(sinkTaskGroup, "sink-record-send-total");
+        double readRate = metrics.currentMetricValueAsDouble(sinkTaskGroup, "sink-record-read-rate");
+        double readTotal = metrics.currentMetricValueAsDouble(sinkTaskGroup, "sink-record-read-total");
+        double sendRate = metrics.currentMetricValueAsDouble(sinkTaskGroup, "sink-record-send-rate");
+        double sendTotal = metrics.currentMetricValueAsDouble(sinkTaskGroup, "sink-record-send-total");
     }
 
     private abstract static class TestSinkTask extends SinkTask  {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -615,12 +615,12 @@ public class WorkerSourceTaskTest extends ThreadedTest {
             group.recordPoll(100, 1000 + i * 100);
             group.recordWrite(10);
         }
-        assertEquals(1900.0, metrics.currentMetricValue(group.metricGroup(), "poll-batch-max-time-ms"), 0.001d);
-        assertEquals(1450.0, metrics.currentMetricValue(group.metricGroup(), "poll-batch-avg-time-ms"), 0.001d);
-        assertEquals(33.333, metrics.currentMetricValue(group.metricGroup(), "source-record-poll-rate"), 0.001d);
-        assertEquals(1000, metrics.currentMetricValue(group.metricGroup(), "source-record-poll-total"), 0.001d);
-        assertEquals(3.3333, metrics.currentMetricValue(group.metricGroup(), "source-record-write-rate"), 0.001d);
-        assertEquals(100, metrics.currentMetricValue(group.metricGroup(), "source-record-write-total"), 0.001d);
+        assertEquals(1900.0, metrics.currentMetricValueAsDouble(group.metricGroup(), "poll-batch-max-time-ms"), 0.001d);
+        assertEquals(1450.0, metrics.currentMetricValueAsDouble(group.metricGroup(), "poll-batch-avg-time-ms"), 0.001d);
+        assertEquals(33.333, metrics.currentMetricValueAsDouble(group.metricGroup(), "source-record-poll-rate"), 0.001d);
+        assertEquals(1000, metrics.currentMetricValueAsDouble(group.metricGroup(), "source-record-poll-total"), 0.001d);
+        assertEquals(3.3333, metrics.currentMetricValueAsDouble(group.metricGroup(), "source-record-write-rate"), 0.001d);
+        assertEquals(100, metrics.currentMetricValueAsDouble(group.metricGroup(), "source-record-write-total"), 0.001d);
     }
 
     private CountDownLatch expectPolls(int minimum, final AtomicInteger count) throws InterruptedException {
@@ -795,19 +795,19 @@ public class WorkerSourceTaskTest extends ThreadedTest {
     private void assertPollMetrics(int minimumPollCountExpected) {
         MetricGroup sourceTaskGroup = workerTask.sourceTaskMetricsGroup().metricGroup();
         MetricGroup taskGroup = workerTask.taskMetricsGroup().metricGroup();
-        double pollRate = metrics.currentMetricValue(sourceTaskGroup, "source-record-poll-rate");
-        double pollTotal = metrics.currentMetricValue(sourceTaskGroup, "source-record-poll-total");
+        double pollRate = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-poll-rate");
+        double pollTotal = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-poll-total");
         if (minimumPollCountExpected > 0) {
-            assertEquals(RECORDS.size(), metrics.currentMetricValue(taskGroup, "batch-size-max"), 0.000001d);
-            assertEquals(RECORDS.size(), metrics.currentMetricValue(taskGroup, "batch-size-avg"), 0.000001d);
+            assertEquals(RECORDS.size(), metrics.currentMetricValueAsDouble(taskGroup, "batch-size-max"), 0.000001d);
+            assertEquals(RECORDS.size(), metrics.currentMetricValueAsDouble(taskGroup, "batch-size-avg"), 0.000001d);
             assertTrue(pollRate > 0.0d);
         } else {
             assertTrue(pollRate == 0.0d);
         }
         assertTrue(pollTotal >= minimumPollCountExpected);
 
-        double writeRate = metrics.currentMetricValue(sourceTaskGroup, "source-record-write-rate");
-        double writeTotal = metrics.currentMetricValue(sourceTaskGroup, "source-record-write-total");
+        double writeRate = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-write-rate");
+        double writeTotal = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-write-total");
         if (minimumPollCountExpected > 0) {
             assertTrue(writeRate > 0.0d);
         } else {
@@ -815,14 +815,14 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         }
         assertTrue(writeTotal >= minimumPollCountExpected);
 
-        double pollBatchTimeMax = metrics.currentMetricValue(sourceTaskGroup, "poll-batch-max-time-ms");
-        double pollBatchTimeAvg = metrics.currentMetricValue(sourceTaskGroup, "poll-batch-avg-time-ms");
+        double pollBatchTimeMax = metrics.currentMetricValueAsDouble(sourceTaskGroup, "poll-batch-max-time-ms");
+        double pollBatchTimeAvg = metrics.currentMetricValueAsDouble(sourceTaskGroup, "poll-batch-avg-time-ms");
         if (minimumPollCountExpected > 0) {
             assertTrue(pollBatchTimeMax >= 0.0d);
         }
         assertTrue(pollBatchTimeAvg >= 0.0d);
-        double activeCount = metrics.currentMetricValue(sourceTaskGroup, "source-record-active-count");
-        double activeCountMax = metrics.currentMetricValue(sourceTaskGroup, "source-record-active-count-max");
+        double activeCount = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-active-count");
+        double activeCountMax = metrics.currentMetricValueAsDouble(sourceTaskGroup, "source-record-active-count-max");
         assertEquals(0, activeCount, 0.000001d);
         if (minimumPollCountExpected > 0) {
             assertEquals(RECORDS.size(), activeCountMax, 0.000001d);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
@@ -314,8 +314,8 @@ public class WorkerTaskTest {
         long totalTime = 27000L;
         double pauseTimeRatio = (double) (3000L + 5000L) / totalTime;
         double runningTimeRatio = (double) (2000L + 4000L + 6000L) / totalTime;
-        assertEquals(pauseTimeRatio, metrics.currentMetricValue(group.metricGroup(), "pause-ratio"), 0.000001d);
-        assertEquals(runningTimeRatio, metrics.currentMetricValue(group.metricGroup(), "running-ratio"), 0.000001d);
+        assertEquals(pauseTimeRatio, metrics.currentMetricValueAsDouble(group.metricGroup(), "pause-ratio"), 0.000001d);
+        assertEquals(runningTimeRatio, metrics.currentMetricValueAsDouble(group.metricGroup(), "running-ratio"), 0.000001d);
     }
 
     private static abstract class TestSinkTask extends SinkTask {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -27,6 +28,9 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.MockConnectMetrics.MockMetricsReporter;
+import org.apache.kafka.connect.runtime.Worker.State;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
@@ -43,7 +47,6 @@ import org.apache.kafka.connect.util.MockTime;
 import org.apache.kafka.connect.util.ThreadedTest;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -59,6 +62,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -76,7 +80,6 @@ public class WorkerTest extends ThreadedTest {
 
     private WorkerConfig config;
     private Worker worker;
-    private ConnectMetrics metrics;
 
     @Mock
     private Plugins plugins;
@@ -103,15 +106,11 @@ public class WorkerTest extends ThreadedTest {
         workerProps.put("internal.key.converter.schemas.enable", "false");
         workerProps.put("internal.value.converter.schemas.enable", "false");
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
+        workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
+        workerProps.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
         config = new StandaloneConfig(workerProps);
-        metrics = new MockConnectMetrics();
 
         PowerMock.mockStatic(Plugins.class);
-    }
-
-    @After
-    public void tearDown() {
-        if (metrics != null) metrics.stop();
     }
 
     @Test
@@ -173,10 +172,15 @@ public class WorkerTest extends ThreadedTest {
         } catch (ConnectException e) {
             // expected
         }
+        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
         worker.stopConnector(CONNECTOR_ID);
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -212,11 +216,17 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertFalse(worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED));
 
+        assertStartupStatistics(worker, 1, 1, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
 
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 1, 1, 0, 0);
         assertFalse(worker.stopConnector(CONNECTOR_ID));
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 1, 1, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -270,14 +280,21 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
+        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
 
         worker.stopConnector(CONNECTOR_ID);
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -331,14 +348,18 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
+        assertStatistics(worker, State.RUNNING, 1, 0);
 
         worker.stopConnector(CONNECTOR_ID);
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -414,8 +435,10 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
+        assertStatistics(worker, State.RUNNING, 1, 0);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         try {
             worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
@@ -431,10 +454,15 @@ public class WorkerTest extends ThreadedTest {
         assertEquals(2, taskConfigs.size());
         assertEquals(expectedTaskProps, taskConfigs.get(0));
         assertEquals(expectedTaskProps, taskConfigs.get(1));
+        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
         worker.stopConnector(CONNECTOR_ID);
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -512,13 +540,21 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 0, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED);
+        assertStatistics(worker, State.RUNNING, 0, 1);
+        assertStartupStatistics(worker, 0, 0, 1, 0);
         assertEquals(new HashSet<>(Arrays.asList(TASK_ID)), worker.taskIds());
         worker.stopAndAwaitTask(TASK_ID);
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 0, 0, 1, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStartupStatistics(worker, 0, 0, 1, 0);
 
         PowerMock.verifyAll();
     }
@@ -555,9 +591,14 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 0, 0, 0, 0);
 
         assertFalse(worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED));
+        assertStartupStatistics(worker, 0, 0, 1, 1);
 
+        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStartupStatistics(worker, 0, 0, 1, 1);
         assertEquals(Collections.emptySet(), worker.taskIds());
 
         PowerMock.verifyAll();
@@ -637,8 +678,11 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
+        assertStatistics(worker, State.RUNNING, 0, 0);
         worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED);
+        assertStatistics(worker, State.RUNNING, 0, 1);
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -717,6 +761,7 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         Map<String, String> connProps = anyConnectorConfigMap();
         connProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
@@ -724,17 +769,57 @@ public class WorkerTest extends ThreadedTest {
         connProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
         connProps.put("value.converter.extra.config", "bar");
         worker.startTask(TASK_ID, connProps, origProps, taskStatusListener, TargetState.STARTED);
+        assertStatistics(worker, State.RUNNING, 0, 1);
         assertEquals(new HashSet<>(Arrays.asList(TASK_ID)), worker.taskIds());
         worker.stopAndAwaitTask(TASK_ID);
+        assertStatistics(worker, State.RUNNING, 0, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
+        assertStatistics(worker, State.STOPPED, 0, 0);
 
         // Validate extra configs got passed through to overridden converters
         assertEquals("foo", keyConverter.getValue().configs.get("extra.config"));
         assertEquals("bar", valueConverter.getValue().configs.get("extra.config"));
 
         PowerMock.verifyAll();
+    }
+
+    private void assertStatistics(Worker worker, State expectedState, int connectors, int tasks) {
+        MetricGroup workerMetrics = worker.workerMetricsGroup().metricGroup();
+        assertEquals(connectors, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-count"), 0.0001d);
+        assertEquals(tasks, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-count"), 0.0001d);
+        assertEquals(expectedState.toString().toLowerCase(Locale.getDefault()),
+                     MockConnectMetrics.currentMetricValueAsString(worker.metrics(), workerMetrics, "status"));
+        assertEquals(tasks, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-count"), 0.0001d);
+    }
+
+    private void assertStartupStatistics(Worker worker, int connectorStartupAttempts, int connectorStartupFailures, int taskStartupAttempts, int taskStartupFailures) {
+        double connectStartupSuccesses = connectorStartupAttempts - connectorStartupFailures;
+        double taskStartupSuccesses = taskStartupAttempts - taskStartupFailures;
+        double connectStartupSuccessPct = 0.0d;
+        double connectStartupFailurePct = 0.0d;
+        double taskStartupSuccessPct = 0.0d;
+        double taskStartupFailurePct = 0.0d;
+        if (connectorStartupAttempts != 0) {
+            connectStartupSuccessPct = connectStartupSuccesses / connectorStartupAttempts;
+            connectStartupFailurePct = (double) connectorStartupFailures / connectorStartupAttempts;
+        }
+        if (taskStartupAttempts != 0) {
+            taskStartupSuccessPct = taskStartupSuccesses / taskStartupAttempts;
+            taskStartupFailurePct = (double) taskStartupFailures / taskStartupAttempts;
+        }
+        MetricGroup workerMetrics = worker.workerMetricsGroup().metricGroup();
+        assertEquals(connectorStartupAttempts, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-startup-attempts-total"), 0.0001d);
+        assertEquals(connectStartupSuccesses, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-startup-success-total"), 0.0001d);
+        assertEquals(connectorStartupFailures, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-startup-failure-total"), 0.0001d);
+        assertEquals(connectStartupSuccessPct, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-startup-success-percentage"), 0.0001d);
+        assertEquals(connectStartupFailurePct, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-startup-failure-percentage"), 0.0001d);
+        assertEquals(taskStartupAttempts, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-startup-attempts-total"), 0.0001d);
+        assertEquals(taskStartupSuccesses, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-startup-success-total"), 0.0001d);
+        assertEquals(taskStartupFailures, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-startup-failure-total"), 0.0001d);
+        assertEquals(taskStartupSuccessPct, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-startup-success-percentage"), 0.0001d);
+        assertEquals(taskStartupFailurePct, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-startup-failure-percentage"), 0.0001d);
     }
 
     private void expectStartStorage() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.MockConnectMetrics.MockMetricsReporter;
-import org.apache.kafka.connect.runtime.Worker.State;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
@@ -62,7 +61,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -171,15 +169,15 @@ public class WorkerTest extends ThreadedTest {
         } catch (ConnectException e) {
             // expected
         }
-        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         worker.stopConnector(CONNECTOR_ID);
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -215,16 +213,16 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertFalse(worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED));
 
         assertStartupStatistics(worker, 1, 1, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
 
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
         assertFalse(worker.stopConnector(CONNECTOR_ID));
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 1, 0, 0);
 
         PowerMock.verifyAll();
@@ -279,20 +277,20 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
-        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
 
         worker.stopConnector(CONNECTOR_ID);
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
 
         PowerMock.verifyAll();
@@ -347,18 +345,18 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
-        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStatistics(worker, 1, 0);
 
         worker.stopConnector(CONNECTOR_ID);
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -434,10 +432,10 @@ public class WorkerTest extends ThreadedTest {
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
 
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
-        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStatistics(worker, 1, 0);
         assertEquals(new HashSet<>(Arrays.asList(CONNECTOR_ID)), worker.connectorNames());
         try {
             worker.startConnector(CONNECTOR_ID, props, ctx, connectorStatusListener, TargetState.STARTED);
@@ -453,15 +451,15 @@ public class WorkerTest extends ThreadedTest {
         assertEquals(2, taskConfigs.size());
         assertEquals(expectedTaskProps, taskConfigs.get(0));
         assertEquals(expectedTaskProps, taskConfigs.get(1));
-        assertStatistics(worker, State.RUNNING, 1, 0);
+        assertStatistics(worker, 1, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         worker.stopConnector(CONNECTOR_ID);
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 1, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.connectorNames());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -539,20 +537,20 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 0, 0, 0, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED);
-        assertStatistics(worker, State.RUNNING, 0, 1);
+        assertStatistics(worker, 0, 1);
         assertStartupStatistics(worker, 0, 0, 1, 0);
         assertEquals(new HashSet<>(Arrays.asList(TASK_ID)), worker.taskIds());
         worker.stopAndAwaitTask(TASK_ID);
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 0, 0, 1, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 0, 0, 1, 0);
 
         PowerMock.verifyAll();
@@ -590,13 +588,13 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 0, 0, 0, 0);
 
         assertFalse(worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED));
         assertStartupStatistics(worker, 0, 0, 1, 1);
 
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertStartupStatistics(worker, 0, 0, 1, 1);
         assertEquals(Collections.emptySet(), worker.taskIds());
 
@@ -677,11 +675,11 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         worker.startTask(TASK_ID, anyConnectorConfigMap(), origProps, taskStatusListener, TargetState.STARTED);
-        assertStatistics(worker, State.RUNNING, 0, 1);
+        assertStatistics(worker, 0, 1);
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
 
         PowerMock.verifyAll();
     }
@@ -760,7 +758,7 @@ public class WorkerTest extends ThreadedTest {
 
         worker = new Worker(WORKER_ID, new MockTime(), plugins, config, offsetBackingStore);
         worker.start();
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         Map<String, String> connProps = anyConnectorConfigMap();
         connProps.put(ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
@@ -768,14 +766,14 @@ public class WorkerTest extends ThreadedTest {
         connProps.put(ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
         connProps.put("value.converter.extra.config", "bar");
         worker.startTask(TASK_ID, connProps, origProps, taskStatusListener, TargetState.STARTED);
-        assertStatistics(worker, State.RUNNING, 0, 1);
+        assertStatistics(worker, 0, 1);
         assertEquals(new HashSet<>(Arrays.asList(TASK_ID)), worker.taskIds());
         worker.stopAndAwaitTask(TASK_ID);
-        assertStatistics(worker, State.RUNNING, 0, 0);
+        assertStatistics(worker, 0, 0);
         assertEquals(Collections.emptySet(), worker.taskIds());
         // Nothing should be left, so this should effectively be a nop
         worker.stop();
-        assertStatistics(worker, State.STOPPED, 0, 0);
+        assertStatistics(worker, 0, 0);
 
         // Validate extra configs got passed through to overridden converters
         assertEquals("foo", keyConverter.getValue().configs.get("extra.config"));
@@ -784,12 +782,10 @@ public class WorkerTest extends ThreadedTest {
         PowerMock.verifyAll();
     }
 
-    private void assertStatistics(Worker worker, State expectedState, int connectors, int tasks) {
+    private void assertStatistics(Worker worker, int connectors, int tasks) {
         MetricGroup workerMetrics = worker.workerMetricsGroup().metricGroup();
         assertEquals(connectors, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "connector-count"), 0.0001d);
         assertEquals(tasks, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-count"), 0.0001d);
-        assertEquals(expectedState.toString().toLowerCase(Locale.getDefault()),
-                     MockConnectMetrics.currentMetricValueAsString(worker.metrics(), workerMetrics, "status"));
         assertEquals(tasks, MockConnectMetrics.currentMetricValueAsDouble(worker.metrics(), workerMetrics, "task-count"), 0.0001d);
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -134,6 +134,8 @@ public class WorkerTest extends ThreadedTest {
         props.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_ID);
         props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
 
+        EasyMock.expect(connector.version()).andReturn("1.0");
+
         EasyMock.expect(plugins.compareAndSwapLoaders(connector))
                 .andReturn(delegatingLoader)
                 .times(2);
@@ -238,6 +240,7 @@ public class WorkerTest extends ThreadedTest {
         props.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_ID);
         props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "WorkerTestConnector");
 
+        EasyMock.expect(connector.version()).andReturn("1.0");
         EasyMock.expect(plugins.compareAndSwapLoaders(connector))
                 .andReturn(delegatingLoader)
                 .times(2);
@@ -298,6 +301,7 @@ public class WorkerTest extends ThreadedTest {
         props.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_ID);
         props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, "WorkerTest");
 
+        EasyMock.expect(connector.version()).andReturn("1.0");
         EasyMock.expect(plugins.compareAndSwapLoaders(connector))
                 .andReturn(delegatingLoader)
                 .times(2);
@@ -374,6 +378,7 @@ public class WorkerTest extends ThreadedTest {
         props.put(ConnectorConfig.NAME_CONFIG, CONNECTOR_ID);
         props.put(ConnectorConfig.CONNECTOR_CLASS_CONFIG, WorkerTestConnector.class.getName());
 
+        EasyMock.expect(connector.version()).andReturn("1.0");
         EasyMock.expect(plugins.compareAndSwapLoaders(connector))
                 .andReturn(delegatingLoader)
                 .times(3);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -106,7 +106,6 @@ public class WorkerTest extends ThreadedTest {
         workerProps.put("internal.key.converter.schemas.enable", "false");
         workerProps.put("internal.value.converter.schemas.enable", "false");
         workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
-        workerProps.put("offset.storage.file.filename", "/tmp/connect.offsets");
         workerProps.put(CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
         config = new StandaloneConfig(workerProps);
 


### PR DESCRIPTION
Added metrics to the Connect worker and rebalancing metrics to the distributed herder.

This is built on top of #3987, and I can rebase this PR once that is merged.