### PR TITLE
KAFKA-6283: Configuration of custom SCRAM SaslServer implementations

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticator.java
@@ -162,7 +162,7 @@ public class SaslServerAuthenticator implements Authenticator {
         if (!ScramMechanism.isScram(mechanism))
             callbackHandler = new SaslServerCallbackHandler(jaasContext);
         else
-            callbackHandler = new ScramServerCallbackHandler(credentialCache.cache(mechanism, ScramCredential.class));
+            callbackHandler = new ScramServerCallbackHandler(credentialCache.cache(mechanism, ScramCredential.class), jaasContext);
         callbackHandler.configure(configs, Mode.SERVER, subject, saslMechanism);
         if (mechanism.equals(SaslConfigs.GSSAPI_MECHANISM)) {
             saslServer = createSaslKerberosServer(callbackHandler, configs, subject);

--- a/clients/src/main/java/org/apache/kafka/common/security/scram/ScramServerCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/scram/ScramServerCallbackHandler.java
@@ -25,15 +25,22 @@ import javax.security.auth.callback.NameCallback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.authenticator.AuthCallbackHandler;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
 
 public class ScramServerCallbackHandler implements AuthCallbackHandler {
 
     private final CredentialCache.Cache<ScramCredential> credentialCache;
+    private final JaasContext jaasContext;
 
-    public ScramServerCallbackHandler(CredentialCache.Cache<ScramCredential> credentialCache) {
+    public ScramServerCallbackHandler(CredentialCache.Cache<ScramCredential> credentialCache, JaasContext jaasContext) {
         this.credentialCache = credentialCache;
+        this.jaasContext = jaasContext;
+    }
+
+    public JaasContext jaasContext() {
+        return jaasContext;
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslServerAuthenticatorTest.java
@@ -22,24 +22,43 @@ import org.apache.kafka.common.network.InvalidReceiveException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.TransportLayer;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.security.JaasContext;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.scram.ScramMechanism;
+import org.apache.kafka.common.security.scram.ScramSaslServer;
+import org.apache.kafka.common.security.scram.ScramServerCallbackHandler;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
 import org.junit.Test;
 
 import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.channels.SocketChannel;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.kafka.common.security.scram.ScramMechanism.SCRAM_SHA_256;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SaslServerAuthenticatorTest {
@@ -101,6 +120,91 @@ public class SaslServerAuthenticatorTest {
             fail("Expected authenticate() to raise an exception");
         } catch (IllegalSaslStateException e) {
             // expected exception
+        }
+    }
+
+    public static class TestScramSaslServer extends ScramSaslServer {
+
+        public TestScramSaslServer(Map<String, ?> props, CallbackHandler cbh) throws NoSuchAlgorithmException {
+            super(ScramMechanism.SCRAM_SHA_256, props, cbh);
+            assertNotNull("JAAS context was null", ((ScramServerCallbackHandler) cbh).jaasContext());
+        }
+    };
+
+    public static class TestScramSaslServerFactory implements SaslServerFactory {
+
+        @Override
+        public SaslServer createSaslServer(String mechanism, String protocol,
+                                           String serverName, Map<String, ?> props, CallbackHandler cbh)
+                throws SaslException {
+            final JaasContext context = ((ScramServerCallbackHandler) cbh).jaasContext();
+            assertNotNull("JAAS Context should be available", context);
+            try {
+                return new TestScramSaslServer(props, cbh);
+            } catch (NoSuchAlgorithmException e) {
+                throw new SaslException("", e);
+            }
+        }
+
+        @Override
+        public String[] getMechanismNames(Map<String, ?> props) {
+            return new String[]{"SCRAM-SHA-256"};
+        }
+    }
+
+    @Test
+    public void testScramSaslServerCanAccessJaasContext() throws Exception {
+        class ScramSaslServerCanAccessJaasContextProvider extends Provider {
+
+            protected ScramSaslServerCanAccessJaasContextProvider() {
+                super("Test SCRAM SASL Server Provider", 1.0,
+                        "This is for testing that a custom SCRAM SaslServer can access the JAAS context");
+                put("SaslServerFactory.SCRAM-SHA-256", TestScramSaslServerFactory.class.getName());
+            }
+        }
+
+        long start = System.currentTimeMillis();
+        final ScramSaslServerCanAccessJaasContextProvider provider = new ScramSaslServerCanAccessJaasContextProvider();
+        while (true) {
+            synchronized (Security.class) {
+                Security.insertProviderAt(provider, 0);
+                try {
+                    TransportLayer transportLayer = EasyMock.mock(TransportLayer.class);
+                    Map<String, ?> configs = Collections.singletonMap(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG,
+                            Collections.singletonList(SCRAM_SHA_256.mechanismName()));
+
+                    Socket socket = EasyMock.mock(Socket.class);
+                    EasyMock.expect(socket.getLocalAddress()).andReturn(InetAddress.getByName("127.0.0.1"));
+
+                    SocketChannel socketChannel = EasyMock.mock(SocketChannel.class);
+                    EasyMock.expect(socketChannel.socket()).andReturn(socket);
+
+                    EasyMock.expect(transportLayer.socketChannel()).andReturn(socketChannel);
+
+                    EasyMock.replay(transportLayer, socketChannel, socket);
+
+                    SaslServerAuthenticator authenticator = setupAuthenticator(configs, transportLayer);
+                    final Method createSaslServerMethod = SaslServerAuthenticator.class.getDeclaredMethod("createSaslServer", String.class);
+                    createSaslServerMethod.setAccessible(true);
+                    createSaslServerMethod.invoke(authenticator, "SCRAM-SHA-256");
+                    final Field saslServerField = SaslServerAuthenticator.class.getDeclaredField("saslServer");
+                    saslServerField.setAccessible(true);
+
+                    final Object fieldValue = saslServerField.get(authenticator);
+
+                    if (fieldValue instanceof TestScramSaslServer) {
+                        // It can happen that other tests can interfere with this one because of the
+                        // global nature of the installed security providers,
+                        // so we loop until this test passes
+                        break;
+                    }
+                    if (System.currentTimeMillis()-start > TimeUnit.MINUTES.toMillis(2)) {
+                        fail("Timeout");
+                    }
+                } finally {
+                    Security.removeProvider(provider.getName());
+                }
+            }
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/scram/ScramSaslServerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/scram/ScramSaslServerTest.java
@@ -43,7 +43,7 @@ public class ScramSaslServerTest {
         CredentialCache.Cache<ScramCredential> credentialCache = new CredentialCache().createCache(mechanism.mechanismName(), ScramCredential.class);
         credentialCache.put(USER_A, formatter.generateCredential("passwordA", 4096));
         credentialCache.put(USER_B, formatter.generateCredential("passwordB", 4096));
-        ScramServerCallbackHandler callbackHandler = new ScramServerCallbackHandler(credentialCache);
+        ScramServerCallbackHandler callbackHandler = new ScramServerCallbackHandler(credentialCache, null);
         saslServer = new ScramSaslServer(mechanism, new HashMap<String, Object>(), callbackHandler);
     }
 


### PR DESCRIPTION
Pass the jaasContext to the ScramServerCallbackHandler, so that custom implementations of a SCRAM SaslServer have access to the JAAS configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
