### PR TITLE
appends Materialized#with to include the ability to specify the store name as well as the serdes

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Materialized.java
@@ -153,7 +153,26 @@ public class Materialized<K, V, S extends StateStore> {
      */
     public static <K, V, S extends StateStore> Materialized<K, V, S> with(final Serde<K> keySerde,
                                                                           final Serde<V> valueSerde) {
-        return new Materialized<K, V, S>((String) null).withKeySerde(keySerde).withValueSerde(valueSerde);
+        return Materialized.with(null, keySerde, valueSerde);
+    }
+
+    /**
+     * Materialize a {@link StateStore} with the provided store name and key and value {@link Serde}s.
+     *
+     * @param storeName     the name of the underlying {@link KTable} state store; valid characters are ASCII
+     * @param keySerde      the key {@link Serde} to use. If the {@link Serde} is null, then the default key
+     *                      serde from configs will be used
+     * @param valueSerde    the value {@link Serde} to use. If the {@link Serde} is null, then the default value
+     *                      serde from configs will be used
+     * @param <K>           key type
+     * @param <V>           value type
+     * @param <S>           store type
+     * @return a new {@link Materialized} instance with the given key and value serdes
+     */
+    public static <K, V, S extends StateStore> Materialized<K, V, S> with(final String storeName,
+                                                                          final Serde<K> keySerde,
+                                                                          final Serde<V> valueSerde) {
+        return new Materialized<K, V, S>(storeName).withKeySerde(keySerde).withValueSerde(valueSerde);
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/MaterializedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/MaterializedTest.java
@@ -18,10 +18,14 @@
 package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class MaterializedTest {
 
@@ -50,5 +54,20 @@ public class MaterializedTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerIfSessionBytesStoreSupplierIsNull() {
         Materialized.as((SessionBytesStoreSupplier) null);
+    }
+
+    @Test
+    public void shouldSetStoreNameUsingWith() {
+        final String expectedName = "some.name";
+        final Serde<Integer> intSerde = new Serdes.IntegerSerde();
+        final Serde<String> stringSerde = new Serdes.StringSerde();
+
+        assertTrue(Materialized.with(expectedName, intSerde, stringSerde).storeName.equals(expectedName));
+        assertTrue(Materialized.with(expectedName, intSerde, stringSerde).keySerde.equals(intSerde));
+        assertTrue(Materialized.with(expectedName, intSerde, stringSerde).valueSerde.equals(stringSerde));
+
+        assertTrue(Materialized.with(intSerde, stringSerde).storeName == null);
+        assertTrue(Materialized.with(intSerde, stringSerde).keySerde.equals(intSerde));
+        assertTrue(Materialized.with(intSerde, stringSerde).valueSerde.equals(stringSerde));
     }
 }


### PR DESCRIPTION
`Materialized#with` doesn't allow you to specify both a store name and the key/value serdes. If you specify the name using `#as`, then the serdes are implied/inferred to be for `Serde<Object>` and it becomes ugly to use `#withKeySerde`, `#withValueSerde`, etc. This overload of `Materialized#with` allows both the store name *and* the specific Serdes desired to be specified in one go.

I've updated `MaterializedTest` with the expected new behaviour as well as the old behaviour (i.e. `null` store name when not specified).

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
