### PR TITLE
KAFKA-6041: "--producer.config" option doesn't work"

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -112,23 +112,26 @@ object ConsoleProducer {
   }
 
   def getNewProducerProps(config: ProducerConfig): Properties = {
-    val props = producerProps(config)
-
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokerList)
-    props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec)
+    //    val props = producerProps(config)
+    val props = new Properties
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokerList) 
+    props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec) 
     props.put(ProducerConfig.SEND_BUFFER_CONFIG, config.socketBuffer.toString)
     props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, config.retryBackoffMs.toString)
     props.put(ProducerConfig.METADATA_MAX_AGE_CONFIG, config.metadataExpiryMs.toString)
-    props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, config.maxBlockMs.toString)
+    props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, config.maxBlockMs.toString) 
     props.put(ProducerConfig.ACKS_CONFIG, config.requestRequiredAcks)
-    props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, config.requestTimeoutMs.toString)
+    props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, config.requestTimeoutMs.toString) 
     props.put(ProducerConfig.RETRIES_CONFIG, config.messageSendMaxRetries.toString)
-    props.put(ProducerConfig.LINGER_MS_CONFIG, config.sendTimeout.toString)
-    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, config.maxMemoryBytes.toString)
-    props.put(ProducerConfig.BATCH_SIZE_CONFIG, config.maxPartitionMemoryBytes.toString)
+    props.put(ProducerConfig.LINGER_MS_CONFIG, config.sendTimeout.toString) 
+    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, config.maxMemoryBytes.toString) 
+    props.put(ProducerConfig.BATCH_SIZE_CONFIG, config.maxPartitionMemoryBytes.toString) 
     props.put(ProducerConfig.CLIENT_ID_CONFIG, "console-producer")
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer")
+
+    val propsConfig = producerProps(config)
+    props ++= propsConfig
 
     props
   }

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -112,7 +112,6 @@ object ConsoleProducer {
   }
 
   def getNewProducerProps(config: ProducerConfig): Properties = {
-    //    val props = producerProps(config)
     val props = new Properties
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, config.brokerList) 
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, config.compressionCodec) 


### PR DESCRIPTION
The configured parameters in the config\producer.properties file will be overwritten by the parameter default values.

For example:

//modify the config\producer.properties file:
bootstrap.servers=kafkahost:9092
linger.ms=2000
batch.size=1024

//excute the bin\Kafka-console-producer.sh 
bin\Kafka-console-producer --topic test --producer.config config/producer.properties

//while excuting the ConsoleProducer Class, the batch.size is set  to 200, the linger.ms is set to 1000, the bootstrap.servers is set to localhost:9092. 


The correct way is to overwrite the default parameters values by configured values.