### PR TITLE
MINOR: Improve on reset integration test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -203,9 +203,9 @@ public abstract class AbstractResetIntegrationTest {
     void shouldNotAllowToResetWhileStreamsIsRunning() throws Exception {
         appID = testId + "-not-reset-during-runtime";
         final String[] parameters = new String[] {
-                "--application-id", appID,
-                "--bootstrap-servers", cluster.bootstrapServers(),
-                "--input-topics", NON_EXISTING_TOPIC };
+            "--application-id", appID,
+            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--input-topics", NON_EXISTING_TOPIC };
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
@@ -225,9 +225,9 @@ public abstract class AbstractResetIntegrationTest {
     public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
         appID = testId + "-not-reset-without-input-topic";
         final String[] parameters = new String[] {
-                "--application-id", appID,
-                "--bootstrap-servers", cluster.bootstrapServers(),
-                "--input-topics", NON_EXISTING_TOPIC };
+            "--application-id", appID,
+            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--input-topics", NON_EXISTING_TOPIC };
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
@@ -239,9 +239,9 @@ public abstract class AbstractResetIntegrationTest {
     public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
         appID = testId + "-not-reset-without-intermediate-topic";
         final String[] parameters = new String[] {
-                "--application-id", appID,
-                "--bootstrap-servers", cluster.bootstrapServers(),
-                "--input-topics", NON_EXISTING_TOPIC };
+            "--application-id", appID,
+            "--bootstrap-servers", cluster.bootstrapServers(),
+            "--input-topics", NON_EXISTING_TOPIC };
         final Properties cleanUpConfig = new Properties();
         cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
         cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
@@ -257,7 +257,7 @@ public abstract class AbstractResetIntegrationTest {
         // RUN
         KafkaStreams streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), STREAMS_CONFIG);
         streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC,10);
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC, 10);
 
         streams.close();
         TestUtils.waitForCondition(consumerGroupInactiveCondition, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT,
@@ -274,7 +274,7 @@ public abstract class AbstractResetIntegrationTest {
 
         // RE-RUN
         streams.start();
-        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC,10);
+        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC, 10);
         streams.close();
 
         assertThat(resultRerun, equalTo(result));
@@ -395,7 +395,7 @@ public abstract class AbstractResetIntegrationTest {
         // RUN
         KafkaStreams streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), STREAMS_CONFIG);
         streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC,10);
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC, 10);
 
         streams.close();
         TestUtils.waitForCondition(consumerGroupInactiveCondition, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT,
@@ -443,7 +443,7 @@ public abstract class AbstractResetIntegrationTest {
         // RUN
         KafkaStreams streams = new KafkaStreams(setupTopologyWithoutIntermediateUserTopic(), STREAMS_CONFIG);
         streams.start();
-        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived( RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC, 10);
+        final List<KeyValue<Long, Long>> result = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC, 10);
 
         streams.close();
         TestUtils.waitForCondition(consumerGroupInactiveCondition, TIMEOUT_MULTIPLIER * STREAMS_CONSUMER_TIMEOUT,
@@ -469,7 +469,7 @@ public abstract class AbstractResetIntegrationTest {
 
         // RE-RUN
         streams.start();
-        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC,10);
+        final List<KeyValue<Long, Long>> resultRerun = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(RESULT_CONSUMER_CONFIG, OUTPUT_TOPIC, 10);
         streams.close();
 
         assertThat(resultRerun, equalTo(result));

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -21,7 +21,6 @@ import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.test.IntegrationTest;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -48,11 +47,6 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
         // very long sleep times
         brokerProps.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
         CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        afterClassCleanup();
     }
 
     @Before

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -27,7 +27,10 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import kafka.tools.StreamsResetter;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Collection;
 import java.util.Properties;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -38,23 +41,18 @@ import java.util.List;
  * Tests local state store and global application cleanup.
  */
 @Category({IntegrationTest.class})
+@RunWith(value = Parameterized.class)
 public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
-    @ClassRule
-    public static final EmbeddedKafkaCluster CLUSTER;
     private static final long CLEANUP_CONSUMER_TIMEOUT = 2000L;
     private static final String APP_ID = "Integration-test";
+
     private static final String NON_EXISTING_TOPIC = "nonExistingTopic";
+
     private static int testNo = 1;
 
-    static {
-        final Properties props = new Properties();
-        // we double the value passed to `time.sleep` in each iteration in one of the map functions, so we disable
-        // expiration of connections by the brokers to avoid errors when `AdminClient` sends requests after potentially
-        // very long sleep times
-        props.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
-        CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS, props);
-        cluster = CLUSTER;
+    public ResetIntegrationTest(boolean sslEnabled) {
+        super(sslEnabled);
     }
 
     @AfterClass

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -16,39 +16,39 @@
  */
 package org.apache.kafka.streams.integration;
 
-import org.apache.kafka.clients.consumer.ConsumerConfig;
+import kafka.server.KafkaConfig$;
+import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.test.IntegrationTest;
+
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import kafka.tools.StreamsResetter;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Properties;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
 
 
 /**
  * Tests local state store and global application cleanup.
  */
 @Category({IntegrationTest.class})
-@RunWith(value = Parameterized.class)
 public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
-    CLUSTER = new EmbeddedKafkaCluster(1);
+    @ClassRule
+    public static final EmbeddedKafkaCluster CLUSTER;
 
-    private static final long CLEANUP_CONSUMER_TIMEOUT = 2000L;
-    private static final String APP_ID = "Integration-test";
+    private static final String TEST_ID = "reset-integration-test";
 
-    private static final String NON_EXISTING_TOPIC = "nonExistingTopic";
-
-    private static int testNo = 1;
+    static {
+        final Properties brokerProps = new Properties();
+        // we double the value passed to `time.sleep` in each iteration in one of the map functions, so we disable
+        // expiration of connections by the brokers to avoid errors when `AdminClient` sends requests after potentially
+        // very long sleep times
+        brokerProps.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
+        CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
+    }
 
     @AfterClass
     public static void afterClass() {
@@ -57,11 +57,13 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Before
     public void before() throws Exception {
+        testId = TEST_ID;
+        cluster = CLUSTER;
         prepareTest();
     }
 
     @After
-    void after() throws Exception {
+    public void after() throws Exception {
         cleanupTest();
     }
 
@@ -97,36 +99,11 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     @Test
     public void shouldNotAllowToResetWhenInputTopicAbsent() throws Exception {
-
-        final List<String> parameterList = new ArrayList<>(
-                Arrays.asList("--application-id", APP_ID + testNo,
-                        "--bootstrap-servers", CLUSTER.bootstrapServers(),
-                        "--input-topics", NON_EXISTING_TOPIC));
-
-        final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
-        final Properties cleanUpConfig = new Properties();
-        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
-
-        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
-        Assert.assertEquals(1, exitCode);
+        super.shouldNotAllowToResetWhenInputTopicAbsent();
     }
 
     @Test
     public void shouldNotAllowToResetWhenIntermediateTopicAbsent() throws Exception {
-
-        final List<String> parameterList = new ArrayList<>(
-                Arrays.asList("--application-id", APP_ID + testNo,
-                        "--bootstrap-servers", CLUSTER.bootstrapServers(),
-                        "--intermediate-topics", NON_EXISTING_TOPIC));
-
-        final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
-        final Properties cleanUpConfig = new Properties();
-        cleanUpConfig.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 100);
-        cleanUpConfig.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "" + CLEANUP_CONSUMER_TIMEOUT);
-
-        final int exitCode = new StreamsResetter().run(parameters, cleanUpConfig);
-        Assert.assertEquals(1, exitCode);
+        super.shouldNotAllowToResetWhenIntermediateTopicAbsent();
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationTest.java
@@ -16,21 +16,18 @@
  */
 package org.apache.kafka.streams.integration;
 
-import kafka.server.KafkaConfig$;
-import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import kafka.tools.StreamsResetter;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.Collection;
 import java.util.Properties;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -44,6 +41,8 @@ import java.util.List;
 @RunWith(value = Parameterized.class)
 public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
+    CLUSTER = new EmbeddedKafkaCluster(1);
+
     private static final long CLEANUP_CONSUMER_TIMEOUT = 2000L;
     private static final String APP_ID = "Integration-test";
 
@@ -51,20 +50,20 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
     private static int testNo = 1;
 
-    public ResetIntegrationTest(boolean sslEnabled) {
-        super(sslEnabled);
-    }
-
     @AfterClass
-    public static void globalCleanup() {
-        afterClassGlobalCleanup();
+    public static void afterClass() {
+        afterClassCleanup();
     }
 
     @Before
     public void before() throws Exception {
-        beforePrepareTest();
+        prepareTest();
     }
 
+    @After
+    void after() throws Exception {
+        cleanupTest();
+    }
 
     @Test
     public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
@@ -101,7 +100,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
         final List<String> parameterList = new ArrayList<>(
                 Arrays.asList("--application-id", APP_ID + testNo,
-                        "--bootstrap-servers", bootstrapServers,
+                        "--bootstrap-servers", CLUSTER.bootstrapServers(),
                         "--input-topics", NON_EXISTING_TOPIC));
 
         final String[] parameters = parameterList.toArray(new String[parameterList.size()]);
@@ -118,7 +117,7 @@ public class ResetIntegrationTest extends AbstractResetIntegrationTest {
 
         final List<String> parameterList = new ArrayList<>(
                 Arrays.asList("--application-id", APP_ID + testNo,
-                        "--bootstrap-servers", bootstrapServers,
+                        "--bootstrap-servers", CLUSTER.bootstrapServers(),
                         "--intermediate-topics", NON_EXISTING_TOPIC));
 
         final String[] parameters = parameterList.toArray(new String[parameterList.size()]);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -23,7 +23,6 @@ import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -60,11 +59,6 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         }
 
         CLUSTER = new EmbeddedKafkaCluster(1, brokerProps);
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        afterClassCleanup();
     }
 
     @Before

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -49,20 +49,8 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         }
     }
 
-    @ClassRule
-    public static final EmbeddedKafkaCluster CLUSTER;
-
-    static {
-        final Properties props = new Properties();
-        // we double the value passed to `time.sleep` in each iteration in one of the map functions, so we disable
-        // expiration of connections by the brokers to avoid errors when `AdminClient` sends requests after potentially
-        // very long sleep times
-        props.put(KafkaConfig$.MODULE$.ConnectionsMaxIdleMsProp(), -1L);
-        props.put(KafkaConfig$.MODULE$.ListenersProp(), "SSL://localhost:0");
-        props.put(KafkaConfig$.MODULE$.InterBrokerListenerNameProp(), "SSL");
-        props.putAll(sslConfig);
-        CLUSTER = new EmbeddedKafkaCluster(NUM_BROKERS, props);
-        cluster = CLUSTER;
+    public ResetIntegrationWithSslTest(boolean sslEnabled) {
+        super(sslEnabled);
     }
 
     @AfterClass
@@ -75,7 +63,7 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
         beforePrepareTest();
     }
 
-    Properties getClientSslConfig() {
+    Properties getSslClientConfig() {
         final Properties props = new Properties();
 
         props.put("bootstrap.servers", CLUSTER.bootstrapServers());

--- a/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/ResetIntegrationWithSslTest.java
@@ -83,4 +83,9 @@ public class ResetIntegrationWithSslTest extends AbstractResetIntegrationTest {
     public void testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic() throws Exception {
         super.testReprocessingFromScratchAfterResetWithoutIntermediateUserTopic();
     }
+
+    @Test
+    public void testReprocessingFromScratchAfterResetWithIntermediateUserTopic() throws Exception {
+        super.testReprocessingFromScratchAfterResetWithIntermediateUserTopic();
+    }
 }


### PR DESCRIPTION
1. Refactor AbstractResetIntegrationTest with producer / consumer / streams config, along with common client config embedded with ssl configs if necessary.
2. Use specific test id to replace the testNo suffix.
3. In testReprocessingFromScratchAfterResetWithIntermediateUserTopic, additional check on intermediate result.
4. Add the same result for SSL test suite as well.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
