### PR TITLE
KAFKA-6303: Potential lack of synchronization in NioEchoServer

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -227,7 +227,9 @@ public class NioEchoServer extends Thread {
                             if (key.isAcceptable()) {
                                 SocketChannel socketChannel = ((ServerSocketChannel) key.channel()).accept();
                                 socketChannel.configureBlocking(false);
-                                newChannels.add(socketChannel);
+                                synchronized (newChannels) {
+                                    newChannels.add(socketChannel);
+                                }
                                 selector.wakeup();
                             }
                             it.remove();


### PR DESCRIPTION
In the run() method:

                                SocketChannel socketChannel = ((ServerSocketChannel) key.channel()).accept();
                                socketChannel.configureBlocking(false);
                                newChannels.add(socketChannel);

Modification to newChannels should be protected by synchronized block.

- [ ] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
