### PR TITLE
MINOR: remove unnecessary null checks

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
+++ b/clients/src/main/java/org/apache/kafka/common/serialization/StringDeserializer.java
@@ -34,7 +34,7 @@ public class StringDeserializer implements Deserializer<String> {
         Object encodingValue = configs.get(propertyName);
         if (encodingValue == null)
             encodingValue = configs.get("deserializer.encoding");
-        if (encodingValue != null && encodingValue instanceof String)
+        if (encodingValue instanceof String)
             encoding = (String) encodingValue;
     }
 

--- a/clients/src/test/java/org/apache/kafka/test/MockProducerInterceptor.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockProducerInterceptor.java
@@ -51,7 +51,7 @@ public class MockProducerInterceptor implements ClusterResourceListener, Produce
         Object o = configs.get(APPEND_STRING_PROP);
         if (o == null)
             throw new ConfigException("Mock producer interceptor expects configuration " + APPEND_STRING_PROP);
-        if (o != null && o instanceof String)
+        if (o instanceof String)
             appendStr = (String) o;
 
         // clientId also must be in configs

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -499,7 +499,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         final Serializer<V> valSerializer = produced.valueSerde() == null ? null : produced.valueSerde().serializer();
         final StreamPartitioner<? super K, ? super V> partitioner = produced.streamPartitioner();
 
-        if (partitioner == null && keySerializer != null && keySerializer instanceof WindowedSerializer) {
+        if (partitioner == null && keySerializer instanceof WindowedSerializer) {
             final StreamPartitioner<K, V> windowedPartitioner = (StreamPartitioner<K, V>) new WindowedStreamPartitioner<Object, V>(topic, (WindowedSerializer) keySerializer);
             builder.internalTopologyBuilder.addSink(name, topic, keySerializer, valSerializer, windowedPartitioner, this.name);
         } else {


### PR DESCRIPTION
Remove unnecessary null check in StringDeserializer, MockProducerInterceptor and KStreamImpl.