### PR TITLE
KAFKA-6023 ThreadCache#sizeBytes() should check overflow

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -205,10 +205,6 @@ public class ThreadCache {
                 return Long.MAX_VALUE;
             }
         }
-
-        if (isOverflowing(size)) {
-            return Long.MAX_VALUE;
-        }
         return size;
     }
 
@@ -223,10 +219,6 @@ public class ThreadCache {
             if (isOverflowing(sizeInBytes)) {
                 return Long.MAX_VALUE;
             }
-        }
-
-        if (isOverflowing(sizeInBytes)) {
-            return Long.MAX_VALUE;
         }
         return sizeInBytes;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/ThreadCache.java
@@ -220,6 +220,13 @@ public class ThreadCache {
         long sizeInBytes = 0;
         for (final NamedCache namedCache : caches.values()) {
             sizeInBytes += namedCache.sizeInBytes();
+            if (isOverflowing(sizeInBytes)) {
+                return Long.MAX_VALUE;
+            }
+        }
+
+        if (isOverflowing(sizeInBytes)) {
+            return Long.MAX_VALUE;
         }
         return sizeInBytes;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -511,6 +511,16 @@ public class ThreadCacheTest {
         assertNull(threadCache.get(namespace, null));
     }
 
+    @Test
+    public void shouldTestSizeInBytes() {
+        final ThreadCache cache = new ThreadCache(logContext, 100000, new MockStreamsMetrics(new Metrics()));
+        cache.put(namespace1, Bytes.wrap(new byte[]{1}), cleanEntry(new byte[] {1}));
+        cache.put(namespace2, Bytes.wrap(new byte[]{1}), cleanEntry(new byte[] {1}));
+        assertEquals(cache.sizeBytes() + cache.size(), 2 * memoryCacheEntrySize(new byte[1], new byte[1], ""));
+        cache.close(namespace2);
+        assertEquals(cache.sizeBytes() + cache.size(), memoryCacheEntrySize(new byte[1], new byte[1], ""));
+    }
+
     private LRUCacheEntry dirtyEntry(final byte[] key) {
         return new LRUCacheEntry(key, true, -1, -1, -1, "");
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ThreadCacheTest.java
@@ -512,13 +512,11 @@ public class ThreadCacheTest {
     }
 
     @Test
-    public void shouldTestSizeInBytes() {
+    public void shouldCalculateSizeInBytes() {
         final ThreadCache cache = new ThreadCache(logContext, 100000, new MockStreamsMetrics(new Metrics()));
-        cache.put(namespace1, Bytes.wrap(new byte[]{1}), cleanEntry(new byte[] {1}));
-        cache.put(namespace2, Bytes.wrap(new byte[]{1}), cleanEntry(new byte[] {1}));
-        assertEquals(cache.sizeBytes() + cache.size(), 2 * memoryCacheEntrySize(new byte[1], new byte[1], ""));
-        cache.close(namespace2);
-        assertEquals(cache.sizeBytes() + cache.size(), memoryCacheEntrySize(new byte[1], new byte[1], ""));
+        NamedCache.LRUNode node = new NamedCache.LRUNode(Bytes.wrap(new byte[]{1}), dirtyEntry(new byte[]{0}));
+        cache.put(namespace1, Bytes.wrap(new byte[]{1}), cleanEntry(new byte[]{0}));
+        assertEquals(cache.sizeBytes(), node.size());
     }
 
     private LRUCacheEntry dirtyEntry(final byte[] key) {


### PR DESCRIPTION
    long sizeBytes() {
        long sizeInBytes = 0;
        for (final NamedCache namedCache : caches.values()) {
            sizeInBytes += namedCache.sizeInBytes();
        }
        return sizeInBytes;
    }
The summation w.r.t. sizeInBytes may overflow.
Check similar to what is done in size() should be performed.