### PR TITLE
MINOR: KafkaFutureImpl#addWaiter should be protected

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
@@ -192,7 +192,7 @@ public class KafkaFutureImpl<T> extends KafkaFuture<T> {
         return future;
     }
 
-    public synchronized void addWaiter(BiConsumer<? super T, ? super Throwable> action) {
+    protected synchronized void addWaiter(BiConsumer<? super T, ? super Throwable> action) {
         if (exception != null) {
             action.accept(null, exception);
         } else if (done) {


### PR DESCRIPTION
KafkaFutureImpl#addWaiter should be protected, just like KafkaFuture#addWaiter.  As described in KIP-218, whenComplete is the public API, not addWaiter.