### PR TITLE
MINOR: Use Scala Future in CoreUtils test

### DIFF
--- a/core/src/main/scala/kafka/utils/CoreUtils.scala
+++ b/core/src/main/scala/kafka/utils/CoreUtils.scala
@@ -309,6 +309,10 @@ object CoreUtils extends Logging {
    * keys often exist in the map, avoiding the need to create a new value. `createValue`
    * may be invoked more than once if multiple threads attempt to insert a key at the same
    * time, but the same inserted value will be returned to all threads.
+   *
+   * In Scala 2.12, `ConcurrentMap.getOrElse` has the same behaviour as this method, but that
+   * is not the case in Scala 2.11. We can remove this method once we drop support for Scala
+   * 2.11.
    */
   def atomicGetOrUpdate[K, V](map: concurrent.Map[K, V], key: K, createValue: => V): V = {
     map.get(key) match {

--- a/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
@@ -192,7 +192,7 @@ class CoreUtilsTest extends JUnitSuite {
     val map = new ConcurrentHashMap[Int, AtomicInteger]().asScala
     implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(nThreads))
     try {
-      Await.ready(Future.traverse(1 to count) { i =>
+      Await.result(Future.traverse(1 to count) { i =>
         Future {
           CoreUtils.atomicGetOrUpdate(map, 0, {
             createdCount.incrementAndGet

--- a/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/CoreUtilsTest.scala
@@ -18,7 +18,7 @@
 package kafka.utils
 
 import java.util.{Arrays, UUID}
-import java.util.concurrent.{ ConcurrentHashMap, Executors }
+import java.util.concurrent.{ConcurrentHashMap, Executors, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.ReentrantLock
 import java.nio.ByteBuffer
@@ -33,10 +33,12 @@ import org.junit.Test
 import org.apache.kafka.common.utils.{Base64, Utils}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 
-class UtilsTest extends JUnitSuite {
+class CoreUtilsTest extends JUnitSuite {
 
-  private val logger = Logger.getLogger(classOf[UtilsTest])
+  private val logger = Logger.getLogger(classOf[CoreUtilsTest])
   val clusterIdPattern = Pattern.compile("[a-zA-Z0-9_\\-]+")
 
   @Test
@@ -183,31 +185,26 @@ class UtilsTest extends JUnitSuite {
   }
 
   @Test
-  def testGetOrElseUpdateAtomically(): Unit = {
+  def testAtomicGetOrUpdate(): Unit = {
     val count = 1000
     val nThreads = 5
     val createdCount = new AtomicInteger
     val map = new ConcurrentHashMap[Int, AtomicInteger]().asScala
-    val executor = Executors.newFixedThreadPool(nThreads)
+    implicit val executionContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(nThreads))
     try {
-      for (i <- 1 to count) {
-        executor.submit(new Runnable() {
-          def run() {
-            CoreUtils.atomicGetOrUpdate(map, 0, {
-              createdCount.incrementAndGet
-              new AtomicInteger
-            }).incrementAndGet()
-          }
-        })
-      }
-      executor.shutdown()
-      executor.awaitTermination(1000, java.util.concurrent.TimeUnit.MILLISECONDS)
-
+      Await.ready(Future.traverse(1 to count) { i =>
+        Future {
+          CoreUtils.atomicGetOrUpdate(map, 0, {
+            createdCount.incrementAndGet
+            new AtomicInteger
+          }).incrementAndGet()
+        }
+      }, Duration(1, TimeUnit.MINUTES))
       assertEquals(count, map(0).get)
       val created = createdCount.get
       assertTrue(s"Too many creations $created", created > 0 && created <= nThreads)
     } finally {
-      executor.shutdownNow()
+      executionContext.shutdownNow()
     }
   }
 }


### PR DESCRIPTION
Also rename UtilsTest to CoreUtilsTest and note
that `getOrElseUpdate` has the right behaviour
in Scala 2.12.