### PR TITLE
KAFKA-6561: Change visibility of aclMatch in SimpleAclAuthorizer to allow access from subclasses

### DIFF
--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -143,7 +143,7 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
     } else false
   }
 
-  private def aclMatch(operations: Operation, resource: Resource, principal: KafkaPrincipal, host: String, permissionType: PermissionType, acls: Set[Acl]): Boolean = {
+  protected def aclMatch(operations: Operation, resource: Resource, principal: KafkaPrincipal, host: String, permissionType: PermissionType, acls: Set[Acl]): Boolean = {
     acls.find { acl =>
       acl.permissionType == permissionType &&
         (acl.principal == principal || acl.principal == Acl.WildCardPrincipal) &&


### PR DESCRIPTION
Currently the visibility of the aclMatch function in the SimpleAclAuthorizer class is set to private, thus prohibiting subclasses from overriding this method. I think this was originally done as this function is not supposed to be part of the public Api of this class, which makes sense.
However when creating a custom authorizer this would be a very useful method to override, as it allows to reuse a large amount of boilerplate code around loading and applying ACLs and simply changing the way that ACLs are matched.

By changing the visibility to _protected_ we allow subclasses to override this.
