### PR TITLE
HOTFIX: Fix lgtm.com alerts (dead code and out-of-bounds error)

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosRule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosRule.java
@@ -126,7 +126,7 @@ class KerberosRule {
             if (paramNum != null) {
                 try {
                     int num = Integer.parseInt(paramNum);
-                    if (num < 0 || num > params.length) {
+                    if (num < 0 || num >= params.length) {
                         throw new BadFormatString("index " + num + " from " + format +
                                 " is outside of the valid range 0 to " +
                                 (params.length - 1));

--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosRule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosRule.java
@@ -107,8 +107,8 @@ class KerberosRule {
     }
 
     /**
-     * Replace the numbered parameters of the form $n where n is from 1 to
-     * the length of params. Normal text is copied directly and $n is replaced
+     * Replace the numbered parameters of the form $n where n is from 0 to
+     * the length of params - 1. Normal text is copied directly and $n is replaced
      * by the corresponding parameter.
      * @param format the string to replace parameters again
      * @param params the list of parameters

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosRuleTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosRuleTest.java
@@ -22,28 +22,28 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 public class KerberosRuleTest {
-	
-	@Test
-	public void testReplaceParameters() throws BadFormatString {
-		// positive test cases
-		assertEquals(KerberosRule.replaceParameters("", new String[0]), "");
-		assertEquals(KerberosRule.replaceParameters("hello", new String[0]), "hello");
-		assertEquals(KerberosRule.replaceParameters("", new String[]{"too", "many", "parameters", "are", "ok"}), "");
-		assertEquals(KerberosRule.replaceParameters("hello", new String[]{"too", "many", "parameters", "are", "ok"}), "hello");
-		assertEquals(KerberosRule.replaceParameters("hello $0", new String[]{"too", "many", "parameters", "are", "ok"}), "hello too");
-		assertEquals(KerberosRule.replaceParameters("hello $0", new String[]{"no recursion $1"}), "hello no recursion $1");
 
-		// negative test cases
-		try {
-			KerberosRule.replaceParameters("$0", new String[]{});
-			fail("An out-of-bounds parameter number should trigger an exception!");
-		} catch (BadFormatString bfs) {
-		}
-		try {
-			KerberosRule.replaceParameters("hello $a", new String[]{"does not matter"});
-			fail("A malformed parameter name should trigger an exception!");
-		} catch (BadFormatString bfs) {
-		}
-	}
+    @Test
+    public void testReplaceParameters() throws BadFormatString {
+        // positive test cases
+        assertEquals(KerberosRule.replaceParameters("", new String[0]), "");
+        assertEquals(KerberosRule.replaceParameters("hello", new String[0]), "hello");
+        assertEquals(KerberosRule.replaceParameters("", new String[]{"too", "many", "parameters", "are", "ok"}), "");
+        assertEquals(KerberosRule.replaceParameters("hello", new String[]{"too", "many", "parameters", "are", "ok"}), "hello");
+        assertEquals(KerberosRule.replaceParameters("hello $0", new String[]{"too", "many", "parameters", "are", "ok"}), "hello too");
+        assertEquals(KerberosRule.replaceParameters("hello $0", new String[]{"no recursion $1"}), "hello no recursion $1");
+
+        // negative test cases
+        try {
+            KerberosRule.replaceParameters("$0", new String[]{});
+            fail("An out-of-bounds parameter number should trigger an exception!");
+        } catch (BadFormatString bfs) {
+        }
+        try {
+            KerberosRule.replaceParameters("hello $a", new String[]{"does not matter"});
+            fail("A malformed parameter name should trigger an exception!");
+        } catch (BadFormatString bfs) {
+        }
+    }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosRuleTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/kerberos/KerberosRuleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.security.kerberos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class KerberosRuleTest {
+	
+	@Test
+	public void testReplaceParameters() throws BadFormatString {
+		// positive test cases
+		assertEquals(KerberosRule.replaceParameters("", new String[0]), "");
+		assertEquals(KerberosRule.replaceParameters("hello", new String[0]), "hello");
+		assertEquals(KerberosRule.replaceParameters("", new String[]{"too", "many", "parameters", "are", "ok"}), "");
+		assertEquals(KerberosRule.replaceParameters("hello", new String[]{"too", "many", "parameters", "are", "ok"}), "hello");
+		assertEquals(KerberosRule.replaceParameters("hello $0", new String[]{"too", "many", "parameters", "are", "ok"}), "hello too");
+		assertEquals(KerberosRule.replaceParameters("hello $0", new String[]{"no recursion $1"}), "hello no recursion $1");
+
+		// negative test cases
+		try {
+			KerberosRule.replaceParameters("$0", new String[]{});
+			fail("An out-of-bounds parameter number should trigger an exception!");
+		} catch (BadFormatString bfs) {
+		}
+		try {
+			KerberosRule.replaceParameters("hello $a", new String[]{"does not matter"});
+			fail("A malformed parameter name should trigger an exception!");
+		} catch (BadFormatString bfs) {
+		}
+	}
+
+}


### PR DESCRIPTION
This fixes two alerts flagged on [lgtm.com](https://lgtm.com) for Apache Kafka.

1. This [dead code alert](https://lgtm.com/projects/g/apache/kafka/snapshot/6abe9363dbc8d7295055865233071ef51dce1f3a/files/tools/src/main/java/org/apache/kafka/trogdor/rest/RestExceptionMapper.java?sort=name&dir=ASC&mode=heatmap&excluded=false#xbfc4f8e26024a8f4:1) where `InvalidTypeIdException` indirectly extends `JsonMappingException`. The flagged condition with the type test appears after the type test for the latter and thus makes its body dead. I opted to change the order of the tests. Please let me know if this is the intended behavior.

2. The second commit addresses this [out-of-bounds alert](https://lgtm.com/projects/g/apache/kafka/snapshot/6abe9363dbc8d7295055865233071ef51dce1f3a/files/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosRule.java?sort=name&dir=ASC&mode=heatmap&excluded=false#x40b686b508503559:1).

More alerts can be found [here](https://lgtm.com/projects/g/apache/kafka/alerts/). Note that my colleague Aditya Sharad addressed some of those in the now outdated #2939.

@mjsax I don't know any committers here, apart from you, so maybe you could have a look? How are you doing by the way? Long time no see...
  