### PR TITLE
MINOR mirror make will throw null pointer exception when value is null and shutdown

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -426,7 +426,11 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
           try {
             while (!exitingOnSendFailure && !shuttingDown && mirrorMakerConsumer.hasData) {
               val data = mirrorMakerConsumer.receive()
-              trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+              if (data.value != null) {
+                trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+              } else {
+                trace("Sending message with null value and offset %d".format( data.offset))
+              }
               val records = messageHandler.handle(data)
               records.asScala.foreach(producer.send)
               maybeFlushAndCommitOffsets()


### PR DESCRIPTION
when enable trace level log for mirror maker, when the message value is null, it will throw null pointer exceptions. and the mirror maker will shut down because of that. 