### PR TITLE
KAFKA-6026: Fix for indefinite wait in KafkaFutureImpl

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
@@ -104,7 +104,7 @@ public class KafkaFutureImpl<T> extends KafkaFuture<T> {
                         wrapAndThrow(exception);
                     if (done)
                         return value;
-                    if (delta > waitTimeMs) {
+                    if (delta >= waitTimeMs) {
                         throw new TimeoutException();
                     }
                     this.wait(waitTimeMs - delta);

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -172,5 +173,21 @@ public class KafkaFutureTest {
         assertFalse(allFuture.isCancelled());
         assertFalse(allFuture.isCompletedExceptionally());
         allFuture.get();
+    }
+
+    @Test
+    public void testGetTimeout() throws Exception {
+        final KafkaFutureImpl<String> future = new KafkaFutureImpl<>();
+        final long waitMs = 20;
+
+        long startMs = System.currentTimeMillis();
+
+        try {
+            future.get(waitMs, TimeUnit.MILLISECONDS);
+            Assert.fail("Expected a TimeoutException");
+        } catch (TimeoutException e) {
+            long stopMs = System.currentTimeMillis();
+            assertTrue(stopMs - startMs >= waitMs);
+        }
     }
 }


### PR DESCRIPTION
Not passing 0 to wait in KafkaFuture implementation. The case where the timeout argument is 0 is already taken care of in the definition of waitTimeMs which is at least 1.
The contribution is my original work and I license the work to the project under the project's open source license