### PR TITLE
KAFKA-6494; ConfigCommand update to use AdminClient for broker configs

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/DescribeConfigsResponse.java
@@ -74,7 +74,7 @@ public class DescribeConfigsResponse extends AbstractResponse {
             new Field(CONFIG_NAME_KEY_NAME, STRING),
             new Field(CONFIG_VALUE_KEY_NAME, NULLABLE_STRING),
             new Field(READ_ONLY_KEY_NAME, BOOLEAN),
-            new Field(IS_DEFAULT_KEY_NAME, BOOLEAN),
+            new Field(CONFIG_SOURCE_KEY_NAME, INT8),
             new Field(IS_SENSITIVE_KEY_NAME, BOOLEAN),
             new Field(CONFIG_SYNONYMS_KEY_NAME, new ArrayOf(DESCRIBE_CONFIGS_RESPONSE_SYNONYM_V1)));
 

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -410,7 +410,7 @@ object ConfigCommand extends Config {
     val entityName = parser.accepts("entity-name", "Name of entity (topic name/client id/user principal name/broker id)")
             .withRequiredArg
             .ofType(classOf[String])
-    val entityDefault = parser.accepts("entity-default", "Default entity name for clients/users (applies to corresponding entity type in command line)")
+    val entityDefault = parser.accepts("entity-default", "Default entity name for clients/users/brokers (applies to corresponding entity type in command line)")
 
     val nl = System.getProperty("line.separator")
     val addConfig = parser.accepts("add-config", "Key Value pairs of configs to add. Square brackets can be used to group values which contain commas: 'k1=v1,k2=[v1,v2,v2],k3=v3'. The following is a list of valid configurations: " +

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -17,7 +17,8 @@
 
 package kafka.admin
 
-import java.util.Properties
+import java.util.concurrent.TimeUnit
+import java.util.{Collections, Properties}
 
 import joptsimple._
 import kafka.common.Config
@@ -27,6 +28,9 @@ import kafka.server.{ConfigEntityName, ConfigType, DynamicConfig}
 import kafka.utils.CommandLineUtils
 import kafka.utils.Implicits._
 import kafka.zk.{AdminZkClient, KafkaZkClient}
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.{AlterConfigsOptions, Config => JConfig, ConfigEntry, DescribeConfigsOptions, AdminClient => JAdminClient}
+import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.security.JaasUtils
 import org.apache.kafka.common.security.scram._
 import org.apache.kafka.common.utils.{Sanitizer, Time, Utils}
@@ -52,6 +56,9 @@ import scala.collection.JavaConverters._
 object ConfigCommand extends Config {
 
   val DefaultScramIterations = 4096
+  val BrokerConfigsUpdatableUsingZooKeeper = Set(DynamicConfig.Broker.LeaderReplicationThrottledRateProp,
+    DynamicConfig.Broker.FollowerReplicationThrottledRateProp,
+    DynamicConfig.Broker.ReplicaAlterLogDirsIoMaxBytesPerSecondProp)
 
   def main(args: Array[String]): Unit = {
 
@@ -63,21 +70,26 @@ object ConfigCommand extends Config {
     opts.checkArgs()
 
     val time = Time.SYSTEM
-    val zkClient = KafkaZkClient(opts.options.valueOf(opts.zkConnectOpt), JaasUtils.isZkSecurityEnabled, 30000, 30000,
-      Int.MaxValue, time)
-    val adminZkClient = new AdminZkClient(zkClient)
 
-    try {
-      if (opts.options.has(opts.alterOpt))
-        alterConfig(zkClient, opts, adminZkClient)
-      else if (opts.options.has(opts.describeOpt))
-        describeConfig(zkClient, opts, adminZkClient)
-    } catch {
-      case e: Throwable =>
-        println("Error while executing config command " + e.getMessage)
-        println(Utils.stackTrace(e))
-    } finally {
-      zkClient.close()
+    if (opts.options.has(opts.zkConnectOpt)) {
+      val zkClient = KafkaZkClient(opts.options.valueOf(opts.zkConnectOpt), JaasUtils.isZkSecurityEnabled, 30000, 30000,
+        Int.MaxValue, time)
+      val adminZkClient = new AdminZkClient(zkClient)
+
+      try {
+        if (opts.options.has(opts.alterOpt))
+          alterConfig(zkClient, opts, adminZkClient)
+        else if (opts.options.has(opts.describeOpt))
+          describeConfig(zkClient, opts, adminZkClient)
+      } catch {
+        case e: Throwable =>
+          println("Error while executing config command " + e.getMessage)
+          println(Utils.stackTrace(e))
+      } finally {
+        zkClient.close()
+      }
+    } else {
+      processBrokerConfig(opts)
     }
   }
 
@@ -90,6 +102,10 @@ object ConfigCommand extends Config {
 
     if (entityType == ConfigType.User)
       preProcessScramCredentials(configsToBeAdded)
+    if (entityType == ConfigType.Broker) {
+      require(configsToBeAdded.asScala.keySet.forall(BrokerConfigsUpdatableUsingZooKeeper.contains),
+        s"--bootstrap-server option must be specified to update broker configs $configsToBeAdded")
+    }
 
     // compile the final set of configs
     val configs = adminZkClient.fetchEntityConfig(entityType, entityName)
@@ -172,6 +188,93 @@ object ConfigCommand extends Config {
       Seq.empty
   }
 
+  private def processBrokerConfig(opts: ConfigCommandOptions): Unit = {
+
+    val props = if (opts.options.has(opts.commandConfigOpt)) Utils.loadProps(opts.options.valueOf(opts.commandConfigOpt)) else new Properties()
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, opts.options.valueOf(opts.bootstrapServerOpt))
+    val adminClient = JAdminClient.create(props)
+    val entityName = if (opts.options.has(opts.entityName))
+      opts.options.valueOf(opts.entityName)
+    else if (opts.options.has(opts.entityDefault))
+      ""
+    else
+      throw new IllegalArgumentException("At least one of --entity-name or --entity-default must be specified with --bootstrap-server")
+
+    val entityTypes = opts.options.valuesOf(opts.entityType).asScala
+    if (entityTypes.size != 1)
+      throw new IllegalArgumentException("Exactly one --entity-type must be specified with --bootstrap-server")
+    if (entityTypes.head != ConfigType.Broker)
+      throw new IllegalArgumentException(s"--zookeeper option must be specified for entity-type $entityTypes")
+
+    try {
+      if (opts.options.has(opts.alterOpt))
+        alterBrokerConfig(adminClient, opts, entityName)
+      else if (opts.options.has(opts.describeOpt))
+        describeBrokerConfig(adminClient, opts, entityName)
+    } catch {
+      case e: Throwable =>
+        println("Error while executing config command " + e.getMessage)
+        println(Utils.stackTrace(e))
+    } finally {
+      adminClient.close()
+    }
+
+  }
+
+  private[admin] def alterBrokerConfig(adminClient: JAdminClient, opts: ConfigCommandOptions, entityName: String) {
+    val configsToBeAdded = parseConfigsToBeAdded(opts).asScala.map { case (k, v) => (k, new ConfigEntry(k, v)) }
+    val configsToBeDeleted = parseConfigsToBeDeleted(opts)
+
+    // compile the final set of configs
+    val configResource = new ConfigResource(ConfigResource.Type.BROKER, entityName)
+    val oldConfig = brokerConfig(adminClient, entityName, includeSynonyms = false)
+        .map { entry => (entry.name, entry) }.toMap
+
+    // fail the command if any of the configs to be deleted does not exist
+    val invalidConfigs = configsToBeDeleted.filterNot(oldConfig.contains)
+    if (invalidConfigs.nonEmpty)
+      throw new InvalidConfigException(s"Invalid config(s): ${invalidConfigs.mkString(",")}")
+
+    val newEntries = oldConfig ++ configsToBeAdded -- configsToBeDeleted
+    val sensitiveEntries = newEntries.filter(_._2.value == null)
+    if (sensitiveEntries.nonEmpty)
+      throw new InvalidConfigException(s"All sensitive broker config entries must be specified for --alter, missing entries: ${sensitiveEntries.keySet}")
+    val newConfig = new JConfig(newEntries.asJava.values)
+
+    val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+    adminClient.alterConfigs(Map(configResource -> newConfig).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
+
+    if (entityName.nonEmpty)
+      println(s"Completed updating config for broker: $entityName.")
+    else
+      println(s"Completed updating default config for brokers in the cluster,")
+  }
+
+  private def describeBrokerConfig(adminClient: JAdminClient, opts: ConfigCommandOptions, entityName: String) {
+    val configs = brokerConfig(adminClient, entityName, includeSynonyms = true)
+    if (entityName.nonEmpty)
+      println(s"Configs for broker $entityName are:")
+    else
+      println(s"Default config for brokers in the cluster are:")
+    configs.foreach { config =>
+      val synonyms = config.synonyms.asScala.map(synonym => s"${synonym.source}:${synonym.name}=${synonym.value}").mkString(", ")
+      println(s"  ${config.name}=${config.value} sensitive=${config.isSensitive} synonyms={$synonyms}")
+    }
+  }
+
+  private def brokerConfig(adminClient: JAdminClient, entityName: String, includeSynonyms: Boolean): Seq[ConfigEntry] = {
+    val configResource = new ConfigResource(ConfigResource.Type.BROKER, entityName)
+    val configSource = if (!entityName.isEmpty)
+      ConfigEntry.ConfigSource.DYNAMIC_BROKER_CONFIG
+    else
+      ConfigEntry.ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG
+    val describeOpts = new DescribeConfigsOptions().includeSynonyms(includeSynonyms)
+    val configs = adminClient.describeConfigs(Collections.singleton(configResource), describeOpts).all.get(30, TimeUnit.SECONDS)
+    configs.get(configResource).entries.asScala
+      .filter(entry => entry.source == configSource)
+      .toSeq
+  }
+
   case class Entity(entityType: String, sanitizedName: Option[String]) {
     val entityPath = sanitizedName match {
       case Some(n) => entityType + "/" + n
@@ -249,12 +352,16 @@ object ConfigCommand extends Config {
     }
   }
 
+  private def entityNames(opts: ConfigCommandOptions): Seq[String] = {
+    val namesIterator = opts.options.valuesOf(opts.entityName).iterator
+    opts.options.specs.asScala
+      .filter(spec => spec.options.contains("entity-name") || spec.options.contains("entity-default"))
+      .map(spec => if (spec.options.contains("entity-name")) namesIterator.next else "")
+  }
+
   private def parseQuotaEntity(opts: ConfigCommandOptions): ConfigEntity = {
     val types = opts.options.valuesOf(opts.entityType).asScala
-    val namesIterator = opts.options.valuesOf(opts.entityName).iterator
-    val names = opts.options.specs.asScala
-                    .filter(spec => spec.options.contains("entity-name") || spec.options.contains("entity-default"))
-                    .map(spec => if (spec.options.contains("entity-name")) namesIterator.next else "")
+    val names = entityNames(opts)
 
     if (opts.options.has(opts.alterOpt) && names.size != types.size)
       throw new IllegalArgumentException("--entity-name or --entity-default must be specified with each --entity-type for --alter")
@@ -285,6 +392,16 @@ object ConfigCommand extends Config {
             .withRequiredArg
             .describedAs("urls")
             .ofType(classOf[String])
+    val bootstrapServerOpt = parser.accepts("bootstrap-server", "The Kafka server to connect to. " +
+      "This is required for describing and altering broker configs.")
+      .withRequiredArg
+      .describedAs("server to connect to")
+      .ofType(classOf[String])
+    val commandConfigOpt = parser.accepts("command-config", "Property file containing configs to be passed to Admin Client. " +
+      "This is required for describing and altering broker configs.")
+      .withRequiredArg
+      .describedAs("command config property file")
+      .ofType(classOf[String])
     val alterOpt = parser.accepts("alter", "Alter the configuration for the entity.")
     val describeOpt = parser.accepts("describe", "List configs for the given entity.")
     val entityType = parser.accepts("entity-type", "Type of entity (topics/clients/users/brokers)")
@@ -321,12 +438,16 @@ object ConfigCommand extends Config {
         CommandLineUtils.printUsageAndDie(parser, "Command must include exactly one action: --describe, --alter")
 
       // check required args
-      CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt, entityType)
       CommandLineUtils.checkInvalidArgs(parser, options, alterOpt, Set(describeOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, describeOpt, Set(alterOpt, addConfig, deleteConfig))
       val entityTypeVals = options.valuesOf(entityType).asScala
+
+      if (options.has(bootstrapServerOpt) == options.has(zkConnectOpt))
+        throw new IllegalArgumentException("Only one of --bootstrap-server or --zookeeper must be specified")
+      if (entityTypeVals.contains(ConfigType.Client) || entityTypeVals.contains(ConfigType.Topic) || entityTypeVals.contains(ConfigType.User))
+        CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt, entityType)
       if(options.has(alterOpt)) {
-        if (entityTypeVals.contains(ConfigType.User) || entityTypeVals.contains(ConfigType.Client)) {
+        if (entityTypeVals.contains(ConfigType.User) || entityTypeVals.contains(ConfigType.Client) || entityTypeVals.contains(ConfigType.Broker)) {
           if (!options.has(entityName) && !options.has(entityDefault))
             throw new IllegalArgumentException("--entity-name or --entity-default must be specified with --alter of users/clients")
         } else if (!options.has(entityName))

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -287,9 +287,9 @@ class AdminManager(val config: KafkaConfig,
       def allConfigs(config: AbstractConfig) = {
         config.originals.asScala.filter(_._2 != null) ++ config.values.asScala
       }
-      def createResponseConfig(allConfigs: Map[String, Any],
+      def createResponseConfig(configs: Map[String, Any],
                                createConfigEntry: (String, Any) => DescribeConfigsResponse.ConfigEntry): DescribeConfigsResponse.Config = {
-        val filteredConfigPairs = allConfigs.filter { case (configName, _) =>
+        val filteredConfigPairs = configs.filter { case (configName, _) =>
           /* Always returns true if configNames is None */
           configNames.forall(_.contains(configName))
         }.toIndexedSeq
@@ -317,7 +317,7 @@ class AdminManager(val config: KafkaConfig,
               createResponseConfig(allConfigs(config),
                 createBrokerConfigEntry(perBrokerConfig = true, includeSynonyms))
             else
-              throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId}, but received $resource.name")
+              throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId} or empty string, but received $resource.name")
 
           case resourceType => throw new InvalidRequestException(s"Unsupported resource type: $resourceType")
         }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -284,8 +284,11 @@ class AdminManager(val config: KafkaConfig,
   def describeConfigs(resourceToConfigNames: Map[Resource, Option[Set[String]]], includeSynonyms: Boolean): Map[Resource, DescribeConfigsResponse.Config] = {
     resourceToConfigNames.map { case (resource, configNames) =>
 
-      def createResponseConfig(config: AbstractConfig, createConfigEntry: (String, Any) => DescribeConfigsResponse.ConfigEntry): DescribeConfigsResponse.Config = {
-        val allConfigs = config.originals.asScala.filter(_._2 != null) ++ config.values.asScala
+      def allConfigs(config: AbstractConfig) = {
+        config.originals.asScala.filter(_._2 != null) ++ config.values.asScala
+      }
+      def createResponseConfig(allConfigs: Map[String, Any],
+                               createConfigEntry: (String, Any) => DescribeConfigsResponse.ConfigEntry): DescribeConfigsResponse.Config = {
         val filteredConfigPairs = allConfigs.filter { case (configName, _) =>
           /* Always returns true if configNames is None */
           configNames.forall(_.contains(configName))
@@ -304,14 +307,17 @@ class AdminManager(val config: KafkaConfig,
             // Consider optimizing this by caching the configs or retrieving them from the `Log` when possible
             val topicProps = adminZkClient.fetchEntityConfig(ConfigType.Topic, topic)
             val logConfig = LogConfig.fromProps(KafkaServer.copyKafkaConfigToLog(config), topicProps)
-            createResponseConfig(logConfig, createTopicConfigEntry(logConfig, topicProps, includeSynonyms))
+            createResponseConfig(allConfigs(logConfig), createTopicConfigEntry(logConfig, topicProps, includeSynonyms))
 
           case ResourceType.BROKER =>
-            val brokerId = resourceNameToBrokerId(resource.name)
-            if (brokerId == config.brokerId)
-              createResponseConfig(config, createBrokerConfigEntry(includeSynonyms))
+            if (resource.name == null || resource.name.isEmpty)
+              createResponseConfig(config.dynamicConfig.currentDynamicDefaultConfigs,
+                createBrokerConfigEntry(perBrokerConfig = false, includeSynonyms))
+            else if (resourceNameToBrokerId(resource.name) == config.brokerId)
+              createResponseConfig(allConfigs(config),
+                createBrokerConfigEntry(perBrokerConfig = true, includeSynonyms))
             else
-              throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId}, but received $brokerId")
+              throw new InvalidRequestException(s"Unexpected broker id, expected ${config.brokerId}, but received $resource.name")
 
           case resourceType => throw new InvalidRequestException(s"Unsupported resource type: $resourceType")
         }
@@ -361,8 +367,12 @@ class AdminManager(val config: KafkaConfig,
           case ResourceType.BROKER =>
             val brokerId = if (resource.name == null || resource.name.isEmpty)
               None
-            else
-              Some(resourceNameToBrokerId(resource.name))
+            else {
+              val id = resourceNameToBrokerId(resource.name)
+              if (id != this.config.brokerId)
+                throw new InvalidRequestException(s"Unexpected broker id, expected ${this.config.brokerId}, but received $resource.name")
+              Some(id)
+            }
             val configProps = new Properties
             config.entries.asScala.foreach { configEntry =>
               configProps.setProperty(configEntry.name, configEntry.value)
@@ -459,13 +469,14 @@ class AdminManager(val config: KafkaConfig,
     new DescribeConfigsResponse.ConfigEntry(name, valueAsString, source, isSensitive, false, synonyms.asJava)
   }
 
-  private def createBrokerConfigEntry(includeSynonyms: Boolean)
+  private def createBrokerConfigEntry(perBrokerConfig: Boolean, includeSynonyms: Boolean)
                                      (name: String, value: Any): DescribeConfigsResponse.ConfigEntry = {
     val allNames = brokerSynonyms(name)
     val configEntryType = configType(name, allNames)
     val isSensitive = configEntryType == ConfigDef.Type.PASSWORD
     val valueAsString = if (isSensitive) null else ConfigDef.convertToString(value, configEntryType)
     val allSynonyms = configSynonyms(name, allNames, isSensitive)
+        .filter(perBrokerConfig || _.source == ConfigSource.DYNAMIC_DEFAULT_BROKER_CONFIG)
     val synonyms = if (!includeSynonyms) List.empty else allSynonyms
     val source = if (allSynonyms.isEmpty) ConfigSource.DEFAULT_CONFIG else allSynonyms.head.source
     val readOnly = !allNames.exists(DynamicBrokerConfig.AllDynamicConfigs.contains)


### PR DESCRIPTION
Use new AdminClient for describing and altering broker configs using ConfigCommand. Broker quota configs as well as other configs will continue to be processed directly using ZooKeeper until KIP-248 is implemented.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
