### PR TITLE
MINOR: Simplify log cleaner and fix compiler warnings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
@@ -29,6 +29,7 @@ public abstract class AbstractOptions<T extends AbstractOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      */
+    @SuppressWarnings("unchecked")
     public T timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return (T) this;

--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -48,9 +48,9 @@ public abstract class KafkaFuture<T> implements Future<T> {
 
     private static class AllOfAdapter<R> extends BiConsumer<R, Throwable> {
         private int remainingResponses;
-        private KafkaFuture future;
+        private KafkaFuture<?> future;
 
-        public AllOfAdapter(int remainingResponses, KafkaFuture future) {
+        public AllOfAdapter(int remainingResponses, KafkaFuture<?> future) {
             this.remainingResponses = remainingResponses;
             this.future = future;
             maybeComplete();
@@ -91,7 +91,7 @@ public abstract class KafkaFuture<T> implements Future<T> {
      */
     public static KafkaFuture<Void> allOf(KafkaFuture<?>... futures) {
         KafkaFuture<Void> allOfFuture = new KafkaFutureImpl<>();
-        AllOfAdapter allOfWaiter = new AllOfAdapter(futures.length, allOfFuture);
+        AllOfAdapter<Object> allOfWaiter = new AllOfAdapter<>(futures.length, allOfFuture);
         for (KafkaFuture<?> future : futures) {
             future.addWaiter(allOfWaiter);
         }

--- a/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/AbstractConfig.java
@@ -260,7 +260,7 @@ public class AbstractConfig {
      * @return The list of configured instances
      */
     public <T> List<T> getConfiguredInstances(String key, Class<T> t) {
-        return getConfiguredInstances(key, t, Collections.EMPTY_MAP);
+        return getConfiguredInstances(key, t, Collections.<String, Object>emptyMap());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -867,6 +867,7 @@ public class ConfigDef {
 
         @Override
         public void ensureValid(final String name, final Object value) {
+            @SuppressWarnings("unchecked")
             List<String> values = (List<String>) value;
             for (String string : values) {
                 validString.ensureValid(name, string);

--- a/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.common.config;
 
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
-import org.apache.kafka.common.security.auth.DefaultPrincipalBuilder;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -41,8 +40,10 @@ public class SslConfigs {
      * @deprecated As of 1.0.0. This field will be removed in a future major release. In recent versions,
      *   the config is optional and there is no default.
      */
+    // use FQN to avoid import deprecation warning
     @Deprecated
-    public static final String DEFAULT_PRINCIPAL_BUILDER_CLASS = DefaultPrincipalBuilder.class.getName();
+    public static final String DEFAULT_PRINCIPAL_BUILDER_CLASS =
+            org.apache.kafka.common.security.auth.DefaultPrincipalBuilder.class.getName();
 
     public static final String SSL_PROTOCOL_CONFIG = "ssl.protocol";
     public static final String SSL_PROTOCOL_DOC = "The SSL protocol used to generate the SSLContext. "

--- a/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
@@ -142,7 +142,7 @@ public class KafkaFutureImpl<T> extends KafkaFuture<T> {
     @Override
     public <R> KafkaFuture<R> thenApply(Function<T, R> function) {
         KafkaFutureImpl<R> future = new KafkaFutureImpl<R>();
-        addWaiter(new Applicant(function, future));
+        addWaiter(new Applicant<>(function, future));
         return future;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilders.java
@@ -23,9 +23,7 @@ import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.authenticator.DefaultKafkaPrincipalBuilder;
-import org.apache.kafka.common.security.auth.DefaultPrincipalBuilder;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
-import org.apache.kafka.common.security.auth.PrincipalBuilder;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
 import org.apache.kafka.common.security.kerberos.KerberosShortNamer;
 import org.apache.kafka.common.utils.Utils;
@@ -122,13 +120,15 @@ public class ChannelBuilders {
             throw new IllegalArgumentException("`mode` must be non-null if `securityProtocol` is `" + securityProtocol + "`");
     }
 
+    // Use FQN to avoid deprecated import warnings
     @SuppressWarnings("deprecation")
-    private static PrincipalBuilder createPrincipalBuilder(Class<?> principalBuilderClass, Map<String, ?> configs) {
-        PrincipalBuilder principalBuilder;
+    private static org.apache.kafka.common.security.auth.PrincipalBuilder createPrincipalBuilder(
+            Class<?> principalBuilderClass, Map<String, ?> configs) {
+        org.apache.kafka.common.security.auth.PrincipalBuilder principalBuilder;
         if (principalBuilderClass == null)
-            principalBuilder = new DefaultPrincipalBuilder();
+            principalBuilder = new org.apache.kafka.common.security.auth.DefaultPrincipalBuilder();
         else
-            principalBuilder = (PrincipalBuilder) Utils.newInstance(principalBuilderClass);
+            principalBuilder = (org.apache.kafka.common.security.auth.PrincipalBuilder) Utils.newInstance(principalBuilderClass);
         principalBuilder.configure(configs);
         return principalBuilder;
     }
@@ -145,13 +145,15 @@ public class ChannelBuilders {
             builder = new DefaultKafkaPrincipalBuilder(kerberosShortNamer);
         } else if (KafkaPrincipalBuilder.class.isAssignableFrom(principalBuilderClass)) {
             builder = (KafkaPrincipalBuilder) Utils.newInstance(principalBuilderClass);
-        } else if (PrincipalBuilder.class.isAssignableFrom(principalBuilderClass)) {
-            PrincipalBuilder oldPrincipalBuilder = createPrincipalBuilder(principalBuilderClass, configs);
+        } else if (org.apache.kafka.common.security.auth.PrincipalBuilder.class.isAssignableFrom(principalBuilderClass)) {
+            org.apache.kafka.common.security.auth.PrincipalBuilder oldPrincipalBuilder =
+                    createPrincipalBuilder(principalBuilderClass, configs);
             builder = DefaultKafkaPrincipalBuilder.fromOldPrincipalBuilder(authenticator, transportLayer,
                     oldPrincipalBuilder, kerberosShortNamer);
         } else {
             throw new InvalidConfigurationException("Type " + principalBuilderClass.getName() + " is not " +
-                    "an instance of " + PrincipalBuilder.class.getName() + " or " + KafkaPrincipalBuilder.class.getName());
+                    "an instance of " + org.apache.kafka.common.security.auth.PrincipalBuilder.class.getName() + " or " +
+                    KafkaPrincipalBuilder.class.getName());
         }
 
         if (builder instanceof Configurable)

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -81,6 +81,7 @@ public class SaslChannelBuilder implements ChannelBuilder {
             this.configs = configs;
             boolean hasKerberos;
             if (mode == Mode.SERVER) {
+                @SuppressWarnings("unchecked")
                 List<String> enabledMechanisms = (List<String>) this.configs.get(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG);
                 hasKerberos = enabledMechanisms == null || enabledMechanisms.contains(SaslConfigs.GSSAPI_MECHANISM);
             } else {

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/DefaultKafkaPrincipalBuilder.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.security.auth.AuthenticationContext;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.KafkaPrincipalBuilder;
 import org.apache.kafka.common.security.auth.PlaintextAuthenticationContext;
-import org.apache.kafka.common.security.auth.PrincipalBuilder;
 import org.apache.kafka.common.security.auth.SaslAuthenticationContext;
 import org.apache.kafka.common.security.auth.SslAuthenticationContext;
 import org.apache.kafka.common.security.kerberos.KerberosName;
@@ -47,27 +46,28 @@ import static java.util.Objects.requireNonNull;
  *
  * NOTE: This is an internal class and can change without notice. Unlike normal implementations
  * of {@link KafkaPrincipalBuilder}, there is no default no-arg constructor since this class
- * must adapt implementations of the older {@link PrincipalBuilder} interface.
+ * must adapt implementations of the older {@link org.apache.kafka.common.security.auth.PrincipalBuilder} interface.
  */
 public class DefaultKafkaPrincipalBuilder implements KafkaPrincipalBuilder, Closeable {
+    // Use FQN to avoid import deprecation warnings
     @SuppressWarnings("deprecation")
-    private final PrincipalBuilder oldPrincipalBuilder;
+    private final org.apache.kafka.common.security.auth.PrincipalBuilder oldPrincipalBuilder;
     private final Authenticator authenticator;
     private final TransportLayer transportLayer;
     private final KerberosShortNamer kerberosShortNamer;
 
     /**
-     * Construct a new instance which wraps an instance of the older {@link PrincipalBuilder}.
+     * Construct a new instance which wraps an instance of the older {@link org.apache.kafka.common.security.auth.PrincipalBuilder}.
      *
      * @param authenticator The authenticator in use
      * @param transportLayer The underlying transport layer
-     * @param oldPrincipalBuilder Instance of {@link PrincipalBuilder}
+     * @param oldPrincipalBuilder Instance of {@link org.apache.kafka.common.security.auth.PrincipalBuilder}
      * @param kerberosShortNamer Kerberos name rewrite rules or null if none have been configured
      */
     @SuppressWarnings("deprecation")
     public static DefaultKafkaPrincipalBuilder fromOldPrincipalBuilder(Authenticator authenticator,
                                                                        TransportLayer transportLayer,
-                                                                       PrincipalBuilder oldPrincipalBuilder,
+                                                                       org.apache.kafka.common.security.auth.PrincipalBuilder oldPrincipalBuilder,
                                                                        KerberosShortNamer kerberosShortNamer) {
         return new DefaultKafkaPrincipalBuilder(
                 requireNonNull(authenticator),
@@ -79,7 +79,7 @@ public class DefaultKafkaPrincipalBuilder implements KafkaPrincipalBuilder, Clos
     @SuppressWarnings("deprecation")
     private DefaultKafkaPrincipalBuilder(Authenticator authenticator,
                                          TransportLayer transportLayer,
-                                         PrincipalBuilder oldPrincipalBuilder,
+                                         org.apache.kafka.common.security.auth.PrincipalBuilder oldPrincipalBuilder,
                                          KerberosShortNamer kerberosShortNamer) {
         this.authenticator = authenticator;
         this.transportLayer = transportLayer;

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -146,6 +146,7 @@ public class SaslServerAuthenticator implements Authenticator {
         this.transportLayer = transportLayer;
 
         this.configs = configs;
+        @SuppressWarnings("unchecked")
         List<String> enabledMechanisms = (List<String>) this.configs.get(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG);
         if (enabledMechanisms == null || enabledMechanisms.isEmpty())
             throw new IllegalArgumentException("No SASL mechanisms are enabled");

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -327,6 +327,7 @@ public class Utils {
                 argTypes[i] = (Class<?>) params[2 * i];
                 args[i] = params[(2 * i) + 1];
             }
+            @SuppressWarnings("unchecked")
             Constructor<T> constructor = (Constructor<T>) c.getConstructor(argTypes);
             return constructor.newInstance(args);
         } catch (NoSuchMethodException e) {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/MockConnectMetrics.java
@@ -136,6 +136,7 @@ public class MockConnectMetrics extends ConnectMetrics {
          * @param metricName the name of the metric that was registered most recently
          * @return the current value of the metric
          */
+        @SuppressWarnings("deprecation")
         public double currentMetricValue(MetricName metricName) {
             KafkaMetric metric = metricsByName.get(metricName);
             return metric != null ? metric.value() : Double.NaN;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -677,6 +677,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
         return expectSendRecord(anyTimes, isRetry, false);
     }
 
+    @SuppressWarnings("unchecked")
     private Capture<ProducerRecord<byte[], byte[]>> expectSendRecord(boolean anyTimes, boolean isRetry, boolean succeed) throws InterruptedException {
         expectConvertKeyValue(anyTimes);
         expectApplyTransformationChain(anyTimes);

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -155,7 +155,7 @@ class Log(@volatile var dir: File,
   /* last time it was flushed */
   private val lastflushedTime = new AtomicLong(time.milliseconds)
 
-  def initFileSize() : Int = {
+  def initFileSize: Int = {
     if (config.preallocate)
       config.segmentSize
     else
@@ -408,7 +408,7 @@ class Log(@volatile var dir: File,
                                       rollJitterMs = config.randomSegmentJitter,
                                       time = time,
                                       fileAlreadyExists = false,
-                                      initFileSize = this.initFileSize(),
+                                      initFileSize = this.initFileSize,
                                       preallocate = config.preallocate))
     } else if (!dir.getAbsolutePath.endsWith(Log.DeleteDirSuffix)) {
       recoverLog()
@@ -1575,7 +1575,7 @@ class Log(@volatile var dir: File,
    * @param oldSegments The old log segments to delete from the log
    * @param isRecoveredSwapFile true if the new segment was created from a swap file during recovery after a crash
    */
-  private[log] def replaceSegments(newSegment: LogSegment, oldSegments: Seq[LogSegment], isRecoveredSwapFile : Boolean = false) {
+  private[log] def replaceSegments(newSegment: LogSegment, oldSegments: Seq[LogSegment], isRecoveredSwapFile: Boolean = false) {
     lock synchronized {
       // need to do this in two phases to be crash safe AND do the delete asynchronously
       // if we crash in the middle of this we complete the swap in loadSegments()
@@ -1584,9 +1584,9 @@ class Log(@volatile var dir: File,
       addSegment(newSegment)
 
       // delete the old files
-      for(seg <- oldSegments) {
+      for (seg <- oldSegments) {
         // remove the index entry
-        if(seg.baseOffset != newSegment.baseOffset)
+        if (seg.baseOffset != newSegment.baseOffset)
           segments.remove(seg.baseOffset)
         // delete segment
         asyncDeleteSegment(seg)

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -440,7 +440,7 @@ object DumpLogSegments {
     val shallowOffsetNotFound = new mutable.HashMap[String, ArrayBuffer[(Long, Long)]]
 
     def recordMismatchTimeIndex(file: File, indexTimestamp: Long, logTimestamp: Long) {
-      var misMatchesSeq = misMatchesForTimeIndexFilesMap.getOrElse(file.getAbsolutePath, new ArrayBuffer[(Long, Long)]())
+      val misMatchesSeq = misMatchesForTimeIndexFilesMap.getOrElse(file.getAbsolutePath, new ArrayBuffer[(Long, Long)]())
       if (misMatchesSeq.isEmpty)
         misMatchesForTimeIndexFilesMap.put(file.getAbsolutePath, misMatchesSeq)
       misMatchesSeq += ((indexTimestamp, logTimestamp))


### PR DESCRIPTION
- Simplify LogCleaner.cleanSegments and add comment regarding thread
unsafe usage of `LogSegment.append`. This was a result of investigating
KAFKA-4972.
- Fix compiler warnings (in some cases use the fully qualified name as a
workaround for deprecation warnings in import statements).