### PR TITLE
MINOR: Changed visibility of methods in ClusterConnectionStates to private

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -199,7 +199,7 @@ final class ClusterConnectionStates {
      *
      * @param nodeState The node state object to update
      */
-    public void resetReconnectBackoff(NodeConnectionState nodeState) {
+    private void resetReconnectBackoff(NodeConnectionState nodeState) {
         nodeState.failedAttempts = 0;
         nodeState.reconnectBackoffMs = this.reconnectBackoffInitMs;
     }
@@ -211,7 +211,7 @@ final class ClusterConnectionStates {
      *
      * @param nodeState The node state object to update
      */
-    public void updateReconnectBackoff(NodeConnectionState nodeState) {
+    private void updateReconnectBackoff(NodeConnectionState nodeState) {
         if (this.reconnectBackoffMaxMs > this.reconnectBackoffInitMs) {
             nodeState.failedAttempts += 1;
             double backoffExp = Math.min(nodeState.failedAttempts - 1, this.reconnectBackoffMaxExp);


### PR DESCRIPTION
The methods resetReconnectBackoff and updateReconnectBackoff in ClusterConnectionStates both take an instance of a private inner class as parameter and thus cannot be called from outside the class anyway.