### PR TITLE
KAFKA-6630: Speed up the processing of TopicDeletionStopReplicaResponseReceived events on the controller

### DIFF
--- a/core/src/main/scala/kafka/controller/ControllerContext.scala
+++ b/core/src/main/scala/kafka/controller/ControllerContext.scala
@@ -39,12 +39,12 @@ class ControllerContext {
   private var liveBrokersUnderlying: Set[Broker] = Set.empty
   private var liveBrokerIdsUnderlying: Set[Int] = Set.empty
 
-  def partitionReplicaAssignment(topicPartition: TopicPartition) : Seq[Int] = {
+  def partitionReplicaAssignment(topicPartition: TopicPartition): Seq[Int] = {
     partitionReplicaAssignmentUnderlying.getOrElse(topicPartition.topic, mutable.Map.empty)
       .getOrElse(topicPartition.partition, Seq.empty)
   }
 
-  def clearTopicsState(): Unit = {
+  private def clearTopicsState(): Unit = {
     allTopics = Set.empty
     partitionReplicaAssignmentUnderlying.clear()
     partitionLeadershipInfo.clear()
@@ -52,18 +52,18 @@ class ControllerContext {
     replicasOnOfflineDirs.clear()
   }
 
-  def updatePartitionReplicaAssignment(topicPartition: TopicPartition, newReplicas: Seq[Int]) : Unit = {
+  def updatePartitionReplicaAssignment(topicPartition: TopicPartition, newReplicas: Seq[Int]): Unit = {
     partitionReplicaAssignmentUnderlying.getOrElseUpdate(topicPartition.topic, mutable.Map.empty)
       .put(topicPartition.partition, newReplicas)
   }
 
-  def partitionReplicaAssignmentForTopic(topic : String) : Map[TopicPartition, Seq[Int]] = {
+  def partitionReplicaAssignmentForTopic(topic : String): Map[TopicPartition, Seq[Int]] = {
     partitionReplicaAssignmentUnderlying.getOrElse(topic, Map.empty).map {
       case (partition, replicas) => (new TopicPartition(topic, partition), replicas)
     }.toMap
   }
 
-  def allPartitions : Set[TopicPartition] = {
+  def allPartitions: Set[TopicPartition] = {
     partitionReplicaAssignmentUnderlying.flatMap {
       case (topic, topicReplicaAssignment) => topicReplicaAssignment.map {
         case (partition, _) => new TopicPartition(topic, partition)
@@ -138,7 +138,7 @@ class ControllerContext {
     }
   }
 
-  def resetContext() : Unit = {
+  def resetContext(): Unit = {
     if (controllerChannelManager != null) {
       controllerChannelManager.shutdown()
       controllerChannelManager = null
@@ -150,7 +150,7 @@ class ControllerContext {
     liveBrokers = Set.empty
   }
 
-  def removeTopic(topic: String) = {
+  def removeTopic(topic: String): Unit = {
     allTopics -= topic
     partitionReplicaAssignmentUnderlying.remove(topic)
     partitionLeadershipInfo.foreach {

--- a/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/PartitionStateMachine.scala
@@ -76,7 +76,7 @@ class PartitionStateMachine(config: KafkaConfig,
    * zookeeper
    */
   private def initializePartitionState() {
-    for (topicPartition <- controllerContext.partitionReplicaAssignment.keys) {
+    for (topicPartition <- controllerContext.allPartitions) {
       // check if leader and isr path exists for partition. If not, then it is in NEW state
       controllerContext.partitionLeadershipInfo.get(topicPartition) match {
         case Some(currentLeaderIsrAndEpoch) =>

--- a/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
+++ b/core/src/main/scala/kafka/controller/TopicDeletionManager.scala
@@ -255,9 +255,8 @@ class TopicDeletionManager(controller: KafkaController,
     // send update metadata so that brokers stop serving data for topics to be deleted
     val partitions = topics.flatMap(controllerContext.partitionsForTopic)
     controller.sendUpdateMetadataRequest(controllerContext.liveOrShuttingDownBrokerIds.toSeq, partitions)
-    val partitionReplicaAssignmentByTopic = controllerContext.partitionReplicaAssignment.groupBy(p => p._1.topic)
     topics.foreach { topic =>
-      onPartitionDeletion(partitionReplicaAssignmentByTopic(topic).keySet)
+      onPartitionDeletion(controllerContext.partitionsForTopic(topic))
     }
   }
 

--- a/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/PartitionStateMachineTest.scala
@@ -80,7 +80,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testNewPartitionToOnlinePartitionTransition(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, NewPartition)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
     EasyMock.expect(mockControllerBrokerRequestBatch.newBatch())
@@ -98,7 +98,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testNewPartitionToOnlinePartitionTransitionZkUtilsExceptionFromCreateStates(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, NewPartition)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
     EasyMock.expect(mockControllerBrokerRequestBatch.newBatch())
@@ -114,7 +114,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testNewPartitionToOnlinePartitionTransitionErrorCodeFromCreateStates(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, NewPartition)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
     EasyMock.expect(mockControllerBrokerRequestBatch.newBatch())
@@ -144,7 +144,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testOnlinePartitionToOnlineTransition(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, OnlinePartition)
     val leaderAndIsr = LeaderAndIsr(brokerId, List(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)
@@ -175,7 +175,7 @@ class PartitionStateMachineTest extends JUnitSuite {
     val otherBrokerId = brokerId + 1
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0), TestUtils.createBroker(otherBrokerId, "host", 0))
     controllerContext.shuttingDownBrokerIds.add(brokerId)
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId, otherBrokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId, otherBrokerId))
     partitionState.put(partition, OnlinePartition)
     val leaderAndIsr = LeaderAndIsr(brokerId, List(brokerId, otherBrokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)
@@ -226,7 +226,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testOfflinePartitionToOnlinePartitionTransition(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, OfflinePartition)
     val leaderAndIsr = LeaderAndIsr(LeaderAndIsr.NoLeader, List(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)
@@ -257,7 +257,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testOfflinePartitionToOnlinePartitionTransitionZkUtilsExceptionFromStateLookup(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, OfflinePartition)
     val leaderAndIsr = LeaderAndIsr(LeaderAndIsr.NoLeader, List(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)
@@ -278,7 +278,7 @@ class PartitionStateMachineTest extends JUnitSuite {
   @Test
   def testOfflinePartitionToOnlinePartitionTransitionErrorCodeFromStateLookup(): Unit = {
     controllerContext.liveBrokers = Set(TestUtils.createBroker(brokerId, "host", 0))
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     partitionState.put(partition, OfflinePartition)
     val leaderAndIsr = LeaderAndIsr(LeaderAndIsr.NoLeader, List(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)

--- a/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ReplicaStateMachineTest.scala
@@ -104,7 +104,7 @@ class ReplicaStateMachineTest extends JUnitSuite {
   @Test
   def testNewReplicaToOnlineReplicaTransition(): Unit = {
     replicaState.put(replica, NewReplica)
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     replicaStateMachine.handleStateChanges(replicas, OnlineReplica)
     assertEquals(OnlineReplica, replicaState(replica))
   }
@@ -150,7 +150,7 @@ class ReplicaStateMachineTest extends JUnitSuite {
   @Test
   def testOnlineReplicaToOnlineReplicaTransition(): Unit = {
     replicaState.put(replica, OnlineReplica)
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
     controllerContext.partitionLeadershipInfo.put(partition, leaderIsrAndControllerEpoch)
     EasyMock.expect(mockControllerBrokerRequestBatch.newBatch())
@@ -168,7 +168,7 @@ class ReplicaStateMachineTest extends JUnitSuite {
     val otherBrokerId = brokerId + 1
     val replicaIds = List(brokerId, otherBrokerId)
     replicaState.put(replica, OnlineReplica)
-    controllerContext.partitionReplicaAssignment.put(partition, replicaIds)
+    controllerContext.updatePartitionReplicaAssignment(partition, replicaIds)
     val leaderAndIsr = LeaderAndIsr(brokerId, replicaIds)
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(leaderAndIsr, controllerEpoch)
     controllerContext.partitionLeadershipInfo.put(partition, leaderIsrAndControllerEpoch)
@@ -225,7 +225,7 @@ class ReplicaStateMachineTest extends JUnitSuite {
   @Test
   def testOfflineReplicaToOnlineReplicaTransition(): Unit = {
     replicaState.put(replica, OfflineReplica)
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
     controllerContext.partitionLeadershipInfo.put(partition, leaderIsrAndControllerEpoch)
     EasyMock.expect(mockControllerBrokerRequestBatch.newBatch())
@@ -299,7 +299,7 @@ class ReplicaStateMachineTest extends JUnitSuite {
   @Test
   def testReplicaDeletionSuccessfulToNonexistentReplicaTransition(): Unit = {
     replicaState.put(replica, ReplicaDeletionSuccessful)
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     replicaStateMachine.handleStateChanges(replicas, NonExistentReplica)
     assertEquals(Seq.empty, controllerContext.partitionReplicaAssignment(partition))
     assertEquals(None, replicaState.get(replica))
@@ -343,7 +343,7 @@ class ReplicaStateMachineTest extends JUnitSuite {
   @Test
   def testReplicaDeletionIneligibleToOnlineReplicaTransition(): Unit = {
     replicaState.put(replica, ReplicaDeletionIneligible)
-    controllerContext.partitionReplicaAssignment.put(partition, Seq(brokerId))
+    controllerContext.updatePartitionReplicaAssignment(partition, Seq(brokerId))
     val leaderIsrAndControllerEpoch = LeaderIsrAndControllerEpoch(LeaderAndIsr(brokerId, List(brokerId)), controllerEpoch)
     controllerContext.partitionLeadershipInfo.put(partition, leaderIsrAndControllerEpoch)
     EasyMock.expect(mockControllerBrokerRequestBatch.newBatch())


### PR DESCRIPTION
This patch tries to speed up the inefficient functions identified in Kafka-6630 by grouping partitions in the ControllerContext.partitionReplicaAssignment variable by topics. Hence trying to find all replicas for a topic won't need to go through all the replicas in the cluster.

Passed all tests using "gradle testAll"

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
