### PR TITLE
KAFKA-6469 Batch ISR change notifications

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -215,6 +215,7 @@ class ReplicaManager(val config: KafkaConfig,
   this.logIdent = s"[ReplicaManager broker=$localBrokerId] "
   private val stateChangeLogger = new StateChangeLogger(localBrokerId, inControllerContext = false, None)
 
+  private val isrChangeNotificationBatchSize = 3000
   private val isrChangeSet: mutable.Set[TopicPartition] = new mutable.HashSet[TopicPartition]()
   private val lastIsrChangeMs = new AtomicLong(System.currentTimeMillis())
   private val lastIsrPropagationMs = new AtomicLong(System.currentTimeMillis())
@@ -260,23 +261,29 @@ class ReplicaManager(val config: KafkaConfig,
   def recordIsrChange(topicPartition: TopicPartition): Unit = {
     isrChangeSet synchronized {
       isrChangeSet += topicPartition
-      lastIsrChangeMs.set(System.currentTimeMillis())
+      lastIsrChangeMs.set(time.milliseconds())
     }
   }
+
   /**
    * This function periodically runs to see if ISR needs to be propagated. It propagates ISR when:
    * 1. There is ISR change not propagated yet.
    * 2. There is no ISR Change in the last five seconds, or it has been more than 60 seconds since the last ISR propagation.
    * This allows an occasional ISR change to be propagated within a few seconds, and avoids overwhelming controller and
    * other brokers when large amount of ISR change occurs.
+   *
+   * ISR changes are batched into chunks of isrChangeNotificationBatchSize TopicPartitions to avoid writing ZNodes which
+   * exceed the default jute.maxbuffer size of 1MB in ZooKeeper. With this batch size, the worst case data size is about
+   * 820k, which gives about 203k of head room for the rest of the ZooKeeper CreateRequest. Since we have no idea what
+   * ACLs or other metadata could be included we need to leave lots of extra room. See KAFKA-6469.
    */
   def maybePropagateIsrChanges(): Unit = {
-    val now = System.currentTimeMillis()
+    val now = time.milliseconds()
     isrChangeSet synchronized {
       if (isrChangeSet.nonEmpty &&
         (lastIsrChangeMs.get() + ReplicaManager.IsrChangePropagationBlackOut < now ||
           lastIsrPropagationMs.get() + ReplicaManager.IsrChangePropagationInterval < now)) {
-        zkClient.propagateIsrChanges(isrChangeSet)
+        isrChangeSet.grouped(isrChangeNotificationBatchSize).foreach(zkClient.propagateIsrChanges)
         isrChangeSet.clear()
         lastIsrPropagationMs.set(now)
       }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -33,7 +33,7 @@ import kafka.server.epoch.util.ReplicaFetcherMockBlockingSend
 import kafka.utils.TestUtils.createBroker
 import kafka.utils.timer.MockTimer
 import kafka.utils.{MockScheduler, MockTime, TestUtils}
-import kafka.zk.KafkaZkClient
+import kafka.zk.{IsrChangeNotificationSequenceZNode, KafkaZkClient}
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.message.StopReplicaRequestData.StopReplicaPartitionState
 import org.apache.kafka.common.metrics.Metrics
@@ -49,7 +49,7 @@ import org.apache.kafka.common.security.auth.KafkaPrincipal
 import org.apache.kafka.common.utils.Time
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition}
-import org.easymock.EasyMock
+import org.easymock.{Capture, EasyMock}
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
 import org.mockito.Mockito
@@ -81,6 +81,44 @@ class ReplicaManagerTest {
   def tearDown(): Unit = {
     TestUtils.clearYammerMetrics()
     metrics.close()
+  }
+
+  @Test
+  def testBatchIsrChanges() : Unit = {
+    val time = new org.apache.kafka.common.utils.MockTime(ReplicaManager.IsrChangePropagationInterval)
+
+    kafkaZkClient = EasyMock.createMock(classOf[KafkaZkClient])
+    val capturedIsrChangeNotifications: Capture[collection.Set[TopicPartition]] = EasyMock.newCapture()
+    EasyMock.expect(kafkaZkClient.propagateIsrChanges(EasyMock.capture(capturedIsrChangeNotifications)))
+        .andAnswer(() => {
+          // Ensure that each serialized ISR change notification is well under the 1MiB limit in ZooKeeper.
+          val serializedSize = {
+            IsrChangeNotificationSequenceZNode.encode(capturedIsrChangeNotifications.getValue).length
+          }
+
+          // Just make sure the size never exceeds around 900KiB.
+          assertTrue(serializedSize < (900 * 1024));
+        }).times(2)
+    EasyMock.replay(kafkaZkClient)
+
+    val props = TestUtils.createBrokerConfig(1, TestUtils.MockZkConnect)
+    val config = KafkaConfig.fromProps(props)
+    val mockLogMgr = TestUtils.createLogManager(config.logDirs.map(new File(_)))
+    val rm = new ReplicaManager(config, metrics, time, kafkaZkClient, new MockScheduler(time), mockLogMgr,
+      new AtomicBoolean(false), QuotaFactory.instantiate(config, metrics, time, ""), new BrokerTopicStats,
+      new MetadataCache(config.brokerId), new LogDirFailureChannel(config.logDirs.size))
+
+    // Topic name which is the maximum length of 249.
+    val largeTopicName = "topic-".padTo(249, "x").mkString
+
+    // 5000 partitions. Large partition numbers chosen to make the serialized values as long as possible.
+    (10000 to 15000)
+      .map(n => new TopicPartition(largeTopicName, n))
+      .foreach(rm.recordIsrChange)
+
+    // Trigger sending of ISR notifications.
+    rm.maybePropagateIsrChanges()
+    EasyMock.verify(kafkaZkClient)
   }
 
   @Test


### PR DESCRIPTION
We've failures in one of our test clusters as the partition count
started to climb north of 60k per broker. We had brokers writing child
nodes under /isr_change_notification that were larger than the
jute.maxbuffer size in ZooKeeper (1MB), causing the ZooKeeper server
to drop the broker's session, effectively bricking the cluster.
    
This can be mitigated by chunking ISR notifications to increase
the maximum number of partitions a broker can host, which is
the purpose of this patch.
    
ReplicaManager#maybePropagateIsrChanges() now batches the set of
TopicPartitions into sets of at most 3200 entries. This ensures that
the JSON payload is never more than around 912k at the worst case.
    
An integration test was added which propagates a set of 5000
TopicPartitions in two batches.
    
The dependency on System.getCurrentTimeMillis() was broken for testing
purposes.