### PR TITLE
MINOR: Fix race condition in Streams EOS system test

### DIFF
--- a/tests/kafkatest/tests/streams/streams_eos_test.py
+++ b/tests/kafkatest/tests/streams/streams_eos_test.py
@@ -118,8 +118,8 @@ class StreamsEosTest(KafkaTest):
         verifier.node.account.ssh("grep ALL-RECORDS-DELIVERED %s" % verifier.STDOUT_FILE, allow_fail=False)
 
     def add_streams(self, processor):
-        processor.start()
         with processor.node.account.monitor_log(processor.STDOUT_FILE) as monitor:
+            processor.start()
             self.wait_for_startup(monitor, processor)
 
     def add_streams2(self, running_processor, processor_to_be_started):


### PR DESCRIPTION
We should start the process only within the `with` block, otherwise the bytes parameter would cause a race condition that result in false alarms of system test failures.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
