### PR TITLE
MINOR: Add docs for ReplicationBytesInPerSec and ReplicationBytesOutPerSec

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -764,8 +764,13 @@
         <td></td>
       </tr>
       <tr>
-        <td>Byte in rate</td>
+        <td>Byte in rate from clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Byte in rate from other brokers</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesInPerSec</td>
         <td></td>
       </tr>
       <tr>
@@ -800,8 +805,13 @@
         <td>Number of records which required message format conversion.</td>
       </tr>
       <tr>
-        <td>Byte out rate</td>
+        <td>Byte out rate to clients</td>
         <td>kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>Byte out rate to other brokers</td>
+        <td>kafka.server:type=BrokerTopicMetrics,name=ReplicationBytesOutPerSec</td>
         <td></td>
       </tr>
       <tr>


### PR DESCRIPTION
Add docs for the ReplicationBytesInPerSec and ReplicationBytesOutPerSec metrics. These metrics were introduced in KIP-153 (KAFKA-5194) but the docs were not updated.

Built site-docs, and viewed them in a web browser to confirm.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)