### PR TITLE
KAFKA-6653: Complete delayed operations even when there is lock contention

### DIFF
--- a/core/src/main/scala/kafka/server/DelayedOperation.scala
+++ b/core/src/main/scala/kafka/server/DelayedOperation.scala
@@ -122,8 +122,12 @@ abstract class DelayedOperation(override val delayMs: Long,
   private def tryCompleteIfLockIsFree(): Boolean = {
     if (lock.tryLock()) {
       try {
-        tryCompletePending.set(false)
-        tryComplete()
+        var done = false
+        do {
+          tryCompletePending.set(false)
+          done = tryComplete()
+        } while (!done && tryCompletePending.get())
+        done
       } finally {
         lock.unlock()
       }

--- a/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelayedOperationTest.scala
@@ -155,10 +155,10 @@ class DelayedOperationTest {
     purgatory.tryCompleteElseWatch(op, Seq(key))
     completionAttemptsRemaining.set(2)
     tryCompleteSemaphore.acquire()
-    val future = runOnAnotherThread(purgatory.checkAndComplete(key), false)
+    val future = runOnAnotherThread(purgatory.checkAndComplete(key), shouldComplete = false)
     TestUtils.waitUntilTrue(() => tryCompleteSemaphore.hasQueuedThreads, "Not attempting to complete")
     purgatory.checkAndComplete(key) // this should not block even though lock is not free
-    assertFalse("Operation not have completed", op.isCompleted)
+    assertFalse("Operation should not have completed", op.isCompleted)
     tryCompleteSemaphore.release()
     future.get(10, TimeUnit.SECONDS)
     assertTrue("Operation should have completed", op.isCompleted)


### PR DESCRIPTION
If there is lock contention while multiple threads check if a delayed operation may be completed (e.g. a produce request with acks=-1), the threads perform completion only if the lock is free, to avoid deadlocks. This leaves a timing window when an operation becomes ready to complete after another thread has acquired the lock and performed the check for completion, but not yet released the lock. The PR adds an additional flag to ensure that the operation is completed in this case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
