### PR TITLE
KAFKA-6318: StreamsResetter should return non-zero return code on error

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -240,7 +240,7 @@ public class StreamsResetter {
     private int maybeResetInputAndSeekToEndIntermediateTopicOffsets(final Map consumerConfig, final boolean dryRun) throws Exception {
         final List<String> inputTopics = options.valuesOf(inputTopicsOption);
         final List<String> intermediateTopics = options.valuesOf(intermediateTopicsOption);
-        int topicNotFound = 0;
+        int topicNotFound = EXIT_CODE_SUCCESS;
 
         final List<String> notFoundInputTopics = new ArrayList<>();
         final List<String> notFoundIntermediateTopics = new ArrayList<>();
@@ -249,7 +249,7 @@ public class StreamsResetter {
 
         if (inputTopics.size() == 0 && intermediateTopics.size() == 0) {
             System.out.println("No input or intermediate topics specified. Skipping seek.");
-            return 0;
+            return EXIT_CODE_SUCCESS;
         }
 
         if (inputTopics.size() != 0) {
@@ -328,13 +328,11 @@ public class StreamsResetter {
             }
 
         } catch (final Exception e) {
-
             System.err.println("ERROR: Resetting offsets failed.");
             throw e;
         }
         System.out.println("Done.");
         return topicNotFound;
-
     }
 
     // visible for testing

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -317,7 +317,7 @@ public class StreamsResetter {
                 for (final String topic : notFoundInputTopics) {
                     System.out.println("Topic: " + topic);
                 }
-                topicNotFound = 1;
+                topicNotFound = EXIT_CODE_ERROR;
             }
 
             if (notFoundIntermediateTopics.size() > 0) {

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -130,7 +130,7 @@ public class StreamsResetter {
 
             final HashMap<Object, Object> consumerConfig = new HashMap<>(config);
             consumerConfig.putAll(properties);
-            maybeResetInputAndSeekToEndIntermediateTopicOffsets(consumerConfig, dryRun);
+            exitCode = maybeResetInputAndSeekToEndIntermediateTopicOffsets(consumerConfig, dryRun);
             maybeDeleteInternalTopics(kafkaAdminClient, dryRun);
 
         } catch (final Throwable e) {
@@ -237,9 +237,10 @@ public class StreamsResetter {
         CommandLineUtils.checkInvalidArgs(optionParser, options, shiftByOption, allScenarioOptions.$minus(shiftByOption));
     }
 
-    private void maybeResetInputAndSeekToEndIntermediateTopicOffsets(final Map consumerConfig, final boolean dryRun) throws Exception {
+    private int maybeResetInputAndSeekToEndIntermediateTopicOffsets(final Map consumerConfig, final boolean dryRun) throws Exception {
         final List<String> inputTopics = options.valuesOf(inputTopicsOption);
         final List<String> intermediateTopics = options.valuesOf(intermediateTopicsOption);
+        int topicNotFound = 0;
 
         final List<String> notFoundInputTopics = new ArrayList<>();
         final List<String> notFoundIntermediateTopics = new ArrayList<>();
@@ -248,7 +249,7 @@ public class StreamsResetter {
 
         if (inputTopics.size() == 0 && intermediateTopics.size() == 0) {
             System.out.println("No input or intermediate topics specified. Skipping seek.");
-            return;
+            return 0;
         }
 
         if (inputTopics.size() != 0) {
@@ -316,6 +317,7 @@ public class StreamsResetter {
                 for (final String topic : notFoundInputTopics) {
                     System.out.println("Topic: " + topic);
                 }
+                topicNotFound = 1;
             }
 
             if (notFoundIntermediateTopics.size() > 0) {
@@ -326,10 +328,13 @@ public class StreamsResetter {
             }
 
         } catch (final Exception e) {
+
             System.err.println("ERROR: Resetting offsets failed.");
             throw e;
         }
         System.out.println("Done.");
+        return topicNotFound;
+
     }
 
     // visible for testing

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -73,6 +73,7 @@ abstract class AbstractResetIntegrationTest {
     private static final String OUTPUT_TOPIC_2 = "outputTopic2";
     private static final String OUTPUT_TOPIC_2_RERUN = "outputTopic2_rerun";
     private static final String INTERMEDIATE_USER_TOPIC = "userTopic";
+    private static final String NON_EXISTING_TOPIC = "nonExistingTopic2";
 
     private static final long STREAMS_CONSUMER_TIMEOUT = 2000L;
     private static final long CLEANUP_CONSUMER_TIMEOUT = 2000L;
@@ -612,13 +613,13 @@ abstract class AbstractResetIntegrationTest {
         Assert.assertEquals(0, exitCode);
     }
 
-    void assertInputTopicDoesNotExist() throws Exception {
+    void shouldNotAllowToResetWhileStreamsIsRunning() throws Exception {
 
         final Properties streamsConfiguration = prepareTest();
         final List<String> parameterList = new ArrayList<>(
                 Arrays.asList("--application-id", APP_ID + testNo,
                         "--bootstrap-servers", bootstrapServers,
-                        "--input-topics", INPUT_TOPIC));
+                        "--input-topics", NON_EXISTING_TOPIC));
 
         final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
         final Properties cleanUpConfig = new Properties();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -612,6 +612,30 @@ abstract class AbstractResetIntegrationTest {
         Assert.assertEquals(0, exitCode);
     }
 
+    void assertInputTopicDoesNotExist() throws Exception {
+
+        final Properties streamsConfiguration = prepareTest();
+        final List<String> parameterList = new ArrayList<>(
+                Arrays.asList("--application-id", APP_ID + testNo,
+                        "--bootstrap-servers", bootstrapServers,
+                        "--input-topics", INPUT_TOPIC));
+
+        final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+
+        // RUN
+        KafkaStreams streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), streamsConfiguration);
+        streams.start();
+
+        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
+        Assert.assertEquals(1, exitCode);
+
+        streams.close();
+
+    }
+
     private void assertInternalTopicsGotDeleted(final String intermediateUserTopic) throws Exception {
         // do not use list topics request, but read from the embedded cluster's zookeeper path directly to confirm
         if (intermediateUserTopic != null) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -81,4 +81,9 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     public void testReprocessingByDurationAfterResetWithoutIntermediateUserTopic() throws Exception {
         super.testReprocessingByDurationAfterResetWithoutIntermediateUserTopic();
     }
+
+    @Test
+    public void testInputTopicAbsentWithoutIntermediateUserTopic() throws Exception {
+        super.assertInputTopicDoesNotExist();
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -18,14 +18,21 @@ package org.apache.kafka.streams.integration;
 
 import kafka.server.KafkaConfig$;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.test.IntegrationTest;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import kafka.tools.StreamsResetter;
 
 import java.util.Properties;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * Tests local state store and global application cleanup.
@@ -35,6 +42,10 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @ClassRule
     public static final EmbeddedKafkaCluster CLUSTER;
+    private static final long CLEANUP_CONSUMER_TIMEOUT = 2000L;
+    private static final String APP_ID = "Integration-test";
+    private static final String NON_EXISTING_TOPIC = "nonExistingTopic";
+    private static int testNo = 1;
 
     static {
         final Properties props = new Properties();
@@ -84,6 +95,41 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void testInputTopicAbsentWithoutIntermediateUserTopic() throws Exception {
-        super.assertInputTopicDoesNotExist();
+        super.shouldNotAllowToResetWhileStreamsIsRunning();
     }
+
+    @Test
+    public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
+
+        final List<String> parameterList = new ArrayList<>(
+                Arrays.asList("--application-id", APP_ID + testNo,
+                        "--bootstrap-servers", bootstrapServers,
+                        "--input-topics", NON_EXISTING_TOPIC));
+
+        final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+
+        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
+        Assert.assertEquals(1, exitCode);
+    }
+
+    @Test
+    public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
+
+        final List<String> parameterList = new ArrayList<>(
+                Arrays.asList("--application-id", APP_ID + testNo,
+                        "--bootstrap-servers", bootstrapServers,
+                        "--intermediate-topics", NON_EXISTING_TOPIC));
+
+        final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
+        final Properties cleanUpConfig = new Properties();
+        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
+        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
+
+        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
+        Assert.assertEquals(1, exitCode);
+    }
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -94,7 +94,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
     }
 
     @Test
-    public void testInputTopicAbsentWithoutIntermediateUserTopic() throws Exception {
+    public void shouldNotAllowToResetWhileStreamsRunning() throws Exception {
         super.shouldNotAllowToResetWhileStreamsIsRunning();
     }
 


### PR DESCRIPTION
If users specify a non-existing topic as input parameter, StreamsResetter only prints out an error message that the topic was not found, but return code is still zero. We should return a non-zero return code for this case.

