### PR TITLE
KAFKA-6274: Use topic plus dash as prefix of auto-generated state store names

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -224,7 +224,7 @@ public class StreamsBuilder {
         materialized.withKeySerde(consumed.keySerde).withValueSerde(consumed.valueSerde);
         return internalStreamsBuilder.table(topic,
                                             new ConsumedInternal<>(consumed),
-                                            new MaterializedInternal<>(materialized, internalStreamsBuilder, topic));
+                                            new MaterializedInternal<>(materialized, internalStreamsBuilder, topic + "-"));
     }
 
     /**
@@ -275,7 +275,7 @@ public class StreamsBuilder {
                                             new MaterializedInternal<>(
                                                     Materialized.<K, V, KeyValueStore<Bytes, byte[]>>with(consumed.keySerde, consumed.valueSerde),
                                                     internalStreamsBuilder,
-                                                    topic));
+                                                    topic + "-"));
     }
 
     /**
@@ -300,7 +300,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
         final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal
-                = new MaterializedInternal<>(materialized, internalStreamsBuilder, topic);
+                = new MaterializedInternal<>(materialized, internalStreamsBuilder, topic + "-");
         return internalStreamsBuilder.table(topic,
                                             new ConsumedInternal<>(Consumed.with(materializedInternal.keySerde(),
                                                                                  materializedInternal.valueSerde())),
@@ -331,7 +331,7 @@ public class StreamsBuilder {
                 new MaterializedInternal<>(
                         Materialized.<K, V, KeyValueStore<Bytes, byte[]>>with(consumed.keySerde, consumed.valueSerde),
                         internalStreamsBuilder,
-                        topic);
+                        topic + "-");
 
 
         return internalStreamsBuilder.globalTable(topic, new ConsumedInternal<>(consumed), materialized);
@@ -399,7 +399,7 @@ public class StreamsBuilder {
         materialized.withKeySerde(consumed.keySerde).withValueSerde(consumed.valueSerde);
         return internalStreamsBuilder.globalTable(topic,
                                                   new ConsumedInternal<>(consumed),
-                                                  new MaterializedInternal<>(materialized, internalStreamsBuilder, topic));
+                                                  new MaterializedInternal<>(materialized, internalStreamsBuilder, topic + "-"));
     }
 
     /**
@@ -432,7 +432,7 @@ public class StreamsBuilder {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(materialized, "materialized can't be null");
         final MaterializedInternal<K, V, KeyValueStore<Bytes, byte[]>> materializedInternal =
-                new MaterializedInternal<>(materialized, internalStreamsBuilder, topic);
+                new MaterializedInternal<>(materialized, internalStreamsBuilder, topic + "-");
         return internalStreamsBuilder.globalTable(topic,
                                                   new ConsumedInternal<>(Consumed.with(materializedInternal.keySerde(),
                                                                                        materializedInternal.valueSerde())),

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -36,12 +36,14 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class StreamsBuilderTest {
 
@@ -159,6 +161,28 @@ public class StreamsBuilderTest {
         final KeyValueStore<Long, String> store = (KeyValueStore) driver.allStateStores().get("store");
         assertThat(store.get(1L), equalTo("value1"));
         assertThat(store.get(2L), equalTo("value2"));
+    }
+
+    @Test
+    public void shouldUseDefaultNodeAndStoreNames() {
+        final String topic = "topic";
+        builder.table(topic,
+                Materialized.<Long, String, KeyValueStore<Bytes, byte[]>>with(Serdes.Long(), Serdes.String()));
+
+        final Iterator<TopologyDescription.Subtopology> subtopologies = builder.build().describe().subtopologies().iterator();
+        final TopologyDescription.Subtopology subtopology = subtopologies.next();
+
+        final Iterator<TopologyDescription.Node> nodes = subtopology.nodes().iterator();
+        TopologyDescription.Node node = nodes.next();
+        assertThat(node.name(), equalTo("KSTREAM-SOURCE-0000000001"));
+        node = nodes.next();
+        assertThat(node.name(), equalTo("KTABLE-SOURCE-0000000002"));
+        final Iterator<String> stores = ((TopologyDescription.Processor) node).stores().iterator();
+        assertThat(stores.next(), equalTo(topic + "-STATE-STORE-0000000000"));
+
+        assertFalse(nodes.hasNext());
+        assertFalse(stores.hasNext());
+        assertFalse(subtopologies.hasNext());
     }
     
     @Test(expected = TopologyException.class)


### PR DESCRIPTION
Use `topic-` as the prefix of the auto-generated state store name.

Also add a unit test for this functionality. 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
