### PR TITLE
KAFKA-6259: Make KafkaStreams.cleanup() clean global state directory

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -908,12 +908,13 @@ public class KafkaStreams {
      * Calling this method triggers a restore of local {@link StateStore}s on the next {@link #start() application start}.
      *
      * @throws IllegalStateException if this {@code KafkaStreams} instance is currently {@link State#RUNNING running}
+     * @throws StreamsException if cleanup failed
      */
     public void cleanUp() {
         if (isRunning()) {
             throw new IllegalStateException("Cannot clean up while running.");
         }
-        stateDirectory.cleanRemovedTasks(0);
+        stateDirectory.clean();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -228,7 +228,7 @@ public class StateDirectory {
             cleanRemovedTasks(0, true);
         } catch (final Exception e) {
             // this is already logged within cleanRemovedTasks
-           throw new StreamsException(e);
+            throw new StreamsException(e);
         }
         try {
             Utils.delete(globalStateDir().getAbsoluteFile());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -256,7 +256,10 @@ public class StateDirectory {
     public synchronized void cleanRemovedTasks(final long cleanupDelayMs) {
         try {
             cleanRemovedTasks(cleanupDelayMs, true);
-        } catch (final IOException cannotHappen) { /* swallowException is set to true */ }
+        } catch (final IOException cannotHappen) {
+            // dummy log to make findbugs happy
+            log.error("{} Failed to delete the state directory due to an unexpected exception.", logPrefix(), cannotHappen);
+        }
     }
 
     private synchronized void cleanRemovedTasks(final long cleanupDelayMs,
@@ -276,7 +279,7 @@ public class StateDirectory {
                         long now = time.milliseconds();
                         long lastModifiedMs = taskDir.lastModified();
                         if (now > lastModifiedMs + cleanupDelayMs) {
-                            log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms)", logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
+                            log.info("{} Deleting obsolete state directory {} for task {} as {}ms has elapsed (cleanup delay is {}ms).", logPrefix(), dirName, id, now - lastModifiedMs, cleanupDelayMs);
                             Utils.delete(taskDir);
                         }
                     }
@@ -286,12 +289,12 @@ public class StateDirectory {
                     if (firstException == null) {
                         firstException = e;
                     }
-                    log.error("{} Failed to delete the state directory due to an unexpected exception", logPrefix(), e);
+                    log.error("{} Failed to delete the state directory due to an unexpected exception.", logPrefix(), e);
                 } finally {
                     try {
                         unlock(id);
                     } catch (IOException e) {
-                        log.error("{} Failed to release the state directory lock", logPrefix());
+                        log.error("{} Failed to release the state directory lock.", logPrefix());
                     }
                 }
             }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -195,9 +195,13 @@ public class StateDirectoryTest {
             directory.lock(task1);
             directory.directoryForTask(new TaskId(2, 0));
 
+            List<File> files = Arrays.asList(appDir.listFiles());
+            assertEquals(3, files.size());
+
             time.sleep(1000);
             directory.cleanRemovedTasks(0);
-            final List<File> files = Arrays.asList(appDir.listFiles());
+
+            files = Arrays.asList(appDir.listFiles());
             assertEquals(2, files.size());
             assertTrue(files.contains(new File(appDir, task0.toString())));
             assertTrue(files.contains(new File(appDir, task1.toString())));
@@ -341,4 +345,17 @@ public class StateDirectoryTest {
         assertTrue(directory.lock(taskId));
     }
 
+    @Test
+    public void shouldCleanupAllTaskDirectoriesIncludingGlobalOne() {
+        directory.directoryForTask(new TaskId(1, 0));
+        directory.globalStateDir();
+
+        List<File> files = Arrays.asList(appDir.listFiles());
+        assertEquals(2, files.size());
+
+        directory.clean();
+
+        files = Arrays.asList(appDir.listFiles());
+        assertEquals(0, files.size());
+    }
 }


### PR DESCRIPTION

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
