### PR TITLE
MINOR: Fix wrong message in `bin/kafka-run-class.sh`.

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -137,7 +137,7 @@ done
 shopt -u nullglob
 
 if [ -z "$CLASSPATH" ] ; then
-  echo "Classpath is empty. Please build the project first e.g. by running './gradlew jar -Pscala_version=$SCALA_VERSION'"
+  echo "Classpath is empty. Please build the project first e.g. by running './gradlew jar -PscalaVersion=$SCALA_VERSION'"
   exit 1
 fi
 


### PR DESCRIPTION
To build jar you need to specify `scalaVersion` instead of `scala_version`.
https://github.com/apache/kafka/blob/8df96a4119a5d46372eecdceb916f80dd073338a/gradle/dependencies.gradle#L34

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
