### PR TITLE
MINOR: wait for broker startup for system tests

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -168,7 +168,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         self.logger.info("Waiting for brokers to register at ZK")
 
         retries = 30
-        expected_broker_ids = "[" + ", ".join(self.idx(node) for node in self.nodes) + "]"
+        expected_broker_ids = "[" + ", ".join(str(self.idx(node)) for node in self.nodes) + "]"
         while retries > 0:
             broker_ids = self.zk.query("/brokers/ids", chroot=self.zk_chroot)
             if broker_ids == expected_broker_ids:

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -169,16 +169,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         retries = 30
         expected_broker_ids = set(self.nodes)
-        broker_ids = set()
-        while retries > 0:
-            for node in self.nodes:
-                if self.is_registered(node):
-                    broker_ids.add(node)
-            if broker_ids == expected_broker_ids:
-                break
-            else:
-                time.sleep(1)
-            retries = retries - 1
+        wait_until({node for node in self.nodes if self.is_registered(node)} == expected_broker_ids, 30, 1)
 
         if retries == 0:
             raise RuntimeError("Kafka servers didn't register at ZK within 30 seconds")

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -167,12 +167,13 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         self.logger.info("Waiting for brokers to register at ZK")
 
-        retries = 30
-        expected_broker_ids = "[" + ", ".join(str(self.idx(node)) for node in self.nodes) + "]"
+        retries = 5
+        expected_broker_ids = set(self.nodes)
+        broker_ids = set()
         while retries > 0:
-            broker_ids = self.zk.query("/brokers/ids", chroot=self.zk_chroot)
-            print broker_ids
-            print expected_broker_ids
+            for node in self.nodes:
+                if self.is_registered(node):
+                    broker_ids.add(node)
             if broker_ids == expected_broker_ids:
                 break
             else:

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -167,7 +167,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         self.logger.info("Waiting for brokers to register at ZK")
 
-        retries = 5
+        retries = 30
         expected_broker_ids = set(self.nodes)
         broker_ids = set()
         while retries > 0:

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -171,6 +171,8 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         expected_broker_ids = "[" + ", ".join(str(self.idx(node)) for node in self.nodes) + "]"
         while retries > 0:
             broker_ids = self.zk.query("/brokers/ids", chroot=self.zk_chroot)
+            print broker_ids
+            print expected_broker_ids
             if broker_ids == expected_broker_ids:
                 break
             else:

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -166,17 +166,16 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         Service.start(self)
 
         self.logger.info("Waiting for brokers to register at ZK")
-        node = self.nodes[0]
 
-        cmd = self.path.script("zookeeper-shell.sh", node) + " " + self.zk_connect_setting() + " ls /brokers/ids"
+        cmd = self.path.script("zookeeper-shell.sh", self.zk) + " " + self.zk_connect_setting() + " ls /brokers/ids"
 
         broker_ids = ""
         for node in self.nodes:
             broker_ids += "%s, " % self.idx(node)
         broker_ids = "[" + broker_ids[:-2] + "]"
 
-        with node.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
-            node.account.ssh(cmd)
+        with self.zk.account.monitor_log(KafkaService.STDOUT_STDERR_CAPTURE) as monitor:
+            self.zk.account.ssh(cmd)
             monitor.wait_until(broker_ids, timeout_sec=30, backoff_sec=.25, err_msg="Kafka servers didn't register at ZK")
 
         # Create topics if necessary

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -169,7 +169,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         retries = 30
         expected_broker_ids = set(self.nodes)
-        wait_until({node for node in self.nodes if self.is_registered(node)} == expected_broker_ids, 30, 1)
+        wait_until(lambda: {node for node in self.nodes if self.is_registered(node)} == expected_broker_ids, 30, 1)
 
         if retries == 0:
             raise RuntimeError("Kafka servers didn't register at ZK within 30 seconds")


### PR DESCRIPTION
Starting up a Kafka cluster with multiple nodes can lead to a race condition if an application wants to create a topic but not all brokers are available yet.

For example:
```
org.apache.kafka.streams.errors.StreamsException: Could not create topic SmokeTest-cntByCnt-repartition.
	at 
...
Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 2.
	at
...
Caused by: org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 2.
```

This should be fixed by making sure all brokers are registered at ZK before creating topics.