### PR TITLE
MINOR: Java 9/10 fixes, gradle and minor deps update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath 'org.scoverage:gradle-scoverage:2.1.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.2'
-    classpath 'org.owasp:dependency-check-gradle:3.0.2'
+    classpath 'org.owasp:dependency-check-gradle:3.1.1'
   }
 }
 
@@ -79,7 +79,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.5.1"
+  gradleVersion = "4.6"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,9 @@ allprojects {
   }
   
   apply plugin: 'idea'
-  apply plugin: "jacoco"
+  // jacoco is not compatible with Java 10 or 11 at the moment, see https://github.com/jacoco/jacoco/issues/629
+  if (!JavaVersion.current().isJava10Compatible())
+    apply plugin: "jacoco"
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'com.github.ben-manes.versions'
 
@@ -385,26 +387,28 @@ subprojects {
   // Ignore core since its a scala project
   if (it.path != ':core') {
 
-    jacoco {
-      toolVersion = "0.8.0"
-    }
+    if (!JavaVersion.current().isJava10Compatible()) {
+      jacoco {
+        toolVersion = "0.8.0"
+      }
 
-    // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock
-    // may report 0 coverage, since the source was modified after initial instrumentation.
-    // See https://github.com/jacoco/jacoco/issues/51
-    jacocoTestReport {
-      dependsOn tasks.test
-      sourceSets sourceSets.main
-      reports {
-        html.enabled = true
-        xml.enabled = true
-        csv.enabled = false
+      // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock
+      // may report 0 coverage, since the source was modified after initial instrumentation.
+      // See https://github.com/jacoco/jacoco/issues/51
+      jacocoTestReport {
+        dependsOn tasks.test
+        sourceSets sourceSets.main
+        reports {
+          html.enabled = true
+          xml.enabled = true
+          csv.enabled = false
+        }
       }
     }
-  }
 
-  def coverageGen = it.path == ':core' ? 'reportScoverage' : 'jacocoTestReport'
-  task reportCoverage(dependsOn: [coverageGen])
+    def coverageGen = it.path == ':core' ? 'reportScoverage' : 'jacocoTestReport'
+    task reportCoverage(dependsOn: [coverageGen])
+  }
 
 }
 
@@ -445,31 +449,34 @@ def fineTuneEclipseClasspathFile(eclipse, project) {
   }
 }
 
-// Aggregates all jacoco results into the root project directory
-task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
-  def javaProjects = subprojects.findAll { it.path != ':core' }
 
-  description = 'Generates an aggregate report from all subprojects'
-  dependsOn(javaProjects.test)
+if (!JavaVersion.current().isJava10Compatible()) {
+  // Aggregates all jacoco results into the root project directory
+  task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
+    def javaProjects = subprojects.findAll { it.path != ':core' }
 
-  additionalSourceDirs = files(javaProjects.sourceSets.main.allSource.srcDirs)
-  sourceDirectories = files(javaProjects.sourceSets.main.allSource.srcDirs)
-  classDirectories =  files(javaProjects.sourceSets.main.output)
-  executionData = files(javaProjects.jacocoTestReport.executionData)
+    description = 'Generates an aggregate report from all subprojects'
+    dependsOn(javaProjects.test)
 
-  reports {
-    html.enabled = true
-    xml.enabled = true
+    additionalSourceDirs = files(javaProjects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(javaProjects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(javaProjects.sourceSets.main.output)
+    executionData = files(javaProjects.jacocoTestReport.executionData)
+
+    reports {
+      html.enabled = true
+      xml.enabled = true
+    }
+
+    // workaround to ignore projects that don't have any tests at all
+    onlyIf = { true }
+    doFirst {
+      executionData = files(executionData.findAll { it.exists() })
+    }
   }
 
-  // workaround to ignore projects that don't have any tests at all
-  onlyIf = { true }
-  doFirst {
-    executionData = files(executionData.findAll { it.exists() })
-  }
+  task reportCoverage(dependsOn: ['jacocoRootReport', 'core:reportCoverage'])
 }
-
-task reportCoverage(dependsOn: ['jacocoRootReport', 'core:reportCoverage'])
 
 for ( sv in availableScalaVersions ) {
   String taskSuffix = sv.replaceAll("\\.", "_")
@@ -592,7 +599,9 @@ project(':core') {
     scoverage libs.scoverageRuntime
   }
 
-  jacocoTestReport.enabled = false
+  if (!JavaVersion.current().isJava10Compatible())
+    jacocoTestReport.enabled = false
+
   scoverage {
     reportDir = file("${rootProject.buildDir}/scoverage")
     highlighting = false

--- a/build.gradle
+++ b/build.gradle
@@ -1205,6 +1205,8 @@ project(':connect:runtime') {
 
     compile libs.jacksonJaxrsJsonProvider
     compile libs.jerseyContainerServlet
+    compile libs.jaxbApi // Jersey dependency that was available in the JDK before Java 9
+    compile libs.activation // Jersey dependency that was available in the JDK before Java 9
     compile libs.jettyServer
     compile libs.jettyServlet
     compile libs.jettyServlets

--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,7 @@ allprojects {
   }
   
   apply plugin: 'idea'
-  // jacoco is not compatible with Java 10 or 11 at the moment, see https://github.com/jacoco/jacoco/issues/629
-  if (!JavaVersion.current().isJava10Compatible())
-    apply plugin: "jacoco"
+  apply plugin: "jacoco"
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'com.github.ben-manes.versions'
 
@@ -387,28 +385,26 @@ subprojects {
   // Ignore core since its a scala project
   if (it.path != ':core') {
 
-    if (!JavaVersion.current().isJava10Compatible()) {
-      jacoco {
-        toolVersion = "0.8.0"
-      }
-
-      // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock
-      // may report 0 coverage, since the source was modified after initial instrumentation.
-      // See https://github.com/jacoco/jacoco/issues/51
-      jacocoTestReport {
-        dependsOn tasks.test
-        sourceSets sourceSets.main
-        reports {
-          html.enabled = true
-          xml.enabled = true
-          csv.enabled = false
-        }
-      }
+    jacoco {
+      toolVersion = "0.8.0"
     }
 
-    def coverageGen = it.path == ':core' ? 'reportScoverage' : 'jacocoTestReport'
-    task reportCoverage(dependsOn: [coverageGen])
+    // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock
+    // may report 0 coverage, since the source was modified after initial instrumentation.
+    // See https://github.com/jacoco/jacoco/issues/51
+    jacocoTestReport {
+      dependsOn tasks.test
+      sourceSets sourceSets.main
+      reports {
+        html.enabled = true
+        xml.enabled = true
+        csv.enabled = false
+      }
+    }
   }
+
+  def coverageGen = it.path == ':core' ? 'reportScoverage' : 'jacocoTestReport'
+  task reportCoverage(dependsOn: [coverageGen])
 
 }
 
@@ -449,34 +445,31 @@ def fineTuneEclipseClasspathFile(eclipse, project) {
   }
 }
 
+// Aggregates all jacoco results into the root project directory
+task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
+  def javaProjects = subprojects.findAll { it.path != ':core' }
 
-if (!JavaVersion.current().isJava10Compatible()) {
-  // Aggregates all jacoco results into the root project directory
-  task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
-    def javaProjects = subprojects.findAll { it.path != ':core' }
+  description = 'Generates an aggregate report from all subprojects'
+  dependsOn(javaProjects.test)
 
-    description = 'Generates an aggregate report from all subprojects'
-    dependsOn(javaProjects.test)
+  additionalSourceDirs = files(javaProjects.sourceSets.main.allSource.srcDirs)
+  sourceDirectories = files(javaProjects.sourceSets.main.allSource.srcDirs)
+  classDirectories =  files(javaProjects.sourceSets.main.output)
+  executionData = files(javaProjects.jacocoTestReport.executionData)
 
-    additionalSourceDirs = files(javaProjects.sourceSets.main.allSource.srcDirs)
-    sourceDirectories = files(javaProjects.sourceSets.main.allSource.srcDirs)
-    classDirectories = files(javaProjects.sourceSets.main.output)
-    executionData = files(javaProjects.jacocoTestReport.executionData)
-
-    reports {
-      html.enabled = true
-      xml.enabled = true
-    }
-
-    // workaround to ignore projects that don't have any tests at all
-    onlyIf = { true }
-    doFirst {
-      executionData = files(executionData.findAll { it.exists() })
-    }
+  reports {
+    html.enabled = true
+    xml.enabled = true
   }
 
-  task reportCoverage(dependsOn: ['jacocoRootReport', 'core:reportCoverage'])
+  // workaround to ignore projects that don't have any tests at all
+  onlyIf = { true }
+  doFirst {
+    executionData = files(executionData.findAll { it.exists() })
+  }
 }
+
+task reportCoverage(dependsOn: ['jacocoRootReport', 'core:reportCoverage'])
 
 for ( sv in availableScalaVersions ) {
   String taskSuffix = sv.replaceAll("\\.", "_")
@@ -599,9 +592,7 @@ project(':core') {
     scoverage libs.scoverageRuntime
   }
 
-  if (!JavaVersion.current().isJava10Compatible())
-    jacocoTestReport.enabled = false
-
+  jacocoTestReport.enabled = false
   scoverage {
     reportDir = file("${rootProject.buildDir}/scoverage")
     highlighting = false

--- a/build.gradle
+++ b/build.gradle
@@ -883,6 +883,8 @@ project(':tools') {
 
     compile libs.jacksonJaxrsJsonProvider
     compile libs.jerseyContainerServlet
+    compile libs.jaxbApi // Jersey dependency that was available in the JDK before Java 9
+    compile libs.activation // Jersey dependency that was available in the JDK before Java 9
     compile libs.jettyServer
     compile libs.jettyServlet
     compile libs.jettyServlets

--- a/build.gradle
+++ b/build.gradle
@@ -386,7 +386,7 @@ subprojects {
   if (it.path != ':core') {
 
     jacoco {
-      toolVersion = "0.8.0"
+      toolVersion = "0.8.1"
     }
 
     // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,6 +47,7 @@ if (hasProperty('scalaVersion')) {
 versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
 
 versions += [
+  activation: "1.1.1",
   apacheda: "1.0.0",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
@@ -58,6 +59,7 @@ versions += [
   jmh: "1.20",
   log4j: "1.2.17",
   scalaLogging: "3.8.0",
+  jaxb: "2.3.0",
   jopt: "5.0.4",
   junit: "4.12",
   lz4: "1.4.1",
@@ -77,6 +79,7 @@ versions += [
 ]
 
 libs += [
+  activation: "javax.activation:activation:$versions.activation",
   argparse4j: "net.sourceforge.argparse4j:argparse4j:$versions.argparse4j",
   apacheda: "org.apache.directory.api:api-all:$versions.apacheda",
   apachedsCoreApi: "org.apache.directory.server:apacheds-core-api:$versions.apacheds",
@@ -91,6 +94,7 @@ libs += [
   easymock: "org.easymock:easymock:$versions.easymock",
   jacksonDatabind: "com.fasterxml.jackson.core:jackson-databind:$versions.jackson",
   jacksonJaxrsJsonProvider: "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$versions.jackson",
+  jaxbApi: "javax.xml.bind:jaxb-api:$versions.jaxb",
   jettyServer: "org.eclipse.jetty:jetty-server:$versions.jetty",
   jettyClient: "org.eclipse.jetty:jetty-client:$versions.jetty",
   jettyServlet: "org.eclipse.jetty:jetty-servlet:$versions.jetty",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -50,30 +50,30 @@ versions += [
   apacheda: "1.0.0",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.58",
+  bcpkix: "1.59",
   easymock: "3.5.1",
   jackson: "2.9.4",
   jetty: "9.2.24.v20180105",
   jersey: "2.25.1",
-  jmh: "1.19",
+  jmh: "1.20",
   log4j: "1.2.17",
-  scalaLogging: "3.7.2",
+  scalaLogging: "3.8.0",
   jopt: "5.0.4",
   junit: "4.12",
-  lz4: "1.4",
+  lz4: "1.4.1",
   metrics: "2.2.0",
   // PowerMock 1.x doesn't support Java 9, so use PowerMock 2.0.0 beta
   powermock: "2.0.0-beta.5",
   reflections: "0.9.11",
   rocksDB: "5.7.3",
-  scalatest: "3.0.4",
+  scalatest: "3.0.5",
   scoverage: "1.3.1",
   slf4j: "1.7.25",
   snappy: "1.1.7.1",
   zkclient: "0.10",
   zookeeper: "3.4.10",
   jfreechart: "1.0.0",
-  mavenArtifact: "3.5.2"
+  mavenArtifact: "3.5.3"
 ]
 
 libs += [


### PR DESCRIPTION
- Added dependencies so that Trogdor and Connect work with Java 9 and 10
- Updated Jacoco to 0.8.1 so that it works with Java 10
- Updated Gradle to 4.6
- A few minor version bumps (not related to Java9/10 fixes)

I tested manually that we can run `./gradlew test` with Java 10
after these changes. There are test failures as EasyMock
and PowerMock will have to be updated to use a newer
ASM version. But compiling successfully and most tests
passing is progress. :)

I also tested manually that Trogdor can be started with Java 10.
It previously failed with a ClassNotFoundError.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
