### PR TITLE
MINOR: Improve a Windows quickstart instruction

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -186,9 +186,10 @@ my test message 2
 
 On Windows use:
 <pre class="brush: bash;">
-&gt; wmic process get processid,caption,commandline | find "java.exe" | find "server-1.properties"
-java.exe    java  -Xmx1G -Xms1G -server -XX:+UseG1GC ... build\libs\kafka_2.11-{{fullDotVersion}}.jar"  kafka.Kafka config\server-1.properties    644
-&gt; taskkill /pid 644 /f
+&gt; wmic process where "caption = 'java.exe' and commandline like '%server-1.properties%'" get processid
+ProcessId
+6016
+&gt; taskkill /pid 6016 /f
 </pre>
 
 <p>Leadership has switched to one of the slaves and node 1 is no longer in the in-sync replica set:</p>


### PR DESCRIPTION
The output of `wmic` can be very long and could truncate the search keywords in the existing command. If those keywords are truncated no process is returned in the output. An update is suggested to the command by which the query is performed inside the `wmic` command itself instead of using pipes and `find`.