### PR TITLE
MINOR: Restore scanning for super types of Connect plugins

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -273,7 +273,6 @@ public class DelegatingClassLoader extends URLClassLoader {
         builder.setClassLoaders(new ClassLoader[]{loader});
         builder.addUrls(urls);
         builder.setScanners(new SubTypesScanner());
-        builder.setExpandSuperTypes(false);
         builder.useParallelExecutor();
         Reflections reflections = new InternalReflections(builder);
 


### PR DESCRIPTION
Enabling scans for super types in reflections is required in order to discover Connect plugins.

Smoke tests, system tests, and manual testing. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
