### PR TITLE
KAFKA-6174; Add methods in Options classes to keep binary compatibility with 0.11

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
@@ -23,7 +23,7 @@ package org.apache.kafka.clients.admin;
  */
 public abstract class AbstractOptions<T extends AbstractOptions> {
 
-    private Integer timeoutMs = null;
+    protected Integer timeoutMs = null;
 
     /**
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
@@ -32,6 +32,27 @@ public class AlterConfigsOptions extends AbstractOptions<AlterConfigsOptions> {
     private boolean validateOnly = false;
 
     /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public AlterConfigsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
+    /**
      * Return true if the request should be validated without altering the configs.
      */
     public boolean shouldValidateOnly() {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
@@ -35,8 +35,8 @@ public class AlterConfigsOptions extends AbstractOptions<AlterConfigsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public AlterConfigsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
@@ -43,16 +43,6 @@ public class AlterConfigsOptions extends AbstractOptions<AlterConfigsOptions> {
     }
 
     /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
-    /**
      * Return true if the request should be validated without altering the configs.
      */
     public boolean shouldValidateOnly() {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
@@ -33,8 +33,8 @@ public class CreateAclsOptions extends AbstractOptions<CreateAclsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public CreateAclsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
@@ -29,4 +29,25 @@ import java.util.Collection;
 @InterfaceStability.Evolving
 public class CreateAclsOptions extends AbstractOptions<CreateAclsOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public CreateAclsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
@@ -40,14 +40,4 @@ public class CreateAclsOptions extends AbstractOptions<CreateAclsOptions> {
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
@@ -43,16 +43,6 @@ public class CreateTopicsOptions extends AbstractOptions<CreateTopicsOptions> {
     }
 
     /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
-    /**
      * Set to true if the request should be validated without creating the topic.
      */
     public CreateTopicsOptions validateOnly(boolean validateOnly) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
@@ -32,6 +32,27 @@ public class CreateTopicsOptions extends AbstractOptions<CreateTopicsOptions> {
     private boolean validateOnly = false;
 
     /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public CreateTopicsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
+    /**
      * Set to true if the request should be validated without creating the topic.
      */
     public CreateTopicsOptions validateOnly(boolean validateOnly) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
@@ -35,8 +35,8 @@ public class CreateTopicsOptions extends AbstractOptions<CreateTopicsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public CreateTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
@@ -29,4 +29,25 @@ import java.util.Collection;
 @InterfaceStability.Evolving
 public class DeleteAclsOptions extends AbstractOptions<DeleteAclsOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public DeleteAclsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
@@ -40,14 +40,4 @@ public class DeleteAclsOptions extends AbstractOptions<DeleteAclsOptions> {
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
@@ -33,8 +33,8 @@ public class DeleteAclsOptions extends AbstractOptions<DeleteAclsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public DeleteAclsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
@@ -33,8 +33,8 @@ public class DeleteTopicsOptions extends AbstractOptions<DeleteTopicsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public DeleteTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
@@ -40,14 +40,4 @@ public class DeleteTopicsOptions extends AbstractOptions<DeleteTopicsOptions> {
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
@@ -29,4 +29,25 @@ import java.util.Collection;
 @InterfaceStability.Evolving
 public class DeleteTopicsOptions extends AbstractOptions<DeleteTopicsOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public DeleteTopicsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
@@ -39,15 +39,4 @@ public class DescribeAclsOptions extends AbstractOptions<DescribeAclsOptions> {
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
@@ -32,8 +32,8 @@ public class DescribeAclsOptions extends AbstractOptions<DescribeAclsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public DescribeAclsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
@@ -28,4 +28,26 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 @InterfaceStability.Evolving
 public class DescribeAclsOptions extends AbstractOptions<DescribeAclsOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public DescribeAclsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
@@ -38,14 +38,4 @@ public class DescribeClusterOptions extends AbstractOptions<DescribeClusterOptio
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
@@ -27,4 +27,25 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 @InterfaceStability.Evolving
 public class DescribeClusterOptions extends AbstractOptions<DescribeClusterOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public DescribeClusterOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
@@ -31,8 +31,8 @@ public class DescribeClusterOptions extends AbstractOptions<DescribeClusterOptio
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public DescribeClusterOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
@@ -29,4 +29,25 @@ import java.util.Collection;
 @InterfaceStability.Evolving
 public class DescribeConfigsOptions extends AbstractOptions<DescribeConfigsOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public DescribeConfigsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
@@ -33,8 +33,8 @@ public class DescribeConfigsOptions extends AbstractOptions<DescribeConfigsOptio
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public DescribeConfigsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
@@ -40,14 +40,4 @@ public class DescribeConfigsOptions extends AbstractOptions<DescribeConfigsOptio
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
@@ -40,14 +40,4 @@ public class DescribeTopicsOptions extends AbstractOptions<DescribeTopicsOptions
         return this;
     }
 
-    /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
@@ -33,8 +33,8 @@ public class DescribeTopicsOptions extends AbstractOptions<DescribeTopicsOptions
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public DescribeTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
@@ -29,4 +29,25 @@ import java.util.Collection;
 @InterfaceStability.Evolving
 public class DescribeTopicsOptions extends AbstractOptions<DescribeTopicsOptions> {
 
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public DescribeTopicsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
@@ -33,8 +33,8 @@ public class ListTopicsOptions extends AbstractOptions<ListTopicsOptions> {
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      *
-     * This method is retained to keep binary compatibility with 0.11
      */
+    // This method is retained to keep binary compatibility with 0.11
     public ListTopicsOptions timeoutMs(Integer timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
@@ -41,16 +41,6 @@ public class ListTopicsOptions extends AbstractOptions<ListTopicsOptions> {
     }
 
     /**
-     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
-     * AdminClient should be used.
-     *
-     * This method is retained to keep binary compatibility with 0.11
-     */
-    public Integer timeoutMs() {
-        return timeoutMs;
-    }
-
-    /**
      * Set whether we should list internal topics.
      *
      * @param listInternal  Whether we should list internal topics.  null means to use

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
@@ -30,6 +30,27 @@ public class ListTopicsOptions extends AbstractOptions<ListTopicsOptions> {
     private boolean listInternal = false;
 
     /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public ListTopicsOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+
+    /**
+     * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     * This method is retained to keep binary compatibility with 0.11
+     */
+    public Integer timeoutMs() {
+        return timeoutMs;
+    }
+
+    /**
      * Set whether we should list internal topics.
      *
      * @param listInternal  Whether we should list internal topics.  null means to use

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -19,6 +19,13 @@
 
 <script id="upgrade-template" type="text/x-handlebars-template">
 
+<h4><a id="upgrade_1_0_1" href="#upgrade_1_0_1">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x or 1.0.0 to 1.0.1</a></h4>
+
+<h5><a id="upgrade_101_notable" href="#upgrade_101_notable">Notable changes in 1.0.1</a></h5>
+<ul>
+  <li>The binary compatibility of subclasses of AbstractOptions with 0.11.x has been restored.
+</ul>
+
 <h4><a id="upgrade_1_0_0" href="#upgrade_1_0_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x or 0.11.0.x to 1.0.0</a></h4>
 <p>Kafka 1.0.0 introduces wire protocol changes. By following the recommended rolling upgrade plan below,
     you guarantee no downtime during the upgrade. However, please review the <a href="#upgrade_100_notable">notable changes in 1.0.0</a> before upgrading.
@@ -30,7 +37,7 @@
     <li> Update server.properties on all brokers and add the following properties. CURRENT_KAFKA_VERSION refers to the version you
         are upgrading from. CURRENT_MESSAGE_FORMAT_VERSION refers to the message format version currently in use. If you have previously
         overridden the message format version, you should keep its current value. Alternatively, if you are upgrading from a version prior
-        to 0.11.0.x, then CURRENT_MESSAGE_FORMAT_VERSION should be set to match CURRENT_KAFKA_VERSION. 
+        to 0.11.0.x, then CURRENT_MESSAGE_FORMAT_VERSION should be set to match CURRENT_KAFKA_VERSION.
         <ul>
             <li>inter.broker.protocol.version=CURRENT_KAFKA_VERSION (e.g. 0.8.2, 0.9.0, 0.10.0, 0.10.1, 0.10.2, 0.11.0).</li>
             <li>log.message.format.version=CURRENT_MESSAGE_FORMAT_VERSION  (See <a href="#upgrade_10_performance_impact">potential performance impact
@@ -47,7 +54,7 @@
     <li> Restart the brokers one by one for the new protocol version to take effect. </li>
     <li> If you have overridden the message format version as instructed above, then you need to do one more rolling restart to
         upgrade it to its latest version. Once all (or most) consumers have been upgraded to 0.11.0 or later,
-        change log.message.format.version to 1.0 on each broker and restart them one by one. Note that the older Scala consumer 
+        change log.message.format.version to 1.0 on each broker and restart them one by one. Note that the older Scala consumer
         does not support the new message format introduced in 0.11, so to avoid the performance cost of down-conversion (or to
         take advantage of <a href="#upgrade_11_exactly_once_semantics">exactly once semantics</a>), the newer Java consumer must be used.</li>
 </ol>


### PR DESCRIPTION
From 0.11 to 1.0, we moved `DescribeClusterOptions timeoutMs(Integer timeoutMs)` from DescribeClusterOptions to AbstractOptions. User reports that code compiled against 0.11.0 fails when it is executed with 1.0 kafka-clients jar. This patch adds back these methods to keep binary compatibility with 0.11.