### PR TITLE
Trogdor's ProducerBench does not fail if topics exists

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -212,6 +212,8 @@
               files="SignalLogger.java"/>
     <suppress checks="IllegalImport"
               files="SignalLogger.java"/>
+    <suppress checks="ParameterNumber"
+              files="ProduceBenchSpec.java"/>
 
     <!-- Log4J-Appender -->
     <suppress checks="CyclomaticComplexity"

--- a/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/MockAdminClient.java
@@ -152,6 +152,7 @@ public class MockAdminClient extends AdminClient {
             if (allTopics.containsKey(topicName)) {
                 future.completeExceptionally(new TopicExistsException(String.format("Topic %s exists already.", topicName)));
                 createTopicResult.put(topicName, future);
+                continue;
             }
             int replicationFactor = newTopic.replicationFactor();
             List<Node> replicas = new ArrayList<>(replicationFactor);

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -137,8 +137,8 @@ public final class WorkerUtils {
      * @return                Collection of topics names that already exist.
      * @throws Throwable if creation of one or more topics fails (except for topic exists case).
      */
-    static Collection<String> createTopics(Logger log, AdminClient adminClient,
-                             Collection<NewTopic> topics) throws Throwable {
+    private static Collection<String> createTopics(Logger log, AdminClient adminClient,
+                                                   Collection<NewTopic> topics) throws Throwable {
         long startMs = Time.SYSTEM.milliseconds();
         int tries = 0;
         List<String> existingTopics = new ArrayList<>();
@@ -207,7 +207,7 @@ public final class WorkerUtils {
      * @throws RuntimeException  If one or more topics have different number of partitions than
      * described in 'topicsInfo'
      */
-    static void verifyTopics(
+    private static void verifyTopics(
         Logger log, AdminClient adminClient,
         Collection<String> topicsToVerify, Map<String, NewTopic> topicsInfo) throws Throwable {
         DescribeTopicsResult topicsResult = adminClient.describeTopics(

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -47,7 +47,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final Map<String, String> producerConf;
     private final int totalTopics;
     private final int activeTopics;
-    private final String topicsPrefix;
+    private final String topicPrefix;
     private final int numPartitions;
     private final short replicationFactor;
 
@@ -63,7 +63,7 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("producerConf") Map<String, String> producerConf,
                          @JsonProperty("totalTopics") int totalTopics,
                          @JsonProperty("activeTopics") int activeTopics,
-                         @JsonProperty("topicPrefix") String topicsPrefix,
+                         @JsonProperty("topicPrefix") String topicPrefix,
                          @JsonProperty("partitionsPerTopic") int partitionsPerTopic,
                          @JsonProperty("replicationFactor") short replicationFactor) {
         super(startMs, durationMs);
@@ -78,7 +78,7 @@ public class ProduceBenchSpec extends TaskSpec {
         this.producerConf = (producerConf == null) ? new TreeMap<String, String>() : producerConf;
         this.totalTopics = totalTopics;
         this.activeTopics = activeTopics;
-        this.topicsPrefix = (topicsPrefix == null) ? DEFAULT_TOPIC_PREFIX : topicsPrefix;
+        this.topicPrefix = (topicPrefix == null) ? DEFAULT_TOPIC_PREFIX : topicPrefix;
         this.numPartitions = (partitionsPerTopic == 0)
                              ? DEFAULT_NUM_PARTITIONS : partitionsPerTopic;
         this.replicationFactor = (replicationFactor == 0)
@@ -131,8 +131,8 @@ public class ProduceBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public String topicsPrefix() {
-        return topicsPrefix;
+    public String topicPrefix() {
+        return topicPrefix;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -33,6 +33,11 @@ import java.util.Set;
  * The specification for a benchmark that produces messages to a set of topics.
  */
 public class ProduceBenchSpec extends TaskSpec {
+
+    private static final String DEFAULT_TOPIC_PREFIX = "produceBenchTopic";
+    private static final int DEFAULT_NUM_PARTITIONS = 1;
+    private static final short DEFAULT_REPLICATION_FACTOR = 3;
+
     private final String producerNode;
     private final String bootstrapServers;
     private final int targetMessagesPerSec;
@@ -42,6 +47,9 @@ public class ProduceBenchSpec extends TaskSpec {
     private final Map<String, String> producerConf;
     private final int totalTopics;
     private final int activeTopics;
+    private final String topicsPrefix;
+    private final int numPartitions;
+    private final short replicationFactor;
 
     @JsonCreator
     public ProduceBenchSpec(@JsonProperty("startMs") long startMs,
@@ -54,7 +62,10 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
                          @JsonProperty("producerConf") Map<String, String> producerConf,
                          @JsonProperty("totalTopics") int totalTopics,
-                         @JsonProperty("activeTopics") int activeTopics) {
+                         @JsonProperty("activeTopics") int activeTopics,
+                         @JsonProperty("topicPrefix") String topicsPrefix,
+                         @JsonProperty("partitionsPerTopic") int partitionsPerTopic,
+                         @JsonProperty("replicationFactor") short replicationFactor) {
         super(startMs, durationMs);
         this.producerNode = (producerNode == null) ? "" : producerNode;
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
@@ -67,6 +78,11 @@ public class ProduceBenchSpec extends TaskSpec {
         this.producerConf = (producerConf == null) ? new TreeMap<String, String>() : producerConf;
         this.totalTopics = totalTopics;
         this.activeTopics = activeTopics;
+        this.topicsPrefix = (topicsPrefix == null) ? DEFAULT_TOPIC_PREFIX : topicsPrefix;
+        this.numPartitions = (partitionsPerTopic == 0)
+                             ? DEFAULT_NUM_PARTITIONS : partitionsPerTopic;
+        this.replicationFactor = (replicationFactor == 0)
+                                 ? DEFAULT_REPLICATION_FACTOR : replicationFactor;
     }
 
     @JsonProperty
@@ -112,6 +128,21 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public int activeTopics() {
         return activeTopics;
+    }
+
+    @JsonProperty
+    public String topicsPrefix() {
+        return topicsPrefix;
+    }
+
+    @JsonProperty
+    public int numPartitions() {
+        return numPartitions;
+    }
+
+    @JsonProperty
+    public short replicationFactor() {
+        return replicationFactor;
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -111,8 +111,7 @@ public class ProduceBenchWorker implements TaskWorker {
                     String name = topicIndexToName(i);
                     newTopics.put(name, new NewTopic(name, spec.numPartitions(), spec.replicationFactor()));
                 }
-                WorkerUtils.verifyTopicsAndCreateNonExistingTopics(
-                    log, spec.bootstrapServers(), newTopics);
+                WorkerUtils.createTopics(log, spec.bootstrapServers(), newTopics, false);
 
                 executor.submit(new SendRecords());
             } catch (Throwable e) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -72,7 +72,7 @@ public class ProduceBenchWorker implements TaskWorker {
      * @return                  The topic name.
      */
     public String topicIndexToName(int topicIndex) {
-        return String.format("%s%05d", spec.topicsPrefix(), topicIndex);
+        return String.format("%s%05d", spec.topicPrefix(), topicIndex);
     }
 
     public ProduceBenchWorker(String id, ProduceBenchSpec spec) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -123,8 +123,11 @@ public class RoundTripWorker implements TaskWorker {
                 if ((spec.partitionAssignments() == null) || spec.partitionAssignments().isEmpty()) {
                     throw new ConfigException("Invalid null or empty partitionAssignments.");
                 }
-                WorkerUtils.createTopics(log, spec.bootstrapServers(),
-                    Collections.singletonList(new NewTopic(TOPIC_NAME, spec.partitionAssignments())));
+                WorkerUtils.createTopics(
+                    log, spec.bootstrapServers(),
+                    Collections.singletonMap(TOPIC_NAME,
+                                             new NewTopic(TOPIC_NAME, spec.partitionAssignments())),
+                    true);
                 executor.submit(new ProducerRunnable());
                 executor.submit(new ConsumerRunnable());
             } catch (Throwable e) {

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -49,7 +49,7 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, 0, null));
         verify(new WorkerStopping(null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, null, 0, 0));
+            0, 0, null, null, null, 0, 0, "test-topic", 1, (short)3));
         verify(new RoundTripWorkloadSpec(0, 0, null, null,
             0, null, null, 0));
         verify(new SampleTaskSpec(0, 0, 0, null));

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -49,7 +49,7 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, 0, null));
         verify(new WorkerStopping(null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, null, 0, 0, "test-topic", 1, (short)3));
+            0, 0, null, null, null, 0, 0, "test-topic", 1, (short) 3));
         verify(new RoundTripWorkloadSpec(0, 0, null, null,
             0, null, null, 0));
         verify(new SampleTaskSpec(0, 0, 0, null));

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -49,13 +50,7 @@ public class WorkerUtilsTest {
     private final Node broker1 = new Node(0, "testHost-1", 1234);
     private final Node broker2 = new Node(1, "testHost-2", 1234);
     private final Node broker3 = new Node(1, "testHost-3", 1234);
-    private final List<Node> cluster = new ArrayList<Node>(2) {
-        {
-            add(broker1);
-            add(broker2);
-            add(broker3);
-        }
-    };
+    private final List<Node> cluster = Arrays.asList(broker1, broker2, broker3);
     private final List<Node> singleReplica = Collections.singletonList(broker1);
 
     private static final String TEST_TOPIC = "test-topic-1";
@@ -78,11 +73,14 @@ public class WorkerUtilsTest {
 
         WorkerUtils.createTopics(log, adminClient, newTopics, true);
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
-        assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
-            {
-                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
-            }
-        }), adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get());
+        assertEquals(
+            new TopicDescription(
+                TEST_TOPIC, false,
+                Collections.singletonList(
+                    new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()))),
+            adminClient.describeTopics(
+                Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get()
+        );
     }
 
     @Test
@@ -92,11 +90,14 @@ public class WorkerUtilsTest {
         WorkerUtils.createTopics(
             log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), true);
 
-        assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
-            {
-                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
-            }
-        }), adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get());
+        assertEquals(
+            new TopicDescription(
+                TEST_TOPIC, false,
+                Collections.singletonList(
+                    new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()))),
+            adminClient.describeTopics(
+                Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get()
+        );
     }
 
     @Test
@@ -169,11 +170,13 @@ public class WorkerUtilsTest {
             log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), false);
 
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
-        assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
-            {
-                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
-            }
-        }), adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get());
+        assertEquals(
+            new TopicDescription(
+                TEST_TOPIC, false,
+                Collections.singletonList(
+                    new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()))),
+            adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get()
+        );
     }
 
     @Test

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -25,7 +25,6 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.clients.admin.MockAdminClient;
 
-import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +35,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -77,7 +77,8 @@ public class WorkerUtilsTest {
     public void testCreateOneTopic() throws Throwable {
         Set<NewTopic> newTopics = Collections.singleton(NEW_TEST_TOPIC);
 
-        WorkerUtils.createTopics(log, adminClient, newTopics);
+        Collection<String> topicsExist = WorkerUtils.createTopics(log, adminClient, newTopics);
+        assertEquals(0, topicsExist.size());
         assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
         assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
             {
@@ -92,7 +93,7 @@ public class WorkerUtilsTest {
         assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
-    @Test(expected = TopicExistsException.class)
+    @Test
     public void testCreateTopicsFailsIfAtLeastOneTopicExists() throws Throwable {
         adminClient.addTopic(
             false,
@@ -106,7 +107,8 @@ public class WorkerUtilsTest {
         newTopics.add(new NewTopic("another-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
         newTopics.add(new NewTopic("one-more-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
 
-        WorkerUtils.createTopics(log, adminClient, newTopics);
+        Collection<String> topicsExist = WorkerUtils.createTopics(log, adminClient, newTopics);
+        assertEquals(1, topicsExist.size());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -18,30 +18,24 @@
 package org.apache.kafka.trogdor.common;
 
 
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.DescribeTopicsOptions;
-import org.apache.kafka.clients.admin.DescribeTopicsResult;
-import org.apache.kafka.clients.admin.ListTopicsOptions;
-import org.apache.kafka.clients.admin.ListTopicsResult;
+
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.TopicPartitionInfo;
-import org.apache.kafka.common.errors.UnknownServerException;
-import org.apache.kafka.common.internals.KafkaFutureImpl;
-import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.Node;
 
+import org.apache.kafka.common.Node;
+import org.apache.kafka.clients.admin.MockAdminClient;
+
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.easymock.EasyMock;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -53,206 +47,148 @@ public class WorkerUtilsTest {
 
     private static final Logger log = LoggerFactory.getLogger(WorkerUtilsTest.class);
 
+    private final Node broker1 = new Node(0, "testHost-1", 1234);
+    private final Node broker2 = new Node(1, "testHost-2", 1234);
+    private final Node broker3 = new Node(1, "testHost-3", 1234);
+    private final List<Node> cluster = new ArrayList<Node>(2) {
+        {
+            add(broker1);
+            add(broker2);
+            add(broker3);
+        }
+    };
+    private final List<Node> singleReplica = Collections.singletonList(broker1);
+
     private static final String TEST_TOPIC = "test-topic-1";
-    private static final short TEST_REPLICATION_FACTOR = 3;
-    private static final int TEST_PARTITIONS = 5;
+    private static final short TEST_REPLICATION_FACTOR = 1;
+    private static final int TEST_PARTITIONS = 1;
     private static final NewTopic NEW_TEST_TOPIC =
         new NewTopic(TEST_TOPIC, TEST_PARTITIONS, TEST_REPLICATION_FACTOR);
 
-    private static final Node TEST_NODE = new Node(1, "localhost", 9092);
-    private static final TopicPartitionInfo TEST_TOPIC_PARTITION =
-        new TopicPartitionInfo(
-            0, TEST_NODE, Collections.singletonList(TEST_NODE), Collections.singletonList(TEST_NODE));
-    private static final TopicDescription TEST_TOPIC_DESCRIPTION =
-        new TopicDescription(TEST_TOPIC, false, Collections.singletonList(TEST_TOPIC_PARTITION));
+    private MockAdminClient adminClient;
 
-    private AdminClient adminClient;
-    private CreateTopicsResult createTopicsResult;
-    private ListTopicsResult listTopicsResult;
-    private DescribeTopicsResult describeTopicsResult;
 
     @Before
     public void setUp() throws Exception {
-        adminClient = EasyMock.mock(AdminClient.class);
-        createTopicsResult = EasyMock.mock(CreateTopicsResult.class);
-        listTopicsResult = EasyMock.mock(ListTopicsResult.class);
-        describeTopicsResult = EasyMock.mock(DescribeTopicsResult.class);
+        adminClient = new MockAdminClient(cluster, broker1);
     }
 
     @Test
     public void testCreateOneTopic() throws Throwable {
         Set<NewTopic> newTopics = Collections.singleton(NEW_TEST_TOPIC);
 
-        expectCreateTopics(newTopics, Collections.<String, Exception>emptyMap());
-
-        EasyMock.replay(createTopicsResult);
-        EasyMock.replay(adminClient);
-
         WorkerUtils.createTopics(log, adminClient, newTopics);
-
-        EasyMock.verify(createTopicsResult);
-        EasyMock.verify(adminClient);
+        assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
+        assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
+            {
+                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
+            }
+        }), adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get());
     }
 
     @Test
     public void testCreateZeroTopicsDoesNothing() throws Throwable {
         WorkerUtils.createTopics(log, adminClient, Collections.<NewTopic>emptyList());
+        assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
-    @Test(expected = UnknownServerException.class)
-    public void testCreateTopicsFailsIfAtLeastOneTopicCreationFails() throws Throwable {
+    @Test(expected = TopicExistsException.class)
+    public void testCreateTopicsFailsIfAtLeastOneTopicExists() throws Throwable {
+        adminClient.addTopic(
+            false,
+            TEST_TOPIC,
+            Collections.singletonList(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList())),
+            null);
+
         List<NewTopic> newTopics = new ArrayList<>();
 
         newTopics.add(NEW_TEST_TOPIC);
         newTopics.add(new NewTopic("another-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
         newTopics.add(new NewTopic("one-more-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
 
-        expectCreateTopics(
-            newTopics,
-            Collections.<String, Exception>singletonMap(TEST_TOPIC, new UnknownServerException()));
-
-        EasyMock.replay(createTopicsResult);
-        EasyMock.replay(adminClient);
-
         WorkerUtils.createTopics(log, adminClient, newTopics);
-
-        EasyMock.verify(createTopicsResult);
-        EasyMock.verify(adminClient);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testExistingTopicsMustHaveRequestedNumberOfPartitions() throws Throwable {
-        Map<String, NewTopic> topics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
+        List<TopicPartitionInfo> tpInfo = new ArrayList<>();
+        tpInfo.add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
+        tpInfo.add(new TopicPartitionInfo(1, broker2, singleReplica, Collections.<Node>emptyList()));
+        adminClient.addTopic(
+            false,
+            TEST_TOPIC,
+            tpInfo,
+            null);
 
-        expectListTopics(topics.keySet());
-        expectDescribeTopics(topics.keySet(), 1);
-
-        EasyMock.replay(listTopicsResult);
-        EasyMock.replay(describeTopicsResult);
-        EasyMock.replay(adminClient);
-
-        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
-
-        EasyMock.verify(listTopicsResult);
-        EasyMock.verify(describeTopicsResult);
-        EasyMock.verify(adminClient);
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC));
     }
 
     @Test
     public void testExistingTopicsNotCreated() throws Throwable {
-        Map<String, NewTopic> topics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
+        final String existingTopic = "existing-topic";
+        List<TopicPartitionInfo> tpInfo = new ArrayList<>();
+        tpInfo.add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
+        tpInfo.add(new TopicPartitionInfo(1, broker2, singleReplica, Collections.<Node>emptyList()));
+        tpInfo.add(new TopicPartitionInfo(2, broker3, singleReplica, Collections.<Node>emptyList()));
+        adminClient.addTopic(
+            false,
+            existingTopic,
+            tpInfo,
+            null);
 
-        expectListTopics(topics.keySet());
-        expectDescribeTopics(topics.keySet(), TEST_PARTITIONS);
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(
+            log, adminClient,
+            Collections.singletonMap(
+                existingTopic,
+                new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR)));
 
-        EasyMock.replay(listTopicsResult);
-        EasyMock.replay(describeTopicsResult);
-        EasyMock.replay(adminClient);
-
-        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
-
-        EasyMock.verify(listTopicsResult);
-        EasyMock.verify(describeTopicsResult);
-        EasyMock.verify(adminClient);
+        assertEquals(Collections.singleton(existingTopic), adminClient.listTopics().names().get());
     }
 
     @Test
     public void testCreatesNotExistingTopics() throws Throwable {
-        Map<String, NewTopic> topics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
+        // should be no topics before the call
+        assertEquals(0, adminClient.listTopics().names().get().size());
 
-        expectListTopics(Collections.<String>emptySet());
-        expectCreateTopics(topics.values(), Collections.<String, Exception>emptyMap());
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC));
 
-        EasyMock.replay(listTopicsResult);
-        EasyMock.replay(createTopicsResult);
-        EasyMock.replay(adminClient);
-
-        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
-
-        EasyMock.verify(listTopicsResult);
-        EasyMock.verify(createTopicsResult);
-        EasyMock.verify(adminClient);
+        assertEquals(Collections.singleton(TEST_TOPIC), adminClient.listTopics().names().get());
+        assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
+            {
+                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
+            }
+        }), adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get());
     }
 
     @Test
     public void testCreatesOneTopicVerifiesOneTopic() throws Throwable {
-        final String newTopicName = "new-topic";
-        Map<String, NewTopic> existingTopics = Collections.singletonMap(
-            TEST_TOPIC, NEW_TEST_TOPIC);
+        final String existingTopic = "existing-topic";
+        List<TopicPartitionInfo> tpInfo = new ArrayList<>();
+        tpInfo.add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
+        tpInfo.add(new TopicPartitionInfo(1, broker2, singleReplica, Collections.<Node>emptyList()));
+        adminClient.addTopic(
+            false,
+            existingTopic,
+            tpInfo,
+            null);
 
-        NewTopic newTopic = new NewTopic(newTopicName, TEST_PARTITIONS, TEST_REPLICATION_FACTOR);
+        Map<String, NewTopic> topics = new HashMap<>();
+        topics.put(existingTopic,
+                   new NewTopic(existingTopic, tpInfo.size(), TEST_REPLICATION_FACTOR));
+        topics.put(TEST_TOPIC, NEW_TEST_TOPIC);
 
-        expectListTopics(existingTopics.keySet());
-        expectDescribeTopics(existingTopics.keySet(), TEST_PARTITIONS);
-        expectCreateTopics(Collections.singleton(newTopic), Collections.<String, Exception>emptyMap());
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
 
-        EasyMock.replay(listTopicsResult);
-        EasyMock.replay(describeTopicsResult);
-        EasyMock.replay(createTopicsResult);
-        EasyMock.replay(adminClient);
-
-        Map<String, NewTopic> allTopics = new HashMap<>();
-        allTopics.putAll(existingTopics);
-        allTopics.put(newTopicName, newTopic);
-        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, allTopics);
-
-        EasyMock.verify(listTopicsResult);
-        EasyMock.verify(describeTopicsResult);
-        EasyMock.verify(createTopicsResult);
-        EasyMock.verify(adminClient);
+        assertEquals(Utils.mkSet(existingTopic, TEST_TOPIC), adminClient.listTopics().names().get());
     }
 
     @Test
     public void testCreateNonExistingTopicsWithZeroTopicsDoesNothing() throws Throwable {
         WorkerUtils.verifyTopicsAndCreateNonExistingTopics(
             log, adminClient, Collections.<String, NewTopic>emptyMap());
-    }
-
-    private void expectCreateTopics(
-        Collection<NewTopic> newTopics, Map<String, Exception> exceptions) {
-        Map<String, KafkaFuture<Void>> topicFutures = new HashMap<>(newTopics.size());
-        for (NewTopic newTopic: newTopics) {
-            KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
-            topicFutures.put(newTopic.name(), future);
-            Exception res = exceptions.get(newTopic.name());
-            if (res == null) {
-                future.complete(null);
-            } else {
-                future.completeExceptionally(res);
-            }
-        }
-        EasyMock.expect(adminClient.createTopics(EasyMock.anyObject(Collection.class)))
-            .andReturn(createTopicsResult).anyTimes();
-        EasyMock.expect(createTopicsResult.values())
-            .andReturn(topicFutures).anyTimes();
-    }
-
-    private void expectListTopics(Set<String> topics) {
-        KafkaFutureImpl<Set<String>> future = new KafkaFutureImpl<>();
-        future.complete(topics);
-
-        EasyMock.expect(adminClient.listTopics(EasyMock.anyObject(ListTopicsOptions.class)))
-            .andReturn(listTopicsResult).anyTimes();
-        EasyMock.expect(listTopicsResult.names()).andReturn(future);
-    }
-
-    private void expectDescribeTopics(Set<String> topics, int partitions) {
-        Map<String, TopicDescription> topicDescriptionMap = new HashMap<>();
-        List<TopicPartitionInfo> topicPartitions = new ArrayList<>();
-        for (int i = 0; i < partitions; i++) {
-            topicPartitions.add(TEST_TOPIC_PARTITION);
-        }
-
-        KafkaFutureImpl<Map<String, TopicDescription>>  future = new KafkaFutureImpl<>();
-        for (String topic: topics) {
-            TopicDescription description = new TopicDescription(topic, false, topicPartitions);
-            topicDescriptionMap.put(topic, description);
-        }
-        future.complete(topicDescriptionMap);
-        EasyMock.expect(adminClient.describeTopics(
-            EasyMock.anyObject(Collection.class), EasyMock.anyObject(DescribeTopicsOptions.class)))
-            .andReturn(describeTopicsResult).anyTimes();
-        EasyMock.expect(describeTopicsResult.all()).andReturn(future);
+        assertEquals(0, adminClient.listTopics().names().get().size());
     }
 
 }

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -86,6 +86,20 @@ public class WorkerUtilsTest {
     }
 
     @Test
+    public void testCreateRetriesOnTimeout() throws Throwable {
+        adminClient.timeoutNextRequest(1);
+
+        WorkerUtils.createTopics(
+            log, adminClient, Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC), true);
+
+        assertEquals(new TopicDescription(TEST_TOPIC, false, new ArrayList<TopicPartitionInfo>() {
+            {
+                add(new TopicPartitionInfo(0, broker1, singleReplica, Collections.<Node>emptyList()));
+            }
+        }), adminClient.describeTopics(Collections.singleton(TEST_TOPIC)).values().get(TEST_TOPIC).get());
+    }
+
+    @Test
     public void testCreateZeroTopicsDoesNothing() throws Throwable {
         WorkerUtils.createTopics(log, adminClient, Collections.<String, NewTopic>emptyMap(), true);
         assertEquals(0, adminClient.listTopics().names().get().size());

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/WorkerUtilsTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.trogdor.common;
+
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DescribeTopicsOptions;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsOptions;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.easymock.EasyMock;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class WorkerUtilsTest {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerUtilsTest.class);
+
+    private static final String TEST_TOPIC = "test-topic-1";
+    private static final short TEST_REPLICATION_FACTOR = 3;
+    private static final int TEST_PARTITIONS = 5;
+    private static final NewTopic NEW_TEST_TOPIC =
+        new NewTopic(TEST_TOPIC, TEST_PARTITIONS, TEST_REPLICATION_FACTOR);
+
+    private static final Node TEST_NODE = new Node(1, "localhost", 9092);
+    private static final TopicPartitionInfo TEST_TOPIC_PARTITION =
+        new TopicPartitionInfo(
+            0, TEST_NODE, Collections.singletonList(TEST_NODE), Collections.singletonList(TEST_NODE));
+    private static final TopicDescription TEST_TOPIC_DESCRIPTION =
+        new TopicDescription(TEST_TOPIC, false, Collections.singletonList(TEST_TOPIC_PARTITION));
+
+    private AdminClient adminClient;
+    private CreateTopicsResult createTopicsResult;
+    private ListTopicsResult listTopicsResult;
+    private DescribeTopicsResult describeTopicsResult;
+
+    @Before
+    public void setUp() throws Exception {
+        adminClient = EasyMock.mock(AdminClient.class);
+        createTopicsResult = EasyMock.mock(CreateTopicsResult.class);
+        listTopicsResult = EasyMock.mock(ListTopicsResult.class);
+        describeTopicsResult = EasyMock.mock(DescribeTopicsResult.class);
+    }
+
+    @Test
+    public void testCreateOneTopic() throws Throwable {
+        Set<NewTopic> newTopics = Collections.singleton(NEW_TEST_TOPIC);
+
+        expectCreateTopics(newTopics, Collections.<String, Exception>emptyMap());
+
+        EasyMock.replay(createTopicsResult);
+        EasyMock.replay(adminClient);
+
+        WorkerUtils.createTopics(log, adminClient, newTopics);
+
+        EasyMock.verify(createTopicsResult);
+        EasyMock.verify(adminClient);
+    }
+
+    @Test
+    public void testCreateZeroTopicsDoesNothing() throws Throwable {
+        WorkerUtils.createTopics(log, adminClient, Collections.<NewTopic>emptyList());
+    }
+
+    @Test(expected = UnknownServerException.class)
+    public void testCreateTopicsFailsIfAtLeastOneTopicCreationFails() throws Throwable {
+        List<NewTopic> newTopics = new ArrayList<>();
+
+        newTopics.add(NEW_TEST_TOPIC);
+        newTopics.add(new NewTopic("another-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
+        newTopics.add(new NewTopic("one-more-topic", TEST_PARTITIONS, TEST_REPLICATION_FACTOR));
+
+        expectCreateTopics(
+            newTopics,
+            Collections.<String, Exception>singletonMap(TEST_TOPIC, new UnknownServerException()));
+
+        EasyMock.replay(createTopicsResult);
+        EasyMock.replay(adminClient);
+
+        WorkerUtils.createTopics(log, adminClient, newTopics);
+
+        EasyMock.verify(createTopicsResult);
+        EasyMock.verify(adminClient);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExistingTopicsMustHaveRequestedNumberOfPartitions() throws Throwable {
+        Map<String, NewTopic> topics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
+
+        expectListTopics(topics.keySet());
+        expectDescribeTopics(topics.keySet(), 1);
+
+        EasyMock.replay(listTopicsResult);
+        EasyMock.replay(describeTopicsResult);
+        EasyMock.replay(adminClient);
+
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
+
+        EasyMock.verify(listTopicsResult);
+        EasyMock.verify(describeTopicsResult);
+        EasyMock.verify(adminClient);
+    }
+
+    @Test
+    public void testExistingTopicsNotCreated() throws Throwable {
+        Map<String, NewTopic> topics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
+
+        expectListTopics(topics.keySet());
+        expectDescribeTopics(topics.keySet(), TEST_PARTITIONS);
+
+        EasyMock.replay(listTopicsResult);
+        EasyMock.replay(describeTopicsResult);
+        EasyMock.replay(adminClient);
+
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
+
+        EasyMock.verify(listTopicsResult);
+        EasyMock.verify(describeTopicsResult);
+        EasyMock.verify(adminClient);
+    }
+
+    @Test
+    public void testCreatesNotExistingTopics() throws Throwable {
+        Map<String, NewTopic> topics = Collections.singletonMap(TEST_TOPIC, NEW_TEST_TOPIC);
+
+        expectListTopics(Collections.<String>emptySet());
+        expectCreateTopics(topics.values(), Collections.<String, Exception>emptyMap());
+
+        EasyMock.replay(listTopicsResult);
+        EasyMock.replay(createTopicsResult);
+        EasyMock.replay(adminClient);
+
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, topics);
+
+        EasyMock.verify(listTopicsResult);
+        EasyMock.verify(createTopicsResult);
+        EasyMock.verify(adminClient);
+    }
+
+    @Test
+    public void testCreatesOneTopicVerifiesOneTopic() throws Throwable {
+        final String newTopicName = "new-topic";
+        Map<String, NewTopic> existingTopics = Collections.singletonMap(
+            TEST_TOPIC, NEW_TEST_TOPIC);
+
+        NewTopic newTopic = new NewTopic(newTopicName, TEST_PARTITIONS, TEST_REPLICATION_FACTOR);
+
+        expectListTopics(existingTopics.keySet());
+        expectDescribeTopics(existingTopics.keySet(), TEST_PARTITIONS);
+        expectCreateTopics(Collections.singleton(newTopic), Collections.<String, Exception>emptyMap());
+
+        EasyMock.replay(listTopicsResult);
+        EasyMock.replay(describeTopicsResult);
+        EasyMock.replay(createTopicsResult);
+        EasyMock.replay(adminClient);
+
+        Map<String, NewTopic> allTopics = new HashMap<>();
+        allTopics.putAll(existingTopics);
+        allTopics.put(newTopicName, newTopic);
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(log, adminClient, allTopics);
+
+        EasyMock.verify(listTopicsResult);
+        EasyMock.verify(describeTopicsResult);
+        EasyMock.verify(createTopicsResult);
+        EasyMock.verify(adminClient);
+    }
+
+    @Test
+    public void testCreateNonExistingTopicsWithZeroTopicsDoesNothing() throws Throwable {
+        WorkerUtils.verifyTopicsAndCreateNonExistingTopics(
+            log, adminClient, Collections.<String, NewTopic>emptyMap());
+    }
+
+    private void expectCreateTopics(
+        Collection<NewTopic> newTopics, Map<String, Exception> exceptions) {
+        Map<String, KafkaFuture<Void>> topicFutures = new HashMap<>(newTopics.size());
+        for (NewTopic newTopic: newTopics) {
+            KafkaFutureImpl<Void> future = new KafkaFutureImpl<>();
+            topicFutures.put(newTopic.name(), future);
+            Exception res = exceptions.get(newTopic.name());
+            if (res == null) {
+                future.complete(null);
+            } else {
+                future.completeExceptionally(res);
+            }
+        }
+        EasyMock.expect(adminClient.createTopics(EasyMock.anyObject(Collection.class)))
+            .andReturn(createTopicsResult).anyTimes();
+        EasyMock.expect(createTopicsResult.values())
+            .andReturn(topicFutures).anyTimes();
+    }
+
+    private void expectListTopics(Set<String> topics) {
+        KafkaFutureImpl<Set<String>> future = new KafkaFutureImpl<>();
+        future.complete(topics);
+
+        EasyMock.expect(adminClient.listTopics(EasyMock.anyObject(ListTopicsOptions.class)))
+            .andReturn(listTopicsResult).anyTimes();
+        EasyMock.expect(listTopicsResult.names()).andReturn(future);
+    }
+
+    private void expectDescribeTopics(Set<String> topics, int partitions) {
+        Map<String, TopicDescription> topicDescriptionMap = new HashMap<>();
+        List<TopicPartitionInfo> topicPartitions = new ArrayList<>();
+        for (int i = 0; i < partitions; i++) {
+            topicPartitions.add(TEST_TOPIC_PARTITION);
+        }
+
+        KafkaFutureImpl<Map<String, TopicDescription>>  future = new KafkaFutureImpl<>();
+        for (String topic: topics) {
+            TopicDescription description = new TopicDescription(topic, false, topicPartitions);
+            topicDescriptionMap.put(topic, description);
+        }
+        future.complete(topicDescriptionMap);
+        EasyMock.expect(adminClient.describeTopics(
+            EasyMock.anyObject(Collection.class), EasyMock.anyObject(DescribeTopicsOptions.class)))
+            .andReturn(describeTopicsResult).anyTimes();
+        EasyMock.expect(describeTopicsResult.all()).andReturn(future);
+    }
+
+}


### PR DESCRIPTION
Added configs to ProducerBenchSpec:
topicPrefix: name of topics will be of format topicPrefix + topic index. If not provided, default is "produceBenchTopic".
partitionsPerTopic: number of partitions per topic. If not provided, default is 1.
replicationFactor: replication factor per topic. If not provided, default is 3.

The behavior of producer bench is changed such that if some or all topics already exist (with topic names = topicPrefix + topic index), and they have the same number of partitions as requested, the worker uses those topics and does not fail. The producer bench fails if one or more existing topics has number of partitions that is different from expected number of partitions.

Added unit test for WorkerUtils -- for existing methods and new methods.

Fixed bug in MockAdminClient, where createTopics() would over-write existing topic's replication factor and number of partitions while correctly completing the appropriate futures exceptionally with `TopicExistsException`.