### PR TITLE
KAFKA-6578: Changed the Connect distributed and standalone main method to log all exceptions

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -58,8 +58,6 @@ public class ConnectDistributed {
             Exit.exit(1);
         }
 
-        int statusCode = 0;
-
         try {
             Time time = Time.SYSTEM;
             log.info("Kafka Connect distributed worker initializing ...");
@@ -104,7 +102,7 @@ public class ConnectDistributed {
             } catch (Exception e) {
                 log.error("Failed to start Connect", e);
                 connect.stop();
-                statusCode = 2;
+                Exit.exit(3);
             }
 
             // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
@@ -112,11 +110,7 @@ public class ConnectDistributed {
 
         } catch (Throwable t) {
             log.error("Stopping due to error", t);
-            if (statusCode == 0) statusCode = 3;
-        }
-
-        if (statusCode != 0) {
-            Exit.exit(statusCode);
+            Exit.exit(2);
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -58,6 +58,8 @@ public class ConnectDistributed {
             Exit.exit(1);
         }
 
+        int statusCode = 0;
+
         try {
             Time time = Time.SYSTEM;
             log.info("Kafka Connect distributed worker initializing ...");
@@ -102,6 +104,7 @@ public class ConnectDistributed {
             } catch (Exception e) {
                 log.error("Failed to start Connect", e);
                 connect.stop();
+                statusCode = 2;
             }
 
             // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
@@ -109,6 +112,11 @@ public class ConnectDistributed {
 
         } catch (Throwable t) {
             log.error("Stopping due to error", t);
+            if (statusCode == 0) statusCode = 3;
+        }
+
+        if (statusCode != 0) {
+            Exit.exit(statusCode);
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -58,52 +58,57 @@ public class ConnectDistributed {
             Exit.exit(1);
         }
 
-        Time time = Time.SYSTEM;
-        log.info("Kafka Connect distributed worker initializing ...");
-        long initStart = time.hiResClockMs();
-        WorkerInfo initInfo = new WorkerInfo();
-        initInfo.logAll();
-
-        String workerPropsFile = args[0];
-        Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
-                Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.<String, String>emptyMap();
-
-        log.info("Scanning for plugin classes. This might take a moment ...");
-        Plugins plugins = new Plugins(workerProps);
-        plugins.compareAndSwapWithDelegatingLoader();
-        DistributedConfig config = new DistributedConfig(workerProps);
-
-        String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
-        log.debug("Kafka cluster ID: {}", kafkaClusterId);
-
-        RestServer rest = new RestServer(config);
-        URI advertisedUrl = rest.advertisedUrl();
-        String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
-
-        KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore();
-        offsetBackingStore.configure(config);
-
-        Worker worker = new Worker(workerId, time, plugins, config, offsetBackingStore);
-
-        Converter internalValueConverter = worker.getInternalValueConverter();
-        StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter);
-        statusBackingStore.configure(config);
-
-        ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(internalValueConverter, config);
-
-        DistributedHerder herder = new DistributedHerder(config, time, worker,
-                kafkaClusterId, statusBackingStore, configBackingStore,
-                advertisedUrl.toString());
-        final Connect connect = new Connect(herder, rest);
-        log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);
         try {
-            connect.start();
-        } catch (Exception e) {
-            log.error("Failed to start Connect", e);
-            connect.stop();
-        }
+            Time time = Time.SYSTEM;
+            log.info("Kafka Connect distributed worker initializing ...");
+            long initStart = time.hiResClockMs();
+            WorkerInfo initInfo = new WorkerInfo();
+            initInfo.logAll();
 
-        // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
-        connect.awaitStop();
+            String workerPropsFile = args[0];
+            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
+                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.<String, String>emptyMap();
+
+            log.info("Scanning for plugin classes. This might take a moment ...");
+            Plugins plugins = new Plugins(workerProps);
+            plugins.compareAndSwapWithDelegatingLoader();
+            DistributedConfig config = new DistributedConfig(workerProps);
+
+            String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
+            log.debug("Kafka cluster ID: {}", kafkaClusterId);
+
+            RestServer rest = new RestServer(config);
+            URI advertisedUrl = rest.advertisedUrl();
+            String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+
+            KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore();
+            offsetBackingStore.configure(config);
+
+            Worker worker = new Worker(workerId, time, plugins, config, offsetBackingStore);
+
+            Converter internalValueConverter = worker.getInternalValueConverter();
+            StatusBackingStore statusBackingStore = new KafkaStatusBackingStore(time, internalValueConverter);
+            statusBackingStore.configure(config);
+
+            ConfigBackingStore configBackingStore = new KafkaConfigBackingStore(internalValueConverter, config);
+
+            DistributedHerder herder = new DistributedHerder(config, time, worker,
+                    kafkaClusterId, statusBackingStore, configBackingStore,
+                    advertisedUrl.toString());
+            final Connect connect = new Connect(herder, rest);
+            log.info("Kafka Connect distributed worker initialization took {}ms", time.hiResClockMs() - initStart);
+            try {
+                connect.start();
+            } catch (Exception e) {
+                log.error("Failed to start Connect", e);
+                connect.stop();
+            }
+
+            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
+            connect.awaitStop();
+
+        } catch (Throwable t) {
+            log.error("Stopping due to error", t);
+        }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -62,6 +62,9 @@ public class ConnectStandalone {
             Exit.exit(1);
         }
 
+        int statusCode = 0;
+        String errorMessage = null;
+
         try {
             Time time = Time.SYSTEM;
             log.info("Kafka Connect standalone worker initializing ...");
@@ -112,6 +115,7 @@ public class ConnectStandalone {
             } catch (Throwable t) {
                 log.error("Stopping after connector error", t);
                 connect.stop();
+                statusCode = 2;
             }
 
             // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
@@ -119,6 +123,11 @@ public class ConnectStandalone {
 
         } catch (Throwable t) {
             log.error("Stopping due to error", t);
+            if (statusCode == 0) statusCode = 3;
+        }
+
+        if (statusCode != 0) {
+            Exit.exit(statusCode);
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -62,8 +62,6 @@ public class ConnectStandalone {
             Exit.exit(1);
         }
 
-        int statusCode = 0;
-
         try {
             Time time = Time.SYSTEM;
             log.info("Kafka Connect standalone worker initializing ...");
@@ -114,7 +112,7 @@ public class ConnectStandalone {
             } catch (Throwable t) {
                 log.error("Stopping after connector error", t);
                 connect.stop();
-                statusCode = 2;
+                Exit.exit(3);
             }
 
             // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
@@ -122,11 +120,7 @@ public class ConnectStandalone {
 
         } catch (Throwable t) {
             log.error("Stopping due to error", t);
-            if (statusCode == 0) statusCode = 3;
-        }
-
-        if (statusCode != 0) {
-            Exit.exit(statusCode);
+            Exit.exit(2);
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -63,7 +63,6 @@ public class ConnectStandalone {
         }
 
         int statusCode = 0;
-        String errorMessage = null;
 
         try {
             Time time = Time.SYSTEM;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -62,58 +62,63 @@ public class ConnectStandalone {
             Exit.exit(1);
         }
 
-        Time time = Time.SYSTEM;
-        log.info("Kafka Connect standalone worker initializing ...");
-        long initStart = time.hiResClockMs();
-        WorkerInfo initInfo = new WorkerInfo();
-        initInfo.logAll();
-
-        String workerPropsFile = args[0];
-        Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
-                Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.<String, String>emptyMap();
-
-        log.info("Scanning for plugin classes. This might take a moment ...");
-        Plugins plugins = new Plugins(workerProps);
-        plugins.compareAndSwapWithDelegatingLoader();
-        StandaloneConfig config = new StandaloneConfig(workerProps);
-
-        String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
-        log.debug("Kafka cluster ID: {}", kafkaClusterId);
-
-        RestServer rest = new RestServer(config);
-        URI advertisedUrl = rest.advertisedUrl();
-        String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
-
-        Worker worker = new Worker(workerId, time, plugins, config, new FileOffsetBackingStore());
-
-        Herder herder = new StandaloneHerder(worker, kafkaClusterId);
-        final Connect connect = new Connect(herder, rest);
-        log.info("Kafka Connect standalone worker initialization took {}ms", time.hiResClockMs() - initStart);
-
         try {
-            connect.start();
-            for (final String connectorPropsFile : Arrays.copyOfRange(args, 1, args.length)) {
-                Map<String, String> connectorProps = Utils.propsToStringMap(Utils.loadProps(connectorPropsFile));
-                FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>(new Callback<Herder.Created<ConnectorInfo>>() {
-                    @Override
-                    public void onCompletion(Throwable error, Herder.Created<ConnectorInfo> info) {
-                        if (error != null)
-                            log.error("Failed to create job for {}", connectorPropsFile);
-                        else
-                            log.info("Created connector {}", info.result().name());
-                    }
-                });
-                herder.putConnectorConfig(
-                        connectorProps.get(ConnectorConfig.NAME_CONFIG),
-                        connectorProps, false, cb);
-                cb.get();
-            }
-        } catch (Throwable t) {
-            log.error("Stopping after connector error", t);
-            connect.stop();
-        }
+            Time time = Time.SYSTEM;
+            log.info("Kafka Connect standalone worker initializing ...");
+            long initStart = time.hiResClockMs();
+            WorkerInfo initInfo = new WorkerInfo();
+            initInfo.logAll();
 
-        // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
-        connect.awaitStop();
+            String workerPropsFile = args[0];
+            Map<String, String> workerProps = !workerPropsFile.isEmpty() ?
+                    Utils.propsToStringMap(Utils.loadProps(workerPropsFile)) : Collections.<String, String>emptyMap();
+
+            log.info("Scanning for plugin classes. This might take a moment ...");
+            Plugins plugins = new Plugins(workerProps);
+            plugins.compareAndSwapWithDelegatingLoader();
+            StandaloneConfig config = new StandaloneConfig(workerProps);
+
+            String kafkaClusterId = ConnectUtils.lookupKafkaClusterId(config);
+            log.debug("Kafka cluster ID: {}", kafkaClusterId);
+
+            RestServer rest = new RestServer(config);
+            URI advertisedUrl = rest.advertisedUrl();
+            String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+
+            Worker worker = new Worker(workerId, time, plugins, config, new FileOffsetBackingStore());
+
+            Herder herder = new StandaloneHerder(worker, kafkaClusterId);
+            final Connect connect = new Connect(herder, rest);
+            log.info("Kafka Connect standalone worker initialization took {}ms", time.hiResClockMs() - initStart);
+
+            try {
+                connect.start();
+                for (final String connectorPropsFile : Arrays.copyOfRange(args, 1, args.length)) {
+                    Map<String, String> connectorProps = Utils.propsToStringMap(Utils.loadProps(connectorPropsFile));
+                    FutureCallback<Herder.Created<ConnectorInfo>> cb = new FutureCallback<>(new Callback<Herder.Created<ConnectorInfo>>() {
+                        @Override
+                        public void onCompletion(Throwable error, Herder.Created<ConnectorInfo> info) {
+                            if (error != null)
+                                log.error("Failed to create job for {}", connectorPropsFile);
+                            else
+                                log.info("Created connector {}", info.result().name());
+                        }
+                    });
+                    herder.putConnectorConfig(
+                            connectorProps.get(ConnectorConfig.NAME_CONFIG),
+                            connectorProps, false, cb);
+                    cb.get();
+                }
+            } catch (Throwable t) {
+                log.error("Stopping after connector error", t);
+                connect.stop();
+            }
+
+            // Shutdown will be triggered by Ctrl-C or via HTTP shutdown request
+            connect.awaitStop();
+
+        } catch (Throwable t) {
+            log.error("Stopping due to error", t);
+        }
     }
 }


### PR DESCRIPTION
Any exception thrown by calls within a `main()` method are not logged unless explicitly done so. This change simply adds a try-catch block around most of the content of the distributed and standalone `main()` methods.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
