### PR TITLE
KAFKA-6326: when broker is unavailable, fast revover

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClientUtils.java
@@ -86,11 +86,15 @@ public class NetworkClientUtils {
             return true;
 
         long attemptStartTime = time.milliseconds();
-        while (!client.isReady(node, attemptStartTime) && attemptStartTime < expiryTime && !fastTimeout.booleanValue()) {
+        while (!client.isReady(node, attemptStartTime) && attemptStartTime < expiryTime) {
             if (client.connectionFailed(node)) {
                 throw new IOException("Connection to " + node + " failed.");
             }
             long pollTimeout = expiryTime - attemptStartTime;
+            if (fastTimeout.booleanValue()) {
+                pollTimeout = 1;
+                expiryTime = 0;
+            }
             client.poll(pollTimeout, attemptStartTime);
             if (client.authenticationException(node) != null)
                 throw client.authenticationException(node);

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -177,6 +177,7 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
       // The call to shutdownLatch.await() in ShutdownableThread.shutdown() serves as a synchronization barrier that
       // hands off the NetworkClient from the RequestSendThread to the ZkEventThread.
       brokerState.requestSendThread.fastTimeout = true
+      brokerState.requestSendThread.networkClient.wakeup();
       brokerState.requestSendThread.shutdown()
       brokerState.networkClient.close()
       brokerState.messageQueue.clear()
@@ -209,7 +210,7 @@ class RequestSendThread(val controllerId: Int,
   extends ShutdownableThread(name = name) {
 
   private val socketTimeoutMs = config.controllerSocketTimeoutMs
-  var fastTimeout: Boolean = false
+  @volatile var fastTimeout: Boolean = false
 
   override def doWork(): Unit = {
 

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -176,6 +176,7 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
       // non-threadsafe classes as described in KAFKA-4959.
       // The call to shutdownLatch.await() in ShutdownableThread.shutdown() serves as a synchronization barrier that
       // hands off the NetworkClient from the RequestSendThread to the ZkEventThread.
+      brokerState.requestSendThread.fastTimeout = true
       brokerState.requestSendThread.shutdown()
       brokerState.networkClient.close()
       brokerState.messageQueue.clear()
@@ -208,6 +209,7 @@ class RequestSendThread(val controllerId: Int,
   extends ShutdownableThread(name = name) {
 
   private val socketTimeoutMs = config.controllerSocketTimeoutMs
+  var fastTimeout: Boolean = false
 
   override def doWork(): Unit = {
 
@@ -266,7 +268,7 @@ class RequestSendThread(val controllerId: Int,
   private def brokerReady(): Boolean = {
     try {
       if (!NetworkClientUtils.isReady(networkClient, brokerNode, time.milliseconds())) {
-        if (!NetworkClientUtils.awaitReady(networkClient, brokerNode, time, socketTimeoutMs))
+        if (!NetworkClientUtils.awaitReady(networkClient, brokerNode, time, socketTimeoutMs, fastTimeout))
           throw new SocketTimeoutException(s"Failed to connect within $socketTimeoutMs ms")
 
         info(s"Controller $controllerId connected to $brokerNode for sending state change requests")


### PR DESCRIPTION
- when broker is unavailable(such as broker's machine is down), controller will wait 30 sec timeout by dedault. it seems to be that the timeout waiting is not necessary. It will be increase the MTTR of dead broker .
![_f7d1d2b4-39ae-4e02-8519-99bcba849668](https://user-images.githubusercontent.com/231336/33720382-c38061d8-db9e-11e7-8a57-083d25abe1a8.png)
