### PR TITLE
HOTFIX: ambiguity issue calling putAll() in scala compilation against JAVA 9

### DIFF
--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -368,7 +368,9 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     )
     invalidProps.foreach { case (k, v) =>
       val newProps = new Properties
-      newProps.putAll(props)
+      props.asScala.foreach { case (k,v) => 
+        newProps.put(k, v)
+      }
       props.put(k, v)
       reconfigureServers(props, perBrokerConfig = false, (k, props.getProperty(k)), expectFailure = true)
     }

--- a/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerIntegrationTest.scala
@@ -18,7 +18,6 @@
 package kafka.log
 
 import java.io.File
-import java.util
 import java.util.Properties
 
 import kafka.api.KAFKA_0_11_0_IV0


### PR DESCRIPTION
The cause for compilation error in JDK 9.0 was an ambiguity issue in scalac:
```
both method putAll in class Properties of type (x$1: java.util.Map[_, _])Unit
and  method putAll in class Hashtable of type (x$1: java.util.Map[_ <: Object, _ <: Object])Unit
match argument types (java.util.Properties)
      newProps.putAll(props)
```
This pull request fixes this error by avoiding the call to``` putAll ```and instead uses the ```put ```method directly. 
