### PR TITLE
MINOR: schema equality check failing for complex objects

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -643,7 +643,7 @@ public class JsonConverter implements Converter {
                 }
                 case STRUCT: {
                     Struct struct = (Struct) value;
-                    if (struct.schema() != schema)
+                    if (!struct.schema().equals(schema))
                         throw new DataException("Mismatching schema.");
                     ObjectNode obj = JsonNodeFactory.instance.objectNode();
                     for (Field field : schema.fields()) {


### PR DESCRIPTION
*The schema equality need to be done with the equals method to avoid unwanted side effects. When applied to complex objects with the same schema it was failing.*

*To test the faulty behaviour try calling the method on a complex object (at least 3 levels of nesting and array fields with a lot of objects).*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
