### PR TITLE
MINOR: Fix incorrect JavaDoc (type mismatch)

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/Stores.java
@@ -55,7 +55,7 @@ import java.util.Objects;
  * KeyValueBytesStoreSupplier storeSupplier = Stores.inMemoryKeyValueStore("queryable-store-name");
  * KTable<Long,String> table = builder.table(
  *   "topicName",
- *   Materialized.as(storeSupplier)
+ *   Materialized.<Long,String>as(storeSupplier)
  *               .withKeySerde(Serdes.Long())
  *               .withValueSerde(Serdes.String())
  *               .withCachingDisabled());


### PR DESCRIPTION
Omitting the type would lead to a compilation error, because if the method is not parametrized, the type parameter of Serde would be Object, instead of Long and String.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
