### PR TITLE
KAFKA-6467: Enforce layout of dependencies within a connect plugin to be deterministic

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -34,6 +34,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Connect plugin utility methods.
@@ -208,7 +209,7 @@ public class PluginUtils {
      */
     public static List<Path> pluginUrls(Path topPath) throws IOException {
         boolean containsClassFiles = false;
-        Set<Path> archives = new HashSet<>();
+        Set<Path> archives = new TreeSet<>();
         LinkedList<DirectoryEntry> dfs = new LinkedList<>();
         Set<Path> visited = new HashSet<>();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -159,6 +160,21 @@ public class PluginUtilsTest {
     }
 
     @Test
+    public void testOrderOfPluginUrlsWithJars() throws Exception {
+        createBasicDirectoryLayout();
+        // Here this method is just used to create the files. The result is not used.
+        createBasicExpectedUrls();
+
+        List<Path> actual = PluginUtils.pluginUrls(pluginPath);
+        // simple-transform.jar is created first. In most systems, without sorting within the
+        // PluginUtils is would be placed before another-transform.jar often though not always
+        // and this test case would be flaky.
+        int i = Arrays.toString(actual.toArray()).indexOf("another-transform.jar");
+        int j = Arrays.toString(actual.toArray()).indexOf("simple-transform.jar");
+        assert i < j;
+    }
+
+    @Test
     public void testPluginUrlsWithZips() throws Exception {
         createBasicDirectoryLayout();
 
@@ -262,9 +278,8 @@ public class PluginUtilsTest {
     }
 
     private void assertUrls(List<Path> expected, List<Path> actual) {
-        List<Path> actualCopy = new ArrayList<>(actual);
         Collections.sort(expected);
-        Collections.sort(actualCopy);
-        assertEquals(expected, actualCopy);
+        // not sorting 'actual' because it should be returned sorted from withing the PluginUtils.
+        assertEquals(expected, actual);
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -166,12 +166,13 @@ public class PluginUtilsTest {
         createBasicExpectedUrls();
 
         List<Path> actual = PluginUtils.pluginUrls(pluginPath);
-        // simple-transform.jar is created first. In most systems, without sorting within the
-        // PluginUtils is would be placed before another-transform.jar often though not always
-        // and this test case would be flaky.
+        // 'simple-transform.jar' is created first. In many cases, without sorting within the
+        // PluginUtils, this jar will be placed before 'another-transform.jar'. However this is
+        // not guaranteed because a DirectoryStream does not maintain a certain order in its
+        // results. Besides this test case, sorted order in every call to assertUrls below.
         int i = Arrays.toString(actual.toArray()).indexOf("another-transform.jar");
         int j = Arrays.toString(actual.toArray()).indexOf("simple-transform.jar");
-        assert i < j;
+        assertTrue(i < j);
     }
 
     @Test


### PR DESCRIPTION
Adds alphanumeric ordering of dependencies as they added to a Connect plugin's class loader path. 

This makes the layout of the dependencies consistent across systems and deployments. Dependencies should still, in principle, not include conflicts and ideally order should not matter. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
