### PR TITLE
KAFKA-6214: enable use of in-memory store for standby tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -140,11 +140,8 @@ public class ProcessorStateManager implements StateManager {
         final TopicPartition storePartition = new TopicPartition(topic, getPartition(topic));
 
         if (isStandby) {
-            if (store.persistent()) {
-                log.trace("Preparing standby replica of persistent state store {} with changelog topic {}", store.name(), topic);
-
-                restoreCallbacks.put(topic, stateRestoreCallback);
-            }
+            log.trace("Preparing standby replica of  state store {} with changelog topic {}", store.name(), topic);
+            restoreCallbacks.put(topic, stateRestoreCallback);
         } else {
             log.trace("Restoring state store {} from changelog topic {}", store.name(), topic);
             final StateRestorer restorer = new StateRestorer(storePartition,


### PR DESCRIPTION
Remove the flag in `ProcessorStateManager` that checks if a store is persistent when registering it as a standby task.
Updated the smoke test to use an in-memory store.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
