### PR TITLE
KAFKA-6269: KTable restore fails after rebalance

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -55,6 +55,8 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     private boolean closed;
     private final Map<TopicPartition, Long> beginningOffsets;
     private final Map<TopicPartition, Long> endOffsets;
+    private final Map<TopicPartition, Long> updatedEndOffsets;
+    private int endOffsetChecks = 0;
 
     private Queue<Runnable> pollTasks;
     private KafkaException exception;
@@ -69,6 +71,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         this.closed = false;
         this.beginningOffsets = new HashMap<>();
         this.endOffsets = new HashMap<>();
+        this.updatedEndOffsets = new HashMap<>();
         this.pollTasks = new LinkedList<>();
         this.exception = null;
         this.wakeup = new AtomicBoolean(false);
@@ -288,6 +291,10 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         endOffsets.putAll(newOffsets);
     }
 
+    public synchronized void simulateEndOffsetsUpdatedByAnotherThread(Map<TopicPartition, Long> newOffsets){
+        updatedEndOffsets.putAll(newOffsets);
+    }
+
     @Override
     public synchronized Map<MetricName, ? extends Metric> metrics() {
         ensureNotClosed();
@@ -347,8 +354,11 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     @Override
     public synchronized Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
         Map<TopicPartition, Long> result = new HashMap<>();
+        if (!updatedEndOffsets.isEmpty()) {
+            endOffsetChecks+=1;
+        }
         for (TopicPartition tp : partitions) {
-            Long endOffset = endOffsets.get(tp);
+            Long endOffset = endOffsetChecks < 2 ? endOffsets.get(tp) : updatedEndOffsets.get(tp);
             if (endOffset == null)
                 throw new IllegalStateException("The partition " + tp + " does not have an end offset.");
             result.put(tp, endOffset);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -291,7 +291,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         endOffsets.putAll(newOffsets);
     }
 
-    public synchronized void simulateEndOffsetsUpdatedByAnotherThread(Map<TopicPartition, Long> newOffsets){
+    public synchronized void simulateEndOffsetsUpdatedByAnotherThread(Map<TopicPartition, Long> newOffsets) {
         updatedEndOffsets.putAll(newOffsets);
     }
 
@@ -355,7 +355,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     public synchronized Map<TopicPartition, Long> endOffsets(Collection<TopicPartition> partitions) {
         Map<TopicPartition, Long> result = new HashMap<>();
         if (!updatedEndOffsets.isEmpty()) {
-            endOffsetChecks+=1;
+            endOffsetChecks += 1;
         }
         for (TopicPartition tp : partitions) {
             Long endOffset = endOffsetChecks < 2 ? endOffsets.get(tp) : updatedEndOffsets.get(tp);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -197,7 +197,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
             throw new IllegalStateException("Cannot add records for a partition that is not assigned to the consumer");
         List<ConsumerRecord<K, V>> recs = this.records.get(tp);
         if (recs == null) {
-            recs = new ArrayList<ConsumerRecord<K, V>>();
+            recs = new ArrayList<>();
             this.records.put(tp, recs);
         }
         recs.add(record);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -115,6 +115,10 @@ public class StateRestorer {
         return offsetLimit;
     }
 
+    boolean isChangeLogTopic() {
+        return offsetLimit == Long.MAX_VALUE;
+    }
+
     private Long readTo(final long endOffset) {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -115,10 +115,6 @@ public class StateRestorer {
         return offsetLimit;
     }
 
-    boolean isChangeLogTopic() {
-        return offsetLimit == Long.MAX_VALUE;
-    }
-
     private Long readTo(final long endOffset) {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -276,7 +276,7 @@ public class StoreChangelogReader implements ChangelogReader {
         final Iterator<ConsumerRecord<byte[], byte[]>> consumerRecordIterator = records.iterator();
 
         while (consumerRecordIterator.hasNext()) {
-            ConsumerRecord<byte[], byte[]> record = consumerRecordIterator.next();
+            final ConsumerRecord<byte[], byte[]> record = consumerRecordIterator.next();
             offset = record.offset();
             if (restorer.hasCompleted(offset, endOffset)) {
                 break;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -273,7 +273,10 @@ public class StoreChangelogReader implements ChangelogReader {
         final List<KeyValue<byte[], byte[]>> restoreRecords = new ArrayList<>();
         long offset = -1;
 
-        for (final ConsumerRecord<byte[], byte[]> record : records) {
+        final Iterator<ConsumerRecord<byte[], byte[]>> consumerRecordIterator = records.iterator();
+
+        while (consumerRecordIterator.hasNext()) {
+            ConsumerRecord<byte[], byte[]> record = consumerRecordIterator.next();
             offset = record.offset();
             if (restorer.hasCompleted(offset, endOffset)) {
                 break;
@@ -292,7 +295,7 @@ public class StoreChangelogReader implements ChangelogReader {
             restorer.restoreBatchCompleted(offset + 1, records.size());
         }
 
-        return restoreConsumer.position(restorer.partition());
+        return consumerRecordIterator.hasNext() ? consumerRecordIterator.next().offset() : restoreConsumer.position(restorer.partition());
     }
 
     private boolean hasPartition(final TopicPartition topicPartition) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -252,7 +252,7 @@ public class StoreChangelogReader implements ChangelogReader {
         final long pos = processNext(allRecords.records(topicPartition), restorer, endOffset);
         restorer.setRestoredOffset(pos);
         if (restorer.hasCompleted(pos, endOffset)) {
-            if (pos > endOffset + 1) {
+            if (pos > endOffset) {
                 throw new TaskMigratedException(task, topicPartition, endOffset, pos);
             }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.integration;
+
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
+import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestCondition;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+@Category({IntegrationTest.class})
+public class KTableSourceTopicRestartIntegrationTest {
+
+
+    private static final int NUM_BROKERS = 1;
+    private static final String SOURCE_TOPIC = "source-topic";
+    private static final String TABLE_SOURCE_TOPIC = "table-source-topic";
+
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS);
+    private final Time time = CLUSTER.time;
+    private KafkaStreams streamsOne;
+    private KafkaStreams streamsTwo;
+    private static final Properties PRODUCER_CONFIG = new Properties();
+    private static final Properties STREAMS_CONFIG = new Properties();
+    private static final Serde<String> STRING_SERDE = Serdes.String();
+    private static final Serde<Long> LONG_SERDE = Serdes.Long();
+
+
+    @BeforeClass
+    public static void setUpBeforeAllTests() throws Exception {
+
+        CLUSTER.createTopic(SOURCE_TOPIC, 1, 1);
+        CLUSTER.createTopic(TABLE_SOURCE_TOPIC, 1, 1);
+
+        STREAMS_CONFIG.put(StreamsConfig.APPLICATION_ID_CONFIG, "ktable-restore-from-source");
+        STREAMS_CONFIG.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        STREAMS_CONFIG.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        STREAMS_CONFIG.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        STREAMS_CONFIG.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        STREAMS_CONFIG.put(IntegrationTestUtils.INTERNAL_LEAVE_GROUP_ON_CLOSE, true);
+        STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 5);
+        STREAMS_CONFIG.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
+        STREAMS_CONFIG.put(ConsumerConfig.GROUP_ID_CONFIG, "ktable-group");
+
+
+        PRODUCER_CONFIG.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+        PRODUCER_CONFIG.put(ProducerConfig.ACKS_CONFIG, "all");
+        PRODUCER_CONFIG.put(ProducerConfig.RETRIES_CONFIG, 0);
+        PRODUCER_CONFIG.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        PRODUCER_CONFIG.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    }
+
+
+    @After
+    public void after() throws IOException {
+        IntegrationTestUtils.purgeLocalStreamsState(STREAMS_CONFIG);
+    }
+
+
+    @Test
+    public void shouldRestoreOnlyToLastCommit() throws Exception {
+        try {
+            final StreamsBuilder streamsBuilder = new StreamsBuilder();
+            final Map<String, Long> readKeyValues = new HashMap<>();
+
+            streamsBuilder.<String, String>stream(SOURCE_TOPIC)
+                .groupByKey()
+                .count()
+                .toStream()
+                .to(TABLE_SOURCE_TOPIC, Produced.with(STRING_SERDE, LONG_SERDE));
+
+            KTable<String, Long> countsTable = streamsBuilder.table(TABLE_SOURCE_TOPIC,
+                                                                    Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>with(STRING_SERDE, LONG_SERDE)
+                .withLoggingEnabled(new HashMap<String, String>())
+                .withCachingDisabled());
+
+            countsTable.toStream().foreach(new ForeachAction<String, Long>() {
+                @Override
+                public void apply(String key, Long value) {
+                    readKeyValues.put(key, value);
+                }
+            });
+
+            streamsOne = new KafkaStreams(streamsBuilder.build(), STREAMS_CONFIG);
+            streamsOne.setGlobalStateRestoreListener(new TestingStateRestoreListener("streams-one"));
+            streamsOne.start();
+
+            streamsTwo = new KafkaStreams(streamsBuilder.build(), STREAMS_CONFIG);
+            streamsTwo.setGlobalStateRestoreListener(new TestingStateRestoreListener("streams-two"));
+            streamsTwo.start();
+
+
+            final List<KeyValue<String, String>> initialKeyValues = Arrays.asList(
+                new KeyValue<>("a", "A3"),
+                new KeyValue<>("b", "B3"),
+                new KeyValue<>("c", "C3"),
+                new KeyValue<>("d", "D3"),
+                new KeyValue<>("e", "E3"),
+                new KeyValue<>("f", "F3")
+            );
+            IntegrationTestUtils.produceKeyValuesSynchronously(SOURCE_TOPIC, initialKeyValues, PRODUCER_CONFIG, time);
+
+            TestUtils.waitForCondition(new TestCondition() {
+                @Override
+                public boolean conditionMet() {
+                    return readKeyValues.size() == 6;
+                }
+            }, "Table did not get all values");
+
+            streamsTwo.close();
+            streamsTwo.cleanUp();
+
+
+            final List<KeyValue<String, String>> additionalValuesWritten = Arrays.asList(
+                new KeyValue<>("g", "G3"),
+                new KeyValue<>("i", "I5"),
+                new KeyValue<>("j", "K6"),
+                new KeyValue<>("l", "K6"),
+                new KeyValue<>("m", "K6"),
+                new KeyValue<>("n", "K6")
+            );
+
+
+            IntegrationTestUtils.produceKeyValuesSynchronously(SOURCE_TOPIC, additionalValuesWritten, PRODUCER_CONFIG, time);
+
+            final List<KeyValue<String,Long>> valuesToTableTopics = Arrays.asList(
+                new KeyValue<>("FOO", 10L),
+                new KeyValue<>("BAR", 20L),
+                new KeyValue<>("BAZ", 30L)
+
+            );
+
+            PRODUCER_CONFIG.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+            IntegrationTestUtils.produceKeyValuesSynchronously(TABLE_SOURCE_TOPIC, valuesToTableTopics, PRODUCER_CONFIG, time);
+            // sleeps needed for forcing recovery
+            Thread.sleep(5000L);
+
+            streamsTwo = new KafkaStreams(streamsBuilder.build(), STREAMS_CONFIG);
+            streamsTwo.setGlobalStateRestoreListener(new TestingStateRestoreListener("streams-two-restarted"));
+            // expecting this to fail as restoration
+            streamsTwo.start();
+            // sleep needed to for restoration
+            Thread.sleep(5000L);
+
+
+        } finally {
+            streamsOne.close(5, TimeUnit.SECONDS);
+            streamsTwo.close(5, TimeUnit.SECONDS);
+        }
+    }
+
+
+    private static class TestingStateRestoreListener implements StateRestoreListener {
+
+        private String streamsInstance;
+
+        public TestingStateRestoreListener(String streamsInstance) {
+            this.streamsInstance = streamsInstance;
+        }
+
+        @Override
+        public void onRestoreStart(TopicPartition topicPartition, String storeName, long startingOffset, long endingOffset) {
+            System.out.println("["+streamsInstance+"] recovering for TopicPartition " +topicPartition+" storeName " + storeName +" offset " +startingOffset + " ending offset "+ endingOffset);
+        }
+
+        @Override
+        public void onBatchRestored(TopicPartition topicPartition, String storeName, long batchEndOffset, long numRestored) {
+
+        }
+
+        @Override
+        public void onRestoreEnd(TopicPartition topicPartition, String storeName, long totalRestored) {
+            System.out.println("["+streamsInstance+"] Done recovering for TopicPartition " + topicPartition +  " storeName " + storeName +" totalRestored " +totalRestored);
+        }
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -94,7 +94,6 @@ public class KTableSourceTopicRestartIntegrationTest {
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
         STREAMS_CONFIG.put(ConsumerConfig.GROUP_ID_CONFIG, "ktable-group");
 
-
         PRODUCER_CONFIG.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         PRODUCER_CONFIG.put(ProducerConfig.ACKS_CONFIG, "all");
         PRODUCER_CONFIG.put(ProducerConfig.RETRIES_CONFIG, 0);
@@ -124,8 +123,8 @@ public class KTableSourceTopicRestartIntegrationTest {
 
             KTable<String, Long> countsTable = streamsBuilder.table(TABLE_SOURCE_TOPIC,
                                                                     Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>with(STRING_SERDE, LONG_SERDE)
-                .withLoggingEnabled(new HashMap<String, String>())
-                .withCachingDisabled());
+                                                                        .withLoggingEnabled(new HashMap<String, String>())
+                                                                        .withCachingDisabled());
 
             countsTable.toStream().foreach(new ForeachAction<String, Long>() {
                 @Override
@@ -141,7 +140,6 @@ public class KTableSourceTopicRestartIntegrationTest {
             streamsTwo = new KafkaStreams(streamsBuilder.build(), STREAMS_CONFIG);
             streamsTwo.setGlobalStateRestoreListener(new TestingStateRestoreListener("streams-two"));
             streamsTwo.start();
-
 
             final List<KeyValue<String, String>> initialKeyValues = Arrays.asList(
                 new KeyValue<>("a", "A3"),
@@ -163,7 +161,6 @@ public class KTableSourceTopicRestartIntegrationTest {
             streamsTwo.close();
             streamsTwo.cleanUp();
 
-
             final List<KeyValue<String, String>> additionalValuesWritten = Arrays.asList(
                 new KeyValue<>("g", "G3"),
                 new KeyValue<>("i", "I5"),
@@ -173,10 +170,9 @@ public class KTableSourceTopicRestartIntegrationTest {
                 new KeyValue<>("n", "K6")
             );
 
-
             IntegrationTestUtils.produceKeyValuesSynchronously(SOURCE_TOPIC, additionalValuesWritten, PRODUCER_CONFIG, time);
 
-            final List<KeyValue<String,Long>> valuesToTableTopics = Arrays.asList(
+            final List<KeyValue<String, Long>> valuesToTableTopics = Arrays.asList(
                 new KeyValue<>("FOO", 10L),
                 new KeyValue<>("BAR", 20L),
                 new KeyValue<>("BAZ", 30L)
@@ -213,7 +209,9 @@ public class KTableSourceTopicRestartIntegrationTest {
 
         @Override
         public void onRestoreStart(TopicPartition topicPartition, String storeName, long startingOffset, long endingOffset) {
-            System.out.println("["+streamsInstance+"] recovering for TopicPartition " +topicPartition+" storeName " + storeName +" offset " +startingOffset + " ending offset "+ endingOffset);
+            System.out.println(
+                "[" + streamsInstance + "] recovering for TopicPartition " + topicPartition + " storeName " + storeName + " offset " + startingOffset
+                + " ending offset " + endingOffset);
         }
 
         @Override
@@ -223,7 +221,8 @@ public class KTableSourceTopicRestartIntegrationTest {
 
         @Override
         public void onRestoreEnd(TopicPartition topicPartition, String storeName, long totalRestored) {
-            System.out.println("["+streamsInstance+"] Done recovering for TopicPartition " + topicPartition +  " storeName " + storeName +" totalRestored " +totalRestored);
+            System.out.println("[" + streamsInstance + "] Done recovering for TopicPartition " + topicPartition + " storeName " + storeName + " totalRestored "
+                               + totalRestored);
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -208,7 +208,7 @@ public class KTableSourceTopicRestartIntegrationTest {
     private void produceKeyValues(String... keys) throws ExecutionException, InterruptedException {
         final List<KeyValue<String, String>> keyValueList = new ArrayList<>();
 
-        for (String key : keys) {
+        for (final String key : keys) {
             keyValueList.add(new KeyValue<>(key, key + "1"));
         }
 
@@ -221,7 +221,10 @@ public class KTableSourceTopicRestartIntegrationTest {
     private class UpdatingSourceTopicOnRestoreStartStateRestoreListener implements StateRestoreListener {
 
         @Override
-        public void onRestoreStart(TopicPartition topicPartition, String storeName, long startingOffset, long endingOffset) {
+        public void onRestoreStart(final TopicPartition topicPartition,
+                                   final String storeName,
+                                   final long startingOffset,
+                                   final long endingOffset) {
             try {
                 // need two values appended to log to trigger issue
                 produceKeyValues("d", "e");
@@ -231,11 +234,16 @@ public class KTableSourceTopicRestartIntegrationTest {
         }
 
         @Override
-        public void onBatchRestored(TopicPartition topicPartition, String storeName, long batchEndOffset, long numRestored) {
+        public void onBatchRestored(final TopicPartition topicPartition,
+                                    final String storeName,
+                                    final long batchEndOffset,
+                                    final long numRestored) {
         }
 
         @Override
-        public void onRestoreEnd(TopicPartition topicPartition, String storeName, long totalRestored) {
+        public void onRestoreEnd(final TopicPartition topicPartition,
+                                 final String storeName,
+                                 final long totalRestored) {
         }
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -85,7 +85,6 @@ public class KTableSourceTopicRestartIntegrationTest {
         STREAMS_CONFIG.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 5);
         STREAMS_CONFIG.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class);
 
-
         PRODUCER_CONFIG.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
         PRODUCER_CONFIG.put(ProducerConfig.ACKS_CONFIG, "all");
         PRODUCER_CONFIG.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -130,7 +129,7 @@ public class KTableSourceTopicRestartIntegrationTest {
 
             produceKeyValues("f", "g", "h");
 
-            assertNumberValuesRead(readKeyValues, 8, "Table did not get all values after restart");
+            assertNumberValuesRead(readKeyValues, 7, "Table did not get all values after restart");
 
         } finally {
             streamsOne.close(5, TimeUnit.SECONDS);
@@ -157,7 +156,7 @@ public class KTableSourceTopicRestartIntegrationTest {
 
             produceKeyValues("f", "g", "h");
 
-            assertNumberValuesRead(readKeyValues, 8, "Table did not get all values after restart");
+            assertNumberValuesRead(readKeyValues, 7, "Table did not get all values after restart");
 
         } finally {
             streamsOne.close(5, TimeUnit.SECONDS);
@@ -223,9 +222,9 @@ public class KTableSourceTopicRestartIntegrationTest {
                                    final long endingOffset) {
             try {
                 // need two values appended to log to trigger issue
-                produceKeyValues("d", "e");
+                produceKeyValues("d");
             } catch (ExecutionException | InterruptedException e) {
-                  throw new RuntimeException(e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -123,7 +123,7 @@ public class KTableSourceTopicRestartIntegrationTest {
 
             streamsOne.close();
             streamsOne = new KafkaStreams(streamsBuilder.build(), STREAMS_CONFIG);
-            // the state restore listener will append two records to the log
+            // the state restore listener will append one record to the log
             streamsOne.setGlobalStateRestoreListener(new UpdatingSourceTopicOnRestoreStartStateRestoreListener());
             streamsOne.start();
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableSourceTopicRestartIntegrationTest.java
@@ -150,7 +150,7 @@ public class KTableSourceTopicRestartIntegrationTest {
 
             streamsOne.close();
             streamsOne = new KafkaStreams(streamsBuilder.build(), STREAMS_CONFIG);
-            // the state restore listener will append two records to the log
+            // the state restore listener will append one record to the log
             streamsOne.setGlobalStateRestoreListener(new UpdatingSourceTopicOnRestoreStartStateRestoreListener());
             streamsOne.start();
 
@@ -221,7 +221,6 @@ public class KTableSourceTopicRestartIntegrationTest {
                                    final long startingOffset,
                                    final long endingOffset) {
             try {
-                // need two values appended to log to trigger issue
                 produceKeyValues("d");
             } catch (ExecutionException | InterruptedException e) {
                 throw new RuntimeException(e);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -119,7 +119,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRestoreAllMessagesFromBeginningWhenCheckpointNull() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition, 0);
+        setupConsumer(messages, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
         changelogReader.restore(active);
@@ -129,7 +129,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRecoverFromInvalidOffsetExceptionAndFinishRestore() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition, 0);
+        setupConsumer(messages, topicPartition);
         consumer.setException(new InvalidOffsetException("Try Again!") {
             @Override
             public Set<TopicPartition> partitions() {
@@ -153,7 +153,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRestoreMessagesFromCheckpoint() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition, 0);
+        setupConsumer(messages, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, 5L, Long.MAX_VALUE, true,
                                                    "storeName"));
 
@@ -164,7 +164,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldClearAssignmentAtEndOfRestore() {
         final int messages = 1;
-        setupConsumer(messages, topicPartition, 0);
+        setupConsumer(messages, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
 
@@ -174,7 +174,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldRestoreToLimitWhenSupplied() {
-        setupConsumer(10, topicPartition, 0);
+        setupConsumer(10, topicPartition);
         final StateRestorer restorer = new StateRestorer(topicPartition, restoreListener, null, 3, true,
                                                          "storeName");
         changelogReader.register(restorer);
@@ -191,9 +191,9 @@ public class StoreChangelogReaderTest {
         final MockRestoreCallback callbackTwo = new MockRestoreCallback();
         final CompositeRestoreListener restoreListener1 = new CompositeRestoreListener(callbackOne);
         final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
-        setupConsumer(10, topicPartition, 0);
-        setupConsumer(5, one, 0);
-        setupConsumer(3, two, 0);
+        setupConsumer(10, topicPartition);
+        setupConsumer(5, one);
+        setupConsumer(3, two);
 
         changelogReader
             .register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName1"));
@@ -218,9 +218,9 @@ public class StoreChangelogReaderTest {
         final MockStateRestoreListener callbackTwo = new MockStateRestoreListener();
         final CompositeRestoreListener restoreListener1 = new CompositeRestoreListener(callbackOne);
         final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
-        setupConsumer(10, topicPartition, 0);
-        setupConsumer(5, one, 0);
-        setupConsumer(3, two, 0);
+        setupConsumer(10, topicPartition);
+        setupConsumer(5, one);
+        setupConsumer(3, two);
 
         changelogReader
             .register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName1"));
@@ -268,7 +268,7 @@ public class StoreChangelogReaderTest {
         final StateRestorer
             restorer =
             new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName");
-        setupConsumer(0, topicPartition, 0);
+        setupConsumer(0, topicPartition);
         changelogReader.register(restorer);
 
         changelogReader.restore(active);
@@ -279,7 +279,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotRestoreAnythingWhenCheckpointAtEndOffset() {
         final Long endOffset = 10L;
-        setupConsumer(endOffset, topicPartition, 0);
+        setupConsumer(endOffset, topicPartition);
         final StateRestorer
             restorer =
             new StateRestorer(topicPartition, restoreListener, endOffset, Long.MAX_VALUE, true, "storeName");
@@ -293,7 +293,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldReturnRestoredOffsetsForPersistentStores() {
-        setupConsumer(10, topicPartition, 0);
+        setupConsumer(10, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
         changelogReader.restore(active);
@@ -303,7 +303,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldNotReturnRestoredOffsetsForNonPersistentStore() {
-        setupConsumer(10, topicPartition, 0);
+        setupConsumer(10, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false,
                                                    "storeName"));
         changelogReader.restore(active);
@@ -329,7 +329,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldCompleteImmediatelyWhenEndOffsetIs0() {
         final Collection<TopicPartition> expected = Collections.singleton(topicPartition);
-        setupConsumer(0, topicPartition, 0);
+        setupConsumer(0, topicPartition);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "store"));
         final Collection<TopicPartition> restored = changelogReader.restore(active);
         assertThat(restored, equalTo(expected));
@@ -340,7 +340,7 @@ public class StoreChangelogReaderTest {
         final MockRestoreCallback callbackTwo = new MockRestoreCallback();
         final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
 
-        setupConsumer(1, topicPartition, 0);
+        setupConsumer(1, topicPartition);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 10L));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false, "storeName"));
 
@@ -354,7 +354,7 @@ public class StoreChangelogReaderTest {
 
         addRecords(9, topicPartition, 1);
 
-        setupConsumer(3, postInitialization, 0);
+        setupConsumer(3, postInitialization);
         consumer.updateBeginningOffsets(Collections.singletonMap(postInitialization, 0L));
         consumer.updateEndOffsets(Collections.singletonMap(postInitialization, 3L));
 
@@ -369,9 +369,9 @@ public class StoreChangelogReaderTest {
     }
 
     @Test
-    public void shouldThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestore() {
+    public void shouldThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestoreForChangelogTopic() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition, 6);
+        setupConsumer(messages, topicPartition);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 5L));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
             "storeName"));
@@ -385,11 +385,62 @@ public class StoreChangelogReaderTest {
         } catch (final TaskMigratedException expected) { /* ignore */ }
     }
 
+    @Test
+    public void shouldThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestoreForChangelogTopicAfterComplete() {
+        final int messages = 10;
+        setupConsumer(messages, topicPartition);
+        consumer.simulateEndOffsetsUpdatedByAnotherThread(Collections.singletonMap(topicPartition, 12L));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
+                                                   "storeName"));
+        expect(active.restoringTaskFor(topicPartition)).andReturn(task);
+        replay(active);
+
+        try {
+            changelogReader.restore(active);
+            fail("Should have thrown TaskMigratedException");
+        } catch (final TaskMigratedException expected) { /* ignore */ }
+    }
+
+    @Test
+    public void shouldNotThrowTaskMigratedExceptionIfEndOffsetIsUpdatedDuringRestoreForSourceTopicAfterComplete() {
+        final int messages = 10;
+        setupConsumer(messages, topicPartition);
+        consumer.simulateEndOffsetsUpdatedByAnotherThread(Collections.singletonMap(topicPartition, 11L));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 10, true,
+                                                   "storeName"));
+
+        expect(active.restoringTaskFor(topicPartition)).andReturn(task);
+        replay(active);
+
+        try {
+            changelogReader.restore(active);
+        } catch (final TaskMigratedException expected) {
+            fail("Should not have thrown TaskMigratedException for source topic");
+        }
+    }
+
+    @Test
+    public void shouldNotThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestoreForSourceTopic() {
+        final int messages = 10;
+        setupConsumer(messages, topicPartition);
+        consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 5L));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 5, true,
+                                                   "storeName"));
+
+        expect(active.restoringTaskFor(topicPartition)).andReturn(task);
+        replay(active);
+
+        try {
+            changelogReader.restore(active);
+        } catch (final TaskMigratedException expected) {
+            fail("Should not have thrown TaskMigratedException for source topic");
+        }
+    }
+
     private void setupConsumer(final long messages,
-                               final TopicPartition topicPartition,
-                               final int startingOffset) {
+                               final TopicPartition topicPartition) {
         assignPartition(messages, topicPartition);
-        addRecords(messages, topicPartition, startingOffset);
+        addRecords(messages, topicPartition, 0);
         consumer.assign(Collections.<TopicPartition>emptyList());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -442,7 +442,6 @@ public class StoreChangelogReaderTest {
     public void shouldNotThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestoreForSourceTopic() {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
-        consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 5L));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 5, true, "storeName"));
 
         expect(active.restoringTaskFor(topicPartition)).andReturn(task);
@@ -475,10 +474,10 @@ public class StoreChangelogReaderTest {
         //EOS enabled so commit marker at offset 5 so records start at 6
         addRecords(5, topicPartition, 6);
         consumer.assign(Collections.<TopicPartition>emptyList());
-        // commit marker is 5 so ending offset is 6
-        consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 6L));
+        // commit marker is 5 so ending offset is 12
+        consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 12L));
 
-        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 11, true, "storeName"));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 6, true, "storeName"));
 
         expect(active.restoringTaskFor(topicPartition)).andReturn(task);
         replay(active);

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -119,7 +119,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRestoreAllMessagesFromBeginningWhenCheckpointNull() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition);
+        setupConsumer(messages, topicPartition, 0);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
         changelogReader.restore(active);
@@ -153,7 +153,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRestoreMessagesFromCheckpoint() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition);
+        setupConsumer(messages, topicPartition, 0);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, 5L, Long.MAX_VALUE, true,
                                                    "storeName"));
 
@@ -164,7 +164,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldClearAssignmentAtEndOfRestore() {
         final int messages = 1;
-        setupConsumer(messages, topicPartition);
+        setupConsumer(messages, topicPartition, 0);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
 
@@ -174,7 +174,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldRestoreToLimitWhenSupplied() {
-        setupConsumer(10, topicPartition);
+        setupConsumer(10, topicPartition, 0);
         final StateRestorer restorer = new StateRestorer(topicPartition, restoreListener, null, 3, true,
                                                          "storeName");
         changelogReader.register(restorer);
@@ -191,9 +191,9 @@ public class StoreChangelogReaderTest {
         final MockRestoreCallback callbackTwo = new MockRestoreCallback();
         final CompositeRestoreListener restoreListener1 = new CompositeRestoreListener(callbackOne);
         final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
-        setupConsumer(10, topicPartition);
-        setupConsumer(5, one);
-        setupConsumer(3, two);
+        setupConsumer(10, topicPartition, 0);
+        setupConsumer(5, one, 0);
+        setupConsumer(3, two, 0);
 
         changelogReader
             .register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName1"));
@@ -218,9 +218,9 @@ public class StoreChangelogReaderTest {
         final MockStateRestoreListener callbackTwo = new MockStateRestoreListener();
         final CompositeRestoreListener restoreListener1 = new CompositeRestoreListener(callbackOne);
         final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
-        setupConsumer(10, topicPartition);
-        setupConsumer(5, one);
-        setupConsumer(3, two);
+        setupConsumer(10, topicPartition, 0);
+        setupConsumer(5, one, 0);
+        setupConsumer(3, two, 0);
 
         changelogReader
             .register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName1"));
@@ -268,7 +268,7 @@ public class StoreChangelogReaderTest {
         final StateRestorer
             restorer =
             new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName");
-        setupConsumer(0, topicPartition);
+        setupConsumer(0, topicPartition, 0);
         changelogReader.register(restorer);
 
         changelogReader.restore(active);
@@ -279,7 +279,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotRestoreAnythingWhenCheckpointAtEndOffset() {
         final Long endOffset = 10L;
-        setupConsumer(endOffset, topicPartition);
+        setupConsumer(endOffset, topicPartition, 0);
         final StateRestorer
             restorer =
             new StateRestorer(topicPartition, restoreListener, endOffset, Long.MAX_VALUE, true, "storeName");
@@ -293,7 +293,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldReturnRestoredOffsetsForPersistentStores() {
-        setupConsumer(10, topicPartition);
+        setupConsumer(10, topicPartition, 0);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
                                                    "storeName"));
         changelogReader.restore(active);
@@ -303,7 +303,7 @@ public class StoreChangelogReaderTest {
 
     @Test
     public void shouldNotReturnRestoredOffsetsForNonPersistentStore() {
-        setupConsumer(10, topicPartition);
+        setupConsumer(10, topicPartition, 0);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false,
                                                    "storeName"));
         changelogReader.restore(active);
@@ -329,7 +329,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldCompleteImmediatelyWhenEndOffsetIs0() {
         final Collection<TopicPartition> expected = Collections.singleton(topicPartition);
-        setupConsumer(0, topicPartition);
+        setupConsumer(0, topicPartition, 0);
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "store"));
         final Collection<TopicPartition> restored = changelogReader.restore(active);
         assertThat(restored, equalTo(expected));
@@ -340,7 +340,7 @@ public class StoreChangelogReaderTest {
         final MockRestoreCallback callbackTwo = new MockRestoreCallback();
         final CompositeRestoreListener restoreListener2 = new CompositeRestoreListener(callbackTwo);
 
-        setupConsumer(1, topicPartition);
+        setupConsumer(1, topicPartition, 0);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 10L));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, false, "storeName"));
 
@@ -354,7 +354,7 @@ public class StoreChangelogReaderTest {
 
         addRecords(9, topicPartition, 1);
 
-        setupConsumer(3, postInitialization);
+        setupConsumer(3, postInitialization, 0);
         consumer.updateBeginningOffsets(Collections.singletonMap(postInitialization, 0L));
         consumer.updateEndOffsets(Collections.singletonMap(postInitialization, 3L));
 
@@ -371,7 +371,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestore() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition);
+        setupConsumer(messages, topicPartition, 6);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 5L));
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
             "storeName"));
@@ -386,9 +386,10 @@ public class StoreChangelogReaderTest {
     }
 
     private void setupConsumer(final long messages,
-                               final TopicPartition topicPartition) {
+                               final TopicPartition topicPartition,
+                               final int startingOffset) {
         assignPartition(messages, topicPartition);
-        addRecords(messages, topicPartition, 0);
+        addRecords(messages, topicPartition, startingOffset);
         consumer.assign(Collections.<TopicPartition>emptyList());
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -27,7 +27,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.StreamsException;
-import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.test.MockRestoreCallback;
 import org.apache.kafka.test.MockStateRestoreListener;
@@ -369,7 +368,7 @@ public class StoreChangelogReaderTest {
     }
 
     @Test
-    public void shouldThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestore() {
+    public void shouldNotThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestore() {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 5L));
@@ -379,10 +378,7 @@ public class StoreChangelogReaderTest {
         expect(active.restoringTaskFor(topicPartition)).andReturn(task);
         replay(active);
 
-        try {
-            changelogReader.restore(active);
-            fail("Should have thrown TaskMigratedException");
-        } catch (final TaskMigratedException expected) { /* ignore */ }
+        changelogReader.restore(active);
     }
 
     private void setupConsumer(final long messages,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.test.MockRestoreCallback;
 import org.apache.kafka.test.MockStateRestoreListener;
@@ -368,7 +369,7 @@ public class StoreChangelogReaderTest {
     }
 
     @Test
-    public void shouldNotThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestore() {
+    public void shouldThrowTaskMigratedExceptionIfEndOffsetGetsExceededDuringRestore() {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 5L));
@@ -378,7 +379,10 @@ public class StoreChangelogReaderTest {
         expect(active.restoringTaskFor(topicPartition)).andReturn(task);
         replay(active);
 
-        changelogReader.restore(active);
+        try {
+            changelogReader.restore(active);
+            fail("Should have thrown TaskMigratedException");
+        } catch (final TaskMigratedException expected) { /* ignore */ }
     }
 
     private void setupConsumer(final long messages,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -129,7 +129,7 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldRecoverFromInvalidOffsetExceptionAndFinishRestore() {
         final int messages = 10;
-        setupConsumer(messages, topicPartition);
+        setupConsumer(messages, topicPartition, 0);
         consumer.setException(new InvalidOffsetException("Try Again!") {
             @Override
             public Set<TopicPartition> partitions() {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -410,8 +410,6 @@ public class StoreChangelogReaderTest {
         // records have offsets of 0..9 10 is commit marker so 11 is end offset
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 11L));
 
-        consumer.assign(Collections.<TopicPartition>emptyList());
-
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName"));
 
         expect(active.restoringTaskFor(topicPartition)).andReturn(task);
@@ -426,8 +424,6 @@ public class StoreChangelogReaderTest {
     public void shouldNotThrowTaskMigratedExceptionDuringRestoreForChangelogTopicWhenEndOffsetNotExceededEOSDisabled() {
         final int totalMessages = 10;
         setupConsumer(totalMessages, topicPartition);
-
-        consumer.assign(Collections.<TopicPartition>emptyList());
 
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName"));
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -91,8 +91,7 @@ public class StoreChangelogReaderTest {
         };
 
         final StoreChangelogReader changelogReader = new StoreChangelogReader(consumer, stateRestoreListener, logContext);
-        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
-                                                   "storeName"));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName"));
         changelogReader.restore(active);
         assertTrue(functionCalled.get());
     }
@@ -119,8 +118,7 @@ public class StoreChangelogReaderTest {
     public void shouldRestoreAllMessagesFromBeginningWhenCheckpointNull() {
         final int messages = 10;
         setupConsumer(messages, topicPartition);
-        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true,
-                                                   "storeName"));
+        changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, Long.MAX_VALUE, true, "storeName"));
         changelogReader.restore(active);
         assertThat(callback.restored.size(), equalTo(messages));
     }
@@ -409,6 +407,7 @@ public class StoreChangelogReaderTest {
     public void shouldNotThrowTaskMigratedExceptionDuringRestoreForChangelogTopicWhenEndOffsetNotExceededEOSEnabled() {
         final int totalMessages = 10;
         setupConsumer(totalMessages, topicPartition);
+        // records have offsets of 0..9 10 is commit marker so 11 is end offset
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 11L));
 
         consumer.assign(Collections.<TopicPartition>emptyList());
@@ -476,6 +475,7 @@ public class StoreChangelogReaderTest {
         //EOS enabled so commit marker at offset 5 so records start at 6
         addRecords(5, topicPartition, 6);
         consumer.assign(Collections.<TopicPartition>emptyList());
+        // commit marker is 5 so ending offset is 6
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 6L));
 
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 11, true, "storeName"));
@@ -490,12 +490,8 @@ public class StoreChangelogReaderTest {
     @Test
     public void shouldNotThrowTaskMigratedExceptionIfEndOffsetNotExceededDuringRestoreForSourceTopicEOSEnabled() {
         final int totalMessages = 10;
-        assignPartition(totalMessages, topicPartition);
-        // records 0..4 last offset before commit is 4
-        addRecords(5, topicPartition, 0);
-        //EOS enabled so commit marker at offset 5 so records start at 6
-        addRecords(5, topicPartition, 6);
-        consumer.assign(Collections.<TopicPartition>emptyList());
+        setupConsumer(totalMessages, topicPartition);
+        // records have offsets 0..9 10 is commit marker so 11 is ending offset
         consumer.updateEndOffsets(Collections.singletonMap(topicPartition, 11L));
 
         changelogReader.register(new StateRestorer(topicPartition, restoreListener, null, 11, true, "storeName"));


### PR DESCRIPTION
- If more records are left when restoration is completed, return offset of next record
- added integration test to verify behavior vs unit test as hard to mock all relevant behavior for all moving parts.
- updated unit test


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
