### PR TITLE
KAFKA-6134: Read partition reassignment lazily on event handling

### DIFF
--- a/core/src/main/scala/kafka/utils/ZkUtils.scala
+++ b/core/src/main/scala/kafka/utils/ZkUtils.scala
@@ -800,7 +800,7 @@ class ZkUtils(zkClientWrap: ZooKeeperClientWrapper,
     jsonPartitionMapOpt match {
       case Some(jsonPartitionMap) =>
         val reassignedPartitions = parsePartitionReassignmentData(jsonPartitionMap)
-        reassignedPartitions.map(p => p._1 -> new ReassignedPartitionsContext(p._2))
+        reassignedPartitions.map(p => p._1 -> ReassignedPartitionsContext(p._2))
       case None => Map.empty[TopicAndPartition, ReassignedPartitionsContext]
     }
   }


### PR DESCRIPTION
This patch prevents an O(n^2) increase in memory utilization during partition reassignment. Instead of storing the reassigned partitions in the `PartitionReassignment` object (which is added after ever individual partition reassignment), we read the data fresh from ZK when processing the event.