### PR TITLE
MINOR: Reduce ZK reads and ensure ZK watch is set for listener update

### DIFF
--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -377,6 +377,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     brokerIds.foreach { brokerId =>
       val brokerModificationsHandler = new BrokerModificationsHandler(this, eventManager, brokerId)
       zkClient.registerZNodeChangeHandler(brokerModificationsHandler)
+      zkClient.pathExists(brokerModificationsHandler.path) // Ensure watch is set for the path
       brokerModificationsHandlers.put(brokerId, brokerModificationsHandler)
     }
   }
@@ -404,8 +405,8 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     unregisterBrokerModificationsHandler(deadBrokers)
   }
 
-  private def onBrokerUpdate(updatedBrokers: Seq[Int]) {
-    info(s"Broker info update callback for ${updatedBrokers.mkString(",")}")
+  private def onBrokerUpdate(updatedBrokerId: Int) {
+    info(s"Broker info update callback for $updatedBrokerId")
     sendUpdateMetadataRequest(controllerContext.liveOrShuttingDownBrokerIds.toSeq)
   }
 
@@ -1244,25 +1245,19 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     }
   }
 
-  case object BrokerModifications extends ControllerEvent {
+  case class BrokerModifications(brokerId: Int) extends ControllerEvent {
     override def state: ControllerState = ControllerState.BrokerChange
 
     override def process(): Unit = {
       if (!isActive) return
-      val curBrokers = zkClient.getAllBrokersInCluster.toSet
-      val updatedBrokers = controllerContext.liveBrokers.filter { broker =>
-        val existingBroker = curBrokers.find(_.id == broker.id)
-        existingBroker match {
-          case Some(b) => broker.endPoints != b.endPoints
-          case None => false
-        }
-      }
-      if (updatedBrokers.nonEmpty) {
-        val updatedBrokerIdsSorted = updatedBrokers.map(_.id).toSeq.sorted
-        info(s"Updated brokers: $updatedBrokers")
+      val newMetadata = zkClient.getBroker(brokerId)
+      val oldMetadata = controllerContext.liveBrokers.find(_.id == brokerId)
+      if (newMetadata.nonEmpty && oldMetadata.nonEmpty && newMetadata.map(_.endPoints) != oldMetadata.map(_.endPoints)) {
+        info(s"Updated broker: $newMetadata")
 
+        val curBrokers = controllerContext.liveBrokers -- oldMetadata ++ newMetadata
         controllerContext.liveBrokers = curBrokers // Update broker metadata
-        onBrokerUpdate(updatedBrokerIdsSorted)
+        onBrokerUpdate(brokerId)
       }
     }
   }
@@ -1525,7 +1520,7 @@ class BrokerModificationsHandler(controller: KafkaController, eventManager: Cont
   override val path: String = BrokerIdZNode.path(brokerId)
 
   override def handleDataChange(): Unit = {
-    eventManager.put(controller.BrokerModifications)
+    eventManager.put(controller.BrokerModifications(brokerId))
   }
 }
 

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -376,8 +376,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
     debug(s"Register BrokerModifications handler for $brokerIds")
     brokerIds.foreach { brokerId =>
       val brokerModificationsHandler = new BrokerModificationsHandler(this, eventManager, brokerId)
-      zkClient.registerZNodeChangeHandler(brokerModificationsHandler)
-      zkClient.pathExists(brokerModificationsHandler.path) // Ensure watch is set for the path
+      zkClient.registerZNodeChangeHandlerAndCheckExistence(brokerModificationsHandler)
       brokerModificationsHandlers.put(brokerId, brokerModificationsHandler)
     }
   }
@@ -1253,7 +1252,7 @@ class KafkaController(val config: KafkaConfig, zkClient: KafkaZkClient, time: Ti
       val newMetadata = zkClient.getBroker(brokerId)
       val oldMetadata = controllerContext.liveBrokers.find(_.id == brokerId)
       if (newMetadata.nonEmpty && oldMetadata.nonEmpty && newMetadata.map(_.endPoints) != oldMetadata.map(_.endPoints)) {
-        info(s"Updated broker: $newMetadata")
+        info(s"Updated broker: ${newMetadata.get}")
 
         val curBrokers = controllerContext.liveBrokers -- oldMetadata ++ newMetadata
         controllerContext.liveBrokers = curBrokers // Update broker metadata


### PR DESCRIPTION
Ensures that ZK watch is set for each live broker for listener update notifications in the controller by invoking `pathExists` since a watch is registered only if `exists` or `getData` is invoked after `registerZNodeChangeHandler`. Also avoids reading all brokers from ZooKeeper when a broker metadata is modified by passing in brokerId to `BrokerModifications` and reading only the updated broker.

The existing listener update test verifies both these changes. Earlier, the test did not detect missing watch for the last broker since metadata of all brokers were read from ZK (adding a watch for all) when any broker was updated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
