### PR TITLE
KAFKA-6428: Generate findbugs output for CI and fail builds for 'high' level warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,16 @@ The checkstyle warnings will be found in `reports/checkstyle/reports/main.html` 
 subproject build directories. They are also are printed to the console. The build will fail if Checkstyle fails.
 
 #### Findbugs ####
-Findbugs uses static analysis to look for bugs in the code.
+Findbugs uses static analysis to look for bugs in the code. Findbugs is executed as part of the normal build process
+and will be included in CI testing. Normally xml reports are generated which are not very human readable unless processed
+by Jenkins. If you want to use check Findbugs results during development, run it so it generates HTML output:
+
 You can run findbugs using:
 
-    ./gradlew findbugsMain findbugsTest -x test
+    ./gradlew findbugsMain findbugsTest -x test -PhtmlFindBugsReport=true
 
 The findbugs warnings will be found in `reports/findbugs/main.html` and `reports/findbugs/test.html` files in the subproject build
-directories.  Use -PxmlFindBugsReport=true to generate an XML report instead of an HTML one.
+directories.
 
 ### Common build options ###
 

--- a/build.gradle
+++ b/build.gradle
@@ -371,13 +371,14 @@ subprojects {
       toolVersion = "3.0.1"
       excludeFilter = file("$rootDir/gradle/findbugs-exclude.xml")
       ignoreFailures = false
+      reportLevel = "high"
     }
     test.dependsOn('findbugsMain')
 
     tasks.withType(FindBugs) {
       reports {
-        xml.enabled(project.hasProperty('xmlFindBugsReport'))
-        html.enabled(!project.hasProperty('xmlFindBugsReport'))
+        xml.enabled(!project.hasProperty('htmlFindBugsReport'))
+        html.enabled(project.hasProperty('htmlFindBugsReport'))
       }
     }
   }


### PR DESCRIPTION
We already had findbugs running and it looks like sufficient warnings should cause errors. This PR does a few things. First, it changes to generating xml reports (which CI likes) by default. We already seem to have the Jenkins plugins setup to consume these, so we should immediately start seeing the output on Jenkins. This seems better than the current html default since most devs probably aren't looking at the html reports unless they are specifically looking at findbugs issues. Second, it explicitly sets the report level we want to trigger failures on.

I think we were already failing the build based on the current settings, we just didn't have any high-level warnings. But this sets us up not to only fail the builds but also have some visibility via jenkins reports.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
