### PR TITLE
KAFKA-6035: Avoid creating changelog topics for state stores that are directly piped to a sink topic

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -75,7 +75,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K> implements KTable<K, 
 
     private static final String SELECT_NAME = "KTABLE-SELECT-";
 
-    private static final String TOSTREAM_NAME = "KTABLE-TOSTREAM-";
+    public static final String TOSTREAM_NAME = "KTABLE-TOSTREAM-";
 
     private final ProcessorSupplier<?, ?> processorSupplier;
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -89,7 +89,8 @@ public abstract class AbstractTask implements Task {
                 topology.storeToChangelogTopic(),
                 changelogReader,
                 eosEnabled,
-                logContext);
+                logContext,
+                topology.stateStoreToChangelogTopicOnlyForRestoring());
         } catch (final IOException e) {
             throw new ProcessorStateException(String.format("%sError while creating the state manager", logPrefix), e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorTopology.java
@@ -33,6 +33,7 @@ public class ProcessorTopology {
     private final List<StateStore> globalStateStores;
     private final Map<String, String> storeToChangelogTopic;
     private final Set<String> repartitionTopics;
+    private final Map<String, String> stateStoreToChangelogTopicOnlyForRestoring;
 
     public static ProcessorTopology with(final List<ProcessorNode> processorNodes,
                                          final Map<String, SourceNode> sourcesByTopic,
@@ -44,7 +45,8 @@ public class ProcessorTopology {
                 stateStoresByName,
                 Collections.<StateStore>emptyList(),
                 storeToChangelogTopic,
-                Collections.<String>emptySet());
+                Collections.<String>emptySet(),
+                Collections.<String, String>emptyMap());
     }
 
     static ProcessorTopology withSources(final List<ProcessorNode> processorNodes,
@@ -55,7 +57,8 @@ public class ProcessorTopology {
                 Collections.<StateStore>emptyList(),
                 Collections.<StateStore>emptyList(),
                 Collections.<String, String>emptyMap(),
-                Collections.<String>emptySet());
+                Collections.<String>emptySet(),
+                Collections.<String, String>emptyMap());
     }
 
     static ProcessorTopology withLocalStores(final List<StateStore> stateStores,
@@ -66,7 +69,8 @@ public class ProcessorTopology {
                 stateStores,
                 Collections.<StateStore>emptyList(),
                 storeToChangelogTopic,
-                Collections.<String>emptySet());
+                Collections.<String>emptySet(),
+                Collections.<String, String>emptyMap());
     }
 
     static ProcessorTopology withGlobalStores(final List<StateStore> stateStores,
@@ -77,7 +81,8 @@ public class ProcessorTopology {
                 Collections.<StateStore>emptyList(),
                 stateStores,
                 storeToChangelogTopic,
-                Collections.<String>emptySet());
+                Collections.<String>emptySet(),
+                Collections.<String, String>emptyMap());
     }
 
     static ProcessorTopology withRepartitionTopics(final List<ProcessorNode> processorNodes,
@@ -89,7 +94,8 @@ public class ProcessorTopology {
                 Collections.<StateStore>emptyList(),
                 Collections.<StateStore>emptyList(),
                 Collections.<String, String>emptyMap(),
-                repartitionTopics);
+                repartitionTopics,
+                Collections.<String, String>emptyMap());
     }
 
     public ProcessorTopology(final List<ProcessorNode> processorNodes,
@@ -98,7 +104,8 @@ public class ProcessorTopology {
                              final List<StateStore> stateStores,
                              final List<StateStore> globalStateStores,
                              final Map<String, String> stateStoreToChangelogTopic,
-                             final Set<String> repartitionTopics) {
+                             final Set<String> repartitionTopics,
+                             final Map<String, String> stateStoreToChangelogTopicOnlyForRestoring) {
         this.processorNodes = Collections.unmodifiableList(processorNodes);
         this.sourcesByTopic = Collections.unmodifiableMap(sourcesByTopic);
         this.sinksByTopic = Collections.unmodifiableMap(sinksByTopic);
@@ -106,6 +113,7 @@ public class ProcessorTopology {
         this.globalStateStores = Collections.unmodifiableList(globalStateStores);
         this.storeToChangelogTopic = Collections.unmodifiableMap(stateStoreToChangelogTopic);
         this.repartitionTopics = Collections.unmodifiableSet(repartitionTopics);
+        this.stateStoreToChangelogTopicOnlyForRestoring = stateStoreToChangelogTopicOnlyForRestoring;
     }
 
     public Set<String> sourceTopics() {
@@ -146,6 +154,10 @@ public class ProcessorTopology {
 
     public Map<String, String> storeToChangelogTopic() {
         return storeToChangelogTopic;
+    }
+
+    public Map<String, String> stateStoreToChangelogTopicOnlyForRestoring() {
+        return stateStoreToChangelogTopicOnlyForRestoring;
     }
 
     boolean isRepartitionTopic(String topic) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -101,6 +101,21 @@ public class InternalTopologyBuilderTest {
     }
 
     @Test
+    public void shouldRemoveChangelogTopicsForStateStoresDirectlyPipedToSink() {
+        final StateStoreSupplier supplier = new MockStateStoreSupplier("store-1", false);
+        builder.addStateStore(supplier);
+        builder.setApplicationId("X");
+        builder.addSource(null, "source-1", null, null, null, "topic-1");
+        builder.addProcessor("processor-1", new MockProcessorSupplier(), "source-1");
+        builder.connectProcessorAndStateStores("processor-1", "store-1");
+        builder.addSink("sink", "sink-topic", null, null, null, "processor-1");
+
+        Map<String, String> storeToChangelogTopic = builder.build(null).storeToChangelogTopic();
+
+        assertEquals(0, storeToChangelogTopic.size());
+    }
+
+    @Test
     public void shouldAddPatternSourceWithoutOffsetReset() {
         final Pattern expectedPattern = Pattern.compile("test-.*");
         

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorStateManagerTest.java
@@ -163,7 +163,8 @@ public class ProcessorStateManagerTest {
             },
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         try {
             stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
@@ -190,7 +191,8 @@ public class ProcessorStateManagerTest {
             },
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         try {
             stateMgr.register(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
@@ -239,7 +241,8 @@ public class ProcessorStateManagerTest {
             storeToChangelogTopic,
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         try {
             stateMgr.register(store1, store1.stateRestoreCallback);
@@ -272,7 +275,8 @@ public class ProcessorStateManagerTest {
             Collections.<String, String>emptyMap(),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
         try {
             stateMgr.register(mockStateStore, mockStateStore.stateRestoreCallback);
 
@@ -307,7 +311,8 @@ public class ProcessorStateManagerTest {
             },
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
         try {
             // make sure the checkpoint file isn't deleted
             assertTrue(checkpointFile.exists());
@@ -342,7 +347,8 @@ public class ProcessorStateManagerTest {
             Collections.<String, String>emptyMap(),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
         stateMgr.register(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
         assertNotNull(stateMgr.getStore(nonPersistentStoreName));
     }
@@ -361,7 +367,8 @@ public class ProcessorStateManagerTest {
             Collections.<String, String>emptyMap(),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
         stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
         stateMgr.close(null);
         final Map<TopicPartition, Long> read = checkpoint.read();
@@ -378,7 +385,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(persistentStore.name(), persistentStoreTopicName),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
         stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
 
         stateMgr.checkpoint(Collections.singletonMap(persistentStorePartition, 10L));
@@ -396,7 +404,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(persistentStore.name(), persistentStoreTopicName),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
         final byte[] bytes = Serdes.Integer().serializer().serialize("", 10);
@@ -427,7 +436,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(nonPersistentStoreName, nonPersistentStoreTopicName),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         stateMgr.register(nonPersistentStore, nonPersistentStore.stateRestoreCallback);
         stateMgr.checkpoint(Collections.singletonMap(topicPartition, 876L));
@@ -446,7 +456,8 @@ public class ProcessorStateManagerTest {
             Collections.<String, String>emptyMap(),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         stateMgr.register(persistentStore, persistentStore.stateRestoreCallback);
 
@@ -467,7 +478,8 @@ public class ProcessorStateManagerTest {
             Collections.<String, String>emptyMap(),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         try {
             stateManager.register(new MockStateStore(ProcessorStateManager.CHECKPOINT_FILE_NAME, true), null);
@@ -487,7 +499,8 @@ public class ProcessorStateManagerTest {
             Collections.<String, String>emptyMap(),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         stateManager.register(mockStateStore, null);
 
@@ -511,7 +524,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(storeName, changelogTopic),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         final MockStateStore stateStore = new MockStateStore(storeName, true) {
             @Override
@@ -540,7 +554,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(storeName, changelogTopic),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         final MockStateStore stateStore = new MockStateStore(storeName, true) {
             @Override
@@ -568,7 +583,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(storeName, changelogTopic),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         final AtomicBoolean flushedStore = new AtomicBoolean(false);
 
@@ -603,7 +619,8 @@ public class ProcessorStateManagerTest {
             Collections.singletonMap(storeName, changelogTopic),
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
 
         final AtomicBoolean closedStore = new AtomicBoolean(false);
 
@@ -643,7 +660,8 @@ public class ProcessorStateManagerTest {
                 Collections.<String, String>emptyMap(),
                 changelogReader,
                 true,
-                logContext);
+                logContext,
+                Collections.<String, String>emptyMap());
 
             assertFalse(checkpointFile.exists());
         } finally {
@@ -674,7 +692,8 @@ public class ProcessorStateManagerTest {
                 storeToChangelog,
                 changelogReader,
                 false,
-                logContext);
+                logContext,
+                Collections.<String, String>emptyMap());
 
         final MockStateStore stateStore = new MockStateStore(storeName, true);
         final MockStateStore stateStore2 = new MockStateStore(store2Name, true);
@@ -709,7 +728,8 @@ public class ProcessorStateManagerTest {
             },
             changelogReader,
             false,
-            logContext);
+            logContext,
+            Collections.<String, String>emptyMap());
     }
 
     private MockStateStore getPersistentStore() {


### PR DESCRIPTION
This PR aims to optimize topology by eliminating state stores that are directly piped to a sink topic. 
There few things to note:

- If topology sink operator is `toStream`, then we consider the operator just before `toStream` and check if it has state store.

- Just removing the state store from `storeToChangelogTopic` can cause a problem in case of failure, especially with `EoS`. So, what we propose here is that if the sink operator contains state store, then i) we remove selected state stores from `storeToChangelogTopic` and put it into `stateStoreToChangelogTopicOnlyForRestoring`.  The first step will make sure that selected state stores will not `write` to changelog topic. The second step is only needed when the state store `reads` from changelog topic (say, in case of failure).