### PR TITLE
MINOR: improve trogdor commandline

### DIFF
--- a/config/trogdor.conf
+++ b/config/trogdor.conf
@@ -1,0 +1,9 @@
+{
+    "platform": "org.apache.kafka.trogdor.basic.BasicPlatform", "nodes": {
+        "node0": {
+            "hostname": "localhost",
+            "trogdor.agent.port": 8888,
+            "trogdor.coordinator.port": 8889
+        }
+    }
+}

--- a/config/trogdor.conf
+++ b/config/trogdor.conf
@@ -1,4 +1,20 @@
 {
+    "_comment": [
+        "Licensed to the Apache Software Foundation (ASF) under one or more",
+        "contributor license agreements.  See the NOTICE file distributed with",
+        "this work for additional information regarding copyright ownership.",
+        "The ASF licenses this file to You under the Apache License, Version 2.0",
+        "(the \"License\"); you may not use this file except in compliance with",
+        "the License.  You may obtain a copy of the License at",
+        "",
+        "http://www.apache.org/licenses/LICENSE-2.0",
+        "",
+        "Unless required by applicable law or agreed to in writing, software",
+        "distributed under the License is distributed on an \"AS IS\" BASIS,",
+        "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+        "See the License for the specific language governing permissions and",
+        "limitations under the License."
+    ],
     "platform": "org.apache.kafka.trogdor.basic.BasicPlatform", "nodes": {
         "node0": {
             "hostname": "localhost",

--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -109,14 +109,14 @@ public final class Agent {
             .newArgumentParser("trogdor-agent")
             .defaultHelp(true)
             .description("The Trogdor fault injection agent");
-        parser.addArgument("--agent.config")
+        parser.addArgument("--agent.config", "-c")
             .action(store())
             .required(true)
             .type(String.class)
             .dest("config")
             .metavar("CONFIG")
             .help("The configuration file to use.");
-        parser.addArgument("--node-name")
+        parser.addArgument("--node-name", "-n")
             .action(store())
             .required(true)
             .type(String.class)

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -113,14 +113,14 @@ public final class Coordinator {
             .newArgumentParser("trogdor-coordinator")
             .defaultHelp(true)
             .description("The Trogdor fault injection coordinator");
-        parser.addArgument("--coordinator.config")
+        parser.addArgument("--coordinator.config", "-c")
             .action(store())
             .required(true)
             .type(String.class)
             .dest("config")
             .metavar("CONFIG")
             .help("The configuration file to use.");
-        parser.addArgument("--node-name")
+        parser.addArgument("--node-name", "-n")
             .action(store())
             .required(true)
             .type(String.class)


### PR DESCRIPTION
Allow -c as a synonym for --agent.config and --coordinator.config.

Allow -n as a synonym for --node-name.

Add an example trogdor.conf file.