### PR TITLE
MINOR: Improve exception messages when state stores cannot be accessed.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamThreadStateStoreProvider.java
@@ -45,14 +45,16 @@ public class StreamThreadStateStoreProvider implements StateStoreProvider {
             return Collections.emptyList();
         }
         if (!streamThread.isRunningAndNotRebalancing()) {
-            throw new InvalidStateStoreException("the state store, " + storeName + ", may have migrated to another instance.");
+            throw new InvalidStateStoreException("Cannot get state store " + storeName + " because the stream thread is " +
+                    streamThread.state() + ", not RUNNING");
         }
         final List<T> stores = new ArrayList<>();
         for (Task streamTask : streamThread.tasks().values()) {
             final StateStore store = streamTask.getStore(storeName);
             if (store != null && queryableStoreType.accepts(store)) {
                 if (!store.isOpen()) {
-                    throw new InvalidStateStoreException("the state store, " + storeName + ", may have migrated to another instance.");
+                    throw new InvalidStateStoreException("Cannot get state store " + storeName + " for task " + streamTask +
+                            " because the store is not open. The state store may have migrated to another instances.");
                 }
                 stores.add((T) store);
             }


### PR DESCRIPTION
The messages were previously identical which is a bit of a pain since you have to track down line numbers to see exactly why the exception happened. The messages are also confusing and I think misleading in the first case, where the issue likely isn't that the state store actually moved just that a rebalance is in progress.

Hopefully these are clearer and provide a bit more debugging info.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
