### PR TITLE
MINOR: String concat used in StringBuilder

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -312,7 +312,7 @@ public enum ApiKeys {
         for (ApiKeys key : ApiKeys.values()) {
             b.append("<tr>\n");
             b.append("<td>");
-            b.append("<a href=\"#The_Messages_" + key.name + "\">" + key.name + "</a>");
+            b.append("<a href=\"#The_Messages_").append(key.name).append("\">").append(key.name).append("</a>");
             b.append("</td>");
             b.append("<td>");
             b.append(key.id);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Protocol.java
@@ -131,7 +131,7 @@ public class Protocol {
         for (ApiKeys key : ApiKeys.values()) {
             // Key
             b.append("<h5>");
-            b.append("<a name=\"The_Messages_" + key.name + "\">");
+            b.append("<a name=\"The_Messages_").append(key.name).append("\">");
             b.append(key.name);
             b.append(" API (Key: ");
             b.append(key.id);


### PR DESCRIPTION
This is something I did after my working hours, I would ask people reviewing this do the same, don't take time for this during your work hours.

I try to keep such a PR as limited as possible, for clarity of reading.

==========

A small thing: static analysis ran into a few occurrences of string concatenation being used as argument for a StringBuilder `append()` method. This seems to entirely defeat the purpose of using StringBuilder in the first place.

So I replaced the concatenation with `append()` calls instead, for consistency.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)


