### PR TITLE
KAFKA-6364: second check for ensuring changelog topic not changed during restore

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -290,17 +290,19 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
             subscriptions.requestOffsetReset(tp, OffsetResetStrategy.LATEST);
     }
 
-    // needed for cases where you make a second call to end offsets
-    public synchronized void addEndOffsets(Map<TopicPartition, Long> newOffsets) {
+    // needed for cases where you make a second call to endOffsets
+    public synchronized void addEndOffsets(final Map<TopicPartition, Long> newOffsets) {
         innerUpdateEndOffsets(newOffsets, false);
     }
 
-    public synchronized void updateEndOffsets(Map<TopicPartition, Long> newOffsets) {
+    public synchronized void updateEndOffsets(final Map<TopicPartition, Long> newOffsets) {
         innerUpdateEndOffsets(newOffsets, true);
     }
 
-    private void innerUpdateEndOffsets(Map<TopicPartition, Long> newOffsets, boolean replace) {
-        for (Map.Entry<TopicPartition, Long> entry : newOffsets.entrySet()) {
+    private void innerUpdateEndOffsets(final Map<TopicPartition, Long> newOffsets,
+                                       final boolean replace) {
+
+        for (final Map.Entry<TopicPartition, Long> entry : newOffsets.entrySet()) {
             List<Long> offsets = endOffsets.get(entry.getKey());
             if (offsets == null) {
                 offsets = new ArrayList<>();

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -304,15 +304,10 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
 
         for (final Map.Entry<TopicPartition, Long> entry : newOffsets.entrySet()) {
             List<Long> offsets = endOffsets.get(entry.getKey());
-            if (offsets == null) {
+            if (replace || offsets == null) {
                 offsets = new ArrayList<>();
             }
-            if (replace) {
-                offsets = new ArrayList<>();
-                offsets.add(entry.getValue());
-            } else {
-                offsets.add(entry.getValue());
-            }
+            offsets.add(entry.getValue());
             endOffsets.put(entry.getKey(), offsets);
         }
     }
@@ -463,8 +458,7 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     private Long getEndOffset(List<Long> offsets) {
-
-        if(offsets == null || offsets.isEmpty()) {
+        if (offsets == null || offsets.isEmpty()) {
             return null;
         }
         return offsets.size() > 1 ? offsets.remove(0) : offsets.get(0);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -255,7 +255,7 @@ public class StoreChangelogReader implements ChangelogReader {
                 throw new TaskMigratedException(task, topicPartition, endOffset, pos);
             }
 
-            // not a KTable changelog topic but state store
+            // need to check for changelog topic
             if (restorer.offsetLimit() == Long.MAX_VALUE) {
                 final Long updatedEndOffset = restoreConsumer.endOffsets(Collections.singletonList(topicPartition)).get(topicPartition);
                 if (!restorer.hasCompleted(pos, updatedEndOffset)) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StoreChangelogReader.java
@@ -255,6 +255,15 @@ public class StoreChangelogReader implements ChangelogReader {
                 throw new TaskMigratedException(task, topicPartition, endOffset, pos);
             }
 
+            // not a KTable changelog topic but state store
+            if (restorer.offsetLimit() == Long.MAX_VALUE) {
+                final Long updatedEndOffset = restoreConsumer.endOffsets(Collections.singletonList(topicPartition)).get(topicPartition);
+                if (!restorer.hasCompleted(pos, updatedEndOffset)) {
+                    throw new TaskMigratedException(task, topicPartition, updatedEndOffset, pos);
+                }
+            }
+
+
             log.debug("Completed restoring state from changelog {} with {} records ranging from offset {} to {}",
                       topicPartition,
                       restorer.restoredNumRecords(),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -391,8 +391,7 @@ public class StoreChangelogReaderTest {
             changelogReader.restore(active);
             fail("Should have thrown TaskMigratedException");
         } catch (final TaskMigratedException expected) {
-            // verifies second block threw exception with updated end offset
-            assertTrue(expected.getMessage().contains("end offset 15, current offset 10"));
+            /* ignore */
         }
     }
 
@@ -412,7 +411,10 @@ public class StoreChangelogReaderTest {
         try {
             changelogReader.restore(active);
             fail("Should have thrown TaskMigratedException");
-        } catch (final TaskMigratedException expected) { /* ignore */ }
+        } catch (final TaskMigratedException expected) {
+            // verifies second block threw exception with updated end offset
+            assertTrue(expected.getMessage().contains("end offset 15, current offset 10"));
+        }
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StoreChangelogReaderTest.java
@@ -390,7 +390,10 @@ public class StoreChangelogReaderTest {
         try {
             changelogReader.restore(active);
             fail("Should have thrown TaskMigratedException");
-        } catch (final TaskMigratedException expected) { /* ignore */ }
+        } catch (final TaskMigratedException expected) {
+            // verifies second block threw exception with updated end offset
+            assertTrue(expected.getMessage().contains("end offset 15, current offset 10"));
+        }
     }
 
 


### PR DESCRIPTION
Added a second check for race condition where store changelog topic updated during restore, but not if a KTable changelog topic. 

This will be tricky to test, but I wanted to push the PR to get feedback on the approach.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
