### PR TITLE
KAFKA-6468 Read replication-offset-checkpoint once

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -28,7 +28,7 @@ import kafka.controller.{KafkaController, StateChangeLogger}
 import kafka.log.{Log, LogAppendInfo, LogManager}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
-import kafka.server.checkpoints.OffsetCheckpointFile
+import kafka.server.checkpoints.{CheckpointPersistentCache, CheckpointPersistentCacheFile, OffsetCheckpointFile}
 import kafka.utils._
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
@@ -181,8 +181,12 @@ class ReplicaManager(val config: KafkaConfig,
   val replicaFetcherManager = createReplicaFetcherManager(metrics, time, threadNamePrefix, quotaManagers.follower)
   val replicaAlterLogDirsManager = createReplicaAlterLogDirsManager(quotaManagers.alterLogDirs, brokerTopicStats)
   private val highWatermarkCheckPointThreadStarted = new AtomicBoolean(false)
-  @volatile var highWatermarkCheckpoints = logManager.liveLogDirs.map(dir =>
-    (dir.getAbsolutePath, new OffsetCheckpointFile(new File(dir, ReplicaManager.HighWatermarkFilename), logDirFailureChannel))).toMap
+  @volatile var highWatermarkCheckpoints: Map[String, CheckpointPersistentCache[TopicPartition, Long]] =
+    logManager.liveLogDirs.map(dir =>
+      (dir.getAbsolutePath, new CheckpointPersistentCacheFile[TopicPartition, Long](
+        new File(dir, ReplicaManager.HighWatermarkFilename),
+        OffsetCheckpointFile.Formatter,
+        logDirFailureChannel))).toMap
 
   private var hwThreadInitialized = false
   this.logIdent = s"[ReplicaManager broker=$localBrokerId] "
@@ -244,7 +248,7 @@ class ReplicaManager(val config: KafkaConfig,
 
   def startHighWaterMarksCheckPointThread() = {
     if(highWatermarkCheckPointThreadStarted.compareAndSet(false, true))
-      scheduler.schedule("highwatermark-checkpoint", checkpointHighWatermarks _, period = config.replicaHighWatermarkCheckpointIntervalMs, unit = TimeUnit.MILLISECONDS)
+      scheduler.schedule("highwatermark-checkpoint", checkpointHighWatermarks, period = config.replicaHighWatermarkCheckpointIntervalMs, unit = TimeUnit.MILLISECONDS)
   }
 
   def recordIsrChange(topicPartition: TopicPartition) {
@@ -1384,7 +1388,9 @@ class ReplicaManager(val config: KafkaConfig,
     for ((dir, reps) <- replicasByDir) {
       val hwms = reps.map(r => r.topicPartition -> r.highWatermark.messageOffset).toMap
       try {
-        highWatermarkCheckpoints.get(dir).foreach(_.write(hwms))
+        val cache = highWatermarkCheckpoints(dir)
+        cache.update(hwms)
+        cache.persist()
       } catch {
         case e: KafkaStorageException =>
           error(s"Error while writing to highwatermark file in directory $dir", e)

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointPersistentCache.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointPersistentCache.scala
@@ -1,0 +1,23 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package kafka.server.checkpoints
+
+trait CheckpointPersistentCache[K, V] {
+  def getCheckpoint(key: K): Option[V]
+  def update(entries: Map[K, V]): Unit
+  def persist(): Unit
+}

--- a/core/src/main/scala/kafka/server/checkpoints/CheckpointPersistentCacheFile.scala
+++ b/core/src/main/scala/kafka/server/checkpoints/CheckpointPersistentCacheFile.scala
@@ -1,0 +1,47 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package kafka.server.checkpoints
+
+import java.io.File
+
+import kafka.server.LogDirFailureChannel
+
+class CheckpointPersistentCacheFile[K, V](file: File,
+                                          formatter: CheckpointFileFormatter[(K, V)],
+                                          logDirFailureChannel: LogDirFailureChannel = null,
+                                          logDir: String = null) extends CheckpointPersistentCache[K, V] {
+  private val _checkpointFile: CheckpointFile[(K, V)] = new CheckpointFile[(K, V)](
+    file,
+    0,
+    formatter,
+    logDirFailureChannel,
+    if (logDir == null) file.getParentFile.toString else logDir)
+
+  @volatile private var _entriesMap: collection.Map[K, V] = _checkpointFile.read().toMap
+
+  override def getCheckpoint(key: K): Option[V] = {
+    _entriesMap.get(key)
+  }
+
+  override def persist(): Unit = {
+    _checkpointFile.write(_entriesMap.toSeq)
+  }
+
+  override def update(entries: Map[K, V]): Unit = {
+    _entriesMap = entries
+  }
+}

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -166,8 +166,11 @@ class HighwatermarkPersistenceTest {
   }
 
   def hwmFor(replicaManager: ReplicaManager, topic: String, partition: Int): Long = {
-    replicaManager.highWatermarkCheckpoints(new File(replicaManager.config.logDirs.head).getAbsolutePath).read.getOrElse(
-      new TopicPartition(topic, partition), 0L)
+    val logDir = new File(replicaManager.config.logDirs.head).getAbsolutePath
+    val tp = new TopicPartition(topic, partition)
+    replicaManager.highWatermarkCheckpoints(logDir).getCheckpoint(tp) match {
+      case Some(off) => off
+      case None => 0L
+    }
   }
-
 }

--- a/core/src/test/scala/unit/kafka/server/checkpoints/CheckpointPersistentCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/checkpoints/CheckpointPersistentCacheTest.scala
@@ -1,0 +1,50 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package unit.kafka.server.checkpoints
+
+import kafka.server.checkpoints.{CheckpointPersistentCacheFile, OffsetCheckpointFile}
+import kafka.utils.{Logging, TestUtils}
+import org.apache.kafka.common.TopicPartition
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.scalatest.junit.JUnitSuite
+
+class CheckpointPersistentCacheTest extends JUnitSuite with Logging {
+  @Test
+  def shouldPersistAndOverwriteAndReloadFile(): Unit = {
+    val checkpointFile = TestUtils.tempFile()
+    checkpointFile.deleteOnExit()
+
+    val checkpointStore = new CheckpointPersistentCacheFile[TopicPartition, Long](
+      checkpointFile,
+      OffsetCheckpointFile.Formatter)
+
+    val tp = new TopicPartition("topic1", 0)
+
+    checkpointStore.update(Map(tp -> 55L, new TopicPartition("topic2", 234) -> 19242342458L))
+    checkpointStore.persist()
+
+    assertEquals(55L, checkpointStore.getCheckpoint(tp).get)
+
+    // A new instance should read the cache off disk.
+    val checkpointStore2 = new CheckpointPersistentCacheFile[TopicPartition, Long](
+      checkpointFile,
+      OffsetCheckpointFile.Formatter)
+
+    assertEquals(55L, checkpointStore2.getCheckpoint(tp).get)
+  }
+}


### PR DESCRIPTION
Only read the high watermark checkpoint
file (replication-offset-checkpoint) once. Before this patch, this file
is read every time the broker handles LeaderAndIsrRequest. See
kafka.cluster.Partition#getOrCreateReplica(Int, Boolean).

On my local test cluster of three brokers with around 40k partitions,
the initial LeaderAndIsrRequest refers to every partition in the
cluster, and it can take 20 to 30 minutes to create all of the replicas
because the replication-offset-checkpoint is nearly 2MB.

Changing this code so that we only read this file once on startup
reduces the time to create all replicas to around one minute.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
