### PR TITLE
KAFKA-6659: Improve error message if state store is not found

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -75,7 +75,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
             throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name +
                     " as the store is not connected to the processor. If you add stores manually via '.addStateStore()' " +
                     "make sure to connect the added store to the processor by providing the processor name to " +
-                    "'.addStateStore()' or connect them via '.connectProcessorAndStateStores()'." +
+                    "'.addStateStore()' or connect them via '.connectProcessorAndStateStores()'. " +
                     "DSL users need to provide the store name to '.process()', '.transform()', or '.transformValues()' " +
                     "to connect the store to the corresponding operator. If you do not add stores manually, " +
                     "please file a bug report at https://issues.apache.org/jira/projects/KAFKA.");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -73,7 +73,8 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
         if (!currentNode().stateStores.contains(name)) {
             throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name
-                    + " as the store is not connected to the processor. Please check you connected the store to the processor.");
+                    + " as the store is not connected to the processor. " +
+                    "Please check you have connected the store to the processor.");
         }
 
         return stateManager.getStore(name);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -72,9 +72,13 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         }
 
         if (!currentNode().stateStores.contains(name)) {
-            throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name
-                    + " as the store is not connected to the processor. " +
-                    "Please check you have connected the store to the processor.");
+            throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name +
+                    " as the store is not connected to the processor. If you add stores manually via '.addStateStore()' " +
+                    "make sure to connect the added store to the processor by providing the processor name to " +
+                    "'.addStateStore()' or connect them via '.connectProcessorAndStateStores()'." +
+                    "DSL users need to provide the store name to '.process()', '.transform()', or '.transformValues()' " +
+                    "to connect the store to the corresponding operator. If you do not add stores manually, " +
+                    "please file a bug report at https://issues.apache.org/jira/projects/KAFKA.");
         }
 
         return stateManager.getStore(name);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -72,7 +72,8 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         }
 
         if (!currentNode().stateStores.contains(name)) {
-            throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name);
+            throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name
+                    + " as the store is not connected to the processor. Please check you connected the store to the processor.");
         }
 
         return stateManager.getStore(name);


### PR DESCRIPTION
Update the exception message thrown to state about the state store not found and suggest checking store has been connected to the processor. 
