### PR TITLE
MINOR: Refactor use of regular expressions to use statically compiled variables instead of dynamic regex.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigDef.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * This class is used for specifying the set of expected configurations. For each configuration, you can specify
@@ -81,6 +82,8 @@ public class ConfigDef {
     private final Map<String, ConfigKey> configKeys;
     private final List<String> groups;
     private Set<String> configsWithNoParent;
+
+    private static final Pattern SPLIT_REGEX = Pattern.compile("\\s*,\\s*");
 
     public ConfigDef() {
         configKeys = new LinkedHashMap<>();
@@ -696,7 +699,7 @@ public class ConfigDef {
                         if (trimmed.isEmpty())
                             return Collections.emptyList();
                         else
-                            return Arrays.asList(trimmed.split("\\s*,\\s*", -1));
+                            return Arrays.asList(SPLIT_REGEX.split(trimmed, -1));
                     else
                         throw new ConfigException(name, value, "Expected a comma separated list.");
                 case CLASS:

--- a/clients/src/main/java/org/apache/kafka/common/utils/Base64.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Base64.java
@@ -20,6 +20,8 @@ package org.apache.kafka.common.utils;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Temporary class in order to support Java 7 and Java 9. `DatatypeConverter` is not in the base module of Java 9
@@ -187,6 +189,9 @@ public final class Base64 {
         private static final MethodHandle PRINT;
         private static final MethodHandle PARSE;
 
+        private static final Pattern REPLACE_PLUS_TO_DASH = Pattern.compile("+", Pattern.LITERAL);
+        private static final Pattern REPLACE_FORWARD_SLASH_TO_UNDERSCORE = Pattern.compile("/", Pattern.LITERAL);
+
         static {
             try {
                 Class<?> cls = Class.forName("javax.xml.bind.DatatypeConverter");
@@ -206,9 +211,12 @@ public final class Base64 {
             @Override
             public String encodeToString(byte[] bytes) {
                 String base64EncodedUUID = Java7Factory.encodeToString(bytes);
+
                 //Convert to URL safe variant by replacing + and / with - and _ respectively.
-                String urlSafeBase64EncodedUUID = base64EncodedUUID.replace("+", "-")
-                        .replace("/", "_");
+                String urlSafeBase64EncodedUUID = REPLACE_FORWARD_SLASH_TO_UNDERSCORE.matcher(
+                        REPLACE_PLUS_TO_DASH.matcher(base64EncodedUUID).replaceAll(Matcher.quoteReplacement("-"))
+                ).replaceAll(Matcher.quoteReplacement("_"));
+
                 // Remove the "==" padding at the end.
                 return urlSafeBase64EncodedUUID.substring(0, urlSafeBase64EncodedUUID.length() - 2);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
 import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
@@ -35,6 +36,8 @@ import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
  * Common base class providing configuration for Kafka Connect workers, whether standalone or distributed.
  */
 public class WorkerConfig extends AbstractConfig {
+
+    private static final Pattern SPLIT_REGEX = Pattern.compile("\\s*,\\s*");
 
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
     public static final String BOOTSTRAP_SERVERS_DOC
@@ -211,7 +214,7 @@ public class WorkerConfig extends AbstractConfig {
         String locationList = props.get(WorkerConfig.PLUGIN_PATH_CONFIG);
         return locationList == null
                          ? new ArrayList<String>()
-                         : Arrays.asList(locationList.trim().split("\\s*,\\s*", -1));
+                         : Arrays.asList(SPLIT_REGEX.split(locationList.trim(), -1));
     }
 
     public WorkerConfig(ConfigDef definition, Map<String, String> props) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -34,6 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Connect plugin utility methods.
@@ -42,7 +43,7 @@ public class PluginUtils {
     private static final Logger log = LoggerFactory.getLogger(PluginUtils.class);
 
     // Be specific about javax packages and exclude those existing in Java SE and Java EE libraries.
-    private static final String BLACKLIST = "^(?:"
+    private static final Pattern BLACKLIST = Pattern.compile("^(?:"
             + "java"
             + "|javax\\.accessibility"
             + "|javax\\.activation"
@@ -120,15 +121,15 @@ public class PluginUtils {
             + "|org\\.apache\\.kafka\\.common"
             + "|org\\.apache\\.kafka\\.connect"
             + "|org\\.slf4j"
-            + ")\\..*$";
+            + ")\\..*$");
 
-    private static final String WHITELIST = "^org\\.apache\\.kafka\\.connect\\.(?:"
+    private static final Pattern WHITELIST = Pattern.compile("^org\\.apache\\.kafka\\.connect\\.(?:"
             + "transforms\\.(?!Transformation$).*"
             + "|json\\..*"
             + "|file\\..*"
             + "|converters\\..*"
             + "|storage\\.StringConverter"
-            + ")$";
+            + ")$");
 
     private static final DirectoryStream.Filter<Path> PLUGIN_PATH_FILTER = new DirectoryStream
             .Filter<Path>() {
@@ -146,7 +147,7 @@ public class PluginUtils {
      * @return true if this class should be loaded in isolation, false otherwise.
      */
     public static boolean shouldLoadInIsolation(String name) {
-        return !(name.matches(BLACKLIST) && !name.matches(WHITELIST));
+        return !(BLACKLIST.matcher(name).matches() && !WHITELIST.matcher(name).matches());
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -35,6 +35,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
+import java.util.regex.Pattern;
 
 /**
  * Manages the directories where the state of Tasks owned by a {@link StreamThread} are
@@ -45,6 +46,8 @@ public class StateDirectory {
 
     static final String LOCK_FILE_NAME = ".lock";
     private static final Logger log = LoggerFactory.getLogger(StateDirectory.class);
+
+    private static final Pattern NAME_MATCHER = Pattern.compile("\\d+_\\d+");
 
     private final File stateDir;
     private final HashMap<TaskId, FileChannel> channels = new HashMap<>();
@@ -320,8 +323,7 @@ public class StateDirectory {
         return stateDir.listFiles(new FileFilter() {
             @Override
             public boolean accept(final File pathname) {
-                final String name = pathname.getName();
-                return pathname.isDirectory() && name.matches("\\d+_\\d+");
+                return pathname.isDirectory() && NAME_MATCHER.matcher(pathname.getName()).matches();
             }
         });
     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
@@ -119,8 +119,6 @@ public class OffsetCheckpoint {
      * @throws IllegalArgumentException if the offset checkpoint version is unknown
      */
     public Map<TopicPartition, Long> read() throws IOException {
-
-
         synchronized (lock) {
             try (BufferedReader reader
                      = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/OffsetCheckpoint.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * This class saves out a map of topic/partition=&gt;offsets to a file. The format of the file is UTF-8 text containing the following:
@@ -53,6 +54,8 @@ import java.util.Map;
 public class OffsetCheckpoint {
 
     private static final int VERSION = 0;
+
+    private static final Pattern SPLIT_REGEX = Pattern.compile("\\s+");
 
     private final File file;
     private final Object lock;
@@ -111,12 +114,13 @@ public class OffsetCheckpoint {
         writer.newLine();
     }
 
-
     /**
      * @throws IOException if any file operation fails with an IO exception
      * @throws IllegalArgumentException if the offset checkpoint version is unknown
      */
     public Map<TopicPartition, Long> read() throws IOException {
+
+
         synchronized (lock) {
             try (BufferedReader reader
                      = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
@@ -128,7 +132,7 @@ public class OffsetCheckpoint {
                         final Map<TopicPartition, Long> offsets = new HashMap<>();
                         String line = reader.readLine();
                         while (line != null) {
-                            final String[] pieces = line.split("\\s+");
+                            final String[] pieces = SPLIT_REGEX.split(line);
                             if (pieces.length != 3) {
                                 throw new IOException(
                                     String.format("Malformed line in offset checkpoint file: '%s'.", line));

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -58,6 +58,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A persistent key-value store based on RocksDB.
@@ -251,6 +252,8 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
         }
     }
 
+    private static final Pattern FILE_NAME_MATCHER = Pattern.compile(".*\\.sst");
+
     private void toggleDbForBulkLoading(boolean prepareForBulkload) {
 
         if (prepareForBulkload) {
@@ -259,7 +262,7 @@ public class RocksDBStore<K, V> implements KeyValueStore<K, V> {
             final String[] sstFileNames = dbDir.list(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {
-                    return name.matches(".*\\.sst");
+                    return FILE_NAME_MATCHER.matcher(name).matches();
                 }
             });
 


### PR DESCRIPTION
This is something I did after my working hours, I would ask people reviewing this do the same, don't take time for this during your work hours.

I try to keep such a PR as limited as possible, for clarity of reading.

==========

This PR is focussed on finding all places in the code where regular expressions are used dynamically and converting them to use statically compiled `Pattern` objects instead.

This prevents the regular expression from having to be compiled every single time it is used.

An explanation with code example can be seen here: https://stackoverflow.com/a/1721778

The refactoring was done by going into the source code of String.java and Pattern.java. The code now seen here does it exactly that way I found it in the Oracle JDK source code zip file that's provided along with the install.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)


