### PR TITLE
KAFKA-5989: resume consumption of tasks that have state stores but no changelogging

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -257,11 +257,11 @@ class TaskManager {
      * @throws TaskMigratedException if another thread wrote to the changelog topic that is currently restored
      */
     boolean updateNewAndRestoringTasks() {
-        active.initializeNewTasks();
+        final Set<TopicPartition> resumed = active.initializeNewTasks();
         standby.initializeNewTasks();
 
         final Collection<TopicPartition> restored = changelogReader.restore(active);
-        final Set<TopicPartition> resumed = active.updateRestored(restored);
+        resumed.addAll(active.updateRestored(restored));
 
         if (!resumed.isEmpty()) {
             log.trace("resuming partitions {}", resumed);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/RestoreIntegrationTest.java
@@ -30,15 +30,25 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Reducer;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
 import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -71,6 +81,7 @@ public class RestoreIntegrationTest {
     public static final EmbeddedKafkaCluster CLUSTER =
             new EmbeddedKafkaCluster(NUM_BROKERS);
     private static final String INPUT_STREAM = "input-stream";
+    private static final String INPUT_STREAM_2 = "input-stream-2";
     private final int numberOfKeys = 10000;
     private KafkaStreams kafkaStreams;
     private String applicationId = "restore-test";
@@ -79,9 +90,10 @@ public class RestoreIntegrationTest {
     @BeforeClass
     public static void createTopics() throws InterruptedException {
         CLUSTER.createTopic(INPUT_STREAM, 2, 1);
+        CLUSTER.createTopic(INPUT_STREAM_2, 2, 1);
     }
 
-    private Properties props() {
+    private Properties props(final String applicationId) {
         Properties streamsConfiguration = new Properties();
         streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
@@ -119,7 +131,7 @@ public class RestoreIntegrationTest {
 
 
         final CountDownLatch startupLatch = new CountDownLatch(1);
-        kafkaStreams = new KafkaStreams(builder.build(), props());
+        kafkaStreams = new KafkaStreams(builder.build(), props(applicationId));
         kafkaStreams.setStateListener(new KafkaStreams.StateListener() {
             @Override
             public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
@@ -168,7 +180,7 @@ public class RestoreIntegrationTest {
                 }, Materialized.<Integer, Integer, KeyValueStore<Bytes, byte[]>>as("reduce-store").withLoggingDisabled());
 
         final CountDownLatch startupLatch = new CountDownLatch(1);
-        kafkaStreams = new KafkaStreams(builder.build(), props());
+        kafkaStreams = new KafkaStreams(builder.build(), props(applicationId));
         kafkaStreams.setStateListener(new KafkaStreams.StateListener() {
             @Override
             public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
@@ -181,6 +193,97 @@ public class RestoreIntegrationTest {
         kafkaStreams.start();
 
         assertTrue(startupLatch.await(30, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void shouldProcessDataFromStoresWithLoggingDisabled() throws InterruptedException, ExecutionException {
+
+        IntegrationTestUtils.produceKeyValuesSynchronously(INPUT_STREAM_2,
+                                                           Arrays.asList(KeyValue.pair(1, 1),
+                                                                         KeyValue.pair(2, 2),
+                                                                         KeyValue.pair(3, 3)),
+                                                           TestUtils.producerConfig(CLUSTER.bootstrapServers(),
+                                                                                    IntegerSerializer.class,
+                                                                                    IntegerSerializer.class),
+                                                           CLUSTER.time);
+
+        final KeyValueBytesStoreSupplier lruMapSupplier = Stores.lruMap(INPUT_STREAM_2, 10);
+
+        final StoreBuilder<KeyValueStore<Integer, Integer>> storeBuilder = new KeyValueStoreBuilder<>(lruMapSupplier,
+                                                                                                      Serdes.Integer(),
+                                                                                                      Serdes.Integer(),
+                                                                                                      CLUSTER.time)
+                .withLoggingDisabled();
+
+        final StreamsBuilder streamsBuilder = new StreamsBuilder();
+
+        streamsBuilder.addStateStore(storeBuilder);
+
+        final KStream<Integer, Integer> stream = streamsBuilder.stream(INPUT_STREAM_2);
+        final CountDownLatch processorLatch = new CountDownLatch(3);
+        stream.process(new ProcessorSupplier<Integer, Integer>() {
+            @Override
+            public Processor<Integer, Integer> get() {
+                return new KeyValueStoreProcessor(INPUT_STREAM_2, processorLatch);
+            }
+        }, INPUT_STREAM_2);
+
+        final Topology topology = streamsBuilder.build();
+
+        kafkaStreams = new KafkaStreams(topology, props(applicationId + "-logging-disabled"));
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        kafkaStreams.setStateListener(new KafkaStreams.StateListener() {
+            @Override
+            public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
+                if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
+                    latch.countDown();
+                }
+            }
+        });
+        kafkaStreams.start();
+
+        latch.await(30, TimeUnit.SECONDS);
+
+        assertTrue(processorLatch.await(30, TimeUnit.SECONDS));
+
+    }
+
+
+    public static class KeyValueStoreProcessor implements Processor<Integer, Integer> {
+
+        private String topic;
+        private final CountDownLatch processorLatch;
+
+        private KeyValueStore<Integer, Integer> store;
+
+        public KeyValueStoreProcessor(final String topic, final CountDownLatch processorLatch) {
+            this.topic = topic;
+            this.processorLatch = processorLatch;
+        }
+
+        @Override
+        public void init(final ProcessorContext context) {
+            this.store = (KeyValueStore<Integer, Integer>) context.getStateStore(topic);
+        }
+
+        @Override
+        public void process(final Integer key, final Integer value) {
+            if (key != null) {
+                store.put(key, value);
+                processorLatch.countDown();
+            }
+        }
+
+        @Override
+        public void punctuate(final long timestamp) {
+
+        }
+
+        @Override
+        public void close() {
+
+        }
     }
     
     private void createStateForRestoration()

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -293,7 +294,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldInitializeNewActiveTasks() {
-        active.initializeNewTasks();
+        EasyMock.expect(active.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
         EasyMock.expect(active.updateRestored(EasyMock.<Collection<TopicPartition>>anyObject())).
                 andReturn(Collections.<TopicPartition>emptySet());
         EasyMock.expectLastCall();
@@ -304,7 +305,8 @@ public class TaskManagerTest {
 
     @Test
     public void shouldInitializeNewStandbyTasks() {
-        standby.initializeNewTasks();
+        EasyMock.expect(standby.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
+        EasyMock.expect(active.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
         EasyMock.expect(active.updateRestored(EasyMock.<Collection<TopicPartition>>anyObject())).
                 andReturn(Collections.<TopicPartition>emptySet());
         EasyMock.expectLastCall();
@@ -316,6 +318,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldRestoreStateFromChangeLogReader() {
+        EasyMock.expect(active.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
         EasyMock.expect(changeLogReader.restore(active)).andReturn(taskId0Partitions);
         EasyMock.expect(active.updateRestored(taskId0Partitions)).
                 andReturn(Collections.<TopicPartition>emptySet());
@@ -327,6 +330,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldResumeRestoredPartitions() {
+        EasyMock.expect(active.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
         EasyMock.expect(changeLogReader.restore(active)).andReturn(taskId0Partitions);
         EasyMock.expect(active.updateRestored(taskId0Partitions)).
                 andReturn(taskId0Partitions);
@@ -350,6 +354,7 @@ public class TaskManagerTest {
 
     @Test
     public void shouldReturnFalseWhenThereAreStillNonRunningTasks() {
+        EasyMock.expect(active.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
         EasyMock.expect(active.allTasksRunning()).andReturn(false);
         EasyMock.expect(active.updateRestored(EasyMock.<Collection<TopicPartition>>anyObject())).
                 andReturn(Collections.<TopicPartition>emptySet());
@@ -449,8 +454,24 @@ public class TaskManagerTest {
         verify(active);
     }
 
+    @Test
+    public void shouldResumeConsumptionOfInitializedPartitions() {
+        final Set<TopicPartition> resumed = Collections.singleton(new TopicPartition("topic", 0));
+        EasyMock.expect(active.initializeNewTasks()).andReturn(resumed);
+        EasyMock.expect(active.updateRestored(EasyMock.<Collection<TopicPartition>>anyObject())).
+                andReturn(Collections.<TopicPartition>emptySet());
+        consumer.resume(resumed);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(active, consumer);
+
+        taskManager.updateNewAndRestoringTasks();
+        EasyMock.verify(consumer);
+    }
+
     private void mockAssignStandbyPartitions(final long offset) {
         final Task task = EasyMock.createNiceMock(Task.class);
+        EasyMock.expect(active.initializeNewTasks()).andReturn(new HashSet<TopicPartition>());
         EasyMock.expect(active.allTasksRunning()).andReturn(true);
         EasyMock.expect(active.updateRestored(EasyMock.<Collection<TopicPartition>>anyObject())).
                 andReturn(Collections.<TopicPartition>emptySet());


### PR DESCRIPTION
Stores where logging is disabled where never consumed as the partitions were paused, but never resumed.