### PR TITLE
KAFKA-6161 add base classes for (De)Serializers with empty conf methods

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteArrayDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteArrayDeserializer.java
@@ -16,22 +16,10 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class ByteArrayDeserializer implements Deserializer<byte[]> {
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class ByteArrayDeserializer extends NoConfDeserializer<byte[]> {
 
     @Override
     public byte[] deserialize(String topic, byte[] data) {
         return data;
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteArraySerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteArraySerializer.java
@@ -16,22 +16,10 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class ByteArraySerializer implements Serializer<byte[]> {
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class ByteArraySerializer extends NoConfSerializer<byte[]> {
 
     @Override
     public byte[] serialize(String topic, byte[] data) {
         return data;
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferDeserializer.java
@@ -17,22 +17,13 @@
 package org.apache.kafka.common.serialization;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
 
-public class ByteBufferDeserializer implements Deserializer<ByteBuffer> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class ByteBufferDeserializer extends NoConfDeserializer<ByteBuffer> {
 
     public ByteBuffer deserialize(String topic, byte[] data) {
         if (data == null)
             return null;
 
         return ByteBuffer.wrap(data);
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ByteBufferSerializer.java
@@ -17,13 +17,8 @@
 package org.apache.kafka.common.serialization;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
 
-public class ByteBufferSerializer implements Serializer<ByteBuffer> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class ByteBufferSerializer extends NoConfSerializer<ByteBuffer> {
 
     public byte[] serialize(String topic, ByteBuffer data) {
         if (data == null)
@@ -42,9 +37,5 @@ public class ByteBufferSerializer implements Serializer<ByteBuffer> {
         data.get(ret, 0, ret.length);
         data.rewind();
         return ret;
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/BytesDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/BytesDeserializer.java
@@ -18,22 +18,12 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.utils.Bytes;
 
-import java.util.Map;
-
-public class BytesDeserializer implements Deserializer<Bytes> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class BytesDeserializer extends NoConfDeserializer<Bytes> {
 
     public Bytes deserialize(String topic, byte[] data) {
         if (data == null)
             return null;
 
         return new Bytes(data);
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/DoubleDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/DoubleDeserializer.java
@@ -18,14 +18,7 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.util.Map;
-
-public class DoubleDeserializer implements Deserializer<Double> {
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class DoubleDeserializer extends NoConfDeserializer<Double> {
 
     @Override
     public Double deserialize(String topic, byte[] data) {
@@ -41,10 +34,5 @@ public class DoubleDeserializer implements Deserializer<Double> {
             value |= b & 0xFF;
         }
         return Double.longBitsToDouble(value);
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/DoubleSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/DoubleSerializer.java
@@ -16,14 +16,7 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class DoubleSerializer implements Serializer<Double> {
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
+public class DoubleSerializer extends NoConfSerializer<Double> {
 
     @Override
     public byte[] serialize(String topic, Double data) {
@@ -41,10 +34,5 @@ public class DoubleSerializer implements Serializer<Double> {
             (byte) (bits >>> 8),
             (byte) bits
         };
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ExtendedNoConfDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ExtendedNoConfDeserializer.java
@@ -16,15 +16,15 @@
  */
 package org.apache.kafka.common.serialization;
 
-import org.apache.kafka.common.utils.Bytes;
-
-public class BytesSerializer extends NoConfSerializer<Bytes> {
-
-    public byte[] serialize(String topic, Bytes data) {
-        if (data == null)
-            return null;
-
-        return data.get();
-    }
-}
-
+/**
+ * An extended Deserializer with empty {@code configure()} and {@code close()} methods.
+ *
+ * Prefer {@link ExtendedDeserializer} if both {@code configure()} and {@code close()}
+ * methods are needed to be non-empty.
+ *
+ * Once Kafka drops support for Java 7, the {@code configure()} and
+ * {@code close()} methods will be implemented as default empty methods in
+ * {@link Deserializer} so that backwards compatibility is maintained. This class
+ * may be deprecated once that happens.
+ */
+public abstract class ExtendedNoConfDeserializer<T> extends NoConfDeserializer<T> implements ExtendedDeserializer<T> { }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ExtendedNoConfSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ExtendedNoConfSerializer.java
@@ -16,15 +16,15 @@
  */
 package org.apache.kafka.common.serialization;
 
-import org.apache.kafka.common.utils.Bytes;
-
-public class BytesSerializer extends NoConfSerializer<Bytes> {
-
-    public byte[] serialize(String topic, Bytes data) {
-        if (data == null)
-            return null;
-
-        return data.get();
-    }
-}
-
+/**
+ * An extended Serializer with empty {@code configure()} and {@code close()} methods.
+ *
+ * Prefer {@link ExtendedSerializer} if both {@code configure()} and {@code close()}
+ * methods are needed to be non-empty.
+ *
+ * Once Kafka drops support for Java 7, the {@code configure()} and
+ * {@code close()} methods will be implemented as default empty methods in
+ * {@link Serializer} so that backwards compatibility is maintained. This class
+ * may be deprecated once that happens.
+ */
+public abstract class ExtendedNoConfSerializer<T> extends NoConfSerializer<T> implements ExtendedSerializer<T> { }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/FloatDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/FloatDeserializer.java
@@ -18,14 +18,7 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.util.Map;
-
-public class FloatDeserializer implements Deserializer<Float> {
-
-    @Override
-    public void configure(final Map<String, ?> configs, final boolean isKey) {
-        // nothing to do
-    }
+public class FloatDeserializer extends NoConfDeserializer<Float> {
 
     @Override
     public Float deserialize(final String topic, final byte[] data) {
@@ -42,10 +35,4 @@ public class FloatDeserializer implements Deserializer<Float> {
         }
         return Float.intBitsToFloat(value);
     }
-
-    @Override
-    public void close() {
-        // nothing to do
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/FloatSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/FloatSerializer.java
@@ -16,14 +16,7 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class FloatSerializer implements Serializer<Float> {
-
-    @Override
-    public void configure(final Map<String, ?> configs, final boolean isKey) {
-        // nothing to do
-    }
+public class FloatSerializer extends NoConfSerializer<Float> {
 
     @Override
     public byte[] serialize(final String topic, final Float data) {
@@ -37,10 +30,5 @@ public class FloatSerializer implements Serializer<Float> {
             (byte) (bits >>> 8),
             (byte) bits
         };
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/IntegerDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/IntegerDeserializer.java
@@ -18,14 +18,7 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.util.Map;
-
-public class IntegerDeserializer implements Deserializer<Integer> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
-
+public class IntegerDeserializer extends NoConfDeserializer<Integer> {
     public Integer deserialize(String topic, byte[] data) {
         if (data == null)
             return null;
@@ -39,9 +32,5 @@ public class IntegerDeserializer implements Deserializer<Integer> {
             value |= b & 0xFF;
         }
         return value;
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/IntegerSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/IntegerSerializer.java
@@ -16,14 +16,7 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class IntegerSerializer implements Serializer<Integer> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
-
+public class IntegerSerializer extends NoConfSerializer<Integer> {
     public byte[] serialize(String topic, Integer data) {
         if (data == null)
             return null;
@@ -34,9 +27,5 @@ public class IntegerSerializer implements Serializer<Integer> {
             (byte) (data >>> 8),
             data.byteValue()
         };
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/LongDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/LongDeserializer.java
@@ -18,14 +18,7 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.util.Map;
-
-public class LongDeserializer implements Deserializer<Long> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
-
+public class LongDeserializer extends NoConfDeserializer<Long> {
     public Long deserialize(String topic, byte[] data) {
         if (data == null)
             return null;
@@ -39,9 +32,5 @@ public class LongDeserializer implements Deserializer<Long> {
             value |= b & 0xFF;
         }
         return value;
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/LongSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/LongSerializer.java
@@ -16,14 +16,7 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class LongSerializer implements Serializer<Long> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
-
+public class LongSerializer extends NoConfSerializer<Long> {
     public byte[] serialize(String topic, Long data) {
         if (data == null)
             return null;
@@ -38,9 +31,5 @@ public class LongSerializer implements Serializer<Long> {
             (byte) (data >>> 8),
             data.byteValue()
         };
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/NoConfDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/NoConfDeserializer.java
@@ -16,15 +16,28 @@
  */
 package org.apache.kafka.common.serialization;
 
-import org.apache.kafka.common.utils.Bytes;
+import java.util.Map;
 
-public class BytesSerializer extends NoConfSerializer<Bytes> {
+/**
+ * A Deserializer with empty {@code configure()} and {@code close()} methods.
+ *
+ * Prefer {@link Deserializer} if both {@code configure()} and {@code close()}
+ * methods are needed to be non-empty.
+ *
+ * Once Kafka drops support for Java 7, the {@code configure()} and
+ * {@code close()} methods will be implemented as default empty methods in
+ * {@link Deserializer} so that backwards compatibility is maintained. This class
+ * may be deprecated once that happens.
+ */
+public abstract class NoConfDeserializer<T> implements Deserializer<T> {
 
-    public byte[] serialize(String topic, Bytes data) {
-        if (data == null)
-            return null;
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
 
-        return data.get();
+    @Override
+    public void close() {
+        // nothing to do
     }
 }
-

--- a/clients/src/main/java/org/apache/kafka/common/serialization/NoConfSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/NoConfSerializer.java
@@ -16,15 +16,28 @@
  */
 package org.apache.kafka.common.serialization;
 
-import org.apache.kafka.common.utils.Bytes;
+import java.util.Map;
 
-public class BytesSerializer extends NoConfSerializer<Bytes> {
+/**
+ * A Serializer with empty {@code configure()} and {@code close()} methods.
+ *
+ * Prefer {@link Serializer} if both {@code configure()} and {@code close()}
+ * methods are needed to be non-empty.
+ *
+ * Once Kafka drops support for Java 7, the {@code configure()} and
+ * {@code close()} methods will be implemented as default empty methods in
+ * {@link Serializer} so that backwards compatibility is maintained. This class
+ * may be deprecated once that happens.
+ */
+public abstract class NoConfSerializer<T> implements Serializer<T> {
 
-    public byte[] serialize(String topic, Bytes data) {
-        if (data == null)
-            return null;
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        // nothing to do
+    }
 
-        return data.get();
+    @Override
+    public void close() {
+        // nothing to do
     }
 }
-

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ShortDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ShortDeserializer.java
@@ -18,14 +18,7 @@ package org.apache.kafka.common.serialization;
 
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.util.Map;
-
-public class ShortDeserializer implements Deserializer<Short> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
-
+public class ShortDeserializer extends NoConfDeserializer<Short> {
     public Short deserialize(String topic, byte[] data) {
         if (data == null)
             return null;
@@ -39,9 +32,5 @@ public class ShortDeserializer implements Deserializer<Short> {
             value |= b & 0xFF;
         }
         return value;
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/ShortSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/ShortSerializer.java
@@ -16,14 +16,7 @@
  */
 package org.apache.kafka.common.serialization;
 
-import java.util.Map;
-
-public class ShortSerializer implements Serializer<Short> {
-
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // nothing to do
-    }
-
+public class ShortSerializer extends NoConfSerializer<Short> {
     public byte[] serialize(String topic, Short data) {
         if (data == null)
             return null;
@@ -32,9 +25,5 @@ public class ShortSerializer implements Serializer<Short> {
             (byte) (data >>> 8),
             data.byteValue()
         };
-    }
-
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
@@ -25,7 +25,7 @@ import java.util.Map;
  *  String encoding defaults to UTF8 and can be customized by setting the property key.deserializer.encoding,
  *  value.deserializer.encoding or deserializer.encoding. The first two take precedence over the last.
  */
-public class StringDeserializer implements Deserializer<String> {
+public class StringDeserializer extends NoConfDeserializer<String> {
     private String encoding = "UTF8";
 
     @Override
@@ -48,10 +48,5 @@ public class StringDeserializer implements Deserializer<String> {
         } catch (UnsupportedEncodingException e) {
             throw new SerializationException("Error when deserializing byte[] to string due to unsupported encoding " + encoding);
         }
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/serialization/StringSerializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/StringSerializer.java
@@ -25,7 +25,7 @@ import java.util.Map;
  *  String encoding defaults to UTF8 and can be customized by setting the property key.serializer.encoding,
  *  value.serializer.encoding or serializer.encoding. The first two take precedence over the last.
  */
-public class StringSerializer implements Serializer<String> {
+public class StringSerializer extends NoConfSerializer<String> {
     private String encoding = "UTF8";
 
     @Override
@@ -48,10 +48,5 @@ public class StringSerializer implements Serializer<String> {
         } catch (UnsupportedEncodingException e) {
             throw new SerializationException("Error when serializing string to byte[] due to unsupported encoding " + encoding);
         }
-    }
-
-    @Override
-    public void close() {
-        // nothing to do
     }
 }

--- a/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockDeserializer.java
@@ -18,13 +18,12 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.ClusterResource;
 import org.apache.kafka.common.ClusterResourceListener;
-import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.NoConfDeserializer;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class MockDeserializer implements ClusterResourceListener, Deserializer<byte[]> {
+public class MockDeserializer extends NoConfDeserializer<byte[]> implements ClusterResourceListener {
     public static AtomicInteger initCount = new AtomicInteger(0);
     public static AtomicInteger closeCount = new AtomicInteger(0);
     public static AtomicReference<ClusterResource> clusterMeta = new AtomicReference<>();
@@ -40,10 +39,6 @@ public class MockDeserializer implements ClusterResourceListener, Deserializer<b
 
     public MockDeserializer() {
         initCount.incrementAndGet();
-    }
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/MockSerializer.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSerializer.java
@@ -18,13 +18,12 @@ package org.apache.kafka.test;
 
 import org.apache.kafka.common.ClusterResourceListener;
 import org.apache.kafka.common.ClusterResource;
-import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.NoConfSerializer;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class MockSerializer implements ClusterResourceListener, Serializer<byte[]> {
+public class MockSerializer extends NoConfSerializer<byte[]> implements ClusterResourceListener {
     public static final AtomicInteger INIT_COUNT = new AtomicInteger(0);
     public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
     public static final AtomicReference<ClusterResource> CLUSTER_META = new AtomicReference<>();
@@ -33,10 +32,6 @@ public class MockSerializer implements ClusterResourceListener, Serializer<byte[
 
     public MockSerializer() {
         INIT_COUNT.incrementAndGet();
-    }
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
     }
 
     @Override

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonDeserializer.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonDeserializer.java
@@ -19,25 +19,19 @@ package org.apache.kafka.connect.json;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.Deserializer;
-
-import java.util.Map;
+import org.apache.kafka.common.serialization.NoConfDeserializer;
 
 /**
  * JSON deserializer for Jackson's JsonNode tree model. Using the tree model allows it to work with arbitrarily
  * structured data without having associated Java classes. This deserializer also supports Connect schemas.
  */
-public class JsonDeserializer implements Deserializer<JsonNode> {
+public class JsonDeserializer extends NoConfDeserializer<JsonNode> {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Default constructor needed by Kafka
      */
     public JsonDeserializer() {
-    }
-
-    @Override
-    public void configure(Map<String, ?> props, boolean isKey) {
     }
 
     @Override
@@ -53,10 +47,5 @@ public class JsonDeserializer implements Deserializer<JsonNode> {
         }
 
         return data;
-    }
-
-    @Override
-    public void close() {
-
     }
 }

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonSerializer.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonSerializer.java
@@ -19,15 +19,13 @@ package org.apache.kafka.connect.json;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.Serializer;
-
-import java.util.Map;
+import org.apache.kafka.common.serialization.NoConfSerializer;
 
 /**
  * Serialize Jackson JsonNode tree model objects to UTF-8 JSON. Using the tree model allows handling arbitrarily
  * structured data without corresponding Java classes. This serializer also supports Connect schemas.
  */
-public class JsonSerializer implements Serializer<JsonNode> {
+public class JsonSerializer extends NoConfSerializer<JsonNode> {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -35,10 +33,6 @@ public class JsonSerializer implements Serializer<JsonNode> {
      */
     public JsonSerializer() {
 
-    }
-
-    @Override
-    public void configure(Map<String, ?> config, boolean isKey) {
     }
 
     @Override
@@ -51,10 +45,6 @@ public class JsonSerializer implements Serializer<JsonNode> {
         } catch (Exception e) {
             throw new SerializationException("Error serializing JSON message", e);
         }
-    }
-
-    @Override
-    public void close() {
     }
 
 }

--- a/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.RecordBatch
-import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.NoConfDeserializer
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.{After, Before, Test}
 
@@ -399,11 +399,7 @@ class EpochDrivenReplicationProtocolAcceptanceTest extends ZooKeeperTestHarness 
     createServer(fromProps(config))
   }
 
-  private class StubDeserializer extends Deserializer[Array[Byte]] {
-    override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = {}
-
+  private class StubDeserializer extends NoConfDeserializer[Array[Byte]] {
     override def deserialize(topic: String, data: Array[Byte]): Array[Byte] = { data }
-
-    override def close(): Unit = {}
   }
 }

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/JsonPOJODeserializer.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/JsonPOJODeserializer.java
@@ -18,11 +18,11 @@ package org.apache.kafka.streams.examples.pageview;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.NoConfDeserializer;
 
 import java.util.Map;
 
-public class JsonPOJODeserializer<T> implements Deserializer<T> {
+public class JsonPOJODeserializer<T> extends NoConfDeserializer<T> {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     private Class<T> tClass;
@@ -52,10 +52,5 @@ public class JsonPOJODeserializer<T> implements Deserializer<T> {
         }
 
         return data;
-    }
-
-    @Override
-    public void close() {
-
     }
 }

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/JsonPOJOSerializer.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/pageview/JsonPOJOSerializer.java
@@ -19,11 +19,9 @@ package org.apache.kafka.streams.examples.pageview;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.NoConfSerializer;
 
-import java.util.Map;
-
-public class JsonPOJOSerializer<T> implements Serializer<T> {
+public class JsonPOJOSerializer<T> extends NoConfSerializer<T> {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
@@ -32,10 +30,6 @@ public class JsonPOJOSerializer<T> implements Serializer<T> {
     public JsonPOJOSerializer() {
     }
     
-    @Override
-    public void configure(Map<String, ?> props, boolean isKey) {
-    }
-
     @Override
     public byte[] serialize(String topic, T data) {
         if (data == null)
@@ -46,10 +40,6 @@ public class JsonPOJOSerializer<T> implements Serializer<T> {
         } catch (Exception e) {
             throw new SerializationException("Error serializing JSON message", e);
         }
-    }
-
-    @Override
-    public void close() {
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedDeserializer.java
@@ -19,13 +19,13 @@ package org.apache.kafka.streams.kstream.internals;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.ExtendedDeserializer;
+import org.apache.kafka.common.serialization.ExtendedNoConfDeserializer;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
 
 import static org.apache.kafka.common.serialization.ExtendedDeserializer.Wrapper.ensureExtended;
 
-public class ChangedDeserializer<T> implements ExtendedDeserializer<Change<T>> {
+public class ChangedDeserializer<T> extends ExtendedNoConfDeserializer<Change<T>> {
 
     private static final int NEWFLAG_SIZE = 1;
 
@@ -41,11 +41,6 @@ public class ChangedDeserializer<T> implements ExtendedDeserializer<Change<T>> {
 
     public void setInner(Deserializer<T> inner) {
         this.inner = ensureExtended(inner);
-    }
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // do nothing
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ChangedSerializer.java
@@ -17,16 +17,16 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.ExtendedNoConfSerializer;
 import org.apache.kafka.common.serialization.ExtendedSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.errors.StreamsException;
 
 import java.nio.ByteBuffer;
-import java.util.Map;
 
 import static org.apache.kafka.common.serialization.ExtendedSerializer.Wrapper.ensureExtended;
 
-public class ChangedSerializer<T> implements ExtendedSerializer<Change<T>> {
+public class ChangedSerializer<T> extends ExtendedNoConfSerializer<Change<T>> {
 
     private static final int NEWFLAG_SIZE = 1;
 
@@ -42,11 +42,6 @@ public class ChangedSerializer<T> implements ExtendedSerializer<Change<T>> {
 
     public void setInner(Serializer<T> inner) {
         this.inner = ensureExtended(inner);
-    }
-
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-        // do nothing
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionKeySerde.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionKeySerde.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.kstream.internals;
 
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.NoConfDeserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
@@ -85,15 +86,11 @@ public class SessionKeySerde<K> implements Serde<Windowed<K>> {
         }
     }
 
-    private class SessionKeyDeserializer implements Deserializer<Windowed<K>> {
+    private class SessionKeyDeserializer extends NoConfDeserializer<Windowed<K>> {
         private final Deserializer<K> deserializer;
 
         SessionKeyDeserializer(final Deserializer<K> deserializer) {
             this.deserializer = deserializer;
-        }
-
-        @Override
-        public void configure(final Map<String, ?> configs, final boolean isKey) {
         }
 
         @Override
@@ -102,12 +99,6 @@ public class SessionKeySerde<K> implements Serde<Windowed<K>> {
                 return null;
             }
             return from(data, deserializer, topic);
-        }
-
-
-        @Override
-        public void close() {
-
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/perf/YahooBenchmark.java
+++ b/streams/src/test/java/org/apache/kafka/streams/perf/YahooBenchmark.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.NoConfDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.Consumed;
 import org.apache.kafka.streams.KafkaStreams;
@@ -233,7 +234,7 @@ public class YahooBenchmark {
     }
 
     // Note: these are also in the streams example package, eventuall use 1 file
-    private class JsonPOJODeserializer<T> implements Deserializer<T> {
+    private class JsonPOJODeserializer<T> extends NoConfDeserializer<T> {
         private ObjectMapper objectMapper = new ObjectMapper();
 
         private Class<T> tClass;
@@ -263,11 +264,6 @@ public class YahooBenchmark {
             }
 
             return data;
-        }
-
-        @Override
-        public void close() {
-
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SourceNodeTest.java
@@ -18,12 +18,11 @@ package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.serialization.ExtendedDeserializer;
+import org.apache.kafka.common.serialization.ExtendedNoConfDeserializer;
 import org.apache.kafka.test.MockSourceNode;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,21 +44,15 @@ public class SourceNodeTest {
         assertThat(deserializedValue, is("topic" + headers + "data"));
     }
 
-    public static class TheExtendedDeserializer implements ExtendedDeserializer<String> {
+    public static class TheExtendedDeserializer extends ExtendedNoConfDeserializer<String> {
         @Override
         public String deserialize(final String topic, final Headers headers, final byte[] data) {
             return topic + headers + new String(data, StandardCharsets.UTF_8);
         }
 
         @Override
-        public void configure(final Map<String, ?> configs, final boolean isKey) { }
-
-        @Override
         public String deserialize(final String topic, final byte[] data) {
             return deserialize(topic, null, data);
         }
-
-        @Override
-        public void close() { }
     }
 }


### PR DESCRIPTION
All (de)serializers, which have empty configure() and/or close() methods, are now inherit NoConf(De)Serializer. Also, such classes are created for extended (de)serializers.