### PR TITLE
MINOR: Redirect response code in Connect's RestClient to logs instead of stdout

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -82,7 +82,9 @@ public class RestClient {
             req.method(method);
             req.accept("application/json");
             req.agent("kafka-connect");
-            req.content(new StringContentProvider(serializedBody, StandardCharsets.UTF_8), "application/json");
+            if (serializedBody != null) {
+                req.content(new StringContentProvider(serializedBody, StandardCharsets.UTF_8), "application/json");
+            }
 
             ContentResponse res = req.send();
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/rest/RestClient.java
@@ -87,7 +87,7 @@ public class RestClient {
             ContentResponse res = req.send();
 
             int responseCode = res.getStatus();
-            System.out.println(responseCode);
+            log.debug("Request's response code: {}", responseCode);
             if (responseCode == HttpStatus.NO_CONTENT_204) {
                 return new HttpResponse<>(responseCode, convertHttpFieldsToMap(res.getHeaders()), null);
             } else if (responseCode >= 400) {


### PR DESCRIPTION
Sending the response code of an http request issued via `RestClient` in Connect to stdout seems like a unconventional choice. 

This PR redirects the responds code with a message in the logs at DEBUG level (usually the same level as the one that the caller of `RestClient.httpRequest` uses. 

This fix will also fix system tests that broke by outputting this response code to stdout. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
