### PR TITLE
MINOR: Tag AWS instances with Jenkins build url

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -141,7 +141,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   def name_node(node, name, ec2_instance_name_prefix)
     node.vm.hostname = name
     node.vm.provider :aws do |aws|
-      aws.tags = { 'Name' => ec2_instance_name_prefix + "-" + Socket.gethostname + "-" + name }
+      aws.tags = {
+        'Name' => ec2_instance_name_prefix + "-" + Socket.gethostname + "-" + name,
+        'JenkinsBuildUrl' => ENV['BUILD_URL']
+      }
     end
   end
 


### PR DESCRIPTION
This will allow us to trace leaked instances back to the job,
so that we can figure out what happened and fix the leak.

Testing: Verified Jenkins build URL is set on the AWS instances when running system tests. 
Backporting: Can this be backported to 0.10.2? The oldest branch we can backport the better.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
