### PR TITLE
KAFKA-6638; Leader should remove unassigned replica from ISR

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -259,7 +259,7 @@ class Partition(val topic: String,
       val newInSyncReplicas = partitionStateInfo.basePartitionState.isr.asScala.map(r => getOrCreateReplica(r, partitionStateInfo.isNew)).toSet
       // remove assigned replicas that have been removed by the controller
       (assignedReplicas.map(_.brokerId) -- newAssignedReplicas).foreach(removeReplica)
-      inSyncReplicas = newInSyncReplicas
+      inSyncReplicas = newInSyncReplicas.filter(replica => newAssignedReplicas.contains(replica.brokerId))
 
       info(s"$topicPartition starts at Leader Epoch ${partitionStateInfo.basePartitionState.leaderEpoch} from offset ${getReplica().get.logEndOffset.messageOffset}. Previous Leader Epoch was: $leaderEpoch")
 


### PR DESCRIPTION
During partition reassignment, controller may remove a replica from the replica set while still keeping the replica in the isr set. One solution to fix this issue is to let the controller remove replica from isr set as well. This requires more change in the code because controller needs to update the zookeeper node to change the isr properly. Another solution, which keeps controller simple, is to let leader node remove unassigned replica from the isr set.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
