### PR TITLE
KAFKA-5722: [WIP] New ConfigCommand that uses AdminClient

### DIFF
--- a/bin/kafka-configs.sh
+++ b/bin/kafka-configs.sh
@@ -14,4 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exec $(dirname $0)/kafka-run-class.sh kafka.admin.ConfigCommand "$@"
+
+if [ "${USE_OLD_COMMAND:=false}" = true ] ;
+  then
+    export MAIN_CLASS=kafka.admin.ConfigCommand
+  else
+    export MAIN_CLASS=org.apache.kafka.tools.ConfigCommand
+fi
+
+exec $(dirname $0)/kafka-run-class.sh ${MAIN_CLASS} "$@"

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
+import org.apache.kafka.common.requests.Resource;
 
 import java.util.Collection;
 import java.util.Map;
@@ -561,4 +562,35 @@ public abstract class AdminClient implements AutoCloseable {
      * @since 1.1.0
      */
     public abstract DescribeQuotasResult describeQuotas(Map<QuotaConfigResourceTuple, Collection<String>> configs, DescribeQuotasOptions options);
+
+    /**
+     * Returns the list of quota config entities specified by the parameter.
+     *
+     * @param quotaConfigResource The quota entity that we want to list. If only {@link Resource#type} is given, then
+     *                            the list command will return all entities with the given type. Valid types are
+     *                            {@link org.apache.kafka.common.requests.ResourceType#CLIENT} and
+     *                            {@link org.apache.kafka.common.requests.ResourceType#USER}. If also {@link Resource#name}
+     *                            is specified and not empty, then all children of that entity will be returned.
+     *                            In this case the `type` must be {@link org.apache.kafka.common.requests.ResourceType#USER}.
+     * @return                    A list of quota config resources' names.
+     * @since 1.1.0
+     */
+    public ListQuotasResult listQuotas(Resource quotaConfigResource) {
+        return listQuotas(quotaConfigResource, new ListQuotasOptions());
+    }
+
+    /**
+     * Returns the list of quota config entities specified by the parameter.
+     *
+     * @param quotaConfigResource The quota entity that we want to list. If only {@link Resource#type} is given, then
+     *                            the list command will return all entities with the given type. Valid types are
+     *                            {@link org.apache.kafka.common.requests.ResourceType#CLIENT} and
+     *                            {@link org.apache.kafka.common.requests.ResourceType#USER}. If also {@link Resource#name}
+     *                            is specified and not empty, then all children of that entity will be returned.
+     *                            In this case the `type` must be {@link org.apache.kafka.common.requests.ResourceType#USER}.
+     * @param options             Additional options to list the quota configs.
+     * @return                    A list of quota config resources' names.
+     * @since 1.1.0
+     */
+    public abstract ListQuotasResult listQuotas(Resource quotaConfigResource, ListQuotasOptions options);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClient.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
 
 import java.util.Collection;
 import java.util.Map;
@@ -535,4 +536,29 @@ public abstract class AdminClient implements AutoCloseable {
      */
     public abstract DeleteRecordsResult deleteRecords(Map<TopicPartition, RecordsToDelete> recordsToDelete,
                                                       DeleteRecordsOptions options);
+
+    /**
+     * Get the configuration for the specified quota resources.
+     *
+     * This operation is supported by brokers with version 1.1.0 or higher.
+     *
+     * @param configs                      The user or client resources we want to describe.
+     * @return                             The DescribeConfigsResult
+     * @since 1.1.0
+     */
+    public DescribeQuotasResult describeQuotas(Map<QuotaConfigResourceTuple, Collection<String>> configs) {
+        return describeQuotas(configs, new DescribeQuotasOptions());
+    }
+
+    /**
+     * Get the configuration for the specified quota resources.
+     *
+     * This operation is supported by brokers with version 1.1.0 or higher.
+     *
+     * @param configs                      The user or client resources we want to describe.
+     * @param options                      Additional options to describe the quota configs.
+     * @return                             The DescribeConfigsResult
+     * @since 1.1.0
+     */
+    public abstract DescribeQuotasResult describeQuotas(Map<QuotaConfigResourceTuple, Collection<String>> configs, DescribeQuotasOptions options);
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeQuotasOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeQuotasOptions.java
@@ -15,28 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.common.requests;
+package org.apache.kafka.clients.admin;
 
-public enum ResourceType {
-    UNKNOWN((byte) 0), ANY((byte) 1), TOPIC((byte) 2), GROUP((byte) 3), BROKER((byte) 4), USER((byte) 5), CLIENT((byte) 6);
+import org.apache.kafka.common.annotation.InterfaceStability;
 
-    private static final ResourceType[] VALUES = values();
+import java.util.Map;
 
-    private final byte id;
+/**
+ * Options for {@link AdminClient#describeQuotas(Map, DescribeQuotasOptions)} )}.
+ *
+ * The API of this class is evolving, see {@link AdminClient} for details.
+ */
+@InterfaceStability.Evolving
+public class DescribeQuotasOptions extends AbstractOptions<DescribeQuotasOptions> {
 
-    ResourceType(byte id) {
-        this.id = id;
+    /**
+     * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
+     * AdminClient should be used.
+     *
+     */
+    // This method is retained to keep binary compatibility with 0.11
+    public DescribeQuotasOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
     }
 
-    public byte id() {
-        return id;
-    }
-
-    public static ResourceType forId(byte id) {
-        if (id < 0)
-            throw new IllegalArgumentException("id should be positive, id: " + id);
-        if (id >= VALUES.length)
-            return UNKNOWN;
-        return VALUES[id];
-    }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeQuotasResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeQuotasResult.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@InterfaceStability.Evolving
+public class DescribeQuotasResult {
+    private final Map<QuotaConfigResourceTuple, KafkaFuture<Config>> resultMap;
+
+    DescribeQuotasResult(Map<QuotaConfigResourceTuple, KafkaFuture<Config>> resultMap) {
+        this.resultMap = resultMap;
+    }
+
+    /**
+     * Return a map from resources to futures which can be used to check the status of the configuration for each
+     * resource.
+     */
+    public Map<QuotaConfigResourceTuple, KafkaFuture<Config>> values() {
+        return resultMap;
+    }
+
+    /**
+     * Return a future which succeeds only if all the config descriptions succeed.
+     */
+    public KafkaFuture<Map<QuotaConfigResourceTuple, Config>> all() {
+        return KafkaFuture.allOf(resultMap.values().toArray(new KafkaFuture[0])).
+                thenApply(new KafkaFuture.Function<Void, Map<QuotaConfigResourceTuple, Config>>() {
+                    @Override
+                    public Map<QuotaConfigResourceTuple, Config> apply(Void v) {
+                        Map<QuotaConfigResourceTuple, Config> configs = new HashMap<>(resultMap.size());
+                        for (Map.Entry<QuotaConfigResourceTuple, KafkaFuture<Config>> entry : resultMap.entrySet()) {
+                            try {
+                                configs.put(entry.getKey(), entry.getValue().get());
+                            } catch (InterruptedException | ExecutionException e) {
+                                // This should be unreachable, because allOf ensured that all the futures
+                                // completed successfully.
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        return configs;
+                    }
+                });
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListQuotasOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListQuotasOptions.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+@InterfaceStability.Evolving
+public class ListQuotasOptions extends AbstractOptions<ListQuotasOptions> {
+
+    public ListQuotasOptions timeoutMs(Integer timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        return this;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListQuotasResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListQuotasResult.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
+import java.util.List;
+
+@InterfaceStability.Evolving
+public class ListQuotasResult {
+
+    private final KafkaFuture<List<String>> quotaNamesFuture;
+
+    public ListQuotasResult(KafkaFuture<List<String>> quotaNamesFuture) {
+        this.quotaNamesFuture = quotaNamesFuture;
+    }
+
+    public KafkaFuture<List<String>> quotaNamesFuture() {
+        return quotaNamesFuture;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -28,7 +28,7 @@ public final class ConfigResource {
      * Type of resource.
      */
     public enum Type {
-        BROKER, TOPIC, UNKNOWN;
+        BROKER, TOPIC, USER, CLIENT, UNKNOWN
     }
 
     private final Type type;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -53,6 +53,8 @@ import org.apache.kafka.common.requests.DescribeGroupsRequest;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.DescribeLogDirsRequest;
 import org.apache.kafka.common.requests.DescribeLogDirsResponse;
+import org.apache.kafka.common.requests.DescribeQuotasRequest;
+import org.apache.kafka.common.requests.DescribeQuotasResponse;
 import org.apache.kafka.common.requests.EndTxnRequest;
 import org.apache.kafka.common.requests.EndTxnResponse;
 import org.apache.kafka.common.requests.FetchRequest;
@@ -171,7 +173,9 @@ public enum ApiKeys {
     SASL_AUTHENTICATE(36, "SaslAuthenticate", SaslAuthenticateRequest.schemaVersions(),
             SaslAuthenticateResponse.schemaVersions()),
     CREATE_PARTITIONS(37, "CreatePartitions", CreatePartitionsRequest.schemaVersions(),
-            CreatePartitionsResponse.schemaVersions());
+            CreatePartitionsResponse.schemaVersions()),
+    DESCRIBE_QUOTAS(38, "DescribeQuotas", DescribeQuotasRequest.schemaVersions(),
+            DescribeQuotasResponse.schemaVersions());
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -75,6 +75,8 @@ import org.apache.kafka.common.requests.ListGroupsRequest;
 import org.apache.kafka.common.requests.ListGroupsResponse;
 import org.apache.kafka.common.requests.ListOffsetRequest;
 import org.apache.kafka.common.requests.ListOffsetResponse;
+import org.apache.kafka.common.requests.ListQuotasRequest;
+import org.apache.kafka.common.requests.ListQuotasResponse;
 import org.apache.kafka.common.requests.MetadataRequest;
 import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.OffsetCommitRequest;
@@ -175,7 +177,9 @@ public enum ApiKeys {
     CREATE_PARTITIONS(37, "CreatePartitions", CreatePartitionsRequest.schemaVersions(),
             CreatePartitionsResponse.schemaVersions()),
     DESCRIBE_QUOTAS(38, "DescribeQuotas", DescribeQuotasRequest.schemaVersions(),
-            DescribeQuotasResponse.schemaVersions());
+            DescribeQuotasResponse.schemaVersions()),
+    LIST_QUOTAS(39, "ListQuotas", ListQuotasRequest.schemaVersions(),
+            ListQuotasResponse.schemaVersions());
 
     private static final ApiKeys[] ID_TO_TYPE;
     private static final int MIN_API_KEY = 0;

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -214,6 +214,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
                 return new SaslAuthenticateRequest(struct, apiVersion);
             case CREATE_PARTITIONS:
                 return new CreatePartitionsRequest(struct, apiVersion);
+            case DESCRIBE_QUOTAS:
+                return new DescribeQuotasRequest(struct, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractRequest.java
@@ -216,6 +216,8 @@ public abstract class AbstractRequest extends AbstractRequestResponse {
                 return new CreatePartitionsRequest(struct, apiVersion);
             case DESCRIBE_QUOTAS:
                 return new DescribeQuotasRequest(struct, apiVersion);
+            case LIST_QUOTAS:
+                return new ListQuotasRequest(struct, apiVersion);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseRequest`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -148,6 +148,8 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
                 return new CreatePartitionsResponse(struct);
             case DESCRIBE_QUOTAS:
                 return new DescribeQuotasResponse(struct);
+            case LIST_QUOTAS:
+                return new ListQuotasResponse(struct);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -146,6 +146,8 @@ public abstract class AbstractResponse extends AbstractRequestResponse {
                 return new SaslAuthenticateResponse(struct);
             case CREATE_PARTITIONS:
                 return new CreatePartitionsResponse(struct);
+            case DESCRIBE_QUOTAS:
+                return new DescribeQuotasResponse(struct);
             default:
                 throw new AssertionError(String.format("ApiKey %s is not currently handled in `parseResponse`, the " +
                         "code should be updated to do so.", apiKey));

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
@@ -99,6 +99,14 @@ public class DescribeConfigsResponse extends AbstractResponse {
         private final boolean isDefault;
         private final boolean readOnly;
 
+        public ConfigEntry(String name, String value) {
+            this.name = name;
+            this.value = value;
+            this.isSensitive = false;
+            this.isDefault = false;
+            this.readOnly = false;
+        }
+
         public ConfigEntry(String name, String value, boolean isSensitive, boolean isDefault, boolean readOnly) {
             this.name = name;
             this.value = value;

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuotasRequest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.protocol.types.Type.INT8;
+import static org.apache.kafka.common.protocol.types.Type.NULLABLE_STRING;
+import static org.apache.kafka.common.protocol.types.Type.STRING;
+
+public class DescribeQuotasRequest extends AbstractRequest {
+
+    private static final String QUOTA_CONFIG_RESOURCE = "quota_config_resource";
+    private static final String CHILD_QUOTA_CONFIG_RESOURCE = "child_quota_config_resource";
+    private static final String QUOTA_TYPE_KEY_NAME = "type";
+    private static final String QUOTA_NAME_KEY_NAME = "name";
+    private static final String CONFIG_NAME_KEY_NAME = "config_name";
+    private static final String RESOURCE = "resource";
+
+    private static final Schema QUOTA_SCHEMA_V0 = new Schema(
+            new Field(QUOTA_TYPE_KEY_NAME, INT8),
+            new Field(QUOTA_NAME_KEY_NAME, NULLABLE_STRING)
+    );
+
+    private static final Schema RESOURCE_SCHEMA = new Schema(
+            new Field(QUOTA_CONFIG_RESOURCE, QUOTA_SCHEMA_V0),
+            new Field(CHILD_QUOTA_CONFIG_RESOURCE, QUOTA_SCHEMA_V0),
+            new Field(CONFIG_NAME_KEY_NAME, new ArrayOf(STRING)));
+
+    private static final Schema DESCRIBE_QUOTAS_REQUEST_SCHEMA_V0 = new Schema(
+            new Field(RESOURCE, new ArrayOf(RESOURCE_SCHEMA))
+    );
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{DESCRIBE_QUOTAS_REQUEST_SCHEMA_V0};
+    }
+
+    public static class Builder extends AbstractRequest.Builder {
+        private final Map<QuotaConfigResourceTuple, Collection<String>> quotaConfigSettings;
+
+        public Builder(Map<QuotaConfigResourceTuple, Collection<String>> quotaConfigSettings) {
+            super(ApiKeys.DESCRIBE_QUOTAS);
+            this.quotaConfigSettings = quotaConfigSettings;
+        }
+
+        @Override
+        public DescribeQuotasRequest build(short version) {
+            return new DescribeQuotasRequest(version, quotaConfigSettings);
+        }
+    }
+
+    private final Map<QuotaConfigResourceTuple, Collection<String>> quotaConfigSettings;
+
+    public DescribeQuotasRequest(short version, Map<QuotaConfigResourceTuple, Collection<String>> quotaConfigSettings) {
+        super(version);
+        this.quotaConfigSettings = quotaConfigSettings;
+    }
+
+    public DescribeQuotasRequest(Struct struct, short version) {
+        super(version);
+        Object[] resourcesObjectArray = struct.getArray(RESOURCE);
+        quotaConfigSettings = new HashMap<>(resourcesObjectArray.length);
+        for (Object resourceObj : resourcesObjectArray) {
+            Struct resource = (Struct) resourceObj;
+            QuotaConfigResourceTuple tuple = new QuotaConfigResourceTuple(
+                    unwrapQuotaConfigResource(resource.getStruct(QUOTA_CONFIG_RESOURCE)),
+                    unwrapQuotaConfigResource(resource.getStruct(CHILD_QUOTA_CONFIG_RESOURCE))
+            );
+            Object[] configNamesArray = resource.getArray(CONFIG_NAME_KEY_NAME);
+            Collection<String> configNames;
+            if (configNamesArray != null) {
+                configNames = new ArrayList<>(configNamesArray.length);
+                for (Object configNameObj : configNamesArray)
+                    configNames.add((String) configNameObj);
+            } else {
+                configNames = new ArrayList<>(0);
+            }
+            quotaConfigSettings.put(tuple, configNames);
+        }
+    }
+
+    public Map<QuotaConfigResourceTuple, Collection<String>> quotaConfigSettings() {
+        return Collections.unmodifiableMap(quotaConfigSettings);
+    }
+
+    private Struct wrapQuotaConfigResource(Resource quota, Struct parent, String field) {
+        Struct struct = parent.instance(field);
+        struct.set(QUOTA_TYPE_KEY_NAME, quota.type().id());
+        struct.set(QUOTA_NAME_KEY_NAME, quota.name());
+        return struct;
+    }
+
+    private Resource unwrapQuotaConfigResource(Struct quotaStruct) {
+        ResourceType type = ResourceType.forId(quotaStruct.getByte(QUOTA_TYPE_KEY_NAME));
+        return new Resource(type, quotaStruct.getString(QUOTA_NAME_KEY_NAME));
+    }
+
+    @Override
+    protected Struct toStruct() {
+        Struct struct = new Struct(ApiKeys.DESCRIBE_QUOTAS.requestSchema(version()));
+        List<Struct> resourceStruct = new LinkedList<>();
+        for (Map.Entry<QuotaConfigResourceTuple, Collection<String>> entry : quotaConfigSettings.entrySet()) {
+            Struct resource = struct.instance(RESOURCE);
+
+            QuotaConfigResourceTuple tuple = entry.getKey();
+            resource.set(QUOTA_CONFIG_RESOURCE, wrapQuotaConfigResource(tuple.quotaConfigResource(), resource, QUOTA_CONFIG_RESOURCE));
+            resource.set(CHILD_QUOTA_CONFIG_RESOURCE, wrapQuotaConfigResource(tuple.childQuotaConfigResource(), resource, CHILD_QUOTA_CONFIG_RESOURCE));
+
+            String[] configNames = entry.getValue() == null ? null : entry.getValue().toArray(new String[0]);
+            resource.set(CONFIG_NAME_KEY_NAME, configNames);
+            resourceStruct.add(resource);
+        }
+        struct.set(RESOURCE, resourceStruct.toArray(new Struct[0]));
+        return struct;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+//        short version = version();
+//        switch (version) {
+//            case 0:
+//                ApiError error = ApiError.fromThrowable(e);
+//                Map<Resource, DescribeConfigsResponse.Config> errors = new HashMap<>(resources().size());
+//                DescribeConfigsResponse.Config config = new DescribeConfigsResponse.Config(error,
+//                        Collections.<DescribeConfigsResponse.ConfigEntry>emptyList());
+//                for (Resource resource : resources())
+//                    errors.put(resource, config);
+//                return new DescribeConfigsResponse(throttleTimeMs, errors);
+//            default:
+//                throw new IllegalArgumentException(String.format("Version %d is not valid. Valid versions for %s are 0 to %d",
+//                        version, this.getClass().getSimpleName(), ApiKeys.DESCRIBE_CONFIGS.latestVersion()));
+//        }
+        return null;
+    }
+
+    public static DescribeQuotasRequest parse(ByteBuffer buffer, short version) {
+        return new DescribeQuotasRequest(ApiKeys.DESCRIBE_QUOTAS.parseRequest(version, buffer), version);
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuotasResponse.java
@@ -38,6 +38,8 @@ import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
 import static org.apache.kafka.common.protocol.types.Type.INT8;
 import static org.apache.kafka.common.protocol.types.Type.NULLABLE_STRING;
 import static org.apache.kafka.common.protocol.types.Type.STRING;
+import static org.apache.kafka.common.requests.DescribeQuotasRequest.unwrapQuotaConfigResource;
+import static org.apache.kafka.common.requests.DescribeQuotasRequest.wrapQuotaConfigResource;
 
 public class DescribeQuotasResponse extends AbstractResponse {
 
@@ -113,18 +115,6 @@ public class DescribeQuotasResponse extends AbstractResponse {
 
     public Map<QuotaConfigResourceTuple, DescribeConfigsResponse.Config> quotaConfigSettings() {
         return Collections.unmodifiableMap(configs);
-    }
-
-    private Struct wrapQuotaConfigResource(Resource quota, Struct parent, String typeName) {
-        Struct struct = parent.instance(typeName);
-        struct.set(QUOTA_TYPE_KEY_NAME, quota.type().id());
-        struct.set(QUOTA_NAME_KEY_NAME, quota.name());
-        return struct;
-    }
-
-    private Resource unwrapQuotaConfigResource(Struct quotaStruct) {
-        ResourceType type = ResourceType.forId(quotaStruct.getByte(QUOTA_TYPE_KEY_NAME));
-        return new Resource(type, quotaStruct.getString(QUOTA_NAME_KEY_NAME));
     }
 
     private DescribeConfigsResponse.Config unwrapConfig(Struct struct) {

--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeQuotasResponse.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_MESSAGE;
+import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
+import static org.apache.kafka.common.protocol.types.Type.BOOLEAN;
+import static org.apache.kafka.common.protocol.types.Type.INT8;
+import static org.apache.kafka.common.protocol.types.Type.NULLABLE_STRING;
+import static org.apache.kafka.common.protocol.types.Type.STRING;
+
+public class DescribeQuotasResponse extends AbstractResponse {
+
+    private static final String QUOTA_CONFIG_RESOURCE = "quota_config_resource";
+    private static final String CHILD_QUOTA_CONFIG_RESOURCE = "child_quota_config_resource";
+    private static final String QUOTA_TYPE_KEY_NAME = "type";
+    private static final String QUOTA_NAME_KEY_NAME = "name";
+
+    private static final String RESOURCE_KEY_NAME = "resource";
+    private static final String CONFIG_KEY_NAME = "config";
+
+    private static final String CONFIG_ENTRY_KEY_NAME = "config_entry";
+    private static final String CONFIG_NAME_KEY_NAME = "config_name";
+    private static final String CONFIG_VALUE_KEY_NAME = "config_value";
+    private static final String IS_SENSITIVE_KEY_NAME = "is_sensitive";
+    private static final String IS_DEFAULT_KEY_NAME = "is_default";
+    private static final String READ_ONLY_KEY_NAME = "read_only";
+
+    private static final Schema QUOTA_SCHEMA_V0 = new Schema(
+            new Field(QUOTA_TYPE_KEY_NAME, INT8),
+            new Field(QUOTA_NAME_KEY_NAME, NULLABLE_STRING)
+    );
+
+    private static final Schema CONFIG_ENTRY_SCHEMA_V0 = new Schema(
+            new Field(CONFIG_NAME_KEY_NAME, STRING),
+            new Field(CONFIG_VALUE_KEY_NAME, NULLABLE_STRING),
+            new Field(READ_ONLY_KEY_NAME, BOOLEAN),
+            new Field(IS_DEFAULT_KEY_NAME, BOOLEAN),
+            new Field(IS_SENSITIVE_KEY_NAME, BOOLEAN));
+
+    private static final Schema CONFIG_SCHEMA_V0 = new Schema(
+            ERROR_CODE,
+            ERROR_MESSAGE,
+            new Field(CONFIG_ENTRY_KEY_NAME, new ArrayOf(CONFIG_ENTRY_SCHEMA_V0))
+    );
+
+    private static final Schema RESOURCE_SCHEMA_V0 = new Schema(
+            new Field(QUOTA_CONFIG_RESOURCE, QUOTA_SCHEMA_V0),
+            new Field(CHILD_QUOTA_CONFIG_RESOURCE, QUOTA_SCHEMA_V0),
+            new Field(CONFIG_KEY_NAME, CONFIG_SCHEMA_V0)
+    );
+
+    private static final Schema DESCRIBE_QUOTAS_RESPONSE_SCHEMA_V0 = new Schema(
+            THROTTLE_TIME_MS,
+            new Field(RESOURCE_KEY_NAME, new ArrayOf(RESOURCE_SCHEMA_V0)));
+
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{DESCRIBE_QUOTAS_RESPONSE_SCHEMA_V0};
+    }
+
+    private final int throttleTimeMs;
+    private final Map<QuotaConfigResourceTuple, DescribeConfigsResponse.Config> configs;
+
+    public DescribeQuotasResponse(int throttleTimeMs, Map<QuotaConfigResourceTuple, DescribeConfigsResponse.Config> configs) {
+        this.throttleTimeMs = throttleTimeMs;
+        this.configs = configs;
+    }
+
+    public DescribeQuotasResponse(Struct struct) {
+        throttleTimeMs = struct.get(THROTTLE_TIME_MS);
+        Object[] resourcesArray = struct.getArray(RESOURCE_KEY_NAME);
+        configs = new HashMap<>(resourcesArray.length);
+        for (Object resourceObj : resourcesArray) {
+            Struct resourceStruct = (Struct) resourceObj;
+            QuotaConfigResourceTuple tuple =
+                    new QuotaConfigResourceTuple(
+                            unwrapQuotaConfigResource(resourceStruct.getStruct(QUOTA_CONFIG_RESOURCE)),
+                            unwrapQuotaConfigResource(resourceStruct.getStruct(CHILD_QUOTA_CONFIG_RESOURCE)));
+            configs.put(tuple, unwrapConfig(resourceStruct.getStruct(CONFIG_KEY_NAME)));
+        }
+    }
+
+    public Map<QuotaConfigResourceTuple, DescribeConfigsResponse.Config> quotaConfigSettings() {
+        return Collections.unmodifiableMap(configs);
+    }
+
+    private Struct wrapQuotaConfigResource(Resource quota, Struct parent, String typeName) {
+        Struct struct = parent.instance(typeName);
+        struct.set(QUOTA_TYPE_KEY_NAME, quota.type().id());
+        struct.set(QUOTA_NAME_KEY_NAME, quota.name());
+        return struct;
+    }
+
+    private Resource unwrapQuotaConfigResource(Struct quotaStruct) {
+        ResourceType type = ResourceType.forId(quotaStruct.getByte(QUOTA_TYPE_KEY_NAME));
+        return new Resource(type, quotaStruct.getString(QUOTA_NAME_KEY_NAME));
+    }
+
+    private DescribeConfigsResponse.Config unwrapConfig(Struct struct) {
+        ApiError error = new ApiError(struct);
+        Collection<DescribeConfigsResponse.ConfigEntry> entries = new ArrayList<>();
+        Object[] configEntriesStructArray = struct.getArray(CONFIG_ENTRY_KEY_NAME);
+        for (Object configEntryStructObj : configEntriesStructArray) {
+            Struct configEntryStruct = (Struct) configEntryStructObj;
+            String configName = configEntryStruct.getString(CONFIG_NAME_KEY_NAME);
+            String configValue = configEntryStruct.getString(CONFIG_VALUE_KEY_NAME);
+            boolean isSensitive = configEntryStruct.getBoolean(IS_SENSITIVE_KEY_NAME);
+            boolean isDefault = configEntryStruct.getBoolean(IS_DEFAULT_KEY_NAME);
+            boolean readOnly = configEntryStruct.getBoolean(READ_ONLY_KEY_NAME);
+            entries.add(new DescribeConfigsResponse.ConfigEntry(configName, configValue, isSensitive, isDefault, readOnly));
+        }
+        return new DescribeConfigsResponse.Config(error, entries);
+    }
+
+    private Struct wrapConfig(DescribeConfigsResponse.Config config, Struct parent) {
+        Struct struct = parent.instance(CONFIG_KEY_NAME);
+        config.error().write(struct);
+        List<Struct> entryStructs = new ArrayList<>(config.entries().size());
+        for (DescribeConfigsResponse.ConfigEntry entry : config.entries()) {
+            Struct entryStruct = struct.instance(CONFIG_ENTRY_KEY_NAME);
+            entryStruct.set(CONFIG_NAME_KEY_NAME, entry.name());
+            entryStruct.set(CONFIG_VALUE_KEY_NAME, entry.value());
+            entryStruct.set(IS_SENSITIVE_KEY_NAME, entry.isSensitive());
+            entryStruct.set(IS_DEFAULT_KEY_NAME, entry.isDefault());
+            entryStruct.set(READ_ONLY_KEY_NAME, entry.isReadOnly());
+            entryStructs.add(entryStruct);
+        }
+        struct.set(CONFIG_ENTRY_KEY_NAME, entryStructs.toArray(new Struct[0]));
+        return struct;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        for (DescribeConfigsResponse.Config response : configs.values())
+            updateErrorCounts(errorCounts, response.error().error());
+        return errorCounts;
+    }
+
+    @Override
+    protected Struct toStruct(short version) {
+        Struct struct = new Struct(ApiKeys.DESCRIBE_QUOTAS.responseSchema(version));
+        struct.set(THROTTLE_TIME_MS, throttleTimeMs);
+        List<Struct> resourceStructList = new ArrayList<>(configs.entrySet().size());
+        for (Map.Entry<QuotaConfigResourceTuple, DescribeConfigsResponse.Config> entry : configs.entrySet()) {
+            Struct resource = struct.instance(RESOURCE_KEY_NAME);
+            resource.set(QUOTA_CONFIG_RESOURCE, wrapQuotaConfigResource(entry.getKey().quotaConfigResource(), resource, QUOTA_CONFIG_RESOURCE));
+            resource.set(CHILD_QUOTA_CONFIG_RESOURCE, wrapQuotaConfigResource(entry.getKey().childQuotaConfigResource(), resource, CHILD_QUOTA_CONFIG_RESOURCE));
+            resource.set(CONFIG_KEY_NAME, wrapConfig(entry.getValue(), resource));
+            resourceStructList.add(resource);
+        }
+        struct.set(RESOURCE_KEY_NAME, resourceStructList.toArray(new Struct[0]));
+        return struct;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListQuotasRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListQuotasRequest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import static org.apache.kafka.common.protocol.types.Type.INT8;
+import static org.apache.kafka.common.protocol.types.Type.NULLABLE_STRING;
+import static org.apache.kafka.common.requests.DescribeQuotasRequest.unwrapQuotaConfigResource;
+import static org.apache.kafka.common.requests.DescribeQuotasRequest.wrapQuotaConfigResource;
+
+public class ListQuotasRequest extends AbstractRequest {
+
+    private static final String QUOTA_CONFIG_RESOURCE_KEY_NAME = "quota_config_resource";
+    private static final String TYPE_KEY_NAME = "type";
+    private static final String NAME_KEY_NAME = "name";
+
+    private static final Schema QUOTA_SCHEMA_V0 = new Schema(
+            new Field(TYPE_KEY_NAME, INT8),
+            new Field(NAME_KEY_NAME, NULLABLE_STRING)
+    );
+
+    private static final Schema LIST_QUOTAS_REQUEST_SCHEMA_V0 = new Schema(
+            new Field(QUOTA_CONFIG_RESOURCE_KEY_NAME, QUOTA_SCHEMA_V0)
+    );
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{LIST_QUOTAS_REQUEST_SCHEMA_V0};
+    }
+
+    public static class Builder extends AbstractRequest.Builder {
+
+        private final Resource quotaConfigResource;
+
+        public Builder(Resource quotaConfigResource) {
+            super(ApiKeys.LIST_QUOTAS);
+            this.quotaConfigResource = quotaConfigResource;
+        }
+
+        @Override
+        public ListQuotasRequest build(short version) {
+            return new ListQuotasRequest(version, quotaConfigResource);
+        }
+    }
+
+    private Resource quotaConfigResource;
+
+    public Resource quotaConfigResource() {
+        return quotaConfigResource;
+    }
+
+    public ListQuotasRequest(short version, Resource quotaConfigResource) {
+        super(version);
+        this.quotaConfigResource = quotaConfigResource;
+    }
+
+    public ListQuotasRequest(Struct struct, short version) {
+        super(version);
+        this.quotaConfigResource = unwrapQuotaConfigResource(struct.getStruct(QUOTA_CONFIG_RESOURCE_KEY_NAME));
+    }
+
+    @Override
+    protected Struct toStruct() {
+        Struct struct = new Struct(LIST_QUOTAS_REQUEST_SCHEMA_V0);
+        Struct quotaConfigEntity = wrapQuotaConfigResource(quotaConfigResource, struct, QUOTA_CONFIG_RESOURCE_KEY_NAME);
+        struct.set(QUOTA_CONFIG_RESOURCE_KEY_NAME, quotaConfigEntity);
+        return struct;
+    }
+
+    @Override
+    public AbstractResponse getErrorResponse(int throttleTimeMs, Throwable e) {
+        short version = version();
+        switch (version) {
+            case 0:
+                return new ListQuotasResponse(throttleTimeMs, ApiError.fromThrowable(e));
+            default:
+                throw new IllegalArgumentException(String.format("Version %d is not valid. Valid versions for %s are 0 to %d",
+                        version, this.getClass().getSimpleName(), ApiKeys.DESCRIBE_QUOTAS.latestVersion()));
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListQuotasResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListQuotasResponse.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
+import static org.apache.kafka.common.protocol.CommonFields.ERROR_MESSAGE;
+import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
+
+public class ListQuotasResponse extends AbstractResponse {
+
+    private static final String QUOTA_CONFIG_ENTITY_NAME_KEY_NAME = "quota_config_entity_name";
+
+    private static final Schema LIST_QUOTAS_REQUEST_SCHEMA_V0 = new Schema(
+            THROTTLE_TIME_MS,
+            ERROR_CODE,
+            ERROR_MESSAGE,
+            new Field(QUOTA_CONFIG_ENTITY_NAME_KEY_NAME, new ArrayOf(Type.STRING))
+    );
+
+    public static Schema[] schemaVersions() {
+        return new Schema[]{LIST_QUOTAS_REQUEST_SCHEMA_V0};
+    }
+
+    private final int throttleTimeMs;
+    private final ApiError apiError;
+    private final List<String> quotaEntityNames;
+
+    public ListQuotasResponse(int throttleTimeMs, List<String> quotaEntityNames) {
+        this.throttleTimeMs = throttleTimeMs;
+        this.apiError = ApiError.NONE;
+        this.quotaEntityNames = quotaEntityNames;
+    }
+
+    public ListQuotasResponse(int throttleTimeMs, ApiError error) {
+        this.throttleTimeMs = throttleTimeMs;
+        this.apiError = error;
+        this.quotaEntityNames = new ArrayList<>(0);
+    }
+
+    public ListQuotasResponse(Struct struct) {
+        throttleTimeMs = struct.get(THROTTLE_TIME_MS);
+        apiError = new ApiError(struct);
+        Object[] entityNames = struct.getArray(QUOTA_CONFIG_ENTITY_NAME_KEY_NAME);
+        quotaEntityNames = new ArrayList<>(entityNames.length);
+        for (Object entityName : entityNames) {
+            quotaEntityNames.add((String) entityName);
+        }
+    }
+
+    public List<String> quotaEntityNames() {
+        return Collections.unmodifiableList(quotaEntityNames);
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        Map<Errors, Integer> errorCounts = new HashMap<>();
+        updateErrorCounts(errorCounts, apiError.error());
+        return errorCounts;
+    }
+
+    @Override
+    protected Struct toStruct(short version) {
+        Struct struct = new Struct(ApiKeys.LIST_QUOTAS.responseSchema(version));
+        struct.set(THROTTLE_TIME_MS, throttleTimeMs);
+        apiError.write(struct);
+        struct.set(QUOTA_CONFIG_ENTITY_NAME_KEY_NAME, quotaEntityNames.toArray(new String[quotaEntityNames.size()]));
+        return struct;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/requests/QuotaConfigResourceTuple.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/QuotaConfigResourceTuple.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import java.util.Objects;
+
+/**
+ * Stores a child and its parent resource. This is used for representing a (user, client) resource tuple where
+ * the user part considered to be the parent resource and the client is the child.
+ */
+public final class QuotaConfigResourceTuple {
+
+    private final Resource quotaConfigResource;
+    private final Resource childQuotaConfigResource;
+
+    public Resource quotaConfigResource() {
+        return quotaConfigResource;
+    }
+
+    public Resource childQuotaConfigResource() {
+        return childQuotaConfigResource;
+    }
+
+    public QuotaConfigResourceTuple(Resource quotaConfigResource) {
+        Objects.requireNonNull(quotaConfigResource, "Quota-config resource must have a value");
+
+        this.quotaConfigResource = quotaConfigResource;
+        this.childQuotaConfigResource = new Resource(ResourceType.UNKNOWN, "");
+    }
+
+    public QuotaConfigResourceTuple(Resource quotaConfigResource, Resource childQuotaConfigResource) {
+        Objects.requireNonNull(quotaConfigResource, "Quota-config resource must have a value");
+        Objects.requireNonNull(childQuotaConfigResource, "The child quota-config resource must have a value");
+
+        this.quotaConfigResource = quotaConfigResource;
+        this.childQuotaConfigResource = childQuotaConfigResource;
+    }
+
+    @Override
+    public int hashCode() {
+        return 71 * quotaConfigResource.hashCode() + childQuotaConfigResource.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null)
+            return false;
+        if (obj == this)
+            return true;
+        if (!(obj instanceof QuotaConfigResourceTuple))
+            return false;
+
+        QuotaConfigResourceTuple other = (QuotaConfigResourceTuple) obj;
+
+        boolean parentEquals = quotaConfigResource.equals(other.quotaConfigResource);
+        boolean childEquals = childQuotaConfigResource.equals(other.childQuotaConfigResource);
+
+        return parentEquals && childEquals;
+    }
+
+    @Override
+    public String toString() {
+        return "UserQuotaConfigResource=(" + (quotaConfigResource == null ? "null" : quotaConfigResource.toString()) +
+                "), ClientQuotaConfigResource=(" + (childQuotaConfigResource == null ? "null" : childQuotaConfigResource.toString()) + ")";
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -49,7 +49,9 @@ import org.apache.kafka.common.requests.DeleteAclsResponse.AclFilterResponse;
 import org.apache.kafka.common.requests.DeleteRecordsResponse;
 import org.apache.kafka.common.requests.DescribeAclsResponse;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
+import org.apache.kafka.common.requests.DescribeQuotasResponse;
 import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
 import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.common.resource.ResourceFilter;
 import org.apache.kafka.common.resource.ResourceType;
@@ -77,6 +79,7 @@ import java.util.concurrent.Future;
 import static java.util.Arrays.asList;
 import static org.apache.kafka.common.requests.ResourceType.BROKER;
 import static org.apache.kafka.common.requests.ResourceType.TOPIC;
+import static org.apache.kafka.common.requests.ResourceType.USER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -385,6 +388,23 @@ public class KafkaAdminClientTest {
             DescribeConfigsResult result2 = env.adminClient().describeConfigs(Collections.singleton(
                 new ConfigResource(ConfigResource.Type.BROKER, "0")));
             result2.all().get();
+        }
+    }
+
+    @Test
+    public void testDescribeQuotas() throws Exception {
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+            env.kafkaClient().setNodeApiVersions(NodeApiVersions.create());
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+            env.kafkaClient().setNode(env.cluster().controller());
+            env.kafkaClient().prepareResponse(new DescribeQuotasResponse(0,
+                    Collections.singletonMap(
+                            new QuotaConfigResourceTuple(new org.apache.kafka.common.requests.Resource(USER, "user1")),
+                            new DescribeConfigsResponse.Config(ApiError.NONE,
+                                    Collections.<DescribeConfigsResponse.ConfigEntry>emptySet()))));
+            DescribeQuotasResult result = env.adminClient().describeQuotas(Collections.singletonMap(
+                    new QuotaConfigResourceTuple(new org.apache.kafka.common.requests.Resource(USER, "user1")), (Collection<String>) Collections.<String>emptyList()));
+            result.all().get();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
+import org.apache.kafka.common.requests.Resource;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -278,6 +279,11 @@ public class MockAdminClient extends AdminClient {
 
     @Override
     public DescribeQuotasResult describeQuotas(Map<QuotaConfigResourceTuple, Collection<String>> configs, DescribeQuotasOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ListQuotasResult listQuotas(Resource quotaConfigResource, ListQuotasOptions options) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -273,6 +274,11 @@ public class MockAdminClient extends AdminClient {
         } else {
             throw new UnsupportedOperationException("Not implemented yet");
         }
+    }
+
+    @Override
+    public DescribeQuotasResult describeQuotas(Map<QuotaConfigResourceTuple, Collection<String>> configs, DescribeQuotasOptions options) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     @Override

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -458,6 +458,19 @@ class AdminManager(val config: KafkaConfig,
     }
   }
 
+  def listQuotas(resource: Resource): Seq[String] = {
+    resource.`type` match {
+      case ResourceType.USER =>
+        Option(resource.name) match {
+          case Some(userName) if userName.length > 0 => adminZkClient.listChildrenConfigs(ConfigType.User, userName)
+          case _ => adminZkClient.listChildrenConfigs(ConfigType.User)
+        }
+      case ResourceType.CLIENT =>
+        adminZkClient.listChildrenConfigs(ConfigType.Client)
+      case _ => throw new InvalidRequestException("Invalid resource type provided")
+    }
+  }
+
   def shutdown() {
     topicPurgatory.shutdown()
     CoreUtils.swallow(createTopicPolicy.foreach(_.close()), this)

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -337,6 +337,18 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
   }
 
   /**
+    * validates broker configs
+    * @param brokerId
+    * @param configs
+    */
+  def validateBrokerConfig(brokerId: Int, configs: Properties): Unit = {
+    DynamicConfig.Broker.validate(configs)
+    if (!zkClient.brokerExists(brokerId))
+      throw new AdminOperationException(s"Broker ID ${brokerId} does not exist.")
+    LogConfig.validate(configs)
+  }
+
+  /**
    * Update the config for an existing topic and create a change notification so the change will propagate to other brokers
    *
    * @param topic: The topic for which configs are being changed

--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -431,5 +431,12 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
       .map(entityPath => (entityPath, fetchEntityConfig(rootEntityType, entityPath))).toMap
   }
 
+  def listChildrenConfigs(rootEntityName: String): Seq[String] = {
+    zkClient.getChildren(ConfigEntityTypeZNode.path(rootEntityName))
+  }
+
+  def listChildrenConfigs(rootEntityName: String, childEntityName: String): Seq[String] = {
+    zkClient.getChildren(ConfigEntityZNode.path(rootEntityName, childEntityName))
+  }
 }
 

--- a/core/src/main/scala/kafka/zk/KafkaZkClient.scala
+++ b/core/src/main/scala/kafka/zk/KafkaZkClient.scala
@@ -344,6 +344,15 @@ class KafkaZkClient private (zooKeeperClient: ZooKeeperClient, isSecure: Boolean
   }
 
   /**
+    * Checks the broker existence
+    * @param brokerId
+    * @return true if the broker exists else false
+    */
+  def brokerExists(brokerId: Int): Boolean = {
+    pathExists(BrokerIdZNode.path(brokerId))
+  }
+
+  /**
    * Sets the topic znode with the given assignment.
    * @param topic the topic whose assignment is being set.
    * @param assignment the partition to replica mapping to set for the given topic

--- a/tools/src/main/java/org/apache/kafka/tools/ConfigCommand.java
+++ b/tools/src/main/java/org/apache/kafka/tools/ConfigCommand.java
@@ -1,0 +1,623 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentAction;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
+import net.sourceforge.argparse4j.inf.Namespace;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.admin.DescribeQuotasResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.requests.QuotaConfigResourceTuple;
+import org.apache.kafka.common.requests.Resource;
+import org.apache.kafka.common.requests.ResourceType;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
+
+/**
+ * This script can be used to change configs for topics/clients/users/brokers dynamically
+ * An entity described or altered by the command may be one of:
+ * <ul>
+ *     <li> topic: --entity-type topics --entity-name <topic>
+ *     <li> client: --entity-type clients --entity-name <client-id>
+ *     <li> user: --entity-type users --entity-name <user-principal>
+ *     <li> <user, client>: --entity-type users --entity-name <user-principal> --entity-type clients --entity-name <client-id>
+ *     <li> broker: --entity-type brokers --entity-name <broker>
+ * </ul>
+ * --entity-default may be used instead of --entity-name when describing or altering default configuration for users and clients.
+ *
+ */
+public class ConfigCommand {
+
+    private AdminClient client;
+    private ConfigCommandOptions opts;
+
+    public static void main(String[] args) {
+        new ConfigCommand().run(args);
+    }
+
+    void run(String[] args) {
+        try {
+            doRun(args);
+        } catch (IOException | ConfigCommandException | ArgumentParserException e) {
+            System.err.println("Unexpected error during initialization: ");
+            e.printStackTrace(System.err);
+            opts.printHelp();
+        }
+    }
+
+    void doRun(String[] args) throws ArgumentParserException, ConfigCommandException, IOException {
+        opts = new ConfigCommandOptions();
+        opts.parseArgs(args);
+
+        Properties props = new Properties();
+        if (opts.has(ConfigCommandOptions.CONFIG_PROPERTIES)) {
+            try (FileInputStream propsFile = new FileInputStream(opts.getConfigProperties())) {
+                props.load(propsFile);
+            }
+        } else {
+            props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, opts.getBootstrapServers());
+        }
+
+        this.client = createAdminClient(props);
+
+        if (opts.has(ConfigCommandOptions.DESCRIBE)) {
+            describeAndPrintConfigs();
+        } else if (opts.has(ConfigCommandOptions.ALTER)) {
+            alterAndPrintResult();
+        }
+    }
+
+    private Map<?, KafkaFuture<Config>> describeConfigs() throws ConfigCommandException {
+        ConfigResource.Type resourceType = getConfigResourceType(opts);
+        if (resourceType == ConfigResource.Type.TOPIC) {
+            if (opts.getEntityName() == null) {
+                try {
+                    Map<ConfigResource, KafkaFuture<Config>> configs = new HashMap<>();
+                    for (String topic : client.listTopics().names().get()) {
+                        configs.putAll(describeSingleConfig(resourceType, topic));
+                    }
+                    return configs;
+                } catch (InterruptedException | ExecutionException e) {
+                    throw new ConfigCommandException(e);
+                }
+            } else {
+                return describeSingleConfig(resourceType, opts.getEntityName());
+            }
+        } else if (resourceType == ConfigResource.Type.BROKER) { // describe configs protocol is interpreted over TOPIC and BROKER types only
+            return describeSingleConfig(resourceType, opts.getEntityName());
+        } else if (resourceType == ConfigResource.Type.USER || resourceType == ConfigResource.Type.CLIENT) {
+            ConfigResource.Type childResourceType = getChildConfigResourceType(opts);
+            ConfigResource resource = new ConfigResource(resourceType, opts.getEntityDefault() ? "<default>" : opts.getEntityName());
+            if (ConfigResource.Type.UNKNOWN == childResourceType) {
+                return describeSingleQuotaConfig(resource);
+            } else {
+                ConfigResource childResource = new ConfigResource(childResourceType, opts.getChildEntityDefault() ? "<default>" : opts.getChildEntityName());
+                return describeSingleQuotaConfig(resource, childResource);
+            }
+        } else {
+            throw new IllegalArgumentException("Illegal type specified for the resource");
+        }
+    }
+
+    private Map<ConfigResource, KafkaFuture<Config>> describeSingleConfig(ConfigResource.Type type, String name) {
+        ConfigResource resource = new ConfigResource(type, name);
+        DescribeConfigsResult result = client.describeConfigs(Collections.singletonList(resource));
+        return result.values();
+    }
+
+    private Map<?, KafkaFuture<Config>> describeSingleQuotaConfig(ConfigResource resource) {
+        DescribeQuotasResult result = client.describeQuotas(Collections.singletonMap(
+                new QuotaConfigResourceTuple(configResourceToResource(resource)), (Collection<String>) Collections.<String>emptyList()));
+        return result.values();
+    }
+
+    private Map<?, KafkaFuture<Config>> describeSingleQuotaConfig(ConfigResource resource, ConfigResource childResource) {
+        DescribeQuotasResult result = client.describeQuotas(Collections.singletonMap(
+                new QuotaConfigResourceTuple(configResourceToResource(resource),
+                        configResourceToResource(childResource)), (Collection<String>) Collections.<String>emptyList()));
+        return result.values();
+    }
+
+    private Resource configResourceToResource(ConfigResource configResource) {
+        ResourceType resourceType;
+        switch (configResource.type()) {
+            case TOPIC:
+                resourceType = ResourceType.TOPIC;
+                break;
+            case BROKER:
+                resourceType = ResourceType.BROKER;
+                break;
+            case USER:
+                resourceType = ResourceType.USER;
+                break;
+            case CLIENT:
+                resourceType = ResourceType.CLIENT;
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected resource type " + configResource.type());
+        }
+        return new Resource(resourceType, configResource.name());
+    }
+
+    private <T> Map<T, Config> waitForDescribedConfigs(Map<?, KafkaFuture<Config>> describe, Class<T> clazz) throws ConfigCommandException {
+        Map<T, Config> result = new HashMap<>(describe.size());
+        for (Map.Entry<?, KafkaFuture<Config>> entry : describe.entrySet()) {
+            try {
+                result.put(clazz.cast(entry.getKey()), entry.getValue().get());
+            } catch (InterruptedException | ExecutionException e) {
+                throw new ConfigCommandException(e);
+            }
+        }
+        return result;
+    }
+
+    private void describeAndPrintConfigs() throws ConfigCommandException {
+        printConfigs(waitForDescribedConfigs(describeConfigs(), Object.class));
+    }
+
+    private void alterAndPrintResult() throws ConfigCommandException {
+        try {
+            Map<ConfigResource, Config> configs = new HashMap<>();
+            // compute the result
+            if (opts.has(ConfigCommandOptions.DELETE_CONFIG)) {
+                configs = deleteConfigsFromResources();
+            } else if (opts.has(ConfigCommandOptions.ADD_CONFIG)) {
+                configs = getAddConfigs();
+            }
+            // alter
+            client.alterConfigs(configs).all().get();
+            // describe the current state
+            System.out.println("Configs have been altered. The current state of the specified resource is shown below.");
+            describeAndPrintConfigs();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new ConfigCommandException(e);
+        }
+    }
+
+    private Map<ConfigResource, Config> deleteConfigsFromResources() throws ConfigCommandException {
+        // list the existing configs
+        Map<ConfigResource, Config> configResourceMap = waitForDescribedConfigs(describeConfigs(), ConfigResource.class);
+        // create a new map without the defaults and the deleted ones
+        Map<ConfigResource, Config> filteredConfigs = new HashMap<>();
+        for (Map.Entry<ConfigResource, Config> entry : configResourceMap.entrySet()) {
+            Collection<ConfigEntry> entryCollection = new LinkedList<>();
+            for (ConfigEntry ce : entry.getValue().entries()) {
+                // filter default and deleted values
+                if (!ce.isDefault() && !opts.getDeleteConfigs().contains(ce.name())) {
+                    entryCollection.add(ce);
+                }
+            }
+            filteredConfigs.put(entry.getKey(), new Config(entryCollection));
+        }
+        return filteredConfigs;
+    }
+
+    private Map<ConfigResource, Config> getAddConfigs() {
+        Collection<ConfigEntry> configEntries = new LinkedList<>();
+        for (Map.Entry<String, String> config : opts.getAddConfigs().entrySet()) {
+            configEntries.add(new ConfigEntry(config.getKey(), config.getValue()));
+        }
+        ConfigResource resource = new ConfigResource(getConfigResourceType(opts), opts.getEntityName());
+        return Collections.singletonMap(resource, new Config(configEntries));
+    }
+
+    private <T> void printConfigs(Map<T, Config> configs) throws ConfigCommandException {
+        for (Map.Entry<T, Config> config : configs.entrySet()) {
+            System.out.println();
+            if (config.getKey() instanceof ConfigResource) {
+                ConfigResource key = (ConfigResource) config.getKey();
+                System.out.format("%115s", "CONFIGS FOR " + key.type() + " " + key.name() + "%n");
+            } else if (config.getKey() instanceof QuotaConfigResourceTuple) {
+                QuotaConfigResourceTuple key = (QuotaConfigResourceTuple) config.getKey();
+                Resource parent = key.quotaConfigResource();
+                Resource child = key.childQuotaConfigResource();
+                if (child != null && child.type() != ResourceType.UNKNOWN) {
+                    System.out.format("%115s", "CONFIGS FOR (USER, CLIENT) (" + parent.name() + ", " + child.name() + ")%n");
+                } else {
+                    System.out.format("%115s", "CONFIGS FOR " + parent.type() + " " + parent.name() + "%n");
+                }
+            }
+            System.out.println();
+            System.out.format("%60s   %-70s%10s%11s%9s%n", "Name", "Value", "Sensitive", "Read-only", "Default");
+            for (ConfigEntry entry : config.getValue().entries()) {
+                String value = entry.value();
+                if (value != null && value.length() > 70) {
+                    System.out.format("%60s = %-70s%10s%11s%9s%n", entry.name(), entry.value().substring(0, 70), entry.isSensitive(), entry.isReadOnly(), entry.isDefault());
+                    System.out.format("%60s   %-70s%n", "", entry.value().substring(70, entry.value().length()));
+                } else {
+                    System.out.format("%60s = %-70s%10s%11s%9s%n", entry.name(), entry.value(), entry.isSensitive(), entry.isReadOnly(), entry.isDefault());
+                }
+            }
+        }
+    }
+
+    /**
+     * <b>Visible for testing only.</b>
+     * @return an {@link AdminClient}.
+     */
+    AdminClient createAdminClient(Properties props) {
+        return AdminClient.create(props);
+    }
+
+    private ConfigResource.Type getConfigResourceType(ConfigCommandOptions opts) {
+        ConfigCommandOptions.EntityTypes entityType = opts.getEntityType();
+        return toConfigResourceType(entityType);
+    }
+
+    private ConfigResource.Type getChildConfigResourceType(ConfigCommandOptions opts) {
+        ConfigCommandOptions.EntityTypes entityType = opts.getChildEntityType();
+        return toConfigResourceType(entityType);
+    }
+
+    private ConfigResource.Type toConfigResourceType(ConfigCommandOptions.EntityTypes entityType) {
+        if (entityType == ConfigCommandOptions.EntityTypes.TOPICS) {
+            return ConfigResource.Type.TOPIC;
+        } else if (entityType == ConfigCommandOptions.EntityTypes.BROKERS) {
+            return ConfigResource.Type.BROKER;
+        } else if (entityType == ConfigCommandOptions.EntityTypes.USERS) {
+            return ConfigResource.Type.USER;
+        } else if (entityType == ConfigCommandOptions.EntityTypes.CLIENTS) {
+            return ConfigResource.Type.CLIENT;
+        } else {
+            return ConfigResource.Type.UNKNOWN;
+        }
+    }
+
+    static class ConfigCommandException extends Exception {
+
+        ConfigCommandException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    static class ConfigCommandOptions {
+
+        private ArgumentParser parser;
+        private Namespace ns;
+        private Map<String, String> configs;
+
+        private static final String ESCAPE_QUOTES_PATTERN = "[(^')(^\")('$)(\"$)]";
+
+        private enum EntityTypes {
+            TOPICS("topics"),
+            CLIENTS("clients"),
+            USERS("users"),
+            BROKERS("brokers");
+
+            private String name;
+
+            EntityTypes(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+
+        static final String BOOTSTRAP_SERVERS = "bootstrapServers";
+        static final String CONFIG_PROPERTIES = "configProperties";
+        static final String DESCRIBE = "describe";
+        static final String ALTER = "alter";
+        static final String ENTITY_TYPE = "entityType";
+        static final String ENTITY_NAME = "entityName";
+        static final String ENTITY_DEFAULT = "entityDefault";
+        static final String CHILD_ENTITY_TYPE = "childEntityType";
+        static final String CHILD_ENTITY_NAME = "childEntityName";
+        static final String CHILD_ENTITY_DEFAULT = "childEntityDefault";
+        static final String FORCE = "force";
+        static final String ADD_CONFIG = "addConfig";
+        static final String DELETE_CONFIG = "deleteConfig";
+
+        ConfigCommandOptions() {
+
+            this.parser = ArgumentParsers
+                    .newArgumentParser("config-command")
+                    .defaultHelp(true)
+                    .description("Change configs for topics, clients, users, brokers dynamically.");
+
+            // valid for describe and alter modes
+            EntityStoreAction entityStoreAction = new EntityStoreAction();
+            EntityDefaultStoreAction defaultStoreAction = new EntityDefaultStoreAction();
+            this.parser.addArgument("--entity-type")
+                    .action(entityStoreAction)
+                    .required(true)
+                    .type(Arguments.enumStringType(EntityTypes.class))
+                    .dest(ENTITY_TYPE)
+                    .help("REQUIRED: the type of entity (topics/clients/users/brokers)");
+
+            MutuallyExclusiveGroup nameOptions = parser
+                    .addMutuallyExclusiveGroup()
+                    .required(true)
+                    .description("You can specify only one in --entity-name and --entity-default");
+
+            nameOptions.addArgument("--entity-name")
+                    .action(entityStoreAction)
+                    .type(String.class)
+                    .dest(ENTITY_NAME)
+                    .help("Name of entity (client id/user principal name)");
+            nameOptions.addArgument("--entity-default")
+                    .action(defaultStoreAction)
+                    .dest(ENTITY_DEFAULT)
+                    .help("Default entity name for clients/users (applies to corresponding entity type in command line)");
+
+            this.parser.addArgument("--force")
+                    .type(String.class)
+                    .dest(FORCE)
+                    .help("Suppresses console prompts");
+
+            // valid only for alter mode
+            this.parser.addArgument("--add-config")
+                    .type(String.class)
+                    .dest(ADD_CONFIG)
+                    .help("Key Value pairs of configs to add. Square brackets can be used to group values which contain commas: 'k1=v1,k2=[v1,v2,v2],k3=v3'.");
+            this.parser.addArgument("--delete-config")
+                    .type(String.class)
+                    .dest(DELETE_CONFIG)
+                    .help("Config keys to remove in the following form: 'k1,k2'.");
+
+            MutuallyExclusiveGroup operationOptions = parser
+                    .addMutuallyExclusiveGroup()
+                    .required(true)
+                    .description("You can specify only one in --alter, --describe");
+            operationOptions.addArgument("--describe")
+                    .action(storeTrue())
+                    .dest(DESCRIBE)
+                    .help("List configs for the given entity.");
+            operationOptions.addArgument("--alter")
+                    .action(storeTrue())
+                    .dest(ALTER)
+                    .help("Alter the configuration for the entity.");
+
+            MutuallyExclusiveGroup serverOptions = parser
+                    .addMutuallyExclusiveGroup()
+                    .required(true)
+                    .description("You can specify only one in --bootstrap-servers, --config.properties");
+            serverOptions.addArgument("--bootstrap-servers")
+                    .type(String.class)
+                    .dest(BOOTSTRAP_SERVERS)
+                    .help("REQUIRED: The broker list string in the form HOST1:PORT1,HOST2:PORT2.");
+            serverOptions.addArgument("--config.properties")
+                    .type(String.class)
+                    .dest(CONFIG_PROPERTIES)
+                    .help("REQUIRED: The config properties file for the Admin Client.");
+        }
+
+        String getBootstrapServers() {
+            return this.ns.getString(BOOTSTRAP_SERVERS);
+        }
+
+        String getConfigProperties() {
+            return this.ns.getString(CONFIG_PROPERTIES);
+        }
+
+        EntityTypes getEntityType() {
+            return ns.get(ENTITY_TYPE);
+        }
+
+        String getEntityName() {
+            return ns.getString(ENTITY_NAME);
+        }
+
+        EntityTypes getChildEntityType() {
+            return ns.get(CHILD_ENTITY_TYPE);
+        }
+
+        String getChildEntityName() {
+            return ns.get(CHILD_ENTITY_NAME);
+        }
+
+        boolean getChildEntityDefault() {
+            Boolean def = ns.getBoolean(CHILD_ENTITY_DEFAULT);
+            return def == null ? false : def;
+        }
+
+        Map<String, String> getAddConfigs() {
+            return Collections.unmodifiableMap(configs);
+        }
+
+        Set<String> getDeleteConfigs() {
+            return Collections.unmodifiableSet(configs.keySet());
+        }
+
+        boolean getEntityDefault() {
+            Boolean def = ns.getBoolean(ENTITY_DEFAULT);
+            return def == null ? false : def;
+        }
+
+        boolean isForced() {
+            return ns.getBoolean(FORCE);
+        }
+
+        void printHelp() {
+            parser.printHelp();
+        }
+
+        void parseArgs(String[] args) throws ArgumentParserException {
+            // late initialization
+            if (ns == null) {
+                ns = parser.parseArgs(args);
+                configs = parseConfigs();
+            }
+            //perform extra validation
+            validate();
+        }
+
+        private Map<String, String> parseConfigs() throws ArgumentParserException {
+            Map<String, String> confs;
+            if (has(ConfigCommandOptions.DELETE_CONFIG)) {
+                String[] configsToDelete = ns.getString(DELETE_CONFIG).replaceAll(ESCAPE_QUOTES_PATTERN, "").split(",");
+                confs = new HashMap<>(configsToDelete.length);
+                for (String config : configsToDelete) {
+                    confs.put(config, null);
+                }
+            } else if (has(ConfigCommandOptions.ADD_CONFIG)) {
+                String[] configsToAdd = ns.getString(ADD_CONFIG).replaceAll(ESCAPE_QUOTES_PATTERN, "").split(",");
+                confs = new HashMap<>();
+                for (String config : configsToAdd) {
+                    String[] configArray = config.trim().split("=");
+                    if (configArray.length != 2) {
+                        throw new ArgumentParserException("Invalid config specified" + config, parser);
+                    }
+                    confs.put(configArray[0], configArray[1]);
+                }
+            } else {
+                confs = new HashMap<>();
+            }
+            return confs;
+        }
+
+        private void validate() throws ArgumentParserException {
+            // in case of alter having an entity name and an add or delete config is a must
+            if (has(ALTER)) {
+                if (!(has(ADD_CONFIG) || has(DELETE_CONFIG))) {
+                    throw new ArgumentParserException("If --alter specified, you must also specify --add-config or --delete-config", parser);
+                }
+                if (!has(ENTITY_NAME)) {
+                    throw new ArgumentParserException("If --alter specified, you must also specify --entity-name", parser);
+                }
+            } else if (has(DESCRIBE) && (has(ADD_CONFIG) || has(DELETE_CONFIG))) {
+                throw new ArgumentParserException("If --describe specified, --add-config and --delete-config are not valid options", parser);
+            }
+        }
+
+        private boolean has(String option) {
+            if (this.ns.get(option) instanceof Boolean)
+                return this.ns.getBoolean(option);
+            else
+                return this.ns.get(option) != null;
+        }
+
+        private void checkRequiredArgs(ArgumentParser parser, List<String> required) throws ArgumentParserException {
+            for (String arg: required) {
+                if (!has(arg))
+                    throw new ArgumentParserException("Missing required argument \"" + arg + "\"", parser);
+            }
+        }
+
+        private static class EntityStoreAction implements ArgumentAction {
+
+            @Override
+            public void run(ArgumentParser parser, Argument arg, Map<String, Object> attrs, String flag, Object value) throws ArgumentParserException {
+                // handle entity types
+                switch (arg.getDest()) {
+                    case ENTITY_TYPE:
+                        EntityTypes entityType = (EntityTypes) attrs.get(ENTITY_TYPE);
+                        if (entityType == null) {
+                            attrs.put(arg.getDest(), value);
+                        } else {
+                            EntityTypes childEntityType = (EntityTypes) attrs.get(CHILD_ENTITY_TYPE);
+                            if (childEntityType == null) {
+                                if (entityType == EntityTypes.BROKERS || entityType == EntityTypes.TOPICS) {
+                                    throw new ArgumentParserException("Child entity type can only be specified for users and clients", parser);
+                                } else {
+                                    attrs.put(CHILD_ENTITY_TYPE, value);
+                                }
+                            } else {
+                                throw new ArgumentParserException("Child entity has already been specified", parser);
+                            }
+                        }
+                        break;
+                    case ENTITY_NAME:
+                        String entityName = (String) attrs.get(ENTITY_NAME);
+                        if (entityName == null) {
+                            attrs.put(arg.getDest(), value);
+                        } else {
+                            String childEntityName = (String) attrs.get(CHILD_ENTITY_NAME);
+                            if (childEntityName == null) {
+                                attrs.put(CHILD_ENTITY_NAME, value);
+                            } else {
+                                throw new ArgumentParserException("Child entity has already been specified", parser);
+                            }
+                        }
+                        break;
+                    default:
+                        throw new ArgumentParserException("Action used on invalid argument", parser);
+                }
+            }
+
+            @Override
+            public void onAttach(Argument arg) {
+
+            }
+
+            @Override
+            public boolean consumeArgument() {
+                return true;
+            }
+        }
+
+        private static class EntityDefaultStoreAction implements ArgumentAction {
+
+            @Override
+            public void run(ArgumentParser parser, Argument arg, Map<String, Object> attrs, String flag, Object value) throws ArgumentParserException {
+                if (!attrs.containsKey(ENTITY_DEFAULT)) {
+                    attrs.put(ENTITY_DEFAULT, null);
+                }
+                if (!attrs.containsKey(CHILD_ENTITY_DEFAULT)) {
+                    attrs.put(CHILD_ENTITY_DEFAULT, null);
+                }
+                Boolean entityDefault = (Boolean) attrs.get(ENTITY_DEFAULT);
+                if (entityDefault == null) {
+                    attrs.put(arg.getDest(), true);
+                } else {
+                    Boolean childEntityDefault = (Boolean) attrs.get(CHILD_ENTITY_DEFAULT);
+                    if (childEntityDefault == null) {
+                        attrs.put(CHILD_ENTITY_DEFAULT, true);
+                    } else {
+                        throw new ArgumentParserException("Child entity has already been specified", parser);
+                    }
+                }
+            }
+
+            @Override
+            public void onAttach(Argument arg) {
+
+            }
+
+            @Override
+            public boolean consumeArgument() {
+                return false;
+            }
+        }
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandOptionsTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandOptionsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.tools;
+
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+
+public class ConfigCommandOptionsTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testBootstrapServersRequired() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("argument --bootstrap-servers is required");
+        opts.parseArgs(new String[0]);
+    }
+
+    @Test
+    public void testEntityTypeRequired() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("argument --entity-type is required");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testAlterOrDescribeRequired() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("one of the arguments --describe --alter is required");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "topics").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testAlterOrDescribeExclusion() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("argument --describe: not allowed with argument --alter");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "topics", "--alter", "--describe").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testAlterAndNoAddOrDelete() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("If --alter specified, you must also specify --add-config or --delete-config");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "topics", "--alter").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testEntityNameWithAlterRequired() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("If --alter specified, you must also specify --entity-name");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "topics", "--alter", "--add-config", "\"K=V\"").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testDescribeWithAddOrDeleteFails() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("If --describe specified, --add-config and --delete-config are not valid options");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "topics", "--describe", "--add-config", "\"K=V\"").toArray(new String[]{}));
+
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("If --describe specified, --add-config and --delete-config are not valid options");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "topics", "--describe", "--delete-config", "\"K\"").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testInvalidEntityType() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("argument --entity-type: could not convert 'invalid_type'");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--entity-type", "invalid_type", "--describe").toArray(new String[]{}));
+    }
+
+    @Test
+    public void testBootstrapServersAndConfigPropertiesSpecified() throws Exception {
+        ConfigCommand.ConfigCommandOptions opts = new ConfigCommand.ConfigCommandOptions();
+        expectedException.expect(ArgumentParserException.class);
+        expectedException.expectMessage("argument --config.properties: not allowed with argument --bootstrap-servers");
+        opts.parseArgs(Arrays.asList("--bootstrap-servers", "localhost:9092", "--config.properties", "invalid_file").toArray(new String[]{}));
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
+++ b/tools/src/test/java/org/apache/kafka/tools/ConfigCommandTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.kafka.tools;
+
+import org.apache.kafka.clients.admin.AdminClientUnitTestEnv;
+import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.requests.DescribeConfigsResponse;
+import org.apache.kafka.common.requests.Resource;
+import org.apache.kafka.common.requests.ResourceType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.createMockBuilder;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+
+public class ConfigCommandTest {
+
+    private static AdminClientUnitTestEnv mockClientEnv(String... configVals) {
+        HashMap<Integer, Node> nodes = new HashMap<>();
+        nodes.put(0, new Node(0, "localhost", 8121));
+        nodes.put(1, new Node(1, "localhost", 8122));
+        nodes.put(2, new Node(2, "localhost", 8123));
+        Cluster cluster = new Cluster("mockClusterId", nodes.values(),
+                Collections.<PartitionInfo>emptySet(), Collections.<String>emptySet(),
+                Collections.<String>emptySet(), nodes.get(0));
+        return new AdminClientUnitTestEnv(cluster, configVals);
+    }
+
+    @Test
+    public void testDescribeBrokerConfigs() throws Exception {
+        Map<Resource, DescribeConfigsResponse.Config> configs = new HashMap<>();
+        configs.put(
+                new Resource(ResourceType.BROKER, "0"),
+                new DescribeConfigsResponse.Config(
+                        ApiError.NONE,
+                        Collections.singletonList(
+                                new DescribeConfigsResponse.ConfigEntry("ssl.truststore.type", "JKS", false, true, true))));
+        DescribeConfigsResponse response = new DescribeConfigsResponse(1000, configs);
+
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+
+            ConfigCommand cmd = createMockBuilder(ConfigCommand.class).addMockedMethod("createAdminClient", Properties.class).createMock();
+            expect(cmd.createAdminClient(anyObject(Properties.class))).andReturn(env.adminClient());
+            replay(cmd);
+
+            env.kafkaClient().setNode(env.cluster().controller());
+            env.kafkaClient().prepareResponse(response);
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+
+            String hostPort = String.format("%s:%s", env.cluster().controller().host(), env.cluster().controller().port());
+            cmd.doRun(Arrays.asList("--bootstrap-servers", hostPort, "--entity-type", "brokers", "--entity-name", Integer.toString(env.cluster().controller().id()), "--describe").toArray(new String[]{}));
+            verify(cmd);
+        }
+    }
+
+    @Test
+    public void testDescribeTopicConfigs() throws Exception {
+        Map<Resource, DescribeConfigsResponse.Config> configs = new HashMap<>();
+        configs.put(
+                new Resource(ResourceType.TOPIC, "topicA"),
+                new DescribeConfigsResponse.Config(
+                        ApiError.NONE,
+                        Collections.singletonList(
+                                new DescribeConfigsResponse.ConfigEntry("compression.type", "snappy", false, true, true))));
+        DescribeConfigsResponse response = new DescribeConfigsResponse(1000, configs);
+
+        try (AdminClientUnitTestEnv env = mockClientEnv()) {
+
+            ConfigCommand cmd = createMockBuilder(ConfigCommand.class).addMockedMethod("createAdminClient", Properties.class).createMock();
+            expect(cmd.createAdminClient(anyObject(Properties.class))).andReturn(env.adminClient());
+            replay(cmd);
+
+            env.kafkaClient().setNode(env.cluster().controller());
+            env.kafkaClient().prepareResponse(response);
+            env.kafkaClient().prepareMetadataUpdate(env.cluster(), Collections.<String>emptySet());
+
+            String hostPort = String.format("%s:%s", env.cluster().controller().host(), env.cluster().controller().port());
+            cmd.doRun(Arrays.asList("--bootstrap-servers", hostPort, "--entity-type", "topics", "--entity-name", "topicA", "--describe").toArray(new String[]{}));
+            verify(cmd);
+        }
+    }
+}


### PR DESCRIPTION
This is the pull request to include ListQuotas, DescribeQuotas and AlterQuotas protocols with a new ConfigCommand in the tools module.

Testing: unit tests and integration tests to verify the end-to-end behavior of the new protocols. Also unit tests in both tools and core modules to verify the correctness of each components.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
