### PR TITLE
KAFKA-6163 fail fast on startup

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -350,6 +350,8 @@ class LogManager(logDirs: Seq[File],
     } catch {
       case e: ExecutionException =>
         error("There was an error in one of the threads during logs loading: " + e.getCause)
+        // skip loading remaining logs so we fail faster
+        threadPools.foreach(_.shutdownNow())
         throw e.getCause
     } finally {
       threadPools.foreach(_.shutdown())


### PR DESCRIPTION
skip loading remaining logs if we encounter an unrecoverable error on startup

@hachikuji @ijuma 