### PR TITLE
MINOR: Not enough replica exception should never happen for delete records

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DeleteRecordsResponse.java
@@ -78,7 +78,6 @@ public class DeleteRecordsResponse extends AbstractResponse {
      * UNKNOWN_TOPIC_OR_PARTITION (3)
      * NOT_LEADER_FOR_PARTITION (6)
      * REQUEST_TIMED_OUT (7)
-     * NOT_ENOUGH_REPLICAS (19)
      * UNKNOWN (-1)
      */
 

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -545,8 +545,7 @@ class ReplicaManager(val config: KafkaConfig,
                    _: NotLeaderForPartitionException |
                    _: OffsetOutOfRangeException |
                    _: PolicyViolationException |
-                   _: KafkaStorageException |
-                   _: NotEnoughReplicasException) =>
+                   _: KafkaStorageException) =>
             (topicPartition, LogDeleteRecordsResult(-1L, -1L, Some(e)))
           case t: Throwable =>
             error("Error processing delete records operation on partition %s".format(topicPartition), t)


### PR DESCRIPTION
When reviewing https://github.com/apache/kafka/pull/4132, I felt that NOT_ENOUGH_REPLICAS should never happen actually. Hence proposing to remove it from the listed error code as well in the broker-side capture clause.

Testing added in 4132 should have been sufficient.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
