### PR TITLE
KAFKA-6168 Connect Schema comparison is slow for large schemas

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -94,7 +94,7 @@ public class ConnectSchema implements Schema {
     private final String doc;
     private final Map<String, String> parameters;
     // precomputed hash code. There is no need to re-compute every time hashCode() is called.
-    private final int hash;
+    private Integer hash = null;
 
     /**
      * Construct a Schema. Most users should not construct schemas manually, preferring {@link SchemaBuilder} instead.
@@ -120,7 +120,6 @@ public class ConnectSchema implements Schema {
 
         this.keySchema = keySchema;
         this.valueSchema = valueSchema;
-        this.hash = Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc, parameters);
     }
 
     /**
@@ -299,6 +298,10 @@ public class ConnectSchema implements Schema {
 
     @Override
     public int hashCode() {
+        if (this.hash == null) {
+            this.hash = Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc,
+                parameters);
+        }
         return this.hash;
     }
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -93,6 +93,7 @@ public class ConnectSchema implements Schema {
     // Optional human readable documentation describing this schema.
     private final String doc;
     private final Map<String, String> parameters;
+    private final int hc;  // precomputed hash code
 
     /**
      * Construct a Schema. Most users should not construct schemas manually, preferring {@link SchemaBuilder} instead.
@@ -118,6 +119,7 @@ public class ConnectSchema implements Schema {
 
         this.keySchema = keySchema;
         this.valueSchema = valueSchema;
+        this.hc = Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc, parameters);
     }
 
     /**
@@ -283,20 +285,20 @@ public class ConnectSchema implements Schema {
         if (o == null || getClass() != o.getClass()) return false;
         ConnectSchema schema = (ConnectSchema) o;
         return Objects.equals(optional, schema.optional) &&
+                Objects.equals(version, schema.version) &&
+                Objects.equals(name, schema.name) &&
+                Objects.equals(doc, schema.doc) &&
                 Objects.equals(type, schema.type) &&
                 Objects.equals(defaultValue, schema.defaultValue) &&
                 Objects.equals(fields, schema.fields) &&
                 Objects.equals(keySchema, schema.keySchema) &&
                 Objects.equals(valueSchema, schema.valueSchema) &&
-                Objects.equals(name, schema.name) &&
-                Objects.equals(version, schema.version) &&
-                Objects.equals(doc, schema.doc) &&
                 Objects.equals(parameters, schema.parameters);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc, parameters);
+        return this.hc;
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -93,7 +93,8 @@ public class ConnectSchema implements Schema {
     // Optional human readable documentation describing this schema.
     private final String doc;
     private final Map<String, String> parameters;
-    private final int hc;  // precomputed hash code
+    // precomputed hash code. There is no need to re-compute every time hashCode() is called.
+    private final int hash;
 
     /**
      * Construct a Schema. Most users should not construct schemas manually, preferring {@link SchemaBuilder} instead.
@@ -119,7 +120,7 @@ public class ConnectSchema implements Schema {
 
         this.keySchema = keySchema;
         this.valueSchema = valueSchema;
-        this.hc = Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc, parameters);
+        this.hash = Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc, parameters);
     }
 
     /**
@@ -298,7 +299,7 @@ public class ConnectSchema implements Schema {
 
     @Override
     public int hashCode() {
-        return this.hc;
+        return this.hash;
     }
 
     @Override


### PR DESCRIPTION
Re-arrange order of comparisons in equals() to evaluate non-composite fields first
Cache hash code