### PR TITLE
KAFKA-6258; SSLTransportLayer should keep reading from socket until either the buffer is full or the socket has no more data

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class SslTransportLayer implements TransportLayer {
     private static final Logger log = LoggerFactory.getLogger(SslTransportLayer.class);
 
-    private enum State {
+    protected enum State {
         HANDSHAKE,
         HANDSHAKE_FAILED,
         READY,
@@ -60,7 +60,7 @@ public class SslTransportLayer implements TransportLayer {
 
     private HandshakeStatus handshakeStatus;
     private SSLEngineResult handshakeResult;
-    private State state;
+    protected State state;
     private SslAuthenticationException handshakeException;
     private ByteBuffer netReadBuffer;
     private ByteBuffer netWriteBuffer;

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -482,7 +482,8 @@ public class SslTransportLayer implements TransportLayer {
 
 
     /**
-    * Reads a sequence of bytes from this channel into the given buffer.
+    * Reads a sequence of bytes from this channel into the given buffer. Reads as much as possible
+    * until either the dst buffer is full or there is no more data in the socket.
     *
     * @param dst The buffer into which bytes are to be transferred
     * @return The number of bytes read, possible zero or -1 if the channel has reached end-of-stream
@@ -501,6 +502,7 @@ public class SslTransportLayer implements TransportLayer {
         }
 
         boolean isClosed = false;
+        // Each loop reads at most once from the socket.
         while (dst.remaining() > 0) {
             int netread = 0;
             netReadBuffer = Utils.ensureCapacity(netReadBuffer, netReadBufferSize());

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class SslTransportLayer implements TransportLayer {
     private static final Logger log = LoggerFactory.getLogger(SslTransportLayer.class);
 
-    protected enum State {
+    private enum State {
         HANDSHAKE,
         HANDSHAKE_FAILED,
         READY,
@@ -60,7 +60,7 @@ public class SslTransportLayer implements TransportLayer {
 
     private HandshakeStatus handshakeStatus;
     private SSLEngineResult handshakeResult;
-    protected State state;
+    private State state;
     private SslAuthenticationException handshakeException;
     private ByteBuffer netReadBuffer;
     private ByteBuffer netWriteBuffer;

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -89,7 +89,7 @@ public class SslTransportLayer implements TransportLayer {
         this.netReadBuffer = ByteBuffer.allocate(netReadBufferSize());
         this.netWriteBuffer = ByteBuffer.allocate(netWriteBufferSize());
         this.appReadBuffer = ByteBuffer.allocate(applicationBufferSize());
-        
+
         //clear & set netRead & netWrite buffers
         netWriteBuffer.position(0);
         netWriteBuffer.limit(0);
@@ -500,8 +500,9 @@ public class SslTransportLayer implements TransportLayer {
             read = readFromAppBuffer(dst);
         }
 
-        int netread = 0;
-        if (dst.remaining() > 0) {
+        boolean isClosed = false;
+        while (dst.remaining() > 0) {
+            int netread = 0;
             netReadBuffer = Utils.ensureCapacity(netReadBuffer, netReadBufferSize());
             if (netReadBuffer.remaining() > 0)
                 netread = readFromSocketChannel();
@@ -547,15 +548,19 @@ public class SslTransportLayer implements TransportLayer {
                     // If data has been read and unwrapped, return the data. Close will be handled on the next poll.
                     if (appReadBuffer.position() == 0 && read == 0)
                         throw new EOFException();
-                    else
+                    else {
+                        isClosed = true;
                         break;
+                    }
                 }
             }
+            if (read == 0 && netread < 0)
+                throw new EOFException("EOF during read");
+            if (netread <= 0 || isClosed)
+                break;
         }
         // If data has been read and unwrapped, return the data even if end-of-stream, channel will be closed
         // on a subsequent poll.
-        if (read == 0 && netread < 0)
-            throw new EOFException("EOF during read");
         return read;
     }
 
@@ -771,7 +776,7 @@ public class SslTransportLayer implements TransportLayer {
     protected int netReadBufferSize() {
         return sslEngine.getSession().getPacketBufferSize();
     }
-    
+
     protected int netWriteBufferSize() {
         return sslEngine.getSession().getPacketBufferSize();
     }
@@ -779,7 +784,7 @@ public class SslTransportLayer implements TransportLayer {
     protected int applicationBufferSize() {
         return sslEngine.getSession().getApplicationBufferSize();
     }
-    
+
     protected ByteBuffer netReadBuffer() {
         return netReadBuffer;
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -62,6 +62,7 @@ public class NioEchoServer extends Thread {
     private volatile WritableByteChannel outputChannel;
     private final CredentialCache credentialCache;
     private final Metrics metrics;
+    private int numSent = 0;
 
     public NioEchoServer(ListenerName listenerName, SecurityProtocol securityProtocol, AbstractConfig config,
             String serverHost, ChannelBuilder channelBuilder, CredentialCache credentialCache) throws Exception {
@@ -157,13 +158,19 @@ public class NioEchoServer extends Thread {
                         selector.unmute(channelId);
                     }
                 }
-                for (Send send : selector.completedSends())
+                for (Send send : selector.completedSends()) {
                     selector.unmute(send.destination());
+                    numSent += 1;
+                }
 
             }
         } catch (IOException e) {
             // ignore
         }
+    }
+
+    public int numSent() {
+        return numSent;
     }
 
     private String id(SocketChannel channel) {

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -16,10 +16,13 @@
  */
 package org.apache.kafka.common.network;
 
+import java.nio.channels.SelectionKey;
+import javax.net.ssl.SSLEngine;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.memory.SimpleMemoryPool;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.ssl.SslFactory;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestCondition;
@@ -83,8 +86,14 @@ public class SslSelectorTest extends SelectorTest {
     public void testDisconnectWithIntermediateBufferedBytes() throws Exception {
         int requestSize = 100 * 1024;
         final String node = "0";
-        connect(node, new InetSocketAddress("localhost", server.port));
         String request = TestUtils.randomString(requestSize);
+
+        this.selector.close();
+
+        this.channelBuilder = new TestSslChannelBuilder(Mode.CLIENT);
+        this.channelBuilder.configure(sslClientConfigs);
+        this.selector = new Selector(5000, metrics, time, "MetricGroup", channelBuilder, new LogContext());
+        connect(node, new InetSocketAddress("localhost", server.port));
         selector.send(createSend(node, request));
 
         TestUtils.waitForCondition(new TestCondition() {
@@ -142,7 +151,7 @@ public class SslSelectorTest extends SelectorTest {
         Map<String, Object> sslServerConfigs = TestSslUtils.createSslConfig(false, true, Mode.SERVER, trustStoreFile, "server");
         channelBuilder = new SslChannelBuilder(Mode.SERVER);
         channelBuilder.configure(sslServerConfigs);
-        selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup", 
+        selector = new Selector(NetworkReceive.UNLIMITED, 5000, metrics, time, "MetricGroup",
                 new HashMap<String, String>(), true, false, channelBuilder, pool, new LogContext());
 
         try (ServerSocketChannel ss = ServerSocketChannel.open()) {
@@ -222,6 +231,44 @@ public class SslSelectorTest extends SelectorTest {
 
     private SslSender createSender(InetSocketAddress serverAddress, byte[] payload) {
         return new SslSender(serverAddress, payload);
+    }
+
+    private static class TestSslChannelBuilder extends SslChannelBuilder {
+
+        public TestSslChannelBuilder(Mode mode) {
+            super(mode);
+        }
+
+        @Override
+        protected SslTransportLayer buildTransportLayer(SslFactory sslFactory, String id, SelectionKey key, String host) throws IOException {
+            SocketChannel socketChannel = (SocketChannel) key.channel();
+            SSLEngine sslEngine = sslFactory.createSslEngine(host, socketChannel.socket().getPort());
+            TestSslTransportLayer transportLayer = new TestSslTransportLayer(id, key, sslEngine);
+            transportLayer.startHandshake();
+            return transportLayer;
+        }
+
+        /*
+         * TestSslTransportLayer will read from socket once every two tries. This increases
+         * the chance that there will be bytes buffered in the transport layer after read().
+         */
+        class TestSslTransportLayer extends SslTransportLayer {
+            boolean muteSocket = false;
+
+            public TestSslTransportLayer(String channelId, SelectionKey key, SSLEngine sslEngine) throws IOException {
+                super(channelId, key, sslEngine);
+            }
+
+            @Override
+            protected int readFromSocketChannel() throws IOException {
+                if (muteSocket) {
+                    muteSocket = false;
+                    return 0;
+                }
+                muteSocket = true;
+                return super.readFromSocketChannel();
+            }
+        }
     }
 
 }

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -13,7 +13,6 @@
 package kafka.api
 
 import java.util
-import java.util.{Collections, Properties}
 
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
@@ -70,49 +69,6 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
 
     // create the test topic with all the brokers as replicas
     TestUtils.createTopic(this.zkUtils, topic, 2, serverCount, this.servers)
-  }
-
-  @Test
-  def testPollWithRemainingDataInConsumerBuffer() {
-    val producer = producers.head
-
-    val props = new Properties(consumerConfig)
-    props.setProperty(ConsumerConfig.RECEIVE_BUFFER_CONFIG, "102400") // 100 KB socket read buffer size
-    props.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "2")
-    val consumer = TestUtils.createNewConsumer(brokerList,
-      securityProtocol = this.securityProtocol,
-      trustStoreFile = this.trustStoreFile,
-      saslProperties = this.clientSaslProperties,
-      props = Some(props))
-
-    consumer.subscribe(Collections.singletonList(topic))
-    TestUtils.waitUntilTrue(() => {
-      consumer.poll(0)
-      !consumer.assignment.isEmpty
-    }, "Expected non-empty assignment")
-
-    // Make sure partitions leaders are different
-    assertEquals(2, producer.partitionsFor(topic).asScala.map(_.leader().id()).toSet.size)
-    // The large message has 80KB data, which is 5X as large as size of SSLTransportLayer's netReadBuffer but smaller than socket read buffer size.
-    val smallRecord = new ProducerRecord(topic, 0, "key".getBytes(), "a".getBytes)
-    val largerRecord = new ProducerRecord(topic, 1, "key".getBytes(), ("a" * 80 * 1024).getBytes)
-
-    producer.send(smallRecord).get()
-    producer.send(smallRecord).get()
-    producer.send(smallRecord).get()
-    producer.send(smallRecord).get()
-
-    try {
-      // First poll should return one record from partition 0
-      assertEquals(1, consumer.poll(100).asScala.size)
-      producer.send(largerRecord).get()
-      // The large message with 80 KB data should be fetched within two poll() because the message size is smaller than socket buffer size.
-      val records1 = consumer.poll(100).asScala
-      val records2 = consumer.poll(100).asScala
-      assertTrue((records1 ++ records2).map(_.partition()).toSeq.contains(1))
-    } finally {
-      consumer.close()
-    }
   }
 
   @Test


### PR DESCRIPTION
When consumer uses plaintext and there is remaining data in consumer's buffer, consumer.poll() will read all data available from the socket buffer to consumer buffer. However, if consumer uses ssl and there is remaining data, consumer.poll() may only read 16 KB (the size of SslTransportLayer.appReadBuffer) from socket buffer. This will reduce efficient of consumer.poll() by asking user to call more poll() to get the same amount of data.

Furthermore, we observe that for users who naively sleep a constant time after each consumer.poll(), some partition will lag behind after they switch from plaintext to ssl. Here is the explanation why this can happen.

Say there are 1 partition of 1MB/sec and 9 partition of 32KB/sec. Leaders of these partitions are all different and consumer is consuming these 10 partitions. Let's also assume that socket read buffer size is large enough and consume sleeps 1 sec between consumer.poll(). 1 sec is long enough for consumer to receive the FetchResponse back from broker.

When consumer uses plaintext, each consumer.poll() will read all data from the socket buffer and it means 1 MB data is read from each partition.

When consumer uses ssl, each consumer.poll() is likely to find that there is some data available in the memory. In this case consumer only reads 16 KB data from other sockets, particularly the socket for the broker with the large partition. Then the throughput of the large partition will be limited to 16KB/sec.

Arguably user should not sleep 1 sec if its consumer is lagging behind. But on Kafka dev side it is nice to keep the previous behavior and optimize consumer.poll() to read as much data from socket as possible.