### PR TITLE
KAFKA-6332: Kafka system tests should use nc instead of log grep to d…

### DIFF
--- a/tests/kafkatest/services/monitor/jmx.py
+++ b/tests/kafkatest/services/monitor/jmx.py
@@ -18,6 +18,7 @@ import os
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.util import wait_until
 from kafkatest.version import get_version, V_0_11_0_0, DEV_BRANCH
+from kafkatest.utils.util import listening
 
 class JmxMixin(object):
     """This mixin helps existing service subclasses start JmxTool on their worker nodes and collect jmx stats.
@@ -59,10 +60,7 @@ class JmxMixin(object):
         # JmxTool is not particularly robust to slow-starting processes. In order to ensure JmxTool doesn't fail if the
         # process we're trying to monitor takes awhile before listening on the JMX port, wait until we can see that port
         # listening before even launching JmxTool
-        def check_jmx_port_listening():
-            return 0 == node.account.ssh("nc -z 127.0.0.1 %d" % self.jmx_port, allow_fail=True)
-
-        wait_until(check_jmx_port_listening, timeout_sec=30, backoff_sec=.1,
+        wait_until(lambda: listening(self.logger, node, self.jmx_port), timeout_sec=30, backoff_sec=.1,
                    err_msg="%s: Never saw JMX port for %s start listening" % (node.account, self))
 
         # To correctly wait for requested JMX metrics to be added we need the --wait option for JmxTool. This option was

--- a/tests/kafkatest/services/security/templates/minikdc.properties
+++ b/tests/kafkatest/services/security/templates/minikdc.properties
@@ -14,4 +14,5 @@
 # limitations under the License.
 
 kdc.bind.address=0.0.0.0
+kdc.port=11111
 


### PR DESCRIPTION
…etect start-up

- Extracted a new function (listening) in system test utils module to test whether a specified port on a specified node is listening for connections.
- Refactored system tests to use the new function to test whether a particular server is started / listening on a port (instead of grepping for lines in server logs). 
- Specified kdc.port for the MiniKdc server in minikdc.properties so that the server does not listen for connections on a "random" port.
- Fixed a typo in the documentation of the node_is_reachable function in utils/util.py

Testing done:
- Executed the following system tests:
sanity_checks tests,  simple_consumer_shell_test.py, consumer_group_command_test.py, trogdor_test.py, zookeeper_security_upgrade_test.py

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
