### PR TITLE
KAFKA-6591: Move super user check before ACL matching 

### DIFF
--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -112,7 +112,6 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
 
     val principal = session.principal
     val host = session.clientAddress.getHostAddress
-    val acls = getMatchingAcls(resource.resourceType, resource.name)
 
     val authorized = if (isSuperUser(operation, resource, principal, host)) {
       // Check if the user is a superuser to avoid needlessly checking all ACLs
@@ -122,7 +121,7 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
       // User is no superuser, load ACLs
       // To avoid unnecessarily loading ACLs for super users we need to nest this as a second if
       // statement to allow loading ACLs before this check buf after performing the superuser check
-      val acls = getAcls(resource) ++ getAcls(new Resource(resource.resourceType, Resource.WildCardResource))
+      val acls = getMatchingAcls(resource.resourceType, resource.name)
 
       if (acls.isEmpty) {
         // No ACLs found for this resource, permission is determined by value of config allow.everyone.if.no.acl.found

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -113,40 +113,40 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
     val principal = session.principal
     val host = session.clientAddress.getHostAddress
 
-    val authorized = if (isSuperUser(operation, resource, principal, host)) {
-      // Check if the user is a superuser to avoid needlessly checking all ACLs
-      // for superusers
-      true
-    } else {
-      // User is no superuser, load ACLs
-      // To avoid unnecessarily loading ACLs for super users we need to nest this as a second if
-      // statement to allow loading ACLs before this check buf after performing the superuser check
-      val acls = getMatchingAcls(resource.resourceType, resource.name)
-
+    def isEmptyAclAndAuthorized(acls: Set[Acl]): Boolean = {
       if (acls.isEmpty) {
         // No ACLs found for this resource, permission is determined by value of config allow.everyone.if.no.acl.found
         authorizerLogger.debug(s"No acl found for resource $resource, authorized = $shouldAllowEveryoneIfNoAclIsFound")
         shouldAllowEveryoneIfNoAclIsFound
-      } else {
-        // ACLs found for this resource
-        // Check if there is any Deny acl match that would disallow this operation.
-        val denyMatch = aclMatch(operation, resource, principal, host, Deny, acls)
-
-        // Check if there are any Allow ACLs which would allow this operation.
-        // Allowing read, write, delete, or alter implies allowing describe.
-        // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
-        val allowOps = operation match {
-          case Describe => Set[Operation](Describe, Read, Write, Delete, Alter)
-          case DescribeConfigs => Set[Operation](DescribeConfigs, AlterConfigs)
-          case _ => Set[Operation](operation)
-        }
-        val allowMatch = allowOps.exists(operation => aclMatch(operation, resource, principal, host, Allow, acls))
-
-        //we allow an operation if no acls are found and user has configured to allow all users
-        //when no acls are found or if no deny acls are found and at least one allow acls matches.
-        !denyMatch && allowMatch
-      }
+      } else false
     }
+
+    def denyAclExists(acls: Set[Acl]): Boolean = {
+      // Check if there are any Deny ACLs which would forbid this operation.
+      aclMatch(operation, resource, principal, host, Deny, acls)
+    }
+
+    def allowAclExists(acls: Set[Acl]): Boolean = {
+      // Check if there are any Allow ACLs which would allow this operation.
+      // Allowing read, write, delete, or alter implies allowing describe.
+      // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
+      val allowOps = operation match {
+        case Describe => Set[Operation](Describe, Read, Write, Delete, Alter)
+        case DescribeConfigs => Set[Operation](DescribeConfigs, AlterConfigs)
+        case _ => Set[Operation](operation)
+      }
+      allowOps.exists(operation => aclMatch(operation, resource, principal, host, Allow, acls))
+    }
+
+    def aclsAllowAccess = {
+      //we allow an operation if no acls are found and user has configured to allow all users
+      //when no acls are found or if no deny acls are found and at least one allow acls matches.
+      val acls = getMatchingAcls(resource.resourceType, resource.name)
+      isEmptyAclAndAuthorized(acls) || (!denyAclExists(acls) && allowAclExists(acls))
+    }
+
+    // Evaluate if operation is allowed
+    val authorized = isSuperUser(operation, resource, principal, host) || aclsAllowAccess
 
     logAuditMessage(principal, authorized, operation, resource, host)
     authorized

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -114,34 +114,43 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
     val host = session.clientAddress.getHostAddress
     val acls = getMatchingAcls(resource.resourceType, resource.name)
 
-    // Check if there is any Deny acl match that would disallow this operation.
-    val denyMatch = aclMatch(operation, resource, principal, host, Deny, acls)
+    val authorized = if (isSuperUser(operation, resource, principal, host)) {
+      // Check if the user is a superuser to avoid needlessly checking all ACLs
+      // for superusers
+      true
+    } else {
+      // User is no superuser, load ACLs
+      // To avoid unnecessarily loading ACLs for super users we need to nest this as a second if
+      // statement to allow loading ACLs before this check buf after performing the superuser check
+      val acls = getAcls(resource) ++ getAcls(new Resource(resource.resourceType, Resource.WildCardResource))
 
-    // Check if there are any Allow ACLs which would allow this operation.
-    // Allowing read, write, delete, or alter implies allowing describe.
-    // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
-    val allowOps = operation match {
-      case Describe => Set[Operation](Describe, Read, Write, Delete, Alter)
-      case DescribeConfigs => Set[Operation](DescribeConfigs, AlterConfigs)
-      case _ => Set[Operation](operation)
+      if (acls.isEmpty) {
+        // No ACLs found for this resource, permission is determined by value of config allow.everyone.if.no.acl.found
+        authorizerLogger.debug(s"No acl found for resource $resource, authorized = $shouldAllowEveryoneIfNoAclIsFound")
+        shouldAllowEveryoneIfNoAclIsFound
+      } else {
+        // ACLs found for this resource
+        // Check if there is any Deny acl match that would disallow this operation.
+        val denyMatch = aclMatch(operation, resource, principal, host, Deny, acls)
+
+        // Check if there are any Allow ACLs which would allow this operation.
+        // Allowing read, write, delete, or alter implies allowing describe.
+        // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
+        val allowOps = operation match {
+          case Describe => Set[Operation](Describe, Read, Write, Delete, Alter)
+          case DescribeConfigs => Set[Operation](DescribeConfigs, AlterConfigs)
+          case _ => Set[Operation](operation)
+        }
+        val allowMatch = allowOps.exists(operation => aclMatch(operation, resource, principal, host, Allow, acls))
+
+        //we allow an operation if no acls are found and user has configured to allow all users
+        //when no acls are found or if no deny acls are found and at least one allow acls matches.
+        !denyMatch && allowMatch
+      }
     }
-    val allowMatch = allowOps.exists(operation => aclMatch(operation, resource, principal, host, Allow, acls))
-
-    //we allow an operation if a user is a super user or if no acls are found and user has configured to allow all users
-    //when no acls are found or if no deny acls are found and at least one allow acls matches.
-    val authorized = isSuperUser(operation, resource, principal, host) ||
-      isEmptyAclAndAuthorized(operation, resource, principal, host, acls) ||
-      (!denyMatch && allowMatch)
 
     logAuditMessage(principal, authorized, operation, resource, host)
     authorized
-  }
-
-  def isEmptyAclAndAuthorized(operation: Operation, resource: Resource, principal: KafkaPrincipal, host: String, acls: Set[Acl]): Boolean = {
-    if (acls.isEmpty) {
-      authorizerLogger.debug(s"No acl found for resource $resource, authorized = $shouldAllowEveryoneIfNoAclIsFound")
-      shouldAllowEveryoneIfNoAclIsFound
-    } else false
   }
 
   def isSuperUser(operation: Operation, resource: Resource, principal: KafkaPrincipal, host: String): Boolean = {


### PR DESCRIPTION
Currently the check whether a user as a super user in SimpleAclAuthorizer is performed only after all other ACLs have been evaluated. Since all requests from a super user are granted we don't really need to apply the ACLs.

This commit returns true if the user is a super user before checking ACLs, thus bypassing the needless evaluation effort.