### PR TITLE
KAFKA-6260: Ensure selection keys are removed from all collections on socket close

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -117,6 +117,10 @@ public class KafkaChannel {
         return id;
     }
 
+    public SelectionKey selectionKey() {
+        return transportLayer.selectionKey();
+    }
+
     /**
      * externally muting a channel should be done via selector to ensure proper state handling
      */

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -64,6 +64,11 @@ public class PlaintextTransportLayer implements TransportLayer {
     }
 
     @Override
+    public SelectionKey selectionKey() {
+        return key;
+    }
+
+    @Override
     public boolean isOpen() {
         return socketChannel.isOpen();
     }
@@ -191,7 +196,6 @@ public class PlaintextTransportLayer implements TransportLayer {
 
     /**
      * Adds the interestOps to selectionKey.
-     * @param ops
      */
     @Override
     public void addInterestOps(int ops) {
@@ -201,7 +205,6 @@ public class PlaintextTransportLayer implements TransportLayer {
 
     /**
      * Removes the interestOps from selectionKey.
-     * @param ops
      */
     @Override
     public void removeInterestOps(int ops) {

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextTransportLayer.java
@@ -78,20 +78,10 @@ public class PlaintextTransportLayer implements TransportLayer {
         return socketChannel.isConnected();
     }
 
-    /**
-     * Closes this channel
-     *
-     * @throws IOException If I/O error occurs
-     */
     @Override
     public void close() throws IOException {
-        try {
-            socketChannel.socket().close();
-            socketChannel.close();
-        } finally {
-            key.attach(null);
-            key.cancel();
-        }
+        socketChannel.socket().close();
+        socketChannel.close();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -214,6 +214,8 @@ public class Selector implements Selectable, AutoCloseable {
         }
     }
 
+    // Visible to allow test cases to override. In particular, we use this to implement a blocking connect
+    // in order to simulate "immediately connected" sockets.
     protected boolean doConnect(SocketChannel channel, InetSocketAddress address) throws IOException {
         try {
             return channel.connect(address);

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -224,7 +224,7 @@ public class Selector implements Selectable, AutoCloseable {
                 immediatelyConnectedKeys.add(key);
                 key.interestOps(0);
             }
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             socketChannel.close();
             throw e;
         }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -131,6 +131,11 @@ public class SslTransportLayer implements TransportLayer {
     }
 
     @Override
+    public SelectionKey selectionKey() {
+        return key;
+    }
+
+    @Override
     public boolean isOpen() {
         return socketChannel.isOpen();
     }

--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -174,13 +174,8 @@ public class SslTransportLayer implements TransportLayer {
         } catch (IOException ie) {
             log.warn("Failed to send SSL Close message ", ie);
         } finally {
-            try {
-                socketChannel.socket().close();
-                socketChannel.close();
-            } finally {
-                key.attach(null);
-                key.cancel();
-            }
+            socketChannel.socket().close();
+            socketChannel.close();
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/TransportLayer.java
@@ -25,6 +25,7 @@ package org.apache.kafka.common.network;
  */
 import java.io.IOException;
 import java.nio.channels.FileChannel;
+import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.channels.GatheringByteChannel;
@@ -60,13 +61,16 @@ public interface TransportLayer extends ScatteringByteChannel, GatheringByteChan
      */
     SocketChannel socketChannel();
 
+    /**
+     * Get the underlying selection key
+     */
+    SelectionKey selectionKey();
 
     /**
      * This a no-op for the non-secure PLAINTEXT implementation. For SSL, this performs
      * SSL handshake. The SSL handshake includes client authentication if configured using
-     * {@link org.apache.kafka.common.config.SslConfigsSslConfigs#SSL_CLIENT_AUTH_CONFIG}.
-     * @throws AuthenticationException if handshake fails due to an
-     *         {@link javax.net.ssl.SSLExceptionSSLException}.
+     * {@link org.apache.kafka.common.config.SslConfigs#SSL_CLIENT_AUTH_CONFIG}.
+     * @throws AuthenticationException if handshake fails due to an {@link javax.net.ssl.SSLException}.
      * @throws IOException if read or write fails with an I/O error.
     */
     void handshake() throws AuthenticationException, IOException;

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -519,6 +519,7 @@ public class SelectorTest {
         SelectionKey selectionKey = control.createMock(SelectionKey.class);
         expect(selectionKey.channel()).andReturn(SocketChannel.open());
         expect(selectionKey.readyOps()).andStubReturn(SelectionKey.OP_CONNECT);
+        expect(kafkaChannel.selectionKey()).andStubReturn(selectionKey);
 
         control.replay();
 

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -252,11 +252,6 @@ public class SelectorTest {
         sendAndReceive(node, requestPrefix, 0, reqs);
     }
 
-
-
-    /**
-     * Test sending an empty string
-     */
     @Test
     public void testEmptyRequest() throws Exception {
         String node = "0";
@@ -590,7 +585,7 @@ public class SelectorTest {
         }
     }
 
-    private void verifySelectorEmpty() throws Exception {
+    protected void verifySelectorEmpty() throws Exception {
         for (KafkaChannel channel : selector.channels())
             selector.close(channel.id());
         selector.poll(0);

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -361,7 +361,7 @@ public class SelectorTest {
     }
 
     @Test
-    public void testImmediatelyConnectedCleanedAfterClose() throws Exception {
+    public void testImmediatelyConnectedCleaned() throws Exception {
         Metrics metrics = new Metrics(); // new metrics object to avoid metric registration conflicts
         Selector selector = new Selector(5000, metrics, time, "MetricGroup", channelBuilder, new LogContext()) {
             @Override
@@ -375,15 +375,15 @@ public class SelectorTest {
         };
 
         try {
-            testImmediatelyConnectedCleanedAfterClose(selector, true);
-            testImmediatelyConnectedCleanedAfterClose(selector, false);
+            testImmediatelyConnectedCleaned(selector, true);
+            testImmediatelyConnectedCleaned(selector, false);
         } finally {
             selector.close();
             metrics.close();
         }
     }
 
-    private void testImmediatelyConnectedCleanedAfterClose(Selector selector, boolean closeAfterFirstPoll) throws Exception {
+    private void testImmediatelyConnectedCleaned(Selector selector, boolean closeAfterFirstPoll) throws Exception {
         String id = "0";
         selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
         verifyNonEmptyImmediatelyConnectedKeys(selector);

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.TestCondition;
 import org.apache.kafka.test.TestUtils;
 import org.easymock.IMocksControl;
 import org.junit.After;
@@ -105,16 +106,29 @@ public class SelectorTest {
      */
     @Test
     public void testServerDisconnect() throws Exception {
-        String node = "0";
+        final String node = "0";
 
         // connect and do a simple request
         blockingConnect(node);
         assertEquals("hello", blockingRequest(node, "hello"));
 
+        KafkaChannel channel = selector.channel(node);
+
         // disconnect
         this.server.closeConnections();
-        while (!selector.disconnected().containsKey(node))
-            selector.poll(1000L);
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                try {
+                    selector.poll(1000L);
+                    return selector.disconnected().containsKey(node);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }, 5000, "Failed to observe disconnected node in disconnected set");
+
+        assertNull(channel.selectionKey().attachment());
 
         // reconnect and do another request
         blockingConnect(node);
@@ -329,6 +343,7 @@ public class SelectorTest {
         assertNull("Channel not removed from closingChannels", selector.closingChannel(id));
         assertTrue("Unexpected disconnect notification", selector.disconnected().isEmpty());
         assertEquals(ChannelState.EXPIRED, channel.state());
+        assertNull(channel.selectionKey().attachment());
         selector.poll(0);
         assertTrue("Unexpected disconnect notification", selector.disconnected().isEmpty());
     }
@@ -347,19 +362,37 @@ public class SelectorTest {
 
     @Test
     public void testImmediatelyConnectedCleanedAfterClose() throws Exception {
-        testImmediatelyConnectedCleanedAfterClose(true);
-        testImmediatelyConnectedCleanedAfterClose(false);
+        Metrics metrics = new Metrics(); // new metrics object to avoid metric registration conflicts
+        Selector selector = new Selector(5000, metrics, time, "MetricGroup", channelBuilder, new LogContext()) {
+            @Override
+            protected boolean doConnect(SocketChannel channel, InetSocketAddress address) throws IOException {
+                // Use a blocking connect to trigger the immediately connected path
+                channel.configureBlocking(true);
+                boolean connected = super.doConnect(channel, address);
+                channel.configureBlocking(false);
+                return connected;
+            }
+        };
+
+        try {
+            testImmediatelyConnectedCleanedAfterClose(selector, true);
+            testImmediatelyConnectedCleanedAfterClose(selector, false);
+        } finally {
+            selector.close();
+            metrics.close();
+        }
     }
 
-    private void testImmediatelyConnectedCleanedAfterClose(boolean closeAfterFirstPoll) throws Exception {
+    private void testImmediatelyConnectedCleanedAfterClose(Selector selector, boolean closeAfterFirstPoll) throws Exception {
         String id = "0";
-        selector.blockingConnect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
+        selector.connect(id, new InetSocketAddress("localhost", server.port), BUFFER_SIZE, BUFFER_SIZE);
+        verifyNonEmptyImmediatelyConnectedKeys(selector);
         if (closeAfterFirstPoll) {
             selector.poll(0);
-            verifyNoImmediatelyConnectedKeys();
+            verifyEmptyImmediatelyConnectedKeys(selector);
         }
         selector.close(id);
-        verifySelectorEmpty();
+        verifySelectorEmpty(selector);
     }
 
     @Test
@@ -528,9 +561,11 @@ public class SelectorTest {
         expectLastCall().andThrow(new IOException());
 
         SelectionKey selectionKey = control.createMock(SelectionKey.class);
+        expect(kafkaChannel.selectionKey()).andStubReturn(selectionKey);
         expect(selectionKey.channel()).andReturn(SocketChannel.open());
         expect(selectionKey.readyOps()).andStubReturn(SelectionKey.OP_CONNECT);
-        expect(kafkaChannel.selectionKey()).andStubReturn(selectionKey);
+        selectionKey.cancel();
+        expectLastCall();
 
         control.replay();
 
@@ -540,6 +575,7 @@ public class SelectorTest {
 
         assertFalse(selector.connected().contains(kafkaChannel.id()));
         assertTrue(selector.disconnected().containsKey(kafkaChannel.id()));
+        assertNull(selectionKey.attachment());
 
         control.verify();
     }
@@ -563,6 +599,7 @@ public class SelectorTest {
     private void blockingConnect(String node) throws IOException {
         blockingConnect(node, new InetSocketAddress("localhost", server.port));
     }
+
     protected void blockingConnect(String node, InetSocketAddress serverAddr) throws IOException {
         selector.connect(node, serverAddr, BUFFER_SIZE, BUFFER_SIZE);
         while (!selector.connected().contains(node))
@@ -601,22 +638,35 @@ public class SelectorTest {
         }
     }
 
-    private void verifyNoImmediatelyConnectedKeys() throws Exception {
-        Field field = selector.getClass().getDeclaredField("immediatelyConnectedKeys");
-        ensureEmptySelectorField(field);
+    private void verifyNonEmptyImmediatelyConnectedKeys(Selector selector) throws Exception {
+        Field field = Selector.class.getDeclaredField("immediatelyConnectedKeys");
+        field.setAccessible(true);
+        Collection<?> immediatelyConnectedKeys = (Collection<?>) field.get(selector);
+        assertFalse(immediatelyConnectedKeys.isEmpty());
+    }
+
+    private void verifyEmptyImmediatelyConnectedKeys(Selector selector) throws Exception {
+        Field field = Selector.class.getDeclaredField("immediatelyConnectedKeys");
+        ensureEmptySelectorField(selector, field);
     }
 
     protected void verifySelectorEmpty() throws Exception {
-        for (KafkaChannel channel : selector.channels())
+        verifySelectorEmpty(this.selector);
+    }
+
+    private void verifySelectorEmpty(Selector selector) throws Exception {
+        for (KafkaChannel channel : selector.channels()) {
             selector.close(channel.id());
+            assertNull(channel.selectionKey().attachment());
+        }
         selector.poll(0);
         selector.poll(0); // Poll a second time to clear everything
-        for (Field field : selector.getClass().getDeclaredFields()) {
-            ensureEmptySelectorField(field);
+        for (Field field : Selector.class.getDeclaredFields()) {
+            ensureEmptySelectorField(selector, field);
         }
     }
 
-    private void ensureEmptySelectorField(Field field) throws Exception {
+    private void ensureEmptySelectorField(Selector selector, Field field) throws Exception {
         field.setAccessible(true);
         Object obj = field.get(selector);
         if (obj instanceof Collection)

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -44,7 +44,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * A set of tests for the selector. These use a test harness that runs a simple socket server that echos back responses.


### PR DESCRIPTION
When a socket is closed, we must remove corresponding selection keys from internal collections. This fixes an NPE which is caused by attempting to access the selection key's attached channel after it had been cleared after disconnecting.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
