### PR TITLE
MINOR: Error messages and comments had a typo in a config name. The correct …

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -212,7 +212,7 @@ public class ProducerConfig extends AbstractConfig {
     /** <code> transaction.timeout.ms </code> */
     public static final String TRANSACTION_TIMEOUT_CONFIG = "transaction.timeout.ms";
     public static final String TRANSACTION_TIMEOUT_DOC = "The maximum amount of time in ms that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction." +
-            "If this value is larger than the max.transaction.timeout.ms setting in the broker, the request will fail with a `InvalidTransactionTimeout` error.";
+            "If this value is larger than the transaction.max.timeout.ms setting in the broker, the request will fail with a `InvalidTransactionTimeout` error.";
 
     /** <code> transactional.id </code> */
     public static final String TRANSACTIONAL_ID_CONFIG = "transactional.id";

--- a/clients/src/main/java/org/apache/kafka/common/errors/InvalidTxnTimeoutException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/InvalidTxnTimeoutException.java
@@ -18,7 +18,7 @@ package org.apache.kafka.common.errors;
 
 /**
  * The transaction coordinator returns this error code if the timeout received via the InitProducerIdRequest is larger than
- * the `max.transaction.timeout.ms` config value.
+ * the `transaction.max.timeout.ms` config value.
  */
 public class InvalidTxnTimeoutException extends ApiException {
     private static final long serialVersionUID = 1L;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -474,7 +474,7 @@ public enum Errors {
             }
         }),
     INVALID_TRANSACTION_TIMEOUT(50, "The transaction timeout is larger than the maximum value allowed by " +
-                "the broker (as configured by max.transaction.timeout.ms).",
+                "the broker (as configured by transaction.max.timeout.ms).",
         new ApiExceptionBuilder() {
             @Override
             public ApiException build(String message) {


### PR DESCRIPTION
…config name is transaction.max.timeout.ms

I built the site docs and the javadocs, and verified that the docs have the right config name.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
