### PR TITLE
Kafka-3832: Kafka Connect's JSON Converter never outputs a null value

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -563,8 +563,12 @@ public class JsonConverter implements Converter, HeaderConverter {
      * @param value the value
      * @return JsonNode-encoded version
      */
-    private JsonNode convertToJsonWithEnvelope(Schema schema, Object value) {
-        return new JsonSchema.Envelope(asJsonSchema(schema), convertToJson(schema, value)).toJsonNode();
+    protected JsonNode convertToJsonWithEnvelope(Schema schema, Object value) {
+        if (value == null){
+            return null;
+        } else {
+            return new JsonSchema.Envelope(asJsonSchema(schema), convertToJson(schema, value)).toJsonNode();
+        }
     }
 
     private JsonNode convertToJsonWithoutEnvelope(Schema schema, Object value) {

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -755,6 +755,11 @@ public class JsonConverterTest {
         assertEquals(new SchemaAndValue(Schema.STRING_SCHEMA, "foo-bar-baz"), converter.toConnectHeader(TOPIC, "headerName", "{ \"schema\": { \"type\": \"string\" }, \"payload\": \"foo-bar-baz\" }".getBytes()));
     }
 
+    @Test
+    public void nullTestconvertToJsonWithEnvelope() {
+        assertNull(new JsonConverter().convertToJsonWithEnvelope(Schema.STRING_SCHEMA, null));
+    }
+
 
     private JsonNode parse(byte[] json) {
         try {


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

@rhauch , have added null condition in the method convertToJsonWithEnvelope ,to return null instead of empty Envelope, when enableSchemas=true.

Would also implement a similar change to toConnectData method, based on your feedback with changes made for fromConnectData method.

let me know, if there is any problem with the implementation or my understanding about the KAFKA-3832. 

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
