### PR TITLE
KAFKA-6181 Examining log messages with {{--deep-iteration}} should show superset of fields

### DIFF
--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -383,11 +383,11 @@ object DumpLogSegments {
             nonConsecutivePairsForLogFilesMap.put(file.getAbsolutePath, nonConsecutivePairsSeq)
           }
           lastOffset = record.offset
-
-          print("offset: " + record.offset + " position: " + validBytes +
+          print("offset: " + record.offset + " baseOffset: " + batch.baseOffset + " lastOffset: " + batch.lastOffset +" baseSequence: "+ batch.baseSequence 
+              +" lastSequence: "+ batch.lastSequence + " producerEpoch: "+ batch.producerEpoch + " partitionLeaderEpoch: " + batch.partitionLeaderEpoch +"position: " + validBytes +
             " " + batch.timestampType + ": " + record.timestamp + " isvalid: " + record.isValid +
-            " keysize: " + record.keySize + " valuesize: " + record.valueSize + " magic: " + batch.magic +
-            " compresscodec: " + batch.compressionType)
+            " keysize: " + record.keySize + " valuesize: " + record.valueSize +" size: "+ batch.sizeInBytes +" magic: " + batch.magic +
+            " compresscodec: " + batch.compressionType + " crc: " + record.checksumOrNull)
 
           if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
             print(" producerId: " + batch.producerId + " producerEpoch: " + batch.producerEpoch + " sequence: " + record.sequence +


### PR DESCRIPTION
Printing log data on Kafka brokers using kafka.tools.DumpLogSegments --deep-iteration option doesn't print all the fields.
Adding missing fields in the log data on kafka brokers
Adding following fields in the deep-interation option:

baseOffset
lastOffset
baseSequence
lastSequence
producerEpoch
partitionLeaderEpoch
size
crc

thanks,
Nikhil

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
