### PR TITLE
MINOR: Allow users to specify 'if-not-exists' when creating topics while testing

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -311,6 +311,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
                 'replication-factor': topic_cfg.get('replication-factor', 1)
             }
 
+        if topic_cfg.get('if-not-exists', False):
+            cmd += ' --if-not-exists'
+
         if "configs" in topic_cfg.keys() and topic_cfg["configs"] is not None:
             for config_name, config_value in topic_cfg["configs"].items():
                 cmd += " --config %s=%s" % (config_name, str(config_value))


### PR DESCRIPTION
Would like to be able to add the `--if-not-exists` flag when creating topics during setup in some of our tests; this small change adds that option to `KafkaService` in `services/kafka/kafka.py`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
