### PR TITLE
MINOR KAFKA-3978 followup

### DIFF
--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -175,8 +175,10 @@ class Replica(val brokerId: Int,
   def convertHWToLocalOffsetMetadata() {
     if (isLocal) {
       highWatermarkMetadata = log.get.convertToOffsetMetadata(highWatermarkMetadata.messageOffset).getOrElse {
-        val firstOffset = log.get.logSegments.head.baseOffset
-        new LogOffsetMetadata(firstOffset, firstOffset, 0)
+        log.get.convertToOffsetMetadata(logStartOffset).getOrElse {
+          val firstSegmentOffset = log.get.logSegments.head.baseOffset
+          new LogOffsetMetadata(firstSegmentOffset, firstSegmentOffset, 0)
+        }
       }
     } else {
       throw new KafkaException(s"Should not construct complete high watermark on partition $topicPartition's non-local replica $brokerId")


### PR DESCRIPTION
We should use logStartOffset as HW offset if the current HW offset is out of range.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
