### PR TITLE
KAFKA-6277: Ensure loadClass for plugin class loaders is thread-safe.

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginClassLoader.java
@@ -26,8 +26,8 @@ import java.net.URLClassLoader;
  * A custom classloader dedicated to loading Connect plugin classes in classloading isolation.
  * <p>
  * Under the current scheme for classloading isolation in Connect, a plugin classloader loads the
- * classes that finds in its urls. For classes that are either not found or are not supposed to be
- * loaded in isolation, this plugin classloader delegates their loading to its parent. This makes
+ * classes that it finds in its urls. For classes that are either not found or are not supposed to
+ * be loaded in isolation, this plugin classloader delegates their loading to its parent. This makes
  * this classloader a child-first classloader.
  */
 public class PluginClassLoader extends URLClassLoader {


### PR DESCRIPTION
`loadClass` needs to be synchronized to protect subsequent calls to `defineClass`. 

Details in the javadoc of this PR as well as here too: https://docs.oracle.com/javase/7/docs/technotes/guides/lang/cl-mt.html

/cc @ewencp @rhauch 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
