### PR TITLE
MINOR: Don't register signal handlers if running on Windows

### DIFF
--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -18,6 +18,7 @@
 package kafka
 
 import java.util.Properties
+import java.util.concurrent.ConcurrentHashMap
 
 import sun.misc.{Signal, SignalHandler}
 import joptsimple.OptionParser
@@ -26,7 +27,6 @@ import kafka.server.{KafkaServer, KafkaServerStartable}
 import kafka.utils.{CommandLineUtils, Exit, Logging}
 import org.apache.kafka.common.utils.{OperatingSystem, Utils}
 
-import scala.collection.mutable
 import scala.collection.JavaConverters._
 
 object Kafka extends Logging {
@@ -56,7 +56,7 @@ object Kafka extends Logging {
   }
 
   private def registerLoggingSignalHandler(): Unit = {
-    val jvmSignalHandlers = mutable.Map[String, SignalHandler]()
+    val jvmSignalHandlers = new ConcurrentHashMap[String, SignalHandler]().asScala
     val handler = new SignalHandler() {
       override def handle(signal: Signal) {
         info(s"Terminating process due to signal $signal")

--- a/core/src/main/scala/kafka/Kafka.scala
+++ b/core/src/main/scala/kafka/Kafka.scala
@@ -18,13 +18,13 @@
 package kafka
 
 import java.util.Properties
-import sun.misc.{Signal, SignalHandler}
 
+import sun.misc.{Signal, SignalHandler}
 import joptsimple.OptionParser
 import kafka.utils.Implicits._
 import kafka.server.{KafkaServer, KafkaServerStartable}
 import kafka.utils.{CommandLineUtils, Exit, Logging}
-import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.utils.{OperatingSystem, Utils}
 
 import scala.collection.mutable
 import scala.collection.JavaConverters._
@@ -68,9 +68,12 @@ object Kafka extends Logging {
       if (oldHandler != null)
         jvmSignalHandlers.put(signalName, oldHandler)
     }
-    registerHandler("TERM")
-    registerHandler("INT")
-    registerHandler("HUP")
+
+    if (!OperatingSystem.IS_WINDOWS) {
+      registerHandler("TERM")
+      registerHandler("INT")
+      registerHandler("HUP")
+    }
   }
 
   def main(args: Array[String]): Unit = {

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -238,7 +238,6 @@ class LogTest {
 
             override def read(startOffset: Long, maxOffset: Option[Long], maxSize: Int, maxPosition: Long,
                               minOneMessage: Boolean): FetchDataInfo = {
-              new Exception().printStackTrace()
               segmentsWithReads += this
               super.read(startOffset, maxOffset, maxSize, maxPosition, minOneMessage)
             }


### PR DESCRIPTION
The following happens on Windows for `HUP`:

[2017-10-11 21:45:11,642] FATAL  (kafka.Kafka$)
java.lang.IllegalArgumentException: Unknown signal: HUP
        at sun.misc.Signal.<init>(Unknown Source)
        at kafka.Kafka$.registerHandler$1(Kafka.scala:67)
        at kafka.Kafka$.registerLoggingSignalHandler(Kafka.scala:73)
        at kafka.Kafka$.main(Kafka.scala:82)
        at kafka.Kafka.main(Kafka.scala)

I thought it was safer not to register them at all since the additional
logging is a nice to have and we haven't tested it on Windows.

Also changed map to be concurrent and removed stray
printStackTrace in test.