### PR TITLE
KAFKA-6658: Fix RoundTripWorkload and make k/v generation configurable

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConstantPayloadGenerator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConstantPayloadGenerator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.trogdor.workload;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A PayloadGenerator which always generates a constant payload.
+ */
+public class ConstantPayloadGenerator implements PayloadGenerator {
+    private final int size;
+    private final byte[] value;
+
+    @JsonCreator
+    public ConstantPayloadGenerator(@JsonProperty("size") int size,
+                                    @JsonProperty("value") byte[] value) {
+        this.size = size;
+        this.value = (value == null || value.length == 0) ? new byte[size] : value;
+    }
+
+    @JsonProperty
+    public int size() {
+        return size;
+    }
+
+    @JsonProperty
+    public byte[] value() {
+        return value;
+    }
+
+    @Override
+    public byte[] generate(long position) {
+        byte[] next = new byte[size];
+        for (int i = 0; i < next.length; i += value.length) {
+            System.arraycopy(value, 0, next, i, Math.min(next.length - i, value.length));
+        }
+        return next;
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/PayloadGeneratorManager.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/PayloadGeneratorManager.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.trogdor.workload;
+
+/**
+ * Maintains the position number for a PayloadGenerator.
+ */
+public final class PayloadGeneratorManager {
+    private final PayloadGenerator generator;
+    private long position = 0;
+
+    public PayloadGeneratorManager(PayloadGenerator generator) {
+        this.generator = generator;
+    }
+
+    public synchronized byte[] next() {
+        return generator.generate(position++);
+    }
+
+    public synchronized void setPosition(long position) {
+        this.position = position;
+    }
+
+    public synchronized long position() {
+        return this.position;
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/PayloadIterator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/PayloadIterator.java
@@ -45,7 +45,7 @@ public final class PayloadIterator implements Iterator<byte[]> {
         throw new UnsupportedOperationException();
     }
 
-    public synchronized void setPosition(long position) {
+    public synchronized void seek(long position) {
         this.position = position;
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/PayloadIterator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/PayloadIterator.java
@@ -17,19 +17,32 @@
 
 package org.apache.kafka.trogdor.workload;
 
+import java.util.Iterator;
+
 /**
- * Maintains the position number for a PayloadGenerator.
+ * An iterator which wraps a PayloadGenerator.
  */
-public final class PayloadGeneratorManager {
+public final class PayloadIterator implements Iterator<byte[]> {
     private final PayloadGenerator generator;
     private long position = 0;
 
-    public PayloadGeneratorManager(PayloadGenerator generator) {
+    public PayloadIterator(PayloadGenerator generator) {
         this.generator = generator;
     }
 
+    @Override
+    public boolean hasNext() {
+        return true;
+    }
+
+    @Override
     public synchronized byte[] next() {
         return generator.generate(position++);
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
     }
 
     public synchronized void setPosition(long position) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -37,7 +37,8 @@ public class ProduceBenchSpec extends TaskSpec {
     private final String bootstrapServers;
     private final int targetMessagesPerSec;
     private final int maxMessages;
-    private final int messageSize;
+    private final PayloadGenerator keyGenerator;
+    private final PayloadGenerator valueGenerator;
     private final Map<String, String> producerConf;
     private final int totalTopics;
     private final int activeTopics;
@@ -49,7 +50,8 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("bootstrapServers") String bootstrapServers,
                          @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
                          @JsonProperty("maxMessages") int maxMessages,
-                         @JsonProperty("messageSize") int messageSize,
+                         @JsonProperty("keyGenerator") PayloadGenerator keyGenerator,
+                         @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
                          @JsonProperty("producerConf") Map<String, String> producerConf,
                          @JsonProperty("totalTopics") int totalTopics,
                          @JsonProperty("activeTopics") int activeTopics) {
@@ -58,7 +60,10 @@ public class ProduceBenchSpec extends TaskSpec {
         this.bootstrapServers = (bootstrapServers == null) ? "" : bootstrapServers;
         this.targetMessagesPerSec = targetMessagesPerSec;
         this.maxMessages = maxMessages;
-        this.messageSize = (messageSize == 0) ? PayloadGenerator.DEFAULT_MESSAGE_SIZE : messageSize;
+        this.keyGenerator = keyGenerator == null ?
+            new SequentialPayloadGenerator(4, 0) : keyGenerator;
+        this.valueGenerator = valueGenerator == null ?
+            new ConstantPayloadGenerator(512, new byte[0]) : valueGenerator;
         this.producerConf = (producerConf == null) ? new TreeMap<String, String>() : producerConf;
         this.totalTopics = totalTopics;
         this.activeTopics = activeTopics;
@@ -85,8 +90,13 @@ public class ProduceBenchSpec extends TaskSpec {
     }
 
     @JsonProperty
-    public int messageSize() {
-        return messageSize;
+    public PayloadGenerator keyGenerator() {
+        return keyGenerator;
+    }
+
+    @JsonProperty
+    public PayloadGenerator valueGenerator() {
+        return valueGenerator;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -91,7 +91,7 @@ public class ProduceBenchWorker implements TaskWorker {
         if (!running.compareAndSet(false, true)) {
             throw new IllegalStateException("ProducerBenchWorker is already running.");
         }
-        log.info("{}: Activating ProduceBenchWorker.", id);
+        log.info("{}: Activating ProduceBenchWorker with {}", id, spec);
         this.executor = Executors.newScheduledThreadPool(1,
             ThreadUtils.createThreadFactory("ProduceBenchWorkerThread%d", false));
         this.status = status;
@@ -172,7 +172,9 @@ public class ProduceBenchWorker implements TaskWorker {
 
         private final KafkaProducer<byte[], byte[]> producer;
 
-        private final PayloadGenerator payloadGenerator;
+        private final PayloadGeneratorManager keys;
+
+        private final PayloadGeneratorManager values;
 
         private final Throttle throttle;
 
@@ -187,7 +189,8 @@ public class ProduceBenchWorker implements TaskWorker {
                 props.setProperty(entry.getKey(), entry.getValue());
             }
             this.producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
-            this.payloadGenerator = new PayloadGenerator(spec.messageSize());
+            this.keys = new PayloadGeneratorManager(spec.keyGenerator());
+            this.values = new PayloadGeneratorManager(spec.valueGenerator());
             this.throttle = new SendRecordsThrottle(perPeriod, producer);
         }
 
@@ -199,8 +202,10 @@ public class ProduceBenchWorker implements TaskWorker {
                 try {
                     for (int m = 0; m < spec.maxMessages(); m++) {
                         for (int i = 0; i < spec.activeTopics(); i++) {
-                            ProducerRecord<byte[], byte[]> record = payloadGenerator.nextRecord(topicIndexToName(i));
-                            future = producer.send(record, new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
+                            ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[], byte[]>(
+                                topicIndexToName(i), 0, keys.next(), values.next());
+                            future = producer.send(record,
+                                new SendRecordsCallback(this, Time.SYSTEM.milliseconds()));
                         }
                         throttle.increment();
                     }
@@ -216,7 +221,6 @@ public class ProduceBenchWorker implements TaskWorker {
                 statusUpdaterFuture.cancel(false);
                 new StatusUpdater(histogram).run();
                 long curTimeMs = Time.SYSTEM.milliseconds();
-                log.info("Produced {}", payloadGenerator);
                 log.info("Sent {} total record(s) in {} ms.  status: {}",
                     histogram.summarize().numSamples(), curTimeMs - startTimeMs, status.get());
             }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -172,9 +172,9 @@ public class ProduceBenchWorker implements TaskWorker {
 
         private final KafkaProducer<byte[], byte[]> producer;
 
-        private final PayloadGeneratorManager keys;
+        private final PayloadIterator keys;
 
-        private final PayloadGeneratorManager values;
+        private final PayloadIterator values;
 
         private final Throttle throttle;
 
@@ -189,8 +189,8 @@ public class ProduceBenchWorker implements TaskWorker {
                 props.setProperty(entry.getKey(), entry.getValue());
             }
             this.producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
-            this.keys = new PayloadGeneratorManager(spec.keyGenerator());
-            this.values = new PayloadGeneratorManager(spec.valueGenerator());
+            this.keys = new PayloadIterator(spec.keyGenerator());
+            this.values = new PayloadIterator(spec.valueGenerator());
             this.throttle = new SendRecordsThrottle(perPeriod, producer);
         }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -68,6 +69,8 @@ public class RoundTripWorker implements TaskWorker {
     private static final String TOPIC_NAME = "round_trip_topic";
 
     private static final Logger log = LoggerFactory.getLogger(RoundTripWorker.class);
+
+    private static final PayloadGenerator KEY_GENERATOR = new SequentialPayloadGenerator(4, 0);
 
     private final ToReceiveTracker toReceiveTracker = new ToReceiveTracker();
 
@@ -183,7 +186,6 @@ public class RoundTripWorker implements TaskWorker {
             int perPeriod = WorkerUtils.
                 perSecToPerPeriod(spec.targetMessagesPerSec(), THROTTLE_PERIOD_MS);
             this.throttle = new Throttle(perPeriod, THROTTLE_PERIOD_MS);
-            payloadGenerator = new PayloadGenerator(MESSAGE_SIZE, PayloadKeyType.KEY_MESSAGE_INDEX);
         }
 
         @Override
@@ -206,7 +208,9 @@ public class RoundTripWorker implements TaskWorker {
                     }
                     messagesSent++;
                     // we explicitly specify generator position based on message index
-                    ProducerRecord<byte[], byte[]> record = payloadGenerator.nextRecord(TOPIC_NAME, messageIndex);
+                    ProducerRecord<byte[], byte[]> record = new ProducerRecord(TOPIC_NAME, 0,
+                        KEY_GENERATOR.generate(messageIndex),
+                        spec.valueGenerator().generate(messageIndex));
                     producer.send(record, new Callback() {
                         @Override
                         public void onCompletion(RecordMetadata metadata, Exception exception) {
@@ -286,7 +290,7 @@ public class RoundTripWorker implements TaskWorker {
                         pollInvoked++;
                         ConsumerRecords<byte[], byte[]> records = consumer.poll(50);
                         for (ConsumerRecord<byte[], byte[]> record : records.records(TOPIC_NAME)) {
-                            int messageIndex = ByteBuffer.wrap(record.key()).getInt();
+                            int messageIndex = ByteBuffer.wrap(record.key()).order(ByteOrder.LITTLE_ENDIAN).getInt();
                             messagesReceived++;
                             if (toReceiveTracker.removePending(messageIndex)) {
                                 uniqueMessagesReceived++;

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -57,7 +57,8 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         this.targetMessagesPerSec = targetMessagesPerSec;
         this.partitionAssignments = partitionAssignments == null ?
             new TreeMap<Integer, List<Integer>>() : partitionAssignments;
-        this.valueGenerator = valueGenerator;
+        this.valueGenerator = valueGenerator == null ?
+            new UniformRandomPayloadGenerator(32, 123, 10) : valueGenerator;
         this.maxMessages = maxMessages;
     }
 

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -39,6 +39,7 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     private final String bootstrapServers;
     private final int targetMessagesPerSec;
     private final NavigableMap<Integer, List<Integer>> partitionAssignments;
+    private final PayloadGenerator valueGenerator;
     private final int maxMessages;
 
     @JsonCreator
@@ -48,6 +49,7 @@ public class RoundTripWorkloadSpec extends TaskSpec {
              @JsonProperty("bootstrapServers") String bootstrapServers,
              @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
              @JsonProperty("partitionAssignments") NavigableMap<Integer, List<Integer>> partitionAssignments,
+             @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
              @JsonProperty("maxMessages") int maxMessages) {
         super(startMs, durationMs);
         this.clientNode = clientNode == null ? "" : clientNode;
@@ -55,6 +57,7 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         this.targetMessagesPerSec = targetMessagesPerSec;
         this.partitionAssignments = partitionAssignments == null ?
             new TreeMap<Integer, List<Integer>>() : partitionAssignments;
+        this.valueGenerator = valueGenerator;
         this.maxMessages = maxMessages;
     }
 
@@ -76,6 +79,11 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     @JsonProperty
     public NavigableMap<Integer, List<Integer>> partitionAssignments() {
         return partitionAssignments;
+    }
+
+    @JsonProperty
+    public PayloadGenerator valueGenerator() {
+        return valueGenerator;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/SequentialPayloadGenerator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/SequentialPayloadGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.trogdor.workload;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * A PayloadGenerator which generates a sequentially increasing payload.
+ *
+ * The generated number will wrap around to 0 after the maximum value is reached.
+ * Payloads bigger than 8 bytes will always just be padded with zeros after byte 8.
+ */
+public class SequentialPayloadGenerator implements PayloadGenerator {
+    private final int size;
+    private final long startOffset;
+    private final ByteBuffer buf;
+
+    @JsonCreator
+    public SequentialPayloadGenerator(@JsonProperty("size") int size,
+                                      @JsonProperty("offset") long startOffset) {
+        this.size = size;
+        this.startOffset = startOffset;
+        this.buf = ByteBuffer.allocate(8);
+        // Little-endian byte order allows us to support arbitrary lengths more easily,
+        // since the first byte is always the lowest-order byte.
+        this.buf.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    @JsonProperty
+    public int size() {
+        return size;
+    }
+
+    @JsonProperty
+    public long startOffset() {
+        return startOffset;
+    }
+
+    @Override
+    public synchronized byte[] generate(long position) {
+        buf.clear();
+        buf.putLong(position + startOffset);
+        byte[] result = new byte[size];
+        System.arraycopy(buf.array(), 0, result, 0, Math.min(buf.array().length, result.length));
+        return result;
+    }
+}

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/UniformRandomPayloadGenerator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/UniformRandomPayloadGenerator.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.trogdor.workload;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Random;
+
+/**
+ * A PayloadGenerator which generates a uniform random payload.
+ *
+ * This generator generates pseudo-random payloads that can be reproduced from run to run.
+ * The guarantees are the same as those of java.util.Random.
+ *
+ * This payload generator also has the option to append padding bytes at the end of the payload.
+ * The padding bytes are always the same, no matter what the position is.  This is useful when
+ * simulating a partly-compressible stream of user data.
+ */
+public class UniformRandomPayloadGenerator implements PayloadGenerator {
+    private final int size;
+    private final long seed;
+    private final int padding;
+    private final Random random = new Random();
+    private final byte[] padBytes;
+    private final byte[] randomBytes;
+
+    @JsonCreator
+    public UniformRandomPayloadGenerator(@JsonProperty("size") int size,
+                                         @JsonProperty("seed") long seed,
+                                         @JsonProperty("padding") int padding) {
+        this.size = size;
+        this.seed = seed;
+        this.padding = padding;
+        if (padding < 0 || padding > size) {
+            throw new RuntimeException("Invalid value " + padding + " for " +
+                "padding: the number of padding bytes must not be smaller than " +
+                "0 or greater than the total payload size.");
+        }
+        this.padBytes = new byte[padding];
+        random.setSeed(seed);
+        random.nextBytes(padBytes);
+        this.randomBytes = new byte[size - padding];
+    }
+
+    @JsonProperty
+    public int size() {
+        return size;
+    }
+
+    @JsonProperty
+    public long seed() {
+        return seed;
+    }
+
+    @JsonProperty
+    public int padding() {
+        return padding;
+    }
+
+    @Override
+    public synchronized byte[] generate(long position) {
+        byte[] result = new byte[size];
+        if (randomBytes.length > 0) {
+            random.setSeed(seed + position);
+            random.nextBytes(randomBytes);
+            System.arraycopy(randomBytes, 0, result, 0, Math.min(randomBytes.length, result.length));
+        }
+        if (padBytes.length > 0) {
+            System.arraycopy(padBytes, 0, result, randomBytes.length, result.length - randomBytes.length);
+        }
+        return result;
+    }
+}

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -49,9 +49,9 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, 0, null));
         verify(new WorkerStopping(null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, 0, null, 0, 0));
+            0, 0, null, null, null, 0, 0));
         verify(new RoundTripWorkloadSpec(0, 0, null, null,
-            0, null, 0));
+            0, null, null, 0));
         verify(new SampleTaskSpec(0, 0, 0, null));
     }
 

--- a/tools/src/test/java/org/apache/kafka/trogdor/workload/PayloadGeneratorTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/workload/PayloadGeneratorTest.java
@@ -136,7 +136,7 @@ public class PayloadGeneratorTest {
         assertArrayEquals(expected, iter.next());
         assertArrayEquals(expected, iter.next());
         assertEquals(3, iter.position());
-        iter.setPosition(0);
+        iter.seek(0);
         assertEquals(0, iter.position());
     }
 }

--- a/tools/src/test/java/org/apache/kafka/trogdor/workload/PayloadGeneratorTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/workload/PayloadGeneratorTest.java
@@ -84,11 +84,11 @@ public class PayloadGeneratorTest {
 
     @Test
     public void testUniformRandomPayloadGenerator() {
-        PayloadGeneratorManager manager = new PayloadGeneratorManager(
+        PayloadIterator iter = new PayloadIterator(
             new UniformRandomPayloadGenerator(1234, 456, 0));
-        byte[] prev = manager.next();
+        byte[] prev = iter.next();
         for (int uniques = 0; uniques < 1000; ) {
-            byte[] cur = manager.next();
+            byte[] cur = iter.next();
             assertEquals(prev.length, cur.length);
             if (!Arrays.equals(prev, cur)) {
                 uniques++;
@@ -122,5 +122,21 @@ public class PayloadGeneratorTest {
         System.arraycopy(val3, 900, val3End, 0, 100);
         assertArrayEquals(val1End, val2End);
         assertArrayEquals(val1End, val3End);
+    }
+
+    @Test
+    public void testPayloadIterator() {
+        final int expectedSize = 50;
+        PayloadIterator iter = new PayloadIterator(
+            new ConstantPayloadGenerator(expectedSize, new byte[0]));
+        final byte[] expected = new byte[expectedSize];
+        assertEquals(0, iter.position());
+        assertArrayEquals(expected, iter.next());
+        assertEquals(1, iter.position());
+        assertArrayEquals(expected, iter.next());
+        assertArrayEquals(expected, iter.next());
+        assertEquals(3, iter.position());
+        iter.setPosition(0);
+        assertEquals(0, iter.position());
     }
 }


### PR DESCRIPTION
Make PayloadGenerator an interface which can have multiple
implementations: constant, uniform random, sequential.

Allow different payload generators to be used for keys and values.

This change fixes RoundTripWorkload.  Previously RoundTripWorkload was
unable to get the sequence number of the keys that it produced.