### PR TITLE
MINOR: Complete inflight requests in correct order on disconnect

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
+++ b/clients/src/main/java/org/apache/kafka/clients/InFlightRequests.java
@@ -20,11 +20,11 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-
 
 /**
  * The set of requests which have been sent or are being sent but haven't yet received a response
@@ -151,9 +151,14 @@ final class InFlightRequests {
         if (reqs == null) {
             return Collections.emptyList();
         } else {
-            Deque<NetworkClient.InFlightRequest> clearedRequests = requests.remove(node);
+            final Deque<NetworkClient.InFlightRequest> clearedRequests = requests.remove(node);
             inFlightRequestCount.getAndAdd(-clearedRequests.size());
-            return clearedRequests;
+            return new Iterable<NetworkClient.InFlightRequest>() {
+                @Override
+                public Iterator<NetworkClient.InFlightRequest> iterator() {
+                    return clearedRequests.descendingIterator();
+                }
+            };
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/InFlightRequestsTest.java
@@ -17,44 +17,85 @@
 
 package org.apache.kafka.clients;
 
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class InFlightRequestsTest {
 
     private InFlightRequests inFlightRequests;
+    private int correlationId;
+    private String dest = "dest";
+
     @Before
     public void setup() {
         inFlightRequests = new InFlightRequests(12);
-        NetworkClient.InFlightRequest ifr =
-                new NetworkClient.InFlightRequest(null, 0, "dest", null, false, false, null, null, 0);
-        inFlightRequests.add(ifr);
+        correlationId = 0;
     }
 
     @Test
-    public void checkIncrementAndDecrementOnLastSent() {
+    public void testCompleteLastSent() {
+        int correlationId1 = addRequest(dest);
+        int correlationId2 = addRequest(dest);
+        assertEquals(2, inFlightRequests.count());
+
+        assertEquals(correlationId2, inFlightRequests.completeLastSent(dest).header.correlationId());
         assertEquals(1, inFlightRequests.count());
 
-        inFlightRequests.completeLastSent("dest");
+        assertEquals(correlationId1, inFlightRequests.completeLastSent(dest).header.correlationId());
         assertEquals(0, inFlightRequests.count());
     }
 
     @Test
-    public void checkDecrementOnClear() {
-        inFlightRequests.clearAll("dest");
+    public void testClearAll() {
+        int correlationId1 = addRequest(dest);
+        int correlationId2 = addRequest(dest);
+
+        List<NetworkClient.InFlightRequest> clearedRequests = TestUtils.toList(this.inFlightRequests.clearAll(dest));
         assertEquals(0, inFlightRequests.count());
+        assertEquals(2, clearedRequests.size());
+        assertEquals(correlationId1, clearedRequests.get(0).header.correlationId());
+        assertEquals(correlationId2, clearedRequests.get(1).header.correlationId());
     }
 
     @Test
-    public void checkDecrementOnCompleteNext() {
-        inFlightRequests.completeNext("dest");
+    public void testCompleteNext() {
+        int correlationId1 = addRequest(dest);
+        int correlationId2 = addRequest(dest);
+        assertEquals(2, inFlightRequests.count());
+
+        assertEquals(correlationId1, inFlightRequests.completeNext(dest).header.correlationId());
+        assertEquals(1, inFlightRequests.count());
+
+        assertEquals(correlationId2, inFlightRequests.completeNext(dest).header.correlationId());
         assertEquals(0, inFlightRequests.count());
     }
 
     @Test(expected = IllegalStateException.class)
-    public void throwExceptionOnNeverBeforeSeenNode() {
-        inFlightRequests.completeNext("not-added");
+    public void testCompleteNextThrowsIfNoInflights() {
+        inFlightRequests.completeNext(dest);
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void testCompleteLastSentThrowsIfNoInFlights() {
+        inFlightRequests.completeLastSent(dest);
+    }
+
+    private int addRequest(String destination) {
+        int correlationId = this.correlationId;
+        this.correlationId += 1;
+
+        RequestHeader requestHeader = new RequestHeader(ApiKeys.METADATA, (short) 0, "clientId", correlationId);
+        NetworkClient.InFlightRequest ifr = new NetworkClient.InFlightRequest(requestHeader, 0,
+                destination, null, false, false, null, null, 0);
+        inFlightRequests.add(ifr);
+        return correlationId;
+    }
+
 }


### PR DESCRIPTION
NetworkClient should use FIFO order when completing inflight requests following a disconnect.

I've added new unit tests for `InFlightRequests` and `NetworkClient` which verify completion order.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
