### PR TITLE
KAFKA-6554; Missing lastOffsetDelta validation before log append

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/DefaultRecordBatch.java
@@ -106,7 +106,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
     static final int CRC_LENGTH = 4;
     static final int ATTRIBUTES_OFFSET = CRC_OFFSET + CRC_LENGTH;
     static final int ATTRIBUTE_LENGTH = 2;
-    static final int LAST_OFFSET_DELTA_OFFSET = ATTRIBUTES_OFFSET + ATTRIBUTE_LENGTH;
+    public static final int LAST_OFFSET_DELTA_OFFSET = ATTRIBUTES_OFFSET + ATTRIBUTE_LENGTH;
     static final int LAST_OFFSET_DELTA_LENGTH = 4;
     static final int FIRST_TIMESTAMP_OFFSET = LAST_OFFSET_DELTA_OFFSET + LAST_OFFSET_DELTA_LENGTH;
     static final int FIRST_TIMESTAMP_LENGTH = 8;
@@ -118,7 +118,7 @@ public class DefaultRecordBatch extends AbstractRecordBatch implements MutableRe
     static final int PRODUCER_EPOCH_LENGTH = 2;
     static final int BASE_SEQUENCE_OFFSET = PRODUCER_EPOCH_OFFSET + PRODUCER_EPOCH_LENGTH;
     static final int BASE_SEQUENCE_LENGTH = 4;
-    static final int RECORDS_COUNT_OFFSET = BASE_SEQUENCE_OFFSET + BASE_SEQUENCE_LENGTH;
+    public static final int RECORDS_COUNT_OFFSET = BASE_SEQUENCE_OFFSET + BASE_SEQUENCE_LENGTH;
     static final int RECORDS_COUNT_LENGTH = 4;
     static final int RECORDS_OFFSET = RECORDS_COUNT_OFFSET + RECORDS_COUNT_LENGTH;
     public static final int RECORD_BATCH_OVERHEAD = RECORDS_OFFSET;

--- a/core/src/main/scala/kafka/log/LogValidator.scala
+++ b/core/src/main/scala/kafka/log/LogValidator.scala
@@ -77,15 +77,16 @@ private[kafka] object LogValidator extends Logging {
       if (batch.magic >= RecordBatch.MAGIC_VALUE_V2) {
         val countFromOffsets = batch.lastOffset - batch.baseOffset + 1
         if (countFromOffsets <= 0)
-          throw new InvalidRecordException("Batch has an invalid offset range")
+          throw new InvalidRecordException(s"Batch has an invalid offset range: [${batch.baseOffset}, ${batch.lastOffset}]")
 
         // v2 and above messages always have a non-null count
         val count = batch.countOrNull
         if (count <= 0)
-          throw new InvalidRecordException("Invalid reported count for record batch")
+          throw new InvalidRecordException(s"Invalid reported count for record batch: $count")
 
         if (countFromOffsets != batch.countOrNull)
-          throw new InvalidRecordException("Inconsistent batch offset range and count of records")
+          throw new InvalidRecordException(s"Inconsistent batch offset range [${batch.baseOffset}, ${batch.lastOffset}] " +
+            s"and count of records $count")
       }
 
       if (batch.hasProducerId && batch.baseSequence < 0)

--- a/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogValidatorTest.scala
@@ -147,6 +147,61 @@ class LogValidatorTest {
       compressed = true)
   }
 
+  @Test(expected = classOf[InvalidRecordException])
+  def testTooSmallLastOffsetDelta() {
+    validateRecordBatchWithCountOverrides(lastOffsetDelta = 0)
+  }
+
+  @Test(expected = classOf[InvalidRecordException])
+  def testTooLargeLastOffsetDelta() {
+    validateRecordBatchWithCountOverrides(lastOffsetDelta = 15)
+  }
+
+  @Test(expected = classOf[InvalidRecordException])
+  def testNegativeLastOffsetDelta() {
+    validateRecordBatchWithCountOverrides(lastOffsetDelta = -3)
+  }
+
+  @Test(expected = classOf[InvalidRecordException])
+  def testNegativeRecordBatchCount() {
+    validateRecordBatchWithCountOverrides(count = -3)
+  }
+
+  @Test(expected = classOf[InvalidRecordException])
+  def testTooLargeRecordBatchCount() {
+    validateRecordBatchWithCountOverrides(count = 6)
+  }
+
+  @Test(expected = classOf[InvalidRecordException])
+  def testTooSmallRecordBatchCount() {
+    validateRecordBatchWithCountOverrides(count = 0)
+  }
+
+  @Test(expected = classOf[InvalidRecordException])
+  def testNegativeLastOffsetDeltaAndCount() {
+    validateRecordBatchWithCountOverrides(lastOffsetDelta = -3, count = -2)
+  }
+
+  def validateRecordBatchWithCountOverrides(lastOffsetDelta: Int = 2, count: Int = 3) {
+    val now = System.currentTimeMillis()
+    val records = createRecords(magicValue = RecordBatch.MAGIC_VALUE_V2, timestamp = 1234L, codec = CompressionType.NONE)
+    records.buffer.putInt(DefaultRecordBatch.RECORDS_COUNT_OFFSET, count)
+    records.buffer.putInt(DefaultRecordBatch.LAST_OFFSET_DELTA_OFFSET, lastOffsetDelta)
+    LogValidator.validateMessagesAndAssignOffsets(
+      records,
+      offsetCounter = new LongRef(0),
+      time = time,
+      now = now,
+      sourceCodec = DefaultCompressionCodec,
+      targetCodec = DefaultCompressionCodec,
+      compactedTopic = false,
+      magic = RecordBatch.MAGIC_VALUE_V2,
+      timestampType = TimestampType.LOG_APPEND_TIME,
+      timestampDiffMaxMs = 1000L,
+      partitionLeaderEpoch = RecordBatch.NO_PARTITION_LEADER_EPOCH,
+      isFromClient = true)
+  }
+
   @Test
   def testLogAppendTimeWithoutRecompressionV2() {
     checkLogAppendTimeWithoutRecompression(RecordBatch.MAGIC_VALUE_V2)


### PR DESCRIPTION
Add validation checks that the offset range is valid and aligned with the batch count prior to appending to the log. I've added several unit tests to verify the various invalid cases.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
