### PR TITLE
KAFKA-6075 Kafka cannot recover after an unclean shutdown

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -274,20 +274,20 @@ class Log(@volatile var dir: File,
       val filename = file.getName
       if (filename.endsWith(DeletedFileSuffix) || filename.endsWith(CleanedFileSuffix)) {
         // if the file ends in .deleted or .cleaned, delete it
-        Files.deleteIfExists(file.toPath)
+        Files.delete(file.toPath)
       } else if(filename.endsWith(SwapFileSuffix)) {
         // we crashed in the middle of a swap operation, to recover:
         // if a log, delete the .index file, complete the swap operation later
         // if an index just delete it, it will be rebuilt
         val baseFile = new File(CoreUtils.replaceSuffix(file.getPath, SwapFileSuffix, ""))
         if (isIndexFile(baseFile)) {
-          Files.deleteIfExists(file.toPath)
+          Files.delete(file.toPath)
         } else if (isLogFile(baseFile)) {
           // delete the index files
           val offset = offsetFromFile(baseFile)
-          Files.deleteIfExists(Log.offsetIndexFile(dir, offset).toPath)
-          Files.deleteIfExists(Log.timeIndexFile(dir, offset).toPath)
-          Files.deleteIfExists(Log.transactionIndexFile(dir, offset).toPath)
+          Files.delete(Log.offsetIndexFile(dir, offset).toPath)
+          Files.delete(Log.timeIndexFile(dir, offset).toPath)
+          Files.delete(Log.transactionIndexFile(dir, offset).toPath)
           swapFiles += file
         }
       }
@@ -306,7 +306,7 @@ class Log(@volatile var dir: File,
         val logFile = Log.logFile(dir, offset)
         if (!logFile.exists) {
           warn("Found an orphaned index file, %s, with no corresponding log file.".format(file.getAbsolutePath))
-          Files.deleteIfExists(file.toPath)
+          Files.delete(file.toPath)
         }
       } else if (isLogFile(file)) {
         // if it's a log file, load the corresponding log segment
@@ -337,7 +337,7 @@ class Log(@volatile var dir: File,
             case e: java.lang.IllegalArgumentException =>
               warn(s"Found a corrupted index file due to ${e.getMessage}}. deleting ${timeIndexFile.getAbsolutePath}, " +
                 s"${indexFile.getAbsolutePath}, and ${txnIndexFile.getAbsolutePath} and rebuilding index...")
-              Files.deleteIfExists(timeIndexFile.toPath)
+              Files.delete(timeIndexFile.toPath)
               Files.delete(indexFile.toPath)
               segment.txnIndex.delete()
               recoverSegment(segment)

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -274,20 +274,20 @@ class Log(@volatile var dir: File,
       val filename = file.getName
       if (filename.endsWith(DeletedFileSuffix) || filename.endsWith(CleanedFileSuffix)) {
         // if the file ends in .deleted or .cleaned, delete it
-        Files.delete(file.toPath)
+        file.delete()
       } else if(filename.endsWith(SwapFileSuffix)) {
         // we crashed in the middle of a swap operation, to recover:
         // if a log, delete the .index file, complete the swap operation later
         // if an index just delete it, it will be rebuilt
         val baseFile = new File(CoreUtils.replaceSuffix(file.getPath, SwapFileSuffix, ""))
         if (isIndexFile(baseFile)) {
-          Files.delete(file.toPath)
+          file.delete()
         } else if (isLogFile(baseFile)) {
           // delete the index files
           val offset = offsetFromFile(baseFile)
-          Files.delete(Log.offsetIndexFile(dir, offset).toPath)
-          Files.delete(Log.timeIndexFile(dir, offset).toPath)
-          Files.delete(Log.transactionIndexFile(dir, offset).toPath)
+          Log.offsetIndexFile(dir, offset).delete
+          Log.timeIndexFile(dir, offset).delete
+          Log.transactionIndexFile(dir, offset).delete
           swapFiles += file
         }
       }
@@ -306,7 +306,7 @@ class Log(@volatile var dir: File,
         val logFile = Log.logFile(dir, offset)
         if (!logFile.exists) {
           warn("Found an orphaned index file, %s, with no corresponding log file.".format(file.getAbsolutePath))
-          Files.delete(file.toPath)
+          file.delete()
         }
       } else if (isLogFile(file)) {
         // if it's a log file, load the corresponding log segment
@@ -337,8 +337,8 @@ class Log(@volatile var dir: File,
             case e: java.lang.IllegalArgumentException =>
               warn(s"Found a corrupted index file due to ${e.getMessage}}. deleting ${timeIndexFile.getAbsolutePath}, " +
                 s"${indexFile.getAbsolutePath}, and ${txnIndexFile.getAbsolutePath} and rebuilding index...")
-              Files.delete(timeIndexFile.toPath)
-              Files.delete(indexFile.toPath)
+              timeIndexFile.delete()
+              indexFile.delete()
               segment.txnIndex.delete()
               recoverSegment(segment)
           }

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -56,7 +56,10 @@ class BrokerMetadataCheckpoint(val file: File) extends Logging {
   }
 
   def read(): Option[BrokerMetadata] = {
-    new File(file + ".tmp").delete() // try to delete any existing temp files for cleanliness
+    // try to delete any existing temp files for cleanliness
+    val f = new File(file + ".tmp")
+    if (!f.delete())
+      info(s"File ${f.getAbsolutePath} not deleted")
 
     lock synchronized {
       try {

--- a/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
+++ b/core/src/main/scala/kafka/server/BrokerMetadataCheckpoint.scala
@@ -56,7 +56,7 @@ class BrokerMetadataCheckpoint(val file: File) extends Logging {
   }
 
   def read(): Option[BrokerMetadata] = {
-    Files.deleteIfExists(new File(file + ".tmp").toPath()) // try to delete any existing temp files for cleanliness
+    new File(file + ".tmp").delete() // try to delete any existing temp files for cleanliness
 
     lock synchronized {
       try {


### PR DESCRIPTION
As Vahid commented, Files.deleteIfExists(file.toPath) seems to destabilize Windows environment.

This PR reverts to calling delete() directly.