### PR TITLE
KAFKA-5238: BrokerTopicMetrics can be recreated after topic is deleted

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1045,6 +1045,11 @@ class ReplicaManager(val config: KafkaConfig,
 
       val adjustedMaxBytes = math.min(fetchInfo.maxBytes, limitBytes)
       try {
+        brokerTopicStats.allTopicsStats.totalFetchRequestRate.mark()
+        if (allPartitions.contains(tp)) {
+           brokerTopicStats.topicStats(tp.topic).totalFetchRequestRate.mark()
+        }
+
         if (traceEnabled)
           trace(s"Fetching log segment for partition $tp, offset $offset, partition fetch size $partitionFetchSize, " +
             s"remaining response limit $limitBytes" +

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1045,11 +1045,6 @@ class ReplicaManager(val config: KafkaConfig,
 
       val adjustedMaxBytes = math.min(fetchInfo.maxBytes, limitBytes)
       try {
-        brokerTopicStats.allTopicsStats.totalFetchRequestRate.mark()
-        if (allPartitions.contains(tp)) {
-           brokerTopicStats.topicStats(tp.topic).totalFetchRequestRate.mark()
-        }
-
         if (traceEnabled)
           trace(s"Fetching log segment for partition $tp, offset $offset, partition fetch size $partitionFetchSize, " +
             s"remaining response limit $limitBytes" +

--- a/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
+++ b/core/src/test/scala/unit/kafka/metrics/MetricsTest.scala
@@ -71,7 +71,7 @@ class MetricsTest extends KafkaServerTestHarness with Logging {
   }
 
   @Test
-  def testBrokerTopicMetricsUnregisteredAfterDeletingTopicWithDelayedFetches() {
+  def testBrokerTopicMetricsUnregisteredAfterDeletingTopicWithDelayedFetches(): Unit = {
     val topic = "test-broker-topic-metric"
     adminZkClient.createTopic(topic, 2, 1)
     // Produce a few messages and consume them to create the metrics


### PR DESCRIPTION
Avoiding a DelayedFetch recreate the metrics when a topic has been
deleted

developed with @mimaison

added unit test borrowed from @ijuma JIRA