### PR TITLE
KAFKA-6138 Simplify StreamsBuilder#addGlobalStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -476,6 +476,7 @@ public class StreamsBuilder {
      * @throws TopologyException if the processor of state is already registered
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public synchronized StreamsBuilder addGlobalStore(final StoreBuilder storeBuilder,
                                                       final String topic,
                                                       final String sourceName,
@@ -490,6 +491,39 @@ public class StreamsBuilder {
                                               new ConsumedInternal<>(consumed),
                                               processorName,
                                               stateUpdateSupplier);
+        return this;
+    }
+    /**
+     * Adds a global {@link StateStore} to the topology.
+     * The {@link StateStore} sources its data from all partitions of the provided input topic.
+     * There will be exactly one instance of this {@link StateStore} per Kafka Streams instance.
+     * <p>
+     * A {@link SourceNode} with the provided sourceName will be added to consume the data arriving from the partitions
+     * of the input topic.
+     * <p>
+     * The provided {@link ProcessorSupplier} will be used to create an {@link ProcessorNode} that will receive all
+     * records forwarded from the {@link SourceNode}.
+     * This {@link ProcessorNode} should be used to keep the {@link StateStore} up-to-date.
+     * The default {@link TimestampExtractor} as specified in the {@link StreamsConfig config} is used.
+     *
+     * @param storeBuilder          user defined {@link StoreBuilder}; can't be {@code null}
+     * @param topic                 the topic to source the data from
+     * @param consumed              the instance of {@link Consumed} used to define optional parameters; can't be {@code null}
+     * @param stateUpdateSupplier   the instance of {@link ProcessorSupplier}
+     * @return itself
+     * @throws TopologyException if the processor of state is already registered
+     */
+    @SuppressWarnings("unchecked")
+    public synchronized StreamsBuilder addGlobalStore(final StoreBuilder storeBuilder,
+                                                      final String topic,
+                                                      final Consumed consumed,
+                                                      final ProcessorSupplier stateUpdateSupplier) {
+        Objects.requireNonNull(storeBuilder, "storeBuilder can't be null");
+        Objects.requireNonNull(consumed, "consumed can't be null");
+        internalStreamsBuilder.addGlobalStore(storeBuilder,
+                topic,
+                new ConsumedInternal<>(consumed),
+                stateUpdateSupplier);
         return this;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -454,26 +454,7 @@ public class StreamsBuilder {
     }
 
     /**
-     * Adds a global {@link StateStore} to the topology.
-     * The {@link StateStore} sources its data from all partitions of the provided input topic.
-     * There will be exactly one instance of this {@link StateStore} per Kafka Streams instance.
-     * <p>
-     * A {@link SourceNode} with the provided sourceName will be added to consume the data arriving from the partitions
-     * of the input topic.
-     * <p>
-     * The provided {@link ProcessorSupplier} will be used to create an {@link ProcessorNode} that will receive all
-     * records forwarded from the {@link SourceNode}.
-     * This {@link ProcessorNode} should be used to keep the {@link StateStore} up-to-date.
-     * The default {@link TimestampExtractor} as specified in the {@link StreamsConfig config} is used.
-     *
-     * @param storeBuilder          user defined {@link StoreBuilder}; can't be {@code null}
-     * @param sourceName            name of the {@link SourceNode} that will be automatically added
-     * @param topic                 the topic to source the data from
-     * @param consumed              the instance of {@link Consumed} used to define optional parameters; can't be {@code null}
-     * @param processorName         the name of the {@link ProcessorSupplier}
-     * @param stateUpdateSupplier   the instance of {@link ProcessorSupplier}
-     * @return itself
-     * @throws TopologyException if the processor of state is already registered
+     * @deprecated use {@link #addGlobalStore(StoreBuilder, String, Consumed, ProcessorSupplier)} instead
      */
     @SuppressWarnings("unchecked")
     @Deprecated
@@ -493,6 +474,7 @@ public class StreamsBuilder {
                                               stateUpdateSupplier);
         return this;
     }
+
     /**
      * Adds a global {@link StateStore} to the topology.
      * The {@link StateStore} sources its data from all partitions of the provided input topic.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -174,7 +174,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     public synchronized void addStateStore(final StoreBuilder builder) {
         internalTopologyBuilder.addStateStore(builder);
     }
-
+    @Deprecated
     public synchronized void addGlobalStore(final StoreBuilder<KeyValueStore> storeBuilder,
                                             final String sourceName,
                                             final String topic,
@@ -193,5 +193,24 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                                topic,
                                                processorName,
                                                stateUpdateSupplier);
+    }
+    public synchronized void addGlobalStore(final StoreBuilder<KeyValueStore> storeBuilder,
+                                            final String topic,
+                                            final ConsumedInternal consumed,
+                                            final ProcessorSupplier stateUpdateSupplier) {
+        // explicitly disable logging for global stores
+        storeBuilder.withLoggingDisabled();
+        final String sourceName = newProcessorName(KStreamImpl.SOURCE_NAME);
+        final String processorName = newProcessorName(KTableImpl.SOURCE_NAME);
+        final Deserializer keyDeserializer = consumed.keySerde() == null ? null : consumed.keySerde().deserializer();
+        final Deserializer valueDeserializer = consumed.valueSerde() == null ? null : consumed.valueSerde().deserializer();
+        internalTopologyBuilder.addGlobalStore(storeBuilder,
+                sourceName,
+                consumed.timestampExtractor(),
+                keyDeserializer,
+                valueDeserializer,
+                topic,
+                processorName,
+                stateUpdateSupplier);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -174,7 +174,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
     public synchronized void addStateStore(final StoreBuilder builder) {
         internalTopologyBuilder.addStateStore(builder);
     }
-    @Deprecated
+
     public synchronized void addGlobalStore(final StoreBuilder<KeyValueStore> storeBuilder,
                                             final String sourceName,
                                             final String topic,
@@ -202,15 +202,11 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         storeBuilder.withLoggingDisabled();
         final String sourceName = newProcessorName(KStreamImpl.SOURCE_NAME);
         final String processorName = newProcessorName(KTableImpl.SOURCE_NAME);
-        final Deserializer keyDeserializer = consumed.keySerde() == null ? null : consumed.keySerde().deserializer();
-        final Deserializer valueDeserializer = consumed.valueSerde() == null ? null : consumed.valueSerde().deserializer();
-        internalTopologyBuilder.addGlobalStore(storeBuilder,
-                sourceName,
-                consumed.timestampExtractor(),
-                keyDeserializer,
-                valueDeserializer,
-                topic,
-                processorName,
-                stateUpdateSupplier);
+        addGlobalStore(storeBuilder,
+                       sourceName,
+                       topic,
+                       consumed,
+                       processorName,
+                       stateUpdateSupplier);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -194,6 +194,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                                processorName,
                                                stateUpdateSupplier);
     }
+    
     public synchronized void addGlobalStore(final StoreBuilder<KeyValueStore> storeBuilder,
                                             final String topic,
                                             final ConsumedInternal consumed,

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -23,12 +23,15 @@ import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.KStreamImpl;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
 import org.apache.kafka.test.KStreamTestDriver;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.TestUtils;
+import org.easymock.EasyMock;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -195,6 +198,18 @@ public class StreamsBuilderTest {
         builder.stream(Arrays.<String>asList(null, null));
     }
 
+    @Test
+    public void testAddGobalStateStore(){
+        String globalTopicName = "testGlobalTopic";
+        String globalStoreName = "testAddGlobalStore";
+        final StreamsBuilder builder = new StreamsBuilder();
+        KeyValueStoreBuilder t = new KeyValueStoreBuilder();
+        final KeyValueStoreBuilder globalStoreBuilder = EasyMock.createNiceMock(KeyValueStoreBuilder.class);
+        EasyMock.expect(globalStoreBuilder.name()).andReturn(globalStoreName).anyTimes();
+        EasyMock.replay(globalStoreBuilder);
+        builder.addGlobalStore(globalStoreBuilder,globalTopicName,new ConsumedInternal(),new MockProcessorSupplier());
+    }
+
     // TODO: these two static functions are added because some non-TopologyBuilder unit tests need to access the internal topology builder,
     //       which is usually a bad sign of design patterns between TopologyBuilder and StreamThread. We need to consider getting rid of them later
     public static InternalTopologyBuilder internalTopologyBuilder(final StreamsBuilder builder) {
@@ -204,4 +219,6 @@ public class StreamsBuilderTest {
     public static Collection<Set<String>> getCopartitionedGroups(final StreamsBuilder builder) {
         return builder.internalTopologyBuilder.copartitionGroups();
     }
+
+
 }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -23,15 +23,12 @@ import org.apache.kafka.streams.errors.TopologyException;
 import org.apache.kafka.streams.kstream.ForeachAction;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
 import org.apache.kafka.streams.kstream.internals.KStreamImpl;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
 import org.apache.kafka.test.KStreamTestDriver;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.TestUtils;
-import org.easymock.EasyMock;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -196,18 +193,6 @@ public class StreamsBuilderTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowExceptionWhenTopicNamesAreNull() throws Exception {
         builder.stream(Arrays.<String>asList(null, null));
-    }
-
-    @Test
-    public void testAddGobalStateStore(){
-        String globalTopicName = "testGlobalTopic";
-        String globalStoreName = "testAddGlobalStore";
-        final StreamsBuilder builder = new StreamsBuilder();
-        KeyValueStoreBuilder t = new KeyValueStoreBuilder();
-        final KeyValueStoreBuilder globalStoreBuilder = EasyMock.createNiceMock(KeyValueStoreBuilder.class);
-        EasyMock.expect(globalStoreBuilder.name()).andReturn(globalStoreName).anyTimes();
-        EasyMock.replay(globalStoreBuilder);
-        builder.addGlobalStore(globalStoreBuilder,globalTopicName,new ConsumedInternal(),new MockProcessorSupplier());
     }
 
     // TODO: these two static functions are added because some non-TopologyBuilder unit tests need to access the internal topology builder,

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -204,6 +204,4 @@ public class StreamsBuilderTest {
     public static Collection<Set<String>> getCopartitionedGroups(final StreamsBuilder builder) {
         return builder.internalTopologyBuilder.copartitionGroups();
     }
-
-
 }


### PR DESCRIPTION
deprecated StreamsBuilder#addGlobalStore and InternalStreamsBuilder#addGlobalStore
add new StreamsBuilder#addGlobalStore and InternalStreamsBuilder#addGlobalStore without sourceName and processorName as parameter
generate sourceName and processorName by using InternalStreamsBuilder#newProcessorName

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
