### PR TITLE
Remove maven central repository, use only jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenCentral()
     jcenter()
   }
   apply from: file('gradle/buildscript.gradle'), to: buildscript
@@ -37,7 +36,7 @@ apply from: "$rootDir/gradle/dependencies.gradle"
 allprojects {
 
   repositories {
-    mavenCentral()
+    jcenter()
   }
   
   apply plugin: 'idea'


### PR DESCRIPTION
jcenter is a super set on top of maven central, so having both of those repositories is redundant, and the preferred one should be jcenter.