### PR TITLE
MINOR: PartitionReassignmentHandler should only generate event when znode is created

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -1456,6 +1456,9 @@ class TopicDeletionHandler(controller: KafkaController, eventManager: Controller
 class PartitionReassignmentHandler(controller: KafkaController, eventManager: ControllerEventManager) extends ZNodeChangeHandler {
   override val path: String = ReassignPartitionsZNode.path
 
+  // Note that the event is also enqueued when the znode is deleted, but we do it explicitly instead of relying on
+  // handleDeletion(). This approach is more robust as it doesn't depend on the watcher being re-registered after
+  // it's consumed during data changes (we ensure re-registration when the znode is deleted).
   override def handleCreation(): Unit = eventManager.put(controller.PartitionReassignment)
 }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -816,6 +816,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     if (reassignment.isEmpty) {
       info("No more partitions need to be reassigned. Deleting zk path %s".format(ReassignPartitionsZNode.path))
       zkClient.deletePartitionReassignment()
+      zkClient.registerZNodeChangeHandlerAndCheckExistence(partitionReassignmentHandler)
     } else {
       val setDataResponse = zkClient.setPartitionReassignmentRaw(reassignment)
       if (setDataResponse.resultCode == Code.NONODE) {
@@ -1451,8 +1452,6 @@ class PartitionReassignmentHandler(controller: KafkaController, eventManager: Co
   override val path: String = ReassignPartitionsZNode.path
 
   override def handleCreation(): Unit = eventManager.put(controller.PartitionReassignment)
-  override def handleDeletion(): Unit = eventManager.put(controller.PartitionReassignment)
-  override def handleDataChange(): Unit = eventManager.put(controller.PartitionReassignment)
 }
 
 class PartitionReassignmentIsrChangeHandler(controller: KafkaController, eventManager: ControllerEventManager, partition: TopicAndPartition) extends ZNodeChangeHandler {

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -634,7 +634,7 @@ class KafkaZkClient(zooKeeperClient: ZooKeeperClient, isSecure: Boolean) extends
    *
    * @param zNodeChangeHandler
    * @return `true` if the path exists or `false` if it does not
-   * @throws ZooKeeperException if an error is returned by ZooKeeper
+   * @throws KeeperException if an error is returned by ZooKeeper
    */
   def registerZNodeChangeHandlerAndCheckExistence(zNodeChangeHandler: ZNodeChangeHandler): Boolean = {
     zooKeeperClient.registerZNodeChangeHandler(zNodeChangeHandler)

--- a/core/src/main/scala/kafka/zk/ZkData.scala
+++ b/core/src/main/scala/kafka/zk/ZkData.scala
@@ -204,7 +204,7 @@ object DeleteTopicsTopicZNode {
 
 object ReassignPartitionsZNode {
   def path = s"${AdminZNode.path}/reassign_partitions"
-  def encode(reassignment: Map[TopicAndPartition, Seq[Int]]): Array[Byte] = {
+  def encode(reassignment: collection.Map[TopicAndPartition, Seq[Int]]): Array[Byte] = {
     val reassignmentJson = reassignment.map { case (TopicAndPartition(topic, partition), replicas) =>
       Map("topic" -> topic, "partition" -> partition, "replicas" -> replicas)
     }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -470,6 +470,67 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     assertEquals(Seq(3), zkUtils.getReplicasForPartition("customers", 3))
   }
 
+  /**
+   * This test verifies that the Controller restores the watch for the reassignment znode after the first rebalance
+   * completes.
+   */
+  @Test
+  def shouldPerformTwoReassignmentOperationsOverVariousTopics() {
+    servers = TestUtils.createBrokerConfigs(4, zkConnect, false).map(conf => TestUtils.createServer(KafkaConfig.fromProps(conf)))
+
+    createTopic(zkUtils, "orders", Map(0 -> List(0, 1, 2), 1 -> List(0, 1, 2)), servers)
+    createTopic(zkUtils, "payments", Map(0 -> List(0, 1), 1 -> List(0, 1)), servers)
+    createTopic(zkUtils, "deliveries", Map(0 -> List(0)), servers)
+    createTopic(zkUtils, "customers", Map(0 -> List(0), 1 -> List(1), 2 -> List(2), 3 -> List(3)), servers)
+
+    val firstMove = Map(
+      TopicAndPartition("orders", 0) -> Seq(0, 2, 3), //moves
+      TopicAndPartition("orders", 1) -> Seq(0, 1, 2), //stays
+      TopicAndPartition("payments", 1) -> Seq(1, 2), //only define one partition as moving
+      TopicAndPartition("deliveries", 0) -> Seq(1, 2) //increase replication factor
+    )
+
+    new ReassignPartitionsCommand(zkUtils, None, firstMove).reassignPartitions()
+    waitForReassignmentToComplete()
+
+    // Check moved replicas did move
+    assertEquals(Seq(0, 2, 3), zkUtils.getReplicasForPartition("orders", 0))
+    assertEquals(Seq(0, 1, 2), zkUtils.getReplicasForPartition("orders", 1))
+    assertEquals(Seq(1, 2), zkUtils.getReplicasForPartition("payments", 1))
+    assertEquals(Seq(1, 2), zkUtils.getReplicasForPartition("deliveries", 0))
+
+    // Check untouched replicas are still there
+    assertEquals(Seq(0, 1), zkUtils.getReplicasForPartition("payments", 0))
+    assertEquals(Seq(0), zkUtils.getReplicasForPartition("customers", 0))
+    assertEquals(Seq(1), zkUtils.getReplicasForPartition("customers", 1))
+    assertEquals(Seq(2), zkUtils.getReplicasForPartition("customers", 2))
+    assertEquals(Seq(3), zkUtils.getReplicasForPartition("customers", 3))
+
+    // Define a move for some of them
+    val secondMove = Map(
+      TopicAndPartition("orders", 0) -> Seq(0, 2, 3), // stays
+      TopicAndPartition("orders", 1) -> Seq(3, 1, 2), // moves
+      TopicAndPartition("payments", 1) -> Seq(2, 1), // changed assigned leader
+      TopicAndPartition("deliveries", 0) -> Seq(1, 2, 3) //increase replication factor
+    )
+
+    new ReassignPartitionsCommand(zkUtils, None, secondMove).reassignPartitions()
+    waitForReassignmentToComplete()
+
+    // Check moved replicas did move
+    assertEquals(Seq(0, 2, 3), zkUtils.getReplicasForPartition("orders", 0))
+    assertEquals(Seq(3, 1, 2), zkUtils.getReplicasForPartition("orders", 1))
+    assertEquals(Seq(2, 1), zkUtils.getReplicasForPartition("payments", 1))
+    assertEquals(Seq(1, 2, 3), zkUtils.getReplicasForPartition("deliveries", 0))
+
+    //Check untouched replicas are still there
+    assertEquals(Seq(0, 1), zkUtils.getReplicasForPartition("payments", 0))
+    assertEquals(Seq(0), zkUtils.getReplicasForPartition("customers", 0))
+    assertEquals(Seq(1), zkUtils.getReplicasForPartition("customers", 1))
+    assertEquals(Seq(2), zkUtils.getReplicasForPartition("customers", 2))
+    assertEquals(Seq(3), zkUtils.getReplicasForPartition("customers", 3))
+  }
+
   def waitForReassignmentToComplete() {
     waitUntilTrue(() => !zkUtils.pathExists(ReassignPartitionsPath), s"Znode ${ZkUtils.ReassignPartitionsPath} wasn't deleted")
   }

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsClusterTest.scala
@@ -471,11 +471,13 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
   }
 
   /**
-   * This test verifies that the Controller restores the watch for the reassignment znode after the first rebalance
-   * completes.
+   * Verifies that the Controller sets a watcher for the reassignment znode after reassignment completion.
+   * This includes the case where the znode is set immediately after it's deleted (i.e. before the watch is set).
+   * This case relies on the scheduling of the operations, so it won't necessarily fail every time, but it fails
+   * often enough to detect a regression.
    */
   @Test
-  def shouldPerformTwoReassignmentOperationsOverVariousTopics() {
+  def shouldPerformMultipleReassignmentOperationsOverVariousTopics() {
     servers = TestUtils.createBrokerConfigs(4, zkConnect, false).map(conf => TestUtils.createServer(KafkaConfig.fromProps(conf)))
 
     createTopic(zkUtils, "orders", Map(0 -> List(0, 1, 2), 1 -> List(0, 1, 2)), servers)
@@ -524,6 +526,37 @@ class ReassignPartitionsClusterTest extends ZooKeeperTestHarness with Logging {
     assertEquals(Seq(1, 2, 3), zkUtils.getReplicasForPartition("deliveries", 0))
 
     //Check untouched replicas are still there
+    assertEquals(Seq(0, 1), zkUtils.getReplicasForPartition("payments", 0))
+    assertEquals(Seq(0), zkUtils.getReplicasForPartition("customers", 0))
+    assertEquals(Seq(1), zkUtils.getReplicasForPartition("customers", 1))
+    assertEquals(Seq(2), zkUtils.getReplicasForPartition("customers", 2))
+    assertEquals(Seq(3), zkUtils.getReplicasForPartition("customers", 3))
+
+    // We set the znode and then continuously attempt to set it again to exercise the case where the znode is set
+    // immediately after deletion (i.e. before we set the watcher again)
+
+    val thirdMove = Map(TopicAndPartition("orders", 0) -> Seq(1, 2, 3))
+
+    new ReassignPartitionsCommand(zkUtils, None, thirdMove).reassignPartitions()
+
+    val fourthMove = Map(TopicAndPartition("payments", 1) -> Seq(2, 3))
+
+    Iterator.continually {
+      try new ReassignPartitionsCommand(zkUtils, None, fourthMove).reassignPartitions()
+      catch {
+        case _: AdminCommandFailedException => false
+      }
+    }.exists(identity)
+
+    waitForReassignmentToComplete()
+
+    // Check moved replicas for secondMove and fourthMove
+    assertEquals(Seq(1, 2, 3), zkUtils.getReplicasForPartition("orders", 0))
+    assertEquals(Seq(2, 3), zkUtils.getReplicasForPartition("payments", 1))
+
+    //Check untouched replicas are still there
+    assertEquals(Seq(3, 1, 2), zkUtils.getReplicasForPartition("orders", 1))
+    assertEquals(Seq(1, 2, 3), zkUtils.getReplicasForPartition("deliveries", 0))
     assertEquals(Seq(0, 1), zkUtils.getReplicasForPartition("payments", 0))
     assertEquals(Seq(0), zkUtils.getReplicasForPartition("customers", 0))
     assertEquals(Seq(1), zkUtils.getReplicasForPartition("customers", 1))

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -157,4 +157,27 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     assertFalse(statusAndVersion._1)
     assertEquals(-1, statusAndVersion._2)
   }
+
+  def testSetGetAndDeletePartitionReassignment() {
+    zkClient.createRecursive(AdminZNode.path)
+
+    assertEquals(Map.empty, zkClient.getPartitionReassignment)
+
+    val reassignment = Map(
+      TopicAndPartition("topic_a", 0) -> Seq(0, 1, 3),
+      TopicAndPartition("topic_a", 1) -> Seq(2, 1, 3),
+      TopicAndPartition("topic_b", 0) -> Seq(4, 5),
+      TopicAndPartition("topic_c", 0) -> Seq(5, 3)
+    )
+    zkClient.setOrCreatePartitionReassignment(reassignment)
+    assertEquals(reassignment, zkClient.getPartitionReassignment)
+
+    val updatedReassingment = reassignment - TopicAndPartition("topic_b", 0)
+    zkClient.setOrCreatePartitionReassignment(updatedReassingment)
+    assertEquals(updatedReassingment, zkClient.getPartitionReassignment)
+
+    zkClient.deletePartitionReassignment()
+    assertEquals(Map.empty, zkClient.getPartitionReassignment)
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/KafkaZkClientTest.scala
@@ -158,6 +158,7 @@ class KafkaZkClientTest extends ZooKeeperTestHarness {
     assertEquals(-1, statusAndVersion._2)
   }
 
+  @Test
   def testSetGetAndDeletePartitionReassignment() {
     zkClient.createRecursive(AdminZNode.path)
 


### PR DESCRIPTION
We only need to generate the event when the znode is created or deleted.
In the former case, we start the reassignment while in the latter we
re-register the watcher (necessary for the Controller to detect future
reassignments).

During Controller failover, we restart the reassignment without generating
an event so it's not affected by this change.

Also use the Controller cache (`ControllerContext.partitionsBeingReassigned`)
in `removePartitionFromReassignedPartitions` instead of reloading the
data from ZooKeeper.

Overall, we would previously load the reassignment data from ZooKeeper twice
per completed partition whereas now as don't do it at all. As an example,
say there were 30k partitions being reassigned, these changes save the
allocation of 900 million `TopicAndPartition` and `Seq[Int]` (replicas)
instances (could easily amount to 20-40 GB depending on the topic name
length). This matters most in cases where the partitions being reassigned
don't have much data allowing the reassignment to complete reasonably
fast for many of the partitions.