### PR TITLE
KAFKA-6513: Corrected how Converters and HeaderConverters are instantiated and configured

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/HeaderConverter.java
@@ -36,7 +36,7 @@ public interface HeaderConverter extends Configurable, Closeable {
     SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value);
 
     /**
-     * Convert the {@link Header}'s {@link Header#valueAsBytes() value} into its byte array representation.
+     * Convert the {@link Header}'s {@link Header#value() value} into its byte array representation.
      * @param topic the name of the topic for the record containing the header
      * @param headerKey the header's key; may not be null
      * @param schema the schema for the header's value; may be null

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.reflections.Reflections;
 import org.reflections.util.ClasspathHelper;
@@ -57,6 +58,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     private final Map<String, String> aliases;
     private final SortedSet<PluginDesc<Connector>> connectors;
     private final SortedSet<PluginDesc<Converter>> converters;
+    private final SortedSet<PluginDesc<HeaderConverter>> headerConverters;
     private final SortedSet<PluginDesc<Transformation>> transformations;
     private final List<String> pluginPaths;
     private final Map<Path, PluginClassLoader> activePaths;
@@ -69,6 +71,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         this.activePaths = new HashMap<>();
         this.connectors = new TreeSet<>();
         this.converters = new TreeSet<>();
+        this.headerConverters = new TreeSet<>();
         this.transformations = new TreeSet<>();
     }
 
@@ -82,6 +85,10 @@ public class DelegatingClassLoader extends URLClassLoader {
 
     public Set<PluginDesc<Converter>> converters() {
         return converters;
+    }
+
+    public Set<PluginDesc<HeaderConverter>> headerConverters() {
+        return headerConverters;
     }
 
     public Set<PluginDesc<Transformation>> transformations() {
@@ -209,6 +216,8 @@ public class DelegatingClassLoader extends URLClassLoader {
             connectors.addAll(plugins.connectors());
             addPlugins(plugins.converters(), loader);
             converters.addAll(plugins.converters());
+            addPlugins(plugins.headerConverters(), loader);
+            headerConverters.addAll(plugins.headerConverters());
             addPlugins(plugins.transformations(), loader);
             transformations.addAll(plugins.transformations());
         }
@@ -260,6 +269,7 @@ public class DelegatingClassLoader extends URLClassLoader {
         return new PluginScanResult(
                 getPluginDesc(reflections, Connector.class, loader),
                 getPluginDesc(reflections, Converter.class, loader),
+                getPluginDesc(reflections, HeaderConverter.class, loader),
                 getPluginDesc(reflections, Transformation.class, loader)
         );
     }
@@ -314,6 +324,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     private void addAllAliases() {
         addAliases(connectors);
         addAliases(converters);
+        addAliases(headerConverters);
         addAliases(transformations);
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginScanResult.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime.isolation;
 
 import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Collection;
@@ -25,15 +26,18 @@ import java.util.Collection;
 public class PluginScanResult {
     private final Collection<PluginDesc<Connector>> connectors;
     private final Collection<PluginDesc<Converter>> converters;
+    private final Collection<PluginDesc<HeaderConverter>> headerConverters;
     private final Collection<PluginDesc<Transformation>> transformations;
 
     public PluginScanResult(
             Collection<PluginDesc<Connector>> connectors,
             Collection<PluginDesc<Converter>> converters,
+            Collection<PluginDesc<HeaderConverter>> headerConverters,
             Collection<PluginDesc<Transformation>> transformations
     ) {
         this.connectors = connectors;
         this.converters = converters;
+        this.headerConverters = headerConverters;
         this.transformations = transformations;
     }
 
@@ -45,11 +49,18 @@ public class PluginScanResult {
         return converters;
     }
 
+    public Collection<PluginDesc<HeaderConverter>> headerConverters() {
+        return headerConverters;
+    }
+
     public Collection<PluginDesc<Transformation>> transformations() {
         return transformations;
     }
 
     public boolean isEmpty() {
-        return connectors().isEmpty() && converters().isEmpty() && transformations().isEmpty();
+        return connectors().isEmpty()
+               && converters().isEmpty()
+               && headerConverters().isEmpty()
+               && transformations().isEmpty();
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -765,6 +765,7 @@ public class WorkerTest extends ThreadedTest {
         worker.stop();
         assertStatistics(worker, 0, 0);
 
+        // We've mocked the Plugin.newConverter method, so we don't currently configure the converters
         // Validate extra configs got passed through to overridden converters
         assertEquals("foo", keyConverter.getValue().configs.get("extra.config"));
         assertEquals("bar", valueConverter.getValue().configs.get("extra.config"));
@@ -832,19 +833,16 @@ public class WorkerTest extends ThreadedTest {
         if (expectDefaultConverters) {
 
             // Instantiate and configure default
-            EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(), config))
+            EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(),
+                                                 config,
+                                                 true,
+                                                 "key.converter."))
                     .andReturn(keyConverter);
-            keyConverter.configure(
-                    EasyMock.<Map<String, ?>>anyObject(),
-                    EasyMock.anyBoolean()
-            );
-            EasyMock.expectLastCall();
-            EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(), config))
+            EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(),
+                                                 config,
+                                                 false,
+                                                 "value.converter."))
                     .andReturn(valueConverter);
-            valueConverter.configure(
-                    EasyMock.<Map<String, ?>>anyObject(),
-                    EasyMock.anyBoolean()
-            );
             EasyMock.expectLastCall();
         }
 
@@ -853,19 +851,16 @@ public class WorkerTest extends ThreadedTest {
         Converter internalValueConverter = PowerMock.createMock(converterClass);
 
         // Instantiate and configure internal
-        EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(), config))
+        EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(),
+                                             config,
+                                             true,
+                                             "internal.key.converter."))
                 .andReturn(internalKeyConverter);
-        internalKeyConverter.configure(
-                EasyMock.<Map<String, ?>>anyObject(),
-                EasyMock.anyBoolean()
-        );
-        EasyMock.expectLastCall();
-        EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(), config))
+        EasyMock.expect(plugins.newConverter(JsonConverter.class.getName(),
+                                             config,
+                                             false,
+                                             "internal.value.converter."))
                 .andReturn(internalValueConverter);
-        internalValueConverter.configure(
-                EasyMock.<Map<String, ?>>anyObject(),
-                EasyMock.anyBoolean()
-        );
         EasyMock.expectLastCall();
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.runtime.isolation;
+
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.ConverterType;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PluginsTest {
+
+    private static Map<String, String> props;
+    private static Plugins plugins;
+    private AbstractConfig config;
+    private TestConverter converter;
+    private TestHeaderConverter headerConverter;
+
+    @BeforeClass
+    public static void beforeAll() {
+        props = new HashMap<>();
+        props.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
+        props.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
+        props.put("key.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "true");
+        props.put("value.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "true");
+        props.put("key.converter.extra.config", "foo1");
+        props.put("value.converter.extra.config", "foo2");
+        props.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
+        props.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
+        props.put("internal.key.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+        props.put("internal.value.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+        props.put("internal.key.converter.extra.config", "bar1");
+        props.put("internal.value.converter.extra.config", "bar2");
+        props.put(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, TestHeaderConverter.class.getName());
+        props.put("header.converter.extra.config", "baz");
+
+        // Set up the plugins to have no additional plugin directories.
+        // This won't allow us to test classpath isolation, but it will allow us to test some of the utility methods.
+        props.put(WorkerConfig.PLUGIN_PATH_CONFIG, "");
+        plugins = new Plugins(props);
+    }
+
+    @Before
+    public void setup() {
+        this.config = new TestableWorkerConfig(props);
+    }
+
+    @Test
+    public void shouldInstantiateAndConfigureConverters() {
+        instantiateAndConfigureConverter("key.converter.", true);
+        // Validate extra configs got passed through to overridden converters
+        assertConverterType(ConverterType.KEY, converter.configs);
+        assertEquals("true", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
+        assertEquals("foo1", converter.configs.get("extra.config"));
+
+        instantiateAndConfigureConverter("value.converter.", false);
+        // Validate extra configs got passed through to overridden converters
+        assertConverterType(ConverterType.VALUE, converter.configs);
+        assertEquals("true", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
+        assertEquals("foo2", converter.configs.get("extra.config"));
+    }
+
+    @Test
+    public void shouldInstantiateAndConfigureInternalConverters() {
+        instantiateAndConfigureConverter("internal.key.converter.", true);
+        // Validate extra configs got passed through to overridden converters
+        assertConverterType(ConverterType.KEY, converter.configs);
+        assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
+        assertEquals("bar1", converter.configs.get("extra.config"));
+
+        instantiateAndConfigureConverter("internal.value.converter.", false);
+        // Validate extra configs got passed through to overridden converters
+        assertConverterType(ConverterType.VALUE, converter.configs);
+        assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
+        assertEquals("bar2", converter.configs.get("extra.config"));
+    }
+
+    @Test
+    public void shouldInstantiateAndConfigureHeaderConverter() {
+        instantiateAndConfigureHeaderConverter("header.converter.");
+        // Validate extra configs got passed through to overridden converters
+        assertConverterType(ConverterType.HEADER, headerConverter.configs);
+        assertEquals("baz", headerConverter.configs.get("extra.config"));
+    }
+
+    protected void instantiateAndConfigureConverter(String prefix, boolean isKeyConverter) {
+        converter = (TestConverter) plugins.newConverter(TestConverter.class.getName(), config, isKeyConverter, prefix);
+        assertNotNull(converter);
+    }
+
+    protected void instantiateAndConfigureHeaderConverter(String prefix) {
+        headerConverter = (TestHeaderConverter) plugins.newHeaderConverter(TestHeaderConverter.class.getName(), config, prefix);
+        assertNotNull(headerConverter);
+    }
+
+    protected void assertConverterType(ConverterType type, Map<String, ?> props) {
+        assertEquals(type.getName(), props.get(ConverterConfig.TYPE_CONFIG));
+    }
+
+    public static class TestableWorkerConfig extends WorkerConfig {
+        public TestableWorkerConfig(Map<String, String> props) {
+            super(WorkerConfig.baseConfigDef(), props);
+        }
+    }
+
+    public static class TestConverter implements Converter, Configurable {
+        public Map<String, ?> configs;
+
+        public ConfigDef config() {
+            return JsonConverterConfig.configDef();
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            this.configs = configs;
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs, boolean isKey) {
+            this.configs = configs;
+        }
+
+        @Override
+        public byte[] fromConnectData(String topic, Schema schema, Object value) {
+            return new byte[0];
+        }
+
+        @Override
+        public SchemaAndValue toConnectData(String topic, byte[] value) {
+            return null;
+        }
+    }
+
+    public static class TestHeaderConverter implements HeaderConverter {
+        public Map<String, ?> configs;
+
+        @Override
+        public ConfigDef config() {
+            return JsonConverterConfig.configDef();
+        }
+
+        @Override
+        public void configure(Map<String, ?> configs) {
+            this.configs = configs;
+        }
+
+        @Override
+        public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+            return new byte[0];
+        }
+
+        @Override
+        public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -78,13 +78,13 @@ public class PluginsTest {
 
     @Test
     public void shouldInstantiateAndConfigureConverters() {
-        instantiateAndConfigureConverter("key.converter.", true);
+        instantiateAndConfigureConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, true);
         // Validate extra configs got passed through to overridden converters
         assertConverterType(ConverterType.KEY, converter.configs);
         assertEquals("true", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
         assertEquals("foo1", converter.configs.get("extra.config"));
 
-        instantiateAndConfigureConverter("value.converter.", false);
+        instantiateAndConfigureConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, false);
         // Validate extra configs got passed through to overridden converters
         assertConverterType(ConverterType.VALUE, converter.configs);
         assertEquals("true", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
@@ -93,13 +93,13 @@ public class PluginsTest {
 
     @Test
     public void shouldInstantiateAndConfigureInternalConverters() {
-        instantiateAndConfigureConverter("internal.key.converter.", true);
+        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, true);
         // Validate extra configs got passed through to overridden converters
         assertConverterType(ConverterType.KEY, converter.configs);
         assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
         assertEquals("bar1", converter.configs.get("extra.config"));
 
-        instantiateAndConfigureConverter("internal.value.converter.", false);
+        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, false);
         // Validate extra configs got passed through to overridden converters
         assertConverterType(ConverterType.VALUE, converter.configs);
         assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
@@ -108,19 +108,19 @@ public class PluginsTest {
 
     @Test
     public void shouldInstantiateAndConfigureHeaderConverter() {
-        instantiateAndConfigureHeaderConverter("header.converter.");
+        instantiateAndConfigureHeaderConverter(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG);
         // Validate extra configs got passed through to overridden converters
         assertConverterType(ConverterType.HEADER, headerConverter.configs);
         assertEquals("baz", headerConverter.configs.get("extra.config"));
     }
 
-    protected void instantiateAndConfigureConverter(String prefix, boolean isKeyConverter) {
-        converter = (TestConverter) plugins.newConverter(TestConverter.class.getName(), config, isKeyConverter, prefix);
+    protected void instantiateAndConfigureConverter(String configPropName, boolean isKeyConverter) {
+        converter = (TestConverter) plugins.newConverter(config, configPropName, isKeyConverter);
         assertNotNull(converter);
     }
 
-    protected void instantiateAndConfigureHeaderConverter(String prefix) {
-        headerConverter = (TestHeaderConverter) plugins.newHeaderConverter(TestHeaderConverter.class.getName(), config, prefix);
+    protected void instantiateAndConfigureHeaderConverter(String configPropName) {
+        headerConverter = (TestHeaderConverter) plugins.newHeaderConverter(config, configPropName);
         assertNotNull(headerConverter);
     }
 
@@ -144,6 +144,7 @@ public class PluginsTest {
         @Override
         public void configure(Map<String, ?> configs) {
             this.configs = configs;
+            new JsonConverterConfig(configs); // requires the `converter.type` config be set
         }
 
         @Override
@@ -173,6 +174,7 @@ public class PluginsTest {
         @Override
         public void configure(Map<String, ?> configs) {
             this.configs = configs;
+            new JsonConverterConfig(configs); // requires the `converter.type` config be set
         }
 
         @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.isolation.Plugins.ClassLoaderUsage;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.ConverterConfig;
 import org.apache.kafka.connect.storage.ConverterType;
@@ -78,30 +79,26 @@ public class PluginsTest {
 
     @Test
     public void shouldInstantiateAndConfigureConverters() {
-        instantiateAndConfigureConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, true);
+        instantiateAndConfigureConverter(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.CURRENT_CLASSLOADER);
         // Validate extra configs got passed through to overridden converters
-        assertConverterType(ConverterType.KEY, converter.configs);
         assertEquals("true", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
         assertEquals("foo1", converter.configs.get("extra.config"));
 
-        instantiateAndConfigureConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, false);
+        instantiateAndConfigureConverter(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
         // Validate extra configs got passed through to overridden converters
-        assertConverterType(ConverterType.VALUE, converter.configs);
         assertEquals("true", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
         assertEquals("foo2", converter.configs.get("extra.config"));
     }
 
     @Test
     public void shouldInstantiateAndConfigureInternalConverters() {
-        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, true);
+        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.CURRENT_CLASSLOADER);
         // Validate extra configs got passed through to overridden converters
-        assertConverterType(ConverterType.KEY, converter.configs);
         assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
         assertEquals("bar1", converter.configs.get("extra.config"));
 
-        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, false);
+        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
         // Validate extra configs got passed through to overridden converters
-        assertConverterType(ConverterType.VALUE, converter.configs);
         assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
         assertEquals("bar2", converter.configs.get("extra.config"));
     }
@@ -114,13 +111,13 @@ public class PluginsTest {
         assertEquals("baz", headerConverter.configs.get("extra.config"));
     }
 
-    protected void instantiateAndConfigureConverter(String configPropName, boolean isKeyConverter) {
-        converter = (TestConverter) plugins.newConverter(config, configPropName, isKeyConverter);
+    protected void instantiateAndConfigureConverter(String configPropName, ClassLoaderUsage classLoaderUsage) {
+        converter = (TestConverter) plugins.newConverter(config, configPropName, classLoaderUsage);
         assertNotNull(converter);
     }
 
     protected void instantiateAndConfigureHeaderConverter(String configPropName) {
-        headerConverter = (TestHeaderConverter) plugins.newHeaderConverter(config, configPropName);
+        headerConverter = (TestHeaderConverter) plugins.newHeaderConverter(config, configPropName, ClassLoaderUsage.CURRENT_CLASSLOADER);
         assertNotNull(headerConverter);
     }
 


### PR DESCRIPTION
The commits for KIP-145 (KAFKA-5142) changed how the Connect workers instantiate and configure the Converters, and also added the ability to do the same for the new HeaderConverters. However, the last few commits removed the default value for the `converter.type` property for Converters and HeaderConverters, and this broke how the internal converters were being created.

This change corrects the behavior so that the `converter.type` property is always set by the worker (or by the Plugins class), which means the existing Converter implementations will not have to do this. The built-in JsonConverter, ByteArrayConverter, and StringConverter also implement HeaderConverter which implements Configurable, but the Worker and Plugins methods do not yet use the `Configurable.configure(Map)` method and instead still use the `Converter.configure(Map,boolean)`.

Several tests were modified, and a new PluginsTest was added to verify the new behavior in Plugins for instantiating and configuring the Converter and HeaderConverter instances.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
