### PR TITLE
MINOR: Fix javadoc typo

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/header/Headers.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/Headers.java
@@ -41,7 +41,7 @@ public interface Headers extends Iterable<Header> {
      * Removes all headers for the given key returning if the operation succeeded.
      * 
      * @param key to remove all headers for.
-     * @return this instance of the Headers, once the header is added.
+     * @return this instance of the Headers, once the header is removed.
      * @throws IllegalStateException is thrown if headers are in a read-only state.
      */
     Headers remove(String key) throws IllegalStateException;


### PR DESCRIPTION
This is just a minor typo in the javadoc. This contribution is my original work and that I license the work to the project under the project's open source license.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
