### PR TITLE
MINOR: Fix Javadoc Issues

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java
@@ -313,9 +313,10 @@ public class StickyAssignor extends AbstractPartitionAssignor {
     /**
      * determine if the current assignment is a balanced one
      *
+     * @param currentAssignment: the assignment whose balance needs to be checked
      * @param sortedCurrentSubscriptions: an ascending sorted set of consumers based on how many topic partitions are already assigned to them
      * @param allSubscriptions: a mapping of all consumers to all potential topic partitions that can be assigned to them
-     * @return
+     * @return true if the given assignment is balanced; false otherwise
      */
     private boolean isBalanced(Map<String, List<TopicPartition>> currentAssignment,
                                TreeSet<String> sortedCurrentSubscriptions,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/SubscriptionState.java
@@ -51,7 +51,7 @@ import java.util.regex.Pattern;
  *
  * This class also maintains a cache of the latest commit position for each of the assigned
  * partitions. This is updated through {@link #committed(TopicPartition, OffsetAndMetadata)} and can be used
- * to set the initial fetch position (e.g. {@link Fetcher#resetOffset(TopicPartition)}.
+ * to set the initial fetch position (e.g. {@link Fetcher#resetOffsets(Set)}.
  */
 public class SubscriptionState {
     private static final String SUBSCRIPTION_EXCEPTION_MESSAGE =

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -186,7 +186,7 @@ public class MetadataTest {
      * wait forever with a max timeout value of 0
      *
      * @throws Exception
-     * @see https://issues.apache.org/jira/browse/KAFKA-1836
+     * @see <a href=https://issues.apache.org/jira/browse/KAFKA-1836>KAFKA-1836</a>
      */
     @Test
     public void testMetadataUpdateWaitTime() throws Exception {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/StickyAssignorTest.java
@@ -676,7 +676,7 @@ public class StickyAssignorTest {
      * - there is no topic partition that can be moved from one consumer to another with 2+ fewer topic partitions
      *
      * @param subscriptions: topic subscriptions of each consumer
-     * @param assignment: given assignment for balance check
+     * @param assignments: given assignment for balance check
      */
     private static void verifyValidityAndBalance(Map<String, Subscription> subscriptions, Map<String, List<TopicPartition>> assignments) {
         int size = subscriptions.size();


### PR DESCRIPTION
This PR mainly fixes some broken links and invalid references in the clients Javadoc