### PR TITLE
KAFKA-6024 - Move validation in KafkaConsumer ahead of acquireAndEnsu…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -954,11 +954,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      */
     @Override
     public void subscribe(Pattern pattern, ConsumerRebalanceListener listener) {
-        acquireAndEnsureOpen();
         try {
             if (pattern == null)
                 throw new IllegalArgumentException("Topic pattern to subscribe to cannot be null");
 
+            acquireAndEnsureOpen();
             throwIfNoAssignorsConfigured();
 
             log.debug("Subscribed to pattern: {}", pattern);
@@ -1322,12 +1322,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      */
     @Override
     public void seek(TopicPartition partition, long offset) {
-        acquireAndEnsureOpen();
         try {
             if (offset < 0)
                 throw new IllegalArgumentException("seek offset must not be a negative number");
-
             log.debug("Seeking to offset {} for partition {}", offset, partition);
+            acquireAndEnsureOpen();
             this.subscriptions.seek(partition, offset);
         } finally {
             release();
@@ -1342,11 +1341,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @throws IllegalArgumentException if {@code partitions} is {@code null} or the provided TopicPartition is not assigned to this consumer
      */
     public void seekToBeginning(Collection<TopicPartition> partitions) {
-        acquireAndEnsureOpen();
         try {
             if (partitions == null) {
                 throw new IllegalArgumentException("Partitions collection cannot be null");
             }
+            acquireAndEnsureOpen();
             Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
             for (TopicPartition tp : parts) {
                 log.debug("Seeking to beginning of partition {}", tp);
@@ -1368,11 +1367,11 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * @throws IllegalArgumentException if {@code partitions} is {@code null} or the provided TopicPartition is not assigned to this consumer
      */
     public void seekToEnd(Collection<TopicPartition> partitions) {
-        acquireAndEnsureOpen();
         try {
             if (partitions == null) {
                 throw new IllegalArgumentException("Partitions collection cannot be null");
             }
+            acquireAndEnsureOpen();
             Collection<TopicPartition> parts = partitions.size() == 0 ? this.subscriptions.assignedPartitions() : partitions;
             for (TopicPartition tp : parts) {
                 log.debug("Seeking to end of partition {}", tp);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -958,8 +958,8 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
             if (pattern == null)
                 throw new IllegalArgumentException("Topic pattern to subscribe to cannot be null");
 
-            acquireAndEnsureOpen();
             throwIfNoAssignorsConfigured();
+            acquireAndEnsureOpen();
 
             log.debug("Subscribed to pattern: {}", pattern);
             this.subscriptions.subscribe(pattern, listener);


### PR DESCRIPTION
In several methods, parameter validation is done after calling acquireAndEnsureOpen() in Kafka Consumer :

    public void seek(TopicPartition partition, long offset) {
        acquireAndEnsureOpen();
        try {
            if (offset < 0)
                throw new IllegalArgumentException("seek offset must not be a negative number");

Since the value of parameter would not change per invocation, it seems performing validation ahead of acquireAndEnsureOpen() call would be better.
