### PR TITLE
KAFKA-6016: Make the reassign partitions system test use the idempotent producer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -58,7 +58,8 @@ public class ProducerRecord<K, V> {
      * 
      * @param topic The topic the record will be appended to
      * @param partition The partition to which the record should be sent
-     * @param timestamp The timestamp of the record, in milliseconds since epoch.
+     * @param timestamp The timestamp of the record, in milliseconds since epoch. If null, the producer will assign
+     *                  the timestamp using System.currentTimeMillis().
      * @param key The key that will be included in the record
      * @param value The record contents
      * @param headers the headers that will be included in the record
@@ -85,7 +86,8 @@ public class ProducerRecord<K, V> {
      *
      * @param topic The topic the record will be appended to
      * @param partition The partition to which the record should be sent
-     * @param timestamp The timestamp of the record
+     * @param timestamp The timestamp of the record, in milliseconds since epoch. If null, the producer will assign the
+     *                  timestamp using System.currentTimeMillis().
      * @param key The key that will be included in the record
      * @param value The record contents
      */

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -58,7 +58,7 @@ public class ProducerRecord<K, V> {
      * 
      * @param topic The topic the record will be appended to
      * @param partition The partition to which the record should be sent
-     * @param timestamp The timestamp of the record
+     * @param timestamp The timestamp of the record, in milliseconds since epoch.
      * @param key The key that will be included in the record
      * @param value The record contents
      * @param headers the headers that will be included in the record
@@ -168,7 +168,7 @@ public class ProducerRecord<K, V> {
     }
 
     /**
-     * @return The timestamp
+     * @return The timestamp, which is in milliseconds since epoch.
      */
     public Long timestamp() {
         return timestamp;

--- a/tests/kafkatest/services/kafka/config_property.py
+++ b/tests/kafkatest/services/kafka/config_property.py
@@ -33,6 +33,7 @@ NUM_RECOVERY_THREADS_PER_DATA_DIR = "num.recovery.threads.per.data.dir"
 LOG_RETENTION_HOURS = "log.retention.hours"
 LOG_SEGMENT_BYTES = "log.segment.bytes"
 LOG_RETENTION_CHECK_INTERVAL_MS = "log.retention.check.interval.ms"
+LOG_RETENTION_MS = "log.retention.ms"
 LOG_CLEANER_ENABLE = "log.cleaner.enable"
 
 AUTO_CREATE_TOPICS_ENABLE = "auto.create.topics.enable"

--- a/tests/kafkatest/services/kafka/templates/kafka.properties
+++ b/tests/kafkatest/services/kafka/templates/kafka.properties
@@ -30,7 +30,6 @@ num.partitions=1
 num.recovery.threads.per.data.dir=1
 log.retention.hours=168
 log.segment.bytes=1073741824
-log.retention.check.interval.ms=300000
 log.cleaner.enable=false
 
 security.inter.broker.protocol={{ security_config.interbroker_security_protocol }}

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -125,8 +125,8 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         producer_prop_file += "\nrequest.timeout.ms=%d\n" % (self.request_timeout_sec * 1000)
         if self.enable_idempotence:
             self.logger.info("Setting up an idempotent producer")
-            producer_prop_file += "\nmax.in.flight.requests.per.connection=1\n"
-            producer_prop_file += "\nretries=50\n"
+            producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
+            producer_prop_file += "\nretries=1000000\n"
             producer_prop_file += "\nenable.idempotence=true\n"
 
         self.logger.info("verifiable_producer.properties:")

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -56,7 +56,8 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
 
     def __init__(self, context, num_nodes, kafka, topic, max_messages=-1, throughput=100000,
                  message_validator=is_int, compression_types=None, version=DEV_BRANCH, acks=None,
-                 stop_timeout_sec=150, request_timeout_sec=30, log_level="INFO", enable_idempotence=False, offline_nodes=[]):
+                 stop_timeout_sec=150, request_timeout_sec=30, log_level="INFO",
+                 enable_idempotence=False, offline_nodes=[], create_time=-1):
         """
         :param max_messages is a number of messages to be produced per producer
         :param message_validator checks for an expected format of messages produced. There are
@@ -91,6 +92,7 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         self.request_timeout_sec = request_timeout_sec
         self.enable_idempotence = enable_idempotence
         self.offline_nodes = offline_nodes
+        self.create_time = create_time
 
     def java_class_name(self):
         return "VerifiableProducer"
@@ -125,7 +127,7 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         producer_prop_file += "\nrequest.timeout.ms=%d\n" % (self.request_timeout_sec * 1000)
         if self.enable_idempotence:
             self.logger.info("Setting up an idempotent producer")
-            producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
+            producer_prop_file += "\nmax.in.flight.requests.per.connection=2\n"
             producer_prop_file += "\nretries=1000000\n"
             producer_prop_file += "\nenable.idempotence=true\n"
 
@@ -194,6 +196,8 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
             cmd += " --value-prefix %s" % str(idx)
         if self.acks is not None:
             cmd += " --acks %s " % str(self.acks)
+        if self.create_time > -1:
+            cmd += " --message-create-time %s " % str(self.create_time)
 
         cmd += " --producer.config %s" % VerifiableProducer.CONFIG_FILE
         cmd += " 2>> %s | tee -a %s &" % (VerifiableProducer.STDOUT_CAPTURE, VerifiableProducer.STDOUT_CAPTURE)

--- a/tests/kafkatest/services/verifiable_producer.py
+++ b/tests/kafkatest/services/verifiable_producer.py
@@ -127,7 +127,7 @@ class VerifiableProducer(KafkaPathResolverMixin, VerifiableClientMixin, Backgrou
         producer_prop_file += "\nrequest.timeout.ms=%d\n" % (self.request_timeout_sec * 1000)
         if self.enable_idempotence:
             self.logger.info("Setting up an idempotent producer")
-            producer_prop_file += "\nmax.in.flight.requests.per.connection=2\n"
+            producer_prop_file += "\nmax.in.flight.requests.per.connection=5\n"
             producer_prop_file += "\nretries=1000000\n"
             producer_prop_file += "\nenable.idempotence=true\n"
 

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -149,4 +149,5 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
                                         consumer_timeout_ms=60000,
                                         message_validator=is_int)
 
+        self.enable_idempotence=True
         self.run_produce_consume_validate(core_test_action=lambda: self.reassign_partitions(bounce_brokers))

--- a/tests/kafkatest/tests/core/reassign_partitions_test.py
+++ b/tests/kafkatest/tests/core/reassign_partitions_test.py
@@ -17,6 +17,7 @@ from ducktape.mark import parametrize
 from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 
+from kafkatest.services.kafka import config_property
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
 from kafkatest.services.verifiable_producer import VerifiableProducer
@@ -42,15 +43,15 @@ class ReassignPartitionsTest(ProduceConsumeValidateTest):
         self.zk = ZookeeperService(test_context, num_nodes=1)
         self.kafka = KafkaService(test_context, num_nodes=4, zk=self.zk,
                                   server_prop_overides=[
-                                      ["log.retention.check.interval.ms", 6000],
-                                      ["log.segment.bytes", 102400]
+                                      [config_property.LOG_ROLL_TIME_MS, "4500"],
+                                      [config_property.LOG_RETENTION_CHECK_INTERVAL_MS, "5500"],
+                                      [config_property.LOG_RETENTION_MS, "5000"]
                                   ],
                                   topics={self.topic: {
                                       "partitions": self.num_partitions,
                                       "replication-factor": 3,
                                       'configs': {
                                           "min.insync.replicas": 3,
-                                          "retention.bytes": 102400,
                                       }}
                                   })
         self.timeout_sec = 60

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -80,13 +80,22 @@ public class VerifiableProducer {
     // if null, then values are produced without a prefix
     private final Integer valuePrefix;
 
-    public VerifiableProducer(KafkaProducer<String, String> producer, String topic, int throughput, int maxMessages, Integer valuePrefix) {
+    // The create time to set in messages, in milliseconds since epoch
+    private Long createTime;
+
+    private final Long startTime;
+
+    public VerifiableProducer(KafkaProducer<String, String> producer, String topic, int throughput, int maxMessages,
+                              Integer valuePrefix, Long createTime) {
 
         this.topic = topic;
         this.throughput = throughput;
         this.maxMessages = maxMessages;
         this.producer = producer;
         this.valuePrefix = valuePrefix;
+        this.createTime = createTime;
+        this.startTime = System.currentTimeMillis();
+
     }
 
     /** Get the command-line argument parser. */
@@ -144,6 +153,15 @@ public class VerifiableProducer {
                 .metavar("CONFIG_FILE")
                 .help("Producer config properties file.");
 
+        parser.addArgument("--message-create-time")
+                .action(store())
+                .required(false)
+                .setDefault(-1)
+                .type(Integer.class)
+                .metavar("CREATETIME")
+                .dest("createTime")
+                .help("Send messages with creation time starting at the arguments value, in milliseconds since epoch");
+
         parser.addArgument("--value-prefix")
             .action(store())
             .required(false)
@@ -181,6 +199,10 @@ public class VerifiableProducer {
         int throughput = res.getInt("throughput");
         String configFile = res.getString("producer.config");
         Integer valuePrefix = res.getInt("valuePrefix");
+        Long createTime = (long) res.getInt("createTime");
+
+        if (createTime == -1L)
+            createTime = null;
 
         Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, res.getString("brokerList"));
@@ -202,12 +224,14 @@ public class VerifiableProducer {
         StringSerializer serializer = new StringSerializer();
         KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps, serializer, serializer);
 
-        return new VerifiableProducer(producer, topic, throughput, maxMessages, valuePrefix);
+        return new VerifiableProducer(producer, topic, throughput, maxMessages, valuePrefix, createTime);
     }
 
     /** Produce a message with given key and value. */
     public void send(String key, String value) {
-        ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+        ProducerRecord<String, String> record = new ProducerRecord<>(topic, null, createTime, key, value);
+        if (createTime != null)
+            createTime += (System.currentTimeMillis() - startTime);
         numSent++;
         try {
             producer.send(record, new PrintInfoCallback(key, value));

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -231,7 +231,7 @@ public class VerifiableProducer {
     public void send(String key, String value) {
         ProducerRecord<String, String> record = new ProducerRecord<>(topic, null, createTime, key, value);
         if (createTime != null)
-            createTime += (System.currentTimeMillis() - startTime);
+            createTime += System.currentTimeMillis() - startTime;
         numSent++;
         try {
             producer.send(record, new PrintInfoCallback(key, value));


### PR DESCRIPTION
With these changes, we are ensuring that the partitions being reassigned are from non-zero offsets. We also ensure that every message in the log has producerId and sequence number. 

This means that it successfully reproduces https://issues.apache.org/jira/browse/KAFKA-6003, as can be seen below:

```

[2017-10-05 20:57:00,466] ERROR [ReplicaFetcher replicaId=1, leaderId=4, fetcherId=0] Error due to (kafka.server.ReplicaFetcherThread)
kafka.common.KafkaException: Error processing data for partition test_topic-16 offset 682
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2$$anonfun$apply$mcV$sp$1$$anonfun$apply$2.apply(AbstractFetcherThread.scala:203)
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2$$anonfun$apply$mcV$sp$1$$anonfun$apply$2.apply(AbstractFetcherThread.scala:171)
        at scala.Option.foreach(Option.scala:257)
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2$$anonfun$apply$mcV$sp$1.apply(AbstractFetcherThread.scala:171)
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2$$anonfun$apply$mcV$sp$1.apply(AbstractFetcherThread.scala:168)
        at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
        at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2.apply$mcV$sp(AbstractFetcherThread.scala:168)
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2.apply(AbstractFetcherThread.scala:168)
        at kafka.server.AbstractFetcherThread$$anonfun$processFetchRequest$2.apply(AbstractFetcherThread.scala:168)
        at kafka.utils.CoreUtils$.inLock(CoreUtils.scala:218)
        at kafka.server.AbstractFetcherThread.processFetchRequest(AbstractFetcherThread.scala:166)
        at kafka.server.AbstractFetcherThread.doWork(AbstractFetcherThread.scala:109)
        at kafka.utils.ShutdownableThread.run(ShutdownableThread.scala:64)
Caused by: org.apache.kafka.common.errors.UnknownProducerIdException: Found no record of producerId=1000 on the broker. It is possible that the last message with the producerId=1000 has been removed due to hitting the retention limit.
```