### PR TITLE
KAFKA-6264: Log cleaner thread may die on legacy segment containing messages whose offsets are too large

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -49,7 +49,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
   protected val lock = new ReentrantLock
 
   @volatile
-  protected var mmap: MappedByteBuffer = {
+  protected[log] var mmap: MappedByteBuffer = {
     val newlyCreated = file.createNewFile()
     val raf = if (writable) new RandomAccessFile(file, "rw") else new RandomAccessFile(file, "r")
     try {
@@ -88,7 +88,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
 
   /** The number of entries in this index */
   @volatile
-  protected var _entries = mmap.position() / entrySize
+  protected[log] var _entries = mmap.position() / entrySize
 
   /**
    * True iff there are no more slots available in this index

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -351,7 +351,10 @@ class Log(@volatile var dir: File,
           time = time,
           fileAlreadyExists = true)
 
-        try segment.sanityCheck(timeIndexFileNewlyCreated)
+        try {
+          segment.sanityCheck(timeIndexFileNewlyCreated)
+          segment.initializeTimestampMetadata()
+        }
         catch {
           case _: NoSuchFileException =>
             error(s"Could not find offset index file corresponding to log file ${segment.log.file.getAbsolutePath}, " +

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1120,15 +1120,15 @@ class Log(@volatile var dir: File,
           s"for partition $topicPartition is ${config.messageFormatVersion} which is earlier than the minimum " +
           s"required version $KAFKA_0_10_0_IV0")
 
-      // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
-      // constant time access while being safe to use with concurrent collections unlike `toArray`.
-      val segmentsCopy = logSegments.toBuffer
       // For the earliest and latest, we do not need to return the timestamp.
       if (targetTimestamp == ListOffsetRequest.EARLIEST_TIMESTAMP)
         return Some(TimestampOffset(RecordBatch.NO_TIMESTAMP, logStartOffset))
       else if (targetTimestamp == ListOffsetRequest.LATEST_TIMESTAMP)
         return Some(TimestampOffset(RecordBatch.NO_TIMESTAMP, logEndOffset))
 
+      // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
+      // constant time access while being safe to use with concurrent collections unlike `toArray`.
+      val segmentsCopy = logSegments.toBuffer
       val targetSeg = {
         // Get all the segments whose largest timestamp is smaller than target timestamp
         val earlierSegs = segmentsCopy.takeWhile(_.largestTimestamp < targetTimestamp)

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -621,6 +621,12 @@ private[log] class Cleaner(val id: Int,
         val largestOffsetToAppend = result.maxOffset
 
         if ((largestOffsetToAppend - baseOffsetOfLog) > Integer.MAX_VALUE) {
+          // Typically, a segment can only include messages whose offsets can be represented as an integer offset relative
+          // to the baseOffset. #groupSegmentsBySize must already make sure that we do not cross this threshold on a
+          // segment-boundary. So if the largest offset cannot be represented as its base-relative form, we must only
+          // have exactly one segment in such a group.
+          // Note that having a segment with messages that cannot be expressed as an integer in base-relative form is not
+          // a typical scenario, and is only true for segments created before the patch for KAFKA-5413.
           require(numSegmentsInGroup == 1, s"Constructed segment group causes index offset overflow for $topicPartition")
           allowOversizeIndexOffset = true
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -596,7 +596,7 @@ private[log] class Cleaner(val id: Int,
     }
 
     var position = 0
-    var mayBeLegacySegment = false
+    var allowOversizeIndexOffset = false
     while (position < sourceRecords.sizeInBytes) {
       checkDone(topicPartition)
       // read a chunk of messages and copy any that are to be retained to the write buffer to be written out
@@ -623,10 +623,10 @@ private[log] class Cleaner(val id: Int,
 
         if ((largestOffsetToAppend - baseOffsetOfLog) > Integer.MAX_VALUE) {
           require(numSegmentsInGroup == 1, "Constructed segment group causes index offset overflow")
-          mayBeLegacySegment = true
+          allowOversizeIndexOffset = true
 
           debug("Offset overflow during log cleaning " +
-                s"topic: ${topicPartition.topic} largest: $largestOffsetToAppend " +
+                s"topic: $topicPartition largest: $largestOffsetToAppend " +
                 s"first: $firstOffsetToAppend base: $firstOffsetToAppend")
         }
 
@@ -636,7 +636,7 @@ private[log] class Cleaner(val id: Int,
           largestTimestamp = result.maxTimestamp,
           shallowOffsetOfMaxTimestamp = result.shallowOffsetOfMaxTimestamp,
           records = retained,
-          mayBeLegacySegment = mayBeLegacySegment)
+          allowOversizeIndexOffset = allowOversizeIndexOffset)
         throttler.maybeThrottle(outputBuffer.limit())
       }
 

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -618,16 +618,13 @@ private[log] class Cleaner(val id: Int,
         outputBuffer.flip()
         val retained = MemoryRecords.readableRecords(outputBuffer)
         val baseOffsetOfLog = dest.baseOffset
-        val firstOffsetToAppend = retained.batches.iterator.next.baseOffset
         val largestOffsetToAppend = result.maxOffset
 
         if ((largestOffsetToAppend - baseOffsetOfLog) > Integer.MAX_VALUE) {
-          require(numSegmentsInGroup == 1, "Constructed segment group causes index offset overflow")
+          require(numSegmentsInGroup == 1, s"Constructed segment group causes index offset overflow for $topicPartition")
           allowOversizeIndexOffset = true
 
-          debug("Offset overflow during log cleaning " +
-                s"topic: $topicPartition largest: $largestOffsetToAppend " +
-                s"first: $firstOffsetToAppend base: $firstOffsetToAppend")
+          debug(s"Offset overflow during log cleaning topic-partition: $topicPartition largestOffset: $largestOffsetToAppend")
         }
 
         // it's OK not to hold the Log's lock in this case, because this segment is only accessed by other threads

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -185,7 +185,7 @@ class LogSegment private[log] (val log: FileRecords,
           timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestamp)
           bytesSinceLastIndexEntry = 0
         } else {
-          debug("Skipping append to offset index to prevent offset overflow")
+          debug(s"Skipping append to offset index to prevent offset overflow (${log.file.getAbsolutePath})")
         }
       }
       bytesSinceLastIndexEntry += records.sizeInBytes

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -139,10 +139,11 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
     * @return Base-relative offset
     * @throws InvalidOffsetException
     */
-  def getRelativeOffset(offset: Long): Int = {
+  def relativeOffset(offset: Long): Int = {
     val relativeOffset = (offset - baseOffset)
     if (relativeOffset > Integer.MAX_VALUE || relativeOffset < 0)
-      throw new InvalidOffsetException(s"Attempt to append offset $offset to offset index with base offset $baseOffset will cause offset overflow")
+      throw new InvalidOffsetException(
+        s"Attempt to append offset $offset to time index with base offset $baseOffset will cause overflow (${file.getAbsolutePath})")
     relativeOffset.toInt
   }
 
@@ -153,9 +154,9 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
     inLock(lock) {
       require(!isFull, "Attempt to append to a full index (size = " + _entries + ").")
       if (_entries == 0 || offset > _lastOffset) {
-        val relativeOffset = getRelativeOffset(offset)
+        val relOffset = relativeOffset(offset)
         debug("Adding index entry %d => %d to %s.".format(offset, position, file.getName))
-        mmap.putInt(relativeOffset)
+        mmap.putInt(relOffset)
         mmap.putInt(position)
         _entries += 1
         _lastOffset = offset

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -139,8 +139,10 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
     inLock(lock) {
       require(!isFull, "Attempt to append to a full index (size = " + _entries + ").")
       if (_entries == 0 || offset > _lastOffset) {
+        val relativeOffset = offset - baseOffset
+        require(relativeOffset <= Integer.MAX_VALUE, "index offset overflow")
         debug("Adding index entry %d => %d to %s.".format(offset, position, file.getName))
-        mmap.putInt((offset - baseOffset).toInt)
+        mmap.putInt(relativeOffset.toInt)
         mmap.putInt(position)
         _entries += 1
         _lastOffset = offset

--- a/core/src/main/scala/kafka/log/TimeIndex.scala
+++ b/core/src/main/scala/kafka/log/TimeIndex.scala
@@ -97,19 +97,51 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
   }
 
   /**
+    * Convert given offset to base-relative form. This function throws InvalidOffsetException if the conversion results
+    * in overflow or underflow.
+    * @param offset Offset to convert to base-relative form.
+    * @return Base-relative offset.
+    * @throws InvalidOffsetException
+    */
+  def getRelativeOffset(offset: Long): Int = {
+    val relativeOffset = (offset - baseOffset)
+    if (relativeOffset > Integer.MAX_VALUE || relativeOffset < 0)
+      throw new InvalidOffsetException(s"Attempt to append offset $offset to time index with base offset $baseOffset will cause offset overflow")
+
+    relativeOffset.toInt
+  }
+
+  /**
    * Attempt to append a time index entry to the time index.
    * The new entry is appended only if both the timestamp and offsets are greater than the last appended timestamp and
    * the last appended offset.
    *
    * @param timestamp The timestamp of the new time index entry
    * @param offset The offset of the new time index entry
-   * @param skipFullCheck To skip checking whether the segment is full or not. We only skip the check when the segment
+   * @param skipIndexFullCheck To skip checking whether the segment is full or not. We only skip the check when the segment
    *                      gets rolled or the segment is closed.
    */
-  def maybeAppend(timestamp: Long, offset: Long, skipFullCheck: Boolean = false) {
+  def maybeAppend(timestamp: Long, offset: Long, skipIndexFullCheck: Boolean): Unit = {
+    maybeAppend(timestamp, offset, skipIndexFullCheck, mayHaveIndexOverflow = false)
+  }
+
+  /**
+    * NOTE: Read the function description carefully. For most cases, you might want to call append(Long, Int) instead
+    * of calling this function directly.
+    *
+    * Append an entry for the given offset/location pair to the index, allowing for the possiblity that the offset might
+    * overflow the index. If it does and overflow is allowed, this function silently returns without appending to the
+    * index. Note that this `mayHaveIndexOverflow` must only be used for log segments that were created before the patch
+    * for KAFKA-5413. For such segments, it should be fine to skip index entries corresponding to messages that cause an
+    * index overflow.
+    *
+    * This option is only exposed for log recovery and log close.
+    */
+  private[log] def maybeAppend(timestamp: Long, offset: Long, skipIndexFullCheck: Boolean, mayHaveIndexOverflow: Boolean) {
     inLock(lock) {
-      if (!skipFullCheck)
+      if (!skipIndexFullCheck)
         require(!isFull, "Attempt to append to a full time index (size = " + _entries + ").")
+
       // We do not throw exception when the offset equals to the offset of last entry. That means we are trying
       // to insert the same time index entry as the last entry.
       // If the timestamp index entry to be inserted is the same as the last entry, we simply ignore the insertion
@@ -122,13 +154,25 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
       if (_entries != 0 && timestamp < lastEntry.timestamp)
         throw new IllegalStateException("Attempt to append a timestamp (%d) to slot %d no larger than the last timestamp appended (%d) to %s."
             .format(timestamp, _entries, lastEntry.timestamp, file.getAbsolutePath))
+
       // We only append to the time index when the timestamp is greater than the last inserted timestamp.
       // If all the messages are in message format v0, the timestamp will always be NoTimestamp. In that case, the time
       // index will be empty.
       if (timestamp > lastEntry.timestamp) {
+        val relativeOffset =
+          try {
+            getRelativeOffset(offset)
+          }
+          catch {
+            case _: InvalidOffsetException if (mayHaveIndexOverflow) => {
+              debug(s"Skipping time index append: overflow for offset: $offset baseOffset: $baseOffset (${file.getAbsolutePath})")
+              return
+            }
+          }
+
         debug("Adding index entry %d => %d to %s.".format(timestamp, offset, file.getName))
         mmap.putLong(timestamp)
-        mmap.putInt((offset - baseOffset).toInt)
+        mmap.putInt(relativeOffset)
         _entries += 1
         _lastEntry = TimestampOffset(timestamp, offset)
         require(_entries * entrySize == mmap.position(), _entries + " entries but file position in index is " + mmap.position() + ".")

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1218,7 +1218,7 @@ class LogCleanerTest extends JUnitSuite {
   def testLogSegmentWithIndexOffsetOverflow(): Unit = {
     val props = logProps
     // Make sure every append is potentially able to create an index entry
-    props.put(LogConfig.IndexIntervalBytesProp, 1)
+    props.put(LogConfig.IndexIntervalBytesProp, 1: java.lang.Integer)
     val config = LogConfig(props)
 
     val tp = new TopicPartition("test", 0)

--- a/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerTest.scala
@@ -1237,10 +1237,12 @@ class LogCleanerTest extends JUnitSuite {
       if (i == 0)
         log.appendAsFollower(set)        // write the first record using log.append API
       else
-        log.activeSegment.log.append(set)  // write all records directly to the file
+        log.activeSegment.append(offsets.last, 0, offsets.last, set, true)   // write all other records directly to the segment
       i += 1
     }
 
+    // Since we wrote messages directly to the log segment, bypassing the log layer, the log now would be in an
+    // inconsistent state. Reload the log so that the state is recomputed and built up accurately.
     log.close
     log = reloadLog(log, config)
 


### PR DESCRIPTION
Log segments created before the patch for KAFKA-5413 could have messages with offsets greater than baseOffset + Integer.MAX_VALUE. This could cause the offset and time index to overflow, and could also cause various other side effects (for example, compaction could fail for such segments).

This patch includes a workaround for this issue by loosening some checks when trying to append to the index, or when the log cleaner is trying to clean such a segment. We now allow the cleaner to continue processing such segments, but make sure we do not append an index entry corresponding to messages that could cause index overflow. Because we only skip append for the last bit of the segment that causes overflow, from a correctness point-of-view, skipping append to offset and time index should be okay.

However, we do have an implicit assumption that time index contains (maximum_timestamp_in_log, offset_of_maximum_timestamp) as its last entry on clean shutdown / log close -- this assumption would not always remain true with this patch. This means, on log open, in addition to reading the last entry in the time index, we also need to scan all messages after the offset in the last entry to make sure we know the exact (maximum_timestamp_in_log, offset_of_maximum_timestamp).

Note that we continue maintaining the time and offset index accurately for segments not affected by KAFKA-5413.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
