### PR TITLE
MINOR: use bash regex matching instead of egrep inside kafka-run-class.sh

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -38,10 +38,10 @@ should_include_file() {
     return 0
   fi
   file=$1
-  if [ -z "$(echo "$file" | egrep "$regex")" ] ; then
-    return 0
-  else
+  if [[ "$file" =~ $regex ]] ; then
     return 1
+  else
+    return 0
   fi
 }
 


### PR DESCRIPTION
It seems there is no reason to call egrep for each including jar since bash support regex matching.
The reason of why this change might be useful is that we use kafka-run-class.sh for healthcheck and have audit enabled for exec so every launch of healthcheck produces a lot of audit logs. Besides egrep is deprecated.