### PR TITLE
KAFKA-6306: Auto-commit of offsets fail, and not recover forever...

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -717,8 +717,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
         // if the generation is null, we are not part of an active group (and we expect to be).
         // the only thing we can do is fail the commit and let the user rejoin the group in poll()
-        if (generation == null)
+        if (generation == null) {
+            resetGeneration();
             return RequestFuture.failure(new CommitFailedException());
+        }
 
         OffsetCommitRequest.Builder builder = new OffsetCommitRequest.Builder(this.groupId, offsetData).
                 setGenerationId(generation.generationId).


### PR DESCRIPTION
  ###* Auto-commit of offsets fail, and not recover **forever**. at sendOffsetCommitRequest,  while "generation equal NULL",  ConsumerCoordinator request will fail always.  it maybe a bug. error log below:

has more and more warn log ....
"2017-12-01 22:08:39.112 WARN  pool-390-thread-1#1 (ConsumerCoordinator.java:626) - Auto-commit of offsets {drawing_gift_sent-1=OffsetAndMetadata{offset=32150359, metadata=''}} failed for group gift_rich_audience_write: Commit cannot be completed since the group has already rebalanced and assigned the partitions to another member. This means that the time between subsequent calls to poll() was longer than the configured max.poll.interval.ms, which typically implies that the poll loop is spending too much time message processing. You can address this either by increasing the session timeout or by reducing the maximum size of batches returned in poll() with max.poll.records."
#6306

https://issues.apache.org/jira/browse/KAFKA-6306