### PR TITLE
Fix /image 404s in streams doc

### DIFF
--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -700,7 +700,7 @@
                 </ul>
                 <p>The following diagram shows their relationships:</p>
                 <div class="figure align-center" id="id2">
-                    <a class="reference internal image-reference" href="../../../images/streams-stateful_operations.png"><img alt="../../../images/streams-stateful_operations.png" src="../../../images/streams-stateful_operations.png" style="width: 400pt;" /></a>
+                    <img class="centered" src="/{{version}}/images/streams-stateful_operations.png">
                     <p class="caption"><span class="caption-text">Stateful transformations in the DSL.</span></p>
                 </div>
                 <p>Here is an example of a stateful application: the WordCount algorithm.</p>
@@ -2743,7 +2743,7 @@
                             A tumbling window is a hopping window whose window size is equal to its advance interval.
                             Since tumbling windows never overlap, a data record will belong to one and only one window.</p>
                         <div class="figure align-center" id="id3">
-                            <a class="reference internal image-reference" href="../../../images/streams-time-windows-tumbling.png"><img alt="../../../images/streams-time-windows-tumbling.png" src="../../../images/streams-time-windows-tumbling.png" style="width: 400pt;" /></a>
+                            <img class="centered" src="/{{version}}/images/streams-time-windows-tumbling.png">
                             <p class="caption"><span class="caption-text">This diagram shows windowing a stream of data records with tumbling windows.  Windows do not overlap because, by
 definition, the advance interval is identical to the window size.  In this diagram the time numbers represent minutes;
 e.g. t=5 means &#8220;at the five-minute mark&#8221;.  In reality, the unit of time in Kafka Streams is milliseconds, which means
@@ -2793,7 +2793,7 @@ become t=300,000).</span></p>
 </pre></div>
                         </div>
                         <div class="figure align-center" id="id4">
-                            <a class="reference internal image-reference" href="../../../images/streams-time-windows-hopping.png"><img alt="../../../images/streams-time-windows-hopping.png" src="../../../images/streams-time-windows-hopping.png" style="width: 400pt;" /></a>
+                            <img class="centered" src="/{{version}}/images/streams-time-windows-hopping.png">
                             <p class="caption"><span class="caption-text">This diagram shows windowing a stream of data records with hopping windows.  In this diagram the time numbers
 represent minutes; e.g. t=5 means &#8220;at the five-minute mark&#8221;.  In reality, the unit of time in Kafka Streams is
 milliseconds, which means the time numbers would need to be multiplied with 60 * 1,000 to convert from minutes to
@@ -2849,7 +2849,7 @@ milliseconds (e.g. t=5 would become t=300,000).</span></p>
                             0-minute mark (only due to the illustration it looks as if the session goes from 0 to 1), and another starting and
                             ending at the 6-minute mark; and one session for the blue record key, starting and ending at the 2-minute mark.</p>
                         <div class="figure align-center" id="id5">
-                            <a class="reference internal image-reference" href="../../../images/streams-session-windows-01.png"><img alt="../../../images/streams-session-windows-01.png" src="../../../images/streams-session-windows-01.png" style="width: 400pt;" /></a>
+                            <img class="centered" src="/{{version}}/images/streams-session-windows-01.png">
                             <p class="caption"><span class="caption-text">Detected sessions after having received three input records: two records for the green record key at t=0 and t=6, and
 one record for the blue record key at t=2.
 In this diagram the time numbers represent minutes; e.g.  t=5 means &#8220;at the five-minute mark&#8221;.  In reality, the unit
@@ -2862,7 +2862,7 @@ convert from minutes to milliseconds (e.g. t=5 would become t=300,000).</span></
                             consisting of a total of two records.  And, finally, there will be a new session for the blue key starting and ending at
                             time 11.</p>
                         <div class="figure align-center" id="id6">
-                            <a class="reference internal image-reference" href="../../../images/streams-session-windows-02.png"><img alt="../../../images/streams-session-windows-02.png" src="../../../images/streams-session-windows-02.png" style="width: 400pt;" /></a>
+                            <img class="centered" src="/{{version}}/images/streams-session-windows-02.png">
                             <p class="caption"><span class="caption-text">Detected sessions after having received six input records.  Note the two late-arriving data records at t=4 (green) and
 t=5 (blue), which lead to a merge of sessions and an extension of a session, respectively.</span></p>
                         </div>

--- a/docs/streams/developer-guide/interactive-queries.html
+++ b/docs/streams/developer-guide/interactive-queries.html
@@ -54,7 +54,7 @@
         </div>
         <p>The full state of your application is typically <a class="reference internal" href="../architecture.html#streams-architecture-state"><span class="std std-ref">split across many distributed instances of your application</span></a>, and across many state stores that are managed locally by these application instances.</p>
         <div class="figure align-center">
-            <a class="reference internal image-reference" href="../../../images/streams-interactive-queries-03.png"><img alt="../../../images/streams-interactive-queries-03.png" src="../../../images/streams-interactive-queries-03.png" style="width: 400pt; height: 400pt;" /></a>
+            <img class="centered" src="/{{version}}/images/streams-interactive-queries-03.png">
         </div>
         <p>There are local and remote components to interactively querying the state of your application.</p>
         <dl class="docutils">
@@ -108,7 +108,7 @@
             <p>A Kafka Streams application typically runs on multiple instances.  The state that is locally available on any given instance is only a subset of the <a class="reference internal" href="../architecture.html#streams-architecture-state"><span class="std std-ref">application&#8217;s entire state</span></a>.  Querying the local stores on an instance will only return data locally available on that particular instance.</p>
             <p>The method <code class="docutils literal"><span class="pre">KafkaStreams#store(...)</span></code> finds an application instance&#8217;s local state stores by name and type.</p>
             <div class="figure align-center" id="id1">
-                <a class="reference internal image-reference" href="../../../images/streams-interactive-queries-api-01.png"><img alt="../../../images/streams-interactive-queries-api-01.png" src="../../../images/streams-interactive-queries-api-01.png" style="width: 500pt;" /></a>
+                <img class="centered" src="/{{version}}/images/streams-interactive-queries-api-01.png">
                 <p class="caption"><span class="caption-text">Every application instance can directly query any of its local state stores.</span></p>
             </div>
             <p>The <em>name</em> of a state store is defined when you create the store. You can create the store explicitly by using the Processor API or implicitly by using stateful operations in the DSL.</p>
@@ -357,7 +357,7 @@
                 <li>In the RPC layer, <a class="reference internal" href="#streams-developer-guide-interactive-queries-discover-app-instances-and-stores"><span class="std std-ref">discover remote application instances</span></a> and their state stores and <a class="reference internal" href="#streams-developer-guide-interactive-queries-local-stores"><span class="std std-ref">query locally available state stores</span></a> to make the full state of your application queryable. The remote application instances can forward queries to other app instances if a particular instance lacks the local data to respond to a query. The locally available state stores can directly respond to queries.</li>
             </ol>
             <div class="figure align-center" id="id2">
-                <a class="reference internal image-reference" href="../../../images/streams-interactive-queries-api-02.png"><img alt="../../../images/streams-interactive-queries-api-02.png" src="../../../images/streams-interactive-queries-api-02.png" style="width: 500pt;" /></a>
+                <img class="centered" src="/{{version}}/images/streams-interactive-queries-api-02.png">
                 <p class="caption"><span class="caption-text">Discover any running instances of the same application as well as the respective RPC endpoints they expose for
 interactive queries</span></p>
             </div>

--- a/docs/streams/developer-guide/memory-mgmt.html
+++ b/docs/streams/developer-guide/memory-mgmt.html
@@ -143,7 +143,7 @@
         </li>
       </ul>
       <div class="figure align-center">
-        <a class="reference internal image-reference" href="../../../images/streams-cache-and-commit-interval.png"><img alt="../../../images/streams-cache-and-commit-interval.png" src="../../../images/streams-cache-and-commit-interval.png" style="width: 500pt; height: 400pt;" /></a>
+        <img class="centered" src="/{{version}}/images/streams-cache-and-commit-interval.png">
       </div>
     </div>
     <div class="section" id="record-caches-in-the-processor-api">

--- a/docs/streams/developer-guide/running-app.html
+++ b/docs/streams/developer-guide/running-app.html
@@ -97,11 +97,11 @@ $ java -cp path-to-app-fatjar.jar com.example.MyStreamsApp
                   <p>If you need more processing capacity for your stream processing application, you can simply start another instance of your stream processing application, e.g. on another machine, in order to scale out.  The instances of your application will become aware of each other and automatically begin to share the processing work.  More specifically, what will be handed over from the existing instances to the new instances is (some of) the stream tasks that have been run by the existing instances.  Moving stream tasks from one instance to another results in moving the processing work plus any internal state of these stream tasks (the state of a stream task will be re-created in the target instance by restoring the state from its corresponding changelog topic).</p>
                   <p>The various instances of your application each run in their own JVM process, which means that each instance can leverage all the processing capacity that is available to their respective JVM process (minus the capacity that any non-Kafka-Streams part of your application may be using).  This explains why running additional instances will grant your application additional processing capacity.  The exact capacity you will be adding by running a new instance depends of course on the environment in which the new instance runs: available CPU cores, available main memory and Java heap space, local storage, network bandwidth, and so on.  Similarly, if you stop any of the running instances of your application, then you are removing and freeing up the respective processing capacity.</p>
                   <div class="figure align-center" id="id1">
-                      <a class="reference internal image-reference" href="../../../images/streams-elastic-scaling-1.png"><img alt="../../../images/streams-elastic-scaling-1.png" src="../../../images/streams-elastic-scaling-1.png" style="width: 500pt; height: 400pt;" /></a>
+                      <img class="centered" src="/{{version}}/images/streams-elastic-scaling-1.png">
                       <p class="caption"><span class="caption-text">Before adding capacity: only a single instance of your Kafka Streams application is running.  At this point the corresponding Kafka consumer group of your application contains only a single member (this instance).  All data is being read and processed by this single instance.</span></p>
                   </div>
                   <div class="figure align-center" id="id2">
-                      <a class="reference internal image-reference" href="../../../images/streams-elastic-scaling-2.png"><img alt="../../../images/streams-elastic-scaling-2.png" src="../../../images/streams-elastic-scaling-2.png" style="width: 500pt; height: 400pt;" /></a>
+                      <img class="centered" src="/{{version}}/images/streams-elastic-scaling-2.png">
                       <p class="caption"><span class="caption-text">After adding capacity: now two additional instances of your Kafka Streams application are running, and they have automatically joined the application&#8217;s Kafka consumer group for a total of three current members. These three instances are automatically splitting the processing work between each other. The splitting is based on the Kafka topic partitions from which data is being read.</span></p>
                   </div>
               </div>
@@ -114,7 +114,7 @@ $ java -cp path-to-app-fatjar.jar com.example.MyStreamsApp
                       work plus any internal state of these stream tasks. The state of a stream task is recreated in the target instance
                       from its changelog topic.</p>
                   <div class="figure align-center">
-                      <a class="reference internal image-reference" href="../../../images/streams-elastic-scaling-3.png"><img alt="../../../images/streams-elastic-scaling-3.png" src="../../../images/streams-elastic-scaling-3.png" style="width: 500pt; height: 400pt;" /></a>
+                      <img class="centered" src="/{{version}}/images/streams-elastic-scaling-3.png">
                   </div>
               </div>
               <div class="section" id="state-restoration-during-workload-rebalance">


### PR DESCRIPTION

Fixes image 404s in streams docs (e.g. https://kafka.apache.org/documentation/streams/developer-guide/interactive-queries.html).

Related https://github.com/apache/kafka-site/pull/114

  