### PR TITLE
KAFKA-4969: Attempt to evenly distribute load of tasks

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -527,22 +527,22 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             for (String consumer : consumers) {
                 final Map<TaskId, Set<TopicPartition>> standby = new HashMap<>();
                 final ArrayList<AssignedPartition> assignedPartitions = new ArrayList<>();
-                int taskAssignmentLength = numberTasksPerConsumer[consumerTaskIndex];
+                final int taskAssignmentLength = numberTasksPerConsumer[consumerTaskIndex];
 
                 activeEndIndex = activeEndIndex + taskAssignmentLength;
 
                 final List<TaskId> assignedActiveList = interleavedActive.subList(activeStartIndex, activeEndIndex);
                 List<TaskId> assignedStandbyList;
 
-                for (TaskId taskId : assignedActiveList) {
-                    for (TopicPartition partition : partitionsForTask.get(taskId)) {
+                for (final TaskId taskId : assignedActiveList) {
+                    for (final TopicPartition partition : partitionsForTask.get(taskId)) {
                         assignedPartitions.add(new AssignedPartition(taskId, partition));
                     }
                 }
                 activeStartIndex = activeEndIndex;
 
                 if (numberStandbyTasksPerConsumer.length > 0) {
-                    int standbyTaskAssignmentLength = numberStandbyTasksPerConsumer[consumerTaskIndex];
+                    final int standbyTaskAssignmentLength = numberStandbyTasksPerConsumer[consumerTaskIndex];
                     standbyEndIndex = standbyEndIndex + standbyTaskAssignmentLength;
                     assignedStandbyList = interleavedStandby.subList(standbyStartIndex, standbyEndIndex);
                     for (TaskId taskId : assignedStandbyList) {
@@ -576,11 +576,11 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
 
     // visible for testing
     int[] calculateNumAssignments(final int numTasks, final int numConsumers) {
-        int[] numTasksPerClient = new int[numConsumers];
+        final int[] numTasksPerClient = new int[numConsumers];
         if (numTasks % numConsumers == 0) {
             Arrays.fill(numTasksPerClient, numTasks / numConsumers);
         } else {
-            int startingNumTasks = numTasks / numConsumers;
+            final int startingNumTasks = numTasks / numConsumers;
             Arrays.fill(numTasksPerClient, startingNumTasks);
             int totalTasksLeft = numTasks - (startingNumTasks * numConsumers);
             int index = 0;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -516,7 +516,6 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                 final ArrayList<AssignedPartition> assignedPartitions = new ArrayList<>();
 
                 final List<TaskId> assignedActiveList = interleavedActive.get(consumerTaskIndex);
-                List<TaskId> assignedStandbyList;
 
                 for (final TaskId taskId : assignedActiveList) {
                     for (final TopicPartition partition : partitionsForTask.get(taskId)) {
@@ -525,8 +524,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
                 }
 
                 if (!state.standbyTasks().isEmpty()) {
-                    assignedStandbyList = interleavedStandby.get(consumerTaskIndex);
-                    for (TaskId taskId : assignedStandbyList) {
+                    final List<TaskId> assignedStandbyList = interleavedStandby.get(consumerTaskIndex);
+                    for (final TaskId taskId : assignedStandbyList) {
                         Set<TopicPartition> standbyPartitions = standby.get(taskId);
                         if (standbyPartitions == null) {
                             standbyPartitions = new HashSet<>();
@@ -555,22 +554,21 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
     }
 
     // visible for testing
-    List<List<TaskId>> interleaveTasksByGroupId(Collection<TaskId> taskIds, int numberThreads) {
-        final List<TaskId> sortedTasks = new ArrayList<>(taskIds);
+    List<List<TaskId>> interleaveTasksByGroupId(final Collection<TaskId> taskIds, final int numberThreads) {
+        final LinkedList<TaskId> sortedTasks = new LinkedList<>(taskIds);
         Collections.sort(sortedTasks);
-        List<List<TaskId>> taskIdsForConsumerAssignment = new ArrayList<>(numberThreads);
+        final List<List<TaskId>> taskIdsForConsumerAssignment = new ArrayList<>(numberThreads);
         for (int i = 0; i < numberThreads; i++) {
             taskIdsForConsumerAssignment.add(new ArrayList<TaskId>());
         }
-        LinkedList<TaskId> taskIdLinkedList = new LinkedList<>(sortedTasks);
-        while (!taskIdLinkedList.isEmpty()) {
-            for (List<TaskId> taskIdList : taskIdsForConsumerAssignment) {
-                TaskId taskId = taskIdLinkedList.poll();
-                if (taskId != null) {
-                    taskIdList.add(taskId);
+        while (!sortedTasks.isEmpty()) {
+            for (final List<TaskId> taskIdList : taskIdsForConsumerAssignment) {
+                final TaskId taskId = sortedTasks.poll();
+                if (taskId == null) {
+                    break;
                 }
+                taskIdList.add(taskId);
             }
-
         }
         return taskIdsForConsumerAssignment;
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -158,7 +158,10 @@ public class StreamPartitionAssignorTest {
         final List<TaskId> expectedSubList3 = Arrays.asList(taskIdA2, taskIdB1, taskIdC1);
         final List<List<TaskId>> embeddedList = Arrays.asList(expectedSubList1, expectedSubList2, expectedSubList3);
 
-        final List<List<TaskId>> interleavedTaskIds = partitionAssignor.interleaveTasksByGroupId(Arrays.asList(taskIdC0, taskIdC1, taskIdB0, taskIdB1, taskIdB2, taskIdA0, taskIdA1, taskIdA2, taskIdA3), 3);
+        List<TaskId> tasks = Arrays.asList(taskIdC0, taskIdC1, taskIdB0, taskIdB1, taskIdB2, taskIdA0, taskIdA1, taskIdA2, taskIdA3);
+        Collections.shuffle(tasks);
+
+        final List<List<TaskId>> interleavedTaskIds = partitionAssignor.interleaveTasksByGroupId(tasks, 3);
 
         assertThat(interleavedTaskIds, equalTo(embeddedList));
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -161,6 +161,21 @@ public class StreamPartitionAssignorTest {
     }
 
     @Test
+    public void shouldEvenlyDistributeTasksAsMuchAsPossible() {
+        final int[] expectedTasksPerThread = new int[]{2, 2, 2};
+        assertThat(partitionAssignor.calculateNumAssignments(6, 3), equalTo(expectedTasksPerThread));
+
+        final int[] expectedTasksPerThreadII = new int[]{2, 2, 1};
+        assertThat(partitionAssignor.calculateNumAssignments(5, 3), equalTo(expectedTasksPerThreadII));
+
+        final int[] expectedTasksPerThreadIII = new int[]{4, 3, 3, 3};
+        assertThat(partitionAssignor.calculateNumAssignments(13, 4), equalTo(expectedTasksPerThreadIII));
+
+        final int[] expectedTasksPerThreadIV = new int[]{10};
+        assertThat(partitionAssignor.calculateNumAssignments(10, 1), equalTo(expectedTasksPerThreadIV));
+    }
+
+    @Test
     public void testSubscription() throws Exception {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -147,22 +147,15 @@ public class StreamPartitionAssignorTest {
         final TaskId taskIdB0 = new TaskId(1, 0);
         final TaskId taskIdB1 = new TaskId(1, 1);
         final TaskId taskIdB2 = new TaskId(1, 2);
-        final TaskId taskIdB3 = new TaskId(1, 3);
 
         final TaskId taskIdC0 = new TaskId(2, 0);
         final TaskId taskIdC1 = new TaskId(2, 1);
 
-        List<TaskId> expectedInterleavedTaskIds = Arrays.asList(taskIdA0, taskIdB0, taskIdA1, taskIdB1, taskIdA2, taskIdB2, taskIdA3, taskIdB3);
+        final List<TaskId> expectedInterLeavedTaskIds = Arrays.asList(taskIdA0, taskIdB0, taskIdC0, taskIdA1, taskIdB1, taskIdC1, taskIdA2, taskIdB2, taskIdA3);
 
-        List<TaskId> interleavedTaskIds = partitionAssignor.interleaveTasksByGroupId(Arrays.asList(taskIdA0, taskIdA1, taskIdA2, taskIdA3, taskIdB0, taskIdB1, taskIdB2, taskIdB3));
+        final List<TaskId> interleavedTaskIds = partitionAssignor.interleaveTasksByGroupId(Arrays.asList(taskIdC0, taskIdC1, taskIdB0, taskIdB1, taskIdB2, taskIdA0, taskIdA1, taskIdA2, taskIdA3));
 
-        assertThat(interleavedTaskIds, equalTo(expectedInterleavedTaskIds));
-
-        List<TaskId> expectedInterLeavedTaskIdsII = Arrays.asList(taskIdA0, taskIdB0, taskIdC0, taskIdA1, taskIdB1, taskIdC1, taskIdA2, taskIdB2, taskIdA3);
-
-        List<TaskId> interleavedTaskIdsII = partitionAssignor.interleaveTasksByGroupId(Arrays.asList(taskIdC0, taskIdC1, taskIdB0, taskIdB1, taskIdB2, taskIdA0, taskIdA1, taskIdA2, taskIdA3));
-
-        assertThat(interleavedTaskIdsII, equalTo(expectedInterLeavedTaskIdsII));
+        assertThat(interleavedTaskIds, equalTo(expectedInterLeavedTaskIds));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -70,9 +70,11 @@ public class StreamPartitionAssignorTest {
     private final TopicPartition t1p0 = new TopicPartition("topic1", 0);
     private final TopicPartition t1p1 = new TopicPartition("topic1", 1);
     private final TopicPartition t1p2 = new TopicPartition("topic1", 2);
+    private final TopicPartition t1p3 = new TopicPartition("topic1", 3);
     private final TopicPartition t2p0 = new TopicPartition("topic2", 0);
     private final TopicPartition t2p1 = new TopicPartition("topic2", 1);
     private final TopicPartition t2p2 = new TopicPartition("topic2", 2);
+    private final TopicPartition t2p3 = new TopicPartition("topic2", 3);
     private final TopicPartition t3p0 = new TopicPartition("topic3", 0);
     private final TopicPartition t3p1 = new TopicPartition("topic3", 1);
     private final TopicPartition t3p2 = new TopicPartition("topic3", 2);
@@ -248,6 +250,74 @@ public class StreamPartitionAssignorTest {
 
         assertEquals(3, allActiveTasks.size());
         assertEquals(allTasks, allActiveTasks);
+    }
+
+    @Test
+    public void shouldAssignEvenlyAcrossConsumersOneClientMultipleThreads() throws Exception {
+        builder.addSource(null, "source1", null, null, null, "topic1");
+        builder.addSource(null, "source2", null, null, null, "topic2");
+        builder.addProcessor("processor", new MockProcessorSupplier(), "source1");
+        builder.addProcessor("processorII", new MockProcessorSupplier(),  "source2");
+
+        final List<PartitionInfo> localInfos = Arrays.asList(
+            new PartitionInfo("topic1", 0, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic1", 1, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic1", 2, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic1", 3, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic2", 0, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic2", 1, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic2", 2, Node.noNode(), new Node[0], new Node[0]),
+            new PartitionInfo("topic2", 3, Node.noNode(), new Node[0], new Node[0])
+        );
+
+        final Cluster localMetadata = new Cluster(
+            "cluster",
+            Collections.singletonList(Node.noNode()),
+            localInfos, Collections.<String>emptySet(),
+            Collections.<String>emptySet());
+
+        final List<String> topics = Utils.mkList("topic1", "topic2");
+
+        final TaskId taskIdA0 = new TaskId(0, 0);
+        final TaskId taskIdA1 = new TaskId(0, 1);
+        final TaskId taskIdA2 = new TaskId(0, 2);
+        final TaskId taskIdA3 = new TaskId(0, 3);
+
+        final TaskId taskIdB0 = new TaskId(1, 0);
+        final TaskId taskIdB1 = new TaskId(1, 1);
+        final TaskId taskIdB2 = new TaskId(1, 2);
+        final TaskId taskIdB3 = new TaskId(1, 3);
+
+        final UUID uuid1 = UUID.randomUUID();
+
+        mockTaskManager(new HashSet<TaskId>(), new HashSet<TaskId>(), uuid1, builder);
+        configurePartitionAssignor(Collections.<String, Object>emptyMap());
+
+        partitionAssignor.setInternalTopicManager(new MockInternalTopicManager(streamsConfig, mockClientSupplier.restoreConsumer));
+
+        final Map<String, PartitionAssignor.Subscription> subscriptions = new HashMap<>();
+        subscriptions.put("consumer10",
+                          new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, new HashSet<TaskId>(), new HashSet<TaskId>(), userEndPoint).encode()));
+        subscriptions.put("consumer11",
+                          new PartitionAssignor.Subscription(topics, new SubscriptionInfo(uuid1, new HashSet<TaskId>(), new HashSet<TaskId>(), userEndPoint).encode()));
+
+        final Map<String, PartitionAssignor.Assignment> assignments = partitionAssignor.assign(localMetadata, subscriptions);
+
+        // check assigned partitions
+        assertEquals(Utils.mkSet(Utils.mkSet(t1p0, t2p0, t1p1, t2p1), Utils.mkSet(t1p2, t2p2, t1p3, t2p3)),
+                     Utils.mkSet(new HashSet<>(assignments.get("consumer10").partitions()), new HashSet<>(assignments.get("consumer11").partitions())));
+
+        // the first consumer
+        final AssignmentInfo info10 = AssignmentInfo.decode(assignments.get("consumer10").userData());
+
+        final List<TaskId> expectedInfo10TaskIds = Arrays.asList(taskIdA2, taskIdA3, taskIdB2, taskIdB3);
+        assertEquals(expectedInfo10TaskIds, info10.activeTasks);
+
+        // the second consumer
+        final AssignmentInfo info11 = AssignmentInfo.decode(assignments.get("consumer11").userData());
+        final List<TaskId> expectedInfo11TaskIds = Arrays.asList(taskIdA0, taskIdA1, taskIdB0, taskIdB1);
+
+        assertEquals(expectedInfo11TaskIds, info11.activeTasks);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignorTest.java
@@ -138,6 +138,34 @@ public class StreamPartitionAssignorTest {
     }
 
     @Test
+    public void shouldInterleaveTasksByGroupId() {
+        final TaskId taskIdA0 = new TaskId(0, 0);
+        final TaskId taskIdA1 = new TaskId(0, 1);
+        final TaskId taskIdA2 = new TaskId(0, 2);
+        final TaskId taskIdA3 = new TaskId(0, 3);
+
+        final TaskId taskIdB0 = new TaskId(1, 0);
+        final TaskId taskIdB1 = new TaskId(1, 1);
+        final TaskId taskIdB2 = new TaskId(1, 2);
+        final TaskId taskIdB3 = new TaskId(1, 3);
+
+        final TaskId taskIdC0 = new TaskId(2, 0);
+        final TaskId taskIdC1 = new TaskId(2, 1);
+
+        List<TaskId> expectedInterleavedTaskIds = Arrays.asList(taskIdA0, taskIdB0, taskIdA1, taskIdB1, taskIdA2, taskIdB2, taskIdA3, taskIdB3);
+
+        List<TaskId> interleavedTaskIds = partitionAssignor.interleaveTasksByGroupId(Arrays.asList(taskIdA0, taskIdA1, taskIdA2, taskIdA3, taskIdB0, taskIdB1, taskIdB2, taskIdB3));
+
+        assertThat(interleavedTaskIds, equalTo(expectedInterleavedTaskIds));
+
+        List<TaskId> expectedInterLeavedTaskIdsII = Arrays.asList(taskIdA0, taskIdB0, taskIdC0, taskIdA1, taskIdB1, taskIdC1, taskIdA2, taskIdB2, taskIdA3);
+
+        List<TaskId> interleavedTaskIdsII = partitionAssignor.interleaveTasksByGroupId(Arrays.asList(taskIdC0, taskIdC1, taskIdB0, taskIdB1, taskIdB2, taskIdA0, taskIdA1, taskIdA2, taskIdA3));
+
+        assertThat(interleavedTaskIdsII, equalTo(expectedInterLeavedTaskIdsII));
+    }
+
+    @Test
     public void testSubscription() throws Exception {
         builder.addSource(null, "source1", null, null, null, "topic1");
         builder.addSource(null, "source2", null, null, null, "topic2");


### PR DESCRIPTION
This PR is an initial attempt to evenly distribute tasks with heavy processing across clients using a somewhat naive approach.

The rationale is by making sure each task is not comprised entirely of the same `topicGroupId`s, 
then if there is one sub-topology doing heavy processing and another sub-topology that is relatively light, the processing load is somewhat evenly distributed.

This process only looks at active tasks; standby tasks are not given this consideration as we can end up in a state where clients have the same task assignments i.e [aT1, sT2] [aT2, sT1].

We plan to do a follow-on task at a later date where we weigh tasks with state stores to
distribute tasks with state stores evenly.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
