### PR TITLE
MINOR: Use OS-assigned port, in case 9092 is already bound

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -57,7 +57,7 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         // expiration of connections by the brokers to avoid errors when `AdminClient` sends requests after potentially
         // very long sleep times
         props.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
-        props.put(KafkaConfig$.MODULE$.ListenersProp(), "SSL://localhost:9092");
+        props.put(KafkaConfig$.MODULE$.ListenersProp(), "SSL://localhost:0");
         props.put(KafkaConfig$.MODULE$.InterBrokerListenerNameProp(), "SSL");
         props.putAll(sslConfig);
         // we align time to seconds to get clean window boundaries and thus ensure the same result for each run


### PR DESCRIPTION
I found this by running the tests while I happened to have a kafka broker running.

@mjsax please could you review?