### PR TITLE
MINOR: Increase number of messages in replica verification tool test

### DIFF
--- a/tests/kafkatest/tests/tools/replica_verification_test.py
+++ b/tests/kafkatest/tests/tools/replica_verification_test.py
@@ -84,7 +84,7 @@ class ReplicaVerificationToolTest(Test):
                    err_msg="Timed out waiting to reach zero replica lags.")
         self.stop_producer()
 
-        self.start_producer(max_messages=1000, acks=0, timeout=5)
+        self.start_producer(max_messages=10000, acks=0, timeout=5)
         # Verify that there is lag in replicas and is correctly reported by ReplicaVerificationTool
         wait_until(lambda: self.replica_verifier.get_lag_for_partition(TOPIC, 0) > 0, timeout_sec=10,
                    err_msg="Timed out waiting to reach non-zero number of replica lags.")


### PR DESCRIPTION
Increase the number of messages produced to make the test more reliable. The test failed in a recent build and also fails intermittently when run locally. Since the producer uses acks=0 and the test stops as soon as a lag is observed, the change shouldn't have a big impact on the time taken to run when lag is observed sooner.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
