### PR TITLE
KAFKA-5540: Deprecate internal converter configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1327,14 +1327,14 @@ project(':connect:runtime') {
   archivesBaseName = "connect-runtime"
 
   dependencies {
-    compileOnly project(':connect:json')
-    compileOnly project(':connect:transforms')
 
     compile project(':connect:api')
     compile project(':clients')
     compile project(':tools')
-    compile libs.slf4jApi
+    compileOnly project(':connect:json')
+    compileOnly project(':connect:transforms')
 
+    compile libs.slf4jApi
     compile libs.jacksonJaxrsJsonProvider
     compile libs.jerseyContainerServlet
     compile libs.jaxbApi // Jersey dependency that was available in the JDK before Java 9

--- a/build.gradle
+++ b/build.gradle
@@ -1332,7 +1332,7 @@ project(':connect:runtime') {
     compile project(':clients')
     compile project(':tools')
     compile project(':connect:json')
-    compileOnly project(':connect:transforms')
+    compile project(':connect:transforms')
 
     compile libs.slf4jApi
     compile libs.jacksonJaxrsJsonProvider
@@ -1352,8 +1352,6 @@ project(':connect:runtime') {
     testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
-    testCompile project(':connect:json')
-    testCompile project(':connect:transforms')
     testCompile project(':clients').sourceSets.test.output
 
     testRuntime libs.slf4jlog4j

--- a/build.gradle
+++ b/build.gradle
@@ -1328,7 +1328,8 @@ project(':connect:runtime') {
 
   dependencies {
     compile project(':connect:api')
-    compile project(":connect:transforms")
+    compile project(':connect:json')
+    compile project(':connect:transforms')
     compile project(':clients')
     compile project(':tools')
     compile libs.slf4jApi

--- a/build.gradle
+++ b/build.gradle
@@ -1331,7 +1331,7 @@ project(':connect:runtime') {
     compile project(':connect:api')
     compile project(':clients')
     compile project(':tools')
-    compileOnly project(':connect:json')
+    compile project(':connect:json')
     compileOnly project(':connect:transforms')
 
     compile libs.slf4jApi

--- a/build.gradle
+++ b/build.gradle
@@ -1327,9 +1327,10 @@ project(':connect:runtime') {
   archivesBaseName = "connect-runtime"
 
   dependencies {
+    compileOnly project(':connect:json')
+    compileOnly project(':connect:transforms')
+
     compile project(':connect:api')
-    compile project(':connect:json')
-    compile project(':connect:transforms')
     compile project(':clients')
     compile project(':tools')
     compile libs.slf4jApi
@@ -1351,7 +1352,8 @@ project(':connect:runtime') {
     testCompile libs.powermockJunit4
     testCompile libs.powermockEasymock
 
-    testCompile project(":connect:json")
+    testCompile project(':connect:json')
+    testCompile project(':connect:transforms')
     testCompile project(':clients').sourceSets.test.output
 
     testRuntime libs.slf4jlog4j

--- a/config/connect-distributed.properties
+++ b/config/connect-distributed.properties
@@ -34,13 +34,6 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 key.converter.schemas.enable=true
 value.converter.schemas.enable=true
 
-# The internal converter used for offsets, config, and status data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset, config, and status data is never visible outside of Kafka Connect in this format.
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 # Topic to use for storing offsets. This topic should have many partitions and be replicated and compacted.
 # Kafka Connect will attempt to create the topic automatically when needed, but you can always manually create
 # the topic before starting Kafka Connect if a specific topic configuration is needed.

--- a/config/connect-standalone.properties
+++ b/config/connect-standalone.properties
@@ -25,13 +25,6 @@ value.converter=org.apache.kafka.connect.json.JsonConverter
 key.converter.schemas.enable=true
 value.converter.schemas.enable=true
 
-# The internal converter used for offsets and config data is configurable and must be specified, but most users will
-# always want to use the built-in default. Offset and config data is never visible outside of Kafka Connect in this format.
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 offset.storage.file.filename=/tmp/connect.offsets
 # Flush much faster than normal, which is useful for testing/debugging
 offset.flush.interval.ms=10000

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -23,7 +23,10 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.storage.SimpleHeaderConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +40,7 @@ import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
  * Common base class providing configuration for Kafka Connect workers, whether standalone or distributed.
  */
 public class WorkerConfig extends AbstractConfig {
+    private static final Logger log = LoggerFactory.getLogger(WorkerConfig.class);
 
     public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
     public static final String BOOTSTRAP_SERVERS_DOC
@@ -73,6 +77,10 @@ public class WorkerConfig extends AbstractConfig {
                     " header values to strings and deserialize them by inferring the schemas.";
     public static final String HEADER_CONVERTER_CLASS_DEFAULT = SimpleHeaderConverter.class.getName();
 
+    /**
+     * @deprecated As of 1.2.0
+     */
+    @Deprecated
     public static final String INTERNAL_KEY_CONVERTER_CLASS_CONFIG = "internal.key.converter";
     public static final String INTERNAL_KEY_CONVERTER_CLASS_DOC =
             "Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka." +
@@ -80,8 +88,13 @@ public class WorkerConfig extends AbstractConfig {
                     " independent of connectors it allows any connector to work with any serialization format." +
                     " Examples of common formats include JSON and Avro." +
                     " This setting controls the format used for internal bookkeeping data used by the framework, such as" +
-                    " configs and offsets, so users can typically use any functioning Converter implementation.";
+                    " configs and offsets, so users can typically use any functioning Converter implementation." +
+                    " Deprecated; will be removed in an upcoming version.";
 
+    /**
+     * @deprecated As of 1.2.0
+     */
+    @Deprecated
     public static final String INTERNAL_VALUE_CONVERTER_CLASS_CONFIG = "internal.value.converter";
     public static final String INTERNAL_VALUE_CONVERTER_CLASS_DOC =
             "Converter class used to convert between Kafka Connect format and the serialized form that is written to Kafka." +
@@ -89,7 +102,8 @@ public class WorkerConfig extends AbstractConfig {
                     " independent of connectors it allows any connector to work with any serialization format." +
                     " Examples of common formats include JSON and Avro." +
                     " This setting controls the format used for internal bookkeeping data used by the framework, such as" +
-                    " configs and offsets, so users can typically use any functioning Converter implementation.";
+                    " configs and offsets, so users can typically use any functioning Converter implementation." +
+                    " Deprecated; will be removed in an upcoming version.";
 
     public static final String TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG
             = "task.shutdown.graceful.timeout.ms";
@@ -190,9 +204,9 @@ public class WorkerConfig extends AbstractConfig {
                         Importance.HIGH, KEY_CONVERTER_CLASS_DOC)
                 .define(VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS,
                         Importance.HIGH, VALUE_CONVERTER_CLASS_DOC)
-                .define(INTERNAL_KEY_CONVERTER_CLASS_CONFIG, Type.CLASS,
+                .define(INTERNAL_KEY_CONVERTER_CLASS_CONFIG, Type.CLASS, JsonConverter.class,
                         Importance.LOW, INTERNAL_KEY_CONVERTER_CLASS_DOC)
-                .define(INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS,
+                .define(INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, Type.CLASS, JsonConverter.class,
                         Importance.LOW, INTERNAL_VALUE_CONVERTER_CLASS_DOC)
                 .define(TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_CONFIG, Type.LONG,
                         TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS_DEFAULT, Importance.LOW,
@@ -239,6 +253,24 @@ public class WorkerConfig extends AbstractConfig {
                         Importance.LOW, HEADER_CONVERTER_CLASS_DOC);
     }
 
+    private void logDeprecationWarnings(Map<String, String> props) {
+        String[] deprecatedConfigs = new String[] {
+            INTERNAL_KEY_CONVERTER_CLASS_CONFIG,
+            INTERNAL_VALUE_CONVERTER_CLASS_CONFIG
+        };
+        for (String config : deprecatedConfigs) {
+            if (props.containsKey(config)) {
+                log.warn("Configuration {} is deprecated and will be removed in an upcoming version", config);
+            }
+
+            for (String prop : props.keySet()) {
+                if (prop.startsWith(config + ".")) {
+                    log.warn("Configuration property '{}' (along with all configuration for {}) is deprecated and will be removed in an upcoming version", prop, config);
+                }
+            }
+        }
+    }
+
     @Override
     protected Map<String, Object> postProcessParsedConfig(final Map<String, Object> parsedValues) {
         return CommonClientConfigs.postProcessReconnectBackoffConfigs(this, parsedValues);
@@ -253,5 +285,6 @@ public class WorkerConfig extends AbstractConfig {
 
     public WorkerConfig(ConfigDef definition, Map<String, String> props) {
         super(definition, props);
+        logDeprecationWarnings(props);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -264,50 +264,48 @@ public class WorkerConfig extends AbstractConfig {
         };
         for (String config : deprecatedConfigs) {
             if (props.containsKey(config)) {
-                if (INTERNAL_CONVERTER_DEFAULT.equals(getClass(config))) {
-                    log.info(
-                        "Worker configuration property {} is deprecated and may be removed in an upcoming release. "
-                            + "The specified value matches the default, so this property can be safely removed from the worker configuration.",
-                        config
-                    );
+                Class<?> internalConverterClass = getClass(config);
+                logDeprecatedProperty(config, internalConverterClass.getCanonicalName(), INTERNAL_CONVERTER_DEFAULT.getCanonicalName(), null);
+                if (internalConverterClass.equals(INTERNAL_CONVERTER_DEFAULT)) {
+                    // log the properties for this converter ...
                     for (Map.Entry<String, Object> propEntry : originalsWithPrefix(config + ".").entrySet()) {
                         String prop = propEntry.getKey();
-                        if (JsonConverterConfig.SCHEMAS_ENABLE_CONFIG.equals(prop)) {
-                            String propValue = propEntry.getValue().toString();
-                            if (Boolean.FALSE.toString().equals(propValue)) {
-                                log.info(
-                                    "Worker configuration property {} (along with all configuration for {}) is deprecated and may be removed in an upcoming release. "
-                                        + "The specified value matches the default, so this property can be safely removed from the worker configuration.",
-                                    prop,
-                                    config
-                                );
-                            } else {
-                                log.warn(
-                                    "Configuration {} (along with all configuration for {}) is deprecated and may be removed in an upcoming release. "
-                                        + "The current value '{}' does NOT match the default and recommended value 'false'.",
-                                    prop,
-                                    config,
-                                    propValue
-                                );
-                            }
-                        } else {
-                            log.warn(
-                                "Configuration property '{}' (along with all configuration for {}) is deprecated and may be removed in an upcoming release.",
-                                prop,
-                                config
-                            );
-                        }
+                        String propValue = propEntry.getValue().toString();
+                        String defaultValue = JsonConverterConfig.SCHEMAS_ENABLE_CONFIG.equals(prop) ? "false" : null;
+                        logDeprecatedProperty(config + "." + prop, propValue, defaultValue, config);
                     }
-                } else {
-                    log.warn(
-                        "Worker configuration property {} is deprecated and may be removed in an upcoming release. "
-                            + "The specified value '{}' does NOT match the default and recommended value '{}'.",
-                        config,
-                        getClass(config).getCanonicalName(),
-                        INTERNAL_CONVERTER_DEFAULT.getCanonicalName()
-                    );
                 }
             }
+        }
+    }
+
+    private void logDeprecatedProperty(String propName, String propValue, String defaultValue, String prefix) {
+        String prefixNotice = prefix != null
+            ? " (along with all configuration for '" + prefix + "')"
+            : "";
+        if (defaultValue != null && defaultValue.equalsIgnoreCase(propValue)) {
+            log.info(
+                "Worker configuration property '{}'{} is deprecated and may be removed in an upcoming release. "
+                    + "The specified value matches the default, so this property can be safely removed from the worker configuration.",
+                propName,
+                prefixNotice,
+                propValue
+            );
+        } else if (defaultValue != null) {
+            log.warn(
+                "Worker configuration property '{}'{} is deprecated and may be removed in an upcoming release. "
+                    + "The specified value '{}' does NOT match the default and recommended value '{}'.",
+                propName,
+                prefixNotice,
+                propValue,
+                defaultValue
+            );
+        } else {
+            log.warn(
+                "Worker configuration property '{}'{} is deprecated and may be removed in an upcoming release.",
+                propName,
+                prefixNotice
+            );
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -78,7 +78,7 @@ public class WorkerConfig extends AbstractConfig {
     public static final String HEADER_CONVERTER_CLASS_DEFAULT = SimpleHeaderConverter.class.getName();
 
     /**
-     * @deprecated As of 1.2.0
+     * @deprecated As of 2.0.0
      */
     @Deprecated
     public static final String INTERNAL_KEY_CONVERTER_CLASS_CONFIG = "internal.key.converter";
@@ -92,7 +92,7 @@ public class WorkerConfig extends AbstractConfig {
                     " Deprecated; will be removed in an upcoming version.";
 
     /**
-     * @deprecated As of 1.2.0
+     * @deprecated As of 2.0.0
      */
     @Deprecated
     public static final String INTERNAL_VALUE_CONVERTER_CLASS_CONFIG = "internal.value.converter";

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -266,49 +266,46 @@ public class WorkerConfig extends AbstractConfig {
             if (props.containsKey(config)) {
                 if (INTERNAL_CONVERTER_DEFAULT.equals(getClass(config))) {
                     log.info(
-                        "Configuration {} is deprecated and will be removed in an upcoming release. "
-                            + "This value matches the current default, so it can be removed without concern.",
+                        "Worker configuration property {} is deprecated and may be removed in an upcoming release. "
+                            + "The specified value matches the default, so this property can be safely removed from the worker configuration.",
                         config
                     );
+                    for (Map.Entry<String, Object> propEntry : originalsWithPrefix(config + ".").entrySet()) {
+                        String prop = propEntry.getKey();
+                        if (JsonConverterConfig.SCHEMAS_ENABLE_CONFIG.equals(prop)) {
+                            String propValue = propEntry.getValue().toString();
+                            if (Boolean.FALSE.toString().equals(propValue)) {
+                                log.info(
+                                    "Worker configuration property {} (along with all configuration for {}) is deprecated and may be removed in an upcoming release. "
+                                        + "The specified value matches the default, so this property can be safely removed from the worker configuration.",
+                                    prop,
+                                    config
+                                );
+                            } else {
+                                log.warn(
+                                    "Configuration {} (along with all configuration for {}) is deprecated and may be removed in an upcoming release. "
+                                        + "The current value '{}' does NOT match the default and recommended value 'false'.",
+                                    prop,
+                                    config,
+                                    propValue
+                                );
+                            }
+                        } else {
+                            log.warn(
+                                "Configuration property '{}' (along with all configuration for {}) is deprecated and may be removed in an upcoming release.",
+                                prop,
+                                config
+                            );
+                        }
+                    }
                 } else {
                     log.warn(
-                        "Configuration {} is deprecated and will be removed in an upcoming release. "
-                            + "The current value '{}' does NOT match the default of {}, and behavior may change when removed.",
+                        "Worker configuration property {} is deprecated and may be removed in an upcoming release. "
+                            + "The specified value '{}' does NOT match the default and recommended value '{}'.",
                         config,
                         getClass(config).getCanonicalName(),
                         INTERNAL_CONVERTER_DEFAULT.getCanonicalName()
                     );
-                }
-            }
-
-            for (Map.Entry<String, String> propEntry : props.entrySet()) {
-                String prop = propEntry.getKey();
-                if (prop.startsWith(config + ".")) {
-                    if ((config + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG).equals(prop)) {
-                        if (Boolean.FALSE.toString().equals(propEntry.getValue())) {
-                            log.info(
-                                "Configuration {} (along with all configuration for {}) is deprecated and will be removed in an upcoming release. "
-                                    + "This value matches the current default, so it can be removed without concern.",
-                                prop,
-                                config
-                            );
-                        } else {
-                            log.warn(
-                                "Configuration {} (along with all configuration for {}) is deprecated and will be removed in an upcoming release. "
-                                    + "The current value '{}' does NOT match the default of false, and behavior may change when removed.",
-                                prop,
-                                config,
-                                get(prop)
-                            );
-                        }
-                    } else {
-                        log.warn(
-                            "Configuration property '{}' (along with all configuration for {}) is deprecated and will be removed in an upcoming release. "
-                                + "The current value has no default, and behavior may change when removed.",
-                            prop,
-                            config
-                        );
-                    }
                 }
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/Plugins.java
@@ -248,7 +248,7 @@ public class Plugins {
 
                 // If they haven't explicitly specified values for internal.key.converter.schemas.enable
                 // or internal.value.converter.schemas.enable, we can safely default them to false
-                if (!converterConfig.containsKey(classPropertyName + "." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG)) {
+                if (!converterConfig.containsKey(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG)) {
                     converterConfig.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false);
                 }
             }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginsTest.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.isolation.Plugins.ClassLoaderUsage;
@@ -51,6 +52,7 @@ public class PluginsTest {
     private AbstractConfig config;
     private TestConverter converter;
     private TestHeaderConverter headerConverter;
+    private TestInternalConverter internalConverter;
 
     @BeforeClass
     public static void beforeAll() {
@@ -71,10 +73,8 @@ public class PluginsTest {
         props.put("value.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "true");
         props.put("key.converter.extra.config", "foo1");
         props.put("value.converter.extra.config", "foo2");
-        props.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
-        props.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, TestConverter.class.getName());
-        props.put("internal.key.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
-        props.put("internal.value.converter." + JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, "false");
+        props.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, TestInternalConverter.class.getName());
+        props.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, TestInternalConverter.class.getName());
         props.put("internal.key.converter.extra.config", "bar1");
         props.put("internal.value.converter.extra.config", "bar2");
         props.put(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, TestHeaderConverter.class.getName());
@@ -102,15 +102,17 @@ public class PluginsTest {
 
     @Test
     public void shouldInstantiateAndConfigureInternalConverters() {
-        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.CURRENT_CLASSLOADER);
-        // Validate extra configs got passed through to overridden converters
-        assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
-        assertEquals("bar1", converter.configs.get("extra.config"));
+        instantiateAndConfigureInternalConverter(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.CURRENT_CLASSLOADER);
+        // Validate schemas.enable is defaulted to false for internal converter
+        assertEquals(false, internalConverter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
+        // Validate internal converter properties can still be set
+        assertEquals("bar1", internalConverter.configs.get("extra.config"));
 
-        instantiateAndConfigureConverter(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
-        // Validate extra configs got passed through to overridden converters
-        assertEquals("false", converter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
-        assertEquals("bar2", converter.configs.get("extra.config"));
+        instantiateAndConfigureInternalConverter(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
+        // Validate schemas.enable is defaulted to false for internal converter
+        assertEquals(false, internalConverter.configs.get(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG));
+        // Validate internal converter properties can still be set
+        assertEquals("bar2", internalConverter.configs.get("extra.config"));
     }
 
     @Test
@@ -161,6 +163,16 @@ public class PluginsTest {
     protected void instantiateAndConfigureConverter(String configPropName, ClassLoaderUsage classLoaderUsage) {
         converter = (TestConverter) plugins.newConverter(config, configPropName, classLoaderUsage);
         assertNotNull(converter);
+    }
+
+    protected void instantiateAndConfigureHeaderConverter(String configPropName) {
+        headerConverter = (TestHeaderConverter) plugins.newHeaderConverter(config, configPropName, ClassLoaderUsage.CURRENT_CLASSLOADER);
+        assertNotNull(headerConverter);
+    }
+
+    protected void instantiateAndConfigureInternalConverter(String configPropName, ClassLoaderUsage classLoaderUsage) {
+        internalConverter = (TestInternalConverter) plugins.newConverter(config, configPropName, classLoaderUsage);
+        assertNotNull(internalConverter);
     }
 
     protected void assertConverterType(ConverterType type, Map<String, ?> props) {
@@ -228,6 +240,15 @@ public class PluginsTest {
 
         @Override
         public void close() throws IOException {
+        }
+    }
+
+    public static class TestInternalConverter extends JsonConverter {
+        public Map<String, ?> configs;
+
+        public void configure(Map<String, ?> configs) {
+            this.configs = configs;
+            super.configure(configs);
         }
     }
 }

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -79,15 +79,13 @@
     <li>Updated <code>ProcessorStateManager</code> APIs in Kafka Streams for registering state stores to the processor topology. For more details please read the Streams <a href="/{{version}}/documentation/streams/upgrade-guide#streams_api_changes_200">Upgrade Guide</a>.</li>
     <li><a href="https://cwiki.apache.org/confluence/x/AZQ7B">KIP-174</a> deprecates the <code>internal.key.converter</code> and <code>internal.value.converter</code> configurations for Kafka Connect, and establishes <code>org.apache.kafka.connect.json.JsonConverter</code> with the <code>schemas.enable</code> property set to <code>false</code> as the default value for both.</li>
     <li>
-        <a href="https://cwiki.apache.org/confluence/x/AZQ7B">KIP-174</a> deprecates the <code>internal.key.converter</code> and <code>internal.value.converter</code> configurations for Kafka Connect,
-        and establishes <code>org.apache.kafka.connect.json.JsonConverter</code> with the <code>schemas.enable</code> property set to <code>false</code> as the default value for both.
-        If you have the following properties configured for your Connect cluster, they can be safely removed:
-        <code>
-            internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-            internal.key.converter.schemas.enable=false
-            internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-            internal.value.converter.schemas.enable=false
-        </code>
+        In earlier releases, Connect's worker configuration required the <code>internal.key.converter</code> and <code>internal.value.converter</code> properties.
+        In 2.0, these are <a href="https://cwiki.apache.org/confluence/x/AZQ7B">no longer required</a> and default to the JSON converter.
+        You may safely remove these properties from your Connect standalone and distributed worker configurations:<br />
+        <code>internal.key.converter=org.apache.kafka.connect.json.JsonConverter</code>
+        <code>internal.key.converter.schemas.enable=false</code>
+        <code>internal.value.converter=org.apache.kafka.connect.json.JsonConverter</code>
+        <code>internal.value.converter.schemas.enable=false</code>
     </li>
 </ul>
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -77,6 +77,7 @@
     <li>New Kafka Streams configuration parameter <code>upgrade.from</code> added that allows rolling bounce upgrade from older version. </li>
     <li><a href="https://cwiki.apache.org/confluence/x/DVyHB">KIP-284</a> changed the retention time for Kafka Streams repartition topics by setting its default value to <code>Long.MAX_VALUE</code>.</li>
     <li>Updated <code>ProcessorStateManager</code> APIs in Kafka Streams for registering state stores to the processor topology. For more details please read the Streams <a href="/{{version}}/documentation/streams/upgrade-guide#streams_api_changes_200">Upgrade Guide</a>.</li>
+    <li><a href="https://cwiki.apache.org/confluence/x/AZQ7B">KIP-174</a> deprecates the <code>internal.key.converter</code> and <code>internal.value.converter</code> configurations for Kafka Connect, and establishes <code>org.apache.kafka.connect.json.JsonConverter</code> with the <code>schemas.enable</code> property set to <code>false</code> as the default value for both.</li>
 </ul>
 
 <h5><a id="upgrade_200_new_protocols" href="#upgrade_200_new_protocols">New Protocol Versions</a></h5>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -78,6 +78,17 @@
     <li><a href="https://cwiki.apache.org/confluence/x/DVyHB">KIP-284</a> changed the retention time for Kafka Streams repartition topics by setting its default value to <code>Long.MAX_VALUE</code>.</li>
     <li>Updated <code>ProcessorStateManager</code> APIs in Kafka Streams for registering state stores to the processor topology. For more details please read the Streams <a href="/{{version}}/documentation/streams/upgrade-guide#streams_api_changes_200">Upgrade Guide</a>.</li>
     <li><a href="https://cwiki.apache.org/confluence/x/AZQ7B">KIP-174</a> deprecates the <code>internal.key.converter</code> and <code>internal.value.converter</code> configurations for Kafka Connect, and establishes <code>org.apache.kafka.connect.json.JsonConverter</code> with the <code>schemas.enable</code> property set to <code>false</code> as the default value for both.</li>
+    <li>
+        <a href="https://cwiki.apache.org/confluence/x/AZQ7B">KIP-174</a> deprecates the <code>internal.key.converter</code> and <code>internal.value.converter</code> configurations for Kafka Connect,
+        and establishes <code>org.apache.kafka.connect.json.JsonConverter</code> with the <code>schemas.enable</code> property set to <code>false</code> as the default value for both.
+        If you have the following properties configured for your Connect cluster, they can be safely removed:
+        <code>
+            internal.key.converter=org.apache.kafka.connect.json.JsonConverter
+            internal.key.converter.schemas.enable=false
+            internal.value.converter=org.apache.kafka.connect.json.JsonConverter
+            internal.value.converter.schemas.enable=false
+        </code>
+    </li>
 </ul>
 
 <h5><a id="upgrade_200_new_protocols" href="#upgrade_200_new_protocols">New Protocol Versions</a></h5>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -77,7 +77,6 @@
     <li>New Kafka Streams configuration parameter <code>upgrade.from</code> added that allows rolling bounce upgrade from older version. </li>
     <li><a href="https://cwiki.apache.org/confluence/x/DVyHB">KIP-284</a> changed the retention time for Kafka Streams repartition topics by setting its default value to <code>Long.MAX_VALUE</code>.</li>
     <li>Updated <code>ProcessorStateManager</code> APIs in Kafka Streams for registering state stores to the processor topology. For more details please read the Streams <a href="/{{version}}/documentation/streams/upgrade-guide#streams_api_changes_200">Upgrade Guide</a>.</li>
-    <li><a href="https://cwiki.apache.org/confluence/x/AZQ7B">KIP-174</a> deprecates the <code>internal.key.converter</code> and <code>internal.value.converter</code> configurations for Kafka Connect, and establishes <code>org.apache.kafka.connect.json.JsonConverter</code> with the <code>schemas.enable</code> property set to <code>false</code> as the default value for both.</li>
     <li>
         In earlier releases, Connect's worker configuration required the <code>internal.key.converter</code> and <code>internal.value.converter</code> properties.
         In 2.0, these are <a href="https://cwiki.apache.org/confluence/x/AZQ7B">no longer required</a> and default to the JSON converter.

--- a/tests/kafkatest/tests/connect/templates/connect-distributed.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-distributed.properties
@@ -29,11 +29,6 @@ key.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 value.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 {% endif %}
 
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 offset.storage.topic={{ OFFSETS_TOPIC }}
 offset.storage.replication.factor={{ OFFSETS_REPLICATION_FACTOR }}
 offset.storage.partitions={{ OFFSETS_PARTITIONS }}

--- a/tests/kafkatest/tests/connect/templates/connect-standalone.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-standalone.properties
@@ -27,11 +27,6 @@ key.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 value.converter.schemas.enable={{ schemas|default(True)|string|lower }}
 {% endif %}
 
-internal.key.converter=org.apache.kafka.connect.json.JsonConverter
-internal.value.converter=org.apache.kafka.connect.json.JsonConverter
-internal.key.converter.schemas.enable=false
-internal.value.converter.schemas.enable=false
-
 offset.storage.file.filename={{ OFFSETS_FILE }}
 
 # Reduce the admin client request timeouts so that we don't wait the default 120 sec before failing to connect the admin client


### PR DESCRIPTION
Implementation of [KIP-174](https://cwiki.apache.org/confluence/display/KAFKA/KIP-174+-+Deprecate+and+remove+internal+converter+configs+in+WorkerConfig)

Configuration properties 'internal.key.converter' and 'internal.value.converter'
are deprecated, and default to org.apache.kafka.connect.json.JsonConverter.

Warnings are logged if values are specified for either, or if properties that
appear to configure instances of internal converters (i.e., ones prefixed with
either 'internal.key.converter.' or 'internal.value.converter.') are given.

The property 'schemas.enable' is also defaulted to false for internal
JsonConverter instances (both for keys and values) if it isn't specified.

Documentation and code have also been updated with deprecation notices and
annotations, respectively.

Unit tests have been updated in `PluginsTest` to account for the new defaults for `schemas.enable` for internal key/value converters, and to ensure that (for the time being), internal key/value converters are still configurable despite being deprecated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
