### PR TITLE
KAFKA-6422 Mirror maker will throw null pointer exception when the message value is null

### DIFF
--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -427,9 +427,9 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
             while (!exitingOnSendFailure && !shuttingDown && mirrorMakerConsumer.hasData) {
               val data = mirrorMakerConsumer.receive()
               if (data.value != null) {
-                trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+                trace("Sending message with value size %d and offset %d.".format(data.value.length, data.offset))
               } else {
-                trace("Sending message with null value and offset %d".format(data.offset))
+                trace("Sending message with null value and offset %d.".format(data.offset))
               }
               val records = messageHandler.handle(data)
               records.asScala.foreach(producer.send)

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -67,7 +67,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
 
   private[tools] var producer: MirrorMakerProducer = null
   private var mirrorMakerThreads: Seq[MirrorMakerThread] = null
-  private val isShuttingdown: AtomicBoolean = new AtomicBoolean(false)
+  private val isShuttingDown: AtomicBoolean = new AtomicBoolean(false)
   // Track the messages not successfully sent by mirror maker.
   private val numDroppedMessages: AtomicInteger = new AtomicInteger(0)
   private var messageHandler: MirrorMakerMessageHandler = null
@@ -384,7 +384,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
   }
 
   def cleanShutdown() {
-    if (isShuttingdown.compareAndSet(false, true)) {
+    if (isShuttingDown.compareAndSet(false, true)) {
       info("Start clean shutdown.")
       // Shutdown consumer threads.
       info("Shutting down consumer threads.")
@@ -463,7 +463,7 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
         shutdownLatch.countDown()
         info("Mirror maker thread stopped")
         // if it exits accidentally, stop the entire mirror maker
-        if (!isShuttingdown.get()) {
+        if (!isShuttingDown.get()) {
           fatal("Mirror maker thread exited abnormally, stopping the whole mirror maker.")
           sys.exit(-1)
         }

--- a/core/src/main/scala/kafka/tools/MirrorMaker.scala
+++ b/core/src/main/scala/kafka/tools/MirrorMaker.scala
@@ -426,7 +426,11 @@ object MirrorMaker extends Logging with KafkaMetricsGroup {
           try {
             while (!exitingOnSendFailure && !shuttingDown && mirrorMakerConsumer.hasData) {
               val data = mirrorMakerConsumer.receive()
-              trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+              if (data.value != null) {
+                trace("Sending message with value size %d and offset %d".format(data.value.length, data.offset))
+              } else {
+                trace("Sending message with null value and offset %d".format(data.offset))
+              }
               val records = messageHandler.handle(data)
               records.asScala.foreach(producer.send)
               maybeFlushAndCommitOffsets()


### PR DESCRIPTION
when enable trace level log in mirror maker, if the message value is null. it will throw null pointer exception and shutdown the mirror maker.