### PR TITLE
[KAFKA-6482] when produce send a invalidity timestamps, broker will be not delete …

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1211,7 +1211,7 @@ class Log(@volatile var dir: File,
   private def deleteRetentionMsBreachedSegments(): Int = {
     if (config.retentionMs < 0) return 0
     val startMs = time.milliseconds
-    deleteOldSegments((segment, _) => startMs - segment.largestTimestamp > config.retentionMs,
+    deleteOldSegments((segment, _) => startMs - segment.lastModified > config.retentionMs,
       reason = s"retention time ${config.retentionMs}ms breach")
   }
 


### PR DESCRIPTION
when produce send a invalidity timestamps, broker will be not delete files forever...


https://issues.apache.org/jira/browse/KAFKA-6482