### PR TITLE
KAFKA-6032: Unit Tests should be independent of locale settings

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Shell.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Shell.java
@@ -78,7 +78,11 @@ abstract public class Shell {
 
     /** Run a command */
     private void runCommand() throws IOException {
+
         ProcessBuilder builder = new ProcessBuilder(execString());
+        // Ensure that all shell tests will pass on any machine, as the only way to
+        // check a success is by checking the result text.
+        builder.environment().put("LANGUAGE", "en_US");
         Timer timeoutTimer = null;
         completed = new AtomicBoolean(false);
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -45,6 +45,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,6 +54,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -65,8 +67,12 @@ public class Utils {
     // IPv6 is supported with [ip] pattern
     private static final Pattern HOST_PORT_PATTERN = Pattern.compile(".*?\\[?([0-9a-zA-Z\\-%._:]*)\\]?:([0-9]+)");
 
+    // Set up the locale used to generated a human readable printing of digits
+    private static final DecimalFormatSymbols DECIMAL_FORMAT = DecimalFormatSymbols.getInstance(Locale.US);
+
     // Prints up to 2 decimal digits. Used for human readable printing
-    private static final DecimalFormat TWO_DIGIT_FORMAT = new DecimalFormat("0.##");
+    private static final DecimalFormat TWO_DIGIT_FORMAT = new DecimalFormat("0.##", DECIMAL_FORMAT);
+
 
     private static final String[] BYTE_SCALE_SUFFIXES = new String[] {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/ShellTest.java
@@ -51,17 +51,21 @@ public class ShellTest {
     @Test
     public void testAttemptToRunNonExistentProgram() throws Exception {
         assumeTrue(!OperatingSystem.IS_WINDOWS);
+
         try {
             Shell.execCommand(NONEXISTENT_PATH);
             fail("Expected to get an exception when trying to run a program that does not exist");
         } catch (IOException e) {
-            assertTrue(e.getMessage().contains("No such file"));
+            String message = e.getMessage();
+            assertTrue("Unexpected error message '" + message + "'",
+                    message.contains("No such file") || message.contains("error=2"));
         }
     }
 
     @Test
     public void testRunProgramWithErrorReturn() throws Exception {
         assumeTrue(!OperatingSystem.IS_WINDOWS);
+
         try {
             Shell.execCommand("head", "-c", "0", NONEXISTENT_PATH);
             fail("Expected to get an exception when trying to head a nonexistent file");


### PR DESCRIPTION
Allows to run the tests on linux servers without needing the locale set to US.