### PR TITLE
KAFKA-5859: Avoid retaining AbstractRequest in RequestChannel.Response

### DIFF
--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -66,10 +66,61 @@ object RequestChannel extends Logging {
 
   class Request(val processor: Int,
                 val context: RequestContext,
-                val startTimeNanos: Long,
+                startTimeNanos: Long,
                 memoryPool: MemoryPool,
                 @volatile private var buffer: ByteBuffer,
                 metrics: RequestChannel.Metrics) extends BaseRequest {
+    val session = Session(context.principal, context.clientAddress)
+    lazy val timers: RequestTimers = new RequestTimers
+    lazy val bodyAndSize: RequestAndSize = context.parseRequest(buffer)
+    lazy val description: String = s"$header -- ${bodyAndSize.request.toString(requestLogger.underlying.isTraceEnabled)}"
+
+    /** Called only to provide the necessary bits of the Request to the Response **/
+    def toSummary: RequestSummary = new RequestSummary(
+      processor,
+      metrics,
+      context,
+      session,
+      startTimeNanos,
+      description,
+      timers,
+      requestBodySizeInBytes = bodyAndSize.size,
+      isFromFollower = bodyAndSize.request match {
+        case r:FetchRequest => r.isFromFollower
+        case _ => false
+      }
+    )
+
+    def header: RequestHeader = context.header
+
+    trace(s"Processor $processor received request: $description")
+
+    def body[T <: AbstractRequest](implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
+      bodyAndSize.request match {
+        case r: T => r
+        case r =>
+          throw new ClassCastException(s"Expected request with type ${classTag.runtimeClass}, but found ${r.getClass}")
+      }
+    }
+
+    def releaseBuffer(): Unit = {
+      if (buffer != null) {
+        // force evaluation of bodyAndSize and request parsing before buffer is released
+        bodyAndSize
+        memoryPool.release(buffer)
+        buffer = null
+      }
+    }
+
+    override def toString = s"Request(processor=$processor, " +
+      s"connectionId=${context.connectionId}, " +
+      s"session=$session, " +
+      s"listenerName=${context.listenerName}, " +
+      s"securityProtocol=${context.securityProtocol}, " +
+      s"buffer=$buffer)"
+  }
+
+  class RequestTimers {
     // These need to be volatile because the readers are in the network thread and the writers are in the request
     // handler threads or the purgatory threads
     @volatile var requestDequeueTimeNanos = -1L
@@ -81,37 +132,30 @@ object RequestChannel extends Logging {
     @volatile var temporaryMemoryBytes = 0L
     @volatile var recordNetworkThreadTimeCallback: Option[Long => Unit] = None
 
-    val session = Session(context.principal, context.clientAddress)
-    private val bodyAndSize: RequestAndSize = context.parseRequest(buffer)
-
-    def header: RequestHeader = context.header
-    def sizeOfBodyInBytes: Int = bodyAndSize.size
-
-    //most request types are parsed entirely into objects at this point. for those we can release the underlying buffer.
-    //some (like produce, or any time the schema contains fields of types BYTES or NULLABLE_BYTES) retain a reference
-    //to the buffer. for those requests we cannot release the buffer early, but only when request processing is done.
-    if (!header.apiKey.requiresDelayedAllocation) {
-      releaseBuffer()
-    }
-
-    def requestDesc(details: Boolean): String = s"$header -- ${body[AbstractRequest].toString(details)}"
-
-    def body[T <: AbstractRequest](implicit classTag: ClassTag[T], nn: NotNothing[T]): T = {
-      bodyAndSize.request match {
-        case r: T => r
-        case r =>
-          throw new ClassCastException(s"Expected request with type ${classTag.runtimeClass}, but found ${r.getClass}")
-      }
-    }
-
-    trace(s"Processor $processor received request: ${requestDesc(true)}")
-
     def requestThreadTimeNanos = {
       if (apiLocalCompleteTimeNanos == -1L) apiLocalCompleteTimeNanos = Time.SYSTEM.nanoseconds
       math.max(apiLocalCompleteTimeNanos - requestDequeueTimeNanos, 0L)
     }
+  }
+
+  /** Summary of Request without the parsed request **/
+  class RequestSummary(
+    val processor: Int,
+    val metrics: Metrics,
+    val context: RequestContext,
+    val session: Session,
+    startTimeNanos: Long,
+    val description: String,
+    val timers: RequestTimers,
+    requestBodySizeInBytes: Int,
+    isFromFollower: Boolean
+  ) {
+    def header: RequestHeader = context.header
+    def sizeInBytes: Int = requestBodySizeInBytes
 
     def updateRequestMetrics(networkThreadTimeNanos: Long, response: Response) {
+      import timers._
+
       val endTimeNanos = Time.SYSTEM.nanoseconds
       // In some corner cases, apiLocalCompleteTimeNanos may not be set when the request completes if the remote
       // processing time is really small. This value is set in KafkaApis from a request handling thread.
@@ -125,10 +169,10 @@ object RequestChannel extends Logging {
         apiRemoteCompleteTimeNanos = responseCompleteTimeNanos
 
       /**
-       * Converts nanos to millis with micros precision as additional decimal places in the request log have low
-       * signal to noise ratio. When it comes to metrics, there is little difference either way as we round the value
-       * to the nearest long.
-       */
+        * Converts nanos to millis with micros precision as additional decimal places in the request log have low
+        * signal to noise ratio. When it comes to metrics, there is little difference either way as we round the value
+        * to the nearest long.
+        */
       def nanosToMs(nanos: Long): Double = {
         val positiveNanos = math.max(nanos, 0)
         TimeUnit.NANOSECONDS.toMicros(positiveNanos).toDouble / TimeUnit.MILLISECONDS.toMicros(1)
@@ -142,9 +186,8 @@ object RequestChannel extends Logging {
       val responseSendTimeMs = nanosToMs(endTimeNanos - responseDequeueTimeNanos)
       val messageConversionsTimeMs = nanosToMs(messageConversionsTimeNanos)
       val totalTimeMs = nanosToMs(endTimeNanos - startTimeNanos)
-      val fetchMetricNames =
+      val fetchMetricNames: Seq[String] =
         if (header.apiKey == ApiKeys.FETCH) {
-          val isFromFollower = body[FetchRequest].isFromFollower
           Seq(
             if (isFromFollower) RequestMetrics.followFetchMetricName
             else RequestMetrics.consumerFetchMetricName
@@ -162,7 +205,7 @@ object RequestChannel extends Logging {
         m.responseQueueTimeHist.update(Math.round(responseQueueTimeMs))
         m.responseSendTimeHist.update(Math.round(responseSendTimeMs))
         m.totalTimeHist.update(Math.round(totalTimeMs))
-        m.requestBytesHist.update(sizeOfBodyInBytes)
+        m.requestBytesHist.update(sizeInBytes)
         m.messageConversionsTimeHist.foreach(_.update(Math.round(messageConversionsTimeMs)))
         m.tempMemoryBytesHist.foreach(_.update(temporaryMemoryBytes))
       }
@@ -176,7 +219,6 @@ object RequestChannel extends Logging {
       recordNetworkThreadTimeCallback.foreach(record => record(networkThreadTimeNanos))
 
       if (isRequestLoggingEnabled) {
-        val detailsEnabled = requestLogger.underlying.isTraceEnabled
         val responseString =
           if (response.responseSend.isDefined)
             response.responseAsString.getOrElse(
@@ -184,7 +226,7 @@ object RequestChannel extends Logging {
           else ""
 
         val builder = new StringBuilder(256)
-        builder.append("Completed request:").append(requestDesc(detailsEnabled))
+        builder.append("Completed request:").append(description)
           .append(",response:").append(responseString)
           .append(" from connection ").append(context.connectionId)
           .append(";totalTime:").append(totalTimeMs)
@@ -204,28 +246,14 @@ object RequestChannel extends Logging {
         requestLogger.debug(builder.toString)
       }
     }
-
-    def releaseBuffer(): Unit = {
-      if (buffer != null) {
-        memoryPool.release(buffer)
-        buffer = null
-      }
-    }
-
-    override def toString = s"Request(processor=$processor, " +
-      s"connectionId=${context.connectionId}, " +
-      s"session=$session, " +
-      s"listenerName=${context.listenerName}, " +
-      s"securityProtocol=${context.securityProtocol}, " +
-      s"buffer=$buffer)"
-
   }
 
   /** responseAsString should only be defined if request logging is enabled */
-  class Response(val request: Request, val responseSend: Option[Send], val responseAction: ResponseAction,
+  class Response(val request: RequestSummary, val responseSend: Option[Send], val responseAction: ResponseAction,
                  val responseAsString: Option[String]) {
-    request.responseCompleteTimeNanos = Time.SYSTEM.nanoseconds
-    if (request.apiLocalCompleteTimeNanos == -1L) request.apiLocalCompleteTimeNanos = Time.SYSTEM.nanoseconds
+    request.timers.responseCompleteTimeNanos = Time.SYSTEM.nanoseconds
+    if (request.timers.apiLocalCompleteTimeNanos == -1L)
+      request.timers.apiLocalCompleteTimeNanos = Time.SYSTEM.nanoseconds
 
     def processor: Int = request.processor
 
@@ -304,7 +332,7 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
   def receiveResponse(processor: Int): RequestChannel.Response = {
     val response = responseQueues(processor).poll()
     if (response != null)
-      response.request.responseDequeueTimeNanos = Time.SYSTEM.nanoseconds
+      response.request.timers.responseDequeueTimeNanos = Time.SYSTEM.nanoseconds
     response
   }
 

--- a/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
+++ b/core/src/main/scala/kafka/server/ClientRequestQuotaManager.scala
@@ -37,18 +37,18 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
   }
 
   def maybeRecordAndThrottle(request: RequestChannel.Request, sendResponseCallback: Int => Unit): Unit = {
-    if (request.apiRemoteCompleteTimeNanos == -1) {
+    if (request.timers.apiRemoteCompleteTimeNanos == -1) {
       // When this callback is triggered, the remote API call has completed
-      request.apiRemoteCompleteTimeNanos = time.nanoseconds
+      request.timers.apiRemoteCompleteTimeNanos = time.nanoseconds
     }
 
     if (quotasEnabled) {
       val quotaSensors = getOrCreateQuotaSensors(request.session.sanitizedUser, request.header.clientId)
-      request.recordNetworkThreadTimeCallback = Some(timeNanos => recordNoThrottle(quotaSensors, nanosToPercentage(timeNanos)))
+      request.timers.recordNetworkThreadTimeCallback = Some(timeNanos => recordNoThrottle(quotaSensors, nanosToPercentage(timeNanos)))
 
       recordAndThrottleOnQuotaViolation(
           quotaSensors,
-          nanosToPercentage(request.requestThreadTimeNanos),
+          nanosToPercentage(request.timers.requestThreadTimeNanos),
           sendResponseCallback)
     } else {
       sendResponseCallback(0)
@@ -57,8 +57,8 @@ class ClientRequestQuotaManager(private val config: ClientQuotaManagerConfig,
 
   def maybeRecordExempt(request: RequestChannel.Request): Unit = {
     if (quotasEnabled) {
-      request.recordNetworkThreadTimeCallback = Some(timeNanos => recordExempt(nanosToPercentage(timeNanos)))
-      recordExempt(nanosToPercentage(request.requestThreadTimeNanos))
+      request.timers.recordNetworkThreadTimeCallback = Some(timeNanos => recordExempt(nanosToPercentage(timeNanos)))
+      recordExempt(nanosToPercentage(request.timers.requestThreadTimeNanos))
     }
   }
 

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -94,7 +94,7 @@ class KafkaApis(val requestChannel: RequestChannel,
    */
   def handle(request: RequestChannel.Request) {
     try {
-      trace(s"Handling request:${request.requestDesc(true)} from connection ${request.context.connectionId};" +
+      trace(s"Handling request:${request.description} from connection ${request.context.connectionId};" +
         s"securityProtocol:${request.context.securityProtocol},principal:${request.context.principal}")
       request.header.apiKey match {
         case ApiKeys.PRODUCE => handleProduceRequest(request)
@@ -140,7 +140,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       case e: FatalExitError => throw e
       case e: Throwable => handleError(request, e)
     } finally {
-      request.apiLocalCompleteTimeNanos = time.nanoseconds
+      request.timers.apiLocalCompleteTimeNanos = time.nanoseconds
     }
   }
 
@@ -364,7 +364,7 @@ class KafkaApis(val requestChannel: RequestChannel,
    */
   def handleProduceRequest(request: RequestChannel.Request) {
     val produceRequest = request.body[ProduceRequest]
-    val numBytesAppended = request.header.toStruct.sizeOf + request.sizeOfBodyInBytes
+    val numBytesAppended = request.header.toStruct.sizeOf + request.bodyAndSize.size
 
     if (produceRequest.isTransactional) {
       if (!authorize(request.session, Write, new Resource(TransactionalId, produceRequest.transactionalId))) {
@@ -433,7 +433,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
 
       // When this callback is triggered, the remote API call has completed
-      request.apiRemoteCompleteTimeNanos = time.nanoseconds
+      request.timers.apiRemoteCompleteTimeNanos = time.nanoseconds
 
       quotas.produce.maybeRecordAndThrottle(
         request.session.sanitizedUser,
@@ -569,7 +569,7 @@ class KafkaApis(val requestChannel: RequestChannel,
 
       // When this callback is triggered, the remote API call has completed.
       // Record time before any byte-rate throttling.
-      request.apiRemoteCompleteTimeNanos = time.nanoseconds
+      request.timers.apiRemoteCompleteTimeNanos = time.nanoseconds
 
       if (fetchRequest.isFromFollower) {
         // We've already evaluated against the quota and are good to go. Just need to record it now.
@@ -2014,9 +2014,9 @@ class KafkaApis(val requestChannel: RequestChannel,
         case _ =>
           throw new IllegalStateException("Message conversion info is recorded only for Produce/Fetch requests")
       }
-      request.messageConversionsTimeNanos = processingStats.conversionTimeNanos
+      request.timers.messageConversionsTimeNanos = processingStats.conversionTimeNanos
     }
-    request.temporaryMemoryBytes = processingStats.temporaryMemoryBytes
+    request.timers.temporaryMemoryBytes = processingStats.temporaryMemoryBytes
   }
 
   private def handleError(request: RequestChannel.Request, e: Throwable) {
@@ -2065,22 +2065,24 @@ class KafkaApis(val requestChannel: RequestChannel,
     // This case is used when the request handler has encountered an error, but the client
     // does not expect a response (e.g. when produce request has acks set to 0)
     requestChannel.updateErrorMetrics(request.header.apiKey, errorCounts.asScala)
-    requestChannel.sendResponse(new RequestChannel.Response(request, None, CloseConnectionAction, None))
+    requestChannel.sendResponse(new RequestChannel.Response(request.toSummary, None, CloseConnectionAction, None))
   }
 
   private def sendResponse(request: RequestChannel.Request, responseOpt: Option[AbstractResponse]): Unit = {
     // Update error metrics for each error code in the response including Errors.NONE
     responseOpt.foreach(response => requestChannel.updateErrorMetrics(request.header.apiKey, response.errorCounts.asScala))
 
+    val requestSummary = request.toSummary
     responseOpt match {
       case Some(response) =>
         val responseSend = request.context.buildResponse(response)
         val responseString =
           if (RequestChannel.isRequestLoggingEnabled) Some(response.toString(request.context.apiVersion))
           else None
-        requestChannel.sendResponse(new RequestChannel.Response(request, Some(responseSend), SendAction, responseString))
+        requestChannel.sendResponse(new RequestChannel.Response(requestSummary, Some(responseSend), SendAction,
+          responseString))
       case None =>
-        requestChannel.sendResponse(new RequestChannel.Response(request, None, NoOpAction, None))
+        requestChannel.sendResponse(new RequestChannel.Response(requestSummary, None, NoOpAction, None))
     }
   }
 

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -60,7 +60,7 @@ class KafkaRequestHandler(id: Int,
 
         case request: RequestChannel.Request =>
           try {
-            request.requestDequeueTimeNanos = endTime
+            request.timers.requestDequeueTimeNanos = endTime
             trace(s"Kafka request handler $id on broker $brokerId handling request $request")
             apis.handle(request)
           } catch {

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -130,7 +130,7 @@ class SocketServerTest extends JUnitSuite {
     byteBuffer.rewind()
 
     val send = new NetworkSend(request.context.connectionId, byteBuffer)
-    channel.sendResponse(new RequestChannel.Response(request, Some(send), SendAction, Some(request.header.toString)))
+    channel.sendResponse(new RequestChannel.Response(request.toSummary, Some(send), SendAction, Some(request.header.toString)))
   }
 
   def connect(s: SocketServer = server, protocol: SecurityProtocol = SecurityProtocol.PLAINTEXT) = {
@@ -214,7 +214,7 @@ class SocketServerTest extends JUnitSuite {
     for (_ <- 0 until 10) {
       val request = receiveRequest(server.requestChannel)
       assertNotNull("receiveRequest timed out", request)
-      server.requestChannel.sendResponse(new RequestChannel.Response(request, None, RequestChannel.NoOpAction, None))
+      server.requestChannel.sendResponse(new RequestChannel.Response(request.toSummary, None, RequestChannel.NoOpAction, None))
     }
   }
 
@@ -228,7 +228,7 @@ class SocketServerTest extends JUnitSuite {
     for (_ <- 0 until 3) {
       val request = receiveRequest(server.requestChannel)
       assertNotNull("receiveRequest timed out", request)
-      server.requestChannel.sendResponse(new RequestChannel.Response(request, None, RequestChannel.NoOpAction, None))
+      server.requestChannel.sendResponse(new RequestChannel.Response(request.toSummary, None, RequestChannel.NoOpAction, None))
     }
   }
 
@@ -555,7 +555,7 @@ class SocketServerTest extends JUnitSuite {
       // detected. If the buffer is larger than 102400 bytes, a second write is attempted and it fails with an
       // IOException.
       val send = new NetworkSend(request.context.connectionId, ByteBuffer.allocate(550000))
-      channel.sendResponse(new RequestChannel.Response(request, Some(send), SendAction, None))
+      channel.sendResponse(new RequestChannel.Response(request.toSummary, Some(send), SendAction, None))
       TestUtils.waitUntilTrue(() => totalTimeHistCount() == expectedTotalTimeCount,
         s"request metrics not updated, expected: $expectedTotalTimeCount, actual: ${totalTimeHistCount()}")
 


### PR DESCRIPTION
This PR removes the need to keep a reference to the parsed `AbstractRequest` after it's been handled in `KafkaApis`.  A reference to `RequestAndSize` which holds the parsed `AbstractRequest` in  `RequestChannel.Request` was kept in scope as a consequence of being passed into the `RequestChannel.Response` after being handled.  

The Jira ticket [KAFKA-5859](https://issues.apache.org/jira/browse/KAFKA-5859) suggests removing this reference as soon as it's no longer needed.  I considered several implementations and I settled on creating a new type that contains all the relevant information of the Request that is required after it has been handled.  I think this approach allows for the least amount of invasive changes in the Request/Response lifecycle while retaining the immutability of the `RequestChannel.Request`.

A new type called `RequestChannel.RequestSummary` now contains much of the information that was in `RequestChannel.Request` before.  The `RequestChannel.Request` now generates a `RequestChannel.RequestSummary` that is passed into the `RequestChannel.Response` after being handled in `KafkaApis`.  `RequestChannel.RequestSummary` contains information such as:

* A detailed and non-detailed description of the request
* Metrics associated with the request
* Helper methods to update various Request metrics
* A special case describing whether or not the original Request was a `FetchRequest` and whether it was from a follower.  This information is required in the `updateRequestMetrics` metrics helper method.

This change does not make any behaviour changes so no additional tests were added.  I've verified that all unit and integration tests pass and no regressions were introduced.  I'm interested in seeing the before and after results of the Confluent Kafka system tests as described in step 11 of the [Contributing Code Changes](https://cwiki.apache.org/confluence/display/KAFKA/Contributing+Code+Changes#ContributingCodeChanges-PullRequest) section.  I would like to request access to kick off this system tests suite if you agree that it's relevant to this ticket.

This is my first contribution to this project.  I picked up this issue because it was marked with the newbie flag and it seemed like a good opportunity to learn more about about the request and response lifecycle in the Kafka broker.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
