### PR TITLE
MINOR: Bump the request timeout for the transactional message copier

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
+++ b/tools/src/main/java/org/apache/kafka/tools/TransactionalMessageCopier.java
@@ -155,6 +155,12 @@ public class TransactionalMessageCopier {
         props.put(ProducerConfig.BATCH_SIZE_CONFIG, "512");
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "5");
 
+        // Multiple inflights means that when there are rolling bounces and other cluster instability, there is an
+        // increased likelihood of having previously tried batch expire in th accumulator. This is a fatal error
+        // for a transaction, causing the copier to exit. To work around this, we bump the request timeout.
+        // We can get rid of this when KIP-91 is merged.
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "60000");
+
         return new KafkaProducer<>(props);
     }
 


### PR DESCRIPTION
Multiple inflights means that when there are rolling bounces or other cluster instability, there is an increased likelihood of having previously tried batch expire in the accumulator. This is a fatal error
for a transactional producer, causing the `TransactionalMessageCopier` to exit. To work around this, we bump the request timeout. We can get rid of this when KIP-91 is merged.