### PR TITLE
[MINOR] Include isolationLevel in toString of FetchRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -256,6 +256,7 @@ public class FetchRequest extends AbstractRequest {
                     append(", minBytes=").append(minBytes).
                     append(", maxBytes=").append(maxBytes).
                     append(", fetchData=").append(fetchData).
+                    append(", isolationLevel=").append(isolationLevel).
                     append(")");
             return bld.toString();
         }


### PR DESCRIPTION
Include `isolationLevel` in `toString` of `FetchRequest`

This is a follow-up to https://issues.apache.org/jira/browse/KAFKA-4818.