### PR TITLE
Updated kafka-server start/stop scripts to use a pidfile

### DIFF
--- a/bin/kafka-server-start.sh
+++ b/bin/kafka-server-start.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+PIDFILE="${PIDFILE:-"/var/run/kafka.pid"}"
+
 if [ $# -lt 1 ];
 then
 	echo "USAGE: $0 [-daemon] server.properties [--override property=value]*"
@@ -41,4 +43,11 @@ case $COMMAND in
     ;;
 esac
 
+if [ ! -e "${PIDFILE}" ]; then
+  echo "pidfile already exists. maybe kafka is already running under pid $(cat "${PIDFILE}")"
+  exit 1
+fi
+
 exec $base_dir/kafka-run-class.sh $EXTRA_ARGS kafka.Kafka "$@"
+
+echo "$!" > "${PIDFILE}"


### PR DESCRIPTION
Using ps is sometimes not a good idea. Especially if there are multiple kafkas running.

This change implements using a pidfile (that can be changed through environment variables).

This will make things more robust and follow best practices.