### PR TITLE
KAFKA-6057: Users forget `--execute` in the offset reset tool

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -78,7 +78,7 @@ object ConsumerGroupCommand extends Logging {
       else if (opts.options.has(opts.deleteOpt))
         consumerGroupService.deleteGroups()
       else if (opts.options.has(opts.resetOffsetsOpt)) {
-        if(!opts.options.has(opts.executeOpt))
+        if (!opts.options.has(opts.executeOpt))
           System.err.println("Warning: No action will be performed as argument \"" + opts.executeOpt + "\" is missing.")
 
         val offsetsToReset = consumerGroupService.resetOffsets()

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -78,9 +78,6 @@ object ConsumerGroupCommand extends Logging {
       else if (opts.options.has(opts.deleteOpt))
         consumerGroupService.deleteGroups()
       else if (opts.options.has(opts.resetOffsetsOpt)) {
-        if (!opts.options.has(opts.executeOpt))
-          System.err.println("Warning: No action will be performed as argument \"" + opts.executeOpt + "\" is missing.")
-
         val offsetsToReset = consumerGroupService.resetOffsets()
         if (opts.options.has(opts.exportOpt)) {
           val exported = consumerGroupService.exportOffsetsToReset(offsetsToReset)
@@ -1036,15 +1033,15 @@ object ConsumerGroupCommand extends Logging {
         CommandLineUtils.printUsageAndDie(parser, s"Option $deleteOpt either takes $groupOpt, $topicOpt, or both")
 
       if (options.has(resetOffsetsOpt)) {
-        if (!options.has(dryRunOpt) && !options.has(executeOpt)) {
-          Console.err.println("WARN: In a future major release, the default behavior of this command will be to " +
-            "prompt the user before executing the reset rather than doing a dry run. You should add the --dry-run " +
-            "option explicitly if you are scripting this command and want to keep the current default behavior " +
-            "without prompting.")
-        }
-
         if (options.has(dryRunOpt) && options.has(executeOpt))
           CommandLineUtils.printUsageAndDie(parser, s"Option $resetOffsetsOpt only accepts one of $executeOpt and $dryRunOpt")
+
+        if (!options.has(dryRunOpt) && !options.has(executeOpt)) {
+          Console.err.println("WARN: No action will be performed as the --execute option is missing." +
+            "In a future major release, the default behavior of this command will be to prompt the user before " +
+            "executing the reset rather than doing a dry run. You should add the --dry-run option explicitly " +
+            "if you are scripting this command and want to keep the current default behavior without prompting.")
+        }
 
         CommandLineUtils.checkRequiredArgs(parser, options, groupOpt)
         CommandLineUtils.checkInvalidArgs(parser, options, resetToOffsetOpt, allResetOffsetScenarioOpts - resetToOffsetOpt)

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -78,6 +78,9 @@ object ConsumerGroupCommand extends Logging {
       else if (opts.options.has(opts.deleteOpt))
         consumerGroupService.deleteGroups()
       else if (opts.options.has(opts.resetOffsetsOpt)) {
+        if(!opts.options.has(opts.executeOpt))
+          System.err.println("Warning: No action will be performed as argument \"" + opts.executeOpt + "\" is missing.")
+
         val offsetsToReset = consumerGroupService.resetOffsets()
         if (opts.options.has(opts.exportOpt)) {
           val exported = consumerGroupService.exportOffsetsToReset(offsetsToReset)


### PR DESCRIPTION
Add a small warning note when the user does not use the --execute flag.