### PR TITLE
KAFKA-6351: Prevent copying javassist library to Kafka distribution from tools project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -721,7 +721,7 @@ project(':core') {
     from(configurations.archives.artifacts.files) { into("libs/") }
     from(project.siteDocsTar) { into("site-docs/") }
     from(project(':tools').jar) { into("libs/") }
-    from(project(':tools').configurations.runtime) { into("libs/") }
+    from(project(':tools').configurations.runtime) { into("libs/") exclude '**/*javassist*'}
     from(project(':connect:api').jar) { into("libs/") }
     from(project(':connect:api').configurations.runtime) { into("libs/") }
     from(project(':connect:runtime').jar) { into("libs/") }


### PR DESCRIPTION
-  javassist:3.21.0-GA library is coming from :connect:runtime project and javassist:3.20.0-GA library is coming from :tools project. This PR prevents copying javassist while creating Kafka distribution from tools project

