### PR TITLE
Make CONSOLE_OUTPUT_FILE configurable

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -244,7 +244,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ "CONSOLE_OUTPUT_FILE" = "x" ]; then 
+if [ -z "{$CONSOLE_OUTPUT_FILE+x}" ]; then
   CONSOLE_OUTPUT_FILE=$LOG_DIR/$DAEMON_NAME.out
 fi
  

--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -226,7 +226,6 @@ while [ $# -gt 0 ]; do
   case $COMMAND in
     -name)
       DAEMON_NAME=$2
-      CONSOLE_OUTPUT_FILE=$LOG_DIR/$DAEMON_NAME.out
       shift 2
       ;;
     -loggc)
@@ -245,6 +244,10 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "CONSOLE_OUTPUT_FILE" = "x" ]; then 
+  CONSOLE_OUTPUT_FILE=$LOG_DIR/$DAEMON_NAME.out
+fi
+ 
 # GC options
 GC_FILE_SUFFIX='-gc.log'
 GC_LOG_FILE_NAME=''


### PR DESCRIPTION
Even if Kafka is not configured without the console appender the CONSOLE_OUTPUT_FILE is generated. Allowing for this to be configurable offers more flexibility including redirecting `nohup.out` or the resulting redirect to `/dev/null`