### PR TITLE
KAFKA-6207 : Include start of record when RecordIsTooLarge

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -912,15 +912,12 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
      */
     private void ensureValidRecordSize(int size, V recordValue) {
         if (size > this.maxRequestSize) {
-            byte[] byteArr = (byte[]) recordValue;
-            int iSize = byteArr.length;
-            StringBuffer sb = new StringBuffer();
-            for (int i = 0; i < iSize && iSize < 1024; i++) {
-                sb.append((char) byteArr[i]);
-            }
+            String strMessage = (String) recordValue;
+            String strMessageByte = strMessage.length() > 1024 ? strMessage.substring(0, 1023)
+                    : strMessage.substring(0, strMessage.length());
             throw new RecordTooLargeException("The message is " + size
                     + " bytes when serialized which is larger than the maximum request size you have configured with the "
-                    + ProducerConfig.MAX_REQUEST_SIZE_CONFIG + " configuration. The message was : " + sb.toString()
+                    + ProducerConfig.MAX_REQUEST_SIZE_CONFIG + " configuration. The message was : " + strMessageByte
                     + "...");
         }
         if (size > this.totalMemorySize)


### PR DESCRIPTION
When a message is too large to be sent (at org.apache.kafka.clients.producer.KafkaProducer#doSend), the RecordTooLargeException should carry the start of the record (for example, the first 1KB) so that the calling application can debug which message caused the error.

To resolve this, added functionality to log the first 1Kb of message, if RecordIsTooLarge exception is thrown.

Thanks,
Sumit Jawale

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
