### PR TITLE
KAFKA-6517: Avoid deadlock in ZooKeeperClient during session expiry

### DIFF
--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -122,7 +122,7 @@ class ZooKeeperClient(connectString: String,
    * response type (e.g. Seq[CreateRequest] -> Seq[CreateResponse]). Otherwise, the most specific common supertype
    * will be used (e.g. Seq[AsyncRequest] -> Seq[AsyncResponse]).
    */
-  def handleRequests[Req <: AsyncRequest](requests: Seq[Req]): Seq[Req#Response] = inReadLock(initializationLock) {
+  def handleRequests[Req <: AsyncRequest](requests: Seq[Req]): Seq[Req#Response] = {
     if (requests.isEmpty)
       Seq.empty
     else {
@@ -132,10 +132,12 @@ class ZooKeeperClient(connectString: String,
       requests.foreach { request =>
         inFlightRequests.acquire()
         try {
-          send(request) { response =>
-            responseQueue.add(response)
-            inFlightRequests.release()
-            countDownLatch.countDown()
+          inReadLock(initializationLock) {
+            send(request) { response =>
+              responseQueue.add(response)
+              inFlightRequests.release()
+              countDownLatch.countDown()
+            }
           }
         } catch {
           case e: Throwable =>
@@ -148,7 +150,8 @@ class ZooKeeperClient(connectString: String,
     }
   }
 
-  private def send[Req <: AsyncRequest](request: Req)(processResponse: Req#Response => Unit): Unit = {
+  // Visibility to override for testing
+  private[zookeeper] def send[Req <: AsyncRequest](request: Req)(processResponse: Req#Response => Unit): Unit = {
     // Safe to cast as we always create a response of the right type
     def callback(response: AsyncResponse): Unit = processResponse(response.asInstanceOf[Req#Response])
 
@@ -308,6 +311,11 @@ class ZooKeeperClient(connectString: String,
 
   def sessionId: Long = inReadLock(initializationLock) {
     zooKeeper.getSessionId
+  }
+
+  // Only for testing
+  private[zookeeper] def currentZooKeeper: ZooKeeper = inReadLock(initializationLock) {
+    zooKeeper
   }
   
   private def initialize(): Unit = {

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -19,7 +19,7 @@ package kafka.zookeeper
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{ArrayBlockingQueue, CountDownLatch, Semaphore, TimeUnit}
+import java.util.concurrent.{ArrayBlockingQueue, ConcurrentLinkedQueue, CountDownLatch, Executors, Semaphore, TimeUnit}
 
 import com.yammer.metrics.Metrics
 import com.yammer.metrics.core.{Gauge, Meter, MetricName}
@@ -30,7 +30,7 @@ import org.apache.zookeeper.KeeperException.{Code, NoNodeException}
 import org.apache.zookeeper.Watcher.Event.{EventType, KeeperState}
 import org.apache.zookeeper.ZooKeeper.States
 import org.apache.zookeeper.{CreateMode, WatchedEvent, Watcher, ZooDefs, ZooKeeper}
-import org.junit.Assert.{assertArrayEquals, assertEquals, assertNull, assertTrue}
+import org.junit.Assert.{assertArrayEquals, assertEquals, assertFalse, assertNull, assertTrue}
 import org.junit.{After, Before, Test}
 
 import scala.collection.JavaConverters._
@@ -389,23 +389,64 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
     * Tests that if session expiry notification is received while a thread is processing requests,
     * session expiry is handled and the request thread completes with responses to all requests,
     * even though some requests may fail due to session expiry or disconnection.
+    *
+    * Sequence of events on different threads:
+    *   Request thread:
+    *       - Sends `maxInflightRequests` requests (these may complete before session is expired)
+    *   Main thread:
+    *       - Waits for at least one request to be processed (this should succeed)
+    *       - Expires session by creating new client with same session id
+    *       - Unblocks another `maxInflightRequests` requests before and after new client is closed (these may fail)
+    *   ZooKeeperClient Event thread:
+    *       - Delivers responses and session expiry (no ordering guarantee between these, both are processed asynchronously)
+    *   Response executor thread:
+    *       - Blocks subsequent sends by delaying response until session expiry is processed
+    *   ZooKeeperClient Session Expiry Handler:
+    *       - Unblocks subsequent sends
+    *   Main thread:
+    *       - Waits for all sends to complete. The requests sent after session expiry processing should succeed.
     */
   @Test
   def testSessionExpiry(): Unit = {
     val maxInflightRequests = 2
-    val requestThreadSemaphore = new Semaphore(0)
-    val sessionExpireSemaphore = new Semaphore(maxInflightRequests + 1) // expire after a few requests
-    val sendSize = maxInflightRequests * 50
+    val responseExecutor = Executors.newSingleThreadExecutor
+    val sendSemaphore = new Semaphore(0)
+    val sendCompleteSemaphore = new Semaphore(0)
+    val sendSize = maxInflightRequests * 5
     @volatile var resultCodes: Seq[Code] = null
+    val stateChanges = new ConcurrentLinkedQueue[String]()
     val zooKeeperClient = new ZooKeeperClient(zkConnect, zkSessionTimeout, zkConnectionTimeout, maxInflightRequests,
       time, "testGroupType", "testGroupName") {
       override def send[Req <: AsyncRequest](request: Req)(processResponse: Req#Response => Unit): Unit = {
-        requestThreadSemaphore.release()
-        super.send(request)(processResponse)
-        sessionExpireSemaphore.acquire()
+        super.send(request)( response => {
+          responseExecutor.submit(new Runnable {
+            override def run(): Unit = {
+              sendCompleteSemaphore.release()
+              sendSemaphore.acquire()
+              processResponse(response)
+            }
+          })
+        })
       }
     }
     try {
+      zooKeeperClient.registerStateChangeHandler(new StateChangeHandler {
+        override val name: String ="test-state-change-handler"
+        override def afterInitializingSession(): Unit = {
+          verifyHandlerThread()
+          stateChanges.add("afterInitializingSession")
+        }
+        override def beforeInitializingSession(): Unit = {
+          verifyHandlerThread()
+          stateChanges.add("beforeInitializingSession")
+          sendSemaphore.release(sendSize) // Resume remaining sends
+        }
+        private def verifyHandlerThread(): Unit = {
+          val threadName = Thread.currentThread.getName
+          assertTrue(s"Unexpected thread + $threadName", threadName.startsWith(zooKeeperClient.expiryScheduler.threadNamePrefix))
+        }
+      })
+
       val requestThread = new Thread {
         override def run(): Unit = {
           val requests = (1 to sendSize).map(i => GetDataRequest(s"/$i"))
@@ -413,8 +454,7 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
         }
       }
       requestThread.start()
-      requestThreadSemaphore.acquire() // Wait for request thread to start processng requests
-      sessionExpireSemaphore.release(sendSize) // Resume request thread before expiring session
+      sendCompleteSemaphore.acquire() // Wait for request thread to start processing requests
 
       // Trigger session expiry by reusing the session id in another client
       val dummyWatcher = new Watcher {
@@ -424,20 +464,33 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
         zooKeeperClient.currentZooKeeper.getSessionId,
         zooKeeperClient.currentZooKeeper.getSessionPasswd)
       assertNull(anotherZkClient.exists("/nonexistent", false)) // Make sure new client works
+      sendSemaphore.release(maxInflightRequests) // Resume a few more sends which may fail
       anotherZkClient.close()
+      sendSemaphore.release(maxInflightRequests) // Resume a few more sends which may fail
 
       requestThread.join(10000)
       if (requestThread.isAlive) {
         requestThread.interrupt()
         fail("Request thread did not complete")
       }
+      assertEquals(Seq("beforeInitializingSession", "afterInitializingSession"), stateChanges.asScala.toSeq)
 
       assertEquals(resultCodes.size, sendSize)
+      val connectionLostCount = resultCodes.count(_ == Code.CONNECTIONLOSS)
+      assertTrue(s"Unexpected connection lost requests $resultCodes", connectionLostCount <= maxInflightRequests)
       val expiredCount = resultCodes.count(_ == Code.SESSIONEXPIRED)
-      assertTrue(s"Unexpected session expired requests $resultCodes", expiredCount > 0 && expiredCount <= maxInflightRequests)
+      assertTrue(s"Unexpected session expired requests $resultCodes", expiredCount <= maxInflightRequests)
+      assertTrue(s"No connection lost or expired requests $resultCodes", connectionLostCount + expiredCount > 0)
+      assertEquals(Code.NONODE, resultCodes.head)
       assertEquals(Code.NONODE, resultCodes.last)
+      assertTrue(s"Unexpected result code $resultCodes",
+        resultCodes.filterNot(Set(Code.NONODE, Code.SESSIONEXPIRED, Code.CONNECTIONLOSS).contains).isEmpty)
 
-    } finally zooKeeperClient.close()
+    } finally {
+      zooKeeperClient.close()
+      responseExecutor.shutdownNow()
+    }
+    assertFalse("Expiry executor not shutdown", zooKeeperClient.expiryScheduler.isStarted)
   }
 
   def isExpectedMetricName(metricName: MetricName, name: String): Boolean =


### PR DESCRIPTION
`ZooKeeperClient` acquires `initializationLock#writeLock` to establish a new connection while processing session expiry WatchEvent. `ZooKeeperClient#handleRequests` acquires  `initializationLock#readLock`, allowing multiple batches of requests to be processed concurrently, but preventing reconnections while processing requests. At the moment, `handleRequests` holds onto the readLock throughout the method, even while waiting for responses and inflight requests to complete. But responses cannot be delivered if event thread is blocked on the writeLock to process session expiry event. This results in a deadlock. During broker shutdown, the shutdown thread is also blocked since it needs the readLock to perform `ZooKeeperClient#unregisterStateChangeHandler`, which cannot be acquired if a session expiry had occurred earlier since this thread gets queued behind the event handler thread waiting for writeLock.

This PR fixes the issue by limiting locking in `ZooKeeperClient#handleRequests` to just the non-blocking send, so that session expiry handling doesn't get blocked.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
