### PR TITLE
KAFKA-6287: Consumer group command should list simple consumer groups

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -104,6 +104,21 @@ object ConsumerGroupCommand extends Logging {
     e.foreach(debug("Exception in consumer group command", _))
   }
 
+  def convertTimestamp(timeString: String): java.lang.Long = {
+    val datetime: String = timeString match {
+      case ts if ts.split("T")(1).contains("+") || ts.split("T")(1).contains("-") || ts.split("T")(1).contains("Z") => ts.toString
+      case ts => s"${ts}Z"
+    }
+    val date = {
+      try {
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse(datetime)
+      } catch {
+        case _: ParseException => new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX").parse(datetime)
+      }
+    }
+    date.getTime
+  }
+
   def printOffsetsToReset(groupAssignmentsToReset: Map[TopicPartition, OffsetAndMetadata]): Unit = {
     print("\n%-30s %-10s %-15s".format("TOPIC", "PARTITION", "NEW-OFFSET"))
     println()
@@ -154,7 +169,7 @@ object ConsumerGroupCommand extends Logging {
                 // the control should never reach here
                 throw new KafkaException(s"Expected a valid consumer group state, but found '${other.getOrElse("NONE")}'.")
             }
-            state != Some("Dead") && num > 0
+            !state.contains("Dead") && num > 0
           }
       }
     }
@@ -723,8 +738,8 @@ object ConsumerGroupCommand extends Logging {
           (topicPartition, new OffsetAndMetadata(newOffset))
         }.toMap
       } else if (opts.options.has(opts.resetToDatetimeOpt)) {
+        val timestamp = convertTimestamp(opts.options.valueOf(opts.resetToDatetimeOpt))
         partitionsToReset.map { topicPartition =>
-          val timestamp = getDateTime
           val logTimestampOffset = getLogTimestampOffset(topicPartition, timestamp)
           logTimestampOffset match {
             case LogOffsetResult.LogOffset(offset) => (topicPartition, new OffsetAndMetadata(offset))
@@ -783,21 +798,6 @@ object ConsumerGroupCommand extends Logging {
           case _ => offset
         }
       }
-    }
-
-    private[admin] def getDateTime: java.lang.Long = {
-      val datetime: String = opts.options.valueOf(opts.resetToDatetimeOpt) match {
-        case ts if ts.split("T")(1).contains("+") || ts.split("T")(1).contains("-") || ts.split("T")(1).contains("Z") => ts.toString
-        case ts => s"${ts}Z"
-      }
-      val date = {
-        try {
-          new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse(datetime)
-        } catch {
-          case _: ParseException => new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX").parse(datetime)
-        }
-      }
-      date.getTime
     }
 
     override def exportOffsetsToReset(assignmentsToReset: Map[TopicPartition, OffsetAndMetadata]): String = {

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -109,12 +109,10 @@ object ConsumerGroupCommand extends Logging {
       case ts if ts.split("T")(1).contains("+") || ts.split("T")(1).contains("-") || ts.split("T")(1).contains("Z") => ts.toString
       case ts => s"${ts}Z"
     }
-    val date = {
-      try {
-        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse(datetime)
-      } catch {
-        case _: ParseException => new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX").parse(datetime)
-      }
+    val date = try {
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse(datetime)
+    } catch {
+      case _: ParseException => new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX").parse(datetime)
     }
     date.getTime
   }

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -35,7 +35,6 @@ import org.apache.kafka.common.utils.Time
 import scala.collection.{Map, Seq, immutable}
 import scala.math.max
 
-
 /**
  * GroupCoordinator handles general group membership and offset management.
  *
@@ -130,7 +129,7 @@ class GroupCoordinator(val brokerId: Int,
           if (memberId != JoinGroupRequest.UNKNOWN_MEMBER_ID) {
             responseCallback(joinError(memberId, Errors.UNKNOWN_MEMBER_ID))
           } else {
-            val group = groupManager.addGroup(new GroupMetadata(groupId))
+            val group = groupManager.addGroup(new GroupMetadata(groupId, initialState = Empty))
             doJoinGroup(group, memberId, clientId, clientHost, rebalanceTimeoutMs, sessionTimeoutMs, protocolType, protocols, responseCallback)
           }
 
@@ -186,15 +185,15 @@ class GroupCoordinator(val brokerId: Int,
                 // receive the initial JoinGroup response), so just return current group information
                 // for the current generation.
                 responseCallback(JoinGroupResult(
-                  members = if (memberId == group.leaderId) {
+                  members = if (group.isLeader(memberId)) {
                     group.currentMemberMetadata
                   } else {
                     Map.empty
                   },
                   memberId = memberId,
                   generationId = group.generationId,
-                  subProtocol = group.protocol,
-                  leaderId = group.leaderId,
+                  subProtocol = group.protocolOrNull,
+                  leaderId = group.leaderOrNull,
                   error = Errors.NONE))
               } else {
                 // member has changed metadata, so force a rebalance
@@ -208,7 +207,7 @@ class GroupCoordinator(val brokerId: Int,
               addMemberAndRebalance(rebalanceTimeoutMs, sessionTimeoutMs, clientId, clientHost, protocolType, protocols, group, responseCallback)
             } else {
               val member = group.get(memberId)
-              if (memberId == group.leaderId || !member.matches(protocols)) {
+              if (group.isLeader(memberId) || !member.matches(protocols)) {
                 // force a rebalance if a member has changed metadata or if the leader sends JoinGroup.
                 // The latter allows the leader to trigger rebalances for changes affecting assignment
                 // which do not affect the member metadata (such as topic metadata changes for the consumer)
@@ -220,8 +219,8 @@ class GroupCoordinator(val brokerId: Int,
                   members = Map.empty,
                   memberId = memberId,
                   generationId = group.generationId,
-                  subProtocol = group.protocol,
-                  leaderId = group.leaderId,
+                  subProtocol = group.protocolOrNull,
+                  leaderId = group.leaderOrNull,
                   error = Errors.NONE))
               }
             }
@@ -272,7 +271,7 @@ class GroupCoordinator(val brokerId: Int,
             group.get(memberId).awaitingSyncCallback = responseCallback
 
             // if this is the leader, then we can attempt to persist state and transition to stable
-            if (memberId == group.leaderId) {
+            if (group.isLeader(memberId)) {
               info(s"Assignment received from leader for group ${group.groupId} for generation ${group.generationId}")
 
               // fill any missing members with an empty assignment
@@ -409,7 +408,9 @@ class GroupCoordinator(val brokerId: Int,
     validateGroup(groupId) match {
       case Some(error) => responseCallback(offsetMetadata.mapValues(_ => error))
       case None =>
-        val group = groupManager.getGroup(groupId).getOrElse(groupManager.addGroup(new GroupMetadata(groupId)))
+        val group = groupManager.getGroup(groupId).getOrElse {
+          groupManager.addGroup(new GroupMetadata(groupId, initialState = Empty))
+        }
         doCommitOffsets(group, NoMemberId, NoGeneration, producerId, producerEpoch, offsetMetadata, responseCallback)
     }
   }
@@ -426,7 +427,7 @@ class GroupCoordinator(val brokerId: Int,
           case None =>
             if (generationId < 0) {
               // the group is not relying on Kafka for group management, so allow the commit
-              val group = groupManager.addGroup(new GroupMetadata(groupId))
+              val group = groupManager.addGroup(new GroupMetadata(groupId, initialState = Empty))
               doCommitOffsets(group, memberId, generationId, NO_PRODUCER_ID, NO_PRODUCER_EPOCH,
                 offsetMetadata, responseCallback)
             } else {
@@ -460,7 +461,7 @@ class GroupCoordinator(val brokerId: Int,
       if (group.is(Dead)) {
         responseCallback(offsetMetadata.mapValues(_ => Errors.UNKNOWN_MEMBER_ID))
       } else if ((generationId < 0 && group.is(Empty)) || (producerId != NO_PRODUCER_ID)) {
-        // the group is only using Kafka to store offsets
+        // The group is only using Kafka to store offsets.
         // Also, for transactional offset commits we don't need to validate group membership and the generation.
         groupManager.storeOffsets(group, memberId, offsetMetadata, responseCallback, producerId, producerEpoch)
       } else if (group.is(CompletingRebalance)) {
@@ -482,7 +483,7 @@ class GroupCoordinator(val brokerId: Int,
     if (!isActive.get)
       (Errors.COORDINATOR_NOT_AVAILABLE, Map())
     else if (!isCoordinatorForGroup(groupId)) {
-      debug("Could not fetch offsets for group %s (not group coordinator).".format(groupId))
+      debug(s"Could not fetch offsets for group $groupId (not group coordinator)")
       (Errors.NOT_COORDINATOR, Map())
     } else if (isCoordinatorLoadInProgress(groupId))
       (Errors.COORDINATOR_LOAD_IN_PROGRESS, Map())
@@ -754,15 +755,15 @@ class GroupCoordinator(val brokerId: Int,
           for (member <- group.allMemberMetadata) {
             assert(member.awaitingJoinCallback != null)
             val joinResult = JoinGroupResult(
-              members = if (member.memberId == group.leaderId) {
+              members = if (group.isLeader(member.memberId)) {
                 group.currentMemberMetadata
               } else {
                 Map.empty
               },
               memberId = member.memberId,
               generationId = group.generationId,
-              subProtocol = group.protocol,
-              leaderId = group.leaderId,
+              subProtocol = group.protocolOrNull,
+              leaderId = group.leaderOrNull,
               error = Errors.NONE)
 
             member.awaitingJoinCallback(joinResult)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -293,11 +293,15 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
 
   def summary: GroupSummary = {
     if (is(Stable)) {
-      val members = this.members.values.map { member => member.summary(protocol.get) }.toList
-      GroupSummary(state.toString, protocolType.getOrElse(""), protocol.get, members)
+      val protocol = protocolOrNull
+      if (protocol == null)
+        throw new IllegalStateException("Invalid null group protocol for stable group")
+
+      val members = this.members.values.map { member => member.summary(protocol) }
+      GroupSummary(state.toString, protocolType.getOrElse(""), protocol, members.toList)
     } else {
-      val members = this.members.values.map{ member => member.summaryNoMetadata() }.toList
-      GroupSummary(state.toString, protocolType.getOrElse(""), GroupCoordinator.NoProtocol, members)
+      val members = this.members.values.map{ member => member.summaryNoMetadata() }
+      GroupSummary(state.toString, protocolType.getOrElse(""), GroupCoordinator.NoProtocol, members.toList)
     }
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -111,6 +111,22 @@ private object GroupMetadata {
       Stable -> Set(CompletingRebalance),
       PreparingRebalance -> Set(Stable, CompletingRebalance, Empty),
       Empty -> Set(PreparingRebalance))
+
+  def loadGroup(groupId: String,
+                initialState: GroupState,
+                generationId: Int,
+                protocolType: String,
+                protocol: String,
+                leaderId: String,
+                members: Iterable[MemberMetadata]): GroupMetadata = {
+    val group = new GroupMetadata(groupId, initialState)
+    group.generationId = generationId
+    group.protocolType = if (protocolType == null || protocolType.isEmpty) None else Some(protocolType)
+    group.protocol = Option(protocol)
+    group.leaderId = Option(leaderId)
+    members.foreach(group.add)
+    group
+  }
 }
 
 /**
@@ -151,28 +167,22 @@ case class CommitRecordMetadataAndOffset(appendedBatchOffset: Option[Long], offs
  *  3. leader id
  */
 @nonthreadsafe
-private[group] class GroupMetadata(val groupId: String, initialState: GroupState = Empty) extends Logging {
-
-  private var state: GroupState = initialState
-
+private[group] class GroupMetadata(val groupId: String, initialState: GroupState) extends Logging {
   private[group] val lock = new ReentrantLock
 
-  private val members = new mutable.HashMap[String, MemberMetadata]
-
-  private val offsets = new mutable.HashMap[TopicPartition, CommitRecordMetadataAndOffset]
-
-  private val pendingOffsetCommits = new mutable.HashMap[TopicPartition, OffsetAndMetadata]
-
-  private val pendingTransactionalOffsetCommits = new mutable.HashMap[Long, mutable.Map[TopicPartition, CommitRecordMetadataAndOffset]]()
-
-  private var receivedTransactionalOffsetCommits = false
-
-  private var receivedConsumerOffsetCommits = false
-
+  private var state: GroupState = initialState
   var protocolType: Option[String] = None
   var generationId = 0
-  var leaderId: String = null
-  var protocol: String = null
+  private var leaderId: Option[String] = None
+  private var protocol: Option[String] = None
+
+  private val members = new mutable.HashMap[String, MemberMetadata]
+  private val offsets = new mutable.HashMap[TopicPartition, CommitRecordMetadataAndOffset]
+  private val pendingOffsetCommits = new mutable.HashMap[TopicPartition, OffsetAndMetadata]
+  private val pendingTransactionalOffsetCommits = new mutable.HashMap[Long, mutable.Map[TopicPartition, CommitRecordMetadataAndOffset]]()
+  private var receivedTransactionalOffsetCommits = false
+  private var receivedConsumerOffsetCommits = false
+
   var newMemberAdded: Boolean = false
 
   def inLock[T](fun: => T): T = CoreUtils.inLock(lock)(fun)
@@ -182,6 +192,10 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def has(memberId: String) = members.contains(memberId)
   def get(memberId: String) = members(memberId)
 
+  def isLeader(memberId: String): Boolean = leaderId.contains(memberId)
+  def leaderOrNull: String = leaderId.orNull
+  def protocolOrNull: String = protocol.orNull
+
   def add(member: MemberMetadata) {
     if (members.isEmpty)
       this.protocolType = Some(member.protocolType)
@@ -190,18 +204,18 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     assert(this.protocolType.orNull == member.protocolType)
     assert(supportsProtocols(member.protocols))
 
-    if (leaderId == null)
-      leaderId = member.memberId
+    if (leaderId.isEmpty)
+      leaderId = Some(member.memberId)
     members.put(member.memberId, member)
   }
 
   def remove(memberId: String) {
     members.remove(memberId)
-    if (memberId == leaderId) {
+    if (isLeader(memberId)) {
       leaderId = if (members.isEmpty) {
-        null
+        None
       } else {
-        members.keys.head
+        Some(members.keys.head)
       }
     }
   }
@@ -260,11 +274,11 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
     assert(notYetRejoinedMembers == List.empty[MemberMetadata])
     if (members.nonEmpty) {
       generationId += 1
-      protocol = selectProtocol
+      protocol = Some(selectProtocol)
       transitionTo(CompletingRebalance)
     } else {
       generationId += 1
-      protocol = null
+      protocol = None
       transitionTo(Empty)
     }
     receivedConsumerOffsetCommits = false
@@ -274,13 +288,13 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def currentMemberMetadata: Map[String, Array[Byte]] = {
     if (is(Dead) || is(PreparingRebalance))
       throw new IllegalStateException("Cannot obtain member metadata for group in state %s".format(state))
-    members.map{ case (memberId, memberMetadata) => (memberId, memberMetadata.metadata(protocol))}.toMap
+    members.map{ case (memberId, memberMetadata) => (memberId, memberMetadata.metadata(protocol.get))}.toMap
   }
 
   def summary: GroupSummary = {
     if (is(Stable)) {
-      val members = this.members.values.map { member => member.summary(protocol) }.toList
-      GroupSummary(state.toString, protocolType.getOrElse(""), protocol, members)
+      val members = this.members.values.map { member => member.summary(protocol.get) }.toList
+      GroupSummary(state.toString, protocolType.getOrElse(""), protocol.get, members)
     } else {
       val members = this.members.values.map{ member => member.summaryNoMetadata() }.toList
       GroupSummary(state.toString, protocolType.getOrElse(""), GroupCoordinator.NoProtocol, members)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 import com.yammer.metrics.core.Gauge
 import kafka.api.{ApiVersion, KAFKA_0_10_1_IV0}
-import kafka.common.{MessageFormatter, _}
+import kafka.common.{KafkaException, MessageFormatter, OffsetAndMetadata}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.ReplicaManager
 import kafka.utils.CoreUtils.inLock
@@ -221,8 +221,7 @@ class GroupMetadataManager(brokerId: Int,
             throw new IllegalStateException("Append status %s should only have one partition %s"
               .format(responseStatus, groupMetadataPartition))
 
-          // construct the error status in the propagated assignment response
-          // in the cache
+          // construct the error status in the propagated assignment response in the cache
           val status = responseStatus(groupMetadataPartition)
 
           val responseError = if (status.error == Errors.NONE) {
@@ -302,7 +301,7 @@ class GroupMetadataManager(brokerId: Int,
 
     group.inLock {
       if (!group.hasReceivedConsistentOffsetCommits)
-        warn(s"group: ${group.groupId} with leader: ${group.leaderId} has received offset commits from consumers as well " +
+        warn(s"group: ${group.groupId} with leader: ${group.leaderOrNull} has received offset commits from consumers as well " +
           s"as transactional producers. Mixing both types of offset commits will generally result in surprises and " +
           s"should be avoided.")
     }
@@ -624,8 +623,8 @@ class GroupMetadataManager(brokerId: Int,
 
         // load groups which store offsets in kafka, but which have no active members and thus no group
         // metadata stored in the log
-        (emptyGroupOffsets.keySet ++ pendingEmptyGroupOffsets.keySet).foreach { case(groupId) =>
-          val group = new GroupMetadata(groupId)
+        (emptyGroupOffsets.keySet ++ pendingEmptyGroupOffsets.keySet).foreach { groupId =>
+          val group = new GroupMetadata(groupId, initialState = Empty)
           val offsets = emptyGroupOffsets.getOrElse(groupId, Map.empty[TopicPartition, CommitRecordMetadataAndOffset])
           val pendingOffsets = pendingEmptyGroupOffsets.getOrElse(groupId, Map.empty[Long, mutable.Map[TopicPartition, CommitRecordMetadataAndOffset]])
           debug(s"Loaded group metadata $group with offsets $offsets and pending offsets $pendingOffsets")
@@ -1072,11 +1071,12 @@ object GroupMetadataManager {
                                         assignment: Map[String, Array[Byte]],
                                         version: Short = 0): Array[Byte] = {
     val value = if (version == 0) new Struct(GROUP_METADATA_VALUE_SCHEMA_V0) else new Struct(CURRENT_GROUP_VALUE_SCHEMA)
+    val protocol = groupMetadata.protocolOrNull
 
     value.set(PROTOCOL_TYPE_KEY, groupMetadata.protocolType.getOrElse(""))
     value.set(GENERATION_KEY, groupMetadata.generationId)
-    value.set(PROTOCOL_KEY, groupMetadata.protocol)
-    value.set(LEADER_KEY, groupMetadata.leaderId)
+    value.set(PROTOCOL_KEY, protocol)
+    value.set(LEADER_KEY, groupMetadata.leaderOrNull)
 
     val memberArray = groupMetadata.allMemberMetadata.map { memberMetadata =>
       val memberStruct = value.instance(MEMBERS_KEY)
@@ -1088,7 +1088,7 @@ object GroupMetadataManager {
       if (version > 0)
         memberStruct.set(REBALANCE_TIMEOUT_KEY, memberMetadata.rebalanceTimeoutMs)
 
-      val metadata = memberMetadata.metadata(groupMetadata.protocol)
+      val metadata = memberMetadata.metadata(protocol)
       memberStruct.set(SUBSCRIPTION_KEY, ByteBuffer.wrap(metadata))
 
       val memberAssignment = assignment(memberMetadata.memberId)
@@ -1184,36 +1184,28 @@ object GroupMetadataManager {
       val value = valueSchema.read(buffer)
 
       if (version == 0 || version == 1) {
+        val generationId = value.get(GENERATION_KEY).asInstanceOf[Int]
         val protocolType = value.get(PROTOCOL_TYPE_KEY).asInstanceOf[String]
-
+        val protocol = value.get(PROTOCOL_KEY).asInstanceOf[String]
+        val leaderId = value.get(LEADER_KEY).asInstanceOf[String]
         val memberMetadataArray = value.getArray(MEMBERS_KEY)
         val initialState = if (memberMetadataArray.isEmpty) Empty else Stable
 
-        val group = new GroupMetadata(groupId, initialState)
-
-        group.generationId = value.get(GENERATION_KEY).asInstanceOf[Int]
-        group.leaderId = value.get(LEADER_KEY).asInstanceOf[String]
-        group.protocol = value.get(PROTOCOL_KEY).asInstanceOf[String]
-
-        memberMetadataArray.foreach { memberMetadataObj =>
+        val members = memberMetadataArray.map { memberMetadataObj =>
           val memberMetadata = memberMetadataObj.asInstanceOf[Struct]
           val memberId = memberMetadata.get(MEMBER_ID_KEY).asInstanceOf[String]
           val clientId = memberMetadata.get(CLIENT_ID_KEY).asInstanceOf[String]
           val clientHost = memberMetadata.get(CLIENT_HOST_KEY).asInstanceOf[String]
           val sessionTimeout = memberMetadata.get(SESSION_TIMEOUT_KEY).asInstanceOf[Int]
           val rebalanceTimeout = if (version == 0) sessionTimeout else memberMetadata.get(REBALANCE_TIMEOUT_KEY).asInstanceOf[Int]
-
           val subscription = Utils.toArray(memberMetadata.get(SUBSCRIPTION_KEY).asInstanceOf[ByteBuffer])
 
           val member = new MemberMetadata(memberId, groupId, clientId, clientHost, rebalanceTimeout, sessionTimeout,
-            protocolType, List((group.protocol, subscription)))
-
+            protocolType, List((protocol, subscription)))
           member.assignment = Utils.toArray(memberMetadata.get(ASSIGNMENT_KEY).asInstanceOf[ByteBuffer])
-
-          group.add(member)
+          member
         }
-
-        group
+        GroupMetadata.loadGroup(groupId, initialState, generationId, protocolType, protocol, leaderId, members)
       } else {
         throw new IllegalStateException("Unknown group metadata message version")
       }

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -338,7 +338,7 @@ object DumpLogSegments {
 
       val valueString = Json.encodeAsString(Map(
         "protocolType" -> protocolType,
-        "protocol" -> group.protocol,
+        "protocol" -> group.protocolOrNull,
         "generationId" -> group.generationId,
         "assignment" -> assignment
       ).asJava)

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -152,7 +152,7 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
       createClientCredential()
       verifyWithRetry(describeTopic())
     } finally {
-      adminClient.close
+      adminClient.close()
     }
   }
 

--- a/core/src/test/scala/unit/kafka/admin/ConsumerGroupCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ConsumerGroupCommandTest.scala
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.admin
+
+import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
+import java.util.{Collections, Properties}
+
+import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, ConsumerGroupService, KafkaConsumerGroupService, ZkConsumerGroupService}
+import kafka.consumer.{OldConsumer, Whitelist}
+import kafka.integration.KafkaServerTestHarness
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.consumer.{KafkaConsumer, RangeAssignor}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.WakeupException
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.{After, Before}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConverters._
+
+class ConsumerGroupCommandTest extends KafkaServerTestHarness {
+  import ConsumerGroupCommandTest._
+
+  val topic = "foo"
+  val group = "test.group"
+
+  @deprecated("This field will be removed in a future release", "0.11.0.0")
+  private val oldConsumers = new ArrayBuffer[OldConsumer]
+  private var consumerGroupService: List[ConsumerGroupService] = List()
+  private var consumerGroupExecutors: List[AbstractConsumerGroupExecutor] = List()
+
+  // configure the servers and clients
+  override def generateConfigs = {
+    TestUtils.createBrokerConfigs(1, zkConnect, enableControlledShutdown = false).map { props =>
+      KafkaConfig.fromProps(props)
+    }
+  }
+
+  @Before
+  override def setUp() {
+    super.setUp()
+    adminZkClient.createTopic(topic, 1, 1)
+  }
+
+  @After
+  override def tearDown(): Unit = {
+    consumerGroupService.foreach(_.close())
+    consumerGroupExecutors.foreach(_.shutdown())
+    oldConsumers.foreach(_.stop())
+    super.tearDown()
+  }
+
+  @deprecated("This test has been deprecated and will be removed in a future release.", "0.11.1.0")
+  def createOldConsumer(): Unit = {
+    val consumerProps = new Properties
+    consumerProps.setProperty("group.id", group)
+    consumerProps.setProperty("zookeeper.connect", zkConnect)
+    oldConsumers += new OldConsumer(Whitelist(topic), consumerProps)
+  }
+
+  def stopRandomOldConsumer(): Unit = {
+    oldConsumers.head.stop()
+  }
+
+  def getConsumerGroupService(args: Array[String]): ConsumerGroupService = {
+    val opts = new ConsumerGroupCommandOptions(args)
+    val service = if (opts.useOldConsumer) new ZkConsumerGroupService(opts) else new KafkaConsumerGroupService(opts)
+    consumerGroupService = service :: consumerGroupService
+    service
+  }
+
+  def addConsumerGroupExecutor(numConsumers: Int,
+                               topic: String = topic,
+                               group: String = group,
+                               strategy: String = classOf[RangeAssignor].getName): ConsumerGroupExecutor = {
+    val executor = new ConsumerGroupExecutor(brokerList, numConsumers, group, topic, strategy)
+    addExecutor(executor)
+    executor
+  }
+
+  def addSimpleGroupExecutor(partitions: Iterable[TopicPartition] = Seq(new TopicPartition(topic, 0)),
+                             group: String = group): SimpleConsumerGroupExecutor = {
+    val executor = new SimpleConsumerGroupExecutor(brokerList, group, partitions)
+    addExecutor(executor)
+    executor
+  }
+
+  private def addExecutor(executor: AbstractConsumerGroupExecutor): AbstractConsumerGroupExecutor = {
+    consumerGroupExecutors = executor :: consumerGroupExecutors
+    executor
+  }
+
+}
+
+object ConsumerGroupCommandTest {
+
+  abstract class AbstractConsumerThread(broker: String, groupId: String) extends Runnable {
+    val props = new Properties
+    configure(props)
+    val consumer = new KafkaConsumer(props)
+
+    def configure(props: Properties): Unit = {
+      props.put("bootstrap.servers", broker)
+      props.put("group.id", groupId)
+      props.put("key.deserializer", classOf[StringDeserializer].getName)
+      props.put("value.deserializer", classOf[StringDeserializer].getName)
+    }
+
+    def subscribe(): Unit
+
+    def run() {
+      try {
+        subscribe()
+        while (true)
+          consumer.poll(Long.MaxValue)
+      } catch {
+        case _: WakeupException => // OK
+      } finally {
+        consumer.close()
+      }
+    }
+
+    def shutdown() {
+      consumer.wakeup()
+    }
+  }
+
+  class ConsumerThread(broker: String, groupId: String, topic: String, strategy: String)
+    extends AbstractConsumerThread(broker, groupId) {
+
+    override def configure(props: Properties): Unit = {
+      super.configure(props)
+      props.put("partition.assignment.strategy", strategy)
+    }
+
+    override def subscribe(): Unit = {
+      consumer.subscribe(Collections.singleton(topic))
+    }
+  }
+
+  class SimpleConsumerThread(broker: String, groupId: String, partitions: Iterable[TopicPartition])
+    extends AbstractConsumerThread(broker, groupId) {
+
+    override def subscribe(): Unit = {
+      consumer.assign(partitions.toList.asJava)
+    }
+  }
+
+  class AbstractConsumerGroupExecutor(numThreads: Int) {
+    private val executor: ExecutorService = Executors.newFixedThreadPool(numThreads)
+    private val consumers = new ArrayBuffer[AbstractConsumerThread]()
+
+    def submit(consumerThread: AbstractConsumerThread) {
+      consumers += consumerThread
+      executor.submit(consumerThread)
+    }
+
+    def shutdown() {
+      consumers.foreach(_.shutdown())
+      executor.shutdown()
+      try {
+        executor.awaitTermination(5000, TimeUnit.MILLISECONDS)
+      } catch {
+        case e: InterruptedException =>
+          e.printStackTrace()
+      }
+    }
+  }
+
+  class ConsumerGroupExecutor(broker: String, numConsumers: Int, groupId: String, topic: String, strategy: String)
+    extends AbstractConsumerGroupExecutor(numConsumers) {
+
+    for (_ <- 1 to numConsumers) {
+      submit(new ConsumerThread(broker, groupId, topic, strategy))
+    }
+
+  }
+
+  class SimpleConsumerGroupExecutor(broker: String, groupId: String, partitions: Iterable[TopicPartition])
+    extends AbstractConsumerGroupExecutor(1) {
+
+    submit(new SimpleConsumerThread(broker, groupId, partitions))
+  }
+
+}
+

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -16,12 +16,47 @@
  */
 package kafka.admin
 
+import java.util.Properties
+
 import org.junit.Test
 import kafka.admin.ConsumerGroupCommand.ConsumerGroupCommandOptions
 import kafka.admin.ConsumerGroupCommand.ZkConsumerGroupService
+import kafka.consumer.{OldConsumer, Whitelist}
 import kafka.utils.TestUtils
+import org.easymock.EasyMock
 
 class ListConsumerGroupTest extends ConsumerGroupCommandTest {
+
+  @Test
+  def testListGroupWithSomeGroups() {
+    val topicFilter = Whitelist(topic)
+    val props = new Properties
+    props.setProperty("group.id", group)
+    props.setProperty("zookeeper.connect", zkConnect)
+    // mocks
+    val consumer1Mock = EasyMock.createMockBuilder(classOf[OldConsumer]).withConstructor(topicFilter, props).createMock()
+    props.setProperty("group.id", "some.other.group")
+    val consumer2Mock = EasyMock.createMockBuilder(classOf[OldConsumer]).withConstructor(topicFilter, props).createMock()
+
+    // stubs
+    val opts = new ConsumerGroupCommandOptions(Array("--zookeeper", zkConnect))
+    val consumerGroupCommand = new ZkConsumerGroupService(opts)
+
+    // simulation
+    EasyMock.replay(consumer1Mock)
+    EasyMock.replay(consumer2Mock)
+
+    // action/test
+    TestUtils.waitUntilTrue(() => {
+      val groups = consumerGroupCommand.listGroups()
+      groups.size == 2 && groups.contains(group)
+    }, "Expected a different list group results.")
+
+    // cleanup
+    consumerGroupCommand.close()
+    consumer1Mock.stop()
+    consumer2Mock.stop()
+  }
 
   @Test
   def testListGroupWithNoExistingGroup() {

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -43,9 +43,12 @@ class ListConsumerGroupTest extends ConsumerGroupCommandTest {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--list")
     val service = getConsumerGroupService(cgcArgs)
 
+    val expectedGroups = Set(group, simpleGroup)
+    var foundGroups = Set.empty[String]
     TestUtils.waitUntilTrue(() => {
-      service.listGroups().toSet == Set(group, simpleGroup)
-    }, "Expected a stable group with two members in describe group state result.")
+      foundGroups = service.listGroups().toSet
+      expectedGroups == foundGroups
+    }, s"Expected --list to show groups $expectedGroups, but found $foundGroups.")
   }
 
 }

--- a/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ListConsumerGroupTest.scala
@@ -28,7 +28,7 @@ import org.easymock.EasyMock
 class ListConsumerGroupTest extends ConsumerGroupCommandTest {
 
   @Test
-  def testListGroupWithSomeGroups() {
+  def testListOldConsumerGroups() {
     val topicFilter = Whitelist(topic)
     val props = new Properties
     props.setProperty("group.id", group)

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandTest.scala
@@ -35,7 +35,7 @@ import scala.collection.{Seq, mutable}
 import scala.collection.JavaConverters._
 import org.apache.kafka.common.TopicPartition
 
-class ReassignPartitionsCommandTest  extends ZooKeeperTestHarness  with Logging {
+class ReassignPartitionsCommandTest extends ZooKeeperTestHarness with Logging {
   var calls = 0
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ResetConsumerGroupOffsetTest.scala
@@ -16,13 +16,46 @@ import java.io.{BufferedWriter, File, FileWriter}
 import java.text.{ParseException, SimpleDateFormat}
 import java.util.{Calendar, Date, Properties}
 
-import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, KafkaConsumerGroupService}
-import kafka.integration.KafkaServerTestHarness
+import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, ConsumerGroupService, KafkaConsumerGroupService}
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
-import org.junit.{After, Before, Test}
+import org.junit.Assert._
+import org.junit.Test
 
-import scala.collection.mutable.ArrayBuffer
+class TimeConversionTests {
+
+  @Test
+  def testDateTimeFormats() {
+    //check valid formats
+    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"))
+    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
+    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX"))
+    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXX"))
+    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"))
+
+    //check some invalid formats
+    try {
+      invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"))
+      fail("Call to getDateTime should fail")
+    } catch {
+      case _: ParseException =>
+    }
+
+    try {
+      invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.X"))
+      fail("Call to getDateTime should fail")
+    } catch {
+      case _: ParseException =>
+    }
+  }
+
+  private def invokeGetDateTimeMethod(format: SimpleDateFormat) {
+    val checkpoint = new Date()
+    val timestampString = format.format(checkpoint)
+    ConsumerGroupCommand.convertTimestamp(timestampString)
+  }
+
+}
 
 /**
   * Test cases by:
@@ -34,46 +67,27 @@ import scala.collection.mutable.ArrayBuffer
   * - scope=topics+partitions, scenario=to-earliest
   * - export/import
   */
-class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
-
+class ResetConsumerGroupOffsetTest extends ConsumerGroupCommandTest {
+  
   val overridingProps = new Properties()
   val topic1 = "foo1"
   val topic2 = "foo2"
-  val group = "test.group"
-  val props = new Properties
-  val consumerGroupServices = new ArrayBuffer[KafkaConsumerGroupService]
-  val executors = new ArrayBuffer[ConsumerGroupExecutor]
 
   /**
     * Implementations must override this method to return a set of KafkaConfigs. This method will be invoked for every
     * test and should not reuse previous configurations unless they select their ports randomly when servers are started.
     */
-  override def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(1, zkConnect, enableControlledShutdown = false).map(KafkaConfig.fromProps(_, overridingProps))
-
-  @Before
-  override def setUp() {
-    super.setUp()
-
-    props.setProperty("group.id", group)
-  }
-
-  @After
-  override def tearDown() {
-    try {
-      executors.foreach(_.shutdown())
-      consumerGroupServices.foreach(_.close())
-    } finally {
-      super.tearDown()
-    }
-  }
+  override def generateConfigs: Seq[KafkaConfig] = {
+    TestUtils.createBrokerConfigs(1, zkConnect, enableControlledShutdown = false)
+      .map(KafkaConfig.fromProps(_, overridingProps))  
+  } 
 
   @Test
   def testResetOffsetsNotExistingGroup() {
-    createConsumerGroupExecutor(brokerList, 1, group, topic1)
+    addConsumerGroupExecutor(numConsumers = 1, topic1)
 
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", "missing.group", "--all-topics", "--to-current")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     TestUtils.waitUntilTrue(() => {
       val assignmentsToReset = consumerGroupCommand.resetOffsets()
@@ -113,10 +127,9 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     TestUtils.produceMessages(servers, topic1, 100, acks = 1, 100 * 1000)
 
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--dry-run")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
-    val executor = createConsumerGroupExecutor(brokerList, 1, group, topic1)
+    val executor = addConsumerGroupExecutor(numConsumers = 1, topic1)
 
     TestUtils.waitUntilTrue(() => {
       val (_, assignmentsOption) = consumerGroupCommand.collectGroupOffsets()
@@ -134,8 +147,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     executor.shutdown()
 
     val cgcArgs1 = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-datetime", format.format(calendar.getTime))
-    val opts1 = new ConsumerGroupCommandOptions(cgcArgs1)
-    val consumerGroupCommand1 = createConsumerGroupService(opts1)
+    val consumerGroupCommand1 = getConsumerGroupService(cgcArgs1)
 
     TestUtils.waitUntilTrue(() => {
       val assignmentsToReset = consumerGroupCommand1.resetOffsets()
@@ -158,10 +170,9 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     TestUtils.produceMessages(servers, topic1, 50, acks = 1, 100 * 1000)
 
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--dry-run")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
-    val executor = createConsumerGroupExecutor(brokerList, 1, group, topic1)
+    val executor = addConsumerGroupExecutor(numConsumers = 1, topic1)
 
     TestUtils.waitUntilTrue(() => {
       val (_, assignmentsOption) = consumerGroupCommand.collectGroupOffsets()
@@ -178,8 +189,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     executor.shutdown()
 
     val cgcArgs1 = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-datetime", format.format(checkpoint))
-    val opts1 = new ConsumerGroupCommandOptions(cgcArgs1)
-    val consumerGroupCommand1 = createConsumerGroupService(opts1)
+    val consumerGroupCommand1 = getConsumerGroupService(cgcArgs1)
 
     TestUtils.waitUntilTrue(() => {
       val assignmentsToReset = consumerGroupCommand1.resetOffsets()
@@ -192,43 +202,9 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   }
 
   @Test
-  def testDateTimeFormats() {
-    //check valid formats
-    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"))
-    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))
-    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX"))
-    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXX"))
-    invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"))
-
-    //check some invalid formats
-    try {
-      invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"))
-      fail("Call to getDateTime should fail")
-    } catch {
-      case _: ParseException =>
-    }
-
-    try {
-      invokeGetDateTimeMethod(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.X"))
-      fail("Call to getDateTime should fail")
-    } catch {
-      case _: ParseException =>
-    }
-  }
-
-  private def invokeGetDateTimeMethod(format: SimpleDateFormat) {
-    val checkpoint = new Date()
-    val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-datetime", format.format(checkpoint))
-    val opts  = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
-    consumerGroupCommand.getDateTime
-  }
-
-  @Test
   def testResetOffsetsByDuration() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--by-duration", "PT1M")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -247,8 +223,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsByDurationToEarliest() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--by-duration", "PT0.1S")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -266,8 +241,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsToEarliest() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-earliest")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -285,8 +259,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsToLatest() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-latest")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -307,8 +280,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsToCurrentOffset() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-current")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -325,9 +297,9 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     adminZkClient.deleteTopic(topic1)
   }
 
-  private def produceConsumeAndShutdown(consumerGroupCommand: KafkaConsumerGroupService, numConsumers: Int, topic: String, totalMessages: Int) {
+  private def produceConsumeAndShutdown(consumerGroupCommand: ConsumerGroupService, numConsumers: Int, topic: String, totalMessages: Int) {
     TestUtils.produceMessages(servers, topic, totalMessages, acks = 1, 100 * 1000)
-    val executor = createConsumerGroupExecutor(brokerList, numConsumers, group, topic)
+    val executor =  addConsumerGroupExecutor(numConsumers, topic)
 
     TestUtils.waitUntilTrue(() => {
       val (_, assignmentsOption) = consumerGroupCommand.collectGroupOffsets()
@@ -348,8 +320,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsToSpecificOffset() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-offset", "1")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -368,8 +339,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsShiftPlus() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--shift-by", "50")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -389,8 +359,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsShiftMinus() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--shift-by", "-50")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -411,8 +380,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsShiftByLowerThanEarliest() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--shift-by", "-150")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -432,8 +400,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsShiftByHigherThanLatest() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--shift-by", "150")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -453,8 +420,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsToEarliestOnOneTopic() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--topic", topic1, "--to-earliest")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
 
@@ -472,8 +438,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsToEarliestOnOneTopicAndPartition() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--topic", String.format("%s:1", topic1), "--to-earliest")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 2, 1)
 
@@ -495,8 +460,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
       "--topic", topic1,
       "--topic", topic2,
       "--to-earliest")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 1, 1)
     adminZkClient.createTopic(topic2, 1, 1)
@@ -522,8 +486,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
       "--topic", String.format("%s:1", topic1),
       "--topic", String.format("%s:1", topic2),
       "--to-earliest")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 2, 1)
     adminZkClient.createTopic(topic2, 2, 1)
@@ -545,8 +508,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
   @Test
   def testResetOffsetsExportImportPlan() {
     val cgcArgs = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--to-offset","2", "--export")
-    val opts = new ConsumerGroupCommandOptions(cgcArgs)
-    val consumerGroupCommand = createConsumerGroupService(opts)
+    val consumerGroupCommand = getConsumerGroupService(cgcArgs)
 
     adminZkClient.createTopic(topic1, 2, 1)
 
@@ -564,8 +526,7 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
 
 
     val cgcArgsExec = Array("--bootstrap-server", brokerList, "--reset-offsets", "--group", group, "--all-topics", "--from-file", file.getCanonicalPath, "--dry-run")
-    val optsExec = new ConsumerGroupCommandOptions(cgcArgsExec)
-    val consumerGroupCommandExec = createConsumerGroupService(optsExec)
+    val consumerGroupCommandExec = getConsumerGroupService(cgcArgsExec)
 
     TestUtils.waitUntilTrue(() => {
         val assignmentsToReset = consumerGroupCommandExec.resetOffsets()
@@ -588,15 +549,4 @@ class ResetConsumerGroupOffsetTest extends KafkaServerTestHarness {
     ConsumerGroupCommand.main(cgcArgs)
   }
 
-  private def createConsumerGroupExecutor(brokerList: String, numConsumers: Int, groupId: String, topic: String): ConsumerGroupExecutor = {
-    val executor = new ConsumerGroupExecutor(brokerList, numConsumers, groupId, topic)
-    executors += executor
-    executor
-  }
-
-  private def createConsumerGroupService(opts: ConsumerGroupCommandOptions): KafkaConsumerGroupService = {
-    val service = new KafkaConsumerGroupService(opts)
-    consumerGroupServices += service
-    service
-  }
 }

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataTest.scala
@@ -40,7 +40,7 @@ class GroupMetadataTest extends JUnitSuite {
 
   @Before
   def setUp() {
-    group = new GroupMetadata("groupId")
+    group = new GroupMetadata("groupId", initialState = Empty)
   }
 
   @Test
@@ -271,25 +271,25 @@ class GroupMetadataTest extends JUnitSuite {
     group.add(member)
 
     assertEquals(0, group.generationId)
-    assertNull(group.protocol)
+    assertNull(group.protocolOrNull)
 
     group.initNextGeneration()
 
     assertEquals(1, group.generationId)
-    assertEquals("roundrobin", group.protocol)
+    assertEquals("roundrobin", group.protocolOrNull)
   }
 
   @Test
   def testInitNextGenerationEmptyGroup() {
     assertEquals(Empty, group.currentState)
     assertEquals(0, group.generationId)
-    assertNull(group.protocol)
+    assertNull(group.protocolOrNull)
 
     group.transitionTo(PreparingRebalance)
     group.initNextGeneration()
 
     assertEquals(1, group.generationId)
-    assertNull(group.protocol)
+    assertNull(group.protocolOrNull)
   }
 
   @Test


### PR DESCRIPTION
With this patch, simple consumer groups which only use Kafka for offset storage will be viewable using the `--list` option. In addition, this patch fixes a bug in the offset loading logic which caused us to lose the protocol type of empty groups on coordinator failover. I also did some cleanup of the various consumer group command test cases.

For testing, I have added new integration tests which cover listing and describing simple consumer groups. I also added unit tests to cover loading empty groups with assertions on the protocol type.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)

  