### PR TITLE
MINOR: fixing streams test-util compilation errors in Eclipse

### DIFF
--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java
@@ -178,7 +178,7 @@ public class ConsumerRecordFactoryTest {
         }
 
         final List<ConsumerRecord<byte[], byte[]>> records =
-            factory.create(Arrays.<KeyValue<String, Long>>asList(keyValuePairs));
+            factory.create(Arrays.<KeyValue<String, Integer>>asList(keyValuePairs));
 
         for (int i = 0; i < keyValuePairs.length; ++i) {
             verifyRecord(
@@ -207,7 +207,7 @@ public class ConsumerRecordFactoryTest {
         }
 
         final List<ConsumerRecord<byte[], byte[]>> records =
-            factory.create(Arrays.<KeyValue<String, Long>>asList(keyValuePairs));
+            factory.create(Arrays.<KeyValue<String, Integer>>asList(keyValuePairs));
 
         for (int i = 0; i < keyValuePairs.length; ++i) {
             verifyRecord(
@@ -236,7 +236,7 @@ public class ConsumerRecordFactoryTest {
         }
 
         final List<ConsumerRecord<byte[], byte[]>> records =
-            factory.create(Arrays.<KeyValue<String, Long>>asList(keyValuePairs), timestamp, 2L);
+            factory.create(Arrays.<KeyValue<String, Integer>>asList(keyValuePairs), timestamp, 2L);
 
         for (int i = 0; i < keyValuePairs.length; ++i) {
             verifyRecord(


### PR DESCRIPTION
Eclipse (4.7.2 using jdk 1.8.0_151 ) was complaining about 3 compilation errors in 
streams/test-utils/src/test/java/org/apache/kafka/streams/test/ConsumerRecordFactoryTest.java

all three were about generics Long/Integer mismatch

The method create(Integer) in the type
ConsumerRecordFactory<String,Integer> is not applicable for the
arguments (List<KeyValue<String,Long>>)	ConsumerRecordFactoryTest.java	line
181	/test-utils/src/test/java/org/apache/kafka/streams/test	Java Problem
The method create(Integer) in the type
ConsumerRecordFactory<String,Integer> is not applicable for the
arguments (List<KeyValue<String,Long>>)	ConsumerRecordFactoryTest.java	line
210	/test-utils/src/test/java/org/apache/kafka/streams/test	Java Problem
The method create(List<KeyValue<String,Integer>>, long, long) in the
type ConsumerRecordFactory<String,Integer> is not applicable for the
arguments (List<KeyValue<String,Long>>, long,
long)	ConsumerRecordFactoryTest.java	line
239	/test-utils/src/test/java/org/apache/kafka/streams/test	Java Problem

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
