### PR TITLE
MINOR: fix warn logging in RecordCollectorImpl

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -107,7 +107,7 @@ public class RecordCollectorImpl implements RecordCollector {
                     } else {
                         if (sendException == null) {
                             if (exception instanceof ProducerFencedException) {
-                                log.warn(LOG_MESSAGE, key, value, timestamp, topic, exception);
+                                log.warn(LOG_MESSAGE, key, value, timestamp, topic, exception.getMessage());
                                 sendException = new ProducerFencedException(
                                     String.format(EXCEPTION_MESSAGE,
                                                   logPrefix,


### PR DESCRIPTION
Fix warn log message in RecordCollectorImpl so it prints the exception message rather than `{}`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
