### PR TITLE
KAFKA-6296: Increase jitter to fix transient failure in NetworkClientTest.testConnectionDelayDisconnected

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/NetworkClientTest.java
@@ -284,7 +284,7 @@ public class NetworkClientTest {
         client.poll(requestTimeoutMs, time.milliseconds());
         long delay = client.connectionDelay(node, time.milliseconds());
         long expectedDelay = reconnectBackoffMsTest;
-        double jitter = 0.2;
+        double jitter = 0.3;
         assertEquals(expectedDelay, delay, expectedDelay * jitter);
 
         // Sleep until there is no connection delay
@@ -299,7 +299,7 @@ public class NetworkClientTest {
         // Second attempt should take twice as long with twice the jitter
         expectedDelay = Math.round(delay * 2);
         delay = client.connectionDelay(node, time.milliseconds());
-        jitter = 0.4;
+        jitter = 0.6;
         assertEquals(expectedDelay, delay, expectedDelay * jitter);
     }
 


### PR DESCRIPTION
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
