### PR TITLE
KAFKA-6383: complete shutdown for CREATED StreamThreads

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -796,23 +796,23 @@ public class KafkaStreams {
         } else {
             stateDirCleaner.shutdownNow();
 
-            // notify all the threads to stop; avoid deadlocks by stopping any
-            // further state reports from the thread since we're shutting down
-            for (final StreamThread thread : threads) {
-                thread.setStateListener(null);
-                thread.shutdown();
-            }
-            if (globalStreamThread != null) {
-                globalStreamThread.setStateListener(null);
-                globalStreamThread.shutdown();
-            }
-
             // wait for all threads to join in a separate thread;
             // save the current thread so that if it is a stream thread
             // we don't attempt to join it and cause a deadlock
             final Thread shutdownThread = new Thread(new Runnable() {
                 @Override
                 public void run() {
+                    // notify all the threads to stop; avoid deadlocks by stopping any
+                    // further state reports from the thread since we're shutting down
+                    for (final StreamThread thread : threads) {
+                        thread.setStateListener(null);
+                        thread.shutdown();
+                    }
+                    if (globalStreamThread != null) {
+                        globalStreamThread.setStateListener(null);
+                        globalStreamThread.shutdown();
+                    }
+
                     for (final StreamThread thread : threads) {
                         try {
                             if (!thread.isRunning()) {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -796,6 +796,15 @@ public class KafkaStreams {
         } else {
             stateDirCleaner.shutdownNow();
 
+            for (final StreamThread thread : threads) {
+                thread.setStateListener(null);
+                thread.shutdown();
+            }
+            if (globalStreamThread != null) {
+                globalStreamThread.setStateListener(null);
+                globalStreamThread.shutdown();
+            }
+
             // wait for all threads to join in a separate thread;
             // save the current thread so that if it is a stream thread
             // we don't attempt to join it and cause a deadlock
@@ -804,15 +813,6 @@ public class KafkaStreams {
                 public void run() {
                     // notify all the threads to stop; avoid deadlocks by stopping any
                     // further state reports from the thread since we're shutting down
-                    for (final StreamThread thread : threads) {
-                        thread.setStateListener(null);
-                        thread.shutdown();
-                    }
-                    if (globalStreamThread != null) {
-                        globalStreamThread.setStateListener(null);
-                        globalStreamThread.shutdown();
-                    }
-
                     for (final StreamThread thread : threads) {
                         try {
                             if (!thread.isRunning()) {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -796,6 +796,8 @@ public class KafkaStreams {
         } else {
             stateDirCleaner.shutdownNow();
 
+            // notify all the threads to stop; avoid deadlocks by stopping any
+            // further state reports from the thread since we're shutting down
             for (final StreamThread thread : threads) {
                 thread.setStateListener(null);
                 thread.shutdown();
@@ -811,8 +813,6 @@ public class KafkaStreams {
             final Thread shutdownThread = new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    // notify all the threads to stop; avoid deadlocks by stopping any
-                    // further state reports from the thread since we're shutting down
                     for (final StreamThread thread : threads) {
                         try {
                             if (!thread.isRunning()) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -173,6 +173,7 @@ public class StreamThread extends Thread {
     /**
      * Sets the state
      * @param newState New state
+     * @return The state prior to the call to setState, or null if the transition is invalid
      */
     State setState(final State newState) {
         final State oldState;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -174,7 +174,7 @@ public class StreamThread extends Thread {
      * Sets the state
      * @param newState New state
      */
-    boolean setState(final State newState) {
+    State setState(final State newState) {
         final State oldState;
 
         synchronized (stateLock) {
@@ -183,15 +183,15 @@ public class StreamThread extends Thread {
             if (state == State.PENDING_SHUTDOWN && newState != State.DEAD) {
                 // when the state is already in PENDING_SHUTDOWN, all other transitions will be
                 // refused but we do not throw exception here
-                return false;
+                return null;
             } else if (state == State.DEAD) {
                 // when the state is already in NOT_RUNNING, all its transitions
                 // will be refused but we do not throw exception here
-                return false;
+                return null;
             } else if (state == State.PARTITIONS_REVOKED && newState == State.PARTITIONS_REVOKED) {
                 // when the state is already in PARTITIONS_REVOKED, its transition to itself will be
                 // refused but we do not throw exception here
-                return false;
+                return null;
             } else if (!state.isValidTransition(newState)) {
                 log.error("Unexpected state transition from {} to {}", oldState, newState);
                 throw new StreamsException(logPrefix + "Unexpected state transition from " + oldState + " to " + newState);
@@ -211,11 +211,7 @@ public class StreamThread extends Thread {
             stateListener.onChange(this, state, oldState);
         }
 
-        if (oldState == State.CREATED && newState == State.PENDING_SHUTDOWN) {
-            completeShutdown(true);
-        }
-
-        return true;
+        return oldState;
     }
 
     public boolean isRunningAndNotRebalancing() {
@@ -257,7 +253,7 @@ public class StreamThread extends Thread {
 
             final long start = time.milliseconds();
             try {
-                if (!streamThread.setState(State.PARTITIONS_ASSIGNED)) {
+                if (streamThread.setState(State.PARTITIONS_ASSIGNED) == null) {
                     return;
                 }
                 taskManager.createTasks(assignment);
@@ -287,7 +283,7 @@ public class StreamThread extends Thread {
                 taskManager.activeTaskIds(),
                 taskManager.standbyTaskIds());
 
-            if (streamThread.setState(State.PARTITIONS_REVOKED)) {
+            if (streamThread.setState(State.PARTITIONS_REVOKED) != null) {
                 final long start = time.milliseconds();
                 try {
                     // suspend active tasks
@@ -720,8 +716,9 @@ public class StreamThread extends Thread {
     @Override
     public void run() {
         log.info("Starting");
-        if (!setState(State.RUNNING)) {
+        if (setState(State.RUNNING) == null) {
             log.info("StreamThread already shutdown. Not running");
+            completeShutdown(true);
             return;
         }
         boolean cleanRun = false;
@@ -1097,7 +1094,11 @@ public class StreamThread extends Thread {
      */
     public void shutdown() {
         log.info("Informed to shut down");
-        setState(State.PENDING_SHUTDOWN);
+        State oldState = setState(State.PENDING_SHUTDOWN);
+        if (oldState == State.CREATED) {
+            // Start so that we shutdown on the thread
+            this.start();
+        }
     }
 
     private void completeShutdown(final boolean cleanRun) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java
@@ -274,7 +274,11 @@ class TaskManager {
         standby.close(clean);
 
         // remove the changelog partitions from restore consumer
-        restoreConsumer.unsubscribe();
+        try {
+            restoreConsumer.unsubscribe();
+        } catch (final RuntimeException fatalException) {
+            firstException.compareAndSet(null, fatalException);
+        }
         taskCreator.close();
         standbyTaskCreator.close();
 

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.streams;
 
+import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.config.ConfigException;
@@ -31,6 +32,7 @@ import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.processor.internals.GlobalStreamThread;
 import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.MockClientSupplier;
 import org.apache.kafka.test.MockMetricsReporter;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.TestCondition;
@@ -111,6 +113,28 @@ public class KafkaStreamsTest {
         streams.setStateListener(stateListener);
         streams.close();
         Assert.assertEquals(KafkaStreams.State.NOT_RUNNING, streams.state());
+    }
+
+    @Test
+    public void testStreamsCloseWithoutStart() throws Exception {
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.globalTable("anyTopic");
+        MockClientSupplier clientSupplier = new MockClientSupplier();
+        final KafkaStreams streams = new KafkaStreams(builder.build(), new StreamsConfig(props), clientSupplier);
+        streams.close();
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                return streams.state() == KafkaStreams.State.NOT_RUNNING;
+            }
+        }, 10 * 1000, "Streams never stopped.");
+
+        // Ensure that any created clients are closed
+        assertTrue(clientSupplier.consumer.closed());
+        assertTrue(clientSupplier.restoreConsumer.closed());
+        for (MockProducer p : clientSupplier.producers) {
+            assertTrue(p.closed());
+        }
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -116,7 +116,7 @@ public class KafkaStreamsTest {
     }
 
     @Test
-    public void testStreamsCloseWithoutStart() throws Exception {
+    public void shouldCleanupResourcesOnCloseWithoutPreviousStart() throws Exception {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.globalTable("anyTopic");
         MockClientSupplier clientSupplier = new MockClientSupplier();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -438,8 +438,13 @@ public class StreamThreadTest {
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
 
-        StreamThread.StreamsMetricsThreadImpl streamsMetrics = new StreamThread.StreamsMetricsThreadImpl(metrics, "", "", Collections.<String, String>emptyMap());
-        final StreamThread thread = new StreamThread(mockTime,
+        final StreamThread.StreamsMetricsThreadImpl streamsMetrics = new StreamThread.StreamsMetricsThreadImpl(
+                metrics,
+                "",
+                "",
+                Collections.<String, String>emptyMap());
+        final StreamThread thread = new StreamThread(
+                mockTime,
                 config,
                 consumer,
                 consumer,
@@ -463,8 +468,13 @@ public class StreamThreadTest {
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
 
-        StreamThread.StreamsMetricsThreadImpl streamsMetrics = new StreamThread.StreamsMetricsThreadImpl(metrics, "", "", Collections.<String, String>emptyMap());
-        final StreamThread thread = new StreamThread(mockTime,
+        final StreamThread.StreamsMetricsThreadImpl streamsMetrics = new StreamThread.StreamsMetricsThreadImpl(
+                metrics,
+                "",
+                "",
+                Collections.<String, String>emptyMap());
+        final StreamThread thread = new StreamThread(
+                mockTime,
                 config,
                 consumer,
                 consumer,
@@ -477,7 +487,7 @@ public class StreamThreadTest {
         thread.shutdown();
         try {
             thread.join(1000);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
             fail("Join interrupted");
         }
         assertFalse(thread.isAlive());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -449,15 +449,8 @@ public class StreamThreadTest {
                 internalTopologyBuilder,
                 clientId,
                 new LogContext(""));
-        thread.setStateListener(
-            new StreamThread.StateListener() {
-                @Override
-                public void onChange(final Thread t, final ThreadStateTransitionValidator newState, final ThreadStateTransitionValidator oldState) {
-                    if (oldState == StreamThread.State.CREATED && newState == StreamThread.State.RUNNING) {
-                        thread.shutdown();
-                    }
-                }
-            });
+        thread.setState(StreamThread.State.RUNNING);
+        thread.shutdown();
         thread.run();
         EasyMock.verify(taskManager);
     }
@@ -482,6 +475,12 @@ public class StreamThreadTest {
                 clientId,
                 new LogContext(""));
         thread.shutdown();
+        try {
+            thread.join(1000);
+        } catch (InterruptedException e) {
+            fail("Join interrupted");
+        }
+        assertFalse(thread.isAlive());
         EasyMock.verify(taskManager);
     }
 


### PR DESCRIPTION
When transitioning StreamThread from CREATED to PENDING_SHUTDOWN
free up resources from the caller, rather than the stream thread,
since in this case the stream thread was never actually started.

In KakfaStreams.close, shut down the streams threads from the
close thread. StreamThread.shutdown may now block, so call this
from the close thread so that the timeout is honored.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
