### PR TITLE
KAFKA-6308: Connect Struct should use deepEquals/deepHashCode

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -243,7 +243,7 @@ public class Struct {
 
     @Override
     public int hashCode() {
-        return Objects.hash(schema, Arrays.hashCode(values));
+        return Objects.hash(schema, Arrays.deepHashCode(values));
     }
 
     private Field lookupField(String fieldName) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Struct.java
@@ -238,7 +238,7 @@ public class Struct {
         if (o == null || getClass() != o.getClass()) return false;
         Struct struct = (Struct) o;
         return Objects.equals(schema, struct.schema) &&
-                Arrays.equals(values, struct.values);
+                Arrays.deepEquals(values, struct.values);
     }
 
     @Override

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -236,6 +236,32 @@ public class StructTest {
         assertNotEquals(struct1, struct3);
     }
 
+    @Test
+    public void testEqualsWithByteArrayValue() {
+        Struct struct1 = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", "foobar".getBytes());
+        Struct struct2 = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", "foobar".getBytes());
+
+        assertEquals(struct1, struct2);
+    }
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -249,6 +249,7 @@ public class StructTest {
                 .put("boolean", true)
                 .put("string", "foobar")
                 .put("bytes", "foobar".getBytes());
+
         Struct struct2 = new Struct(FLAT_STRUCT_SCHEMA)
                 .put("int8", (byte) 12)
                 .put("int16", (short) 12)
@@ -259,6 +260,7 @@ public class StructTest {
                 .put("boolean", true)
                 .put("string", "foobar")
                 .put("bytes", "foobar".getBytes());
+
         Struct struct3 = new Struct(FLAT_STRUCT_SCHEMA)
                 .put("int8", (byte) 12)
                 .put("int16", (short) 12)

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -27,9 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 public class StructTest {
 
@@ -237,7 +235,7 @@ public class StructTest {
     }
 
     @Test
-    public void testEqualsWithByteArrayValue() {
+    public void testEqualsAndHashCodeWithByteArrayValue() {
         Struct struct1 = new Struct(FLAT_STRUCT_SCHEMA)
                 .put("int8", (byte) 12)
                 .put("int16", (short) 12)
@@ -259,7 +257,10 @@ public class StructTest {
                 .put("string", "foobar")
                 .put("bytes", "foobar".getBytes());
 
-        assertEquals(struct1, struct2);
+        // Testing hashCode against a hardcoded value here would produce a needlessly fragile test. However, based on
+        // the general contract for hashCode, if two objects are equal, their hashCodes must be equal.
+        assertTrue(struct1.equals(struct2) && struct2.equals(struct1));
+        assertTrue(struct1.hashCode() == struct2.hashCode());
     }
 
     @Rule

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -27,7 +27,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+
 
 public class StructTest {
 

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/StructTest.java
@@ -256,11 +256,28 @@ public class StructTest {
                 .put("boolean", true)
                 .put("string", "foobar")
                 .put("bytes", "foobar".getBytes());
+        Struct struct3 = new Struct(FLAT_STRUCT_SCHEMA)
+                .put("int8", (byte) 12)
+                .put("int16", (short) 12)
+                .put("int32", 12)
+                .put("int64", (long) 12)
+                .put("float32", 12.f)
+                .put("float64", 12.)
+                .put("boolean", true)
+                .put("string", "foobar")
+                .put("bytes", "mismatching_string".getBytes());
 
-        // Testing hashCode against a hardcoded value here would produce a needlessly fragile test. However, based on
-        // the general contract for hashCode, if two objects are equal, their hashCodes must be equal.
-        assertTrue(struct1.equals(struct2) && struct2.equals(struct1));
-        assertTrue(struct1.hashCode() == struct2.hashCode());
+        // Verify contract for equals: method must be reflexive and transitive
+        assertEquals(struct1, struct2);
+        assertEquals(struct2, struct1);
+        assertNotEquals(struct1, struct3);
+        assertNotEquals(struct2, struct3);
+        // Testing hashCode against a hardcoded value here would be incorrect: hashCode values need not be equal for any
+        // two distinct executions. However, based on the general contract for hashCode, if two objects are equal, their
+        // hashCodes must be equal. If they are not equal, their hashCodes should not be equal for performance reasons.
+        assertEquals(struct1.hashCode(), struct2.hashCode());
+        assertNotEquals(struct1.hashCode(), struct3.hashCode());
+        assertNotEquals(struct2.hashCode(), struct3.hashCode());
     }
 
     @Rule


### PR DESCRIPTION
This changes the Struct's equals and hashCode method to use Arrays#deepEquals and Arrays#deepHashCode, respectively. This resolves a problem where two structs with values of type byte[] would not be considered equal even though the byte arrays' contents are equal. By using deepEquals, the byte arrays' contents are compared instead of ther identity.

Since this changes the behavior of the equals method for byte array values, the behavior of hashCode must change alongside it to ensure the methods still fulfill the general contract of "equal objects must have equal hashCodes".

Test rationale:
All existing unit tests for equals were untouched and continue to work. A new test method was added to verify the behavior of equals and hashCode for Struct instances that contain a byte array value. I verify the reflixivity and transitivity of equals as well as the fact that equal Structs have equal hashCodes
and not-equal structs do not have equal hashCodes. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
