### PR TITLE
KAFKA-6461 TableTableJoinIntegrationTest is unstable if caching is enabled

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
@@ -79,7 +79,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         @Override
         public void apply(final Long key, final String value) {
             numRecordsExpected++;
-            if (value.equals(expected)) {
+            if (value != null && value.equals(expected)) {
                 boolean ret = finalResultReached.compareAndSet(false, true);
 
                 if (!ret) {

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TableTableJoinIntegrationTest.java
@@ -79,7 +79,7 @@ public class TableTableJoinIntegrationTest extends AbstractJoinIntegrationTest {
         @Override
         public void apply(final Long key, final String value) {
             numRecordsExpected++;
-            if (value != null && value.equals(expected)) {
+            if (expected.equals(value)) {
                 boolean ret = finalResultReached.compareAndSet(false, true);
 
                 if (!ret) {


### PR DESCRIPTION
In test output, NPE is observed on the following line in apply() method:
```
            if (value.equals(expected)) {
```
We should check that value is not null before calling equals()

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
