### PR TITLE
KAFKA-6299. Fix AdminClient error handling when metadata changes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -29,7 +29,7 @@ import java.util.List;
  * <p>
  * This class is not thread-safe!
  */
-interface MetadataUpdater {
+public interface MetadataUpdater {
 
     /**
      * Gets the current cluster info without blocking.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminMetadataManager.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.clients.MetadataUpdater;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Manages the metadata for KafkaAdminClient.
+ *
+ * This class is not thread-safe.  It is only accessed from the AdminClient
+ * service thread (which also uses the NetworkClient).
+ */
+public class AdminMetadataManager {
+    /**
+     * The slf4 logger.
+     */
+    private Logger log;
+
+    /**
+     * The timer.
+     */
+    private final Time time;
+
+    /**
+     * The minimum amount of time that we should wait between subsequent
+     * retries, when fetching metadata.
+     */
+    private final long refreshBackoffMs;
+
+    /**
+     * The minimum amount of time that we should wait before triggering an
+     * automatic metadata refresh.
+     */
+    private final long metadataExpireMs;
+
+    /**
+     * Used to update the NetworkClient metadata.
+     */
+    private final AdminMetadataUpdater updater;
+
+    /**
+     * The current metadata state.
+     */
+    private State state = State.QUIESCENT;
+
+    /**
+     * The time in wall-clock milliseconds when we last updated the metadata.
+     */
+    private long lastMetadataUpdateMs = 0;
+
+    /**
+     * The time in wall-clock milliseconds when we last attempted to fetch new
+     * metadata.
+     */
+    private long lastMetadataFetchAttemptMs = 0;
+
+    /**
+     * The current cluster information.
+     */
+    private Cluster cluster = Cluster.empty();
+
+    /**
+     * If we got an authorization exception when we last attempted to fetch
+     * metadata, this is it; null, otherwise.
+     */
+    private AuthenticationException authException = null;
+
+    public class AdminMetadataUpdater implements MetadataUpdater {
+        @Override
+        public List<Node> fetchNodes() {
+            return cluster.nodes();
+        }
+
+        @Override
+        public boolean isUpdateDue(long now) {
+            return false;
+        }
+
+        @Override
+        public long maybeUpdate(long now) {
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public void handleDisconnection(String destination) {
+            // Do nothing
+        }
+
+        @Override
+        public void handleAuthenticationFailure(AuthenticationException e) {
+            log.info("AdminMetadataManager got AuthenticationException", e);
+            update(Cluster.empty(), time.milliseconds(), e);
+        }
+
+        @Override
+        public void handleCompletedMetadataResponse(RequestHeader requestHeader, long now, MetadataResponse metadataResponse) {
+            // Do nothing
+        }
+
+        @Override
+        public void requestUpdate() {
+            // Do nothing
+        }
+    }
+
+    /**
+     * The current AdminMetadataManager state.
+     */
+    enum State {
+        QUIESCENT,
+        UPDATE_REQUESTED,
+        UPDATE_PENDING;
+    }
+
+    public AdminMetadataManager(LogContext logContext, Time time, long refreshBackoffMs,
+                                long metadataExpireMs) {
+        this.log = logContext.logger(AdminMetadataManager.class);
+        this.time = time;
+        this.refreshBackoffMs = refreshBackoffMs;
+        this.metadataExpireMs = metadataExpireMs;
+        this.updater = new AdminMetadataUpdater();
+    }
+
+    public AdminMetadataUpdater updater() {
+        return updater;
+    }
+
+    boolean isReady() {
+        if (authException != null) {
+            log.trace("Metadata is ready: got authentication exception.");
+            throw authException;
+        }
+        if (cluster.nodes().isEmpty()) {
+            log.trace("Metadata is not ready: bootstrap nodes have not been " +
+                "initialized yet.");
+            return false;
+        }
+        if (cluster.isBootstrapConfigured()) {
+            log.trace("Metadata is not ready: we have not fetched metadata from " +
+                "the bootstrap nodes yet.");
+            return false;
+        }
+        log.trace("Metadata is ready to use.");
+        return true;
+    }
+
+    Node controller() {
+        return cluster.controller();
+    }
+
+    Node nodeById(int nodeId) {
+        return cluster.nodeById(nodeId);
+    }
+
+    void requestUpdate() {
+        if (state == State.QUIESCENT) {
+            state = State.UPDATE_REQUESTED;
+            log.trace("Requesting metadata update.");
+        }
+    }
+
+    void clearController() {
+        if (cluster.controller() != null) {
+            if (log.isTraceEnabled()) {
+                log.trace("Clearing cached controller node {}.", cluster.controller());
+            }
+            this.cluster = new Cluster(cluster.clusterResource().clusterId(),
+                cluster.nodes(),
+                Collections.<PartitionInfo>emptySet(),
+                Collections.<String>emptySet(),
+                Collections.<String>emptySet(),
+                null);
+        }
+    }
+
+    /**
+     * Determine if the AdminClient should fetch new metadata.
+     */
+    boolean shouldFetchMetadata(long now) {
+        switch (state) {
+            case QUIESCENT:
+                if (now > lastMetadataUpdateMs + metadataExpireMs) {
+                    if (now > lastMetadataFetchAttemptMs + refreshBackoffMs) {
+                        return true;
+                    }
+                }
+                return false;
+            case UPDATE_REQUESTED:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Transition into the UPDATE_PENDING state.  Updates lastMetadataFetchAttemptMs.
+     */
+    void transitionToUpdatePending(long now) {
+        this.state = State.UPDATE_PENDING;
+        this.lastMetadataFetchAttemptMs = now;
+    }
+
+    /**
+     * Receive new metadata, and transition into the QUIESCENT state.
+     * Updates lastMetadataUpdateMs, cluster, and authException.
+     */
+    void update(Cluster cluster, long now, AuthenticationException authException) {
+        if (cluster.isBootstrapConfigured()) {
+            log.debug("Setting bootstrap cluster metadata {}.", cluster);
+        } else {
+            log.debug("Received cluster metadata {}{}.",
+                cluster, authException == null ? "" : " with authentication exception.");
+        }
+        this.state = State.QUIESCENT;
+        this.lastMetadataUpdateMs = now;
+        this.authException = authException;
+        if (!cluster.nodes().isEmpty()) {
+            this.cluster = cluster;
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -748,7 +748,7 @@ public class KafkaAdminClient extends AdminClient {
          *
          * @param processor     The timeout processor.
          */
-        private synchronized void timeoutPendingCalls(TimeoutProcessor processor, List<Call> pendingCalls) {
+        private void timeoutPendingCalls(TimeoutProcessor processor, List<Call> pendingCalls) {
             int numTimedOut = processor.handleTimeouts(pendingCalls,
                     "Timed out waiting for a node assignment.");
             if (numTimedOut > 0)
@@ -802,7 +802,7 @@ public class KafkaAdminClient extends AdminClient {
                     node = call.nodeProvider.provide();
                 } catch (Throwable t) {
                     // Handle authentication errors while choosing nodes.
-                    log.debug("Unable to choose node for {}: {}", call, t);
+                    log.debug("Unable to choose node for {}", call, t);
                     pendingIter.remove();
                     call.fail(now, t);
                 }
@@ -1006,21 +1006,6 @@ public class KafkaAdminClient extends AdminClient {
             }
             log.debug("Hard shutdown in {} ms.", curHardShutdownTimeMs - now);
             return false;
-        }
-
-        private void failPendingCalls(long now, Map<Node, List<Call>> callsToSend, Throwable t) {
-            synchronized (this) {
-                for (Call call : newCalls) {
-                    call.fail(now, t);
-                }
-                newCalls.clear();
-            }
-            for (List<Call> calls : callsToSend.values()) {
-                for (Call call : calls) {
-                    call.fail(now, t);
-                }
-            }
-            callsToSend.clear();
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -22,7 +22,6 @@ import org.apache.kafka.clients.ClientRequest;
 import org.apache.kafka.clients.ClientResponse;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.KafkaClient;
-import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResult;
 import org.apache.kafka.clients.admin.DeleteAclsResult.FilterResults;
@@ -44,7 +43,6 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.AuthenticationException;
-import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidRequestException;
@@ -186,9 +184,9 @@ public class KafkaAdminClient extends AdminClient {
     private final Time time;
 
     /**
-     * The cluster metadata used by the KafkaClient.
+     * The cluster metadata manager used by the KafkaClient.
      */
-    private final Metadata metadata;
+    private final AdminMetadataManager metadataManager;
 
     /**
      * The metrics for this KafkaAdminClient.
@@ -327,8 +325,9 @@ public class KafkaAdminClient extends AdminClient {
         try {
             // Since we only request node information, it's safe to pass true for allowAutoTopicCreation (and it
             // simplifies communication with older brokers)
-            Metadata metadata = new Metadata(config.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG),
-                    config.getLong(AdminClientConfig.METADATA_MAX_AGE_CONFIG), true);
+            AdminMetadataManager metadataManager = new AdminMetadataManager(logContext, time,
+                config.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG),
+                config.getLong(AdminClientConfig.METADATA_MAX_AGE_CONFIG));
             List<MetricsReporter> reporters = config.getConfiguredInstances(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG,
                 MetricsReporter.class);
             Map<String, String> metricTags = Collections.singletonMap("client-id", clientId);
@@ -344,7 +343,7 @@ public class KafkaAdminClient extends AdminClient {
                     metrics, time, metricGrpPrefix, channelBuilder, logContext);
             networkClient = new NetworkClient(
                 selector,
-                metadata,
+                metadataManager.updater(),
                 clientId,
                 1,
                 config.getLong(AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG),
@@ -356,7 +355,7 @@ public class KafkaAdminClient extends AdminClient {
                 true,
                 apiVersions,
                 logContext);
-            return new KafkaAdminClient(config, clientId, time, metadata, metrics, networkClient,
+            return new KafkaAdminClient(config, clientId, time, metadataManager, metrics, networkClient,
                 timeoutProcessorFactory, logContext);
         } catch (Throwable exc) {
             closeQuietly(metrics, "Metrics");
@@ -367,35 +366,39 @@ public class KafkaAdminClient extends AdminClient {
         }
     }
 
-    static KafkaAdminClient createInternal(AdminClientConfig config, KafkaClient client, Metadata metadata, Time time) {
+    static KafkaAdminClient createInternal(AdminClientConfig config, KafkaClient client, Time time) {
         Metrics metrics = null;
         String clientId = generateClientId(config);
 
         try {
             metrics = new Metrics(new MetricConfig(), new LinkedList<MetricsReporter>(), time);
-            return new KafkaAdminClient(config, clientId, time, metadata, metrics, client, null,
-                    createLogContext(clientId));
+            LogContext logContext = createLogContext(clientId);
+            AdminMetadataManager metadataManager = new AdminMetadataManager(logContext, time,
+                config.getLong(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG),
+                config.getLong(AdminClientConfig.METADATA_MAX_AGE_CONFIG));
+            return new KafkaAdminClient(config, clientId, time, metadataManager, metrics,
+                client, null, logContext);
         } catch (Throwable exc) {
             closeQuietly(metrics, "Metrics");
             throw new KafkaException("Failed create new KafkaAdminClient", exc);
         }
     }
 
-    private static LogContext createLogContext(String clientId) {
+    static LogContext createLogContext(String clientId) {
         return new LogContext("[AdminClient clientId=" + clientId + "] ");
     }
 
-    private KafkaAdminClient(AdminClientConfig config, String clientId, Time time, Metadata metadata,
-                     Metrics metrics, KafkaClient client, TimeoutProcessorFactory timeoutProcessorFactory,
-                     LogContext logContext) {
+    private KafkaAdminClient(AdminClientConfig config, String clientId, Time time,
+                AdminMetadataManager metadataManager, Metrics metrics, KafkaClient client,
+                TimeoutProcessorFactory timeoutProcessorFactory, LogContext logContext) {
         this.defaultTimeoutMs = config.getInt(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG);
         this.clientId = clientId;
         this.log = logContext.logger(KafkaAdminClient.class);
         this.time = time;
-        this.metadata = metadata;
+        this.metadataManager = metadataManager;
         List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(
             config.getList(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG));
-        this.metadata.update(Cluster.bootstrap(addresses), Collections.<String>emptySet(), time.milliseconds());
+        metadataManager.update(Cluster.bootstrap(addresses), time.milliseconds(), null);
         this.metrics = metrics;
         this.client = client;
         this.runnable = new AdminClientRunnable();
@@ -462,6 +465,13 @@ public class KafkaAdminClient extends AdminClient {
         Node provide();
     }
 
+    private class MetadataUpdateNodeIdProvider implements NodeProvider {
+        @Override
+        public Node provide() {
+            return client.leastLoadedNode(time.milliseconds());
+        }
+    }
+
     private class ConstantNodeIdProvider implements NodeProvider {
         private final int nodeId;
 
@@ -471,7 +481,16 @@ public class KafkaAdminClient extends AdminClient {
 
         @Override
         public Node provide() {
-            return metadata.fetch().nodeById(nodeId);
+            if (metadataManager.isReady() &&
+                    (metadataManager.nodeById(nodeId) != null)) {
+                return metadataManager.nodeById(nodeId);
+            }
+            // If we can't find the node with the given constant ID, we schedule a
+            // metadata update and hope it appears.  This behavior is useful for avoiding
+            // flaky behavior in tests when the cluster is starting up and not all nodes
+            // have appeared.
+            metadataManager.requestUpdate();
+            return null;
         }
     }
 
@@ -481,7 +500,12 @@ public class KafkaAdminClient extends AdminClient {
     private class ControllerNodeProvider implements NodeProvider {
         @Override
         public Node provide() {
-            return metadata.fetch().controller();
+            if (metadataManager.isReady() &&
+                    (metadataManager.controller() != null)) {
+                return metadataManager.controller();
+            }
+            metadataManager.requestUpdate();
+            return null;
         }
     }
 
@@ -491,21 +515,41 @@ public class KafkaAdminClient extends AdminClient {
     private class LeastLoadedNodeProvider implements NodeProvider {
         @Override
         public Node provide() {
-            return client.leastLoadedNode(time.milliseconds());
+            if (metadataManager.isReady()) {
+                // This may return null if all nodes are busy.
+                // In that case, we will postpone node assignment.
+                return client.leastLoadedNode(time.milliseconds());
+            }
+            metadataManager.requestUpdate();
+            return null;
         }
     }
 
     abstract class Call {
+        private final boolean internal;
         private final String callName;
         private final long deadlineMs;
         private final NodeProvider nodeProvider;
         private int tries = 0;
         private boolean aborted = false;
+        private Node curNode = null;
 
-        Call(String callName, long deadlineMs, NodeProvider nodeProvider) {
+        Call(boolean internal, String callName, long deadlineMs, NodeProvider nodeProvider) {
+            this.internal = internal;
             this.callName = callName;
             this.deadlineMs = deadlineMs;
             this.nodeProvider = nodeProvider;
+        }
+
+        Call(String callName, long deadlineMs, NodeProvider nodeProvider) {
+            this.internal = false;
+            this.callName = callName;
+            this.deadlineMs = deadlineMs;
+            this.nodeProvider = nodeProvider;
+        }
+
+        protected Node curNode() {
+            return curNode;
         }
 
         /**
@@ -615,6 +659,10 @@ public class KafkaAdminClient extends AdminClient {
         public String toString() {
             return "Call(callName=" + callName + ", deadlineMs=" + deadlineMs + ")";
         }
+
+        public boolean isInternal() {
+            return internal;
+        }
     }
 
     static class TimeoutProcessorFactory {
@@ -698,43 +746,15 @@ public class KafkaAdminClient extends AdminClient {
         private List<Call> newCalls = new LinkedList<>();
 
         /**
-         * Check if the AdminClient metadata is ready.
-         * We need to know who the controller is, and have a non-empty view of the cluster.
-         *
-         * @param prevMetadataVersion       The previous metadata version which wasn't usable.
-         * @return                          null if the metadata is usable; the current metadata
-         *                                  version otherwise
-         */
-        private Integer checkMetadataReady(Integer prevMetadataVersion) {
-            if (prevMetadataVersion != null) {
-                if (prevMetadataVersion == metadata.version())
-                    return prevMetadataVersion;
-            }
-            Cluster cluster = metadata.fetch();
-            if (cluster.nodes().isEmpty()) {
-                log.trace("Metadata is not ready yet. No cluster nodes found.");
-                return metadata.requestUpdate();
-            }
-            if (cluster.controller() == null) {
-                log.trace("Metadata is not ready yet. No controller found.");
-                return metadata.requestUpdate();
-            }
-            if (prevMetadataVersion != null) {
-                log.trace("Metadata is now ready.");
-            }
-            return null;
-        }
-
-        /**
-         * Time out the elements in the newCalls list which are expired.
+         * Time out the elements in the pendingCalls list which are expired.
          *
          * @param processor     The timeout processor.
          */
-        private synchronized void timeoutNewCalls(TimeoutProcessor processor) {
-            int numTimedOut = processor.handleTimeouts(newCalls,
+        private synchronized void timeoutPendingCalls(TimeoutProcessor processor, List<Call> pendingCalls) {
+            int numTimedOut = processor.handleTimeouts(pendingCalls,
                     "Timed out waiting for a node assignment.");
             if (numTimedOut > 0)
-                log.debug("Timed out {} new calls.", numTimedOut);
+                log.debug("Timed out {} pending calls.", numTimedOut);
         }
 
         /**
@@ -743,7 +763,7 @@ public class KafkaAdminClient extends AdminClient {
          * @param processor     The timeout processor.
          * @param callsToSend   A map of nodes to the calls they need to handle.
          */
-        private void timeoutCallsToSend(TimeoutProcessor processor, Map<Node, List<Call>> callsToSend) {
+        private int timeoutCallsToSend(TimeoutProcessor processor, Map<Node, List<Call>> callsToSend) {
             int numTimedOut = 0;
             for (List<Call> callList : callsToSend.values()) {
                 numTimedOut += processor.handleTimeouts(callList,
@@ -751,48 +771,52 @@ public class KafkaAdminClient extends AdminClient {
             }
             if (numTimedOut > 0)
                 log.debug("Timed out {} call(s) with assigned nodes.", numTimedOut);
+            return numTimedOut;
         }
 
         /**
-         * Choose nodes for the calls in the callsToSend list.
+         * Drain all the calls from newCalls into pendingCalls.
          *
          * This function holds the lock for the minimum amount of time, to avoid blocking
          * users of AdminClient who will also take the lock to add new calls.
-         *
-         * @param now           The current time in milliseconds.
-         * @param callsToSend   A map of nodes to the calls they need to handle.
-         *
          */
-        private void chooseNodesForNewCalls(long now, Map<Node, List<Call>> callsToSend) {
-            List<Call> newCallsToAdd = null;
-            synchronized (this) {
-                if (newCalls.isEmpty()) {
-                    return;
-                }
-                newCallsToAdd = newCalls;
-                newCalls = new LinkedList<>();
-            }
-            for (Call call : newCallsToAdd) {
-                chooseNodeForNewCall(now, callsToSend, call);
+        private synchronized void drainNewCalls(ArrayList<Call> pendingCalls) {
+            if (!newCalls.isEmpty()) {
+                pendingCalls.addAll(newCalls);
+                newCalls.clear();
             }
         }
 
         /**
-         * Choose a node for a new call.
+         * Choose nodes for the calls in the pendingCalls list.
          *
          * @param now           The current time in milliseconds.
+         * @param pendingIter   An iterator yielding pending calls.
          * @param callsToSend   A map of nodes to the calls they need to handle.
-         * @param call          The call.
+         *
          */
-        private void chooseNodeForNewCall(long now, Map<Node, List<Call>> callsToSend, Call call) {
-            Node node = call.nodeProvider.provide();
-            if (node == null) {
-                call.fail(now, new BrokerNotAvailableException(
-                    String.format("Error choosing node for %s: no node found.", call.callName)));
-                return;
+        private void chooseNodesForPendingCalls(long now, Iterator<Call> pendingIter,
+                Map<Node, List<Call>> callsToSend) {
+            while (pendingIter.hasNext()) {
+                Call call = pendingIter.next();
+                Node node = null;
+                try {
+                    node = call.nodeProvider.provide();
+                } catch (Throwable t) {
+                    // Handle authentication errors while choosing nodes.
+                    log.debug("Unable to choose node for {}: {}", call, t);
+                    pendingIter.remove();
+                    call.fail(now, t);
+                }
+                if (node != null) {
+                    log.trace("Assigned {} to node {}", call, node);
+                    pendingIter.remove();
+                    call.curNode = node;
+                    getOrCreateListValue(callsToSend, node).add(call);
+                } else {
+                    log.trace("Unable to assign {} to a node.", call);
+                }
             }
-            log.trace("Assigned {} to {}", call, node);
-            getOrCreateListValue(callsToSend, node).add(call);
         }
 
         /**
@@ -881,37 +905,6 @@ public class KafkaAdminClient extends AdminClient {
         }
 
         /**
-         * If an authentication exception is encountered with connection to any broker,
-         * fail all pending requests.
-         */
-        private void handleAuthenticationException(long now, Map<Node, List<Call>> callsToSend) {
-            AuthenticationException authenticationException = metadata.getAndClearAuthenticationException();
-            if (authenticationException == null) {
-                for (Node node : callsToSend.keySet()) {
-                    authenticationException = client.authenticationException(node);
-                    if (authenticationException != null)
-                        break;
-                }
-            }
-            if (authenticationException != null) {
-                synchronized (this) {
-                    failCalls(now, newCalls, authenticationException);
-                }
-                for (List<Call> calls : callsToSend.values()) {
-                    failCalls(now, calls, authenticationException);
-                }
-                callsToSend.clear();
-            }
-        }
-
-        private void failCalls(long now, List<Call> calls, AuthenticationException authenticationException) {
-            for (Call call : calls) {
-                call.fail(now, authenticationException);
-            }
-            calls.clear();
-        }
-
-        /**
          * Handle responses from the server.
          *
          * @param now                   The current time in milliseconds.
@@ -952,9 +945,14 @@ public class KafkaAdminClient extends AdminClient {
                 if (response.versionMismatch() != null) {
                     call.fail(now, response.versionMismatch());
                 } else if (response.wasDisconnected()) {
-                    call.fail(now, new DisconnectException(String.format(
-                        "Cancelled %s request with correlation id %s due to node %s being disconnected",
-                        call.callName, correlationId, response.destination())));
+                    AuthenticationException authException = client.authenticationException(call.curNode());
+                    if (authException != null) {
+                        call.fail(now, authException);
+                    } else {
+                        call.fail(now, new DisconnectException(String.format(
+                            "Cancelled %s request with correlation id %s due to node %s being disconnected",
+                            call.callName, correlationId, response.destination())));
+                    }
                 } else {
                     try {
                         call.handleResponse(response.responseBody());
@@ -970,13 +968,41 @@ public class KafkaAdminClient extends AdminClient {
             }
         }
 
-        private synchronized boolean threadShouldExit(long now, long curHardShutdownTimeMs,
+        private boolean hasActiveExternalCalls(Collection<Call> calls) {
+            for (Call call : calls) {
+                if (!call.isInternal()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Return true if there are currently active external calls.
+         */
+        private boolean hasActiveExternalCalls(List<Call> pendingCalls,
                 Map<Node, List<Call>> callsToSend, Map<Integer, Call> correlationIdToCalls) {
-            if (newCalls.isEmpty() && callsToSend.isEmpty() && correlationIdToCalls.isEmpty()) {
+            if (hasActiveExternalCalls(pendingCalls)) {
+                return true;
+            }
+            for (List<Call> callList : callsToSend.values()) {
+                if (hasActiveExternalCalls(callList)) {
+                    return true;
+                }
+            }
+            if (hasActiveExternalCalls(correlationIdToCalls.values())) {
+                return true;
+            }
+            return false;
+        }
+
+        private boolean threadShouldExit(long now, long curHardShutdownTimeMs, List<Call> pendingCalls,
+                Map<Node, List<Call>> callsToSend, Map<Integer, Call> correlationIdToCalls) {
+            if (!hasActiveExternalCalls(pendingCalls, callsToSend, correlationIdToCalls)) {
                 log.trace("All work has been completed, and the I/O thread is now exiting.");
                 return true;
             }
-            if (now > curHardShutdownTimeMs) {
+            if (now >= curHardShutdownTimeMs) {
                 log.info("Forcing a hard I/O thread shutdown. Requests in progress will be aborted.");
                 return true;
             }
@@ -984,40 +1010,63 @@ public class KafkaAdminClient extends AdminClient {
             return false;
         }
 
+        private void failPendingCalls(long now, Map<Node, List<Call>> callsToSend, Throwable t) {
+            synchronized (this) {
+                for (Call call : newCalls) {
+                    call.fail(now, t);
+                }
+                newCalls.clear();
+            }
+            for (List<Call> calls : callsToSend.values()) {
+                for (Call call : calls) {
+                    call.fail(now, t);
+                }
+            }
+            callsToSend.clear();
+        }
+
         @Override
         public void run() {
-            /*
+            /**
+             * Calls which have not yet been assigned to a node.
+             * Only accessed from this thread.
+             */
+            ArrayList<Call> pendingCalls = new ArrayList<>();
+
+            /**
              * Maps nodes to calls that we want to send.
+             * Only accessed from this thread.
              */
             Map<Node, List<Call>> callsToSend = new HashMap<>();
 
-            /*
+            /**
              * Maps node ID strings to calls that have been sent.
+             * Only accessed from this thread.
              */
             Map<String, List<Call>> callsInFlight = new HashMap<>();
 
-            /*
+            /**
              * Maps correlation IDs to calls that have been sent.
+             * Only accessed from this thread.
              */
             Map<Integer, Call> correlationIdToCalls = new HashMap<>();
-
-            /*
-             * The previous metadata version which wasn't usable, or null if there is none.
-             */
-            Integer prevMetadataVersion = null;
 
             long now = time.milliseconds();
             log.trace("Thread starting");
             while (true) {
+                // Copy newCalls into pendingCalls.
+                drainNewCalls(pendingCalls);
+
                 // Check if the AdminClient thread should shut down.
                 long curHardShutdownTimeMs = hardShutdownTimeMs.get();
                 if ((curHardShutdownTimeMs != INVALID_SHUTDOWN_TIME) &&
-                        threadShouldExit(now, curHardShutdownTimeMs, callsToSend, correlationIdToCalls))
+                        threadShouldExit(now, curHardShutdownTimeMs, pendingCalls,
+                            callsToSend, correlationIdToCalls))
                     break;
 
                 // Handle timeouts.
                 TimeoutProcessor timeoutProcessor = timeoutProcessorFactory.create(now);
-                timeoutNewCalls(timeoutProcessor);
+                timeoutPendingCalls(timeoutProcessor, pendingCalls);
                 timeoutCallsToSend(timeoutProcessor, callsToSend);
                 timeoutCallsInFlight(timeoutProcessor, callsInFlight);
 
@@ -1026,13 +1075,19 @@ public class KafkaAdminClient extends AdminClient {
                     pollTimeout = Math.min(pollTimeout, curHardShutdownTimeMs - now);
                 }
 
-                // Handle new calls and metadata update requests.
-                prevMetadataVersion = checkMetadataReady(prevMetadataVersion);
-                if (prevMetadataVersion == null) {
-                    chooseNodesForNewCalls(now, callsToSend);
-                    pollTimeout = Math.min(pollTimeout,
-                        sendEligibleCalls(now, callsToSend, correlationIdToCalls, callsInFlight));
+                // Choose nodes for our pending calls.
+                chooseNodesForPendingCalls(now, pendingCalls.iterator(), callsToSend);
+                if (metadataManager.shouldFetchMetadata(now)) {
+                    metadataManager.transitionToUpdatePending(now);
+                    Call metadataCall = makeMetadataCall(now);
+                    // Create a new metadata fetch call and add it to the end of pendingCalls.
+                    // Assign a node for just the new call (we handled the other pending nodes above).
+                    pendingCalls.add(metadataCall);
+                    chooseNodesForPendingCalls(now, pendingCalls.listIterator(pendingCalls.size() - 1),
+                        callsToSend);
                 }
+                pollTimeout = Math.min(pollTimeout,
+                    sendEligibleCalls(now, callsToSend, correlationIdToCalls, callsInFlight));
 
                 // Wait for network responses.
                 log.trace("Entering KafkaClient#poll(timeout={})", pollTimeout);
@@ -1041,7 +1096,6 @@ public class KafkaAdminClient extends AdminClient {
 
                 // Update the current time and handle the latest responses.
                 now = time.milliseconds();
-                handleAuthenticationException(now, callsToSend);
                 handleResponses(now, responses, callsInFlight, correlationIdToCalls);
             }
             int numTimedOut = 0;
@@ -1051,10 +1105,13 @@ public class KafkaAdminClient extends AdminClient {
                         "The AdminClient thread has exited.");
                 newCalls = null;
             }
+            numTimedOut += timeoutProcessor.handleTimeouts(pendingCalls,
+                "The AdminClient thread has exited.");
+            numTimedOut += timeoutCallsToSend(timeoutProcessor, callsToSend);
             numTimedOut += timeoutProcessor.handleTimeouts(correlationIdToCalls.values(),
                     "The AdminClient thread has exited.");
             if (numTimedOut > 0) {
-                log.debug("Timed out {} remaining operations.", numTimedOut);
+                log.debug("Timed out {} remaining operation(s).", numTimedOut);
             }
             closeQuietly(client, "KafkaClient");
             closeQuietly(metrics, "Metrics");
@@ -1106,6 +1163,40 @@ public class KafkaAdminClient extends AdminClient {
                 enqueue(call, now);
             }
         }
+
+        /**
+         * Create a new metadata call.
+         */
+        private Call makeMetadataCall(long now) {
+            return new Call(true, "fetchMetadata", calcDeadlineMs(now, defaultTimeoutMs),
+                    new MetadataUpdateNodeIdProvider()) {
+                @Override
+                public AbstractRequest.Builder createRequest(int timeoutMs) {
+                    // Since this only requests node information, it's safe to pass true
+                    // for allowAutoTopicCreation (and it simplifies communication with
+                    // older brokers)
+                    return new MetadataRequest.Builder(Collections.<String>emptyList(), true);
+                }
+
+                @Override
+                public void handleResponse(AbstractResponse abstractResponse) {
+                    MetadataResponse response = (MetadataResponse) abstractResponse;
+                    metadataManager.update(response.cluster(), time.milliseconds(), null);
+                }
+
+                @Override
+                public void handleFailure(Throwable e) {
+                    if (e instanceof AuthenticationException) {
+                        log.info("Unable to fetch cluster metadata from node {} because of " +
+                            "authentication error", curNode(), e);
+                        metadataManager.update(Cluster.empty(), time.milliseconds(), (AuthenticationException) e);
+                    } else {
+                        log.info("Unable to fetch cluster metadata from node {}",
+                            curNode(), e);
+                    }
+                }
+            };
+        }
     }
 
     /**
@@ -1149,6 +1240,14 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             public void handleResponse(AbstractResponse abstractResponse) {
                 CreateTopicsResponse response = (CreateTopicsResponse) abstractResponse;
+                // Check for controller change
+                for (ApiError error : response.errors().values()) {
+                    if (error.error() == Errors.NOT_CONTROLLER) {
+                        metadataManager.clearController();
+                        metadataManager.requestUpdate();
+                        throw error.exception();
+                    }
+                }
                 // Handle server responses for particular topics.
                 for (Map.Entry<String, ApiError> entry : response.errors().entrySet()) {
                     KafkaFutureImpl<Void> future = topicFutures.get(entry.getKey());
@@ -1212,6 +1311,14 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             void handleResponse(AbstractResponse abstractResponse) {
                 DeleteTopicsResponse response = (DeleteTopicsResponse) abstractResponse;
+                // Check for controller change
+                for (Errors error : response.errors().values()) {
+                    if (error == Errors.NOT_CONTROLLER) {
+                        metadataManager.clearController();
+                        metadataManager.requestUpdate();
+                        throw error.exception();
+                    }
+                }
                 // Handle server responses for particular topics.
                 for (Map.Entry<String, Errors> entry : response.errors().entrySet()) {
                     KafkaFutureImpl<Void> future = topicFutures.get(entry.getKey());
@@ -1982,6 +2089,14 @@ public class KafkaAdminClient extends AdminClient {
             @Override
             public void handleResponse(AbstractResponse abstractResponse) {
                 CreatePartitionsResponse response = (CreatePartitionsResponse) abstractResponse;
+                // Check for controller change
+                for (ApiError error : response.errors().values()) {
+                    if (error.error() == Errors.NOT_CONTROLLER) {
+                        metadataManager.clearController();
+                        metadataManager.requestUpdate();
+                        throw error.exception();
+                    }
+                }
                 for (Map.Entry<String, ApiError> result : response.errors().entrySet()) {
                     KafkaFutureImpl<Void> future = futures.get(result.getKey());
                     if (result.getValue().isSuccess()) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internal/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internal/AdminMetadataManager.java
@@ -151,7 +151,7 @@ public class AdminMetadataManager {
 
     public boolean isReady() {
         if (authException != null) {
-            log.trace("Metadata is ready: got authentication exception.");
+            log.debug("Metadata is not usable: failed to get metadata.", authException);
             throw authException;
         }
         if (cluster.nodes().isEmpty()) {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internal/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internal/AdminMetadataManager.java
@@ -179,7 +179,7 @@ public class AdminMetadataManager {
     public void requestUpdate() {
         if (state == State.QUIESCENT) {
             state = State.UPDATE_REQUESTED;
-            log.trace("Requesting metadata update.");
+            log.debug("Requesting metadata update.");
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -274,7 +274,8 @@ public final class Cluster {
 
     @Override
     public String toString() {
-        return "Cluster(id = " + clusterResource.clusterId() + ", nodes = " + this.nodes + ", partitions = " + this.partitionsByTopicPartition.values() + ", controller = " + controller + ")";
+        return "Cluster(id = " + clusterResource.clusterId() + ", nodes = " + this.nodes +
+            ", partitions = " + this.partitionsByTopicPartition.values() + ", controller = " + controller + ")";
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -274,7 +274,7 @@ public final class Cluster {
 
     @Override
     public String toString() {
-        return "Cluster(id = " + clusterResource.clusterId() + ", nodes = " + this.nodes + ", partitions = " + this.partitionsByTopicPartition.values() + ")";
+        return "Cluster(id = " + clusterResource.clusterId() + ", nodes = " + this.nodes + ", partitions = " + this.partitionsByTopicPartition.values() + ", controller = " + controller + ")";
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -81,6 +81,7 @@ public class MockClient implements KafkaClient {
     private Node node = null;
     private final Set<String> ready = new HashSet<>();
     private final Map<Node, Long> blackedOut = new HashMap<>();
+    private final Map<Node, Long> pendingAuthenticationErrors = new HashMap<>();
     private final Map<Node, AuthenticationException> authenticationErrors = new HashMap<>();
     // Use concurrent queue for requests so that requests may be queried from a different thread
     private final Queue<ClientRequest> requests = new ConcurrentLinkedDeque<>();
@@ -128,9 +129,14 @@ public class MockClient implements KafkaClient {
     }
 
     public void authenticationFailed(Node node, long duration) {
+        pendingAuthenticationErrors.remove(node);
         authenticationErrors.put(node, (AuthenticationException) Errors.SASL_AUTHENTICATION_FAILED.exception());
         disconnect(node.idString());
         blackout(node, duration);
+    }
+
+    public void createPendingAuthenticationError(Node node, long timeoutMs) {
+        pendingAuthenticationErrors.put(node, timeoutMs);
     }
 
     private boolean isBlackedOut(Node node) {
@@ -174,6 +180,26 @@ public class MockClient implements KafkaClient {
 
     @Override
     public void send(ClientRequest request, long now) {
+        // Check if the request is directed to a node with a pending authentication error.
+        for (Iterator<Map.Entry<Node, Long>> authErrorIter =
+             pendingAuthenticationErrors.entrySet().iterator(); authErrorIter.hasNext(); ) {
+            Map.Entry<Node, Long> entry = authErrorIter.next();
+            Node node = entry.getKey();
+            long timeoutMs = entry.getValue();
+            if (node.idString().equals(request.destination())) {
+                authErrorIter.remove();
+                // Set up a disconnected ClientResponse and create an authentication error
+                // for the affected node.
+                authenticationFailed(node, timeoutMs);
+                AbstractRequest.Builder<?> builder = request.requestBuilder();
+                short version = nodeApiVersions.latestUsableVersion(request.apiKey(), builder.oldestAllowedVersion(),
+                    builder.latestAllowedVersion());
+                ClientResponse resp = new ClientResponse(request.makeHeader(version), request.callback(), request.destination(),
+                    request.createdTimeMs(), time.milliseconds(), true, null, null);
+                responses.add(resp);
+                return;
+            }
+        }
         Iterator<FutureResponse> iterator = futureResponses.iterator();
         while (iterator.hasNext()) {
             FutureResponse futureResp = iterator.next();

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -135,8 +135,8 @@ public class MockClient implements KafkaClient {
         blackout(node, duration);
     }
 
-    public void createPendingAuthenticationError(Node node, long timeoutMs) {
-        pendingAuthenticationErrors.put(node, timeoutMs);
+    public void createPendingAuthenticationError(Node node, long blackoutMs) {
+        pendingAuthenticationErrors.put(node, blackoutMs);
     }
 
     private boolean isBlackedOut(Node node) {
@@ -185,12 +185,12 @@ public class MockClient implements KafkaClient {
              pendingAuthenticationErrors.entrySet().iterator(); authErrorIter.hasNext(); ) {
             Map.Entry<Node, Long> entry = authErrorIter.next();
             Node node = entry.getKey();
-            long timeoutMs = entry.getValue();
+            long blackoutMs = entry.getValue();
             if (node.idString().equals(request.destination())) {
                 authErrorIter.remove();
                 // Set up a disconnected ClientResponse and create an authentication error
                 // for the affected node.
-                authenticationFailed(node, timeoutMs);
+                authenticationFailed(node, blackoutMs);
                 AbstractRequest.Builder<?> builder = request.requestBuilder();
                 short version = nodeApiVersions.latestUsableVersion(request.apiKey(), builder.oldestAllowedVersion(),
                     builder.latestAllowedVersion());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/TopicAdminTest.java
@@ -52,7 +52,6 @@ public class TopicAdminTest {
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(cluster)) {
             env.kafkaClient().setNode(cluster.controller());
             env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
             env.kafkaClient().prepareResponse(createTopicResponseWithUnsupportedVersion(newTopic));
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
             boolean created = admin.createTopic(newTopic);
@@ -65,7 +64,7 @@ public class TopicAdminTest {
         final NewTopic newTopic = TopicAdmin.defineTopic("myTopic").partitions(1).compacted().build();
         Cluster cluster = createCluster(1);
         try (AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(cluster)) {
-            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(cluster.nodes().iterator().next());
             env.kafkaClient().prepareResponse(createTopicResponseWithClusterAuthorizationException(newTopic));
             TopicAdmin admin = new TopicAdmin(null, env.adminClient());
             boolean created = admin.createTopic(newTopic);


### PR DESCRIPTION
AdminClient should only call Metadata#requestUpdate when needed.

When AdminClient gets a NOT_CONTROLLER error, it should refresh its metadata and retry the request, rather than making the end-user deal with NotControllerException.

Move AdminClient's metadata management outside of NetworkClient and into AdminMetadataManager.  This will make it easier to do more sophisticated metadata management in the future, such as implementing a NodeProvider which fetches the leaders for topics.

Rather than manipulating newCalls directly, the AdminClient service thread now drains it directly into pendingCalls.  This minimizes the amount of locking we have to do, since pendingCalls is only accessed from the service thread.