### PR TITLE
MINOR: reduce partition state machine debug logging

### DIFF
--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -323,7 +323,7 @@ class PartitionStateMachine(controller: KafkaController, stateChangeLogger: Stat
         stateChangeLog.error(failMsg)
         throw new StateChangeFailedException(stateChangeLog.messageWithPrefix(failMsg), sce)
     }
-    debug(s"After leader election, leader cache is updated to ${controllerContext.partitionLeadershipInfo}")
+    debug(s"After leader election, leader cache for $topicAndPartition is updated to ${controllerContext.partitionLeadershipInfo(topicAndPartition)}")
   }
 
   private def getLeaderIsrAndEpochOrThrowException(topic: String, partition: Int): LeaderIsrAndControllerEpoch = {


### PR DESCRIPTION
PartitionStateMachine.electLeaderForPartition logs all partition states in the cluster. This leads to quadratic logging behavior since PartitionStateMachine.electLeaderForPartition itself gets called on a per-partition basis.

This patch reduces the logging so that only the single partition undergoing leader election gets its state logged.