### PR TITLE
MINOR: Simplify Node.hashCode and equals

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Node.java
+++ b/clients/src/main/java/org/apache/kafka/common/Node.java
@@ -100,13 +100,8 @@ public class Node {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((host == null) ? 0 : host.hashCode());
-        result = prime * result + id;
-        result = prime * result + port;
-        result = prime * result + ((rack == null) ? 0 : rack.hashCode());
-        return result;
+        // keep it cheap since this is called in performance sensitive parts of the code (e.g. RecordAccumulator.ready)
+        return id;
     }
 
     @Override
@@ -117,22 +112,9 @@ public class Node {
             return false;
         if (getClass() != obj.getClass())
             return false;
+        // keep it cheap since this is called in performance sensitive parts of the code (see `hashCode` comment)
         Node other = (Node) obj;
-        if (host == null) {
-            if (other.host != null)
-                return false;
-        } else if (!host.equals(other.host))
-            return false;
-        if (id != other.id)
-            return false;
-        if (port != other.port)
-            return false;
-        if (rack == null) {
-            if (other.rack != null)
-                return false;
-        } else if (!rack.equals(other.rack))
-            return false;
-        return true;
+        return id == other.id;
     }
 
     @Override


### PR DESCRIPTION
This can be a bottleneck in RecordAccumulator.ready if the number of
brokers and partitions is large enough. We just use the `id` since it
should be unique.

Originally reported in https://github.com/apache/kafka/pull/4350:

"Faced with the producer performance degradation in case of high
load and large number of brokers (100), topics (150) and partitions (350).
Made several diagnostic records with the java flight recorder and found that the method HashSet::contains in RecordAccumulator::ready takes about 40% of the whole time of the application. It is caused by re-calculating a hash code of a leader
(Node instance) for every batch entry."

That PR cached the hashCode, which still requires computing the
complex `hashCode` once and does not make `equals` cheap.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
