### PR TITLE
Check null message

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -429,7 +429,12 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
           try {
             while (!exitingOnSendFailure && !shuttingDown && mirrorMakerConsumer.hasData) {
               val data = mirrorMakerConsumer.receive()
-              trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+              if (data.value != null) {
+                trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+              } else {
+                trace("Sending message with null value and offset %d".format(data.offset))
+
+              }
               val records = messageHandler.handle(data)
               records.asScala.foreach(producer.send)
               maybeFlushAndCommitOffsets()

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -744,12 +744,21 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
    */
   trait MirrorMakerMessageHandler {
     def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]]
+    def run(record: BaseConsumerRecord): String
   }
 
   private[tools] object defaultMirrorMakerMessageHandler extends MirrorMakerMessageHandler {
     override def handle(record: BaseConsumerRecord): util.List[ProducerRecord[Array[Byte], Array[Byte]]] = {
       val timestamp: java.lang.Long = if (record.timestamp == Record.NO_TIMESTAMP) null else record.timestamp
       Collections.singletonList(new ProducerRecord[Array[Byte], Array[Byte]](record.topic, null, timestamp, record.key, record.value))
+    }
+
+    override def run(record: BaseConsumerRecord): String = {
+      if (record.value != null) {
+        new String("Sending message with value size %d and offset %d".format(record.value.length, record.offset))
+      } else {
+        new String("Sending message with null value and offset %d".format(record.offset))
+      }
     }
   }
 

--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -58,22 +58,13 @@ class MirrorMakerTest {
   @Test
   def TestDefaultMirrorMakerMessageHandlerWithNullValue()
   {
-    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, Record.NO_TIMESTAMP, TimestampType.CREATE_TIME, "key".getBytes, null)
-    val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
-    assertEquals(1, result.size)
+    val consumerRecordWithNullValue = BaseConsumerRecord("topic", 0, 1L, Record.NO_TIMESTAMP, TimestampType.CREATE_TIME, "key".getBytes, null)
+    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, Record.NO_TIMESTAMP, TimestampType.CREATE_TIME, "key".getBytes, "value".getBytes)
 
-    val producerRecord = result.get(0)
-    assertNull(producerRecord.timestamp)
-    assertEquals("topic", producerRecord.topic)
-    assertNull(producerRecord.partition)
-    assertEquals("key", new String(producerRecord.key))
-    assertNull(producerRecord.value())
+    val logWithNullValue = MirrorMaker.defaultMirrorMakerMessageHandler.run(consumerRecordWithNullValue)
+    val log = MirrorMaker.defaultMirrorMakerMessageHandler.run(consumerRecord)
 
-    if (consumerRecord.value != null) {
-      new String("Sending message with value size %d and offset %d".format(consumerRecord.value.length, consumerRecord.offset))
-    } else {
-      new String("Sending message with null value and offset %d".format(consumerRecord.offset))
-
-    }
+    assertEquals("Sending message with null value and offset 1", logWithNullValue)
+    assertEquals("Sending message with value size 5 and offset 1", log)
   }
 }

--- a/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/MirrorMakerTest.scala
@@ -55,4 +55,25 @@ class MirrorMakerTest {
     assertEquals("value", new String(producerRecord.value))
   }
 
+  @Test
+  def TestDefaultMirrorMakerMessageHandlerWithNullValue()
+  {
+    val consumerRecord = BaseConsumerRecord("topic", 0, 1L, Record.NO_TIMESTAMP, TimestampType.CREATE_TIME, "key".getBytes, null)
+    val result = MirrorMaker.defaultMirrorMakerMessageHandler.handle(consumerRecord)
+    assertEquals(1, result.size)
+
+    val producerRecord = result.get(0)
+    assertNull(producerRecord.timestamp)
+    assertEquals("topic", producerRecord.topic)
+    assertNull(producerRecord.partition)
+    assertEquals("key", new String(producerRecord.key))
+    assertNull(producerRecord.value())
+
+    if (consumerRecord.value != null) {
+      new String("Sending message with value size %d and offset %d".format(consumerRecord.value.length, consumerRecord.offset))
+    } else {
+      new String("Sending message with null value and offset %d".format(consumerRecord.offset))
+
+    }
+  }
 }


### PR DESCRIPTION
When enable the trace level log in mirror maker,  the message could contain null value, and this will throw null pointer exception.

*Summary of testing strategy (including rationale)
1. Create message contain null value and normal message
2. Passing throw testing case
3. and make sure don't not throw any thing