### PR TITLE
KAFKA-6391 ensure topics are created with correct partitions BEFORE building the…

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -666,7 +666,8 @@ public class StreamPartitionAssignorTest {
         // joining the stream and the table
         // this triggers the enforceCopartitioning() routine in the StreamPartitionAssignor,
         // forcing the stream.map to get repartitioned to a topic with four partitions.
-        stream1.join(table1,
+        stream1.join(
+            table1,
             new ValueJoiner() {
                 @Override
                 public Object apply(final Object value1, final Object value2) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -805,7 +805,6 @@ public class StreamPartitionAssignorTest {
         }
     }
 
-
     @Test
     public void shouldNotLoopInfinitelyOnMissingMetadataAndShouldNotCreateRelatedTasks() throws Exception {
         final StreamsBuilder builder = new StreamsBuilder();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -652,7 +652,8 @@ public class StreamPartitionAssignorTest {
             });
 
         // KTable with 4 partitions
-        KTable<Object, Long> table1 = builder.table("topic3")
+        KTable<Object, Long> table1 = builder
+            .table("topic3")
             // force creation of internal repartition topic
             .groupBy(new KeyValueMapper<Object, Object, KeyValue<Object, Object>>() {
                 @Override
@@ -676,7 +677,8 @@ public class StreamPartitionAssignorTest {
         final UUID uuid = UUID.randomUUID();
         final String client = "client1";
 
-        mockTaskManager(Collections.<TaskId>emptySet(),
+        mockTaskManager(
+            Collections.<TaskId>emptySet(),
             Collections.<TaskId>emptySet(),
             UUID.randomUUID(),
             internalTopologyBuilder);
@@ -692,7 +694,7 @@ public class StreamPartitionAssignorTest {
         subscriptions.put(
             client,
             new PartitionAssignor.Subscription(
-                Collections.singletonList("unknownTopic"),
+                Utils.mkList("topic1", "topic3"),
                 new SubscriptionInfo(uuid, emptyTasks, emptyTasks, userEndPoint).encode()
             )
         );
@@ -706,7 +708,7 @@ public class StreamPartitionAssignorTest {
         expectedCreatedInternalTopics.put(applicationId + "-topic3-STATE-STORE-0000000002-changelog", 4);
 
         // check if all internal topics were created as expected
-        assertThat(mockInternalTopicManager.readyTopics, equalTo(expectedCreatedInternalTopics));
+        assertThat(expectedCreatedInternalTopics, equalTo(mockInternalTopicManager.readyTopics));
 
         final List<TopicPartition> expectedAssignment = Arrays.asList(
             new TopicPartition("topic1", 0),
@@ -727,7 +729,7 @@ public class StreamPartitionAssignorTest {
         );
 
         // check if we created a task for all expected topicpartitions.
-        assertThat(new HashSet<>(assignment.get(client).partitions()), equalTo(new HashSet<>(expectedAssignment)));
+        assertThat(new HashSet<>(expectedAssignment), equalTo(new HashSet<>(assignment.get(client).partitions())));
     }
 
     @Test
@@ -738,10 +740,11 @@ public class StreamPartitionAssignorTest {
         builder.addSink("sink", "output", null, null, null, "processor");
 
         final UUID uuid1 = UUID.randomUUID();
-        mockTaskManager(Collections.<TaskId>emptySet(),
-                               Collections.<TaskId>emptySet(),
-                               uuid1,
-                builder);
+        mockTaskManager(
+            Collections.<TaskId>emptySet(),
+            Collections.<TaskId>emptySet(),
+            uuid1,
+            builder);
         configurePartitionAssignor(Collections.singletonMap(StreamsConfig.APPLICATION_SERVER_CONFIG, (Object) userEndPoint));
         final PartitionAssignor.Subscription subscription = partitionAssignor.subscription(Utils.mkSet("input"));
         final SubscriptionInfo subscriptionInfo = SubscriptionInfo.decode(subscription.userData());
@@ -894,7 +897,7 @@ public class StreamPartitionAssignorTest {
         final Map<String, Integer> expectedCreatedInternalTopics = new HashMap<>();
         expectedCreatedInternalTopics.put(applicationId + "-count-repartition", 3);
         expectedCreatedInternalTopics.put(applicationId + "-count-changelog", 3);
-        assertThat(mockInternalTopicManager.readyTopics, equalTo(expectedCreatedInternalTopics));
+        assertThat(expectedCreatedInternalTopics, equalTo(mockInternalTopicManager.readyTopics));
 
         final List<TopicPartition> expectedAssignment = Arrays.asList(
             new TopicPartition("topic1", 0),
@@ -904,7 +907,7 @@ public class StreamPartitionAssignorTest {
             new TopicPartition(applicationId + "-count-repartition", 1),
             new TopicPartition(applicationId + "-count-repartition", 2)
         );
-        assertThat(new HashSet<>(assignment.get(client).partitions()), equalTo(new HashSet<>(expectedAssignment)));
+        assertThat(new HashSet<>(expectedAssignment), equalTo(new HashSet<>(assignment.get(client).partitions())));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -662,6 +662,9 @@ public class StreamPartitionAssignorTest {
             })
             .count(Materialized.<Object, Long, KeyValueStore<Bytes, byte[]>>as("count"));
 
+        // joining the stream and the table
+        // this triggers the enforceCopartitioning() routine in the StreamPartitionAssignor,
+        // forcing the stream.map to get repartitioned to a topic with four partitions.
         stream1.join(table1,
             new ValueJoiner() {
                 @Override
@@ -702,7 +705,7 @@ public class StreamPartitionAssignorTest {
         expectedCreatedInternalTopics.put(applicationId + "-KSTREAM-MAP-0000000001-repartition", 4);
         expectedCreatedInternalTopics.put(applicationId + "-topic3-STATE-STORE-0000000002-changelog", 4);
 
-
+        // check if all internal topics were created as expected
         assertThat(mockInternalTopicManager.readyTopics, equalTo(expectedCreatedInternalTopics));
 
         final List<TopicPartition> expectedAssignment = Arrays.asList(
@@ -722,6 +725,8 @@ public class StreamPartitionAssignorTest {
             new TopicPartition(applicationId + "-KSTREAM-MAP-0000000001-repartition", 2),
             new TopicPartition(applicationId + "-KSTREAM-MAP-0000000001-repartition", 3)
         );
+
+        // check if we created a task for all expected topicpartitions.
         assertThat(new HashSet<>(assignment.get(client).partitions()), equalTo(new HashSet<>(expectedAssignment)));
     }
 


### PR DESCRIPTION
ensure topics are created with correct partitions BEFORE building the metadata for our stream tasks

First ensureCoPartitioning() on repartitionTopicMetadata before creating allRepartitionTopicPartitions

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
