### PR TITLE
KAFKA-6592: ConsoleConsumer should support specifying inner deserializers

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -330,6 +330,14 @@ object ConsoleConsumer extends Logging {
       .withRequiredArg
       .describedAs("deserializer for values")
       .ofType(classOf[String])
+    val innerKeyDeserializerOpt = parser.accepts("key.deserializer.inner.class")
+      .withRequiredArg
+      .describedAs("inner deserializer for key")
+      .ofType(classOf[String])
+    val innerValueDeserializerOpt = parser.accepts("value.deserializer.inner.class")
+      .withRequiredArg
+      .describedAs("inner deserializer for values")
+      .ofType(classOf[String])
     val enableSystestEventsLoggingOpt = parser.accepts("enable-systest-events",
                                                        "Log lifecycle events of the consumer in addition to logging consumed " +
                                                        "messages. (This is specific for system tests.)")
@@ -374,6 +382,8 @@ object ConsoleConsumer extends Logging {
     val bootstrapServer = options.valueOf(bootstrapServerOpt)
     val keyDeserializer = options.valueOf(keyDeserializerOpt)
     val valueDeserializer = options.valueOf(valueDeserializerOpt)
+    val innerKeyDeserializer = options.valueOf(innerKeyDeserializerOpt)
+    val innerValueDeserializer = options.valueOf(innerValueDeserializerOpt)
     val isolationLevel = options.valueOf(isolationLevelOpt).toString
     val formatter: MessageFormatter = messageFormatterClass.newInstance().asInstanceOf[MessageFormatter]
 
@@ -382,6 +392,12 @@ object ConsoleConsumer extends Logging {
     }
     if (valueDeserializer != null && !valueDeserializer.isEmpty) {
       formatterArgs.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializer)
+    }
+    if (innerKeyDeserializer != null && !innerKeyDeserializer.isEmpty) {
+      formatterArgs.setProperty("key.deserializer.inner.class", innerKeyDeserializer)
+    }
+    if (innerValueDeserializer != null && !innerValueDeserializer.isEmpty) {
+      formatterArgs.setProperty("value.deserializer.inner.class", innerValueDeserializer)
     }
     formatter.init(formatterArgs)
 
@@ -523,11 +539,19 @@ class DefaultMessageFormatter extends MessageFormatter {
     if (props.containsKey("line.separator"))
       lineSeparator = props.getProperty("line.separator").getBytes(StandardCharsets.UTF_8)
     // Note that `toString` will be called on the instance returned by `Deserializer.deserialize`
-    if (props.containsKey("key.deserializer"))
+    if (props.containsKey("key.deserializer")) {
       keyDeserializer = Some(Class.forName(props.getProperty("key.deserializer")).newInstance().asInstanceOf[Deserializer[_]])
+      // Instantiate the inner key class if `key.deserializer.inner.class` is specified
+      if (props.containsKey("key.deserializer.inner.class"))
+        keyDeserializer.get.configure(Map("key.deserializer.inner.class" -> props.get("key.deserializer.inner.class")).asJava, true)
+    }
     // Note that `toString` will be called on the instance returned by `Deserializer.deserialize`
-    if (props.containsKey("value.deserializer"))
+    if (props.containsKey("value.deserializer")) {
       valueDeserializer = Some(Class.forName(props.getProperty("value.deserializer")).newInstance().asInstanceOf[Deserializer[_]])
+      // Instantiate the inner value class if `value.deserializer.inner.class` is specified
+      if (props.containsKey("value.deserializer.inner.class"))
+        valueDeserializer.get.configure(Map("value.deserializer.inner.class" -> props.get("value.deserializer.inner.class")).asJava, false)
+    }
   }
 
   def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream) {


### PR DESCRIPTION
For those deserializers with inner deserializer such as WindowedDeserializer, user cannot directly specify the underlying inner class and NullPointerException would be thrown.

This patch adds two new properties named `key.deserializer.inner.class` and `value.deserializer.inner.class`.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
