### PR TITLE
KAFKA-4651: improve test coverage of stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSessionStore.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionKeySerde;
@@ -37,33 +36,6 @@ public class RocksDBSessionStore<K, AGG> extends WrappedStateStore.AbstractState
 
     protected StateSerdes<K, AGG> serdes;
     protected String topic;
-
-    // this is optimizing the case when this store is already a bytes store, in which we can avoid Bytes.wrap() costs
-    private static class RocksDBSessionBytesStore extends RocksDBSessionStore<Bytes, byte[]> {
-        RocksDBSessionBytesStore(final SegmentedBytesStore inner) {
-            super(inner, Serdes.Bytes(), Serdes.ByteArray());
-        }
-
-        @Override
-        public KeyValueIterator<Windowed<Bytes>, byte[]> findSessions(final Bytes key, final long earliestSessionEndTime, final long latestSessionStartTime) {
-            final KeyValueIterator<Bytes, byte[]> bytesIterator = bytesStore.fetch(key, earliestSessionEndTime, latestSessionStartTime);
-            return WrappedSessionStoreIterator.bytesIterator(bytesIterator, serdes);
-        }
-
-        @Override
-        public void remove(final Windowed<Bytes> key) {
-            bytesStore.remove(SessionKeySerde.bytesToBinary(key));
-        }
-
-        @Override
-        public void put(final Windowed<Bytes> sessionKey, final byte[] aggregate) {
-            bytesStore.put(SessionKeySerde.bytesToBinary(sessionKey), aggregate);
-        }
-    }
-
-    static RocksDBSessionStore<Bytes, byte[]> bytesStore(final SegmentedBytesStore inner) {
-        return new RocksDBSessionBytesStore(inner);
-    }
 
     RocksDBSessionStore(final SegmentedBytesStore bytesStore,
                         final Serde<K> keySerde,

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -363,28 +363,6 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         return rocksDbIterator;
     }
 
-    public synchronized KeyValue<Bytes, byte[]> first() {
-        validateStoreOpen();
-
-        final RocksIterator innerIter = db.newIterator();
-        innerIter.seekToFirst();
-        final KeyValue<Bytes, byte[]> pair = new KeyValue<>(new Bytes(innerIter.key()), innerIter.value());
-        innerIter.close();
-
-        return pair;
-    }
-
-    public synchronized KeyValue<Bytes, byte[]> last() {
-        validateStoreOpen();
-
-        final RocksIterator innerIter = db.newIterator();
-        innerIter.seekToLast();
-        final KeyValue<Bytes, byte[]> pair = new KeyValue<>(new Bytes(innerIter.key()), innerIter.value());
-        innerIter.close();
-
-        return pair;
-    }
-
     /**
      * Return an approximate count of key-value mappings in this store.
      *

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -30,12 +30,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public abstract class AbstractKeyValueStoreTest {
@@ -340,5 +346,32 @@ public abstract class AbstractKeyValueStoreTest {
         store.put(5, "five");
         store.flush();
         assertEquals(5, store.approximateNumEntries());
+    }
+
+    @Test
+    public void shouldPutAll() {
+        List<KeyValue<Integer, String>> entries = new ArrayList<>();
+        entries.add(new KeyValue<>(1, "one"));
+        entries.add(new KeyValue<>(2, "two"));
+
+        store.putAll(entries);
+
+        final List<KeyValue<Integer, String>> allReturned = new ArrayList<>();
+        final List<KeyValue<Integer, String>> expectedReturned = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
+        final Iterator<KeyValue<Integer, String>> iterator = store.all();
+
+        while (iterator.hasNext()) {
+            allReturned.add(iterator.next());
+        }
+        assertThat(allReturned, equalTo(expectedReturned));
+
+    }
+
+    @Test
+    public void shouldDeleteFromStore() {
+        store.put(1, "one");
+        store.put(2, "two");
+        store.delete(2);
+        assertNull(store.get(2));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStoreTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
@@ -26,21 +27,31 @@ import org.apache.kafka.streams.state.Stores;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 public class InMemoryKeyValueLoggedStoreTest extends AbstractKeyValueStoreTest {
+
+    private final Serde<String> stringSerde = Serdes.String();
+    private final Serde<Integer> integerSerde = Serdes.Integer();
 
     @SuppressWarnings("unchecked")
     @Override
     protected <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context) {
         final StoreBuilder storeBuilder = Stores.keyValueStoreBuilder(
-                Stores.inMemoryKeyValueStore("my-store"),
-                (Serde<K>) context.keySerde(),
-                (Serde<V>) context.valueSerde())
-                .withLoggingEnabled(Collections.singletonMap("retention.ms", "1000"));
+            Stores.inMemoryKeyValueStore("my-store"),
+            (Serde<K>) context.keySerde(),
+            (Serde<V>) context.valueSerde())
+            .withLoggingEnabled(Collections.singletonMap("retention.ms", "1000"));
 
         final StateStore store = storeBuilder.build();
         store.init(context, store);
@@ -56,5 +67,148 @@ public class InMemoryKeyValueLoggedStoreTest extends AbstractKeyValueStoreTest {
         store.putAll(entries);
         assertEquals(store.get(1), "1");
         assertEquals(store.get(2), "2");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldRemoveLeastUsedEntry() {
+
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(2, integerSerde, stringSerde);
+
+        inMemoryKeyValueLoggedStore.put(1, "one");
+        inMemoryKeyValueLoggedStore.put(2, "two");
+        inMemoryKeyValueLoggedStore.get(1);
+        inMemoryKeyValueLoggedStore.put(3, "three");
+
+        assertThat(inMemoryKeyValueLoggedStore.get(2), nullValue());
+        assertThat(inMemoryKeyValueLoggedStore.get(1), is("one"));
+        assertThat(inMemoryKeyValueLoggedStore.get(3), is("three"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shouldUseContextSerdeWhenNoneProvided() {
+
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(2, null, null);
+
+        inMemoryKeyValueLoggedStore.put(1, "one");
+        inMemoryKeyValueLoggedStore.put(2, "two");
+
+        // still able to access data in store and deserialize using context Serde
+        assertThat(inMemoryKeyValueLoggedStore.get(2), is("two"));
+        assertThat(inMemoryKeyValueLoggedStore.get(1), is("one"));
+    }
+
+    @Test
+    public void shouldReturnCorrectApproximateNumberOfEntries() {
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(3, integerSerde, stringSerde);
+
+        inMemoryKeyValueLoggedStore.put(1, "one");
+        inMemoryKeyValueLoggedStore.put(2, "two");
+        inMemoryKeyValueLoggedStore.put(3, "three");
+
+        assertThat(inMemoryKeyValueLoggedStore.approximateNumEntries(), is(3L));
+    }
+
+    @Test
+    public void shouldReturnAll() {
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(3, integerSerde, stringSerde);
+        inMemoryKeyValueLoggedStore.put(1, "one");
+        inMemoryKeyValueLoggedStore.put(2, "two");
+        inMemoryKeyValueLoggedStore.put(3, "three");
+
+        final List<KeyValue<Integer, String>> allReturned = new ArrayList<>();
+        final List<KeyValue<Integer, String>> expectedReturned = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"), KeyValue.pair(3, "three"));
+        final Iterator<KeyValue<Integer, String>> iterator = inMemoryKeyValueLoggedStore.all();
+
+        while (iterator.hasNext()) {
+            allReturned.add(iterator.next());
+        }
+
+        assertThat(allReturned, equalTo(expectedReturned));
+    }
+
+    @Test
+    public void shouldPutAllInLoggedStore() {
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(3, integerSerde, stringSerde);
+        final List<KeyValue<Integer, String>> allReturned = new ArrayList<>();
+        final List<KeyValue<Integer, String>> initialPutAll = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"), KeyValue.pair(3, "three"));
+
+        inMemoryKeyValueLoggedStore.putAll(initialPutAll);
+
+        final Iterator<KeyValue<Integer, String>> iterator = inMemoryKeyValueLoggedStore.all();
+
+        while (iterator.hasNext()) {
+            allReturned.add(iterator.next());
+        }
+        assertThat(allReturned, equalTo(initialPutAll));
+    }
+
+    @Test
+    public void shouldPutIfAbsentValidUpdate() {
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(3, integerSerde, stringSerde);
+        String returnedValue = inMemoryKeyValueLoggedStore.putIfAbsent(1, "one");
+        // null not previously in store
+        assertNull(returnedValue);
+
+        String attemptedUpdate = inMemoryKeyValueLoggedStore.putIfAbsent(1, "one-more");
+
+        // already in store so sticking with original value, no update
+        assertThat(attemptedUpdate, equalTo("one"));
+    }
+
+
+    @Test
+    public void shouldReturnRange() {
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(3, integerSerde, stringSerde);
+        final List<KeyValue<Integer, String>> allReturnedRange = new ArrayList<>();
+        final List<KeyValue<Integer, String>>
+            initialPutAll =
+            Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"), KeyValue.pair(3, "three"), KeyValue.pair(4, "four"));
+
+        final List<KeyValue<Integer, String>> expectedRange = Arrays.asList(KeyValue.pair(3, "three"), KeyValue.pair(4, "four"));
+        inMemoryKeyValueLoggedStore.putAll(initialPutAll);
+
+        final Iterator<KeyValue<Integer, String>> iterator = inMemoryKeyValueLoggedStore.range(3, 4);
+
+        while (iterator.hasNext()) {
+            allReturnedRange.add(iterator.next());
+        }
+        assertThat(allReturnedRange, equalTo(expectedRange));
+    }
+
+    @Test
+    public void shouldDeleteFromStore() {
+        final InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = getInMemoryLoggedStore(3, integerSerde, stringSerde);
+
+        inMemoryKeyValueLoggedStore.put(1, "one");
+        inMemoryKeyValueLoggedStore.put(2, "two");
+        inMemoryKeyValueLoggedStore.put(3, "three");
+
+        String deletedValue = inMemoryKeyValueLoggedStore.delete(2);
+
+        assertThat(deletedValue, is("two"));
+        assertThat(inMemoryKeyValueLoggedStore.get(2), nullValue());
+    }
+
+
+    @SuppressWarnings("unchecked")
+    private KeyValueStore<Integer, String> getLruCacheInnerStore(final int size,
+                                                                 final Serde<Integer> integerSerde,
+                                                                 final Serde<String> stringSerde) {
+
+        return new MemoryNavigableLRUCache("test-cache", size, integerSerde, stringSerde);
+
+    }
+
+    private InMemoryKeyValueLoggedStore<Integer, String> getInMemoryLoggedStore(final int innerSize,
+                                                                                final Serde<Integer> integerSerde,
+                                                                                final Serde<String> stringSerde) {
+
+        final KeyValueStore<Integer, String> inner = getLruCacheInnerStore(innerSize, integerSerde, stringSerde);
+        InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore = new InMemoryKeyValueLoggedStore<>(inner, integerSerde, stringSerde);
+        inMemoryKeyValueLoggedStore.init(context, inner);
+
+        return inMemoryKeyValueLoggedStore;
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/InMemoryKeyValueLoggedStoreTest.java
@@ -17,37 +17,15 @@
 package org.apache.kafka.streams.state.internals;
 
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.test.KeyValueIteratorStub;
-import org.easymock.EasyMock;
-import org.junit.Before;
-import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
 
 public class InMemoryKeyValueLoggedStoreTest extends AbstractKeyValueStoreTest {
-
-
-    private KeyValueStore<Integer, String> innerKeyValueStore = EasyMock.createNiceMock(KeyValueStore.class);
-    private InMemoryKeyValueLoggedStore<Integer, String> inMemoryKeyValueLoggedStore;
-
-    private final Serde<String> stringSerde = Serdes.String();
-    private final Serde<Integer> integerSerde = Serdes.Integer();
-
 
     @SuppressWarnings("unchecked")
     @Override
@@ -63,151 +41,4 @@ public class InMemoryKeyValueLoggedStoreTest extends AbstractKeyValueStoreTest {
 
         return (KeyValueStore<K, V>) store;
     }
-
-    @Before
-    public void setUp() {
-        innerKeyValueStore.init(EasyMock.isA(ProcessorContext.class), EasyMock.isA(StateStore.class));
-        EasyMock.expect(innerKeyValueStore.name()).andReturn("inner-store").times(2);
-        inMemoryKeyValueLoggedStore = new InMemoryKeyValueLoggedStore<>(innerKeyValueStore, integerSerde, stringSerde);
-    }
-
-    @Test
-    public void shouldPutAll() {
-        List<KeyValue<Integer, String>> entries = new ArrayList<>();
-        entries.add(new KeyValue<>(1, "1"));
-        entries.add(new KeyValue<>(2, "2"));
-
-        innerKeyValueStore.putAll(entries);
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-        inMemoryKeyValueLoggedStore.putAll(entries);
-        EasyMock.verify(innerKeyValueStore);
-    }
-
-    @Test
-    public void shouldReturnCorrectApproximateNumberOfEntries() {
-        innerKeyValueStore.put(1, "one");
-        innerKeyValueStore.put(2, "two");
-        EasyMock.expect(innerKeyValueStore.approximateNumEntries()).andReturn(2L);
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-        inMemoryKeyValueLoggedStore.put(1, "one");
-        inMemoryKeyValueLoggedStore.put(2, "two");
-
-        assertThat(inMemoryKeyValueLoggedStore.approximateNumEntries(), is(2L));
-        EasyMock.verify(innerKeyValueStore);
-    }
-
-    @Test
-    public void shouldReturnAll() {
-        final KeyValueIteratorStub<Integer, String>
-            iteratorStub =
-            new KeyValueIteratorStub<>(Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two")).iterator());
-        innerKeyValueStore.put(1, "one");
-        innerKeyValueStore.put(2, "two");
-        EasyMock.expect(innerKeyValueStore.all()).andReturn(iteratorStub);
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-        inMemoryKeyValueLoggedStore.put(1, "one");
-        inMemoryKeyValueLoggedStore.put(2, "two");
-
-        final List<KeyValue<Integer, String>> allReturned = new ArrayList<>();
-        final List<KeyValue<Integer, String>> expectedReturned = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
-        final Iterator<KeyValue<Integer, String>> iterator = inMemoryKeyValueLoggedStore.all();
-
-        while (iterator.hasNext()) {
-            allReturned.add(iterator.next());
-        }
-
-        assertThat(allReturned, equalTo(expectedReturned));
-        EasyMock.verify(innerKeyValueStore);
-    }
-
-    @Test
-    public void shouldPutAllInLoggedStore() {
-        final KeyValueIteratorStub<Integer, String>
-            iteratorStub =
-            new KeyValueIteratorStub<>(Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two")).iterator());
-        innerKeyValueStore.putAll(Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two")));
-        EasyMock.expect(innerKeyValueStore.all()).andReturn(iteratorStub);
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-
-        final List<KeyValue<Integer, String>> allReturned = new ArrayList<>();
-        final List<KeyValue<Integer, String>> initialPutAll = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
-
-        inMemoryKeyValueLoggedStore.putAll(initialPutAll);
-
-        final Iterator<KeyValue<Integer, String>> iterator = inMemoryKeyValueLoggedStore.all();
-
-        while (iterator.hasNext()) {
-            allReturned.add(iterator.next());
-        }
-        assertThat(allReturned, equalTo(initialPutAll));
-        EasyMock.verify(innerKeyValueStore);
-    }
-
-    @Test
-    public void shouldPutIfAbsentValidUpdate() {
-        EasyMock.expect(innerKeyValueStore.putIfAbsent(1, "one")).andReturn(null);
-        EasyMock.expect(innerKeyValueStore.putIfAbsent(1, "one-more")).andReturn("one");
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-        inMemoryKeyValueLoggedStore.putIfAbsent(1, "one");
-
-        inMemoryKeyValueLoggedStore.putIfAbsent(1, "one-more");
-
-        EasyMock.verify(innerKeyValueStore);
-    }
-
-
-    @Test
-    public void shouldReturnRange() {
-        final List<KeyValue<Integer, String>> keyValueList = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
-        final KeyValueIteratorStub<Integer, String> iteratorStub = new KeyValueIteratorStub<>(keyValueList.iterator());
-        innerKeyValueStore.putAll(keyValueList);
-
-        EasyMock.expect(innerKeyValueStore.range(1, 2)).andReturn(iteratorStub);
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-
-        final List<KeyValue<Integer, String>> allReturnedRange = new ArrayList<>();
-        final List<KeyValue<Integer, String>>
-            initialPutAll =
-            Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
-
-        final List<KeyValue<Integer, String>> expectedRange = Arrays.asList(KeyValue.pair(1, "one"), KeyValue.pair(2, "two"));
-        inMemoryKeyValueLoggedStore.putAll(initialPutAll);
-
-        final Iterator<KeyValue<Integer, String>> iterator = inMemoryKeyValueLoggedStore.range(1, 2);
-
-        while (iterator.hasNext()) {
-            allReturnedRange.add(iterator.next());
-        }
-        assertThat(allReturnedRange, equalTo(expectedRange));
-        EasyMock.verify(innerKeyValueStore);
-    }
-
-    @Test
-    public void shouldDeleteFromStore() {
-        innerKeyValueStore.put(1, "one");
-        innerKeyValueStore.put(2, "two");
-        EasyMock.expect(innerKeyValueStore.delete(2)).andReturn("two");
-        EasyMock.replay(innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.init(context, innerKeyValueStore);
-
-        inMemoryKeyValueLoggedStore.put(1, "one");
-        inMemoryKeyValueLoggedStore.put(2, "two");
-
-        inMemoryKeyValueLoggedStore.delete(2);
-        EasyMock.verify(innerKeyValueStore);
-    }
-
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredKeyValueBytesStoreTest.java
@@ -193,6 +193,20 @@ public class MeteredKeyValueBytesStoreTest {
         EasyMock.verify(inner);
     }
 
+    @Test
+    public void shouldFlushInnerWhenFlushTimeRecords() {
+        inner.flush();
+        EasyMock.expectLastCall().once();
+        init();
+
+        metered.flush();
+
+        final KafkaMetric metric = metric("flush-rate");
+        assertTrue(metric.value() > 0);
+        EasyMock.verify(inner);
+    }
+
+
     private KafkaMetric metric(final MetricName metricName) {
         return this.metrics.metric(metricName);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +50,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -62,13 +62,13 @@ public class RocksDBStoreTest {
 
     private Serializer<String> stringSerializer = new StringSerializer();
     private Deserializer<String> stringDeserializer = new StringDeserializer();
-    private RocksDBStore subject;
+    private RocksDBStore rocksDBStore;
     private MockProcessorContext context;
     private File dir;
 
     @Before
     public void setUp() {
-        subject = new RocksDBStore("test");
+        rocksDBStore = new RocksDBStore("test");
         dir = TestUtils.tempDirectory();
         context = new MockProcessorContext(dir,
             Serdes.String(),
@@ -79,18 +79,18 @@ public class RocksDBStoreTest {
 
     @After
     public void tearDown() {
-        subject.close();
+        rocksDBStore.close();
     }
 
     @Test
     public void shouldNotThrowExceptionOnRestoreWhenThereIsPreExistingRocksDbFiles() throws Exception {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
 
         final String message = "how can a 4 ounce bird carry a 2lb coconut";
         int intKey = 1;
         for (int i = 0; i < 2000000; i++) {
-            subject.put(new Bytes(stringSerializer.serialize(null, "theKeyIs" + intKey++)),
-                stringSerializer.serialize(null, message));
+            rocksDBStore.put(new Bytes(stringSerializer.serialize(null, "theKeyIs" + intKey++)),
+                             stringSerializer.serialize(null, message));
         }
 
         final List<KeyValue<byte[], byte[]>> restoreBytes = new ArrayList<>();
@@ -104,7 +104,7 @@ public class RocksDBStoreTest {
         assertThat(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "restoredKey")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "restoredKey")))),
             equalTo("restoredValue"));
     }
 
@@ -115,7 +115,7 @@ public class RocksDBStoreTest {
         configs.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "test-server:9092");
         configs.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
         MockRocksDbConfigSetter.called = false;
-        subject.openDB(new MockProcessorContext(tempDir, new StreamsConfig(configs)));
+        rocksDBStore.openDB(new MockProcessorContext(tempDir, new StreamsConfig(configs)));
 
         assertTrue(MockRocksDbConfigSetter.called);
     }
@@ -130,7 +130,7 @@ public class RocksDBStoreTest {
             new ThreadCache(new LogContext("testCache "), 0, new MockStreamsMetrics(new Metrics())));
         tmpDir.setReadOnly();
 
-        subject.openDB(tmpContext);
+        rocksDBStore.openDB(tmpContext);
     }
 
     @Test
@@ -146,123 +146,123 @@ public class RocksDBStoreTest {
             new Bytes(stringSerializer.serialize(null, "3")),
             stringSerializer.serialize(null, "c")));
 
-        subject.init(context, subject);
-        subject.putAll(entries);
-        subject.flush();
+        rocksDBStore.init(context, rocksDBStore);
+        rocksDBStore.putAll(entries);
+        rocksDBStore.flush();
 
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "1")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))),
             "a");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "2")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "2")))),
             "b");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "3")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))),
             "c");
     }
 
     @Test
     public void shouldTogglePrepareForBulkloadSetting() {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         RocksDBStore.RocksDBBatchingRestoreCallback restoreListener =
-            (RocksDBStore.RocksDBBatchingRestoreCallback) subject.batchingStateRestoreCallback;
+            (RocksDBStore.RocksDBBatchingRestoreCallback) rocksDBStore.batchingStateRestoreCallback;
 
         restoreListener.onRestoreStart(null, null, 0, 0);
-        assertTrue("Should have set bulk loading to true", subject.isPrepareForBulkload());
+        assertTrue("Should have set bulk loading to true", rocksDBStore.isPrepareForBulkload());
 
         restoreListener.onRestoreEnd(null, null, 0);
-        assertFalse("Should have set bulk loading to false", subject.isPrepareForBulkload());
+        assertFalse("Should have set bulk loading to false", rocksDBStore.isPrepareForBulkload());
     }
 
     @Test
     public void shouldTogglePrepareForBulkloadSettingWhenPrexistingSstFiles() throws Exception {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
 
-        subject.init(context, subject);
-        context.restore(subject.name(), entries);
+        rocksDBStore.init(context, rocksDBStore);
+        context.restore(rocksDBStore.name(), entries);
 
         RocksDBStore.RocksDBBatchingRestoreCallback restoreListener =
-            (RocksDBStore.RocksDBBatchingRestoreCallback) subject.batchingStateRestoreCallback;
+            (RocksDBStore.RocksDBBatchingRestoreCallback) rocksDBStore.batchingStateRestoreCallback;
 
         restoreListener.onRestoreStart(null, null, 0, 0);
-        assertTrue("Should have not set bulk loading to true", subject.isPrepareForBulkload());
+        assertTrue("Should have not set bulk loading to true", rocksDBStore.isPrepareForBulkload());
 
         restoreListener.onRestoreEnd(null, null, 0);
-        assertFalse("Should have set bulk loading to false", subject.isPrepareForBulkload());
+        assertFalse("Should have set bulk loading to false", rocksDBStore.isPrepareForBulkload());
     }
 
     @Test
     public void shouldRestoreAll() throws Exception {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
 
-        subject.init(context, subject);
-        context.restore(subject.name(), entries);
+        rocksDBStore.init(context, rocksDBStore);
+        context.restore(rocksDBStore.name(), entries);
 
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "1")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))),
             "a");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "2")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "2")))),
             "b");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "3")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))),
             "c");
     }
 
     @Test
     public void shouldPutOnlyIfAbsentValue() throws Exception {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         final Bytes keyBytes = new Bytes(stringSerializer.serialize(null, "one"));
         final byte[] valueBytes = stringSerializer.serialize(null, "A");
         final byte[] valueBytesUpdate = stringSerializer.serialize(null, "B");
 
-        subject.putIfAbsent(keyBytes, valueBytes);
-        subject.putIfAbsent(keyBytes, valueBytesUpdate);
+        rocksDBStore.putIfAbsent(keyBytes, valueBytes);
+        rocksDBStore.putIfAbsent(keyBytes, valueBytesUpdate);
 
-        final String retrievedValue = stringDeserializer.deserialize(null, subject.get(keyBytes));
-        assertTrue(retrievedValue.equals("A"));
+        final String retrievedValue = stringDeserializer.deserialize(null, rocksDBStore.get(keyBytes));
+        assertEquals(retrievedValue, "A");
     }
 
     @Test
     public void shouldRetrieveFirstValue() throws Exception {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
 
-        subject.init(context, subject);
-        context.restore(subject.name(), entries);
+        rocksDBStore.init(context, rocksDBStore);
+        context.restore(rocksDBStore.name(), entries);
 
         final KeyValue<byte[], byte[]> keyValue = entries.get(0);
         final KeyValue<Bytes, byte[]> expectedKeyValue = KeyValue.pair(new Bytes(keyValue.key), keyValue.value);
-        final KeyValue<Bytes, byte[]> firstRetrievedEntry = subject.first();
+        final KeyValue<Bytes, byte[]> firstRetrievedEntry = rocksDBStore.first();
 
-        assertTrue(Arrays.equals(expectedKeyValue.key.get(), firstRetrievedEntry.key.get()));
-        assertTrue(Arrays.equals(expectedKeyValue.value, firstRetrievedEntry.value));
+        assertArrayEquals(expectedKeyValue.key.get(), firstRetrievedEntry.key.get());
+        assertArrayEquals(expectedKeyValue.value, firstRetrievedEntry.value);
     }
 
     @Test
     public void shouldRetrieveLastValue() throws Exception {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
 
-        subject.init(context, subject);
-        context.restore(subject.name(), entries);
+        rocksDBStore.init(context, rocksDBStore);
+        context.restore(rocksDBStore.name(), entries);
 
-        final KeyValue<byte[], byte[]> keyValue = entries.get(2);
+        final KeyValue<byte[], byte[]> keyValue = entries.get(entries.size() - 1);
         final KeyValue<Bytes, byte[]> expectedKeyValue = KeyValue.pair(new Bytes(keyValue.key), keyValue.value);
-        final KeyValue<Bytes, byte[]> lastRetrievedEntry = subject.last();
+        final KeyValue<Bytes, byte[]> lastRetrievedEntry = rocksDBStore.last();
 
-        assertTrue(Arrays.equals(expectedKeyValue.key.get(), lastRetrievedEntry.key.get()));
-        assertTrue(Arrays.equals(expectedKeyValue.value, lastRetrievedEntry.value));
+        assertArrayEquals(expectedKeyValue.key.get(), lastRetrievedEntry.key.get());
+        assertArrayEquals(expectedKeyValue.value, lastRetrievedEntry.value);
     }
 
 
@@ -271,10 +271,10 @@ public class RocksDBStoreTest {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
         entries.add(new KeyValue<>("1".getBytes("UTF-8"), (byte[]) null));
 
-        subject.init(context, subject);
-        context.restore(subject.name(), entries);
+        rocksDBStore.init(context, rocksDBStore);
+        context.restore(rocksDBStore.name(), entries);
 
-        final KeyValueIterator<Bytes, byte[]> iterator = subject.all();
+        final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all();
         final Set<String> keys = new HashSet<>();
 
         while (iterator.hasNext()) {
@@ -295,10 +295,10 @@ public class RocksDBStoreTest {
         // this will restore key "1" as WriteBatch applies updates in order
         entries.add(new KeyValue<>("1".getBytes("UTF-8"), "restored".getBytes("UTF-8")));
 
-        subject.init(context, subject);
-        context.restore(subject.name(), entries);
+        rocksDBStore.init(context, rocksDBStore);
+        context.restore(rocksDBStore.name(), entries);
 
-        final KeyValueIterator<Bytes, byte[]> iterator = subject.all();
+        final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all();
         final Set<String> keys = new HashSet<>();
 
         while (iterator.hasNext()) {
@@ -310,17 +310,17 @@ public class RocksDBStoreTest {
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "1")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))),
             "restored");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "2")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "2")))),
             "b");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "3")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))),
             "c");
     }
 
@@ -328,24 +328,24 @@ public class RocksDBStoreTest {
     public void shouldRestoreThenDeleteOnRestoreAll() throws Exception {
         final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
 
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
 
-        context.restore(subject.name(), entries);
+        context.restore(rocksDBStore.name(), entries);
 
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "1")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "1")))),
             "a");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "2")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "2")))),
             "b");
         assertEquals(
             stringDeserializer.deserialize(
                 null,
-                subject.get(new Bytes(stringSerializer.serialize(null, "3")))),
+                rocksDBStore.get(new Bytes(stringSerializer.serialize(null, "3")))),
             "c");
 
         entries.clear();
@@ -354,9 +354,9 @@ public class RocksDBStoreTest {
         entries.add(new KeyValue<>("3".getBytes("UTF-8"), "c".getBytes("UTF-8")));
         entries.add(new KeyValue<>("1".getBytes("UTF-8"), (byte[]) null));
 
-        context.restore(subject.name(), entries);
+        context.restore(rocksDBStore.name(), entries);
 
-        final KeyValueIterator<Bytes, byte[]> iterator = subject.all();
+        final KeyValueIterator<Bytes, byte[]> iterator = rocksDBStore.all();
         final Set<String> keys = new HashSet<>();
 
         while (iterator.hasNext()) {
@@ -370,57 +370,57 @@ public class RocksDBStoreTest {
 
     @Test
     public void shouldThrowNullPointerExceptionOnNullPut() {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         try {
-            subject.put(null, stringSerializer.serialize(null, "someVal"));
+            rocksDBStore.put(null, stringSerializer.serialize(null, "someVal"));
             fail("Should have thrown NullPointerException on null put()");
         } catch (NullPointerException e) { }
     }
 
     @Test
     public void shouldThrowNullPointerExceptionOnNullPutAll() {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         try {
-            subject.put(null, stringSerializer.serialize(null, "someVal"));
+            rocksDBStore.put(null, stringSerializer.serialize(null, "someVal"));
             fail("Should have thrown NullPointerException on null put()");
         } catch (NullPointerException e) { }
     }
 
     @Test
     public void shouldThrowNullPointerExceptionOnNullGet() {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         try {
-            subject.get(null);
+            rocksDBStore.get(null);
             fail("Should have thrown NullPointerException on null get()");
         } catch (NullPointerException e) { }
     }
 
     @Test
     public void shouldThrowNullPointerExceptionOnDelete() {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         try {
-            subject.delete(null);
+            rocksDBStore.delete(null);
             fail("Should have thrown NullPointerException on deleting null key");
         } catch (NullPointerException e) { }
     }
 
     @Test
     public void shouldThrowNullPointerExceptionOnRange() {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         try {
-            subject.range(null, new Bytes(stringSerializer.serialize(null, "2")));
+            rocksDBStore.range(null, new Bytes(stringSerializer.serialize(null, "2")));
             fail("Should have thrown NullPointerException on deleting null key");
         } catch (NullPointerException e) { }
     }
 
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateExceptionOnPutDeletedDir() throws IOException {
-        subject.init(context, subject);
+        rocksDBStore.init(context, rocksDBStore);
         Utils.delete(dir);
-        subject.put(
+        rocksDBStore.put(
             new Bytes(stringSerializer.serialize(null, "anyKey")),
             stringSerializer.serialize(null, "anyValue"));
-        subject.flush();
+        rocksDBStore.flush();
     }
 
     public static class MockRocksDbConfigSetter implements RocksDBConfigSetter {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -50,7 +50,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -234,37 +233,6 @@ public class RocksDBStoreTest {
         final String retrievedValue = stringDeserializer.deserialize(null, rocksDBStore.get(keyBytes));
         assertEquals(retrievedValue, "A");
     }
-
-    @Test
-    public void shouldRetrieveFirstValue() throws Exception {
-        final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
-
-        rocksDBStore.init(context, rocksDBStore);
-        context.restore(rocksDBStore.name(), entries);
-
-        final KeyValue<byte[], byte[]> keyValue = entries.get(0);
-        final KeyValue<Bytes, byte[]> expectedKeyValue = KeyValue.pair(new Bytes(keyValue.key), keyValue.value);
-        final KeyValue<Bytes, byte[]> firstRetrievedEntry = rocksDBStore.first();
-
-        assertArrayEquals(expectedKeyValue.key.get(), firstRetrievedEntry.key.get());
-        assertArrayEquals(expectedKeyValue.value, firstRetrievedEntry.value);
-    }
-
-    @Test
-    public void shouldRetrieveLastValue() throws Exception {
-        final List<KeyValue<byte[], byte[]>> entries = getKeyValueEntries();
-
-        rocksDBStore.init(context, rocksDBStore);
-        context.restore(rocksDBStore.name(), entries);
-
-        final KeyValue<byte[], byte[]> keyValue = entries.get(entries.size() - 1);
-        final KeyValue<Bytes, byte[]> expectedKeyValue = KeyValue.pair(new Bytes(keyValue.key), keyValue.value);
-        final KeyValue<Bytes, byte[]> lastRetrievedEntry = rocksDBStore.last();
-
-        assertArrayEquals(expectedKeyValue.key.get(), lastRetrievedEntry.key.get());
-        assertArrayEquals(expectedKeyValue.value, lastRetrievedEntry.value);
-    }
-
 
     @Test
     public void shouldHandleDeletesOnRestoreAll() throws Exception {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
@@ -135,8 +135,7 @@ public class SegmentsTest {
     @Test
     public void shouldGetCorrectSegmentString() {
         final Segment segment = segments.getOrCreateSegment(0, context);
-        String expectedSegmentString = "Segment(id=0, name=test.0)";
-        assertTrue(segment.toString().equals(expectedSegmentString));
+        assertEquals("Segment(id=0, name=test.0)", segment.toString());
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
@@ -133,6 +133,13 @@ public class SegmentsTest {
     }
 
     @Test
+    public void shouldGetCorrectSegmentString() {
+        final Segment segment = segments.getOrCreateSegment(0, context);
+        String expectedSegmentString = "Segment(id=0, name=test.0)";
+        assertTrue(segment.toString().equals(expectedSegmentString));
+    }
+
+    @Test
     public void shouldCloseAllOpenSegments() {
         final Segment first = segments.getOrCreateSegment(0, context);
         final Segment second = segments.getOrCreateSegment(1, context);


### PR DESCRIPTION
Working on increasing the coverage of stores in unit tests.  
Started with `InMemoryKeyValueLoggedStore` 
![screen shot 2018-02-09 at 1 15 11 pm](https://user-images.githubusercontent.com/199238/36044796-c7ddf31e-0da1-11e8-87a5-1d6727a5fe4d.png)
![screen shot 2018-02-09 at 1 24 38 pm](https://user-images.githubusercontent.com/199238/36044805-cd1bc23e-0da1-11e8-9b57-8f8bfa0a21ea.png)





### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
