### PR TITLE
KAFKA-6536: Adding versions for japicmp-maven-plugin and maven-shade-plugin in

### DIFF
--- a/streams/quickstart/pom.xml
+++ b/streams/quickstart/pom.xml
@@ -64,6 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <phase/>
@@ -74,6 +75,7 @@
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
+                <version>0.11.0</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>


### PR DESCRIPTION
quickstart

*Added versions to japicmp-maven-plugin and maven-shade-plugin 
in quickstart pom.xml. Previously these versions were missing and
the latest versions of the plugins were automatically being used. 
I have explicitly set the version of each plugin to their latest.*
