### PR TITLE
MINOR: Add async and different sync startup modes in connect service test class

### DIFF
--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -102,7 +102,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         super(ConnectServiceBase, self).start()
 
     def start_and_return_immediately(self, node, worker_type, remote_connector_configs):
-        cmd = self.worker_cmd(node, remote_connector_configs)
+        cmd = self.start_cmd(node, remote_connector_configs)
         self.logger.debug("Connect %s command: %s", worker_type, cmd)
         node.account.ssh(cmd)
 
@@ -249,7 +249,7 @@ class ConnectStandaloneService(ConnectServiceBase):
     def node(self):
         return self.nodes[0]
 
-    def worker_cmd(self, node, connector_configs):
+    def start_cmd(self, node, connector_configs):
         cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:
@@ -295,7 +295,7 @@ class ConnectDistributedService(ConnectServiceBase):
         self.status_topic = status_topic
 
     # connector_configs argument is intentionally ignored in distributed service.
-    def worker_cmd(self, node, connector_configs):
+    def start_cmd(self, node, connector_configs):
         cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -41,15 +41,14 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
     LOG4J_CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "connect-log4j.properties")
     PID_FILE = os.path.join(PERSISTENT_ROOT, "connect.pid")
     CONNECT_REST_PORT = 8083
-    """
-    Currently the Connect worker supports waiting on three modes:
-    INSTANT: return immediately
-    LOAD: return after discovering and loading plugins
-    LISTEN: return after opening the REST port.
-    """
+
+    # Currently the Connect worker supports waiting on three modes:
     STARTUP_MODE_INSTANT = 'INSTANT'
+    """STARTUP_MODE_INSTANT: Start Connect worker and return immediately"""
     STARTUP_MODE_LOAD = 'LOAD'
+    """STARTUP_MODE_LOAD: Start Connect worker and return after discovering and loading plugins"""
     STARTUP_MODE_LISTEN = 'LISTEN'
+    """STARTUP_MODE_LISTEN: Start Connect worker and return after opening the REST port."""
 
     logs = {
         "connect_log": {

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -103,7 +103,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
     def start_and_wait_to_load_plugins(self, node, worker_type, remote_connector_configs):
         with node.account.monitor_log(self.LOG_FILE) as monitor:
             self.start_and_return_immediately(node, worker_type, remote_connector_configs)
-            monitor.wait_until('Kafka Connect started', timeout_sec=60,
+            monitor.wait_until('Kafka version', timeout_sec=60,
                                err_msg="Never saw message indicating Kafka Connect finished startup on node: " +
                                        "%s in condition mode: %s" % (str(node.account), self.startup_mode))
 

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -40,6 +40,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
     STDERR_FILE = os.path.join(PERSISTENT_ROOT, "connect.stderr")
     LOG4J_CONFIG_FILE = os.path.join(PERSISTENT_ROOT, "connect-log4j.properties")
     PID_FILE = os.path.join(PERSISTENT_ROOT, "connect.pid")
+    CONNECT_REST_PORT = 8083
 
     logs = {
         "connect_log": {
@@ -78,11 +79,12 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         self.config_template_func = config_template_func
         self.connector_config_templates = connector_config_templates
 
-    def listening(self, node, port=8083):
+    def listening(self, node):
         try:
-            cmd = "nc -z %s %s" % (node.account.hostname, port)
+            cmd = "nc -z %s %s" % (node.account.hostname, self.CONNECT_REST_PORT)
             node.account.ssh_output(cmd, allow_fail=False)
-            self.logger.debug("Connect worker started accepting connections at: '%s:%s')", node.account.hostname, port)
+            self.logger.debug("Connect worker started accepting connections at: '%s:%s')", node.account.hostname,
+                              self.CONNECT_REST_PORT)
             return True
         except (RemoteCommandError, ValueError) as e:
             return False
@@ -229,7 +231,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         raise exception_to_throw
 
     def _base_url(self, node):
-        return 'http://' + node.account.externally_routable_ip + ':' + '8083'
+        return 'http://' + node.account.externally_routable_ip + ':' + str(self.CONNECT_REST_PORT)
 
 
 class ConnectStandaloneService(ConnectServiceBase):

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -20,6 +20,7 @@ import signal
 import time
 
 import requests
+from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.errors import DucktapeError
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -57,6 +58,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         self.kafka = kafka
         self.security_config = kafka.security_config.client_config()
         self.files = files
+        self.startup_mode = 'LISTEN'
         self.environment = {}
 
     def pids(self, node):
@@ -75,6 +77,41 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         """
         self.config_template_func = config_template_func
         self.connector_config_templates = connector_config_templates
+
+    def listening(self, node, port=8083):
+        try:
+            cmd = "nc -z %s %s" % (node.account.hostname, port)
+            node.account.ssh_output(cmd, allow_fail=False)
+            self.logger.debug("Connect worker started accepting connections at: '%s:%s')", node.account.hostname, port)
+            return True
+        except (RemoteCommandError, ValueError) as e:
+            return False
+
+    # Currently the Connect worker supports waiting on three modes:
+    # INSTANT: return immediately
+    # LOAD: return after discovering and loading plugins
+    # LISTEN: return after opening the REST port.
+    def start_async(self, mode='LISTEN'):
+        self.startup_mode = mode
+        self.start()
+
+    def start_and_return_immediately(self, node, worker_type, remote_connector_configs):
+        cmd = self.start_cmd(node, remote_connector_configs)
+        self.logger.debug("Connect %s command: %s", worker_type, cmd)
+        node.account.ssh(cmd)
+
+    def start_and_wait_to_load_plugins(self, node, worker_type, remote_connector_configs):
+        with node.account.monitor_log(self.LOG_FILE) as monitor:
+            self.start_and_return_immediately(node, worker_type, remote_connector_configs)
+            monitor.wait_until('Kafka Connect started', timeout_sec=60,
+                               err_msg="Never saw message indicating Kafka Connect finished startup on node: " +
+                                       "%s in condition mode: %s" % (str(node.account), self.startup_mode))
+
+    def start_and_wait_to_start_listening(self, node, worker_type, remote_connector_configs):
+        self.start_and_return_immediately(node, worker_type, remote_connector_configs)
+        wait_until(lambda: self.listening(node), timeout_sec=60,
+                   err_msg="Kafka Connect failed to start on node: %s in condition mode: %s" %
+                   (str(node.account), self.startup_mode))
 
     def stop_node(self, node, clean_shutdown=True):
         self.logger.info((clean_shutdown and "Cleanly" or "Forcibly") + " stopping Kafka Connect on " + str(node.account))
@@ -229,11 +266,13 @@ class ConnectStandaloneService(ConnectServiceBase):
             remote_connector_configs.append(target_file)
 
         self.logger.info("Starting Kafka Connect standalone process on " + str(node.account))
-        with node.account.monitor_log(self.LOG_FILE) as monitor:
-            cmd = self.start_cmd(node, remote_connector_configs)
-            self.logger.debug("Connect standalone command: %s", cmd)
-            node.account.ssh(cmd)
-            monitor.wait_until('Kafka Connect started', timeout_sec=60, err_msg="Never saw message indicating Kafka Connect finished startup on " + str(node.account))
+        if self.startup_mode == 'LOAD':
+            self.start_and_wait_to_load_plugins(node, 'standalone', remote_connector_configs)
+        elif self.startup_mode == 'LISTEN':
+            self.start_and_wait_to_start_listening(node, 'standalone', remote_connector_configs)
+        else:
+            # mode 'INSTANT' is implied
+            self.start_and_return_immediately(node, 'standalone', remote_connector_configs)
 
         if len(self.pids(node)) == 0:
             raise RuntimeError("No process ids recorded")
@@ -249,7 +288,8 @@ class ConnectDistributedService(ConnectServiceBase):
         self.configs_topic = configs_topic
         self.status_topic = status_topic
 
-    def start_cmd(self, node):
+    # connector_configs argument is intentionally ignored in distributed service.
+    def start_cmd(self, node, connector_configs):
         cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:
@@ -268,11 +308,13 @@ class ConnectDistributedService(ConnectServiceBase):
             raise DucktapeError("Config files are not valid in distributed mode, submit connectors via the REST API")
 
         self.logger.info("Starting Kafka Connect distributed process on " + str(node.account))
-        with node.account.monitor_log(self.LOG_FILE) as monitor:
-            cmd = self.start_cmd(node)
-            self.logger.debug("Connect distributed command: %s", cmd)
-            node.account.ssh(cmd)
-            monitor.wait_until('Kafka Connect started', timeout_sec=60, err_msg="Never saw message indicating Kafka Connect finished startup on " + str(node.account))
+        if self.startup_mode == 'LOAD':
+            self.start_and_wait_to_load_plugins(node, 'distributed', '')
+        elif self.startup_mode == 'LISTEN':
+            self.start_and_wait_to_start_listening(node, 'distributed', '')
+        else:
+            # mode 'INSTANT' is implied
+            self.start_and_return_immediately(node, 'distributed', '')
 
         if len(self.pids(node)) == 0:
             raise RuntimeError("No process ids recorded")

--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -96,7 +96,7 @@ class ConnectServiceBase(KafkaPathResolverMixin, Service):
         self.start()
 
     def start_and_return_immediately(self, node, worker_type, remote_connector_configs):
-        cmd = self.start_cmd(node, remote_connector_configs)
+        cmd = self.worker_cmd(node, remote_connector_configs)
         self.logger.debug("Connect %s command: %s", worker_type, cmd)
         node.account.ssh(cmd)
 
@@ -243,7 +243,7 @@ class ConnectStandaloneService(ConnectServiceBase):
     def node(self):
         return self.nodes[0]
 
-    def start_cmd(self, node, connector_configs):
+    def worker_cmd(self, node, connector_configs):
         cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:
@@ -289,7 +289,7 @@ class ConnectDistributedService(ConnectServiceBase):
         self.status_topic = status_topic
 
     # connector_configs argument is intentionally ignored in distributed service.
-    def start_cmd(self, node, connector_configs):
+    def worker_cmd(self, node, connector_configs):
         cmd = "( export KAFKA_LOG4J_OPTS=\"-Dlog4j.configuration=file:%s\"; " % self.LOG4J_CONFIG_FILE
         cmd += "export KAFKA_OPTS=%s; " % self.security_config.kafka_opts
         for envvar in self.environment:


### PR DESCRIPTION
Allow Connect Service in system tests to start asynchronously. 

Specifically, allow for three startup conditions: 
1. No condition - start async and return immediately. 
2. Semi-async - start immediately after plugins have been discovered successfully. 
3. Sync - start returns after the worker has completed startup. This is the current mode, but its condition is improved by checking that the port of Connect's REST interface is open, rather than that a log line has appeared in the logs. 

An associated system test run has been started here: 
https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/586/

@ewencp @rhauch, I'd appreciate your review. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
