### PR TITLE
KAFKA-6352: Down-convert fetched records lazily for more efficent memory usage

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/AbstractRecords.java
@@ -65,8 +65,10 @@ public abstract class AbstractRecords implements Records {
      * only load records into the heap when down converting), but it's not for the producer. However, down converting
      * in the producer is very uncommon and the extra complexity to handle that case is not worth it.
      */
-    protected ConvertedRecords<MemoryRecords> downConvert(Iterable<? extends RecordBatch> batches, byte toMagic,
-            long firstOffset, Time time) {
+    protected ConvertedRecords<MemoryRecords> downConvert(Iterable<? extends RecordBatch> batches,
+                                                          byte toMagic,
+                                                          long firstOffset,
+                                                          Time time) {
         // maintain the batch along with the decompressed records to avoid the need to decompress again
         List<RecordBatchAndRecords> recordBatchAndRecordsList = new ArrayList<>();
         int totalSizeEstimate = 0;
@@ -118,7 +120,6 @@ public abstract class AbstractRecords implements Records {
                 time.nanoseconds() - startNanos);
         return new ConvertedRecords<>(MemoryRecords.readableRecords(buffer), stats);
     }
-
     /**
      * Return a buffer containing the converted record batches. The returned buffer may not be the same as the received
      * one (e.g. it may require expansion).
@@ -144,6 +145,11 @@ public abstract class AbstractRecords implements Records {
     @Override
     public Iterable<Record> records() {
         return records;
+    }
+
+    @Override
+    public RecordsSend toSend(String destination) {
+        return new RecordsSend(destination, this, RecordsProcessingStats.EMPTY);
     }
 
     private Iterator<Record> recordsIterator() {

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -130,7 +130,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @param size The number of bytes after the start position to include
      * @return A sliced wrapper on this message set limited based on the given position and size
      */
-    public FileRecords read(int position, int size) throws IOException {
+    public FileRecords slice(int position, int size) throws IOException {
         if (position < 0)
             throw new IllegalArgumentException("Invalid position: " + position);
         if (size < 0)

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConvertingRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConvertingRecords.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.utils.Time;
+
+import java.io.IOException;
+import java.nio.channels.GatheringByteChannel;
+
+/**
+ * Records implementation which enables lazy down-conversion to avoid unnecessary memory utilization before
+ * a fetch response is ready to be sent.
+ */
+public class LazyDownConvertingRecords implements Records {
+    private final Records records;
+    private final long firstOffset;
+    private final byte toMagic;
+    private final Time time;
+    private ConvertedRecords<? extends Records> convertedRecords = null;
+
+    public LazyDownConvertingRecords(Records records,
+                                     byte toMagic,
+                                     long firstOffset,
+                                     Time time) {
+        this.records = records;
+        this.toMagic = toMagic;
+        this.firstOffset = firstOffset;
+        this.time = time;
+    }
+
+    @Override
+    public int sizeInBytes() {
+        return convertIfNeeded().records().sizeInBytes();
+    }
+
+    @Override
+    public RecordsSend toSend(String destination) {
+        ConvertedRecords<? extends Records> convertedRecords = convertIfNeeded();
+        return new RecordsSend(destination, convertedRecords.records(), convertedRecords.recordsProcessingStats());
+    }
+
+    @Override
+    public long writeTo(GatheringByteChannel channel, long position, int length) throws IOException {
+        return convertIfNeeded().records().writeTo(channel, position, length);
+    }
+
+    @Override
+    public Iterable<? extends RecordBatch> batches() {
+        return convertIfNeeded().records().batches();
+    }
+
+    @Override
+    public boolean hasMatchingMagic(byte magic) {
+        return convertIfNeeded().records().hasMatchingMagic(magic);
+    }
+
+    @Override
+    public boolean hasCompatibleMagic(byte magic) {
+        return toMagic <= magic;
+    }
+
+    @Override
+    public ConvertedRecords<? extends Records> downConvert(byte toMagic, long firstOffset, Time time) {
+        return records.downConvert(toMagic, firstOffset, time);
+    }
+
+    @Override
+    public Iterable<Record> records() {
+        return convertIfNeeded().records().records();
+    }
+
+    private ConvertedRecords<? extends Records> convertIfNeeded() {
+        if (convertedRecords == null)
+            convertedRecords = records.downConvert(toMagic, firstOffset, time);
+        return convertedRecords;
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/record/MultiRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/MultiRecordsSend.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.network.MultiSend;
+import org.apache.kafka.common.network.Send;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * MultiSend implementation which aggregates processing statistics from multiple topic partitions
+ * in a fetch response. This works tightly with {@link org.apache.kafka.common.requests.FetchResponse}
+ * and is exposed through {@link org.apache.kafka.common.requests.FetchResponse#toSend(String, org.apache.kafka.common.requests.ResponseHeader, short)}.
+ */
+public class MultiRecordsSend extends MultiSend {
+    private final Map<TopicPartition, RecordsProcessingStats> processingStats;
+
+    public MultiRecordsSend(String dest,
+                            List<Send> sends,
+                            Map<TopicPartition, RecordsProcessingStats> processingStats) {
+        super(dest, sends);
+        this.processingStats = processingStats;
+    }
+
+    public Map<TopicPartition, RecordsProcessingStats> processingStats() {
+        return processingStats;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/record/Records.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/Records.java
@@ -16,10 +16,10 @@
  */
 package org.apache.kafka.common.record;
 
+import org.apache.kafka.common.utils.Time;
+
 import java.io.IOException;
 import java.nio.channels.GatheringByteChannel;
-
-import org.apache.kafka.common.utils.Time;
 
 /**
  * Interface for accessing the records contained in a log. The log itself is represented as a sequence of record
@@ -59,6 +59,16 @@ public interface Records {
      * @return The size in bytes of the records
      */
     int sizeInBytes();
+
+    /**
+     * Create a Send for the records. This is abstracted to enable lazy conversion in
+     * {@link LazyDownConvertingRecords} and potentially future cases where we need to process
+     * the fetched records before returning them.
+     *
+     * @param destination the target of the send
+     * @return the send
+     */
+    RecordsSend toSend(String destination);
 
     /**
      * Attempts to write the contents of this buffer to a channel.

--- a/clients/src/main/java/org/apache/kafka/common/record/RecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RecordsSend.java
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.common.requests;
+package org.apache.kafka.common.record;
 
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.network.TransportLayers;
-import org.apache.kafka.common.record.Records;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -30,12 +29,14 @@ public class RecordsSend implements Send {
 
     private final String destination;
     private final Records records;
+    private final RecordsProcessingStats stats;
     private int remaining;
     private boolean pending = false;
 
-    public RecordsSend(String destination, Records records) {
+    public RecordsSend(String destination, Records records, RecordsProcessingStats stats) {
         this.destination = destination;
         this.records = records;
+        this.stats = stats;
         this.remaining = records.sizeInBytes();
     }
 
@@ -70,5 +71,9 @@ public class RecordsSend implements Send {
     @Override
     public long size() {
         return records.sizeInBytes();
+    }
+
+    public RecordsProcessingStats stats() {
+        return stats;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/network/ByteBufferChannel.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/ByteBufferChannel.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.common.requests;
+package org.apache.kafka.common.network;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -117,7 +117,7 @@ public class FileRecordsTest {
      */
     @Test
     public void testRead() throws IOException {
-        FileRecords read = fileRecords.read(0, fileRecords.sizeInBytes());
+        FileRecords read = fileRecords.slice(0, fileRecords.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes(), read.sizeInBytes());
         TestUtils.checkEquals(fileRecords.batches(), read.batches());
 
@@ -125,35 +125,35 @@ public class FileRecordsTest {
         RecordBatch first = items.get(0);
 
         // read from second message until the end
-        read = fileRecords.read(first.sizeInBytes(), fileRecords.sizeInBytes() - first.sizeInBytes());
+        read = fileRecords.slice(first.sizeInBytes(), fileRecords.sizeInBytes() - first.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
         assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
 
         // read from second message and size is past the end of the file
-        read = fileRecords.read(first.sizeInBytes(), fileRecords.sizeInBytes());
+        read = fileRecords.slice(first.sizeInBytes(), fileRecords.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
         assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
 
         // read from second message and position + size overflows
-        read = fileRecords.read(first.sizeInBytes(), Integer.MAX_VALUE);
+        read = fileRecords.slice(first.sizeInBytes(), Integer.MAX_VALUE);
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
         assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
 
         // read from second message and size is past the end of the file on a view/slice
-        read = fileRecords.read(1, fileRecords.sizeInBytes() - 1)
-                .read(first.sizeInBytes() - 1, fileRecords.sizeInBytes());
+        read = fileRecords.slice(1, fileRecords.sizeInBytes() - 1)
+                .slice(first.sizeInBytes() - 1, fileRecords.sizeInBytes());
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
         assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
 
         // read from second message and position + size overflows on a view/slice
-        read = fileRecords.read(1, fileRecords.sizeInBytes() - 1)
-                .read(first.sizeInBytes() - 1, Integer.MAX_VALUE);
+        read = fileRecords.slice(1, fileRecords.sizeInBytes() - 1)
+                .slice(first.sizeInBytes() - 1, Integer.MAX_VALUE);
         assertEquals(fileRecords.sizeInBytes() - first.sizeInBytes(), read.sizeInBytes());
         assertEquals("Read starting from the second message", items.subList(1, items.size()), batches(read));
 
         // read a single message starting from second message
         RecordBatch second = items.get(1);
-        read = fileRecords.read(first.sizeInBytes(), second.sizeInBytes());
+        read = fileRecords.slice(first.sizeInBytes(), second.sizeInBytes());
         assertEquals(second.sizeInBytes(), read.sizeInBytes());
         assertEquals("Read a single message starting from the second message",
                 Collections.singletonList(second), batches(read));
@@ -203,9 +203,9 @@ public class FileRecordsTest {
         RecordBatch batch = batches(fileRecords).get(1);
         int start = fileRecords.searchForOffsetWithSize(1, 0).position;
         int size = batch.sizeInBytes();
-        FileRecords slice = fileRecords.read(start, size);
+        FileRecords slice = fileRecords.slice(start, size);
         assertEquals(Collections.singletonList(batch), batches(slice));
-        FileRecords slice2 = fileRecords.read(start, size - 1);
+        FileRecords slice2 = fileRecords.slice(start, size - 1);
         assertEquals(Collections.emptyList(), batches(slice2));
     }
 
@@ -340,7 +340,7 @@ public class FileRecordsTest {
         RecordBatch batch = batches(fileRecords).get(1);
         int start = fileRecords.searchForOffsetWithSize(1, 0).position;
         int size = batch.sizeInBytes();
-        FileRecords slice = fileRecords.read(start, size - 1);
+        FileRecords slice = fileRecords.slice(start, size - 1);
         Records messageV0 = slice.downConvert(RecordBatch.MAGIC_VALUE_V0, 0, time).records();
         assertTrue("No message should be there", batches(messageV0).isEmpty());
         assertEquals("There should be " + (size - 1) + " bytes", size - 1, messageV0.sizeInBytes());

--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConvertingRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConvertingRecordsTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.network.Send;
+import org.apache.kafka.common.network.ByteBufferChannel;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class LazyDownConvertingRecordsTest {
+
+    private final Time time = new MockTime();
+
+    @Test
+    public void testConversionInSend() throws IOException {
+        byte toMagic = 1;
+        MemoryRecords original = recordSet(RecordBatch.CURRENT_MAGIC_VALUE);
+
+        LazyDownConvertingRecords converting = new LazyDownConvertingRecords(original, toMagic, 0L, time);
+        RecordsSend send = converting.toSend("1");
+        Records converted = recordsFromSend(send);
+        for (RecordBatch batch : converted.batches())
+            assertEquals(toMagic, batch.magic());
+
+        assertEquals(converting.sizeInBytes(), send.size());
+        assertEquals(7, send.stats().numRecordsConverted());
+    }
+
+    @Test
+    public void testBatchIteration() {
+        byte toMagic = 1;
+        MemoryRecords original = recordSet(RecordBatch.CURRENT_MAGIC_VALUE);
+        LazyDownConvertingRecords converting = new LazyDownConvertingRecords(original, toMagic, 0L, time);
+
+        for (RecordBatch batch : converting.batches())
+            assertEquals(toMagic, batch.magic());
+    }
+
+    @Test
+    public void testRecordIteration() {
+        byte toMagic = 0;
+        MemoryRecords original = recordSet(RecordBatch.CURRENT_MAGIC_VALUE);
+        LazyDownConvertingRecords converting = new LazyDownConvertingRecords(original, toMagic, 0L, time);
+        for (Record record : converting.records())
+            assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());
+    }
+
+    private MemoryRecords recordSet(byte magic) {
+        ByteBuffer buffer = ByteBuffer.allocate(2048);
+        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, magic, CompressionType.NONE,
+                TimestampType.CREATE_TIME, 0L);
+        builder.append(10L, "1".getBytes(), "a".getBytes());
+        builder.close();
+
+        builder = MemoryRecords.builder(buffer, magic, CompressionType.NONE, TimestampType.CREATE_TIME, 1L);
+        builder.append(11L, "2".getBytes(), "b".getBytes());
+        builder.append(12L, "3".getBytes(), "c".getBytes());
+        builder.close();
+
+        builder = MemoryRecords.builder(buffer, magic, CompressionType.NONE, TimestampType.CREATE_TIME, 3L);
+        builder.append(13L, "4".getBytes(), "d".getBytes());
+        builder.append(20L, "5".getBytes(), "e".getBytes());
+        builder.append(15L, "6".getBytes(), "f".getBytes());
+        builder.close();
+
+        builder = MemoryRecords.builder(buffer, magic, CompressionType.NONE, TimestampType.CREATE_TIME, 6L);
+        builder.append(16L, "7".getBytes(), "g".getBytes());
+        builder.close();
+
+        buffer.flip();
+        return MemoryRecords.readableRecords(buffer);
+    }
+
+    private Records recordsFromSend(Send send) throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(send.size() * 2);
+        while (!send.completed())
+            send.writeTo(channel);
+        channel.close();
+        return MemoryRecords.readableRecords(channel.buffer());
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.requests;
 
+import org.apache.kafka.common.network.ByteBufferChannel;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.network.ByteBufferChannel;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -248,7 +248,7 @@ class LogSegment private[log] (val log: FileRecords,
         min(min(maxPosition, endPosition) - startPosition, adjustedMaxSize).toInt
     }
 
-    FetchDataInfo(offsetMetadata, log.read(startPosition, fetchSize),
+    FetchDataInfo(offsetMetadata, log.slice(startPosition, fetchSize),
       firstEntryIncomplete = adjustedMaxSize < startOffsetAndSize.size)
   }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -28,6 +28,7 @@ import com.yammer.metrics.core.Gauge
 import kafka.cluster.{BrokerEndPoint, EndPoint}
 import kafka.common.KafkaException
 import kafka.metrics.KafkaMetricsGroup
+import kafka.network.RequestChannel.{AbstractSendResponse, CloseConnectionResponse, NoOpResponse}
 import kafka.security.CredentialProvider
 import kafka.server.KafkaConfig
 import kafka.utils._
@@ -544,7 +545,7 @@ private[kafka] class Processor(val id: Int,
 
   private def processChannelException(channelId: String, errorMessage: String, throwable: Throwable) {
     if (openOrClosingChannel(channelId).isDefined) {
-      error(s"Closing socket for ${channelId} because of error", throwable)
+      error(s"Closing socket for $channelId because of error", throwable)
       close(channelId)
     }
     processException(errorMessage, throwable)
@@ -555,21 +556,20 @@ private[kafka] class Processor(val id: Int,
     while ({curr = requestChannel.receiveResponse(id); curr != null}) {
       val channelId = curr.request.context.connectionId
       try {
-        curr.responseAction match {
-          case RequestChannel.NoOpAction =>
+        curr match {
+          case _: CloseConnectionResponse =>
+            updateRequestMetrics(curr)
+            trace("Closing socket connection actively according to the response code.")
+            close(channelId)
+          case _: NoOpResponse =>
             // There is no response to send to the client, we need to read more pipelined requests
             // that are sitting in the server's socket buffer
             updateRequestMetrics(curr)
             trace("Socket server received empty response to send, registering for read: " + curr)
             openOrClosingChannel(channelId).foreach(c => selector.unmute(c.id))
-          case RequestChannel.SendAction =>
-            val responseSend = curr.responseSend.getOrElse(
-              throw new IllegalStateException(s"responseSend must be defined for SendAction, response: $curr"))
-            sendResponse(curr, responseSend)
-          case RequestChannel.CloseConnectionAction =>
-            updateRequestMetrics(curr)
-            trace("Closing socket connection actively according to the response code.")
-            close(channelId)
+
+          case response: AbstractSendResponse =>
+            sendResponse(response)
         }
       } catch {
         case e: Throwable =>
@@ -579,7 +579,8 @@ private[kafka] class Processor(val id: Int,
   }
 
   /* `protected` for test usage */
-  protected[network] def sendResponse(response: RequestChannel.Response, responseSend: Send) {
+  protected[network] def sendResponse(response: AbstractSendResponse) {
+    val responseSend = response.buildSend()
     val connectionId = response.request.context.connectionId
     trace(s"Socket server received response to send to $connectionId, registering for write and sending data: $response")
     // `channel` can be None if the connection was closed remotely or if selector closed it for being idle for too long

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -185,7 +185,7 @@ object DumpLogSegments {
 
     for(i <- 0 until index.entries) {
       val entry = index.entry(i)
-      val slice = fileRecords.read(entry.position, maxMessageSize)
+      val slice = fileRecords.slice(entry.position, maxMessageSize)
       val firstRecord = slice.records.iterator.next()
       if (firstRecord.offset != entry.offset + index.baseOffset) {
         var misMatchesSeq = misMatchesForIndexFilesMap.getOrElse(file.getAbsolutePath, List[(Long, Long)]())
@@ -223,7 +223,7 @@ object DumpLogSegments {
     for(i <- 0 until timeIndex.entries) {
       val entry = timeIndex.entry(i)
       val position = index.lookup(entry.offset + timeIndex.baseOffset).position
-      val partialFileRecords = fileRecords.read(position, Int.MaxValue)
+      val partialFileRecords = fileRecords.slice(position, Int.MaxValue)
       val batches = partialFileRecords.batches.asScala
       var maxTimestamp = RecordBatch.NO_TIMESTAMP
       // We first find the message by offset then check if the timestamp is correct.

--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -26,7 +26,7 @@ import javax.net.ssl._
 
 import com.yammer.metrics.core.{Gauge, Meter}
 import com.yammer.metrics.{Metrics => YammerMetrics}
-import kafka.network.RequestChannel.SendAction
+import kafka.network.RequestChannel.AbstractSendResponse
 import kafka.security.CredentialProvider
 import kafka.server.KafkaConfig
 import kafka.utils.TestUtils
@@ -120,7 +120,7 @@ class SocketServerTest extends JUnitSuite {
     }
   }
 
-  /* A simple request handler that just echos back the response */
+  /* A simple request handler that just echos back the request as the response */
   def processRequest(channel: RequestChannel) {
     processRequest(channel, receiveRequest(channel))
   }
@@ -128,9 +128,9 @@ class SocketServerTest extends JUnitSuite {
   def processRequest(channel: RequestChannel, request: RequestChannel.Request) {
     val byteBuffer = request.body[AbstractRequest].serialize(request.header)
     byteBuffer.rewind()
-
     val send = new NetworkSend(request.context.connectionId, byteBuffer)
-    channel.sendResponse(new RequestChannel.Response(request, Some(send), SendAction, Some(request.header.toString)))
+    val response = new InitializedSendResponse(request, send)
+    channel.sendResponse(response)
   }
 
   def connect(s: SocketServer = server, protocol: SecurityProtocol = SecurityProtocol.PLAINTEXT) = {
@@ -214,7 +214,7 @@ class SocketServerTest extends JUnitSuite {
     for (_ <- 0 until 10) {
       val request = receiveRequest(server.requestChannel)
       assertNotNull("receiveRequest timed out", request)
-      server.requestChannel.sendResponse(new RequestChannel.Response(request, None, RequestChannel.NoOpAction, None))
+      server.requestChannel.sendResponse(new RequestChannel.NoOpResponse(request))
     }
   }
 
@@ -228,7 +228,7 @@ class SocketServerTest extends JUnitSuite {
     for (_ <- 0 until 3) {
       val request = receiveRequest(server.requestChannel)
       assertNotNull("receiveRequest timed out", request)
-      server.requestChannel.sendResponse(new RequestChannel.Response(request, None, RequestChannel.NoOpAction, None))
+      server.requestChannel.sendResponse(new RequestChannel.NoOpResponse(request))
     }
   }
 
@@ -529,9 +529,9 @@ class SocketServerTest extends JUnitSuite {
                                 protocol: SecurityProtocol, memoryPool: MemoryPool): Processor = {
         new Processor(id, time, config.socketRequestMaxBytes, requestChannel, connectionQuotas,
           config.connectionsMaxIdleMs, listenerName, protocol, config, metrics, credentialProvider, MemoryPool.NONE, new LogContext()) {
-          override protected[network] def sendResponse(response: RequestChannel.Response, responseSend: Send) {
+          override protected[network] def sendResponse(response: RequestChannel.AbstractSendResponse) {
             conn.close()
-            super.sendResponse(response, responseSend)
+            super.sendResponse(response)
           }
         }
       }
@@ -555,7 +555,7 @@ class SocketServerTest extends JUnitSuite {
       // detected. If the buffer is larger than 102400 bytes, a second write is attempted and it fails with an
       // IOException.
       val send = new NetworkSend(request.context.connectionId, ByteBuffer.allocate(550000))
-      channel.sendResponse(new RequestChannel.Response(request, Some(send), SendAction, None))
+      channel.sendResponse(new InitializedSendResponse(request, send))
       TestUtils.waitUntilTrue(() => totalTimeHistCount() == expectedTotalTimeCount,
         s"request metrics not updated, expected: $expectedTotalTimeCount, actual: ${totalTimeHistCount()}")
 
@@ -1124,5 +1124,9 @@ class SocketServerTest extends JUnitSuite {
       val failedConnectionId = allFailedChannels.head
       sockets.filterNot(socket => isSocketConnectionId(failedConnectionId, socket))
     }
+  }
+
+  class InitializedSendResponse(request: RequestChannel.Request, send: Send) extends AbstractSendResponse(request) {
+    override def buildSend(): Send = send
   }
 }


### PR DESCRIPTION
This patch adds support for lazy down-conversion of records for older clients. Effectively, it moves down-conversion out of the handler threads and into the network threads. This should improve memory usage since responses that have only been queued for sending will not occupy the memory needed to hold the converted records.

This is largely a refactor which is covered through existing unit and integration tests. I have also added unit tests for the new `LazyDownConvertingRecords` implementation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
