### PR TITLE
KAFKA-4335: Add batch.size to FileStreamSource connector to prevent OOM

### DIFF
--- a/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
+++ b/connect/file/src/main/java/org/apache/kafka/connect/file/FileStreamSourceConnector.java
@@ -36,13 +36,18 @@ import java.util.Map;
 public class FileStreamSourceConnector extends SourceConnector {
     public static final String TOPIC_CONFIG = "topic";
     public static final String FILE_CONFIG = "file";
+    public static final String TASK_BATCH_SIZE_CONFIG = "batch.size";
+
+    public static final int DEFAULT_TASK_BATCH_SIZE = 2000;
 
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
         .define(FILE_CONFIG, Type.STRING, null, Importance.HIGH, "Source filename. If not specified, the standard input will be used")
-        .define(TOPIC_CONFIG, Type.STRING, Importance.HIGH, "The topic to publish data to");
+        .define(TOPIC_CONFIG, Type.STRING, Importance.HIGH, "The topic to publish data to")
+        .define(TASK_BATCH_SIZE_CONFIG, Type.INT, Importance.LOW, "The maximum number of records the Source task can read from file one time");
 
     private String filename;
     private String topic;
+    private int batchSize = DEFAULT_TASK_BATCH_SIZE;
 
     @Override
     public String version() {
@@ -57,6 +62,14 @@ public class FileStreamSourceConnector extends SourceConnector {
             throw new ConnectException("FileStreamSourceConnector configuration must include 'topic' setting");
         if (topic.contains(","))
             throw new ConnectException("FileStreamSourceConnector should only have a single topic when used as a source.");
+
+        if (props.containsKey(TASK_BATCH_SIZE_CONFIG)) {
+            try {
+                batchSize = Integer.parseInt(props.get(TASK_BATCH_SIZE_CONFIG));
+            } catch (NumberFormatException e) {
+                throw new ConnectException("Invalid FileStreamSourceConnector configuration", e);
+            }
+        }
     }
 
     @Override
@@ -72,6 +85,7 @@ public class FileStreamSourceConnector extends SourceConnector {
         if (filename != null)
             config.put(FILE_CONFIG, filename);
         config.put(TOPIC_CONFIG, topic);
+        config.put(TASK_BATCH_SIZE_CONFIG, String.valueOf(batchSize));
         configs.add(config);
         return configs;
     }

--- a/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
+++ b/connect/file/src/test/java/org/apache/kafka/connect/file/FileStreamSourceTaskTest.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertEquals;
 public class FileStreamSourceTaskTest extends EasyMockSupport {
 
     private static final String TOPIC = "test";
-    private static final String BATCH_SIZE = String.valueOf(FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE);
 
     private File tempFile;
     private Map<String, String> config;


### PR DESCRIPTION
When the source file of `FileStreamSource` is a large file, `FileStreamSourceTask.poll()` will result in OOM. This pull request added `batch.size` parameter which can restrict the poll size.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
