### PR TITLE
KAFKA-6242: Dynamic resize of various broker thread pools

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -174,7 +174,7 @@ class LogManager(logDirs: Seq[File],
   }
 
   def resizeRecoveryThreadPool(newSize: Int): Unit = {
-    info(s"Resize recovery thread pool size for each data dir to $newSize")
+    info(s"Resizing recovery thread pool size for each data dir from $numRecoveryThreadsPerDataDir to $newSize")
     numRecoveryThreadsPerDataDir = newSize
   }
 

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.{Sanitizer, Time}
 
 import scala.collection.mutable
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 object RequestChannel extends Logging {
@@ -239,13 +240,11 @@ object RequestChannel extends Logging {
   case object CloseConnectionAction extends ResponseAction
 }
 
-class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMetricsGroup {
+class RequestChannel(val queueSize: Int) extends KafkaMetricsGroup {
   val metrics = new RequestChannel.Metrics
   private var responseListeners: List[(Int) => Unit] = Nil
   private val requestQueue = new ArrayBlockingQueue[BaseRequest](queueSize)
-  private val responseQueues = new Array[BlockingQueue[RequestChannel.Response]](numProcessors)
-  for(i <- 0 until numProcessors)
-    responseQueues(i) = new LinkedBlockingQueue[RequestChannel.Response]()
+  private val responseQueues = new ConcurrentHashMap[Int, BlockingQueue[RequestChannel.Response]]()
 
   newGauge(
     "RequestQueueSize",
@@ -255,16 +254,23 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
   )
 
   newGauge("ResponseQueueSize", new Gauge[Int]{
-    def value = responseQueues.foldLeft(0) {(total, q) => total + q.size()}
+    def value = responseQueues.values.asScala.foldLeft(0) {(total, q) => total + q.size()}
   })
 
-  for (i <- 0 until numProcessors) {
+  def addProcessor(processorId: Int): Unit = {
+    val responseQueue = new LinkedBlockingQueue[RequestChannel.Response]()
+    responseQueues.put(processorId, responseQueue)
     newGauge("ResponseQueueSize",
       new Gauge[Int] {
-        def value = responseQueues(i).size()
+        def value = responseQueue.size()
       },
-      Map("processor" -> i.toString)
+      Map("processor" -> processorId.toString)
     )
+  }
+
+  def removeProcessor(processorId: Int): Unit = {
+    removeMetric("ResponseQueueSize", Map("processor" -> processorId.toString))
+    responseQueues.remove(processorId)
   }
 
   /** Send a request to be handled, potentially blocking until there is room in the queue for the request */
@@ -287,9 +293,12 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
       trace(message)
     }
 
-    responseQueues(response.processor).put(response)
-    for(onResponse <- responseListeners)
-      onResponse(response.processor)
+    val responseQueue = responseQueues.get(response.processor)
+    if (responseQueue != null) {
+      responseQueue.put(response)
+      for (onResponse <- responseListeners)
+        onResponse(response.processor)
+    }
   }
 
   /** Get the next request or block until specified time has elapsed */
@@ -302,7 +311,10 @@ class RequestChannel(val numProcessors: Int, val queueSize: Int) extends KafkaMe
 
   /** Get a response for the given processor if there is one */
   def receiveResponse(processor: Int): RequestChannel.Response = {
-    val response = responseQueues(processor).poll()
+    val responseQueue = responseQueues.get(processor)
+    if (responseQueue == null)
+      throw new IllegalStateException(s"receiveResponse with invalid processor $processor: processors=${responseQueues.keySet}")
+    val response = responseQueue.poll()
     if (response != null)
       response.request.responseDequeueTimeNanos = Time.SYSTEM.nanoseconds
     response

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -43,6 +43,7 @@ import org.slf4j.event.Level
 
 import scala.collection._
 import JavaConverters._
+import scala.collection.mutable.{ArrayBuffer, Buffer}
 import scala.util.control.ControlThrowable
 
 /**
@@ -54,9 +55,7 @@ import scala.util.control.ControlThrowable
 class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time, val credentialProvider: CredentialProvider) extends Logging with KafkaMetricsGroup {
 
   private val endpoints = config.listeners.map(l => l.listenerName -> l).toMap
-  private val numProcessorThreads = config.numNetworkThreads
   private val maxQueuedRequests = config.queuedMaxRequests
-  private val totalProcessorThreads = numProcessorThreads * endpoints.size
 
   private val maxConnectionsPerIp = config.maxConnectionsPerIp
   private val maxConnectionsPerIpOverrides = config.maxConnectionsPerIpOverrides
@@ -69,8 +68,9 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   private val memoryPoolDepletedTimeMetricName = metrics.metricName("MemoryPoolDepletedTimeTotal", "socket-server-metrics")
   memoryPoolSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
   private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolSensor) else MemoryPool.NONE
-  val requestChannel = new RequestChannel(totalProcessorThreads, maxQueuedRequests)
-  private val processors = new Array[Processor](totalProcessorThreads)
+  val requestChannel = new RequestChannel(maxQueuedRequests)
+  private val processors = mutable.Map[Int, Processor]()
+  private var nextProcessorId = 0
 
   private[network] val acceptors = mutable.Map[EndPoint, Acceptor]()
   private var connectionQuotas: ConnectionQuotas = _
@@ -81,41 +81,21 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
    */
   def startup() {
     this.synchronized {
-
       connectionQuotas = new ConnectionQuotas(maxConnectionsPerIp, maxConnectionsPerIpOverrides)
-
-      val sendBufferSize = config.socketSendBufferBytes
-      val recvBufferSize = config.socketReceiveBufferBytes
-      val brokerId = config.brokerId
-
-      var processorBeginIndex = 0
-      config.listeners.foreach { endpoint =>
-        val listenerName = endpoint.listenerName
-        val securityProtocol = endpoint.securityProtocol
-        val processorEndIndex = processorBeginIndex + numProcessorThreads
-
-        for (i <- processorBeginIndex until processorEndIndex)
-          processors(i) = newProcessor(i, connectionQuotas, listenerName, securityProtocol, memoryPool)
-
-        val acceptor = new Acceptor(endpoint, sendBufferSize, recvBufferSize, brokerId,
-          processors.slice(processorBeginIndex, processorEndIndex), connectionQuotas)
-        acceptors.put(endpoint, acceptor)
-        KafkaThread.nonDaemon(s"kafka-socket-acceptor-$listenerName-$securityProtocol-${endpoint.port}", acceptor).start()
-        acceptor.awaitStartup()
-
-        processorBeginIndex = processorEndIndex
-      }
+      createProcessors(config.numNetworkThreads)
     }
 
     newGauge("NetworkProcessorAvgIdlePercent",
       new Gauge[Double] {
-        private val ioWaitRatioMetricNames = processors.map { p =>
-          metrics.metricName("io-wait-ratio", "socket-server-metrics", p.metricTags)
-        }
 
-        def value = ioWaitRatioMetricNames.map { metricName =>
-          Option(metrics.metric(metricName)).fold(0.0)(_.value)
-        }.sum / totalProcessorThreads
+        def value = SocketServer.this.synchronized {
+          val ioWaitRatioMetricNames = processors.values.map { p =>
+            metrics.metricName("io-wait-ratio", "socket-server-metrics", p.metricTags)
+          }
+          ioWaitRatioMetricNames.map { metricName =>
+            Option(metrics.metric(metricName)).fold(0.0)(_.value)
+          }.sum / processors.size
+        }
       }
     )
     newGauge("MemoryPoolAvailable",
@@ -131,8 +111,37 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
     info("Started " + acceptors.size + " acceptor threads")
   }
 
+  private def createProcessors(newProcessorsPerListener: Int): Unit = synchronized {
+
+    val sendBufferSize = config.socketSendBufferBytes
+    val recvBufferSize = config.socketReceiveBufferBytes
+    val brokerId = config.brokerId
+
+    val numProcessorThreads = config.numNetworkThreads
+    config.listeners.foreach { endpoint =>
+      val listenerName = endpoint.listenerName
+      val securityProtocol = endpoint.securityProtocol
+      val listenerProcessors = new ArrayBuffer[Processor]()
+
+      for (i <- 0 until newProcessorsPerListener) {
+        listenerProcessors += newProcessor(nextProcessorId, connectionQuotas, listenerName, securityProtocol, memoryPool)
+        requestChannel.addProcessor(nextProcessorId)
+        nextProcessorId += 1
+      }
+      listenerProcessors.foreach(p => processors.put(p.id, p))
+
+      val acceptor = acceptors.getOrElseUpdate(endpoint, {
+        val acceptor = new Acceptor(endpoint, sendBufferSize, recvBufferSize, brokerId, connectionQuotas)
+        KafkaThread.nonDaemon(s"kafka-socket-acceptor-$listenerName-$securityProtocol-${endpoint.port}", acceptor).start()
+        acceptor.awaitStartup()
+        acceptor
+      })
+      acceptor.addProcessors(listenerProcessors)
+    }
+  }
+
   // register the processor threads for notification of responses
-  requestChannel.addResponseListener(id => processors(id).wakeup())
+  requestChannel.addResponseListener(id => processors.get(id).foreach(_.wakeup()))
 
   /**
     * Stop processing requests and new connections.
@@ -141,11 +150,19 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
     info("Stopping socket server request processors")
     this.synchronized {
       acceptors.values.foreach(_.shutdown)
-      processors.foreach(_.shutdown)
+      processors.values.foreach(_.shutdown)
       requestChannel.clear()
       stoppedProcessingRequests = true
     }
     info("Stopped socket server request processors")
+  }
+
+  def resizeThreadPool(newNumNetworkThreads: Int): Unit = {
+    val numNetworkThreads = config.numNetworkThreads.toInt
+    if (newNumNetworkThreads > numNetworkThreads)
+      createProcessors(newNumNetworkThreads - numNetworkThreads)
+    else if (newNumNetworkThreads < numNetworkThreads)
+      acceptors.values.foreach(_.removeProcessors(numNetworkThreads - newNumNetworkThreads, requestChannel))
   }
 
   /**
@@ -267,17 +284,25 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
                               val sendBufferSize: Int,
                               val recvBufferSize: Int,
                               brokerId: Int,
-                              processors: Array[Processor],
                               connectionQuotas: ConnectionQuotas) extends AbstractServerThread(connectionQuotas) with KafkaMetricsGroup {
 
   private val nioSelector = NSelector.open()
   val serverChannel = openServerSocket(endPoint.host, endPoint.port)
+  private val processors = new ArrayBuffer[Processor]()
 
-  this.synchronized {
-    processors.foreach { processor =>
+  private[network] def addProcessors(newProcessors: Buffer[Processor]): Unit = synchronized {
+    newProcessors.foreach { processor =>
       KafkaThread.nonDaemon(s"kafka-network-thread-$brokerId-${endPoint.listenerName}-${endPoint.securityProtocol}-${processor.id}",
         processor).start()
     }
+    processors ++= newProcessors
+  }
+
+  private[network] def removeProcessors(removeCount: Int, requestChannel: RequestChannel): Unit = synchronized {
+    val toRemove = processors.takeRight(removeCount)
+    processors.remove(processors.size - removeCount, removeCount)
+    toRemove.foreach(_.shutdown())
+    toRemove.foreach(processor => requestChannel.removeProcessor(processor.id))
   }
 
   /**
@@ -298,13 +323,17 @@ private[kafka] class Acceptor(val endPoint: EndPoint,
               try {
                 val key = iter.next
                 iter.remove()
-                if (key.isAcceptable)
-                  accept(key, processors(currentProcessor))
-                else
+                if (key.isAcceptable) {
+                  val processor = synchronized {
+                    currentProcessor = currentProcessor % processors.size
+                    processors(currentProcessor)
+                  }
+                  accept(key, processor)
+                } else
                   throw new IllegalStateException("Unrecognized key state for acceptor thread.")
 
-                // round robin to the next processor thread
-                currentProcessor = (currentProcessor + 1) % processors.length
+                // round robin to the next processor thread, mod(numProcessors) will be done later
+                currentProcessor = currentProcessor + 1
               } catch {
                 case e: Throwable => error("Error while accepting connection", e)
               }
@@ -446,8 +475,10 @@ private[kafka] class Processor(val id: Int,
       credentialProvider.tokenCache))
   // Visible to override for testing
   protected[network] def createSelector(channelBuilder: ChannelBuilder): KSelector = {
-    if (channelBuilder.isInstanceOf[Reconfigurable])
-      config.addReconfigurable(channelBuilder.asInstanceOf[Reconfigurable])
+    channelBuilder match {
+      case reconfigurable: Reconfigurable => config.addReconfigurable(reconfigurable)
+      case _ =>
+    }
     new KSelector(
       maxRequestSize,
       connectionsMaxIdleMs,

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -161,13 +161,12 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
     info("Stopped socket server request processors")
   }
 
-  def resizeThreadPool(newNumNetworkThreads: Int): Unit = {
-    val numNetworkThreads = config.numNetworkThreads.toInt
-    if (newNumNetworkThreads > numNetworkThreads)
-      createProcessors(newNumNetworkThreads - numNetworkThreads)
-    else if (newNumNetworkThreads < numNetworkThreads)
-      acceptors.values.foreach(_.removeProcessors(numNetworkThreads - newNumNetworkThreads, requestChannel))
-    info(s"Resized network thread pool size for each listener to $newNumNetworkThreads")
+  def resizeThreadPool(oldNumNetworkThreads: Int, newNumNetworkThreads: Int): Unit = {
+    info(s"Resizing network thread pool size for each listener from $oldNumNetworkThreads to $newNumNetworkThreads")
+    if (newNumNetworkThreads > oldNumNetworkThreads)
+      createProcessors(newNumNetworkThreads - oldNumNetworkThreads)
+    else if (newNumNetworkThreads < oldNumNetworkThreads)
+      acceptors.values.foreach(_.removeProcessors(oldNumNetworkThreads - newNumNetworkThreads, requestChannel))
   }
 
   /**

--- a/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
+++ b/core/src/main/scala/kafka/server/DynamicBrokerConfig.scala
@@ -488,7 +488,7 @@ class DynamicThreadPool(server: KafkaServer) extends BrokerReconfigurable {
     if (newConfig.numIoThreads != oldConfig.numIoThreads)
       server.requestHandlerPool.resizeThreadPool(newConfig.numIoThreads)
     if (newConfig.numNetworkThreads != oldConfig.numNetworkThreads)
-      server.socketServer.resizeThreadPool(newConfig.numNetworkThreads)
+      server.socketServer.resizeThreadPool(oldConfig.numNetworkThreads, newConfig.numNetworkThreads)
     if (newConfig.numReplicaFetchers != oldConfig.numReplicaFetchers)
       server.replicaManager.replicaFetcherManager.resizeThreadPool(newConfig.numReplicaFetchers)
     if (newConfig.numRecoveryThreadsPerDataDir != oldConfig.numRecoveryThreadsPerDataDir)

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -982,11 +982,11 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val maxReservedBrokerId: Int = getInt(KafkaConfig.MaxReservedBrokerIdProp)
   var brokerId: Int = getInt(KafkaConfig.BrokerIdProp)
 
-  val numNetworkThreads = getInt(KafkaConfig.NumNetworkThreadsProp)
-  val backgroundThreads = getInt(KafkaConfig.BackgroundThreadsProp)
+  def numNetworkThreads = getInt(KafkaConfig.NumNetworkThreadsProp)
+  def backgroundThreads = getInt(KafkaConfig.BackgroundThreadsProp)
   val queuedMaxRequests = getInt(KafkaConfig.QueuedMaxRequestsProp)
   val queuedMaxBytes = getLong(KafkaConfig.QueuedMaxBytesProp)
-  val numIoThreads = getInt(KafkaConfig.NumIoThreadsProp)
+  def numIoThreads = getInt(KafkaConfig.NumIoThreadsProp)
   def messageMaxBytes = getInt(KafkaConfig.MessageMaxBytesProp)
   val requestTimeoutMs = getInt(KafkaConfig.RequestTimeoutMsProp)
 
@@ -1022,7 +1022,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def logSegmentBytes = getInt(KafkaConfig.LogSegmentBytesProp)
   def logFlushIntervalMessages = getLong(KafkaConfig.LogFlushIntervalMessagesProp)
   val logCleanerThreads = getInt(KafkaConfig.LogCleanerThreadsProp)
-  val numRecoveryThreadsPerDataDir = getInt(KafkaConfig.NumRecoveryThreadsPerDataDirProp)
+  def numRecoveryThreadsPerDataDir = getInt(KafkaConfig.NumRecoveryThreadsPerDataDirProp)
   val logFlushSchedulerIntervalMs = getLong(KafkaConfig.LogFlushSchedulerIntervalMsProp)
   val logFlushOffsetCheckpointIntervalMs = getInt(KafkaConfig.LogFlushOffsetCheckpointIntervalMsProp).toLong
   val logFlushStartOffsetCheckpointIntervalMs = getInt(KafkaConfig.LogFlushStartOffsetCheckpointIntervalMsProp).toLong
@@ -1066,7 +1066,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   val replicaFetchMinBytes = getInt(KafkaConfig.ReplicaFetchMinBytesProp)
   val replicaFetchResponseMaxBytes = getInt(KafkaConfig.ReplicaFetchResponseMaxBytesProp)
   val replicaFetchBackoffMs = getInt(KafkaConfig.ReplicaFetchBackoffMsProp)
-  val numReplicaFetchers = getInt(KafkaConfig.NumReplicaFetchersProp)
+  def numReplicaFetchers = getInt(KafkaConfig.NumReplicaFetchersProp)
   val replicaHighWatermarkCheckpointIntervalMs = getLong(KafkaConfig.ReplicaHighWatermarkCheckpointIntervalMsProp)
   val fetchPurgatoryPurgeIntervalRequests = getInt(KafkaConfig.FetchPurgatoryPurgeIntervalRequestsProp)
   val producerPurgatoryPurgeIntervalRequests = getInt(KafkaConfig.ProducerPurgatoryPurgeIntervalRequestsProp)

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -115,6 +115,7 @@ class KafkaRequestHandlerPool(val brokerId: Int,
 
   def resizeThreadPool(newSize: Int): Unit = synchronized {
     val currentSize = threadPoolSize.get
+    info(s"Resizing request handler thread pool size from $currentSize to $newSize")
     if (newSize > currentSize) {
       for (i <- currentSize until newSize) {
         createHandler(i)
@@ -125,7 +126,6 @@ class KafkaRequestHandlerPool(val brokerId: Int,
       }
     }
     threadPoolSize.set(newSize)
-    info(s"Resized request handler thread pool size to $newSize")
   }
 
   def shutdown(): Unit = synchronized {

--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -21,10 +21,13 @@ import kafka.network._
 import kafka.utils._
 import kafka.metrics.KafkaMetricsGroup
 import java.util.concurrent.{CountDownLatch, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
 
 import com.yammer.metrics.core.Meter
 import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.utils.{KafkaThread, Time}
+
+import scala.collection.mutable
 
 /**
  * A thread that answers kafka requests.
@@ -32,15 +35,16 @@ import org.apache.kafka.common.utils.{KafkaThread, Time}
 class KafkaRequestHandler(id: Int,
                           brokerId: Int,
                           val aggregateIdleMeter: Meter,
-                          val totalHandlerThreads: Int,
+                          val totalHandlerThreads: AtomicInteger,
                           val requestChannel: RequestChannel,
                           apis: KafkaApis,
                           time: Time) extends Runnable with Logging {
   this.logIdent = "[Kafka Request Handler " + id + " on Broker " + brokerId + "], "
   private val latch = new CountDownLatch(1)
+  @volatile private var stopped = false
 
   def run() {
-    while(true) {
+    while (!stopped) {
       // We use a single meter for aggregate idle percentage for the thread pool.
       // Since meter is calculated as total_recorded_value / time_window and
       // time_window is independent of the number of threads, each recorded idle
@@ -50,7 +54,7 @@ class KafkaRequestHandler(id: Int,
       val req = requestChannel.receiveRequest(300)
       val endTime = time.nanoseconds
       val idleTime = endTime - startSelectTime
-      aggregateIdleMeter.mark(idleTime / totalHandlerThreads)
+      aggregateIdleMeter.mark(idleTime / totalHandlerThreads.get)
 
       req match {
         case RequestChannel.ShutdownRequest =>
@@ -69,12 +73,18 @@ class KafkaRequestHandler(id: Int,
               Exit.exit(e.statusCode)
             case e: Throwable => error("Exception when handling request", e)
           } finally {
-              request.releaseBuffer()
+            request.releaseBuffer()
           }
 
         case null => // continue
       }
     }
+    if (stopped)
+        latch.countDown()
+  }
+
+  def stop(): Unit = {
+    stopped = true
   }
 
   def initiateShutdown(): Unit = requestChannel.sendShutdownRequest()
@@ -89,14 +99,33 @@ class KafkaRequestHandlerPool(val brokerId: Int,
                               time: Time,
                               numThreads: Int) extends Logging with KafkaMetricsGroup {
 
+  private val threadPoolSize: AtomicInteger = new AtomicInteger(numThreads)
   /* a meter to track the average free capacity of the request handlers */
   private val aggregateIdleMeter = newMeter("RequestHandlerAvgIdlePercent", "percent", TimeUnit.NANOSECONDS)
 
   this.logIdent = "[Kafka Request Handler on Broker " + brokerId + "], "
-  val runnables = new Array[KafkaRequestHandler](numThreads)
+  val runnables = new mutable.ArrayBuffer[KafkaRequestHandler](numThreads)
   for(i <- 0 until numThreads) {
-    runnables(i) = new KafkaRequestHandler(i, brokerId, aggregateIdleMeter, numThreads, requestChannel, apis, time)
-    KafkaThread.daemon("kafka-request-handler-" + i, runnables(i)).start()
+    createHandler(i)
+  }
+
+  def createHandler(id: Int): Unit = {
+    runnables += new KafkaRequestHandler(id, brokerId, aggregateIdleMeter, threadPoolSize, requestChannel, apis, time)
+    KafkaThread.daemon("kafka-request-handler-" + id, runnables(id)).start()
+  }
+
+  def resizeThreadPool(newSize: Int): Unit = {
+    val currentSize = threadPoolSize.get
+    if (newSize > currentSize) {
+      for (i <- currentSize until newSize) {
+        createHandler(i)
+      }
+    } else if (newSize < currentSize) {
+      for (i <- 1 to (currentSize - newSize)) {
+        runnables.remove(currentSize - i).stop()
+      }
+    }
+    threadPoolSize.set(newSize)
   }
 
   def shutdown() {

--- a/core/src/main/scala/kafka/utils/KafkaScheduler.scala
+++ b/core/src/main/scala/kafka/utils/KafkaScheduler.scala
@@ -120,6 +120,10 @@ class KafkaScheduler(val threads: Int,
         executor.schedule(runnable, delay, unit)
     }
   }
+
+  def resizeThreadPool(newSize: Int): Unit = {
+    executor.setCorePoolSize(newSize)
+  }
   
   def isStarted: Boolean = {
     this synchronized {

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1024,7 +1024,7 @@ object TestUtils extends Logging {
                    topicConfigs = Map(),
                    initialDefaultConfig = defaultConfig,
                    cleanerConfig = cleanerConfig,
-                   ioThreads = 4,
+                   recoveryThreadsPerDataDir = 4,
                    flushCheckMs = 1000L,
                    flushRecoveryOffsetCheckpointMs = 10000L,
                    flushStartOffsetCheckpointMs = 10000L,


### PR DESCRIPTION
Dynamic resize of broker thread pools as described in KIP-226:
 - num.network.threads
 - num.io.threads
 - num.replica.fetchers
 - num.recovery.threads.per.data.dir
 - background.threads

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
