### PR TITLE
KAFKA-4928: Add integration test for DumpLogSegments

### DIFF
--- a/core/src/test/scala/integration/kafka/tools/DumpLogSegmentsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/DumpLogSegmentsIntegrationTest.scala
@@ -29,13 +29,16 @@ import org.apache.kafka.common.serialization.ByteArraySerializer
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+/**
+  * Testing of [[DumpLogSegments]] tool
+  */
 class DumpLogSegmentsIntegrationTest extends KafkaServerTestHarness {
 
   override def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(1, zkConnect)
     .map(KafkaConfig.fromProps(_, new Properties()))
 
   @Test
-  def testSaneOutputForPopulatedLog(): Unit = {
+  def testOutputForJustSentMessagesLogDump(): Unit = {
     val topic = "new-topic"
     val msg = "a test message"
     val producerProps = new Properties

--- a/core/src/test/scala/integration/kafka/tools/DumpLogSegmentsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/DumpLogSegmentsIntegrationTest.scala
@@ -1,0 +1,66 @@
+package integration.kafka.tools
+
+import java.io.{ByteArrayOutputStream, PrintStream}
+import java.util.Properties
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.log.Log
+import kafka.server.KafkaConfig
+import kafka.tools.DumpLogSegments
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DumpLogSegmentsIntegrationTest extends KafkaServerTestHarness {
+
+  override def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(1, zkConnect)
+    .map(KafkaConfig.fromProps(_, new Properties()))
+
+  @Test
+  def testOutputForJustSent3MessagesLogDump(): Unit = {
+    val topic = "new-topic"
+    val msg = "a test message"
+    val producerProps = new Properties
+    producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, TestUtils.getBrokerListStrFromServers(servers))
+    producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
+    producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
+    val producer = new KafkaProducer[Array[Byte], Array[Byte]](producerProps)
+
+    // send 3 messages
+    producer.send(new ProducerRecord(topic, msg.getBytes()))
+    producer.send(new ProducerRecord(topic, msg.getBytes()))
+    producer.send(new ProducerRecord(topic, msg.getBytes()))
+    producer.close()
+
+    val log: Log = servers.head.logManager.logsByTopic(topic).head
+
+    val baos = new ByteArrayOutputStream()
+    val out = new PrintStream(baos)
+    val old = Console.out
+    val err = Console.err
+    try {
+      old.flush()
+      err.flush()
+      // redirect output from console
+      Console.setOut(out)
+      Console.setErr(out)
+      DumpLogSegments.main(
+        Seq(
+          "--files", log.dir.listFiles.filter(_.getName.endsWith(".log")).head.getCanonicalPath,
+          "--deep-iteration"
+        ).toArray
+      )
+      out.flush()
+    } finally {
+      Console.setOut(old)
+      Console.setErr(err)
+    }
+
+    assertTrue(baos.toString.contains("Starting offset: 0"))
+    assertTrue(baos.toString.contains("offset: 0"))
+    assertTrue(baos.toString.contains("offset: 1"))
+    assertTrue(baos.toString.contains("offset: 2"))
+  }
+}

--- a/core/src/test/scala/integration/kafka/tools/DumpLogSegmentsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/tools/DumpLogSegmentsIntegrationTest.scala
@@ -1,3 +1,19 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 package integration.kafka.tools
 
 import java.io.{ByteArrayOutputStream, PrintStream}
@@ -19,7 +35,7 @@ class DumpLogSegmentsIntegrationTest extends KafkaServerTestHarness {
     .map(KafkaConfig.fromProps(_, new Properties()))
 
   @Test
-  def testOutputForJustSent3MessagesLogDump(): Unit = {
+  def testSaneOutputForPopulatedLog(): Unit = {
     val topic = "new-topic"
     val msg = "a test message"
     val producerProps = new Properties


### PR DESCRIPTION
Adding tests for `kafka.tools.DumpLogSegments`