### PR TITLE
MINOR: Update Powermock to fix PushHttpMetricsReporterTest failures

### DIFF
--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -43,11 +43,12 @@ import org.apache.kafka.connect.util.MockTime;
 import org.apache.kafka.connect.util.ThreadedTest;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.api.easymock.annotation.MockStrict;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -76,15 +77,17 @@ public class WorkerTest extends ThreadedTest {
     private Worker worker;
 
     @Mock
-    private Plugins plugins = PowerMock.createMock(Plugins.class);
+    private Plugins plugins;
     @Mock
-    private PluginClassLoader pluginLoader = PowerMock.createMock(PluginClassLoader.class);
+    private PluginClassLoader pluginLoader;
     @Mock
-    private DelegatingClassLoader delegatingLoader =
-            PowerMock.createMock(DelegatingClassLoader.class);
-    private OffsetBackingStore offsetBackingStore = PowerMock.createMock(OffsetBackingStore.class);
-    private TaskStatus.Listener taskStatusListener = PowerMock.createStrictMock(TaskStatus.Listener.class);
-    private ConnectorStatus.Listener connectorStatusListener = PowerMock.createStrictMock(ConnectorStatus.Listener.class);
+    private DelegatingClassLoader delegatingLoader;
+    @Mock
+    private OffsetBackingStore offsetBackingStore;
+    @MockStrict
+    private TaskStatus.Listener taskStatusListener;
+    @MockStrict
+    private ConnectorStatus.Listener connectorStatusListener;
 
     @Before
     public void setup() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -60,7 +60,7 @@ versions += [
   junit: "4.12",
   lz4: "1.3.0",
   metrics: "2.2.0",
-  powermock: "1.6.4",
+  powermock: "2.0.0-beta.5",
   reflections: "0.9.11",
   rocksDB: "5.0.1",
   scalaTest: "3.0.2",


### PR DESCRIPTION
Fixes test failures where old versions of Powermock don't handle nested classes accessing parent field members when using mockStatic.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
