### PR TITLE
Cached hashCode of a Node instance since it is immutable

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Node.java
+++ b/clients/src/main/java/org/apache/kafka/common/Node.java
@@ -23,19 +23,20 @@ public class Node {
 
     private static final Node NO_NODE = new Node(-1, "", -1);
 
-    private int hash = 0;
     private final int id;
     private final String idString;
     private final String host;
     private final int port;
     private final String rack;
 
+    // Cache hashCode as it is called in performance sensitive parts of the code (e.g. RecordAccumulator.ready)
+    private Integer hash;
+
     public Node(int id, String host, int port) {
         this(id, host, port, null);
     }
 
     public Node(int id, String host, int port, String rack) {
-        super();
         this.id = id;
         this.idString = Integer.toString(id);
         this.host = host;
@@ -101,42 +102,30 @@ public class Node {
 
     @Override
     public int hashCode() {
-        if (hash != 0)
-            return hash;
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((host == null) ? 0 : host.hashCode());
-        result = prime * result + id;
-        result = prime * result + port;
-        result = prime * result + ((rack == null) ? 0 : rack.hashCode());
-        this.hash = result;
-        return result;
+        Integer h = this.hash;
+        if (h == null) {
+            int result = 31 + ((host == null) ? 0 : host.hashCode());
+            result = 31 * result + id;
+            result = 31 * result + port;
+            result = 31 * result + ((rack == null) ? 0 : rack.hashCode());
+            this.hash = result;
+            return result;
+        } else {
+            return h;
+        }
     }
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
+        if (obj == null || getClass() != obj.getClass())
             return false;
         Node other = (Node) obj;
-        if (host == null) {
-            if (other.host != null)
-                return false;
-        } else if (!host.equals(other.host))
-            return false;
-        if (id != other.id)
-            return false;
-        if (port != other.port)
-            return false;
-        if (rack == null) {
-            if (other.rack != null)
-                return false;
-        } else if (!rack.equals(other.rack))
-            return false;
-        return true;
+        return (host == null ? other.host == null : host.equals(other.host)) &&
+            id == other.id &&
+            port == other.port &&
+            (rack == null ? other.rack == null : rack.equals(other.rack));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/Node.java
+++ b/clients/src/main/java/org/apache/kafka/common/Node.java
@@ -23,6 +23,7 @@ public class Node {
 
     private static final Node NO_NODE = new Node(-1, "", -1);
 
+    private int hash = 0;
     private final int id;
     private final String idString;
     private final String host;
@@ -100,12 +101,15 @@ public class Node {
 
     @Override
     public int hashCode() {
+        if (hash != 0)
+            return hash;
         final int prime = 31;
         int result = 1;
         result = prime * result + ((host == null) ? 0 : host.hashCode());
         result = prime * result + id;
         result = prime * result + port;
         result = prime * result + ((rack == null) ? 0 : rack.hashCode());
+        this.hash = result;
         return result;
     }
 


### PR DESCRIPTION
`Node` structure is immutable so it is possible to cache `hashCode` of a `Node` instance as it's done in the `TopicPartition` class.
Faced with the producer performance degradation in case of high load and large number of brokers (100), topics (150) and partitions (350). Made several diagnostic records with the java flight recorder and found that the method `HashSet::contains` in [`RecordAccumulator::ready`](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java#L423) takes about 40% of the whole time of the application. It is caused by re-calculating a hash code of a [leader](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java#L433) (`Node` instance) for every [batch entry](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/internals/RecordAccumulator.java#L429). The cached hash code solved this issue and the corresponding time of `HashSet::contains` in `RecordAccumulator::ready` decreased to ~2%.
