### PR TITLE
KAFKA-6464: Fix Base64URL encode padding issue under JRE 1.7

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/utils/Base64.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Base64.java
@@ -240,16 +240,15 @@ public final class Base64 {
 
             @Override
             public String encodeToString(byte[] bytes) {
+                if (bytes.length == 0)
+                    return "";
                 String base64EncodedUUID = Java7Factory.encodeToString(bytes);
-                //Convert to URL safe variant by replacing + and / with - and _ respectively.
-                String urlSafeBase64EncodedUUID = base64EncodedUUID.replace("+", "-")
-                        .replace("/", "_");
+                // Convert to URL safe variant by replacing + and / with - and _ respectively.
+                String urlSafeBase64EncodedUUID = base64EncodedUUID.replace("+", "-").replace("/", "_");
                 // Remove any "=" or "==" padding at the end.
-                return urlSafeBase64EncodedUUID.endsWith("==")
-                        ? urlSafeBase64EncodedUUID.substring(0, urlSafeBase64EncodedUUID.length() - 2)
-                        : urlSafeBase64EncodedUUID.endsWith("=")
-                                ? urlSafeBase64EncodedUUID.substring(0, urlSafeBase64EncodedUUID.length() - 1)
-                                : urlSafeBase64EncodedUUID;
+                // Note that length will be at least 4 here.
+                int index = urlSafeBase64EncodedUUID.indexOf('=', urlSafeBase64EncodedUUID.length() - 2);
+                return index > 0 ? urlSafeBase64EncodedUUID.substring(0, index) : urlSafeBase64EncodedUUID;
             }
 
         };

--- a/clients/src/test/java/org/apache/kafka/common/utils/Base64Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/Base64Test.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.common.utils.Base64.Decoder;
+import org.apache.kafka.common.utils.Base64.Encoder;
+import org.junit.Test;
+
+public class Base64Test {
+
+    @Test
+    public void testBase64UrlEncodeDecode() {
+        confirmInversesForAllThreePaddingCases(Base64.urlEncoderNoPadding(), Base64.urlDecoder());
+    }
+
+    @Test
+    public void testBase64EncodeDecode() {
+        confirmInversesForAllThreePaddingCases(Base64.encoder(), Base64.decoder());
+    }
+
+    private static void confirmInversesForAllThreePaddingCases(Encoder encoder, Decoder decoder) {
+        for (String text : new String[] {"a", "ab", "abc"}) {
+            assertEquals(text, new String(decoder.decode(encoder.encodeToString(text.getBytes(StandardCharsets.UTF_8))),
+                    StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/utils/Base64Test.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/Base64Test.java
@@ -37,7 +37,7 @@ public class Base64Test {
     }
 
     private static void confirmInversesForAllThreePaddingCases(Encoder encoder, Decoder decoder) {
-        for (String text : new String[] {"a", "ab", "abc"}) {
+        for (String text : new String[] {"", "a", "ab", "abc"}) {
             assertEquals(text, new String(decoder.decode(encoder.encodeToString(text.getBytes(StandardCharsets.UTF_8))),
                     StandardCharsets.UTF_8));
         }


### PR DESCRIPTION
The org.apache.kafka.common.utils.Base64 class defers Base64
encoding/decoding to the java.util.Base64 class beginning with
JRE 1.8 but leverages javax.xml.bind.DatatypeConverter under JRE
1.7.  The implementation of the encodeToString(bytes[]) method
returned under JRE 1.7 by Base64.urlEncoderNoPadding() blindly
removed the last two trailing characters of the Base64 encoding
under the assumption that they would always be the string "=="
but that is incorrect; padding can be "=", "==", or non-existent.
This commit fixes that problem.

The commit also adds a Base64.urlDecoder() method that defers to
java.util.Base64 under JRE 1.8+ but leverages
javax.xml.bind.DatatypeConverter under JRE 1.7.

Finally, there is a unit test to confirm that encode/decode are
inverses in both the Base64 and Base64URL cases.

Signed-off-by: Ron Dagostino <rndgstn@gmail.com>
