### PR TITLE
MINOR: clean stateDirectory in TopologyTestDriver

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -172,6 +172,7 @@ public class TopologyTestDriver {
     private StreamTask task;
     private GlobalStateUpdateTask globalStateTask;
 
+    private final StateDirectory stateDirectory;
     private final ProcessorTopology processorTopology;
     private final MockProducer<byte[], byte[]> producer;
 
@@ -221,7 +222,7 @@ public class TopologyTestDriver {
         };
 
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
-        final StateDirectory stateDirectory = new StateDirectory(streamsConfig, mockTime);
+        stateDirectory = new StateDirectory(streamsConfig, mockTime);
         final StreamsMetrics streamsMetrics = new StreamsMetricsImpl(
             new Metrics(),
             "topology-test-driver-stream-metrics",
@@ -564,6 +565,7 @@ public class TopologyTestDriver {
             }
         }
         captureOutputRecords();
+        stateDirectory.clean();
     }
 
     static class MockTime implements Time {


### PR DESCRIPTION
* Specifically, on TopologyTestDriver#close()
* Allow the test driver to clean up any persistant files that may
  have been written by a state store in the topology.
* Add a test verifying that persistent state does get cleaned up. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
