### PR TITLE
MINOR: Bump version to 2.0.0-SNAPSHOT

### DIFF
--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -76,7 +76,9 @@ object ApiVersion {
     // Introduced DeleteGroupsRequest V0 via KIP-229, plus KIP-227 incremental fetch requests,
     // and KafkaStorageException for fetch requests.
     "1.1-IV0" -> KAFKA_1_1_IV0,
-    "1.1" -> KAFKA_1_1_IV0
+    "1.1" -> KAFKA_1_1_IV0,
+    "2.0-IV0" -> KAFKA_2_0_IV0,
+    "2.0" -> KAFKA_2_0_IV0
   )
 
   private val versionPattern = "\\.".r
@@ -192,4 +194,10 @@ case object KAFKA_1_1_IV0 extends ApiVersion {
   val version: String = "1.1-IV0"
   val messageFormatVersion: Byte = RecordBatch.MAGIC_VALUE_V2
   val id: Int = 14
+}
+
+case object KAFKA_2_0_IV0 extends ApiVersion {
+  val version: String = "2.0-IV0"
+  val messageFormatVersion: Byte = RecordBatch.MAGIC_VALUE_V2
+  val id: Int = 15
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 group=org.apache.kafka
 # NOTE: When you change this version number, you should also make sure to update
 # the version numbers in tests/kafkatest/__init__.py and kafka-merge-pr.py.
-version=1.2.0-SNAPSHOT
+version=2.0.0-SNAPSHOT
 scalaVersion=2.11.12
 task=build
 org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m -Xss2m


### PR DESCRIPTION
I proposed last year that the June/July release should be 2.0.0 to allow us to:
- Bump the minimum Java version to 8
- Remove the deprecated Scala clients

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
