### PR TITLE
KAFKA-6323: document that punctuation is called immediately.

### DIFF
--- a/docs/streams/developer-guide.html
+++ b/docs/streams/developer-guide.html
@@ -132,7 +132,7 @@
     // keep the processor context locally because we need it in punctuate() and commit()
     this.context = context;
 
-    // schedule a punctuation method every 1000 milliseconds.
+    // schedule a punctuation method every 1000 milliseconds, the first punctuation will happen immediately.
     this.context.schedule(1000, PunctuationType.WALL_CLOCK_TIME, new Punctuator() {
         @Override
         public void punctuate(long timestamp) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ProcessorContext.java
@@ -108,6 +108,8 @@ public interface ProcessorContext {
      *   independent of whether new messages arrive. <b>NOTE:</b> This is best effort only as its granularity is limited
      *   by how long an iteration of the processing loop takes to complete</li>
      * </ul>
+     * <b>NOTE:</b> the first punctuation will be called immediately, followed by calls at every interval
+     * according to the punctuation type.
      *
      * @param interval the time interval between punctuations
      * @param type one of: {@link PunctuationType#STREAM_TIME}, {@link PunctuationType#WALL_CLOCK_TIME}


### PR DESCRIPTION
If KAFKA-6323 is not a bug, then it needs better documentation.

Alternative to https://github.com/apache/kafka/pull/4301

@mihbor @mjsax