### PR TITLE
MINOR: Free sends in MultiSend as they complete

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/MultiSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/MultiSend.java
@@ -37,6 +37,10 @@ public class MultiSend implements Send {
     private long totalWritten = 0;
     private Send current;
 
+    /**
+     * Construct a MultiSend for the given destination from a queue of Send objects. The queue will be
+     * consumed as the MultiSend progresses (on completion, it will be empty).
+     */
     public MultiSend(String dest, Queue<Send> sends) {
         this.dest = dest;
         this.sendQueue = sends;

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -359,7 +360,7 @@ public class FetchResponse extends AbstractResponse {
         responseHeaderStruct.writeTo(buffer);
         buffer.rewind();
 
-        List<Send> sends = new ArrayList<>();
+        LinkedList<Send> sends = new LinkedList<>();
         sends.add(new ByteBufferSend(dest, buffer));
         addResponseData(responseBodyStruct, throttleTimeMs, dest, sends);
         return new MultiSend(dest, sends);

--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchResponse.java
@@ -29,13 +29,14 @@ import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.record.Records;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 
 import static org.apache.kafka.common.protocol.CommonFields.ERROR_CODE;
 import static org.apache.kafka.common.protocol.CommonFields.PARTITION_ID;
@@ -360,7 +361,7 @@ public class FetchResponse extends AbstractResponse {
         responseHeaderStruct.writeTo(buffer);
         buffer.rewind();
 
-        LinkedList<Send> sends = new LinkedList<>();
+        Queue<Send> sends = new ArrayDeque<>();
         sends.add(new ByteBufferSend(dest, buffer));
         addResponseData(responseBodyStruct, throttleTimeMs, dest, sends);
         return new MultiSend(dest, sends);
@@ -394,7 +395,7 @@ public class FetchResponse extends AbstractResponse {
         return new FetchResponse(ApiKeys.FETCH.responseSchema(version).read(buffer));
     }
 
-    private static void addResponseData(Struct struct, int throttleTimeMs, String dest, List<Send> sends) {
+    private static void addResponseData(Struct struct, int throttleTimeMs, String dest, Queue<Send> sends) {
         Object[] allTopicData = struct.getArray(RESPONSES_KEY_NAME);
 
         if (struct.hasField(ERROR_CODE)) {
@@ -422,7 +423,7 @@ public class FetchResponse extends AbstractResponse {
             addTopicData(dest, sends, (Struct) topicData);
     }
 
-    private static void addTopicData(String dest, List<Send> sends, Struct topicData) {
+    private static void addTopicData(String dest, Queue<Send> sends, Struct topicData) {
         String topic = topicData.get(TOPIC_NAME);
         Object[] allPartitionData = topicData.getArray(PARTITIONS_KEY_NAME);
 
@@ -437,7 +438,7 @@ public class FetchResponse extends AbstractResponse {
             addPartitionData(dest, sends, (Struct) partitionData);
     }
 
-    private static void addPartitionData(String dest, List<Send> sends, Struct partitionData) {
+    private static void addPartitionData(String dest, Queue<Send> sends, Struct partitionData) {
         Struct header = partitionData.getStruct(PARTITION_HEADER_KEY_NAME);
         Records records = partitionData.getRecords(RECORD_SET_KEY_NAME);
 

--- a/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
@@ -40,7 +40,7 @@ public class MultiSendTest {
         ByteBuffer[] chunks = new ByteBuffer[numChunks];
 
         for (int i = 0; i < numChunks; i++) {
-            ByteBuffer buffer = ByteBuffer.wrap(TestUtils.randomBytes(32));
+            ByteBuffer buffer = ByteBuffer.wrap(TestUtils.randomBytes(chunkSize));
             chunks[i] = buffer;
             sends.add(new ByteBufferSend(dest, buffer));
         }

--- a/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
@@ -56,6 +56,7 @@ public class MultiSendTest {
             assertEquals(chunks[i], out.buffer());
         }
 
+        assertEquals(0, send.numResidentSends());
         assertTrue(send.completed());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.common.network;
 
-import org.apache.kafka.common.requests.ByteBufferChannel;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
@@ -51,7 +50,7 @@ public class MultiSendTest {
 
         for (int i = 0; i < numChunks; i++) {
             assertEquals(numChunks - i, send.numResidentSends());
-            ByteBufferChannel out = new NonOverflowingByteBufferChannel(chunkSize);
+            NonOverflowingByteBufferChannel out = new NonOverflowingByteBufferChannel(chunkSize);
             send.writeTo(out);
             out.close();
             assertEquals(chunks[i], out.buffer());
@@ -60,7 +59,7 @@ public class MultiSendTest {
         assertTrue(send.completed());
     }
 
-    private static class NonOverflowingByteBufferChannel extends ByteBufferChannel {
+    private static class NonOverflowingByteBufferChannel extends org.apache.kafka.common.requests.ByteBufferChannel {
 
         private NonOverflowingByteBufferChannel(long size) {
             super(size);

--- a/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/MultiSendTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.network;
+
+import org.apache.kafka.common.requests.ByteBufferChannel;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MultiSendTest {
+
+    @Test
+    public void testSendsFreedAfterWriting() throws IOException {
+        String dest = "1";
+        int numChunks = 4;
+        int chunkSize = 32;
+        int totalSize = numChunks * chunkSize;
+
+        Queue<Send> sends = new LinkedList<>();
+        ByteBuffer[] chunks = new ByteBuffer[numChunks];
+
+        for (int i = 0; i < numChunks; i++) {
+            ByteBuffer buffer = ByteBuffer.wrap(TestUtils.randomBytes(32));
+            chunks[i] = buffer;
+            sends.add(new ByteBufferSend(dest, buffer));
+        }
+
+        MultiSend send = new MultiSend(dest, sends);
+        assertEquals(totalSize, send.size());
+
+        for (int i = 0; i < numChunks; i++) {
+            assertEquals(numChunks - i, send.numResidentSends());
+            ByteBufferChannel out = new NonOverflowingByteBufferChannel(chunkSize);
+            send.writeTo(out);
+            out.close();
+            assertEquals(chunks[i], out.buffer());
+        }
+
+        assertTrue(send.completed());
+    }
+
+    private static class NonOverflowingByteBufferChannel extends ByteBufferChannel {
+
+        private NonOverflowingByteBufferChannel(long size) {
+            super(size);
+        }
+
+        @Override
+        public long write(ByteBuffer[] srcs) throws IOException {
+            // Instead of overflowing, this channel refuses additional writes once the buffer is full,
+            // which allows us to test the MultiSend behavior on a per-send basis.
+            if (!buffer().hasRemaining())
+                return 0;
+            return super.write(srcs);
+        }
+    }
+
+}


### PR DESCRIPTION
Currently we hold onto all Records references in a multi-partition
fetch response until the full response has completed. This can be
a problem when the records have been down-converted since they
will be occupying a potentially large chunk of memory. This patch
changes the behavior in MultiSend so that once a Send is completed,
we no longer keep a reference to it, which will allow the Records
objects to be freed sooner.

I have added a simple unit test to verify that sends are removed as the
MultiSend progresses.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
