### PR TITLE
KAFKA-6010: Relax record conversion time test to avoid build failure

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -595,7 +595,7 @@ public class SslTransportLayerTest {
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
 
-        String message = TestUtils.randomString(10 * 1024);
+        String message = TestUtils.randomString(1024 * 1024);
         NetworkTestUtils.waitForChannelReady(selector, node);
         KafkaChannel channel = selector.channel(node);
         assertTrue("SSL handshake time not recorded", channel.getAndResetNetworkThreadTimeNanos() > 0);
@@ -606,7 +606,8 @@ public class SslTransportLayerTest {
         while (selector.completedSends().isEmpty()) {
             selector.poll(100L);
         }
-        assertTrue("Send time not recorded", channel.getAndResetNetworkThreadTimeNanos() > 0);
+        long sendTimeNanos = channel.getAndResetNetworkThreadTimeNanos();
+        assertTrue("Send time not recorded: " + sendTimeNanos, sendTimeNanos > 0);
         assertEquals("Time not reset", 0, channel.getAndResetNetworkThreadTimeNanos());
         assertFalse("Unexpected bytes buffered", channel.hasBytesBuffered());
         assertEquals(0, selector.completedReceives().size());
@@ -616,7 +617,8 @@ public class SslTransportLayerTest {
             selector.poll(100L);
             assertEquals(0, selector.numStagedReceives(channel));
         }
-        assertTrue("Receive time not recorded", channel.getAndResetNetworkThreadTimeNanos() > 0);
+        long receiveTimeNanos = channel.getAndResetNetworkThreadTimeNanos();
+        assertTrue("Receive time not recorded: " + receiveTimeNanos, receiveTimeNanos > 0);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -649,7 +649,7 @@ public class MemoryRecordsBuilderTest {
         assertNotNull("Records processing info is null", processingStats);
         assertEquals(numRecordsConverted, processingStats.numRecordsConverted());
         // Since nanoTime accuracy on build machines may not be sufficient to measure small conversion times,
-        // only check if the value >= 0.
+        // only check if the value >= 0. Default is -1, so this checks if time has been recorded.
         assertTrue("Processing time not recorded: " + processingStats, processingStats.conversionTimeNanos() >= 0);
         long tempBytes = processingStats.temporaryMemoryBytes();
         if (compressionType == CompressionType.NONE) {

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -648,7 +648,9 @@ public class MemoryRecordsBuilderTest {
             int numRecordsConverted, long finalBytes, long preConvertedBytes) {
         assertNotNull("Records processing info is null", processingStats);
         assertEquals(numRecordsConverted, processingStats.numRecordsConverted());
-        assertTrue("Processing time not recorded", processingStats.conversionTimeNanos() > 0);
+        // Since nanoTime accuracy on build machines may not be sufficient to measure small conversion times,
+        // only check if the value >= 0.
+        assertTrue("Processing time not recorded: " + processingStats, processingStats.conversionTimeNanos() >= 0);
         long tempBytes = processingStats.temporaryMemoryBytes();
         if (compressionType == CompressionType.NONE) {
             if (numRecordsConverted == 0)

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -1078,7 +1078,7 @@ class LogValidatorTest {
     assertNotNull("Records processing info is null", stats)
     assertEquals(numConvertedRecords, stats.numRecordsConverted)
     if (numConvertedRecords > 0)
-      assertTrue(s"Conversion time not recorded $stats", stats.conversionTimeNanos > 0)
+      assertTrue(s"Conversion time not recorded $stats", stats.conversionTimeNanos >= 0)
     val originalSize = records.sizeInBytes
     val tempBytes = stats.temporaryMemoryBytes
     if (numConvertedRecords > 0 && compressed)


### PR DESCRIPTION
For record conversion tests, check time >=0 since conversion times may be too small to be measured accurately. Since default value is -1, the test is still useful. Also increase message size in SslTransportLayerTest#testNetworkThreadTimeRecorded to avoid failures when processing time is too small.