### PR TITLE
KAFKA-6313: Add SLF4J as direct dependency to Kafka core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -549,6 +549,7 @@ project(':core') {
     compile libs.joptSimple
     compile libs.metrics
     compile libs.scala
+    compile libs.slf4jApi
     compile libs.slf4jlog4j
     compile libs.scalaLogging
     compile libs.zkclient


### PR DESCRIPTION
Recent changes are now directly using the SLF4J API, so we should have a direct dependency.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
