### PR TITLE
KAFKA-5327: Console Consumer should only poll for up to max messages

### DIFF
--- a/core/src/main/scala/kafka/consumer/BaseConsumer.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumer.scala
@@ -59,9 +59,6 @@ class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: 
   import org.apache.kafka.clients.consumer.KafkaConsumer
 
   val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](consumerProps)
-  val consumedOffsets = collection.mutable.Map[TopicPartition, Long]()
-  val subscribedPartitions = collection.mutable.Set[TopicPartition]() // avoid creating too many TopicPartition objects
-
   consumerInit()
   var recordIter = consumer.poll(0).iterator
 
@@ -94,24 +91,21 @@ class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: 
     }
   }
 
-  def seekToRealPositionsBeforeExit() {
+  private def seekToRealPositionsBeforeExit() {
+    val smallestUnconsumedOffsets = collection.mutable.Map[TopicPartition, Long]()
     while (recordIter.hasNext) {
       val record = recordIter.next()
-      if (!consumedOffsets.exists(tp => tp._1.topic() == record.topic() && tp._1.partition() == record.partition())) {
-        val tp = new TopicPartition(record.topic(), record.partition())
-        consumedOffsets += tp -> record.offset()
+      val unconsumedPartition = new TopicPartition(record.topic(), record.partition())
+      // only insert the smallest offset for each partition
+      val currentOffset = smallestUnconsumedOffsets.getOrElse(unconsumedPartition, {
+        smallestUnconsumedOffsets += unconsumedPartition -> record.offset()
+        record.offset()
+      })
+      if (currentOffset > record.offset()) {
+        smallestUnconsumedOffsets += unconsumedPartition -> record.offset()
       }
     }
-    consumedOffsets.foreach { case (tp, offset) => consumer.seek(tp, offset) }
-  }
-
-  def updateOffsetForPartition(msg: BaseConsumerRecord) {
-    val partition = subscribedPartitions.find(tp => tp.topic() == msg.topic && tp.partition() == msg.partition).getOrElse {
-      val tp = new TopicPartition(msg.topic, msg.partition)
-      subscribedPartitions += tp
-      tp
-    }
-    consumedOffsets += partition -> (msg.offset + 1L)
+    smallestUnconsumedOffsets.foreach { case (tp, offset) => consumer.seek(tp, offset) }
   }
 
   override def receive(): BaseConsumerRecord = {
@@ -137,8 +131,7 @@ class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: 
   }
 
   override def cleanup() {
-    this.consumedOffsets.clear()
-    this.subscribedPartitions.clear()
+    seekToRealPositionsBeforeExit()
     this.consumer.close()
   }
 

--- a/core/src/main/scala/kafka/consumer/BaseConsumer.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumer.scala
@@ -95,15 +95,11 @@ class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: 
     val smallestUnconsumedOffsets = collection.mutable.Map[TopicPartition, Long]()
     while (recordIter.hasNext) {
       val record = recordIter.next()
-      val unconsumedPartition = new TopicPartition(record.topic(), record.partition())
+      val tp = new TopicPartition(record.topic(), record.partition())
       // only insert the smallest offset for each partition
-      val currentOffset = smallestUnconsumedOffsets.getOrElse(unconsumedPartition, {
-        smallestUnconsumedOffsets += unconsumedPartition -> record.offset()
-        record.offset()
+      smallestUnconsumedOffsets.getOrElse(tp, {
+        smallestUnconsumedOffsets += tp -> record.offset()
       })
-      if (currentOffset > record.offset()) {
-        smallestUnconsumedOffsets += unconsumedPartition -> record.offset()
-      }
     }
     smallestUnconsumedOffsets.foreach { case (tp, offset) => consumer.seek(tp, offset) }
   }

--- a/core/src/main/scala/kafka/consumer/BaseConsumer.scala
+++ b/core/src/main/scala/kafka/consumer/BaseConsumer.scala
@@ -23,6 +23,7 @@ import java.util.regex.Pattern
 import kafka.api.OffsetRequest
 import kafka.common.StreamEndException
 import kafka.message.Message
+import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.common.record.TimestampType
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.Headers
@@ -40,7 +41,6 @@ trait BaseConsumer {
   def stop()
   def cleanup()
   def commit()
-  def resetOffsets(): Unit = {}
 }
 
 @deprecated("This class has been deprecated and will be removed in a future release. " +
@@ -56,10 +56,8 @@ case class BaseConsumerRecord(topic: String,
 
 @deprecated("This class has been deprecated and will be removed in a future release. " +
             "Please use org.apache.kafka.clients.consumer.KafkaConsumer instead.", "0.11.0.0")
-class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: Option[Long], whitelist: Option[String], consumerProps: Properties, val timeoutMs: Long = Long.MaxValue) extends BaseConsumer {
-  import org.apache.kafka.clients.consumer.KafkaConsumer
-
-  val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](consumerProps)
+class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: Option[Long], whitelist: Option[String],
+                       consumer: Consumer[Array[Byte], Array[Byte]], val timeoutMs: Long = Long.MaxValue) extends BaseConsumer {
   consumerInit()
   var recordIter = consumer.poll(0).iterator
 
@@ -92,7 +90,7 @@ class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: 
     }
   }
 
-  override def resetOffsets() {
+  def resetUnconsumedOffsets() {
     val smallestUnconsumedOffsets = collection.mutable.Map[TopicPartition, Long]()
     while (recordIter.hasNext) {
       val record = recordIter.next()
@@ -126,6 +124,7 @@ class NewShinyConsumer(topic: Option[String], partitionId: Option[Int], offset: 
   }
 
   override def cleanup() {
+    resetUnconsumedOffsets()
     this.consumer.close()
   }
 

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -77,12 +77,16 @@ object ConsoleConsumer extends Logging {
         else
           new NewShinyConsumer(Option(conf.topicArg), None, None, Option(conf.whitelistArg), getNewConsumerProps(conf), timeoutMs)
       }
+    run(consumer, conf)
+  }
 
+  private[tools] def run(consumer: BaseConsumer, conf: ConsumerConfig) {
     addShutdownHook(consumer, conf)
 
     try {
       process(conf.maxMessages, conf.formatter, consumer, System.out, conf.skipMessageOnError)
     } finally {
+      consumer.resetOffsets()
       consumer.cleanup()
       conf.formatter.close()
       reportRecordCount()

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -140,6 +140,7 @@ object ConsoleConsumer extends Logging {
   }
 
   def process(maxMessages: Integer, formatter: MessageFormatter, consumer: BaseConsumer, output: PrintStream, skipMessageOnError: Boolean) {
+    lazy val tps = collection.mutable.Set[TopicPartition]() // avoid creating too many TopicPartition objects
     while (messageCount < maxMessages || maxMessages == -1) {
       val msg: BaseConsumerRecord = try {
         consumer.receive()
@@ -158,7 +159,6 @@ object ConsoleConsumer extends Logging {
           return
       }
       messageCount += 1
-      val tps = collection.mutable.Set[TopicPartition]() // avoid creating too many TopicPartition objects
       try {
         formatter.writeTo(new ConsumerRecord(msg.topic, msg.partition, msg.offset, msg.timestamp,
                                              msg.timestampType, 0, 0, 0, msg.key, msg.value, msg.headers), output)

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -203,15 +203,12 @@ object ConsoleConsumer extends Logging {
     }
   }
 
-  def getNewConsumerProps(config: ConsumerConfig): Properties = {
+  private[tools] def getNewConsumerProps(config: ConsumerConfig): Properties = {
     val props = new Properties
-
     props ++= config.consumerProps
     props ++= config.extraConsumerProps
     setAutoOffsetResetValue(config, props)
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServer)
-    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
-    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArrayDeserializer")
     props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, config.isolationLevel)
     props
   }

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -87,8 +87,8 @@ object ConsoleConsumer extends Logging {
     } finally {
       if (!conf.useOldConsumer) {
         val newConsumer = consumer.asInstanceOf[NewShinyConsumer]
-
-        while (consumer.asInstanceOf[NewShinyConsumer].recordIter.hasNext) {
+        // store the real offsets to honor --max-messages instead of max.poll.records
+        while (newConsumer.recordIter.hasNext) {
           val record = newConsumer.recordIter.next()
           if (!consumedOffsets.exists(tp => tp._1.topic() == record.topic() && tp._1.partition() == record.partition())) {
             val tp = new TopicPartition(record.topic(), record.partition())

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -34,7 +34,7 @@ import kafka.utils.Implicits._
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.errors.{AuthenticationException, WakeupException}
 import org.apache.kafka.common.record.TimestampType
-import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.serialization.{ByteArrayDeserializer, Deserializer}
 import org.apache.kafka.common.utils.Utils
 
 import scala.collection.JavaConverters._
@@ -72,7 +72,7 @@ object ConsoleConsumer extends Logging {
         new OldConsumer(conf.filterSpec, props)
       } else {
         val timeoutMs = if (conf.timeoutMs >= 0) conf.timeoutMs else Long.MaxValue
-        val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](getNewConsumerProps(conf))
+        val consumer = new KafkaConsumer(getNewConsumerProps(conf), new ByteArrayDeserializer, new ByteArrayDeserializer)
         if (conf.partitionArg.isDefined)
           new NewShinyConsumer(Option(conf.topicArg), conf.partitionArg, Option(conf.offsetArg), None, consumer, timeoutMs)
         else

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -317,6 +317,28 @@ class ConsoleConsumerTest {
   }
 
   @Test(expected = classOf[IllegalArgumentException])
+  def shouldExitOnInvalidConfigWithSmallMaxMessagesInNewConsumer(): Unit = {
+    Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
+
+    //Given
+    val args: Array[String] = Array(
+      "--bootstrap-server", "localhost:9092",
+      "--topic", "test",
+      "--consumer-property", "max.poll.records=500",
+      "--max-messages", "400")
+
+    try {
+      val config = new ConsoleConsumer.ConsumerConfig(args)
+      val props = ConsoleConsumer.getNewConsumerProps(config)
+      ConsoleConsumer.checkAndMaybeThrowException(config, props)
+    } finally {
+      Exit.resetExitProcedure()
+    }
+
+    fail("Expected consumer property construction to fail due to ineffectively small max messages option")
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
   def shouldExitOnInvalidConfigWithAutoOffsetResetAndConflictingFromBeginningNewConsumer() {
 
     // Override exit procedure to throw an exception instead of exiting, so we can catch the exit

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -317,28 +317,6 @@ class ConsoleConsumerTest {
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def shouldExitOnInvalidConfigWithSmallMaxMessagesInNewConsumer(): Unit = {
-    Exit.setExitProcedure((_, message) => throw new IllegalArgumentException(message.orNull))
-
-    //Given
-    val args: Array[String] = Array(
-      "--bootstrap-server", "localhost:9092",
-      "--topic", "test",
-      "--consumer-property", "max.poll.records=500",
-      "--max-messages", "400")
-
-    try {
-      val config = new ConsoleConsumer.ConsumerConfig(args)
-      val props = ConsoleConsumer.getNewConsumerProps(config)
-      ConsoleConsumer.checkAndMaybeThrowException(config, props)
-    } finally {
-      Exit.resetExitProcedure()
-    }
-
-    fail("Expected consumer property construction to fail due to ineffectively small max messages option")
-  }
-
-  @Test(expected = classOf[IllegalArgumentException])
   def shouldExitOnInvalidConfigWithAutoOffsetResetAndConflictingFromBeginningNewConsumer() {
 
     // Override exit procedure to throw an exception instead of exiting, so we can catch the exit

--- a/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/ConsoleConsumerTest.scala
@@ -20,7 +20,7 @@ package kafka.tools
 import java.io.{PrintStream, FileOutputStream}
 
 import kafka.common.MessageFormatter
-import kafka.consumer.{BaseConsumer, BaseConsumerRecord, NewShinyConsumer}
+import kafka.consumer.{BaseConsumer, BaseConsumerRecord}
 import kafka.utils.{Exit, TestUtils}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.easymock.EasyMock
@@ -489,36 +489,5 @@ class ConsoleConsumerTest {
     assertEquals("group-from-arguments", props.getProperty("group.id"))
 
     Exit.resetExitProcedure()
-  }
-
-  @Test
-  def shouldUpdateOffsetsAndSeekWithMaxMessageLimit() {
-    //Mocks
-    val consumer = EasyMock.createNiceMock(classOf[NewShinyConsumer])
-    val formatter = EasyMock.createNiceMock(classOf[MessageFormatter])
-    val printStream = EasyMock.createNiceMock(classOf[PrintStream])
-
-    //Stubs
-    val record = new BaseConsumerRecord(topic = "foo", partition = 0, offset = 1, key = Array[Byte](), value = Array[Byte]())
-
-    //Expectations
-    val messageLimit: Int = 10
-    ConsoleConsumer.messageCount = 0 // reset message count to zero
-    EasyMock.expect(formatter.writeTo(EasyMock.anyObject(), EasyMock.eq(printStream))).times(messageLimit)
-    EasyMock.expect(consumer.receive()).andReturn(record).times(messageLimit)
-    EasyMock.expect(consumer.updateOffsetForPartition(record))
-    EasyMock.expectLastCall().times(messageLimit)
-    EasyMock.expect(printStream.checkError()).andReturn(false).times(messageLimit)
-    EasyMock.expect(consumer.seekToRealPositionsBeforeExit())
-    EasyMock.expectLastCall().once()
-
-    EasyMock.replay(consumer)
-    EasyMock.replay(formatter)
-    EasyMock.replay(printStream)
-
-    // Test
-    ConsoleConsumer.process(messageLimit, formatter, consumer, printStream, true)
-
-    EasyMock.verify(consumer, formatter, printStream)
   }
 }


### PR DESCRIPTION
Add a check to ensure --max-messages, if set,  must be set no smaller than max.poll.records.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
