### PR TITLE
KAFKA-6511: Corrected list parsing logic

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
@@ -757,12 +757,7 @@ public class Values {
                         return new SchemaAndValue(listSchema, result);
                     }
                     if (parser.canConsume(COMMA_DELIMITER)) {
-                        if (elementSchema == null || elementSchema.type() == Type.STRING) {
-                            // blank value ...
-                            result.add("");
-                            continue;
-                        }
-                        throw new DataException("Array of non-string values may not contain a blank element: " + parser.original());
+                        throw new DataException("Unable to parse an empty array element: " + parser.original());
                     }
                     SchemaAndValue element = parse(parser, true);
                     elementSchema = commonSchemaFor(elementSchema, element);
@@ -790,7 +785,7 @@ public class Values {
                         return new SchemaAndValue(mapSchema, result);
                     }
                     if (parser.canConsume(COMMA_DELIMITER)) {
-                        throw new DataException("Map entry has no key or value: " + parser.original());
+                        throw new DataException("Unable to parse a map entry has no key or value: " + parser.original());
                     }
                     SchemaAndValue key = parse(parser, true);
                     if (key == null || key.value() == null) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
@@ -749,10 +749,10 @@ public class Values {
                 Schema elementSchema = null;
                 while (parser.hasNext()) {
                     if (parser.canConsume(ARRAY_END_DELIMITER)) {
-                        if (elementSchema == null) {
-                            throw new DataException("Unable to parse as list without common element type: " + parser.original());
+                        Schema listSchema = null;
+                        if (elementSchema != null) {
+                            listSchema = SchemaBuilder.array(elementSchema).schema();
                         }
-                        Schema listSchema = SchemaBuilder.array(elementSchema).schema();
                         result = alignListEntriesWithSchema(listSchema, result);
                         return new SchemaAndValue(listSchema, result);
                     }
@@ -777,10 +777,10 @@ public class Values {
                 Schema valueSchema = null;
                 while (parser.hasNext()) {
                     if (parser.canConsume(MAP_END_DELIMITER)) {
-                        if (keySchema == null || valueSchema == null) {
-                            throw new DataException("Unable to parse as map without common key and value types: " + parser.original());
+                        Schema mapSchema = null;
+                        if (keySchema != null && valueSchema != null) {
+                            mapSchema = SchemaBuilder.map(keySchema, valueSchema).schema();
                         }
-                        Schema mapSchema = SchemaBuilder.map(keySchema, valueSchema).schema();
                         result = alignMapKeysAndValuesWithSchema(mapSchema, result);
                         return new SchemaAndValue(mapSchema, result);
                     }

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Values.java
@@ -749,9 +749,20 @@ public class Values {
                 Schema elementSchema = null;
                 while (parser.hasNext()) {
                     if (parser.canConsume(ARRAY_END_DELIMITER)) {
-                        Schema listSchema = elementSchema == null ? null : SchemaBuilder.array(elementSchema).schema();
+                        if (elementSchema == null) {
+                            throw new DataException("Unable to parse as list without common element type: " + parser.original());
+                        }
+                        Schema listSchema = SchemaBuilder.array(elementSchema).schema();
                         result = alignListEntriesWithSchema(listSchema, result);
                         return new SchemaAndValue(listSchema, result);
+                    }
+                    if (parser.canConsume(COMMA_DELIMITER)) {
+                        if (elementSchema == null || elementSchema.type() == Type.STRING) {
+                            // blank value ...
+                            result.add("");
+                            continue;
+                        }
+                        throw new DataException("Array of non-string values may not contain a blank element: " + parser.original());
                     }
                     SchemaAndValue element = parse(parser, true);
                     elementSchema = commonSchemaFor(elementSchema, element);
@@ -760,9 +771,9 @@ public class Values {
                 }
                 // Missing either a comma or an end delimiter
                 if (COMMA_DELIMITER.equals(parser.previous())) {
-                    throw new DataException("Malformed array: missing element after ','");
+                    throw new DataException("Array is missing element after ',': " + parser.original());
                 }
-                throw new DataException("Malformed array: missing terminating ']'");
+                throw new DataException("Array is missing terminating ']': " + parser.original());
             }
 
             if (parser.canConsume(MAP_BEGIN_DELIMITER)) {
@@ -771,17 +782,22 @@ public class Values {
                 Schema valueSchema = null;
                 while (parser.hasNext()) {
                     if (parser.canConsume(MAP_END_DELIMITER)) {
-                        Schema mapSchema =
-                                keySchema == null || valueSchema == null ? null : SchemaBuilder.map(keySchema, valueSchema).schema();
+                        if (keySchema == null || valueSchema == null) {
+                            throw new DataException("Unable to parse as map without common key and value types: " + parser.original());
+                        }
+                        Schema mapSchema = SchemaBuilder.map(keySchema, valueSchema).schema();
                         result = alignMapKeysAndValuesWithSchema(mapSchema, result);
                         return new SchemaAndValue(mapSchema, result);
                     }
+                    if (parser.canConsume(COMMA_DELIMITER)) {
+                        throw new DataException("Map entry has no key or value: " + parser.original());
+                    }
                     SchemaAndValue key = parse(parser, true);
                     if (key == null || key.value() == null) {
-                        throw new DataException("Malformed map entry: null key");
+                        throw new DataException("Map entry may not have a null key: " + parser.original());
                     }
                     if (!parser.canConsume(ENTRY_DELIMITER)) {
-                        throw new DataException("Malformed map entry: missing '='");
+                        throw new DataException("Map entry is missing '=': " + parser.original());
                     }
                     SchemaAndValue value = parse(parser, true);
                     Object entryValue = value != null ? value.value() : null;
@@ -792,9 +808,9 @@ public class Values {
                 }
                 // Missing either a comma or an end delimiter
                 if (COMMA_DELIMITER.equals(parser.previous())) {
-                    throw new DataException("Malformed map: missing element after ','");
+                    throw new DataException("Map is missing element after ',': " + parser.original());
                 }
-                throw new DataException("Malformed array: missing terminating ']'");
+                throw new DataException("Map is missing terminating ']': " + parser.original());
             }
         } catch (DataException e) {
             LOG.debug("Unable to parse the value as a map; reverting to string", e);

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ValuesTest.java
@@ -175,14 +175,32 @@ public class ValuesTest {
     }
 
     /**
-     * We can't infer or successfully parse into a different type, so this returns the same string.
+     * The parsed array has byte values and one int value, so we should return list with single unified type of integers.
      */
     @Test
-    public void shouldParseStringListWithMultipleElementTypesAndReturnString() {
-        String str = "[1, 2, 3, \"four\",,]";
+    public void shouldConvertStringOfListWithMixedElementTypesIntoListWithDifferentElementTypes() {
+        String str = "[1, 2, \"three\"]";
+        List<?> list = Values.convertToList(Schema.STRING_SCHEMA, str);
+        assertEquals(3, list.size());
+        assertEquals(1, ((Number) list.get(0)).intValue());
+        assertEquals(2, ((Number) list.get(1)).intValue());
+        assertEquals("three", list.get(2));
+    }
+
+    /**
+     * We parse into different element types, but cannot infer a common element schema.
+     */
+    @Test
+    public void shouldParseStringListWithMultipleElementTypesAndReturnListWithNoSchema() {
+        String str = "[1, 2, 3, \"four\"]";
         SchemaAndValue result = Values.parseString(str);
-        assertEquals(Type.STRING, result.schema().type());
-        assertEquals(str, result.value());
+        assertNull(result.schema());
+        List<?> list = (List<?>) result.value();
+        assertEquals(4, list.size());
+        assertEquals(1, ((Number) list.get(0)).intValue());
+        assertEquals(2, ((Number) list.get(1)).intValue());
+        assertEquals(3, ((Number) list.get(2)).intValue());
+        assertEquals("four", list.get(3));
     }
 
     /**
@@ -209,8 +227,8 @@ public class ValuesTest {
      * Therefore, we can't represent this.
      */
     @Test(expected = DataException.class)
-    public void shouldFailToConvertToListFromStringWithNonCommonElementType() {
-        Values.convertToList(Schema.STRING_SCHEMA, "[1, 2, 3, \"four\"]");
+    public void shouldFailToConvertToListFromStringWithNonCommonElementTypeAndBlankElement() {
+        Values.convertToList(Schema.STRING_SCHEMA, "[1, 2, 3, \"four\",,,]");
     }
 
     /**


### PR DESCRIPTION
Corrected the parsing of invalid list values. A list can only be parsed if it contains elements that have a common type, and a map can only be parsed if it contains keys with a common type and values with a common type.

This should only be merged to `trunk`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
