### PR TITLE
KAFKA-5117: Add password masking for kafka connect REST endpoint

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.ConfigKey;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigValue;
-import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.errors.NotFoundException;
 import org.apache.kafka.connect.runtime.isolation.Plugins;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -189,7 +189,12 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
         Map<String, String> newConfig = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : config.entrySet()) {
             // Password.toString() will return the hidden value
-            newConfig.put(entry.getKey(), entry.getValue().toString());
+            String value = null;
+            if (entry.getValue() != null) {
+                value = entry.getValue().toString();
+            }
+
+            newConfig.put(entry.getKey(), value);
         }
 
         return newConfig;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -186,30 +186,11 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     }
 
     @Override
-    public ConfigDef configDef(String connName) {
-        Map<String, String> conf = config(connName);
-
-        ConnectorType connectorType = connectorTypeForClass(conf.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG));
-        Connector connector = getConnector(connectorType.toString());
-        if (connector == null) {
-            throw new NotFoundException("No status found for connector " + connName);
-        }
-
-        return connector.config();
-    }
-
-    @Override
     public Map<String, String> maskCredentials(String connName, Map<String, String> config) {
-        ConfigDef configDef = configDef(connName);
         Map<String, String> newConfig = new LinkedHashMap<>();
-
         for (Map.Entry<String, String> entry : config.entrySet()) {
-            final String key = entry.getKey();
-            if (configDef.configKeys().containsKey(key) && configDef.configKeys().get(key).type.equals(ConfigDef.Type.PASSWORD)) {
-                newConfig.put(key, Password.HIDDEN);
-            } else {
-                newConfig.put(key, entry.getValue());
-            }
+            // Password .toString() will return the hidden value
+            newConfig.put(entry.getKey(), entry.getValue().toString());
         }
 
         return newConfig;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -186,7 +186,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     }
 
     @Override
-    public ConfigDef getConfigDef(String connName) {
+    public ConfigDef configDef(String connName) {
         Map<String, String> conf = config(connName);
 
         ConnectorType connectorType = connectorTypeForClass(conf.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG));
@@ -200,7 +200,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public Map<String, String> maskCredentials(String connName, Map<String, String> config) {
-        ConfigDef configDef = getConfigDef(connName);
+        ConfigDef configDef = configDef(connName);
         Map<String, String> newConfig = new LinkedHashMap<>();
 
         for (Map.Entry<String, String> entry : config.entrySet()) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -187,7 +187,10 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
 
     @Override
     public ConfigDef getConfigDef(String connName) {
-        Connector connector = getConnector(connName);
+        Map<String, String> conf = config(connName);
+
+        ConnectorType connectorType = connectorTypeForClass(conf.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG));
+        Connector connector = getConnector(connectorType.toString());
         if (connector == null) {
             throw new NotFoundException("No status found for connector " + connName);
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -403,30 +403,4 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             return null;
         }
     }
-
-    // go through config parameters and replace password field value with "*"
-    // this return a new map, instead of making change to the original object
-    public static Map<String, String> maskCredentials(Map<String, String> config) {
-        if (!config.containsKey(ConnectorConfig.CONNECTOR_CLASS_CONFIG)) {
-            return config;
-        }
-
-        Connector connectorClass = getConnector(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
-
-        Map<String, ConfigDef.ConfigKey> definedConfigKeys = connectorClass.config().configKeys();
-        Map<String, String> newConfig = new LinkedHashMap<>();
-
-        for (Map.Entry<String, String> entry : config.entrySet()) {
-            final String key = entry.getKey();
-            if (definedConfigKeys.containsKey(key) && definedConfigKeys.get(key).type.equals(ConfigDef.Type.PASSWORD)) {
-                newConfig.put(key, "*********");
-            } else {
-                newConfig.put(key, entry.getValue());
-            }
-        }
-
-        return newConfig;
-    }
-
-
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -189,7 +189,7 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
     public Map<String, String> maskCredentials(String connName, Map<String, String> config) {
         Map<String, String> newConfig = new LinkedHashMap<>();
         for (Map.Entry<String, String> entry : config.entrySet()) {
-            // Password .toString() will return the hidden value
+            // Password.toString() will return the hidden value
             newConfig.put(entry.getKey(), entry.getValue().toString());
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractHerder.java
@@ -403,4 +403,30 @@ public abstract class AbstractHerder implements Herder, TaskStatus.Listener, Con
             return null;
         }
     }
+
+    // go through config parameters and replace password field value with "*"
+    // this return a new map, instead of making change to the original object
+    public static Map<String, String> maskCredentials(Map<String, String> config) {
+        if (!config.containsKey(ConnectorConfig.CONNECTOR_CLASS_CONFIG)) {
+            return config;
+        }
+
+        Connector connectorClass = getConnector(config.get(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+
+        Map<String, ConfigDef.ConfigKey> definedConfigKeys = connectorClass.config().configKeys();
+        Map<String, String> newConfig = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> entry : config.entrySet()) {
+            final String key = entry.getKey();
+            if (definedConfigKeys.containsKey(key) && definedConfigKeys.get(key).type.equals(ConfigDef.Type.PASSWORD)) {
+                newConfig.put(key, "*********");
+            } else {
+                newConfig.put(key, entry.getValue());
+            }
+        }
+
+        return newConfig;
+    }
+
+
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -175,7 +175,7 @@ public interface Herder {
      * @param connName name of the connector
      * @return ConfigDef of the connector
      */
-    ConfigDef getConfigDef(String connName);
+    ConfigDef configDef(String connName);
 
     /**
      * Goes through config parameters and replace password field value with "[hidden"]

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -171,13 +171,6 @@ public interface Herder {
     void resumeConnector(String connector);
 
     /**
-     * Given connector name, returns the ConfigDef appropriately
-     * @param connName name of the connector
-     * @return ConfigDef of the connector
-     */
-    ConfigDef configDef(String connName);
-
-    /**
      * Goes through config parameters and replace password field value with "[hidden"]
      * @param connName name of the connector
      * @param config configuration of the connector

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime;
 
-import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Herder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.rest.entities.ConfigInfos;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -168,6 +169,21 @@ public interface Herder {
      * @param connector name of the connector
      */
     void resumeConnector(String connector);
+
+    /**
+     * Given connector name, returns the ConfigDef appropriately
+     * @param connName name of the connector
+     * @return ConfigDef of the connector
+     */
+    ConfigDef getConfigDef(String connName);
+
+    /**
+     * Goes through config parameters and replace password field value with "[hidden"]
+     * @param connName name of the connector
+     * @param config configuration of the connector
+     * @return new map of the configurations, with password omitted from clear-text
+     */
+    Map<String, String> maskCredentials(String connName, Map<String, String> config);
 
     /**
      * Returns a handle to the plugin factory used by this herder and its worker.

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -312,7 +312,12 @@ public class ConnectorsResource {
     // go through config parameters and replace password field value with "*"
     // this return a new map, instead of making change to the original object
     private Map<String, String> maskCredentials(Map<String, String> config) {
-        Connector connectorClass = loadConnectorClass(config.get("connector.class"), Connector.class);
+        final String connectorClassStr = "connector.class";
+        if (!config.containsKey(connectorClassStr)) {
+            return config;
+        }
+
+        Connector connectorClass = loadConnectorClass(config.get(connectorClassStr), Connector.class);
         Map<String, ConfigDef.ConfigKey> definedConfigKeys = connectorClass.config().configKeys();
         Map<String, String> newConfig = new HashMap<>();
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -17,9 +17,6 @@
 package org.apache.kafka.connect.runtime.rest.resources;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
 import org.apache.kafka.connect.runtime.distributed.RebalanceNeededException;
@@ -53,7 +50,6 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.runtime.rest.entities.CreateConnectorRequest;
 import org.apache.kafka.connect.runtime.rest.entities.TaskInfo;
 import org.apache.kafka.connect.runtime.rest.errors.ConnectRestException;
+import org.apache.kafka.connect.runtime.AbstractHerder;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
 import org.slf4j.Logger;
@@ -115,7 +116,7 @@ public class ConnectorsResource {
         FutureCallback<ConnectorInfo> cb = new FutureCallback<>();
         herder.connectorInfo(connector, cb);
         ConnectorInfo connectorInfo = completeOrForwardRequest(cb, "/connectors/" + connector, "GET", null, forward);
-        return new ConnectorInfo(connectorInfo.name(), maskCredentials(connectorInfo.config()), connectorInfo.tasks(), connectorInfo.type());
+        return new ConnectorInfo(connectorInfo.name(), AbstractHerder.maskCredentials(connectorInfo.config()), connectorInfo.tasks(), connectorInfo.type());
     }
 
     @GET

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -116,7 +116,7 @@ public class ConnectorsResource {
         FutureCallback<ConnectorInfo> cb = new FutureCallback<>();
         herder.connectorInfo(connector, cb);
         ConnectorInfo connectorInfo = completeOrForwardRequest(cb, "/connectors/" + connector, "GET", null, forward);
-        return new ConnectorInfo(connectorInfo.name(), AbstractHerder.maskCredentials(connectorInfo.config()), connectorInfo.tasks(), connectorInfo.type());
+        return new ConnectorInfo(connectorInfo.name(), maskCredentials(connectorInfo.config()), connectorInfo.tasks(), connectorInfo.type());
     }
 
     @GET

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.rest.resources;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
@@ -324,7 +325,7 @@ public class ConnectorsResource {
         for (Map.Entry<String, String> entry : config.entrySet()) {
             final String key = entry.getKey();
             if (definedConfigKeys.containsKey(key) && definedConfigKeys.get(key).type.equals(ConfigDef.Type.PASSWORD)) {
-                newConfig.put(key, "*********");
+                newConfig.put(key, Password.HIDDEN);
             } else {
                 newConfig.put(key, entry.getValue());
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -52,7 +52,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -319,7 +319,7 @@ public class ConnectorsResource {
 
         Connector connectorClass = loadConnectorClass(config.get(connectorClassStr), Connector.class);
         Map<String, ConfigDef.ConfigKey> definedConfigKeys = connectorClass.config().configKeys();
-        Map<String, String> newConfig = new HashMap<>();
+        Map<String, String> newConfig = new LinkedHashMap<>();
 
         for (Map.Entry<String, String> entry : config.entrySet()) {
             final String key = entry.getKey();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -49,7 +49,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -180,7 +184,8 @@ public class ConnectorsResource {
         FutureCallback<List<TaskInfo>> cb = new FutureCallback<>();
         herder.taskConfigs(connector, cb);
         List<TaskInfo> taskInfoList = completeOrForwardRequest(cb, "/connectors/" + connector + "/tasks", "GET", null,
-                new TypeReference<List<TaskInfo>>() {}, forward);
+                new TypeReference<List<TaskInfo>>() {
+                }, forward);
         List<TaskInfo> maskedTaskInfoList = new ArrayList<>();
         for (TaskInfo taskInfo : taskInfoList) {
             maskedTaskInfoList.add(new TaskInfo(taskInfo.id(), maskCredentials(taskInfo.config())));

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -312,7 +312,7 @@ public class ConnectorsResource {
     // go through config parameters and replace password field value with "*"
     // this return a new map, instead of making change to the original object
     private Map<String, String> maskCredentials(Map<String, String> config) {
-        final String connectorClassStr = "connector.class";
+        final String connectorClassStr = ConnectorConfig.CONNECTOR_CLASS_CONFIG;
         if (!config.containsKey(connectorClassStr)) {
             return config;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResource.java
@@ -321,11 +321,12 @@ public class ConnectorsResource {
         Map<String, ConfigDef.ConfigKey> definedConfigKeys = connectorClass.config().configKeys();
         Map<String, String> newConfig = new HashMap<>();
 
-        for (String key : config.keySet()) {
+        for (Map.Entry<String, String> entry : config.entrySet()) {
+            final String key = entry.getKey();
             if (definedConfigKeys.containsKey(key) && definedConfigKeys.get(key).type.equals(ConfigDef.Type.PASSWORD)) {
                 newConfig.put(key, "*********");
             } else {
-                newConfig.put(key, config.get(key));
+                newConfig.put(key, entry.getValue());
             }
         }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorsResourceTest.java
@@ -268,7 +268,10 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testGetConnector() throws Throwable {
+        EasyMock.expect(herder.maskCredentials(CONNECTOR_NAME, CONNECTOR_CONFIG)).andReturn(CONNECTOR_CONFIG);
+
         final Capture<Callback<ConnectorInfo>> cb = Capture.newInstance();
+
         herder.connectorInfo(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackResult(cb, new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES,
             ConnectorType.SOURCE));
@@ -276,6 +279,7 @@ public class ConnectorsResourceTest {
         PowerMock.replayAll();
 
         ConnectorInfo connInfo = connectorsResource.getConnector(CONNECTOR_NAME, FORWARD);
+
         assertEquals(new ConnectorInfo(CONNECTOR_NAME, CONNECTOR_CONFIG, CONNECTOR_TASK_NAMES, ConnectorType.SOURCE),
             connInfo);
 
@@ -284,13 +288,15 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testGetConnectorConfig() throws Throwable {
+        EasyMock.expect(herder.maskCredentials(CONNECTOR_NAME, CONNECTOR_CONFIG)).andReturn(CONNECTOR_CONFIG);
+
         final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
         herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackResult(cb, CONNECTOR_CONFIG);
 
         PowerMock.replayAll();
-
         Map<String, String> connConfig = connectorsResource.getConnectorConfig(CONNECTOR_NAME, FORWARD);
+
         assertEquals(CONNECTOR_CONFIG, connConfig);
 
         PowerMock.verifyAll();
@@ -298,6 +304,8 @@ public class ConnectorsResourceTest {
 
     @Test(expected = NotFoundException.class)
     public void testGetConnectorConfigConnectorNotFound() throws Throwable {
+        EasyMock.expect(herder.maskCredentials(CONNECTOR_NAME, CONNECTOR_CONFIG)).andReturn(CONNECTOR_CONFIG);
+
         final Capture<Callback<Map<String, String>>> cb = Capture.newInstance();
         herder.connectorConfig(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackException(cb, new NotFoundException("not found"));
@@ -375,6 +383,10 @@ public class ConnectorsResourceTest {
 
     @Test
     public void testGetConnectorTaskConfigs() throws Throwable {
+        for (int i = 0; i < TASK_CONFIGS.size(); i++) {
+            EasyMock.expect(herder.maskCredentials(CONNECTOR_NAME, TASK_CONFIGS.get(i))).andReturn(TASK_CONFIGS.get(i));
+        }
+
         final Capture<Callback<List<TaskInfo>>> cb = Capture.newInstance();
         herder.taskConfigs(EasyMock.eq(CONNECTOR_NAME), EasyMock.capture(cb));
         expectAndCallbackResult(cb, TASK_INFOS);


### PR DESCRIPTION
*More detailed description of your change,
Mask all password type config parameter with "*********" instead of displaying the plain text in kafka connect REST endpoint.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
