### PR TITLE
Update docs to reflect kafka trademark status

### DIFF
--- a/docs/introduction.html
+++ b/docs/introduction.html
@@ -18,7 +18,7 @@
 <script><!--#include virtual="js/templateData.js" --></script>
 
 <script id="introduction-template" type="text/x-handlebars-template">
-  <h3> Apache Kafka&trade; is <i>a distributed streaming platform</i>. What exactly does that mean?</h3>
+  <h3> Apache Kafka&reg; is <i>a distributed streaming platform</i>. What exactly does that mean?</h3>
   <p>We think of a streaming platform as having three key capabilities:</p>
   <ol>
     <li>It lets you publish and subscribe to streams of records. In this respect it is similar to a message queue or enterprise messaging system.

--- a/docs/uses.html
+++ b/docs/uses.html
@@ -15,7 +15,7 @@
  limitations under the License.
 -->
 
-<p> Here is a description of a few of the popular use cases for Apache Kafka&trade;.
+<p> Here is a description of a few of the popular use cases for Apache Kafka&reg;.
 For an overview of a number of these areas in action, see <a href="https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying/">this blog post</a>. </p>
 
 <h4><a id="uses_messaging" href="#uses_messaging">Messaging</a></h4>


### PR DESCRIPTION
Updated a couple places in docs with the 'registered' trademark symbol.