### PR TITLE
MINOR: Added functionality to discover Kafka as OSGi package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -741,6 +741,8 @@ project(':core') {
   jar.manifest {
     attributes(
       'Version': "${version}"
+      'Bundle-Version': "${version}"
+      'Bundle-SymbolicName': "org.apache.kafka"
     )
   }
 


### PR DESCRIPTION
Added functionality to discover Kafka as an OSGi supported package. Currently Kafka is not supported for usage in bndrun files because of it's missing Bundle-SymbolicName.