### PR TITLE
KAFKA-6632: Very slow hashCode methods in Kafka Connect types

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -299,25 +299,28 @@ public class ConnectSchema implements Schema {
 
     @Override
     public int hashCode() {
-        int result = type != null ? type.hashCode() : 0;
-        result = 31 * result + (optional ? 1 : 0);
-        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
-        if (fields != null) {
-            for (Field f : fields) {
-                result = 31 * result + f.hashCode();
+        if (this.hash == null) {
+            int result = type != null ? type.hashCode() : 0;
+            result = 31 * result + (optional ? 1 : 0);
+            result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+            if (fields != null) {
+                for (Field f : fields) {
+                    result = 31 * result + f.hashCode();
+                }
             }
-        }
-        result = 31 * result + (keySchema != null ? keySchema.hashCode() : 0);
-        result = 31 * result + (valueSchema != null ? valueSchema.hashCode() : 0);
-        result = 31 * result + (name != null ? name.hashCode() : 0);
-        result = 31 * result + (version != null ? version : 0);
-        result = 31 * result + (doc != null ? doc.hashCode() : 0);
-        if (parameters != null) {
-            for (Map.Entry<String, String> e : parameters.entrySet()) {
-                result = 31 * result + e.getKey().hashCode() + e.getValue().hashCode();
+            result = 31 * result + (keySchema != null ? keySchema.hashCode() : 0);
+            result = 31 * result + (valueSchema != null ? valueSchema.hashCode() : 0);
+            result = 31 * result + (name != null ? name.hashCode() : 0);
+            result = 31 * result + (version != null ? version : 0);
+            result = 31 * result + (doc != null ? doc.hashCode() : 0);
+            if (parameters != null) {
+                for (Map.Entry<String, String> e : parameters.entrySet()) {
+                    result = 31 * result + e.getKey().hashCode() + e.getValue().hashCode();
+                }
             }
+            this.hash = result;
         }
-        return result;
+        return this.hash;
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -299,11 +299,25 @@ public class ConnectSchema implements Schema {
 
     @Override
     public int hashCode() {
-        if (this.hash == null) {
-            this.hash = Objects.hash(type, optional, defaultValue, fields, keySchema, valueSchema, name, version, doc,
-                parameters);
+        int result = (type != null ? type.hashCode() : 0);
+        result = 31 * result + (optional ? 1 : 0);
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+        if (fields != null) {
+            for (Field f : fields) {
+                result = 31 * result + f.hashCode();
+            }
         }
-        return this.hash;
+        result = 31 * result + (keySchema != null ? keySchema.hashCode() : 0);
+        result = 31 * result + (valueSchema != null ? valueSchema.hashCode() : 0);
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (version != null ? version : 0);
+        result = 31 * result + (doc != null ? doc.hashCode() : 0);
+        if (parameters != null) {
+            for (Map.Entry<String, String> e : parameters.entrySet()) {
+                result = 31 * result + e.getKey().hashCode() + e.getValue().hashCode();
+            }
+        }
+        return result;
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -299,7 +299,7 @@ public class ConnectSchema implements Schema {
 
     @Override
     public int hashCode() {
-        int result = (type != null ? type.hashCode() : 0);
+        int result = type != null ? type.hashCode() : 0;
         result = 31 * result + (optional ? 1 : 0);
         result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
         if (fields != null) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/Field.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/Field.java
@@ -71,7 +71,10 @@ public class Field {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, index, schema);
+        int result = index;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        result = 31 * result + (schema != null ? schema.hashCode() : 0);
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Objects.hash function is very slow method to calculate hashCode.
This PR change it to more efficient implementation.

Tests.
1) Simple String Schema
* Original hashCode: 2995ms
* My implementation: 517ms
2) Struct Schema
* Original hashCode: 18880
* My implementation: 6026

In real world application this PR increase throughput of Kafka Connect by 20%.


### Committer Checklist (excluded from commit message)
- [X] Verify design and implementation 
- [X] Verify test coverage and CI build status
- [X] Verify documentation (including upgrade notes)
