### PR TITLE
KAFKA-6342 : Move workaround for JSON parsing of non-escaped strings

### DIFF
--- a/core/src/main/scala/kafka/consumer/TopicCount.scala
+++ b/core/src/main/scala/kafka/consumer/TopicCount.scala
@@ -64,7 +64,7 @@ private[kafka] object TopicCount extends Logging {
     var subscriptionPattern: String = null
     var topMap: Map[String, Int] = null
     try {
-      Json.parseFull(topicCountString) match {
+      Json.parseFullIncludingACLs(topicCountString) match {
         case Some(js) =>
           val consumerRegistrationMap = js.asJsonObject
           consumerRegistrationMap.get("pattern") match {

--- a/core/src/main/scala/kafka/consumer/TopicCount.scala
+++ b/core/src/main/scala/kafka/consumer/TopicCount.scala
@@ -64,7 +64,7 @@ private[kafka] object TopicCount extends Logging {
     var subscriptionPattern: String = null
     var topMap: Map[String, Int] = null
     try {
-      Json.parseFullIncludingACLs(topicCountString) match {
+      Json.parseFull(topicCountString) match {
         case Some(js) =>
           val consumerRegistrationMap = js.asJsonObject
           consumerRegistrationMap.get("pattern") match {

--- a/core/src/main/scala/kafka/security/auth/Acl.scala
+++ b/core/src/main/scala/kafka/security/auth/Acl.scala
@@ -58,7 +58,7 @@ object Acl {
     if (bytes == null || bytes.isEmpty)
       return collection.immutable.Set.empty[Acl]
 
-    Json.parseBytes(bytes).map(_.asJsonObject).map { js =>
+    Json.parseBytesIncludingACLs(bytes).map(_.asJsonObject).map { js =>
       //the acl json version.
       require(js(VersionKey).to[Int] == CurrentVersion)
       js(AclsKey).asJsonArray.iterator.map(_.asJsonObject).map { itemJs =>

--- a/core/src/main/scala/kafka/security/auth/Acl.scala
+++ b/core/src/main/scala/kafka/security/auth/Acl.scala
@@ -17,9 +17,15 @@
 
 package kafka.security.auth
 
+import java.nio.charset.StandardCharsets
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
 import kafka.utils.Json
+import kafka.utils.json.JsonValue
 import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.SecurityUtils
+
 import scala.collection.JavaConverters._
 
 object Acl {
@@ -33,6 +39,7 @@ object Acl {
   val VersionKey = "version"
   val CurrentVersion = 1
   val AclsKey = "acls"
+  private val mapper = new ObjectMapper()
 
   /**
    *
@@ -58,7 +65,7 @@ object Acl {
     if (bytes == null || bytes.isEmpty)
       return collection.immutable.Set.empty[Acl]
 
-    Json.parseBytesIncludingACLs(bytes).map(_.asJsonObject).map { js =>
+    tryParseBytesIncludingACLs(bytes).right.map(_.asJsonObject).right.map { js =>
       //the acl json version.
       require(js(VersionKey).to[Int] == CurrentVersion)
       js(AclsKey).asJsonArray.iterator.map(_.asJsonObject).map { itemJs =>
@@ -68,12 +75,28 @@ object Acl {
         val operation = Operation.fromString(itemJs(OperationKey).to[String])
         new Acl(principal, permissionType, host, operation)
       }.toSet
-    }.getOrElse(Set.empty)
+    }.right.getOrElse(Set.empty)
   }
 
   def toJsonCompatibleMap(acls: Set[Acl]): Map[String, Any] = {
     Map(Acl.VersionKey -> Acl.CurrentVersion, Acl.AclsKey -> acls.map(acl => acl.toMap.asJava).toList.asJava)
   }
+
+  /**
+    * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON. This method is currently used
+    * to read the already stored invalid ACLs JSON which was persisted using older versions of Kafka (prior to Kafka 1.1.0). KAFKA-6319
+    */
+  private def tryParseBytesIncludingACLs(input: Array[Byte]): Either[JsonProcessingException, JsonValue] =
+    try Right(mapper.readTree(input)).right.map(JsonValue(_))
+    catch {
+      case _: JsonProcessingException =>
+        // Before 1.0.1, Json#encode did not escape backslash or any other special characters. SSL principals
+        // stored in ACLs may contain backslash as an escape char, making the JSON generated in earlier versions invalid.
+        // Escape backslash and retry to handle these strings which may have been persisted in ZK.
+        // Note that this does not handle all special characters (e.g. non-escaped double quotes are not supported)
+        val escapedInput = new String(input, StandardCharsets.UTF_8).replaceAll("\\\\", "\\\\\\\\")
+        Json.tryParseBytes(escapedInput.getBytes(StandardCharsets.UTF_8))
+    }
 }
 
 /**

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -16,6 +16,8 @@
  */
 package kafka.utils
 
+import java.nio.charset.StandardCharsets
+
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import kafka.utils.json.JsonValue
@@ -42,7 +44,7 @@ object Json {
    * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON. This method is currently used
     * to read the already stored invalid ACLs JSON which was persisted using older versions of Kafka (prior to Kafka 1.1.0). KAFKA-6319
    */
-  def parseFullIncludingACLs(input: String): Option[JsonValue] =
+  def parseBytesIncludingACLs(input: Array[Byte]): Option[JsonValue] =
     try Option(mapper.readTree(input)).map(JsonValue(_))
     catch {
       case _: JsonProcessingException =>
@@ -50,7 +52,7 @@ object Json {
         // stored in ACLs may contain backslash as an escape char, making the JSON generated in earlier versions invalid.
         // Escape backslash and retry to handle these strings which may have been persisted in ZK.
         // Note that this does not handle all special characters (e.g. non-escaped double quotes are not supported)
-        val escapedInput = input.replaceAll("\\\\", "\\\\\\\\")
+        val escapedInput = new String(input, StandardCharsets.UTF_8).replaceAll("\\\\", "\\\\\\\\")
         try Option(mapper.readTree(escapedInput)).map(JsonValue(_))
         catch { case _: JsonProcessingException => None }
     }

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -16,8 +16,6 @@
  */
 package kafka.utils
 
-import java.nio.charset.StandardCharsets
-
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import kafka.utils.json.JsonValue
@@ -33,8 +31,8 @@ object Json {
   private val mapper = new ObjectMapper()
 
   /**
-    * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON.
-    */
+   * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON.
+   */
   def parseFull(input: String): Option[JsonValue] =
     try Option(mapper.readTree(input)).map(JsonValue(_))
     catch { case _: JsonProcessingException => None }

--- a/core/src/main/scala/kafka/utils/Json.scala
+++ b/core/src/main/scala/kafka/utils/Json.scala
@@ -31,9 +31,18 @@ object Json {
   private val mapper = new ObjectMapper()
 
   /**
-   * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON.
-   */
+    * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON.
+    */
   def parseFull(input: String): Option[JsonValue] =
+    try Option(mapper.readTree(input)).map(JsonValue(_))
+    catch { case _: JsonProcessingException => None }
+
+
+  /**
+   * Parse a JSON string into a JsonValue if possible. `None` is returned if `input` is not valid JSON. This method is currently used
+    * to read the already stored invalid ACLs JSON which was persisted using older versions of Kafka (prior to Kafka 1.1.0). KAFKA-6319
+   */
+  def parseFullIncludingACLs(input: String): Option[JsonValue] =
     try Option(mapper.readTree(input)).map(JsonValue(_))
     catch {
       case _: JsonProcessingException =>

--- a/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
@@ -27,11 +27,11 @@ import scala.collection.JavaConverters._
 
 class AclTest extends JUnitSuite {
 
-  val AclJson = "{\"version\": 1, \"acls\": [{\"host\": \"host1\",\"permissionType\": \"Deny\",\"operation\": \"READ\", \"principal\": \"User:alice\"  },  " +
-    "{  \"host\":  \"*\" ,  \"permissionType\": \"Allow\",  \"operation\":  \"Read\", \"principal\": \"User:bob\"  },  " +
-    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:bob\"},  " +
-    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:\\bob\"}, " +
-    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:bob1\\bob2\"}]}"
+  val AclJson = """{"version": 1, "acls": [{"host": "host1","permissionType": "Deny","operation": "READ", "principal": "User:alice"  },
+    {  "host":  "*" ,  "permissionType": "Allow",  "operation":  "Read", "principal": "User:bob"  },
+    {  "host": "host1",  "permissionType": "Deny",  "operation":   "Read" ,  "principal": "User:bob"},
+    {  "host": "host1",  "permissionType": "Deny",  "operation":   "Read" ,  "principal": "User:\\bob"},
+    {  "host": "host1",  "permissionType": "Deny",  "operation":   "Read" ,  "principal": "User:bob1\\bob2"}]}"""
 
   @Test
   def testAclJsonConversion(): Unit = {

--- a/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
@@ -18,11 +18,15 @@ package kafka.security.auth
 
 import java.nio.charset.StandardCharsets.UTF_8
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import kafka.utils.Json
 import org.apache.kafka.common.security.auth.KafkaPrincipal
+import org.junit.Assert.assertEquals
 import org.junit.{Assert, Test}
 import org.scalatest.junit.JUnitSuite
+
 import scala.collection.JavaConverters._
+import scala.collection.Map
 
 class AclTest extends JUnitSuite {
 
@@ -41,6 +45,15 @@ class AclTest extends JUnitSuite {
 
     Assert.assertEquals(acls, Acl.fromBytes(jsonAcls))
     Assert.assertEquals(acls, Acl.fromBytes(AclJson.getBytes(UTF_8)))
+  }
+
+  @Test
+  def testJsonParseWithBackslashEscaping() = {
+    // Test with encoder that properly escapes backslash and quotes
+    val map = Map("foo1" -> """bar1\,bar2""", "foo2" -> """\bar""")
+    val encoded = Json.legacyEncodeAsString(map)
+    val decoded = Json.parseFull(encoded)
+    assertEquals(Json.parseFull("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
   }
 
 }

--- a/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
+++ b/core/src/test/scala/unit/kafka/security/auth/AclTest.scala
@@ -30,8 +30,8 @@ class AclTest extends JUnitSuite {
   val AclJson = "{\"version\": 1, \"acls\": [{\"host\": \"host1\",\"permissionType\": \"Deny\",\"operation\": \"READ\", \"principal\": \"User:alice\"  },  " +
     "{  \"host\":  \"*\" ,  \"permissionType\": \"Allow\",  \"operation\":  \"Read\", \"principal\": \"User:bob\"  },  " +
     "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:bob\"},  " +
-    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:\\\\bob\"}, " +
-    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:bob1\\\\bob2\"}]}"
+    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:\\bob\"}, " +
+    "{  \"host\": \"host1\",  \"permissionType\": \"Deny\",  \"operation\":   \"Read\" ,  \"principal\": \"User:bob1\\bob2\"}]}"
 
   @Test
   def testAclJsonConversion(): Unit = {

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -57,12 +57,12 @@ class JsonTest {
     // Test with encoder that properly escapes backslash and quotes
     val map = Map("foo1" -> """bar1\,bar2""", "foo2" -> """\bar""")
     val encoded = Json.legacyEncodeAsString(map)
-    val decoded = Json.parseFull(encoded)
-    assertEquals(Json.parseFull("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
+    val decoded = Json.parseFullIncludingACLs(encoded)
+    assertEquals(Json.parseFullIncludingACLs("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
 
     // Test strings with non-escaped backslash and quotes. This is to verify that ACLs
     // containing non-escaped chars persisted using 1.0 can be parsed.
-    assertEquals(decoded, Json.parseFull("""{"foo1":"bar1\,bar2", "foo2":"\bar"}"""))
+    assertEquals(decoded, Json.parseFullIncludingACLs("""{"foo1":"bar1\,bar2", "foo2":"\bar"}"""))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -57,12 +57,12 @@ class JsonTest {
     // Test with encoder that properly escapes backslash and quotes
     val map = Map("foo1" -> """bar1\,bar2""", "foo2" -> """\bar""")
     val encoded = Json.legacyEncodeAsString(map)
-    val decoded = Json.parseFullIncludingACLs(encoded)
-    assertEquals(Json.parseFullIncludingACLs("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
+    val decoded = Json.parseFull(encoded)
+    assertEquals(Json.parseFull("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
 
     // Test strings with non-escaped backslash and quotes. This is to verify that ACLs
     // containing non-escaped chars persisted using 1.0 can be parsed.
-    assertEquals(decoded, Json.parseFullIncludingACLs("""{"foo1":"bar1\,bar2", "foo2":"\bar"}"""))
+    assertEquals(decoded, Json.parseFull("""{"foo1":"bar1\,bar2", "foo2":"\bar"}"""))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -54,6 +54,11 @@ class JsonTest {
     Vector(1, 2, 3).map(new IntNode(_)).foreach(arrayNode.add)
     assertEquals(Json.parseFull("[1, 2, 3]"), Some(JsonValue(arrayNode)))
 
+    // Test with encoder that properly escapes backslash and quotes
+    val map = Map("foo1" -> """bar1\,bar2""", "foo2" -> """\bar""")
+    val encoded = Json.legacyEncodeAsString(map)
+    val decoded = Json.parseFull(encoded)
+    assertEquals(Json.parseFull("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -57,19 +57,6 @@ class JsonTest {
   }
 
   @Test
-  def testJsonParseWithBackslashEscaping() = {
-    // Test with encoder that properly escapes backslash and quotes
-    val map = Map("foo1" -> """bar1\,bar2""", "foo2" -> """\bar""")
-    val encoded = Json.legacyEncodeAsString(map)
-    val decoded = Json.parseFull(encoded)
-    assertEquals(Json.parseFull("""{"foo1":"bar1\\,bar2", "foo2":"\\bar"}"""), decoded)
-
-    // Test strings with non-escaped backslash and quotes. This is to verify that ACLs
-    // containing non-escaped chars persisted using 1.0 can be parsed.
-    assertEquals(decoded, Json.parseBytesIncludingACLs("""{"foo1":"bar1\,bar2", "foo2":"\bar"}""".getBytes()))
-  }
-
-  @Test
   def testLegacyEncodeAsString() {
     assertEquals("null", Json.legacyEncodeAsString(null))
     assertEquals("1", Json.legacyEncodeAsString(1))

--- a/core/src/test/scala/unit/kafka/utils/JsonTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/JsonTest.scala
@@ -54,6 +54,10 @@ class JsonTest {
     Vector(1, 2, 3).map(new IntNode(_)).foreach(arrayNode.add)
     assertEquals(Json.parseFull("[1, 2, 3]"), Some(JsonValue(arrayNode)))
 
+  }
+
+  @Test
+  def testJsonParseWithBackslashEscaping() = {
     // Test with encoder that properly escapes backslash and quotes
     val map = Map("foo1" -> """bar1\,bar2""", "foo2" -> """\bar""")
     val encoded = Json.legacyEncodeAsString(map)
@@ -62,7 +66,7 @@ class JsonTest {
 
     // Test strings with non-escaped backslash and quotes. This is to verify that ACLs
     // containing non-escaped chars persisted using 1.0 can be parsed.
-    assertEquals(decoded, Json.parseFull("""{"foo1":"bar1\,bar2", "foo2":"\bar"}"""))
+    assertEquals(decoded, Json.parseBytesIncludingACLs("""{"foo1":"bar1\,bar2", "foo2":"\bar"}""".getBytes()))
   }
 
   @Test


### PR DESCRIPTION
This PR moves the JSON parsing workaround of [this PR](https://github.com/apache/kafka/pull/4303) to new method and uses this method in `ZkClient` etc. classes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
