### PR TITLE
KAFKA-6648 - Fetcher.getTopicMetadata() should return all partitions for each requested topic

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -313,7 +313,7 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
                 if (!shouldRetry) {
                     HashMap<String, List<PartitionInfo>> topicsPartitionInfos = new HashMap<>();
                     for (String topic : cluster.topics())
-                        topicsPartitionInfos.put(topic, cluster.availablePartitionsForTopic(topic));
+                        topicsPartitionInfos.put(topic, cluster.partitionsForTopic(topic));
                     return topicsPartitionInfos;
                 }
             }


### PR DESCRIPTION
this is on the path of `KafkaConsumer.listTopics()`, but more importantly its also on the path of `KafkaConsumer.partitionsFor()`, where it means that under some circumstances the consumer will return only the "healthy" partitions (those with a controller) as opposed to all of the partitions.

this leads to issues downstream where various systems think the partition count on a topic has changed where in reality some broker just went down.
