### PR TITLE
MINOR: Exclude Committer Checklist section from commit message

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 *More detailed description of your change,
 if necessary. The PR title and PR message become
-the squashed commit message so use a separate
+the squashed commit message, so use a separate
 comment to ping reviewers.*
 
 *Summary of testing strategy (including rationale)
@@ -8,7 +8,7 @@ for the feature or bug fix. Unit and/or integration
 tests are expected for any behaviour change and
 system tests should be considered for larger changes.*
 
-### Committer Checklist
+### Committer Checklist (excluded from commit message)
 - [ ] Verify design and implementation 
 - [ ] Verify test coverage and CI build status
 - [ ] Verify documentation (including upgrade notes)

--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -157,16 +157,22 @@ def merge_pr(pr_num, target_ref, title, body, pr_repo_desc):
     merge_message_flags = []
 
     merge_message_flags += ["-m", title]
+    
     if body is not None:
-        # We remove @ symbols from the body to avoid triggering e-mails
-        # to people every time someone creates a public fork of the project.
-        merge_message_flags += ["-m", body.replace("@", "")]
+        # Remove "Committer Checklist" section
+        checklist_index = body.find("### Committer Checklist")
+        if checklist_index != -1:
+            body = body[:checklist_index].rstrip()
+        # Remove @ symbols from the body to avoid triggering e-mails to people every time someone creates a
+        # public fork of the project.
+        body = body.replace("@", "")
+        merge_message_flags += ["-m", body]
 
     authors = "\n".join(["Author: %s" % a for a in distinct_authors])
 
     merge_message_flags += ["-m", authors]
 
-    if (reviewers != ""):
+    if reviewers != "":
         merge_message_flags += ["-m", "Reviewers: %s" % reviewers]
 
     if had_conflicts:


### PR DESCRIPTION
It seems like it's sufficient to be able to refer to it in the PR.

### Committer Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
