### PR TITLE
MINOR: broker down for significant amt of time system test

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -76,6 +76,13 @@ import static org.apache.kafka.common.requests.IsolationLevel.READ_COMMITTED;
  * StreamsConfig streamsConfig = new StreamsConfig(streamsProperties);
  * }</pre>
  *
+ * When increasing both {@link ProducerConfig#RETRIES_CONFIG} and {@link ProducerConfig#MAX_BLOCK_MS_CONFIG} to be more resilient to non-available brokers you should also
+ * consider increasing {@link ConsumerConfig#MAX_POLL_INTERVAL_MS_CONFIG}  using the following guidance:
+ * <pre>
+ *     max.poll.interval.ms > min ( max.block.ms, (retries +1) * request.timeout.ms )
+ * </pre>
+ *
+ *
  * Kafka Streams requires at least the following properties to be set:
  * <ul>
  *  <li>{@link #APPLICATION_ID_CONFIG "application.id"}</li>

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -113,10 +113,10 @@ public class StreamsBrokerDownResilienceTest {
     }
 
     private static boolean confirmCorrectConfigs(Properties properties) {
-        return properties.contains(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) &&
-               properties.contains(StreamsConfig.producerPrefix(ProducerConfig.RETRIES_CONFIG)) &&
-               properties.contains(StreamsConfig.producerPrefix(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG)) &&
-               properties.contains(StreamsConfig.producerPrefix(ProducerConfig.MAX_BLOCK_MS_CONFIG));
+        return properties.containsKey(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)) &&
+               properties.containsKey(StreamsConfig.producerPrefix(ProducerConfig.RETRIES_CONFIG)) &&
+               properties.containsKey(StreamsConfig.producerPrefix(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG)) &&
+               properties.containsKey(StreamsConfig.producerPrefix(ProducerConfig.MAX_BLOCK_MS_CONFIG));
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.kafka.streams.tests;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.Consumed;
@@ -60,13 +58,9 @@ public class StreamsBrokerDownResilienceTest {
         streamsProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
         streamsProperties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
 
-        final int timeout = 15000;
-        // when setting Producer Retries and Request timeout Consumer max.poll.interval > min(max.block.ms, (retries + 1 * request.timeout)
-        streamsProperties.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), timeout * 3);
-        streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.RETRIES_CONFIG), 2);
-        streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), timeout);
-        streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.MAX_BLOCK_MS_CONFIG), timeout * 2);
 
+        // it is expected that max.poll.interval, retries, request.timeout and max.block.ms set
+        // streams_broker_down_resilience_test and passed as args
         if (additionalConfigs != null && !additionalConfigs.equalsIgnoreCase("none")) {
             System.out.println("Updating configs with " + additionalConfigs);
             streamsProperties.putAll(updatedConfigs(additionalConfigs));

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.tests;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.test.TestUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+public class StreamsBrokerDownResilienceTest {
+
+    private static final int KEY = 0;
+    private static final int VALUE = 1;
+
+    private static String SOURCE_TOPIC_1 = "streamsResilienceSource";
+
+    private static String SINK_TOPIC = "streamsResilienceSink";
+
+    public static void main(String[] args) {
+
+        System.out.println("StreamsTest instance started");
+
+        final String kafka = args.length > 0 ? args[0] : "localhost:9092";
+        final String stateDirStr = args.length > 1 ? args[1] : TestUtils.tempDirectory().getAbsolutePath();
+        final String additionalConfigs = args.length > 2 ? args[2] : null;
+
+        final Serde<String> stringSerde = Serdes.String();
+
+        final Properties streamsProperties = new Properties();
+        streamsProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
+        streamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, "kafka-streams-resilience");
+        streamsProperties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsProperties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        streamsProperties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+
+        final int timeout = 15000;
+        // when setting Producer Retries and Request timeout Consumer max.poll.interval > min(max.block.ms, (retries * request.timeout)
+        streamsProperties.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), timeout * 3);
+        streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.RETRIES_CONFIG), 2);
+        streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), timeout);
+        streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.MAX_BLOCK_MS_CONFIG), timeout * 2);
+
+        if (additionalConfigs != null && !additionalConfigs.equalsIgnoreCase("none")) {
+            System.out.println("Updating configs with " + additionalConfigs);
+            streamsProperties.putAll(updatedConfigs(additionalConfigs));
+        }
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.stream(Collections.singletonList(SOURCE_TOPIC_1), Consumed.with(stringSerde, stringSerde))
+            .peek(new ForeachAction<String, String>() {
+                @Override
+                public void apply(String key, String value) {
+                    System.out.println("received key " + key + " and value " + value);
+                }
+            }).to(SINK_TOPIC);
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), streamsProperties);
+
+        streams.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(final Thread t, final Throwable e) {
+                System.err.println("FATAL: An unexpected exception " + e);
+                System.err.flush();
+                streams.close(30, TimeUnit.SECONDS);
+            }
+        });
+        System.out.println("Start Kafka Streams");
+        streams.start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("Shutting down streams now");
+                streams.close(10, TimeUnit.SECONDS);
+            }
+        }));
+
+
+    }
+
+    /**
+     * Takes a string with keys and values separated by '=' and each key value pair
+     * separated by ',' for example max.block.ms=5000,retries=6,request.timeout.ms=6000
+     *
+     * @param formattedConfigs the formatted config string
+     * @return HashMap with keys and values inserted
+     */
+    private static Map<String, String> updatedConfigs(String formattedConfigs) {
+        String[] parts = formattedConfigs.split(",");
+        Map<String, String> updatedConfigs = new HashMap<>();
+        for (String part : parts) {
+            String[] keyValue = part.split("=");
+            updatedConfigs.put(keyValue[KEY], keyValue[VALUE]);
+        }
+        return updatedConfigs;
+    }
+
+}

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsBrokerDownResilienceTest.java
@@ -39,9 +39,9 @@ public class StreamsBrokerDownResilienceTest {
     private static final int KEY = 0;
     private static final int VALUE = 1;
 
-    private static String SOURCE_TOPIC_1 = "streamsResilienceSource";
+    private static final String SOURCE_TOPIC_1 = "streamsResilienceSource";
 
-    private static String SINK_TOPIC = "streamsResilienceSink";
+    private static final String SINK_TOPIC = "streamsResilienceSink";
 
     public static void main(String[] args) {
 
@@ -61,7 +61,7 @@ public class StreamsBrokerDownResilienceTest {
         streamsProperties.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
 
         final int timeout = 15000;
-        // when setting Producer Retries and Request timeout Consumer max.poll.interval > min(max.block.ms, (retries * request.timeout)
+        // when setting Producer Retries and Request timeout Consumer max.poll.interval > min(max.block.ms, (retries + 1 * request.timeout)
         streamsProperties.put(StreamsConfig.consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), timeout * 3);
         streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.RETRIES_CONFIG), 2);
         streamsProperties.put(StreamsConfig.producerPrefix(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG), timeout);

--- a/tests/kafkatest/services/streams.py
+++ b/tests/kafkatest/services/streams.py
@@ -207,3 +207,10 @@ class StreamsBrokerCompatibilityService(StreamsTestBaseService):
                                                                 kafka,
                                                                 "org.apache.kafka.streams.tests.BrokerCompatibilityTest",
                                                                 eosEnabled)
+
+class StreamsBrokerDownResilienceService(StreamsTestBaseService):
+    def __init__(self, test_context, kafka, configs):
+        super(StreamsBrokerDownResilienceService, self).__init__(test_context,
+                                                                 kafka,
+                                                                 "org.apache.kafka.streams.tests.StreamsBrokerDownResilienceTest",
+                                                                 configs)

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -1,0 +1,99 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from ducktape.tests.test import Test
+from ducktape.utils.util import wait_until
+from kafkatest.services.kafka import KafkaService
+from kafkatest.services.streams import StreamsBrokerDownResilienceService
+from kafkatest.services.verifiable_consumer import VerifiableConsumer
+from kafkatest.services.verifiable_producer import VerifiableProducer
+from kafkatest.services.zookeeper import ZookeeperService
+
+
+class StreamsBrokerDownResilience(Test):
+    """
+    This test validates that Streams is resilient to a broker
+    being down longer than specified timeouts in configs
+    """
+
+    inputTopic = "streamsResilienceSource"
+    outputTopic = "streamsResilienceSink"
+    num_messages = 10
+
+    def __init__(self, test_context):
+        super(StreamsBrokerDownResilience, self).__init__(test_context=test_context)
+        self.zk = ZookeeperService(test_context, num_nodes=1)
+        self.kafka = KafkaService(test_context,
+                                  num_nodes=1,
+                                  zk=self.zk,
+                                  topics={
+                                      self.inputTopic: {'partitions': 1, 'replication-factor': 1},
+                                      self.outputTopic: {'partitions': 1, 'replication-factor': 1}
+                                  })
+
+    def get_consumer(self):
+        return VerifiableConsumer(self.test_context,
+                                  1,
+                                  self.kafka,
+                                  self.outputTopic,
+                                  "stream-broker-resilience-verify-consumer",
+                                  max_messages=self.num_messages)
+
+    def get_producer(self):
+        return VerifiableProducer(self.test_context,
+                                  1,
+                                  self.kafka,
+                                  self.inputTopic,
+                                  max_messages=self.num_messages,
+                                  acks=1)
+
+    def assert_produce_consume(self, test_state):
+        producer = self.get_producer()
+        producer.start()
+
+        wait_until(lambda: producer.num_acked > 0,
+                   timeout_sec=30,
+                   err_msg="At %s failed to send messages " % test_state)
+
+        consumer = self.get_consumer()
+        consumer.start()
+
+        wait_until(lambda: consumer.total_consumed() > 0,
+                   timeout_sec=60,
+                   err_msg="At %s streams did not process messages in 60 seconds " % test_state)
+
+    def setUp(self):
+        self.zk.start()
+
+    def test_streams_resilient_to_broker_down(self):
+        self.kafka.start()
+
+        processor = StreamsBrokerDownResilienceService(self.test_context, self.kafka, "none")
+        processor.start()
+
+        self.assert_produce_consume("before_broker_stop")
+
+        node = self.kafka.leader(self.inputTopic)
+
+        self.kafka.stop_node(node)
+
+        time.sleep(70)
+
+        self.kafka.start_node(node)
+
+        self.assert_produce_consume("after_broker_stop")
+
+        self.kafka.stop()

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -31,7 +31,7 @@ class StreamsBrokerDownResilience(Test):
 
     inputTopic = "streamsResilienceSource"
     outputTopic = "streamsResilienceSink"
-    num_messages = 10
+    num_messages = 5
 
     def __init__(self, test_context):
         super(StreamsBrokerDownResilience, self).__init__(test_context=test_context)
@@ -84,6 +84,8 @@ class StreamsBrokerDownResilience(Test):
         processor = StreamsBrokerDownResilienceService(self.test_context, self.kafka, "none")
         processor.start()
 
+        # until KIP-91 is merged we'll only send 5 messages to assert Kafka Streams is running before taking the broker down
+        # After KIP-91 is merged we'll continue to send messages the duration of the test
         self.assert_produce_consume("before_broker_stop")
 
         node = self.kafka.leader(self.inputTopic)


### PR DESCRIPTION
System test where a broker is offline more than the configured timeouts.  In this case:
- Max poll interval set to 45 secs
- Retries set to 2
- Request timeout set to 15 seconds
- Max block ms set to 30 seconds

The broker was taken off-line for 70 seconds or more than double request timeout * num retries

[passing system test results](http://confluent-kafka-branch-builder-system-test-results.s3-us-west-2.amazonaws.com/2017-12-11--001.1513034559--bbejeck--KSTREAMS_1179_broker_down_for_significant_amt_of_time--6ab4802/report.html)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
