### PR TITLE
KAFKA-6405:Fix incorrect comment in MetadataUpdater

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -54,7 +54,7 @@ interface MetadataUpdater {
     long maybeUpdate(long now);
 
     /**
-     * If `request` is a metadata request, handles it and return `true`. Otherwise, returns `false`.
+     * Handle disconnections for metadata requests.
      *
      * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
      * requests with special handling for disconnections of such requests.

--- a/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/clients/MetadataUpdater.java
@@ -70,7 +70,7 @@ interface MetadataUpdater {
     void handleAuthenticationFailure(AuthenticationException exception);
 
     /**
-     * If `request` is a metadata request, handles it and returns `true`. Otherwise, returns `false`.
+     * Handle responses for metadata requests.
      *
      * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
      * requests with special handling for completed receives of such requests.


### PR DESCRIPTION
The comment for 'handleDisconnection' says it can return true or false, but the return type is void.

```java
    /**
     * If `request` is a metadata request, handles it and return `true`. Otherwise, returns `false`.
     *
     * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
     * requests with special handling for disconnections of such requests.
     * @param destination
     */
    void handleDisconnection(String destination);
```

change to
```java
    /**
     * Handle disconnections for metadata requests.
     *
     * This provides a mechanism for the `MetadataUpdater` implementation to use the NetworkClient instance for its own
     * requests with special handling for disconnections of such requests.
     * @param destination
     */
    void handleDisconnection(String destination);
```