### PR TITLE
MINOR: Tighten up locking when aborting expired transactions

### DIFF
--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -482,14 +482,14 @@ class TransactionsTest extends KafkaServerTestHarness {
     // Verify that the first message was aborted and the second one was never written at all.
     val nonTransactionalConsumer = nonTransactionalConsumers(0)
     nonTransactionalConsumer.subscribe(List(topic1).asJava)
-    val records = TestUtils.consumeRemainingRecords(nonTransactionalConsumer, 1000)
+    val records = TestUtils.consumeRecordsFor(nonTransactionalConsumer, 1000)
     assertEquals(1, records.size)
     assertEquals("1", TestUtils.recordValueAsString(records.head))
 
     val transactionalConsumer = transactionalConsumers.head
     transactionalConsumer.subscribe(List(topic1).asJava)
 
-    val transactionalRecords = TestUtils.consumeRemainingRecords(transactionalConsumer, 1000)
+    val transactionalRecords = TestUtils.consumeRecordsFor(transactionalConsumer, 1000)
     assertTrue(transactionalRecords.isEmpty)
   }
 

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1382,13 +1382,21 @@ object TestUtils extends Logging {
     records
   }
 
-  def consumeRemainingRecords[K, V](consumer: KafkaConsumer[K, V], timeout: Long): Seq[ConsumerRecord[K, V]] = {
+  /**
+    * Will consume all the records for the given consumer for the specified duration. If you want to drain all the
+    * remaining messages in the partitions the consumer is subscribed to, the duration should be set high enough so
+    * that the consumer has enough time to poll everything. This would be based on the number of expected messages left
+    * in the topic, and should not be too large (ie. more than a second) in our tests.
+    *
+    * @return All the records consumed by the consumer within the specified duration.
+    */
+  def consumeRecordsFor[K, V](consumer: KafkaConsumer[K, V], duration: Long): Seq[ConsumerRecord[K, V]] = {
     val startTime = System.currentTimeMillis()
     val records = new ArrayBuffer[ConsumerRecord[K, V]]()
     waitUntilTrue(() => {
       records ++= consumer.poll(50).asScala
-      System.currentTimeMillis() - startTime > timeout
-    }, s"The timeout $timeout was greater than the maximum wait time.")
+      System.currentTimeMillis() - startTime > duration
+    }, s"The timeout $duration was greater than the maximum wait time.")
     records
   }
 


### PR DESCRIPTION
This is a followup to #4137 