### PR TITLE
MINOR use proper template classes for internalSelectKey()

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -154,7 +154,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
                 new KeyValueMapper<K, V, KeyValue<K1, V>>() {
                     @Override
                     public KeyValue<K1, V> apply(K key, V value) {
-                        return new KeyValue<>(mapper.apply(key, value), value);
+                        return new KeyValue<K1, V>(mapper.apply(key, value), value);
                     }
                 }
             ),


### PR DESCRIPTION
As pointed out in this thread: http://search-hadoop.com/m/Kafka/uyzND1fy2K7I85G1?subj=Kafka+source+code+Build+Error , Eclipse shows syntax error for the following:
```
                        return new KeyValue<>(mapper.apply(key, value), value);
```