### PR TITLE
KAFKA-6289: NetworkClient should not expose failed internal ApiVersions requests

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -621,7 +621,6 @@ public class NetworkClient implements KafkaClient {
             log.trace("Cancelled request {} {} with correlation id {} due to node {} being disconnected",
                     request.header.apiKey(), request.request, request.header.correlationId(), nodeId);
             if (!request.isInternalRequest)
-
                 responses.add(request.disconnected(now));
             else if (request.header.apiKey() == ApiKeys.METADATA)
                 metadataUpdater.handleDisconnection(request.destination);

--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -620,10 +620,11 @@ public class NetworkClient implements KafkaClient {
         for (InFlightRequest request : this.inFlightRequests.clearAll(nodeId)) {
             log.trace("Cancelled request {} {} with correlation id {} due to node {} being disconnected",
                     request.header.apiKey(), request.request, request.header.correlationId(), nodeId);
-            if (request.isInternalRequest && request.header.apiKey() == ApiKeys.METADATA)
-                metadataUpdater.handleDisconnection(request.destination);
-            else
+            if (!request.isInternalRequest)
+
                 responses.add(request.disconnected(now));
+            else if (request.header.apiKey() == ApiKeys.METADATA)
+                metadataUpdater.handleDisconnection(request.destination);
         }
         AuthenticationException authenticationException = connectionStates.authenticationException(nodeId);
         if (authenticationException != null)

--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -194,7 +194,7 @@ public class NetworkClientTest {
         assertEquals(1, responses.size());
         ClientResponse clientResponse = responses.get(0);
         assertEquals(node.idString(), clientResponse.destination());
-        assertTrue(clientResponse.wasDisconnected());
+        assertTrue("Expected response to fail due to disconnection", clientResponse.wasDisconnected());
     }
 
     @Test
@@ -218,7 +218,6 @@ public class NetworkClientTest {
         assertFalse("After we forced the disconnection the client is no longer ready.", client.ready(node, time.milliseconds()));
         leastNode = client.leastLoadedNode(time.milliseconds());
         assertEquals("There should be NO leastloadednode", leastNode, null);
-        
     }
 
     @Test
@@ -373,10 +372,10 @@ public class NetworkClientTest {
     }
 
     private void awaitInFlightApiVersionRequest() throws Exception {
+        client.ready(node, time.milliseconds());
         TestUtils.waitForCondition(new TestCondition() {
             @Override
             public boolean conditionMet() {
-                client.ready(node, time.milliseconds());
                 client.poll(0, time.milliseconds());
                 return client.hasInFlightRequests(node.idString());
             }

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -19,6 +19,7 @@ package org.apache.kafka.test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -63,12 +64,28 @@ public class MockSelector implements Selectable {
 
     @Override
     public void close(String id) {
-        this.disconnected.put(id, ChannelState.LOCAL_CLOSE);
+        removeSendsForNode(id, completedSends);
+        removeSendsForNode(id, initiatedSends);
+
         for (int i = 0; i < this.connected.size(); i++) {
             if (this.connected.get(i).equals(id)) {
                 this.connected.remove(i);
                 break;
             }
+        }
+    }
+
+    public void serverDisconnect(String id) {
+        this.disconnected.put(id, ChannelState.LOCAL_CLOSE);
+        close(id);
+    }
+
+    private void removeSendsForNode(String id, Collection<Send> sends) {
+        Iterator<Send> iter = sends.iterator();
+        while (iter.hasNext()) {
+            Send send = iter.next();
+            if (id.equals(send.destination()))
+                iter.remove();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -82,7 +82,7 @@ public class MockSelector implements Selectable {
      * the next {@link #poll(long)}.
      */
     public void serverDisconnect(String id) {
-        this.disconnected.put(id, ChannelState.LOCAL_CLOSE);
+        this.disconnected.put(id, ChannelState.READY);
         close(id);
     }
 

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -64,6 +64,8 @@ public class MockSelector implements Selectable {
 
     @Override
     public void close(String id) {
+        // Note that there are no notifications for client-side disconnects
+
         removeSendsForNode(id, completedSends);
         removeSendsForNode(id, initiatedSends);
 
@@ -75,6 +77,10 @@ public class MockSelector implements Selectable {
         }
     }
 
+    /**
+     * Simulate a server disconnect. This id will be present in {@link #disconnected()} on
+     * the next {@link #poll(long)}.
+     */
     public void serverDisconnect(String id) {
         this.disconnected.put(id, ChannelState.LOCAL_CLOSE);
         close(id);


### PR DESCRIPTION
The NetworkClient internally ApiVersion requests to each broker following connection establishment. If this request happens to fail (perhaps due to an incompatible broker), the NetworkClient includes the response in the result of poll(). Applications will generally not be expecting this response which may lead to failed assertions (or in the case of AdminClient, an obscure log message).

I've added test cases which await the ApiVersion request sent by NetworkClient to be in-flight, and then disconnect the connection and verify that the response is not included from poll().

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
