### PR TITLE
KAFKA-4893: Fix conflict between async topic deletion and max topic length

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -2148,13 +2148,14 @@ object Log {
     }
 
     val dirName = dir.getName
-    if (dirName == null || dirName.isEmpty || (!dirName.equals(DeleteDirParent) && !dirName.contains('-')))
+    val dirParentName = if (dir.getParent == null) null else dir.getParentFile.getName
+    if (dirName == null || dirName.isEmpty || dirParentName == null || (!dirParentName.equals(DeleteDirParent) && !dirName.contains('-')))
       throw exception(dir)
     if (dirName.endsWith(DeleteDirSuffix) && !DeleteDirPattern.matcher(dirName).matches ||
         dirName.endsWith(FutureDirSuffix) && !FutureDirPattern.matcher(dirName).matches)
       throw exception(dir)
 
-    if (dir.getParent.equals(DeleteDirParent)) {
+    if (dirParentName.equals(DeleteDirParent)) {
       // the inspected file is inside the 'delete' folder
       val files = dir.listFiles(new FileFilter {
         override def accept(file: File): Boolean =
@@ -2164,7 +2165,7 @@ object Log {
           }
       })
 
-      if (files.isEmpty)
+      if (files == null || files.isEmpty)
         throw exception(dir)
 
       val splits = files(0).getName.split("-")

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -51,6 +51,7 @@ class LogTest {
   val brokerTopicStats = new BrokerTopicStats
   val tmpDir = TestUtils.tempDir()
   val logDir = TestUtils.randomPartitionLogDir(tmpDir)
+  val deleteDir = new File(logDir, Log.DeleteDirParent)
   val mockTime = new MockTime()
 
   @Before
@@ -2417,9 +2418,17 @@ class LogTest {
   @Test
   def testParseTopicPartitionNameWithPeriodForDeletedTopic() {
     val topic = "foo.bar-testtopic"
-    val partition = "42"
-    val dir = new File(logDir, Log.logDeleteDirName(new TopicPartition(topic, partition.toInt)))
-    val topicPartition = Log.parseTopicPartitionName(dir)
+    val partition = 42
+
+    // old topic deletion marker
+    var dir = new File(logDir, Log.logDeleteDirName(new TopicPartition(topic, partition).toString))
+    var topicPartition = Log.parseTopicPartitionName(dir)
+    assertEquals("Unexpected topic name parsed", topic, topicPartition.topic)
+    assertEquals("Unexpected partition number parsed", partition.toInt, topicPartition.partition)
+
+    // new topic deletion marker
+    dir = new File(logDir, Log.logDirName(new TopicPartition(topic, partition)))
+    topicPartition = Log.parseTopicPartitionName(dir)
     assertEquals("Unexpected topic name parsed", topic, topicPartition.topic)
     assertEquals("Unexpected partition number parsed", partition.toInt, topicPartition.partition)
   }
@@ -2478,11 +2487,21 @@ class LogTest {
     } catch {
       case _: KafkaException => // expected
     }
-    // also test the "-delete" marker case
-    val deleteMarkerDir = new File(logDir, Log.logDeleteDirName(new TopicPartition(topic, partition.toInt)))
+
+    // also test the "-delete" marker case (old topic deletion marker)
+    val deleteMarkerDir = new File(logDir, Log.logDeleteDirName(new TopicPartition(topic, partition.toInt).toString))
     try {
       Log.parseTopicPartitionName(deleteMarkerDir)
       fail("KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
+    } catch {
+      case _: KafkaException => // expected
+    }
+
+    // also test the case for dir marked for deletion (new topic deletion marker)
+    val markedForDeletionDir = new File(deleteDir, Log.logDeleteDirName())
+    try {
+      Log.parseTopicPartitionName(markedForDeletionDir)
+      fail("KafkaException should have been thrown for dir: " + markedForDeletionDir.getCanonicalPath)
     } catch {
       case _: KafkaException => // expected
     }
@@ -2500,11 +2519,21 @@ class LogTest {
     } catch {
       case _: KafkaException => // expected
     }
-    // also test the "-delete" marker case
+
+    // also test the "-delete" marker case (old topic deletion marker)
     val deleteMarkerDir = new File(logDir, topicPartitionName(topic, partition) + "." + DeleteDirSuffix)
     try {
       Log.parseTopicPartitionName(deleteMarkerDir)
       fail("KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
+    } catch {
+      case _: KafkaException => // expected
+    }
+
+    // also test the case for dir marked for deletion (new topic deletion marker)
+    val markedForDeletionDir = new File(deleteDir, Log.logDeleteDirName())
+    try {
+      Log.parseTopicPartitionName(markedForDeletionDir)
+      fail("KafkaException should have been thrown for dir: " + markedForDeletionDir.getCanonicalPath)
     } catch {
       case _: KafkaException => // expected
     }
@@ -2521,11 +2550,21 @@ class LogTest {
     } catch {
       case _: KafkaException => // expected
     }
-    // also test the "-delete" marker case
+
+    // also test the "-delete" marker case (old topic deletion marker)
     val deleteMarkerDir = new File(logDir, topic + partition + "." + DeleteDirSuffix)
     try {
       Log.parseTopicPartitionName(deleteMarkerDir)
       fail("KafkaException should have been thrown for dir: " + deleteMarkerDir.getCanonicalPath)
+    } catch {
+      case _: KafkaException => // expected
+    }
+
+    // also test the case for dir marked for deletion (new topic deletion marker)
+    val markedForDeletionDir = new File(deleteDir, Log.logDeleteDirName())
+    try {
+      Log.parseTopicPartitionName(markedForDeletionDir)
+      fail("KafkaException should have been thrown for dir: " + markedForDeletionDir.getCanonicalPath)
     } catch {
       case _: KafkaException => // expected
     }


### PR DESCRIPTION
With async topic deletion the topic partition folder name is affixed with a '.', a UUID, and '-delete'. If topic name length is close to its current limit (249) this could cause an issue because the folder name size goes over 255.
This PR implements the [suggestion solution](https://issues.apache.org/jira/browse/KAFKA-4893?focusedCommentId=15927155) by @onurkaraman in the JIRA.
This implementation is automatically backward compatible, and cleans up any folder marked for deletion using the old method (affixing the folder name).