### PR TITLE
KAFKA-5526: Additional `--describe` views for ConsumerGroupCommand (KIP-175)

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -276,9 +276,9 @@ object ConsumerGroupCommand extends Logging {
 
     def collectGroupOffsets(): (Option[String], Option[Seq[PartitionAssignmentState]])
 
-    def collectGroupMembers(verbose: Boolean): (Option[String], Option[Seq[MemberAssignmentState]]) = (None, None)
+    def collectGroupMembers(verbose: Boolean): (Option[String], Option[Seq[MemberAssignmentState]]) = throw new UnsupportedOperationException
 
-    def collectGroupState(): Option[GroupState] = None
+    def collectGroupState(): Option[GroupState] = throw new UnsupportedOperationException
 
     protected def collectConsumerAssignment(group: String,
                                             coordinator: Option[Node],
@@ -919,6 +919,8 @@ object ConsumerGroupCommand extends Logging {
     val verboseOpt = parser.accepts("verbose", VerboseDoc)
     val offsetsOpt = parser.accepts("offsets", OffsetsDoc)
     val stateOpt = parser.accepts("state", StateDoc)
+    parser.mutuallyExclusive(membersOpt, offsetsOpt, stateOpt)
+
     val options = parser.parse(args : _*)
 
     val useOldConsumer = options.has(zkConnectOpt)
@@ -967,9 +969,6 @@ object ConsumerGroupCommand extends Logging {
         if (!describeOptPresent)
           CommandLineUtils.printUsageAndDie(parser,
               s"Options $membersOpt, $offsetsOpt, and $stateOpt may only be used with $describeOpt.")
-        if (subActions > 1)
-          CommandLineUtils.printUsageAndDie(parser,
-              s"Command may include exactly one $describeOpt sub-action: $membersOpt, $offsetsOpt, $stateOpt.")
       }
 
       if (options.has(deleteOpt) && !options.has(groupOpt) && !options.has(topicOpt))

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -245,8 +245,10 @@ object ConsumerGroupCommand extends Logging {
     private def printState(group: String, state: Option[GroupState]): Unit = {
       // this method is reachable only for the new consumer option (where the given state is always defined)
       if (shouldPrintMemberState(group, Some(state.get.state), Some(1))) {
-        print("\n%-20s %-25s %-20s %s".format("COORDINATOR", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS"))
-        print("\n%-20s %-25s %-20s %s".format(state.get.coordinator.id, state.get.assignmentStrategy, state.get.state, state.get.numMembers))
+        val coordinator = state.get.coordinator.host + ":" + state.get.coordinator.port + " (" + state.get.coordinator.idString + ")"
+        val coordinatorColLen = Math.max(25, coordinator.length)
+        print(s"\n%${-coordinatorColLen}s %-25s %-20s %s".format("COORDINATOR (ID)", "ASSIGNMENT-STRATEGY", "STATE", "#MEMBERS"))
+        print(s"\n%${-coordinatorColLen}s %-25s %-20s %s".format(coordinator, state.get.assignmentStrategy, state.get.state, state.get.numMembers))
         println()
       }
     }

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -208,8 +208,8 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     val state = service.collectGroupState()
     assertTrue(s"Expected the state to be 'Dead', with no members in the group '$group'.",
-        state.isDefined && state.get.state == "Dead" && state.get.numMembers == 0 &&
-        state.get.coordinator != null && servers.map(_.config.brokerId).toList.contains(state.get.coordinator.id)
+        state.state == "Dead" && state.numMembers == 0 &&
+        state.coordinator != null && servers.map(_.config.brokerId).toList.contains(state.coordinator.id)
     )
   }
 
@@ -296,12 +296,11 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     TestUtils.waitUntilTrue(() => {
       val state = service.collectGroupState()
-      state.isDefined &&
-        state.get.state == "Stable" &&
-        state.get.numMembers == 1 &&
-        state.get.assignmentStrategy == "range" &&
-        state.get.coordinator != null &&
-        servers.map(_.config.brokerId).toList.contains(state.get.coordinator.id)
+      state.state == "Stable" &&
+        state.numMembers == 1 &&
+        state.assignmentStrategy == "range" &&
+        state.coordinator != null &&
+        servers.map(_.config.brokerId).toList.contains(state.coordinator.id)
     }, s"Expected a 'Stable' group status, with one member and round robin assignment strategy for group $group.")
   }
 
@@ -316,12 +315,11 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     TestUtils.waitUntilTrue(() => {
       val state = service.collectGroupState()
-      state.isDefined &&
-        state.get.state == "Stable" &&
-        state.get.numMembers == 1 &&
-        state.get.assignmentStrategy == "roundrobin" &&
-        state.get.coordinator != null &&
-        servers.map(_.config.brokerId).toList.contains(state.get.coordinator.id)
+      state.state == "Stable" &&
+        state.numMembers == 1 &&
+        state.assignmentStrategy == "roundrobin" &&
+        state.coordinator != null &&
+        servers.map(_.config.brokerId).toList.contains(state.coordinator.id)
     }, s"Expected a 'Stable' group status, with one member and round robin assignment strategy for group $group.")
   }
 
@@ -419,11 +417,10 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     TestUtils.waitUntilTrue(() => {
       val state = service.collectGroupState()
-      state.isDefined &&
-        state.get.state == "Stable" &&
-        state.get.numMembers == 1 &&
-        state.get.coordinator != null &&
-        servers.map(_.config.brokerId).toList.contains(state.get.coordinator.id)
+      state.state == "Stable" &&
+        state.numMembers == 1 &&
+        state.coordinator != null &&
+        servers.map(_.config.brokerId).toList.contains(state.coordinator.id)
     }, s"Expected the group '$group' to initially become stable, and have a single member.")
 
     // stop the consumer so the group has no active member anymore
@@ -431,7 +428,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     TestUtils.waitUntilTrue(() => {
       val state = service.collectGroupState()
-      state.isDefined && state.get.state == "Empty" && state.get.numMembers == 0 && state.get.assignmentStrategy == ""
+      state.state == "Empty" && state.numMembers == 0 && state.assignmentStrategy == ""
     }, s"Expected the group '$group' to become empty after the only member leaving.")
   }
 
@@ -510,9 +507,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     TestUtils.waitUntilTrue(() => {
       val state = service.collectGroupState()
-      state.isDefined &&
-        state.get.state == "Stable" &&
-        state.get.numMembers == 2
+      state.state == "Stable" && state.numMembers == 2
     }, "Expected two consumers in describe group results")
   }
 
@@ -599,10 +594,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
     TestUtils.waitUntilTrue(() => {
       val state = service.collectGroupState()
-      state.isDefined &&
-        state.get.state == "Stable" &&
-        state.get.group == group &&
-        state.get.numMembers == 2
+      state.state == "Stable" && state.group == group && state.numMembers == 2
     }, "Expected a stable group with two members in describe group state result.")
   }
 

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -154,6 +154,14 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     }
   }
 
+  @Test(expected = classOf[joptsimple.OptionException])
+  def testDescribeWithMultipleSubActions() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group, "--members", "--state")
+    getConsumerGroupService(cgcArgs)
+    fail("Expected an error due to presence of mutually exclusive options")
+  }
+
   @Test
   def testDescribeOffsetsOfNonExistingGroup() {
     TestUtils.createOffsetsTopic(zkUtils, servers)

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -271,8 +271,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
       case Some(memberAssignments) =>
         assertTrue(s"Expected a topic partition assigned to the single group member for group $group",
           memberAssignments.size == 1 &&
-          memberAssignments.head.assignment.isDefined &&
-          memberAssignments.head.assignment.get.size == 1)
+          memberAssignments.head.assignment.size == 1)
     }
   }
 
@@ -473,12 +472,12 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
         assignments.get.count(_.group == group) == 2 &&
         assignments.get.count { x => x.group == group && x.numPartitions == 1 } == 1 &&
         assignments.get.count { x => x.group == group && x.numPartitions == 0 } == 1 &&
-        assignments.get.count(_.assignment.isDefined) == 0
+        assignments.get.count(_.assignment.size > 0) == 0
     }, "Expected rows for consumers with no assigned partitions in describe group results")
 
     val (state, assignments) = service.collectGroupMembers(true)
     assertTrue("Expected additional columns in verbose vesion of describe members",
-        state == Some("Stable") && assignments.get.count(_.assignment.isEmpty) == 0)
+        state == Some("Stable") && assignments.get.count(_.assignment.nonEmpty) > 0)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DescribeConsumerGroupTest.scala
@@ -22,29 +22,36 @@ import java.util.concurrent.TimeUnit
 import java.util.Collections
 import java.util.Properties
 
-import org.junit.Assert._
-import org.junit.{After, Before, Test}
 import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, ConsumerGroupService, KafkaConsumerGroupService, ZkConsumerGroupService}
 import kafka.consumer.OldConsumer
 import kafka.consumer.Whitelist
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
+
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.errors.WakeupException
 import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.Assert._
+import org.junit.{After, Before, Test}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
 
 class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   private val topic = "foo"
   private val group = "test.group"
 
+  private val describeTypeOffsets = Array(Array(""), Array("--offsets"))
+  private val describeTypeMembers = Array(Array("--members"), Array("--members", "--verbose"))
+  private val describeTypeState = Array(Array("--state"))
+  private val describeTypes = describeTypeOffsets ++ describeTypeMembers ++ describeTypeState
+
   @deprecated("This field will be removed in a future release", "0.11.0.0")
   private val oldConsumers = new ArrayBuffer[OldConsumer]
-  private var consumerGroupService: ConsumerGroupService = _
-  private var consumerGroupExecutor: ConsumerGroupExecutor = _
+  private var consumerGroupService: List[ConsumerGroupService] = List()
+  private var consumerGroupExecutor: List[ConsumerGroupExecutor] = List()
 
   // configure the servers and clients
   override def generateConfigs = {
@@ -61,33 +68,31 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @After
   override def tearDown(): Unit = {
-    if (consumerGroupService != null)
-      consumerGroupService.close()
-    if (consumerGroupExecutor != null)
-      consumerGroupExecutor.shutdown()
+    consumerGroupService.foreach(_.close)
+    consumerGroupExecutor.foreach(_.shutdown)
     oldConsumers.foreach(_.stop())
     super.tearDown()
   }
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeNonExistingGroup() {
+  def testDescribeNonExistingGroupWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", "missing.group"))
-    consumerGroupService = new ZkConsumerGroupService(opts)
-    TestUtils.waitUntilTrue(() => consumerGroupService.describeGroup()._2.isEmpty, "Expected no rows in describe group results.")
+    val service = addConsumerGroupService(new ZkConsumerGroupService(opts))
+    TestUtils.waitUntilTrue(() => service.collectGroupOffsets()._2.isEmpty, "Expected no rows in describe group results.")
   }
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeExistingGroup() {
+  def testDescribeExistingGroupWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", group))
-    consumerGroupService = new ZkConsumerGroupService(opts)
+    val service = addConsumerGroupService(new ZkConsumerGroupService(opts))
     TestUtils.waitUntilTrue(() => {
-      val (_, assignments) = consumerGroupService.describeGroup()
+      val (_, assignments) = service.collectGroupOffsets()
       assignments.isDefined &&
       assignments.get.count(_.group == group) == 1 &&
       assignments.get.filter(_.group == group).head.consumerId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE)
@@ -96,14 +101,14 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeExistingGroupWithNoMembers() {
+  def testDescribeExistingGroupWithNoMembersWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", group))
-    consumerGroupService = new ZkConsumerGroupService(opts)
+    val service = addConsumerGroupService(new ZkConsumerGroupService(opts))
 
     TestUtils.waitUntilTrue(() => {
-      val (_, assignments) = consumerGroupService.describeGroup()
+      val (_, assignments) = service.collectGroupOffsets()
       assignments.isDefined &&
       assignments.get.count(_.group == group) == 1 &&
       assignments.get.filter(_.group == group).head.consumerId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE)
@@ -111,7 +116,7 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     oldConsumers.head.stop()
 
     TestUtils.waitUntilTrue(() => {
-      val (_, assignments) = consumerGroupService.describeGroup()
+      val (_, assignments) = service.collectGroupOffsets()
       assignments.isDefined &&
       assignments.get.count(_.group == group) == 1 &&
       assignments.get.filter(_.group == group).head.consumerId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) // the member should be gone
@@ -120,14 +125,14 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
 
   @Test
   @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.0.0")
-  def testDescribeConsumersWithNoAssignedPartitions() {
+  def testDescribeConsumersWithNoAssignedPartitionsWithOldConsumer() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     createOldConsumer()
     createOldConsumer()
     val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect, "--describe", "--group", group))
-    consumerGroupService = new ZkConsumerGroupService(opts)
+    val service = addConsumerGroupService(new ZkConsumerGroupService(opts))
     TestUtils.waitUntilTrue(() => {
-      val (_, assignments) = consumerGroupService.describeGroup()
+      val (_, assignments) = service.collectGroupOffsets()
       assignments.isDefined &&
       assignments.get.count(_.group == group) == 2 &&
       assignments.get.count { x => x.group == group && x.partition.isDefined } == 1 &&
@@ -136,74 +141,217 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeNonExistingGroupWithNewConsumer() {
+  def testDescribeNonExistingGroup() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
-    // run one consumer in the group consuming from a single-partition topic
-    consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
+    val missingGroup = "missing.group"
 
-    // note the group to be queried is a different (non-existing) group
-    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "missing.group")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    consumerGroupService = new KafkaConsumerGroupService(opts)
+    for (describeType <- describeTypes) {
+      // run one consumer in the group consuming from a single-partition topic
+      addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+      // note the group to be queried is a different (non-existing) group
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", missingGroup) ++ describeType
+      val opts = new ConsumerGroupCommandOptions(cgcArgs)
+      val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
 
-    val (state, assignments) = consumerGroupService.describeGroup()
-    assertTrue("Expected the state to be 'Dead' with no members in the group.", state == Some("Dead") && assignments == Some(List()))
+      val output = TestUtils.grabConsoleOutput(service.describeGroup())
+      assertTrue(s"Expected error was not detected for describe option '${describeType.mkString(" ")}'",
+          output.contains(s"Consumer group '$missingGroup' does not exist."))
+    }
   }
 
   @Test
-  def testDescribeExistingGroupWithNewConsumer() {
+  def testDescribeOffsetsOfNonExistingGroup() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
-    // run one consumer in the group consuming from a single-partition topic
-    consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
 
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+    // note the group to be queried is a different (non-existing) group
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "missing.group")
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    val (state, assignments) = service.collectGroupOffsets()
+    assertTrue(s"Expected the state to be 'Dead', with no members in the group '$group'.",
+        state == Some("Dead") && assignments == Some(List()))
+  }
+
+  @Test
+  def testDescribeMembersOfNonExistingGroup() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+    // note the group to be queried is a different (non-existing) group
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "missing.group")
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    val (state, assignments) = service.collectGroupMembers(false)
+    assertTrue(s"Expected the state to be 'Dead', with no members in the group '$group'.",
+        state == Some("Dead") && assignments == Some(List()))
+
+    val (state2, assignments2) = service.collectGroupMembers(true)
+    assertTrue(s"Expected the state to be 'Dead', with no members in the group '$group' (verbose option).",
+        state2 == Some("Dead") && assignments2 == Some(List()))
+  }
+
+  @Test
+  def testDescribeStateOfNonExistingGroup() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+    // note the group to be queried is a different (non-existing) group
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "missing.group")
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    val state = service.collectGroupState()
+    assertTrue(s"Expected the state to be 'Dead', with no members in the group '$group'.",
+        state.isDefined && state.get.state == Some("Dead") && state.get.numMembers == Some(0))
+  }
+
+  @Test
+  def testDescribeExistingGroup() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    for (describeType <- describeTypes) {
+      val group = this.group + describeType.mkString("")
+      // run one consumer in the group consuming from a single-partition topic
+      addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group) ++ describeType
+      val opts = new ConsumerGroupCommandOptions(cgcArgs)
+      val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+      TestUtils.waitUntilTrue(() => {
+          val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroup())
+          output.trim.split("\n").length == 2 && error.isEmpty
+      }, s"Expected a data row and no error in describe results with describe type ${describeType.mkString(" ")}.")
+    }
+  }
+
+  @Test
+  def testDescribeOffsetsOfExistingGroup() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
     val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    consumerGroupService = new KafkaConsumerGroupService(opts)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
 
     TestUtils.waitUntilTrue(() => {
-        val (state, assignments) = consumerGroupService.describeGroup()
+        val (state, assignments) = service.collectGroupOffsets()
         state == Some("Stable") &&
         assignments.isDefined &&
         assignments.get.count(_.group == group) == 1 &&
         assignments.get.filter(_.group == group).head.consumerId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
         assignments.get.filter(_.group == group).head.clientId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
         assignments.get.filter(_.group == group).head.host.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE)
-    }, "Expected a 'Stable' group status, rows and valid values for consumer id / client id / host columns in describe group results.")
+    }, s"Expected a 'Stable' group status, rows and valid values for consumer id / client id / host columns in describe results for group $group.")
   }
 
   @Test
-  def testDescribeExistingGroupWithNoMembersWithNewConsumer() {
+  def testDescribeMembersOfExistingGroup() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
+
     // run one consumer in the group consuming from a single-partition topic
-    consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+        val (state, assignments) = service.collectGroupMembers(false)
+        state == Some("Stable") &&
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 1 &&
+        assignments.get.filter(_.group == group).head.consumerId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
+        assignments.get.filter(_.group == group).head.clientId.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
+        assignments.get.filter(_.group == group).head.host.exists(_.trim != ConsumerGroupCommand.MISSING_COLUMN_VALUE)
+    }, s"Expected a 'Stable' group status, rows and valid member information for group $group.")
+
+    val (state, assignments) = service.collectGroupMembers(true)
+    assertTrue(s"Expected a topic partition assigned to the single group member for group $group",
+        assignments.isDefined &&
+        assignments.get.size == 1 &&
+        assignments.get.head.assignment.isDefined &&
+        assignments.get.head.assignment.get.size == 1)
+  }
+
+  @Test
+  def testDescribeStateOfExistingGroup() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic, "org.apache.kafka.clients.consumer.RoundRobinAssignor"))
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+        val state = service.collectGroupState()
+        state.isDefined &&
+        state.get.state == Some("Stable") &&
+        state.get.numMembers == Some(1) &&
+        state.get.assignmentStrategy == Some("roundrobin")
+    }, s"Expected a 'Stable' group status, with one member and round robin assignment strategy for group $group.")
+  }
+
+  @Test
+  def testDescribeExistingGroupWithNoMembers() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    for (describeType <- describeTypes) {
+      val group = this.group + describeType.mkString("")
+      // run one consumer in the group consuming from a single-partition topic
+      val executor = addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group) ++ describeType
+      val opts = new ConsumerGroupCommandOptions(cgcArgs)
+      val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+      TestUtils.waitUntilTrue(() => {
+        val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroup())
+        output.trim.split("\n").length == 2 && error.isEmpty
+      }, s"Expected describe group results with one data row for describe type '${describeType.mkString(" ")}'")
+
+      // stop the consumer so the group has no active member anymore
+      executor.shutdown()
+
+      TestUtils.waitUntilTrue(() => {
+        TestUtils.grabConsoleError(service.describeGroup()).contains(s"Consumer group '$group' has no active members.")
+      }, s"Expected no active member in describe group results with describe type ${describeType.mkString(" ")}")
+    }
+  }
+
+  @Test
+  def testDescribeOffsetsOfExistingGroupWithNoMembers() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run one consumer in the group consuming from a single-partition topic
+    val executor = addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
 
     val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    consumerGroupService = new KafkaConsumerGroupService(opts)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
 
     TestUtils.waitUntilTrue(() => {
-      val (state, _) = consumerGroupService.describeGroup()
-      state == Some("Stable")
-    }, "Expected the group to initially become stable.")
-
-    // Group assignments in describeGroup rely on finding committed consumer offsets.
-    // Wait for an offset commit before shutting down the group executor.
-    TestUtils.waitUntilTrue(() => {
-      val (_, assignments) = consumerGroupService.describeGroup()
-      assignments.exists(_.exists(_.group == group))
-    }, "Expected to find group in assignments after initial offset commit")
+      val (state, assignments) = service.collectGroupOffsets()
+      state == Some("Stable") && assignments.exists(_.exists(_.group == group))
+    }, "Expected the group to initially become stable, and to find group in assignments after initial offset commit.")
 
     // stop the consumer so the group has no active member anymore
-    consumerGroupExecutor.shutdown()
+    executor.shutdown()
 
-    val (result, succeeded) = TestUtils.computeUntilTrue(consumerGroupService.describeGroup()) { case (state, assignments) =>
-      val testGroupAssignments = assignments.toSeq.flatMap(_.filter(_.group == group))
-      def assignment = testGroupAssignments.head
-      state == Some("Empty") &&
-        testGroupAssignments.size == 1 &&
-        assignment.consumerId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) && // the member should be gone
-        assignment.clientId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
-        assignment.host.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE)
+    val (result, succeeded) = TestUtils.computeUntilTrue(service.collectGroupOffsets()) {
+      case (state, assignments) =>
+        val testGroupAssignments = assignments.toSeq.flatMap(_.filter(_.group == group))
+        def assignment = testGroupAssignments.head
+        state == Some("Empty") &&
+          testGroupAssignments.size == 1 &&
+          assignment.consumerId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) && // the member should be gone
+          assignment.clientId.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE) &&
+          assignment.host.exists(_.trim == ConsumerGroupCommand.MISSING_COLUMN_VALUE)
     }
     val (state, assignments) = result
     assertTrue(s"Expected no active member in describe group results, state: $state, assignments: $assignments",
@@ -211,63 +359,319 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDescribeConsumersWithNoAssignedPartitionsWithNewConsumer() {
+  def testDescribeMembersOfExistingGroupWithNoMembers() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
-    // run two consumers in the group consuming from a single-partition topic
-    consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 2, group, topic)
+
+    // run one consumer in the group consuming from a single-partition topic
+    val executor = addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
 
     val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    consumerGroupService = new KafkaConsumerGroupService(opts)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
 
     TestUtils.waitUntilTrue(() => {
-      val (state, assignments) = consumerGroupService.describeGroup()
+      val (state, assignments) = service.collectGroupMembers(false)
+      state == Some("Stable") && assignments.exists(_.exists(_.group == group))
+    }, "Expected the group to initially become stable, and to find group in assignments after initial offset commit.")
+
+    // stop the consumer so the group has no active member anymore
+    executor.shutdown()
+
+    TestUtils.waitUntilTrue(() => {
+      val (state, assignments) = service.collectGroupMembers(false)
+      state == Some("Empty") && assignments.isDefined && assignments.get.isEmpty
+    }, s"Expected no member in describe group members results for group '$group'")
+  }
+
+  @Test
+  def testDescribeStateOfExistingGroupWithNoMembers() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run one consumer in the group consuming from a single-partition topic
+    val executor = addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+      val state = service.collectGroupState()
+      state.isDefined && state.get.state == Some("Stable") && state.get.numMembers == Some(1)
+    }, "Expected the group '$group' to initially become stable, and have a single member.")
+
+    // stop the consumer so the group has no active member anymore
+    executor.shutdown()
+
+    TestUtils.waitUntilTrue(() => {
+      val state = service.collectGroupState()
+      state.isDefined && state.get.state == Some("Empty") && state.get.numMembers == Some(0) && state.get.assignmentStrategy == Some("")
+    }, "Expected the group '$group' to become empty after the only member leaving.")
+  }
+
+  @Test
+  def testDescribeWithConsumersWithoutAssignedPartitions() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    for (describeType <- describeTypes) {
+      val group = this.group + describeType.mkString("")
+      // run one consumer in the group consuming from a single-partition topic
+      val executor = addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic))
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group) ++ describeType
+      val opts = new ConsumerGroupCommandOptions(cgcArgs)
+      val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+      TestUtils.waitUntilTrue(() => {
+        val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroup())
+        val expectedNumRows = if (describeTypeMembers.contains(describeType)) 3 else 2
+        error.isEmpty && output.trim.split("\n").size == expectedNumRows
+      }, s"Expected a single data row in describe group result with describe type '${describeType.mkString(" ")}'")
+    }
+  }
+
+  @Test
+  def testDescribeOffsetsWithConsumersWithoutAssignedPartitions() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run two consumers in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic))
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+      val (state, assignments) = service.collectGroupOffsets()
       state == Some("Stable") &&
         assignments.isDefined &&
-        assignments.get.count(_.group == group) == 2 &&
-        assignments.get.count { x => x.group == group && x.partition.isDefined } == 1 &&
-        assignments.get.count { x => x.group == group && x.partition.isEmpty } == 1
+        assignments.get.count(_.group == group) == 1 &&
+        assignments.get.count { x => x.group == group && x.partition.isDefined } == 1
     }, "Expected rows for consumers with no assigned partitions in describe group results")
   }
 
   @Test
-  def testDescribeWithMultiPartitionTopicAndMultipleConsumersWithNewConsumer() {
+  def testDescribeMembersWithConsumersWithoutAssignedPartitions() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run two consumers in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic))
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+      val (state, assignments) = service.collectGroupMembers(false)
+      state == Some("Stable") &&
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 2 &&
+        assignments.get.count { x => x.group == group && x.numPartitions.isDefined && x.numPartitions.get == 1 } == 1 &&
+        assignments.get.count { x => x.group == group && x.numPartitions.isDefined && x.numPartitions.get == 0 } == 1 &&
+        assignments.get.count(_.assignment.isDefined) == 0
+    }, "Expected rows for consumers with no assigned partitions in describe group results")
+
+    val (state, assignments) = service.collectGroupMembers(true)
+    assertTrue("Expected additional columns in verbose vesion of describe members",
+        state == Some("Stable") && assignments.get.count(_.assignment.isEmpty) == 0)
+  }
+
+  @Test
+  def testDescribeStateWithConsumersWithoutAssignedPartitions() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+
+    // run two consumers in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic))
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+      val state = service.collectGroupState()
+      state.isDefined &&
+        state.get.state == Some("Stable") &&
+        state.get.numMembers == Some(2)
+    }, "Expected two consumers in describe group results")
+  }
+
+  @Test
+  def testDescribeWithMultiPartitionTopicAndMultipleConsumers() {
     TestUtils.createOffsetsTopic(zkUtils, servers)
     val topic2 = "foo2"
     adminZkClient.createTopic(topic2, 2, 1)
 
+    for (describeType <- describeTypes) {
+      val group = this.group + describeType.mkString("")
+      // run two consumers in the group consuming from a two-partition topic
+      addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic2))
+      val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group) ++ describeType
+      val opts = new ConsumerGroupCommandOptions(cgcArgs)
+      val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+      TestUtils.waitUntilTrue(() => {
+        val (output, error) = TestUtils.grabConsoleOutputAndError(service.describeGroup())
+        val expectedNumRows = if (describeTypeState.contains(describeType)) 2 else 3
+        error.isEmpty && output.trim.split("\n").size == expectedNumRows
+      }, s"Expected a single data row in describe group result with describe type '${describeType.mkString(" ")}'")
+    }
+  }
+
+  @Test
+  def testDescribeOffsetsWithMultiPartitionTopicAndMultipleConsumers() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+    val topic2 = "foo2"
+    AdminUtils.createTopic(zkUtils, topic2, 2, 1)
+
     // run two consumers in the group consuming from a two-partition topic
-    consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 2, group, topic2)
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic2))
 
     val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    consumerGroupService = new KafkaConsumerGroupService(opts)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
 
     TestUtils.waitUntilTrue(() => {
-      val (state, assignments) = consumerGroupService.describeGroup()
+      val (state, assignments) = service.collectGroupOffsets()
       state == Some("Stable") &&
-      assignments.isDefined &&
-      assignments.get.count(_.group == group) == 2 &&
-      assignments.get.count{ x => x.group == group && x.partition.isDefined} == 2 &&
-      assignments.get.count{ x => x.group == group && x.partition.isEmpty} == 0
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 2 &&
+        assignments.get.count{ x => x.group == group && x.partition.isDefined} == 2 &&
+        assignments.get.count{ x => x.group == group && x.partition.isEmpty} == 0
     }, "Expected two rows (one row per consumer) in describe group results.")
   }
 
   @Test
-  def testDescribeGroupWithNewConsumerWithShortInitializationTimeout() {
-    // Let creation of the offsets topic happen during group initialisation to ensure that initialization doesn't
+  def testDescribeMembersWithMultiPartitionTopicAndMultipleConsumers() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+    val topic2 = "foo2"
+    AdminUtils.createTopic(zkUtils, topic2, 2, 1)
+
+    // run two consumers in the group consuming from a two-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic2))
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+      val (state, assignments) = service.collectGroupMembers(false)
+      state == Some("Stable") &&
+        assignments.isDefined &&
+        assignments.get.count(_.group == group) == 2 &&
+        assignments.get.count{ x => x.group == group && x.numPartitions.isDefined && x.numPartitions.get == 1 } == 2 &&
+        assignments.get.count{ x => x.group == group && x.numPartitions.isDefined && x.numPartitions.get == 0 } == 0
+    }, "Expected two rows (one row per consumer) in describe group members results.")
+
+    val (state, assignments) = service.collectGroupMembers(true)
+    assertTrue("Expected additional columns in verbose vesion of describe members",
+        state == Some("Stable") && assignments.get.count(_.assignment.isEmpty) == 0)
+  }
+
+  @Test
+  def testDescribeStateWithMultiPartitionTopicAndMultipleConsumers() {
+    TestUtils.createOffsetsTopic(zkUtils, servers)
+    val topic2 = "foo2"
+    AdminUtils.createTopic(zkUtils, topic2, 2, 1)
+
+    // run two consumers in the group consuming from a two-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 2, group, topic2))
+
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group)
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    TestUtils.waitUntilTrue(() => {
+      val state = service.collectGroupState()
+      state.isDefined &&
+        state.get.state == Some("Stable") &&
+        state.get.group == group &&
+        state.get.numMembers == Some(2)
+    }, "Expected a stable group with two members in describe group state result.")
+  }
+
+  @Test
+  def testDescribeGroupWithShortInitializationTimeout() {
+    // Let creation of the offsets topic happen during group initialization to ensure that initialization doesn't
+    // complete before the timeout expires
+
+    val describeType = describeTypes(Random.nextInt(describeTypes.length))
+    val group = this.group + describeType.mkString("")
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+    // set the group initialization timeout too low for the group to stabilize
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--timeout", "1", "--group", group) ++ describeType
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    try {
+      TestUtils.grabConsoleOutputAndError(service.describeGroup())
+      fail(s"The consumer group command should have failed due to low initialization timeout (describe type: ${describeType.mkString(" ")})")
+    } catch {
+      case _: TimeoutException => // OK
+    }
+  }
+
+  @Test
+  def testDescribeGroupOffsetsWithShortInitializationTimeout() {
+    // Let creation of the offsets topic happen during group initialization to ensure that initialization doesn't
     // complete before the timeout expires
 
     // run one consumer in the group consuming from a single-partition topic
-    consumerGroupExecutor = new ConsumerGroupExecutor(brokerList, 1, group, topic)
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
 
     // set the group initialization timeout too low for the group to stabilize
-    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", "group", "--timeout", "1")
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group, "--timeout", "1")
     val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    consumerGroupService = new KafkaConsumerGroupService(opts)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
 
     try {
-      consumerGroupService.describeGroup()
+      service.collectGroupOffsets()
+      fail("The consumer group command should fail due to low initialization timeout")
+    } catch {
+      case _: TimeoutException => // OK
+    }
+  }
+
+  @Test
+  def testDescribeGroupMembersWithShortInitializationTimeout() {
+    // Let creation of the offsets topic happen during group initialization to ensure that initialization doesn't
+    // complete before the timeout expires
+
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+
+    // set the group initialization timeout too low for the group to stabilize
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group, "--timeout", "1")
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    try {
+      service.collectGroupMembers(false)
+      fail("The consumer group command should fail due to low initialization timeout")
+    } catch {
+      case _: TimeoutException => // OK
+        try {
+          service.collectGroupMembers(true)
+          fail("The consumer group command should fail due to low initialization timeout (verbose)")
+        } catch {
+          case _: TimeoutException => // OK
+        }
+    }
+  }
+
+  @Test
+  def testDescribeGroupStateWithShortInitializationTimeout() {
+    // Let creation of the offsets topic happen during group initialization to ensure that initialization doesn't
+    // complete before the timeout expires
+
+    // run one consumer in the group consuming from a single-partition topic
+    addConsumerGroupExecutor(new ConsumerGroupExecutor(brokerList, 1, group, topic))
+
+    // set the group initialization timeout too low for the group to stabilize
+    val cgcArgs = Array("--bootstrap-server", brokerList, "--describe", "--group", group, "--timeout", "1")
+    val opts = new ConsumerGroupCommandOptions(cgcArgs)
+    val service = addConsumerGroupService(new KafkaConsumerGroupService(opts))
+
+    try {
+      service.collectGroupState()
       fail("The consumer group command should fail due to low initialization timeout")
     } catch {
       case _: TimeoutException => // OK
@@ -281,15 +685,27 @@ class DescribeConsumerGroupTest extends KafkaServerTestHarness {
     consumerProps.setProperty("zookeeper.connect", zkConnect)
     oldConsumers += new OldConsumer(Whitelist(topic), consumerProps)
   }
+
+  def addConsumerGroupService(service: ConsumerGroupService): ConsumerGroupService = {
+    consumerGroupService = service :: consumerGroupService
+    service
+  }
+
+  def addConsumerGroupExecutor(executor: ConsumerGroupExecutor): ConsumerGroupExecutor = {
+    consumerGroupExecutor = executor :: consumerGroupExecutor
+    executor
+  }
 }
 
 
-class ConsumerThread(broker: String, id: Int, groupId: String, topic: String) extends Runnable {
+class ConsumerThread(broker: String, id: Int, groupId: String, topic: String, strategy: String)
+    extends Runnable {
   val props = new Properties
   props.put("bootstrap.servers", broker)
   props.put("group.id", groupId)
   props.put("key.deserializer", classOf[StringDeserializer].getName)
   props.put("value.deserializer", classOf[StringDeserializer].getName)
+  props.put("partition.assignment.strategy", strategy)
   val consumer = new KafkaConsumer(props)
 
   def run() {
@@ -310,11 +726,11 @@ class ConsumerThread(broker: String, id: Int, groupId: String, topic: String) ex
 }
 
 
-class ConsumerGroupExecutor(broker: String, numConsumers: Int, groupId: String, topic: String) {
+class ConsumerGroupExecutor(broker: String, numConsumers: Int, groupId: String, topic: String, strategy: String = "org.apache.kafka.clients.consumer.RangeAssignor") {
   val executor: ExecutorService = Executors.newFixedThreadPool(numConsumers)
   private val consumers = new ArrayBuffer[ConsumerThread]()
   for (i <- 1 to numConsumers) {
-    val consumer = new ConsumerThread(broker, i, groupId, topic)
+    val consumer = new ConsumerThread(broker, i, groupId, topic, strategy)
     consumers += consumer
     executor.submit(consumer)
   }

--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -119,7 +119,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     val executor = createConsumerGroupExecutor(brokerList, 1, group, topic1)
 
     TestUtils.waitUntilTrue(() => {
-      val (_, assignmentsOption) = consumerGroupCommand.describeGroup()
+      val (_, assignmentsOption) = consumerGroupCommand.collectGroupOffsets()
       assignmentsOption match {
         case Some(assignments) =>
           val sumOffset = assignments.filter(_.topic.exists(_ == topic1))
@@ -164,7 +164,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     val executor = createConsumerGroupExecutor(brokerList, 1, group, topic1)
 
     TestUtils.waitUntilTrue(() => {
-      val (_, assignmentsOption) = consumerGroupCommand.describeGroup()
+      val (_, assignmentsOption) = consumerGroupCommand.collectGroupOffsets()
       assignmentsOption match {
         case Some(assignments) =>
           val sumOffset = (assignments.filter(_.topic.exists(_ == topic1))
@@ -330,7 +330,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     val executor = createConsumerGroupExecutor(brokerList, numConsumers, group, topic)
 
     TestUtils.waitUntilTrue(() => {
-      val (_, assignmentsOption) = consumerGroupCommand.describeGroup()
+      val (_, assignmentsOption) = consumerGroupCommand.collectGroupOffsets()
       assignmentsOption match {
         case Some(assignments) =>
           val sumOffset = assignments.filter(_.topic.exists(_ == topic))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1503,7 +1503,7 @@ object TestUtils extends Logging {
   def grabConsoleOutput(f: => Unit) : String = {
     val out = new ByteArrayOutputStream
     try scala.Console.withOut(out)(f)
-    finally scala.Console.out.flush
+    finally scala.Console.out.flush()
     out.toString
   }
 
@@ -1513,7 +1513,7 @@ object TestUtils extends Logging {
   def grabConsoleError(f: => Unit) : String = {
     val err = new ByteArrayOutputStream
     try scala.Console.withErr(err)(f)
-    finally scala.Console.err.flush
+    finally scala.Console.err.flush()
     err.toString
   }
 
@@ -1523,16 +1523,10 @@ object TestUtils extends Logging {
   def grabConsoleOutputAndError(f: => Unit) : (String, String) = {
     val out = new ByteArrayOutputStream
     val err = new ByteArrayOutputStream
-    try {
-      scala.Console.withOut(out) {
-        scala.Console.withErr(err) {
-          f
-        }
-      }
-    }
+    try scala.Console.withOut(out)(scala.Console.withErr(err)(f))
     finally {
-      scala.Console.out.flush
-      scala.Console.err.flush
+      scala.Console.out.flush()
+      scala.Console.err.flush()
     }
     (out.toString, err.toString)
   }

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1507,6 +1507,36 @@ object TestUtils extends Logging {
     out.toString
   }
 
+  /**
+   * Capture the console error during the execution of the provided function.
+   */
+  def grabConsoleError(f: => Unit) : String = {
+    val err = new ByteArrayOutputStream
+    try scala.Console.withErr(err)(f)
+    finally scala.Console.err.flush
+    err.toString
+  }
+
+  /**
+   * Capture both the console output and console error during the execution of the provided function.
+   */
+  def grabConsoleOutputAndError(f: => Unit) : (String, String) = {
+    val out = new ByteArrayOutputStream
+    val err = new ByteArrayOutputStream
+    try {
+      scala.Console.withOut(out) {
+        scala.Console.withErr(err) {
+          f
+        }
+      }
+    }
+    finally {
+      scala.Console.out.flush
+      scala.Console.err.flush
+    }
+    (out.toString, err.toString)
+  }
+
 }
 
 class IntEncoder(props: VerifiableProperties = null) extends Encoder[Int] {


### PR DESCRIPTION
The `--describe` option of ConsumerGroupCommand is expanded, as proposed in [KIP-175](https://cwiki.apache.org/confluence/display/KAFKA/KIP-175%3A+Additional+%27--describe%27+views+for+ConsumerGroupCommand), to support:
* `--describe` or `--describe --offsets`: listing of current group offsets
* `--describe --members` or `--describe --members --verbose`: listing of group members
* `--describe --state`: group status

Example: With a single partition topic `test1` and a double partition topic `test2`, consumers `consumer1` and `consumer11` subscribed to `test`, consumers `consumer2` and `consumer22` and `consumer222` subscribed to `test2`, and all consumers belonging to group `test-group`, this is an output example of the new options above for `test-group`:

```
--describe, or --describe --offsets:

TOPIC           PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG             CONSUMER-ID                                     HOST            CLIENT-ID
test2           0          0               0               0               consumer2-bad9496d-0889-47ab-98ff-af17d9460382  /127.0.0.1      consumer2
test2           1          0               0               0               consumer22-c45e6ee2-0c7d-44a3-94a8-9627f63fb411 /127.0.0.1      consumer22
test1           0          0               0               0               consumer1-d51b0345-3194-4305-80db-81a68fa6c5bf  /127.0.0.1      consumer1
```

```
--describe --members

CONSUMER-ID                                      HOST            CLIENT-ID       #PARTITIONS
consumer2-bad9496d-0889-47ab-98ff-af17d9460382   /127.0.0.1      consumer2       1
consumer222-ed2108cd-d368-41f1-8514-5b72aa835bcc /127.0.0.1      consumer222     0
consumer11-dc8295d7-8f3f-4438-9b11-7270bab46760  /127.0.0.1      consumer11      0
consumer22-c45e6ee2-0c7d-44a3-94a8-9627f63fb411  /127.0.0.1      consumer22      1
consumer1-d51b0345-3194-4305-80db-81a68fa6c5bf   /127.0.0.1      consumer1       1
```

```
--describe --members --verbose

CONSUMER-ID                                      HOST            CLIENT-ID       #PARTITIONS     ASSIGNMENT
consumer2-bad9496d-0889-47ab-98ff-af17d9460382   /127.0.0.1      consumer2       1               test2(0)
consumer222-ed2108cd-d368-41f1-8514-5b72aa835bcc /127.0.0.1      consumer222     0               -
consumer11-dc8295d7-8f3f-4438-9b11-7270bab46760  /127.0.0.1      consumer11      0               -
consumer22-c45e6ee2-0c7d-44a3-94a8-9627f63fb411  /127.0.0.1      consumer22      1               test2(1)
consumer1-d51b0345-3194-4305-80db-81a68fa6c5bf   /127.0.0.1      consumer1       1               test1(0)
```

```
--describe --state

COORDINATOR (ID)         ASSIGNMENT-STRATEGY       STATE                #MEMBERS
localhost:9092 (0)       range                     Stable               5
```

Note that this PR also addresses the issue reported in [KAFKA-6158](https://issues.apache.org/jira/browse/KAFKA-6158) by dynamically setting the width of columns `TOPIC`, `CONSUMER-ID`, `HOST`, `CLIENT-ID` and `COORDINATOR (ID)`. This avoid truncation of column values when they go over the current fixed width of these columns.

The code has been restructured to better support testing of individual values and also the console output. Unit tests have been updated and extended to take advantage of this restructuring.
