### PR TITLE
MINOR: Correct KafkaProducer Javadoc spelling of property 'max.in.flight.requests.per.connection'

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -151,7 +151,7 @@ import static org.apache.kafka.common.serialization.ExtendedSerializer.Wrapper.e
  * <p>
  * To enable idempotence, the <code>enable.idempotence</code> configuration must be set to true. If set, the
  * <code>retries</code> config will be defaulted to <code>Integer.MAX_VALUE</code>, the
- * <code>max.inflight.requests.per.connection</code> config will be defaulted to <code>1</code>,
+ * <code>max.in.flight.requests.per.connection</code> config will be defaulted to <code>1</code>,
  * and <code>acks</code> config will be defaulted to <code>all</code>. There are no API changes for the idempotent
  * producer, so existing applications will not need to be modified to take advantage of this feature.
  * </p>


### PR DESCRIPTION
Currently, in branches _trunk_, _0.11.0_, and _1.0_ the property **max.in.flight.requests.per.connection** is incorrectly misspelled as _max.inflight.requests.per.connection_

@harshach @ijuma @guozhangwang can you please review. Thank you.
