### PR TITLE
MINOR: Refactor cleanupGroupMetadata

### DIFF
--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -375,7 +375,6 @@ class GroupCoordinator(val brokerId: Int,
       }
 
       if (eligibleGroups.nonEmpty) {
-        // note: there is a lock on the group when the function 'removeAllOffsets()' is called inside 'cleanupGroupMetadata(...)'
         val offsetsRemoved = groupManager.cleanupGroupMetadata(eligibleGroups, group => {
           group.removeAllOffsets()
         })
@@ -571,7 +570,6 @@ class GroupCoordinator(val brokerId: Int,
   }
 
   def handleDeletedPartitions(topicPartitions: Seq[TopicPartition]) {
-    // note: there is a lock on the group when the function 'removeOffsets(...)' is called inside 'cleanupGroupMetadata(...)'
     val offsetsRemoved = groupManager.cleanupGroupMetadata(groupManager.currentGroups, group => {
       group.removeOffsets(topicPartitions)
     })

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -375,6 +375,7 @@ class GroupCoordinator(val brokerId: Int,
       }
 
       if (eligibleGroups.nonEmpty) {
+        // note: there is a lock on the group when the function 'removeAllOffsets()' is called inside 'cleanupGroupMetadata(...)'
         val offsetsRemoved = groupManager.cleanupGroupMetadata(eligibleGroups, group => {
           group.removeAllOffsets()
         })
@@ -570,6 +571,7 @@ class GroupCoordinator(val brokerId: Int,
   }
 
   def handleDeletedPartitions(topicPartitions: Seq[TopicPartition]) {
+    // note: there is a lock on the group when the function 'removeOffsets(...)' is called inside 'cleanupGroupMetadata(...)'
     val offsetsRemoved = groupManager.cleanupGroupMetadata(groupManager.currentGroups, group => {
       group.removeOffsets(topicPartitions)
     })

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -375,7 +375,7 @@ class GroupCoordinator(val brokerId: Int,
       }
 
       if (eligibleGroups.nonEmpty) {
-        groupManager.cleanupGroupMetadata(None, eligibleGroups, Long.MaxValue)
+        groupManager.cleanupGroupMetadata(eligibleGroups, eligibleGroups.map(group => group -> group.allOffsets).toMap)
         groupErrors ++= eligibleGroups.map(_.groupId -> Errors.NONE).toMap
         info(s"The following groups were deleted: ${eligibleGroups.map(_.groupId).mkString(", ")}")
       }
@@ -568,7 +568,7 @@ class GroupCoordinator(val brokerId: Int,
   }
 
   def handleDeletedPartitions(topicPartitions: Seq[TopicPartition]) {
-    groupManager.cleanupGroupMetadata(Some(topicPartitions), groupManager.currentGroups, time.milliseconds())
+    groupManager.cleanupGroupMetadata(Some(topicPartitions))
   }
 
   private def validateGroup(groupId: String): Option[Errors] = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupCoordinator.scala
@@ -375,9 +375,11 @@ class GroupCoordinator(val brokerId: Int,
       }
 
       if (eligibleGroups.nonEmpty) {
-        groupManager.cleanupGroupMetadata(eligibleGroups, eligibleGroups.map(group => group -> group.allOffsets).toMap)
+        val offsetsRemoved = groupManager.cleanupGroupMetadata(eligibleGroups, group => {
+          group.removeAllOffsets()
+        })
         groupErrors ++= eligibleGroups.map(_.groupId -> Errors.NONE).toMap
-        info(s"The following groups were deleted: ${eligibleGroups.map(_.groupId).mkString(", ")}")
+        info(s"The following groups were deleted: ${eligibleGroups.map(_.groupId).mkString(", ")}. A total of $offsetsRemoved offsets were removed.")
       }
 
       groupErrors
@@ -568,7 +570,10 @@ class GroupCoordinator(val brokerId: Int,
   }
 
   def handleDeletedPartitions(topicPartitions: Seq[TopicPartition]) {
-    groupManager.cleanupGroupMetadata(Some(topicPartitions))
+    val offsetsRemoved = groupManager.cleanupGroupMetadata(groupManager.currentGroups, group => {
+      group.removeOffsets(topicPartitions)
+    })
+    info(s"Removed $offsetsRemoved offsets associated with deleted partitions: ${topicPartitions.mkString(", ")}.")
   }
 
   private def validateGroup(groupId: String): Option[Errors] = {

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadata.scala
@@ -421,9 +421,10 @@ private[group] class GroupMetadata(val groupId: String, initialState: GroupState
   def hasPendingOffsetCommitsFromProducer(producerId: Long) =
     pendingTransactionalOffsetCommits.contains(producerId)
 
+  def removeAllOffsets(): immutable.Map[TopicPartition, OffsetAndMetadata] = removeOffsets(offsets.keySet.toSeq)
+
   def removeOffsets(topicPartitions: Seq[TopicPartition]): immutable.Map[TopicPartition, OffsetAndMetadata] = {
     topicPartitions.flatMap { topicPartition =>
-
       pendingOffsetCommits.remove(topicPartition)
       pendingTransactionalOffsetCommits.foreach { case (_, pendingOffsets) =>
         pendingOffsets.remove(topicPartition)

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -713,81 +713,118 @@ class GroupMetadataManager(brokerId: Int,
 
   // visible for testing
   private[group] def cleanupGroupMetadata(): Unit = {
-    cleanupGroupMetadata(None, groupMetadataCache.values, time.milliseconds())
+    cleanupGroupMetadata(None)
   }
 
-  def cleanupGroupMetadata(deletedTopicPartitions: Option[Seq[TopicPartition]],
-                           groups: Iterable[GroupMetadata],
-                           startMs: Long) {
+  def createTombstones(group: GroupMetadata,
+                       removedOffsets: Map[TopicPartition, OffsetAndMetadata],
+                       groupIsDead: Boolean,
+                       generation: Int): Int = {
+    val groupId = group.groupId
     var offsetsRemoved = 0
 
-    groups.foreach { group =>
-      val groupId = group.groupId
-      val (removedOffsets, groupIsDead, generation) = group.inLock {
-        val removedOffsets = deletedTopicPartitions match {
+    val offsetsPartition = partitionFor(groupId)
+    val appendPartition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, offsetsPartition)
+    getMagic(offsetsPartition) match {
+      case Some(magicValue) =>
+        // We always use CREATE_TIME, like the producer. The conversion to LOG_APPEND_TIME (if necessary) happens automatically.
+        val timestampType = TimestampType.CREATE_TIME
+        val timestamp = time.milliseconds()
+
+        replicaManager.nonOfflinePartition(appendPartition).foreach { partition =>
+          val tombstones = ListBuffer.empty[SimpleRecord]
+          removedOffsets.foreach { case (topicPartition, offsetAndMetadata) =>
+            trace(s"Removing expired/deleted offset and metadata for $groupId, $topicPartition: $offsetAndMetadata")
+            val commitKey = GroupMetadataManager.offsetCommitKey(groupId, topicPartition)
+            tombstones += new SimpleRecord(timestamp, commitKey, null)
+          }
+          trace(s"Marked ${removedOffsets.size} offsets in $appendPartition for deletion.")
+
+          // We avoid writing the tombstone when the generationId is 0, since this group is only using
+          // Kafka for offset storage.
+          if (groupIsDead && groupMetadataCache.remove(groupId, group) && generation > 0) {
+            // Append the tombstone messages to the partition. It is okay if the replicas don't receive these (say,
+            // if we crash or leaders move) since the new leaders will still expire the consumers with heartbeat and
+            // retry removing this group.
+            val groupMetadataKey = GroupMetadataManager.groupMetadataKey(group.groupId)
+            tombstones += new SimpleRecord(timestamp, groupMetadataKey, null)
+            trace(s"Group $groupId removed from the metadata cache and marked for deletion in $appendPartition.")
+          }
+
+          if (tombstones.nonEmpty) {
+            try {
+              // do not need to require acks since even if the tombstone is lost,
+              // it will be appended again in the next purge cycle
+              val records = MemoryRecords.withRecords(magicValue, 0L, compressionType, timestampType, tombstones: _*)
+              partition.appendRecordsToLeader(records, isFromClient = false, requiredAcks = 0)
+
+              offsetsRemoved += removedOffsets.size
+              trace(s"Successfully appended ${tombstones.size} tombstones to $appendPartition for expired/deleted " +
+                s"offsets and/or metadata for group $groupId")
+            } catch {
+              case t: Throwable =>
+                error(s"Failed to append ${tombstones.size} tombstones to $appendPartition for expired/deleted " +
+                  s"offsets and/or metadata for group $groupId.", t)
+              // ignore and continue
+            }
+          }
+        }
+
+      case None =>
+        info(s"BrokerId $brokerId is no longer a coordinator for the group $groupId. Proceeding cleanup for other alive groups")
+    }
+
+    offsetsRemoved
+  }
+
+  def deleteGroupOffsets(
+        group: GroupMetadata,
+        offsets: Either[(Option[Seq[TopicPartition]], Long), GroupMetadata => Map[TopicPartition, OffsetAndMetadata]]):
+            (Map[TopicPartition, OffsetAndMetadata], Boolean, Int) = {
+
+    val removedOffsets = offsets match {
+      case Left((deletedTopicPartitions, startMs)) =>
+        deletedTopicPartitions match {
           case Some(topicPartitions) => group.removeOffsets(topicPartitions)
           case None => group.removeExpiredOffsets(startMs)
         }
-
-        if (group.is(Empty) && !group.hasOffsets) {
-          info(s"Group $groupId transitioned to Dead in generation ${group.generationId}")
-          group.transitionTo(Dead)
+      case Right(collectOffsetsToRemove) =>
+        collectOffsetsToRemove.apply(group) match {
+          case null => Map[TopicPartition, OffsetAndMetadata]()
+          case offsets => group.removeOffsets(offsets.keys.toSeq)
         }
-        (removedOffsets, group.is(Dead), group.generationId)
-      }
-
-      val offsetsPartition = partitionFor(groupId)
-      val appendPartition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, offsetsPartition)
-      getMagic(offsetsPartition) match {
-        case Some(magicValue) =>
-          // We always use CREATE_TIME, like the producer. The conversion to LOG_APPEND_TIME (if necessary) happens automatically.
-          val timestampType = TimestampType.CREATE_TIME
-          val timestamp = time.milliseconds()
-
-          replicaManager.nonOfflinePartition(appendPartition).foreach { partition =>
-            val tombstones = ListBuffer.empty[SimpleRecord]
-            removedOffsets.foreach { case (topicPartition, offsetAndMetadata) =>
-              trace(s"Removing expired/deleted offset and metadata for $groupId, $topicPartition: $offsetAndMetadata")
-              val commitKey = GroupMetadataManager.offsetCommitKey(groupId, topicPartition)
-              tombstones += new SimpleRecord(timestamp, commitKey, null)
-            }
-            trace(s"Marked ${removedOffsets.size} offsets in $appendPartition for deletion.")
-
-            // We avoid writing the tombstone when the generationId is 0, since this group is only using
-            // Kafka for offset storage.
-            if (groupIsDead && groupMetadataCache.remove(groupId, group) && generation > 0) {
-              // Append the tombstone messages to the partition. It is okay if the replicas don't receive these (say,
-              // if we crash or leaders move) since the new leaders will still expire the consumers with heartbeat and
-              // retry removing this group.
-              val groupMetadataKey = GroupMetadataManager.groupMetadataKey(group.groupId)
-              tombstones += new SimpleRecord(timestamp, groupMetadataKey, null)
-              trace(s"Group $groupId removed from the metadata cache and marked for deletion in $appendPartition.")
-            }
-
-            if (tombstones.nonEmpty) {
-              try {
-                // do not need to require acks since even if the tombstone is lost,
-                // it will be appended again in the next purge cycle
-                val records = MemoryRecords.withRecords(magicValue, 0L, compressionType, timestampType, tombstones: _*)
-                partition.appendRecordsToLeader(records, isFromClient = false, requiredAcks = 0)
-
-                offsetsRemoved += removedOffsets.size
-                trace(s"Successfully appended ${tombstones.size} tombstones to $appendPartition for expired/deleted " +
-                  s"offsets and/or metadata for group $groupId")
-              } catch {
-                case t: Throwable =>
-                  error(s"Failed to append ${tombstones.size} tombstones to $appendPartition for expired/deleted " +
-                    s"offsets and/or metadata for group $groupId.", t)
-                // ignore and continue
-              }
-            }
-          }
-
-        case None =>
-          info(s"BrokerId $brokerId is no longer a coordinator for the group $groupId. Proceeding cleanup for other alive groups")
-      }
     }
 
+    if (group.is(Empty) && !group.hasOffsets) {
+      info(s"Group ${group.groupId} transitioned to Dead in generation ${group.generationId}")
+      group.transitionTo(Dead)
+    }
+    (removedOffsets, group.is(Dead), group.generationId)
+  }
+
+  def cleanupGroupMetadata(groups: Iterable[GroupMetadata],
+                           collectOffsetsToRemove: GroupMetadata => Map[TopicPartition, OffsetAndMetadata]): Unit = {
+    var offsetsRemoved = 0
+    groups.foreach { group =>
+      val groupId = group.groupId
+      val (removedOffsets, groupIsDead, generation) = group.inLock {
+        deleteGroupOffsets(group, Right(collectOffsetsToRemove))
+      }
+      offsetsRemoved += createTombstones(group, removedOffsets, groupIsDead, generation)
+    }
+    info(s"Removed $offsetsRemoved expired offsets.")
+  }
+
+  def cleanupGroupMetadata(deletedTopicPartitions: Option[Seq[TopicPartition]]) {
+    val startMs = time.milliseconds()
+    var offsetsRemoved = 0
+    groupMetadataCache.foreach { case (groupId, group) =>
+      val groupId = group.groupId
+      val (removedOffsets, groupIsDead, generation) = group.inLock {
+        deleteGroupOffsets(group, Left(deletedTopicPartitions, startMs))
+      }
+      offsetsRemoved += createTombstones(group, removedOffsets, groupIsDead, generation)
+    }
     info(s"Removed $offsetsRemoved expired offsets in ${time.milliseconds() - startMs} milliseconds.")
   }
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -714,13 +714,19 @@ class GroupMetadataManager(brokerId: Int,
   // visible for testing
   private[group] def cleanupGroupMetadata(): Unit = {
     val startMs = time.milliseconds()
-    // note: there is a lock on the group when the function 'removeExpiredOffsets(...)' is called inside 'cleanupGroupMetadata(...)'
     val offsetsRemoved = cleanupGroupMetadata(groupMetadataCache.values, group => {
       group.removeExpiredOffsets(time.milliseconds())
     })
     info(s"Removed $offsetsRemoved expired offsets in ${time.milliseconds() - startMs} milliseconds.")
   }
 
+  /**
+    * This function is used to clean up group offsets given the groups and also a function that performs the offset deletion.
+    * @param groups Groups whose metadata are to be cleaned up
+    * @param selector A function that implements deletion of (all or part of) group offsets. This function is called while
+    *                 a group lock is held, therefore there is no need for the caller to also obtain a group lock.
+    * @return The cumulative number of offsets removed
+    */
   def cleanupGroupMetadata(groups: Iterable[GroupMetadata], selector: GroupMetadata => Map[TopicPartition, OffsetAndMetadata]): Int = {
     var offsetsRemoved = 0
 

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -714,6 +714,7 @@ class GroupMetadataManager(brokerId: Int,
   // visible for testing
   private[group] def cleanupGroupMetadata(): Unit = {
     val startMs = time.milliseconds()
+    // note: there is a lock on the group when the function 'removeExpiredOffsets(...)' is called inside 'cleanupGroupMetadata(...)'
     val offsetsRemoved = cleanupGroupMetadata(groupMetadataCache.values, group => {
       group.removeExpiredOffsets(time.milliseconds())
     })


### PR DESCRIPTION
Refactoring avoids the need to call this method with a infinity as current time to remove all group offsets (when manually deleting the group).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
