### PR TITLE
MINOR: Update jetty, jackson, gradle and jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.4.1"
+  gradleVersion = "4.5.1"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []
@@ -384,7 +384,12 @@ subprojects {
 
   // Ignore core since its a scala project
   if (it.path != ':core') {
-    // NOTE: Gradles Jacoco plugin does not support "offline instrumentation" this means that classes mocked by PowerMock
+
+    jacoco {
+      toolVersion = "0.8.0"
+    }
+
+    // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock
     // may report 0 coverage, since the source was modified after initial instrumentation.
     // See https://github.com/jacoco/jacoco/issues/51
     jacocoTestReport {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ versions += [
   argparse4j: "0.7.0",
   bcpkix: "1.58",
   easymock: "3.5.1",
-  jackson: "2.9.3",
+  jackson: "2.9.4",
   jetty: "9.2.22.v20170606",
   jersey: "2.25.1",
   jmh: "1.19",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ versions += [
   bcpkix: "1.58",
   easymock: "3.5.1",
   jackson: "2.9.4",
-  jetty: "9.2.22.v20170606",
+  jetty: "9.2.24.v20180105",
   jersey: "2.25.1",
   jmh: "1.19",
   log4j: "1.2.17",


### PR DESCRIPTION
- Gradle update adds support for Java 10
- Jacoco update adds support for Java 9
- Jackson bug fix update adds more serialization
robustness checks
- Jetty bug fix update

Relying on existing tests for verification.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
