### PR TITLE
KAFKA-6656; Config tool should return non-zero status code on failure

### DIFF
--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -65,12 +65,12 @@ object ConfigCommand extends Config {
     DynamicConfig.Broker.ReplicaAlterLogDirsIoMaxBytesPerSecondProp)
 
   def main(args: Array[String]): Unit = {
-    val opts = new ConfigCommandOptions(args)
-
-    if (args.length == 0)
-      CommandLineUtils.printUsageAndDie(opts.parser, "Add/Remove entity config for a topic, client, user or broker")
-
     try {
+      val opts = new ConfigCommandOptions(args)
+
+      if (args.length == 0)
+        CommandLineUtils.printUsageAndDie(opts.parser, "Add/Remove entity config for a topic, client, user or broker")
+
       opts.checkArgs()
 
       if (opts.options.has(opts.zkConnectOpt)) {
@@ -79,7 +79,7 @@ object ConfigCommand extends Config {
         processBrokerConfig(opts)
       }
     } catch {
-      case e @ (_: IllegalArgumentException | _: InvalidConfigException) =>
+      case e @ (_: IllegalArgumentException | _: InvalidConfigException | _: OptionException) =>
         logger.debug(s"Failed config command with args $args", e)
         System.err.println(e.getMessage)
         Exit.exit(1)

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -87,8 +87,7 @@ object ConfigCommand extends Config {
           describeConfig(zkClient, opts, adminZkClient)
       } catch {
         case e: Throwable =>
-          println("Error while executing config command " + e.getMessage)
-          println(Utils.stackTrace(e))
+          throw new RuntimeException("Error while executing config command", e)
       } finally {
         zkClient.close()
       }
@@ -219,12 +218,10 @@ object ConfigCommand extends Config {
         describeBrokerConfig(adminClient, opts, entityName)
     } catch {
       case e: Throwable =>
-        println("Error while executing config command " + e.getMessage)
-        println(Utils.stackTrace(e))
+        throw new RuntimeException("Error while executing config command", e)
     } finally {
       adminClient.close()
     }
-
   }
 
   private[admin] def alterBrokerConfig(adminClient: JAdminClient, opts: ConfigCommandOptions, entityName: String) {

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -70,9 +70,9 @@ object ConfigCommand extends Config {
     if (args.length == 0)
       CommandLineUtils.printUsageAndDie(opts.parser, "Add/Remove entity config for a topic, client, user or broker")
 
-    opts.checkArgs()
-
     try {
+      opts.checkArgs()
+
       if (opts.options.has(opts.zkConnectOpt)) {
         processCommandWithZk(opts.options.valueOf(opts.zkConnectOpt), opts)
       } else {
@@ -85,7 +85,7 @@ object ConfigCommand extends Config {
         Exit.exit(1)
 
       case t: Throwable =>
-        System.err.println("Error while executing config command")
+        System.err.println(s"Error while executing config command with args $args")
         t.printStackTrace(System.err)
         Exit.exit(1)
     }

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -80,12 +80,13 @@ object ConfigCommand extends Config {
       }
     } catch {
       case e @ (_: IllegalArgumentException | _: InvalidConfigException) =>
+        logger.debug(s"Failed config command with args $args", e)
         System.err.println(e.getMessage)
         Exit.exit(1)
 
       case t: Throwable =>
         System.err.println("Error while executing config command")
-        t.printStackTrace()
+        t.printStackTrace(System.err)
         Exit.exit(1)
     }
   }


### PR DESCRIPTION
We should propagate exceptions when altering or describing configs in order to ensure that the command fails with a non-zero status.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
