### PR TITLE
KAFKA-6647 KafkaStreams.cleanUp creates .lock file in directory it tries to clean

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -164,7 +164,6 @@ public class StateDirectory {
         if (lock != null) {
             locks.put(taskId, new LockAndOwner(Thread.currentThread().getName(), lock));
 
-            System.out.println("locked " + lockFile);
             log.debug("{} Acquired state dir lock for task {}", logPrefix(), taskId);
         }
         return lock != null;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -329,7 +329,8 @@ public class StateDirectory {
     private FileChannel getOrCreateFileChannel(final TaskId taskId,
                                                final Path lockPath) throws IOException {
         if (!channels.containsKey(taskId)) {
-            channels.put(taskId, FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE));
+            channels.put(taskId, FileChannel.open(lockPath, StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE, StandardOpenOption.DELETE_ON_CLOSE));
         }
         return channels.get(taskId);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -138,7 +138,7 @@ public class StateDirectory {
         }
 
         try {
-            lockFile = new File(stateDir, taskId+LOCK_FILE_NAME);
+            lockFile = new File(stateDir, taskId + LOCK_FILE_NAME);
         } catch (ProcessorStateException e) {
             // directoryForTask could be throwing an exception if another thread
             // has concurrently deleted the directory

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -138,7 +138,7 @@ public class StateDirectory {
         }
 
         try {
-            lockFile = new File(directoryForTask(taskId), LOCK_FILE_NAME);
+            lockFile = new File(stateDir, taskId+LOCK_FILE_NAME);
         } catch (ProcessorStateException e) {
             // directoryForTask could be throwing an exception if another thread
             // has concurrently deleted the directory

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -100,6 +100,10 @@ public class StateDirectory {
         return taskDir;
     }
 
+    File stateDir() {
+        return stateDir;
+    }
+
     /**
      * Get or create the directory for the global stores.
      * @return directory for the global stores
@@ -160,6 +164,7 @@ public class StateDirectory {
         if (lock != null) {
             locks.put(taskId, new LockAndOwner(Thread.currentThread().getName(), lock));
 
+            System.out.println("locked " + lockFile);
             log.debug("{} Acquired state dir lock for task {}", logPrefix(), taskId);
         }
         return lock != null;


### PR DESCRIPTION
Specify StandardOpenOption#DELETE_ON_CLOSE when creating the FileChannel.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
