### PR TITLE
KAFKA-6345: Keep a separate count of in-flight requests to avoid ConcurrentModificationException.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -69,7 +69,8 @@ final class InFlightRequests {
      */
     public NetworkClient.InFlightRequest completeNext(String node) {
         NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).pollLast();
-        inFlightRequestCount.decrementAndGet();
+        if (inFlightRequest != null)
+            inFlightRequestCount.decrementAndGet();
         return inFlightRequest;
     }
 
@@ -88,7 +89,8 @@ final class InFlightRequests {
      */
     public NetworkClient.InFlightRequest completeLastSent(String node) {
         NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).pollFirst();
-        inFlightRequestCount.decrementAndGet();
+        if (inFlightRequestCount != null)
+            inFlightRequestCount.decrementAndGet();
         return inFlightRequest;
     }
 
@@ -152,7 +154,8 @@ final class InFlightRequests {
             return Collections.emptyList();
         } else {
             Deque<NetworkClient.InFlightRequest> clearedRequests = requests.remove(node);
-            inFlightRequestCount.getAndAdd(-clearedRequests.size());
+            if (clearedRequests != null)
+                inFlightRequestCount.getAndAdd(-clearedRequests.size());
             return clearedRequests;
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -69,8 +69,7 @@ final class InFlightRequests {
      */
     public NetworkClient.InFlightRequest completeNext(String node) {
         NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).pollLast();
-        if (inFlightRequest != null)
-            inFlightRequestCount.decrementAndGet();
+        inFlightRequestCount.decrementAndGet();
         return inFlightRequest;
     }
 
@@ -89,8 +88,7 @@ final class InFlightRequests {
      */
     public NetworkClient.InFlightRequest completeLastSent(String node) {
         NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).pollFirst();
-        if (inFlightRequestCount != null)
-            inFlightRequestCount.decrementAndGet();
+        inFlightRequestCount.decrementAndGet();
         return inFlightRequest;
     }
 
@@ -154,8 +152,7 @@ final class InFlightRequests {
             return Collections.emptyList();
         } else {
             Deque<NetworkClient.InFlightRequest> clearedRequests = requests.remove(node);
-            if (clearedRequests != null)
-                inFlightRequestCount.getAndAdd(-clearedRequests.size());
+            inFlightRequestCount.getAndAdd(-clearedRequests.size());
             return clearedRequests;
         }
     }

--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 
 /**
  * The set of requests which have been sent or are being sent but haven't yet received a response
@@ -31,6 +33,8 @@ final class InFlightRequests {
 
     private final int maxInFlightRequestsPerConnection;
     private final Map<String, Deque<NetworkClient.InFlightRequest>> requests = new HashMap<>();
+    /** Thread safe total number of in flight requests. */
+    private final AtomicInteger inFlightRequestCount = new AtomicInteger(0);
 
     public InFlightRequests(int maxInFlightRequestsPerConnection) {
         this.maxInFlightRequestsPerConnection = maxInFlightRequestsPerConnection;
@@ -47,6 +51,7 @@ final class InFlightRequests {
             this.requests.put(destination, reqs);
         }
         reqs.addFirst(request);
+        inFlightRequestCount.incrementAndGet();
     }
 
     /**
@@ -63,7 +68,9 @@ final class InFlightRequests {
      * Get the oldest request (the one that will be completed next) for the given node
      */
     public NetworkClient.InFlightRequest completeNext(String node) {
-        return requestQueue(node).pollLast();
+        NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).pollLast();
+        inFlightRequestCount.decrementAndGet();
+        return inFlightRequest;
     }
 
     /**
@@ -80,7 +87,9 @@ final class InFlightRequests {
      * @return The request
      */
     public NetworkClient.InFlightRequest completeLastSent(String node) {
-        return requestQueue(node).pollFirst();
+        NetworkClient.InFlightRequest inFlightRequest = requestQueue(node).pollFirst();
+        inFlightRequestCount.decrementAndGet();
+        return inFlightRequest;
     }
 
     /**
@@ -114,13 +123,10 @@ final class InFlightRequests {
     }
 
     /**
-     * Count all in-flight requests for all nodes
+     * Count all in-flight requests for all nodes. This method is thread safe, but may lag the actual count.
      */
     public int count() {
-        int total = 0;
-        for (Deque<NetworkClient.InFlightRequest> deque : this.requests.values())
-            total += deque.size();
-        return total;
+        return inFlightRequestCount.get();
     }
 
     /**
@@ -141,8 +147,14 @@ final class InFlightRequests {
      * @return All the in-flight requests for that node that have been removed
      */
     public Iterable<NetworkClient.InFlightRequest> clearAll(String node) {
-        Deque<NetworkClient.InFlightRequest> reqs = requests.remove(node);
-        return (reqs == null) ? Collections.<NetworkClient.InFlightRequest>emptyList() : reqs;
+        Deque<NetworkClient.InFlightRequest> reqs = requests.get(node);
+        if (reqs == null) {
+            return Collections.emptyList();
+        } else {
+            Deque<NetworkClient.InFlightRequest> clearedRequests = requests.remove(node);
+            inFlightRequestCount.getAndAdd(-clearedRequests.size());
+            return clearedRequests;
+        }
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.kafka.clients;
 
 import org.junit.Before;
@@ -7,37 +24,37 @@ import static org.junit.Assert.assertEquals;
 
 public class InFlightRequestsTest {
 
-  private InFlightRequests inFlightRequests;
-  @Before
-  public void setup() {
-    inFlightRequests = new InFlightRequests(12);
-    NetworkClient.InFlightRequest ifr =
-        new NetworkClient.InFlightRequest(null, 0, "dest", null, false, false, null, null, 0);
-    inFlightRequests.add(ifr);
-  }
+    private InFlightRequests inFlightRequests;
+    @Before
+    public void setup() {
+        inFlightRequests = new InFlightRequests(12);
+        NetworkClient.InFlightRequest ifr =
+                new NetworkClient.InFlightRequest(null, 0, "dest", null, false, false, null, null, 0);
+        inFlightRequests.add(ifr);
+    }
 
-  @Test
-  public void checkIncrementAndDecrementOnLastSent() {
-    assertEquals(1, inFlightRequests.count());
+    @Test
+    public void checkIncrementAndDecrementOnLastSent() {
+        assertEquals(1, inFlightRequests.count());
 
-    inFlightRequests.completeLastSent("dest");
-    assertEquals(0, inFlightRequests.count());
-  }
+        inFlightRequests.completeLastSent("dest");
+        assertEquals(0, inFlightRequests.count());
+    }
 
-  @Test
-  public void checkDecrementOnClear() {
-    inFlightRequests.clearAll("dest");
-    assertEquals(0, inFlightRequests.count());
-  }
+    @Test
+    public void checkDecrementOnClear() {
+        inFlightRequests.clearAll("dest");
+        assertEquals(0, inFlightRequests.count());
+    }
 
-  @Test
-  public void checkDecrementOnCompleteNext() {
-    inFlightRequests.completeNext("dest");
-    assertEquals(0, inFlightRequests.count());
-  }
+    @Test
+    public void checkDecrementOnCompleteNext() {
+        inFlightRequests.completeNext("dest");
+        assertEquals(0, inFlightRequests.count());
+    }
 
-  @Test(expected = IllegalStateException.class)
-  public void throwExceptionOnNeverBeforeSeenNode() {
-    inFlightRequests.completeNext("not-added");
-  }
+    @Test(expected = IllegalStateException.class)
+    public void throwExceptionOnNeverBeforeSeenNode() {
+        inFlightRequests.completeNext("not-added");
+    }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -1,0 +1,4 @@
+package org.apache.kafka.clients;
+
+public class InFlightRequestsTest {
+}

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -1,4 +1,43 @@
 package org.apache.kafka.clients;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
 public class InFlightRequestsTest {
+
+  private InFlightRequests inFlightRequests;
+  @Before
+  public void setup() {
+    inFlightRequests = new InFlightRequests(12);
+    NetworkClient.InFlightRequest ifr =
+        new NetworkClient.InFlightRequest(null, 0, "dest", null, false, false, null, null, 0);
+    inFlightRequests.add(ifr);
+  }
+
+  @Test
+  public void checkIncrementAndDecrementOnLastSent() {
+    assertEquals(1, inFlightRequests.count());
+
+    inFlightRequests.completeLastSent("dest");
+    assertEquals(0, inFlightRequests.count());
+  }
+
+  @Test
+  public void checkDecrementOnClear() {
+    inFlightRequests.clearAll("dest");
+    assertEquals(0, inFlightRequests.count());
+  }
+
+  @Test
+  public void checkDecrementOnCompleteNext() {
+    inFlightRequests.completeNext("dest");
+    assertEquals(0, inFlightRequests.count());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void throwExceptionOnNeverBeforeSeenNode() {
+    inFlightRequests.completeNext("not-added");
+  }
 }


### PR DESCRIPTION
This keeps a separate count of the number of in flight requests so that sensor threads will not need to deal with ConcurrentModfiicationException.

This would probably still be correct with volatile rather than AtomicInteger, but FindBugs flags the use of volatile as the count is incremented and decremented.
