### PR TITLE
MINOR: Cancel port forwarding for HttpMetricsCollector during cleanup

### DIFF
--- a/tests/kafkatest/services/monitor/http.py
+++ b/tests/kafkatest/services/monitor/http.py
@@ -173,6 +173,7 @@ class _ReverseForwarder(object):
         self.logger = logger
         self._node = node
         self._local_port = local_port
+        self._remote_port = remote_port
 
         self.logger.debug('Forwarding %s port %d to driver port %d', node, remote_port, local_port)
 
@@ -189,6 +190,7 @@ class _ReverseForwarder(object):
         self._accept_thread.join(30)
         if self._accept_thread.isAlive():
             raise RuntimeError("Failed to stop reverse forwarder on %s", self._node)
+        self._transport.cancel_port_forward('', self._remote_port)
 
     def _accept(self):
         while not self._stopping:


### PR DESCRIPTION
Currently port forwarding is setup for HttpMetricsCollector when the Service's start_node method is called, but not canceled during stop. This hasn't presented a problem so far because we don't have tests that use this *and* restart the service. However, if a test/service does that, it will throw an exception since the port is already bound.

This just does the cleanup when stopping so a subsequent attempt to start again will succeed.

https://jenkins.confluent.io/job/system-test-kafka-branch-builder/1320 is a test run for a Test that uses ProducerPerformanceService, which in turn uses HttpMetricsCollector to validate the change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
