### PR TITLE
MINOR: Use GitHub git repo for push by default

### DIFF
--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -48,8 +48,8 @@ CAPITALIZED_PROJECT_NAME = "kafka".upper()
 REPO_HOME = os.environ.get("%s_HOME" % CAPITALIZED_PROJECT_NAME, os.getcwd())
 # Remote name which points to the GitHub site
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache-github")
-# Remote name which points to Apache git
-PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache")
+# Remote name where we want to push the changes to (GitHub by default, but Apache Git would work if GitHub is down)
+PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache-github")
 # ASF JIRA username
 JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "")
 # ASF JIRA password


### PR DESCRIPTION
GitBox (write support for the GItHub git repository) has been enable as per:

https://issues.apache.org/jira/browse/INFRA-15676

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
