### PR TITLE
KAFKA-6331; Fix transient failure in AdminClientIntegrationTest.testAlterReplicaLogDirs

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -327,7 +327,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       TestUtils.waitUntilTrue(() => {
         val logDir = server.logManager.getLog(tp).get.dir.getParent
         secondReplicaAssignment(new TopicPartitionReplica(topic, 0, server.config.brokerId)) == logDir
-      }, "timed out waiting for replica movement", 6000L)
+      }, "timed out waiting for replica movement")
     }
 
     // Verify that replica can be moved to the specified log directory while the producer is sending messages
@@ -354,18 +354,18 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     }
 
     try {
-      TestUtils.waitUntilTrue(() => numMessages.get > 10, s"only $numMessages messages are produced before timeout", 6000L)
+      TestUtils.waitUntilTrue(() => numMessages.get > 10, s"only $numMessages messages are produced before timeout")
       client.alterReplicaLogDirs(firstReplicaAssignment.asJava, new AlterReplicaLogDirsOptions).all.get
       servers.foreach { server =>
         TestUtils.waitUntilTrue(() => {
           val logDir = server.logManager.getLog(tp).get.dir.getParent
           firstReplicaAssignment(new TopicPartitionReplica(topic, 0, server.config.brokerId)) == logDir
-        }, "timed out waiting for replica movement", 6000L)
+        }, "timed out waiting for replica movement")
       }
 
       val currentMessagesNum = numMessages.get
       TestUtils.waitUntilTrue(() => numMessages.get - currentMessagesNum > 10,
-        s"only ${numMessages.get - currentMessagesNum} messages are produced within timeout after replica movement", 6000L)
+        s"only ${numMessages.get - currentMessagesNum} messages are produced within timeout after replica movement")
     } finally running.set(false)
 
     val finalNumMessages = Await.result(producerFuture, Duration(20, TimeUnit.SECONDS))


### PR DESCRIPTION
KAFKA-6331; Fix transient failure in AdminClientIntegrationTest.testAlterReplicaLogDirs

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
