### PR TITLE
KAFKA-6101 Reconnecting to broker does not exponentially backoff

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -19,8 +19,6 @@ package org.apache.kafka.clients;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.kafka.common.errors.AuthenticationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +28,6 @@ import java.util.Map;
  *
  */
 final class ClusterConnectionStates {
-    private static final Logger log = LoggerFactory.getLogger(ClusterConnectionStates.class);
     private final long reconnectBackoffInitMs;
     private final long reconnectBackoffMaxMs;
     private final static int RECONNECT_BACKOFF_EXP_BASE = 2;

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -110,9 +110,9 @@ final class ClusterConnectionStates {
      */
     public void connecting(String id, long now) {
         if (nodeState.containsKey(id)) {
-          NodeConnectionState node = nodeState.get(id);
-          node.lastConnectAttemptMs = now;
-          node.state = ConnectionState.CONNECTING;
+            NodeConnectionState node = nodeState.get(id);
+            node.lastConnectAttemptMs = now;
+            node.state = ConnectionState.CONNECTING;
         } else {
             nodeState.put(id, new NodeConnectionState(ConnectionState.CONNECTING, now,
                 this.reconnectBackoffInitMs));

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -18,10 +18,7 @@
 package org.apache.kafka.clients;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
-import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.utils.MockTime;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,15 +42,17 @@ public class ClusterConnectionStatesTest {
     @Test
     public void testExponentialReconnectBackoff() {
         // Calculate fixed components for backoff process
-        int RECONNECT_BACKOFF_EXP_BASE = 2;
-        double reconnectBackoffMaxExp = Math.log(reconnectBackoffMaxTest / (double) Math.max(reconnectBackoffMsTest, 1)) / Math.log(RECONNECT_BACKOFF_EXP_BASE);
+        final int reconnectBackoffExpBase = 2;
+        double reconnectBackoffMaxExp = Math.log(reconnectBackoffMaxTest / (double) Math.max(reconnectBackoffMsTest, 1))
+            / Math.log(reconnectBackoffExpBase);
 
         // Run through 10 disconnects and check that reconnect backoff value is within expected range for every attempt
         for (int i = 0; i < 10; i++) {
             connectionStates.connecting(nodeId1, time.milliseconds());
             connectionStates.disconnected(nodeId1, time.milliseconds());
             // Calculate expected backoff value without jitter
-            long expectedBackoff = Math.round(Math.pow(RECONNECT_BACKOFF_EXP_BASE, Math.min(i, reconnectBackoffMaxExp)) * reconnectBackoffMsTest);
+            long expectedBackoff = Math.round(Math.pow(reconnectBackoffExpBase, Math.min(i, reconnectBackoffMaxExp))
+                * reconnectBackoffMsTest);
             long currentBackoff = connectionStates.connectionDelay(nodeId1, time.milliseconds());
             assertEquals(expectedBackoff, currentBackoff, reconnectBackoffJitter * expectedBackoff);
             time.sleep(connectionStates.connectionDelay(nodeId1, time.milliseconds()) + 1);

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClusterConnectionStatesTest {
+    protected final MockTime time = new MockTime();
+    protected final long reconnectBackoffMsTest = 10 * 1000;
+    protected final long reconnectBackoffMaxTest = 60 * 1000;
+    protected final double reconnectBackoffJitter = 0.2;
+    private final String nodeId = "1001";
+
+    private ClusterConnectionStates connectionStates;
+
+    @Before
+    public void setup() {
+        this.connectionStates = new ClusterConnectionStates(reconnectBackoffMsTest, reconnectBackoffMaxTest);
+    }
+
+    @Test
+    public void testMaxReconnectBackoff() {
+        Long effectiveMaxReconnectBackoff = Math.round(reconnectBackoffMaxTest * (1 + reconnectBackoffJitter));
+        connectionStates.connecting(nodeId, time.milliseconds());
+        time.sleep(1000);
+        connectionStates.disconnected(nodeId, time.milliseconds());
+
+        // Do 100 reconnect attempts and check that MaxReconnectBackoff (plus jitter) is not exceeded
+        for (int i = 0; i < 100; i++) {
+            long reconnectBackoff = connectionStates.connectionDelay(nodeId, time.milliseconds());
+            assertTrue("Expected reconnect backoff to be below 'reconnect.backoff.max.ms' (with 20% jitter).", reconnectBackoff <= effectiveMaxReconnectBackoff);
+            assertFalse("Expected connection to be blocked immediately after disconnect.", connectionStates.canConnect(nodeId, time.milliseconds()));
+            time.sleep(reconnectBackoff + 1);
+            assertTrue("Expected connection to be ready for reconnect after waiting for backoff time to pass.", connectionStates.canConnect(nodeId, time.milliseconds()));
+            connectionStates.connecting(nodeId, time.milliseconds());
+            time.sleep(10);
+            connectionStates.disconnected(nodeId, time.milliseconds());
+        }
+    }
+}


### PR DESCRIPTION
For reconnection, share the nodeState if one exists.
Only update its state and lastConnectAttemptMs.