### PR TITLE
KAFKA-6604; ReplicaManager should not remove partitions on the log directory from high watermark checkpoint file

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1384,12 +1384,10 @@ class ReplicaManager(val config: KafkaConfig,
     for ((dir, reps) <- replicasByDir) {
       val hwms = reps.map(r => r.topicPartition -> r.highWatermark.messageOffset).toMap
       try {
-        highWatermarkCheckpoints.get(dir) match {
-          case Some(checkpointFile) =>
-            val previousHwms = checkpointFile.read()
-            val previousHwmsOfExistingReplicas = previousHwms.filterKeys(tp => logManager.getLog(tp).nonEmpty)
-            checkpointFile.write(previousHwmsOfExistingReplicas ++ hwms)
-          case None =>
+        highWatermarkCheckpoints.get(dir).foreach { checkpointFile =>
+          val previousHwms = checkpointFile.read()
+          val previousHwmsOfExistingReplicas = previousHwms.filterKeys(tp => logManager.getLog(tp).nonEmpty)
+          checkpointFile.write(previousHwmsOfExistingReplicas ++ hwms)
         }
       } catch {
         case e: KafkaStorageException =>


### PR DESCRIPTION
This patch fixes an issue to prevent broker from unnecessarily truncating many partitions to log start offset.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
