### PR TITLE
KAFKA-6473: Add MockProcessorContext to public test-utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1003,6 +1003,7 @@ project(':streams:examples') {
     compile project(':connect:json')  // this dependency should be removed after we unify data API
     compile libs.slf4jlog4j
 
+    testCompile project(':clients').sourceSets.test.output // for org.apache.kafka.test.IntegrationTest
     testCompile project(':streams:test-utils')
     testCompile libs.junit
   }

--- a/build.gradle
+++ b/build.gradle
@@ -1000,10 +1000,10 @@ project(':streams:examples') {
 
   dependencies {
     compile project(':streams')
-    compile project(':streams:test-utils')
     compile project(':connect:json')  // this dependency should be removed after we unify data API
     compile libs.slf4jlog4j
 
+    testCompile project(':streams:test-utils')
     testCompile libs.junit
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1000,8 +1000,11 @@ project(':streams:examples') {
 
   dependencies {
     compile project(':streams')
+    compile project(':streams:test-utils')
     compile project(':connect:json')  // this dependency should be removed after we unify data API
     compile libs.slf4jlog4j
+
+    testCompile libs.junit
   }
 
   javadoc {

--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -66,6 +66,7 @@
                 </ul>
                 </li>
                 <li><a class="reference internal" href="#writing-streams-back-to-kafka" id="id25">Writing streams back to Kafka</a></li>
+                <li><a class="reference internal" href="#testing-a-streams-app" id="id26">Testing a Streams application</a></li>
             </ul>
         </div>
         <div class="section" id="overview">
@@ -3154,6 +3155,10 @@ t=5 (blue), which lead to a merge of sessions and an extension of a session, res
                     retry on delivery failure or to prevent message duplication).</p>
 </div>
 </div>
+        <div class="section" id="testing-a-streams-app">
+            <a class="headerlink" href="#testing-a-streams-app" title="Permalink to this headline"><h2>Testing a Streams application</a></h2>
+            Kafka Streams comes with a <code>test-utils</code> module to help you test your application <a href="testing.html">here</a>.
+        </div>
 </div>
 
 

--- a/docs/streams/developer-guide/index.html
+++ b/docs/streams/developer-guide/index.html
@@ -40,6 +40,7 @@
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="write-streams.html">Writing a Streams Application</a></li>
+<li class="toctree-l1"><a class="reference internal" href="testing.html">Testing a Streams Application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="config-streams.html">Configuring a Streams Application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="dsl-api.html">Streams DSL</a></li>
 <li class="toctree-l1"><a class="reference internal" href="processor-api.html">Processor API</a></li>

--- a/docs/streams/developer-guide/index.html
+++ b/docs/streams/developer-guide/index.html
@@ -40,7 +40,6 @@
 <div class="toctree-wrapper compound">
 <ul>
 <li class="toctree-l1"><a class="reference internal" href="write-streams.html">Writing a Streams Application</a></li>
-<li class="toctree-l1"><a class="reference internal" href="testing.html">Testing a Streams Application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="config-streams.html">Configuring a Streams Application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="dsl-api.html">Streams DSL</a></li>
 <li class="toctree-l1"><a class="reference internal" href="processor-api.html">Processor API</a></li>

--- a/docs/streams/developer-guide/processor-api.html
+++ b/docs/streams/developer-guide/processor-api.html
@@ -205,7 +205,7 @@ final MockProcessorContext context = new MockProcessorContext(config);
 processorUnderTest.process("key", "value");
 
 final Iterator&lt;CapturedForward&gt; forwarded = context.forwarded().iterator();
-assertEquals(forwarded.next().kv(), new KeyValue<>(..., ...));
+assertEquals(forwarded.next().keyValue(), new KeyValue<>(..., ...));
 assertFalse(forwarded.hasNext());
 
 // you can reset forwards to clear the captured data. This may be helpful in constructing longer scenarios.

--- a/docs/streams/developer-guide/processor-api.html
+++ b/docs/streams/developer-guide/processor-api.html
@@ -166,95 +166,11 @@
         <div class="section" id="unit-testing-processors">
             <h2>
                 <a class="toc-backref" href="#id9">Unit Testing Processors</a>
-                <a class="headerlink" href="#connecting-processors-and-state-stores"
-                   title="Permalink to this headline"></a>
+                <a class="headerlink" href="#unit-testing-processors" title="Permalink to this headline"></a>
             </h2>
             <p>
-                Once you have a processor implementation, you will want to test it.
-                Because the <code>Processor</code> forwards its results to the context rather than returning them,
-                Unit testing requires a mocked context capable of capturing forwarded data for inspection.
-                For this reason, we provide a <code>MockProcessorContext</code> in our <code>test-utils</code>module.
-            </p>
-            <p>
-                Instructions on importing the <code>test-utils</code> module are <a href="testing.html">here</a>.
-            </p>
-            <b>Construction</b>
-            <p>
-            To begin with, instantiate your processor and initialize it with the mock context:
-            <pre>
-final Processor processorUnderTest = ...;
-final MockProcessorContext context = new MockProcessorContext();
-processorUnderTest.init(context);
-                </pre>
-            If you need to pass configuration to your processor or set the default serdes, you can create the mock with
-            config:
-            <pre>
-final Properties config = new Properties();
-config.put(StreamsConfig.APPLICATION_ID_CONFIG, "unit-test");
-config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
-config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
-config.put("some.other.config", "some config value");
-final MockProcessorContext context = new MockProcessorContext(config);
-                </pre>
-            </p>
-            <b>Captured data</b>
-            <p>
-                The mock will capture any values that your processor forwards. You can make assertions on them:
-            <pre>
-processorUnderTest.process("key", "value");
-
-final Iterator&lt;CapturedForward&gt; forwarded = context.forwarded().iterator();
-assertEquals(forwarded.next().keyValue(), new KeyValue&lt;&gt;(..., ...));
-assertFalse(forwarded.hasNext());
-
-// you can reset forwards to clear the captured data. This may be helpful in constructing longer scenarios.
-context.resetForwards();
-
-assertEquals(context.forwarded().size(), 0);
-            </pre>
-            If your processor forwards to specific child processors, you can query the context for captured data by child name:
-            <pre>
-final List&lt;CapturedForward&gt; captures = context.forwarded("childProcessorName");
-            </pre>
-            The mock also captures whether your processor has called <code>commit()</code> on the context:
-            <pre>
-assertTrue(context.committed());
-
-// commit captures can also be reset.
-context.resetCommit();
-
-assertFalse(context.committed());
-            </pre>
-            </p>
-            <b>Setting record metadata</b>
-            <p>
-                In case your processor logic depends on the record metadata (topic, partition, offset, or timestamp),
-                you can set them on the context, either all together or individually:
-                <pre>
-context.setRecordMetadata("topicName", /*partition*/ 0, /*offset*/ 0L, /*timestamp*/ 0L);
-context.setTopic("topicName");
-context.setPartition(0);
-context.setOffset(0L);
-context.setTimestamp(0L);
-                </pre>
-                Once these are set, the context will continue returning the same values, until you set new ones.
-            </p>
-            <b>Verifying punctuators</b>
-            <p>
-                As discussed above, processors can schedule punctuators to handle periodic tasks.
-                The mock context does <i>not</i> automatically execute punctuators, but it does capture them to
-                allow you to unit test them as well:
-                <pre>
-final MockProcessorContext.CapturedPunctuator capturedPunctuator = context.scheduledPunctuators().get(0);
-final long interval = capturedPunctuator.getIntervalMs();
-final PunctuationType type = capturedPunctuator.getType();
-final boolean cancelled = capturedPunctuator.cancelled();
-final Punctuator punctuator = capturedPunctuator.getPunctuator();
-punctuator.punctuate(/*timestamp*/ 0L);
-                </pre>
-                If you need to write tests involving automatic firing of scheduled punctuators, we recommend creating a
-                simple topology with your processor and using the <a href="testing.html#testing-topologytestdriver"><code>TopologyTestDriver</code></a>.
+                Kafka Streams comes with a <code>test-utils</code> module to help you write unit tests for your
+                processors <a href="testing.html#unit-testing-processors">here</a>.
             </p>
         </div>
         <div class="section" id="state-stores">

--- a/docs/streams/developer-guide/processor-api.html
+++ b/docs/streams/developer-guide/processor-api.html
@@ -41,13 +41,16 @@
             <p class="topic-title first"><b>Table of Contents</b></p>
             <ul class="simple">
                 <li><a class="reference internal" href="#overview" id="id1">Overview</a></li>
-                <li><a class="reference internal" href="#defining-a-stream-processor" id="id2">Defining a Stream Processor</a></li>
-                <li><a class="reference internal" href="#state-stores" id="id3">State Stores</a><ul>
-                    <li><a class="reference internal" href="#defining-and-creating-a-state-store" id="id4">Defining and creating a State Store</a></li>
-                    <li><a class="reference internal" href="#fault-tolerant-state-stores" id="id5">Fault-tolerant State Stores</a></li>
-                    <li><a class="reference internal" href="#enable-or-disable-fault-tolerance-of-state-stores-store-changelogs" id="id6">Enable or Disable Fault Tolerance of State Stores (Store Changelogs)</a></li>
-                    <li><a class="reference internal" href="#implementing-custom-state-stores" id="id7">Implementing Custom State Stores</a></li>
-                </ul>
+                <li><a class="reference internal" href="#defining-a-stream-processor" id="id2">Defining a Stream
+                    Processor</a></li>
+                <li><a class="reference internal" href="#unit-testing-processors" id="id9">Unit Testing Processors</a></li>
+                <li><a class="reference internal" href="#state-stores" id="id3">State Stores</a>
+                    <ul>
+                        <li><a class="reference internal" href="#defining-and-creating-a-state-store" id="id4">Defining and creating a State Store</a></li>
+                        <li><a class="reference internal" href="#fault-tolerant-state-stores" id="id5">Fault-tolerant State Stores</a></li>
+                        <li><a class="reference internal" href="#enable-or-disable-fault-tolerance-of-state-stores-store-changelogs" id="id6">Enable or Disable Fault Tolerance of State Stores (Store Changelogs)</a></li>
+                        <li><a class="reference internal" href="#implementing-custom-state-stores" id="id7">Implementing Custom State Stores</a></li>
+                    </ul>
                 </li>
                 <li><a class="reference internal" href="#connecting-processors-and-state-stores" id="id8">Connecting Processors and State Stores</a></li>
             </ul>
@@ -98,11 +101,12 @@
                 callbacks with different <code class="docutils literal"><span class="pre">PunctuationType</span></code> types within the same processor by calling <code class="docutils literal"><span class="pre">ProcessorContext#schedule()</span></code> multiple
                 times inside <code class="docutils literal"><span class="pre">init()</span></code> method.</p>
             <div class="admonition attention">
-                <p class="first admonition-title">Attention</p>
+                <p class="first admonition-title"><b>Attention</b></p>
                 <p class="last">Stream-time is only advanced if all input partitions over all input topics have new data (with newer timestamps) available.
                     If at least one partition does not have any new data available, stream-time will not be advanced and thus <code class="docutils literal"><span class="pre">punctuate()</span></code> will not be triggered if <code class="docutils literal"><span class="pre">PunctuationType.STREAM_TIME</span></code> was specified.
                     This behavior is independent of the configured timestamp extractor, i.e., using <code class="docutils literal"><span class="pre">WallclockTimestampExtractor</span></code> does not enable wall-clock triggering of <code class="docutils literal"><span class="pre">punctuate()</span></code>.</p>
             </div>
+            <p><b>Example</b></p>
             <p>The following example <code class="docutils literal"><span class="pre">Processor</span></code> defines a simple word-count algorithm and the following actions are performed:</p>
             <ul class="simple">
                 <li>In the <code class="docutils literal"><span class="pre">init()</span></code> method, schedule the punctuation every 1000 time units (the time unit is normally milliseconds, which in this example would translate to punctuation every 1 second) and retrieve the local state store by its name &#8220;Counts&#8221;.</li>
@@ -158,6 +162,100 @@
                     leverage <a class="reference internal" href="#streams-developer-guide-state-store"><span class="std std-ref">state stores</span></a> to maintain processing states to, for example, remember recently
                     arrived records for stateful processing needs like aggregations and joins. For more information, see the <a class="reference internal" href="#streams-developer-guide-state-store"><span class="std std-ref">state stores</span></a> documentation.</p>
             </div>
+        </div>
+        <div class="section" id="unit-testing-processors">
+            <h2>
+                <a class="toc-backref" href="#id9">Unit Testing Processors</a>
+                <a class="headerlink" href="#connecting-processors-and-state-stores"
+                   title="Permalink to this headline"></a>
+            </h2>
+            <p>
+                Once you have a processor implementation, you will want to test it.
+                Because the <code>Processor</code> forwards its results to the context rather than returning them,
+                Unit testing requires a mocked context capable of capturing forwarded data for inspection.
+                For this reason, we provide a <code>MockProcessorContext</code> in our <code>test-utils</code>module.
+            </p>
+            <p>
+                Instructions on importing the <code>test-utils</code> module are <a href="testing.html">here</a>.
+            </p>
+            <b>Construction</b>
+            <p>
+            To begin with, instantiate your processor and initialize it with the mock context:
+            <pre>
+final Processor processorUnderTest = ...;
+final MockProcessorContext context = new MockProcessorContext();
+processorUnderTest.init(context);
+                </pre>
+            If you need to pass configuration to your processor or set the default serdes, you can create the mock with
+            config:
+            <pre>
+final Properties config = new Properties();
+config.put(StreamsConfig.APPLICATION_ID_CONFIG, "unit-test");
+config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
+config.put("some.other.config", "some config value");
+final MockProcessorContext context = new MockProcessorContext(config);
+                </pre>
+            </p>
+            <b>Captured data</b>
+            <p>
+                The mock will capture any values that your processor forwards. You can make assertions on them:
+            <pre>
+processorUnderTest.process("key", "value");
+
+final Iterator&lt;CapturedForward&gt; forwarded = context.forwarded().iterator();
+assertEquals(forwarded.next().kv(), new KeyValue<>(..., ...));
+assertFalse(forwarded.hasNext());
+
+// you can reset forwards to clear the captured data. This may be helpful in constructing longer scenarios.
+context.resetForwards();
+
+assertEquals(context.forwarded().size(), 0);
+            </pre>
+            If your processor forwards to specific child processors, you can query the context for captured data by child name:
+            <pre>
+final List&lt;CapturedForward&gt; captures = context.forwarded("childProcessorName");
+            </pre>
+            The mock also captures whether your processor has called <code>commit()</code> on the context:
+            <pre>
+assertTrue(context.committed());
+
+// commit captures can also be reset.
+context.resetCommit();
+
+assertFalse(context.committed());
+            </pre>
+            </p>
+            <b>Setting record metadata</b>
+            <p>
+                In case your processor logic depends on the record metadata (topic, partition, offset, or timestamp),
+                you can set them on the context, either all together or individually:
+                <pre>
+context.setRecordMetadata("topicName", /*partition*/ 0, /*offset*/ 0L, /*timestamp*/ 0L);
+context.setTopic("topicName");
+context.setPartition(0);
+context.setOffset(0L);
+context.setTimestamp(0L);
+                </pre>
+                Once these are set, the context will continue returning the same values, until you set new ones.
+            </p>
+            <b>Verifying punctuators</b>
+            <p>
+                As discussed above, processors can schedule punctuators to handle periodic tasks.
+                The mock context does <i>not</i> automatically execute punctuators, but it does capture them to
+                allow you to unit test them as well:
+                <pre>
+final MockProcessorContext.CapturedPunctuator capturedPunctuator = context.scheduledPunctuators().get(0);
+final long interval = capturedPunctuator.getIntervalMs();
+final PunctuationType type = capturedPunctuator.getType();
+final boolean cancelled = capturedPunctuator.cancelled();
+final Punctuator punctuator = capturedPunctuator.getPunctuator();
+punctuator.punctuate(/*timestamp*/ 0L);
+                </pre>
+                If you need to write tests involving automatic firing of scheduled punctuators, we recommend creating a
+                simple topology with your processor and using the <a href="testing.html#testing-topologytestdriver"><code>TopologyTestDriver</code></a>.
+            </p>
         </div>
         <div class="section" id="state-stores">
             <span id="streams-developer-guide-state-store"></span><h2><a class="toc-backref" href="#id3">State Stores</a><a class="headerlink" href="#state-stores" title="Permalink to this headline"></a></h2>

--- a/docs/streams/developer-guide/processor-api.html
+++ b/docs/streams/developer-guide/processor-api.html
@@ -205,7 +205,7 @@ final MockProcessorContext context = new MockProcessorContext(config);
 processorUnderTest.process("key", "value");
 
 final Iterator&lt;CapturedForward&gt; forwarded = context.forwarded().iterator();
-assertEquals(forwarded.next().keyValue(), new KeyValue<>(..., ...));
+assertEquals(forwarded.next().keyValue(), new KeyValue&lt;&gt;(..., ...));
 assertFalse(forwarded.hasNext());
 
 // you can reset forwards to clear the captured data. This may be helpful in constructing longer scenarios.

--- a/docs/streams/developer-guide/testing.html
+++ b/docs/streams/developer-guide/testing.html
@@ -45,8 +45,8 @@
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;
     </pre>
-    <div class="section" id="testing-topologytestdriver">
-        <span id="streams-testing-topologytestdriver"></span><h2><a class="toc-backref" href="#id1">TopologyTestDriver</a><a class="headerlink" href="#testing-topologytestdriver" title="Permalink to this headline"></a></h2>
+   <div class="section" id="testing-topologytestdriver">
+        <span id="streams-testing-topologytestdriver"></span><h2><a class="toc-backref" href="#testing-topologytestdriver">Test Driver for Streams Applications</a><a class="headerlink" href="#testing-topologytestdriver" title="Permalink to this headline"></a></h2>
 
         <p>
         The test-utils package provides a <code>TopologyTestDriver</code> that can be used pipe data through a <code>Topology</code> that is either assembled manually

--- a/docs/streams/developer-guide/testing.html
+++ b/docs/streams/developer-guide/testing.html
@@ -45,13 +45,16 @@
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;
     </pre>
-    <p>
-    The test-utils package provides a <code>TopologyTestDriver</code> that can be used pipe data through a <code>Topology</code> that is either assembled manually
-    using Processor API or via the DSL using <code>StreamsBuilder</code>.
-    The test driver simulates the library runtime that continuously fetches records from input topics and processes them by traversing the topology.
-    You can use the test driver to verify that your specified processor topology computes the correct result with the manually piped in data records.
-    The test driver captures the results records and allows to query its embedded state stores.
-    <pre>
+    <div class="section" id="testing-topologytestdriver">
+        <span id="streams-testing-topologytestdriver"></span><h2><a class="toc-backref" href="#id1">TopologyTestDriver</a><a class="headerlink" href="#testing-topologytestdriver" title="Permalink to this headline"></a></h2>
+
+        <p>
+        The test-utils package provides a <code>TopologyTestDriver</code> that can be used pipe data through a <code>Topology</code> that is either assembled manually
+        using Processor API or via the DSL using <code>StreamsBuilder</code>.
+        The test driver simulates the library runtime that continuously fetches records from input topics and processes them by traversing the topology.
+        You can use the test driver to verify that your specified processor topology computes the correct result with the manually piped in data records.
+        The test driver captures the results records and allows to query its embedded state stores.
+        <pre>
 // Processor API
 Topology topology = new Topology();
 topology.addSource("sourceProcessor", "input-topic");
@@ -68,62 +71,62 @@ Properties config = new Properties();
 config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
 config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
 TopologyTestDriver testDriver = new TopologyTestDriver(topology, config);
-    </pre>
-    <p>
-    The test driver accepts <code>ConsumerRecord</code>s with key and value type <code>byte[]</code>.
-    Because <code>byte[]</code> types can be problematic, you can use the <code>ConsumerRecordFactory</code> to generate those records
-    by providing regular Java types for key and values and the corresponding serializers.
-    </p>
-    <pre>
+        </pre>
+        <p>
+        The test driver accepts <code>ConsumerRecord</code>s with key and value type <code>byte[]</code>.
+        Because <code>byte[]</code> types can be problematic, you can use the <code>ConsumerRecordFactory</code> to generate those records
+        by providing regular Java types for key and values and the corresponding serializers.
+        </p>
+        <pre>
 ConsumerRecordFactory&lt;String, Integer&gt; factory = new ConsumerRecordFactory&lt;&gt;("input-topic", new StringSerializer(), new IntegerSerializer());
 testDriver.pipe(factory.create("key", 42L));
-    </pre>
-    <p>
-    To verify the output, the test driver produces <code>ProducerRecord</code>s with key and value type <code>byte[]</code>.
-    For result verification, you can specify corresponding deserializers when reading the output record from the driver.
-    <pre>
+        </pre>
+        <p>
+        To verify the output, the test driver produces <code>ProducerRecord</code>s with key and value type <code>byte[]</code>.
+        For result verification, you can specify corresponding deserializers when reading the output record from the driver.
+        <pre>
 ProducerRecord&lt;String, Integer&gt; outputRecord = testDriver.readOutput("output-topic", new StringDeserializer(), new LongDeserializer());
-    </pre>
-    <p>
-    For result verification, you can use <code>OutputVerifier</code>.
-    It offers helper methods to compare only certain parts of the result record:
-    for example, you might only care about the key and value, but not the timestamp of the result record.
-    </p>
-    <pre>
+        </pre>
+        <p>
+        For result verification, you can use <code>OutputVerifier</code>.
+        It offers helper methods to compare only certain parts of the result record:
+        for example, you might only care about the key and value, but not the timestamp of the result record.
+        </p>
+        <pre>
 OutputVerifier.compareKeyValue(outputRecord, "key", 42L); // throws AssertionError if key or value does not match
-    </pre>
-    <p>
-    <code>TopologyTestDriver</code> supports punctuations, too.
-    Event-time punctuations are triggered automatically based on the processed records' timestamps.
-    Wall-clock-time punctuations can also be triggered by advancing the test driver's wall-clock-time (the driver mocks wall-clock-time internally to give users control over it).
-    </p>
-    <pre>
+        </pre>
+        <p>
+        <code>TopologyTestDriver</code> supports punctuations, too.
+        Event-time punctuations are triggered automatically based on the processed records' timestamps.
+        Wall-clock-time punctuations can also be triggered by advancing the test driver's wall-clock-time (the driver mocks wall-clock-time internally to give users control over it).
+        </p>
+        <pre>
 testDriver.advanceWallClockTime(20L);
-    </pre>
-    </div>
-    <p>
-    Additionally, you can access state stores via the test driver before or after a test.
-    Accessing stores before a test is useful to pre-populate a store with some initial values.
-    After data was processed, expected updates to the store can be verified.
-    </p>
-    <pre>
+        </pre>
+        </div>
+        <p>
+        Additionally, you can access state stores via the test driver before or after a test.
+        Accessing stores before a test is useful to pre-populate a store with some initial values.
+        After data was processed, expected updates to the store can be verified.
+        </p>
+        <pre>
 KeyValueStore store = testDriver.getKeyValueStore("store-name");
-    </pre>
-    <p>
-    Note, that you should always close the test driver at the end to make sure all resources are release properly.
-    </p>
-    <pre>
+        </pre>
+        <p>
+        Note, that you should always close the test driver at the end to make sure all resources are release properly.
+        </p>
+        <pre>
 testDriver.close();
-    </pre>
+        </pre>
 
-    <h2>Example</h2>
-    <p>
-    The following example demonstrates how to use the test driver and helper classes.
-    The example creates a topology that computes the maximum value per key using a key-value-store.
-    While processing, no output is generated, but only the store is updated.
-    Output is only sent downstream based on event-time and wall-clock punctuations.
-    </p>
-    <pre>
+        <h3>Example</h3>
+        <p>
+        The following example demonstrates how to use the test driver and helper classes.
+        The example creates a topology that computes the maximum value per key using a key-value-store.
+        While processing, no output is generated, but only the store is updated.
+        Output is only sent downstream based on event-time and wall-clock punctuations.
+        </p>
+        <pre>
 private TopologyTestDriver testDriver;
 private KeyValueStore&lt;String, Long&gt; store;
 
@@ -266,12 +269,13 @@ public class CustomMaxAggregator implements Processor&lt;String, Long&gt; {
     @Override
     public void close() {}
 }
-    </pre>
-  <div class="pagination">
-  <div class="pagination">
-    <a href="/{{version}}/documentation/streams/developer-guide/datatypes" class="pagination__btn pagination__btn__prev">Previous</a>
-    <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries" class="pagination__btn pagination__btn__next">Next</a>
-  </div>
+        </pre>
+    </div>
+    <div class="pagination">
+    <div class="pagination">
+        <a href="/{{version}}/documentation/streams/developer-guide/datatypes" class="pagination__btn pagination__btn__prev">Previous</a>
+        <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries" class="pagination__btn pagination__btn__next">Next</a>
+    </div>
 </script>
 
 <!--#include virtual="../../../includes/_header.htm" -->

--- a/docs/streams/developer-guide/testing.html
+++ b/docs/streams/developer-guide/testing.html
@@ -18,26 +18,40 @@
 <script><!--#include virtual="../../js/templateData.js" --></script>
 
 <script id="content-template" type="text/x-handlebars-template">
-  <!-- h1>Developer Guide for Kafka Streams</h1 -->
-  <div class="sub-nav-sticky">
-    <div class="sticky-top">
-      <!-- div style="height:35px">
-        <a href="/{{version}}/documentation/streams/">Introduction</a>
-        <a class="active-menu-item" href="/{{version}}/documentation/streams/developer-guide">Developer Guide</a>
-        <a href="/{{version}}/documentation/streams/core-concepts">Concepts</a>
-        <a href="/{{version}}/documentation/streams/quickstart">Run Demo App</a>
-        <a href="/{{version}}/documentation/streams/tutorial">Tutorial: Write App</a>
-      </div -->
+    <!-- h1>Developer Guide for Kafka Streams</h1 -->
+    <div class="sub-nav-sticky">
+        <div class="sticky-top">
+            <!-- div style="height:35px">
+              <a href="/{{version}}/documentation/streams/">Introduction</a>
+              <a class="active-menu-item" href="/{{version}}/documentation/streams/developer-guide">Developer Guide</a>
+              <a href="/{{version}}/documentation/streams/core-concepts">Concepts</a>
+              <a href="/{{version}}/documentation/streams/quickstart">Run Demo App</a>
+              <a href="/{{version}}/documentation/streams/tutorial">Tutorial: Write App</a>
+            </div -->
+        </div>
     </div>
-  </div>
 
-  <div class="section" id="testing">
-    <span id="streams-developer-guide-testing"></span><h1>Testing a Streams Application<a class="headerlink" href="#testing" title="Permalink to this headline"></a></h1>
-    <p>
-      To test a Kafka Streams application, Kafka provides a test-utils artifact that can be added as regular dependency to your test code base.
-      Example <code>pom.xml</code> snippet when using Maven:
-    </p>
-    <pre>
+    <div class="section" id="testing">
+        <span id="streams-developer-guide-testing"></span>
+        <h1>Testing Kafka Streams<a class="headerlink" href="#testing" title="Permalink to this headline"></a></h1>
+        <div class="contents local topic" id="table-of-contents">
+            <p class="topic-title first"><b>Table of Contents</b></p>
+            <ul class="simple">
+                <li><a class="reference internal" href="#test-utils-artifact">Importing the test utilities</a></li>
+                <li><a class="reference internal" href="#testing-topologytestdriver">Testing Streams applications</a>
+                </li>
+                <li><a class="reference internal" href="#unit-testing-processors">Unit testing Processors</a>
+                </li>
+            </ul>
+        </div>
+        <div class="section" id="test-utils-artifact">
+            <h2><a class="toc-backref" href="#test-utils-artifact" title="Permalink to this headline">Importing the test
+                utilities</a></h2>
+            <p>
+                To test a Kafka Streams application, Kafka provides a test-utils artifact that can be added as regular
+                dependency to your test code base. Example <code>pom.xml</code> snippet when using Maven:
+            </p>
+            <pre>
 &lt;dependency&gt;
     &lt;groupId&gt;org.apache.kafka&lt;/groupId&gt;
     &lt;artifactId&gt;kafka-streams-test-utils&lt;/artifactId&gt;
@@ -45,16 +59,21 @@
     &lt;scope&gt;test&lt;/scope&gt;
 &lt;/dependency&gt;
     </pre>
-   <div class="section" id="testing-topologytestdriver">
-        <span id="streams-testing-topologytestdriver"></span><h2><a class="toc-backref" href="#testing-topologytestdriver">Test Driver for Streams Applications</a><a class="headerlink" href="#testing-topologytestdriver" title="Permalink to this headline"></a></h2>
+        </div>
+        <div class="section" id="testing-topologytestdriver">
+            <h2><a class="toc-backref" href="#testing-topologytestdriver" title="Permalink to this headline">Testing a
+                Streams application</a></h2>
 
-        <p>
-        The test-utils package provides a <code>TopologyTestDriver</code> that can be used pipe data through a <code>Topology</code> that is either assembled manually
-        using Processor API or via the DSL using <code>StreamsBuilder</code>.
-        The test driver simulates the library runtime that continuously fetches records from input topics and processes them by traversing the topology.
-        You can use the test driver to verify that your specified processor topology computes the correct result with the manually piped in data records.
-        The test driver captures the results records and allows to query its embedded state stores.
-        <pre>
+            <p>
+                The test-utils package provides a <code>TopologyTestDriver</code> that can be used pipe data through a
+                <code>Topology</code> that is either assembled manually
+                using Processor API or via the DSL using <code>StreamsBuilder</code>.
+                The test driver simulates the library runtime that continuously fetches records from input topics and
+                processes them by traversing the topology.
+                You can use the test driver to verify that your specified processor topology computes the correct result
+                with the manually piped in data records.
+                The test driver captures the results records and allows to query its embedded state stores.
+            <pre>
 // Processor API
 Topology topology = new Topology();
 topology.addSource("sourceProcessor", "input-topic");
@@ -72,61 +91,65 @@ config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
 config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
 TopologyTestDriver testDriver = new TopologyTestDriver(topology, config);
         </pre>
-        <p>
-        The test driver accepts <code>ConsumerRecord</code>s with key and value type <code>byte[]</code>.
-        Because <code>byte[]</code> types can be problematic, you can use the <code>ConsumerRecordFactory</code> to generate those records
-        by providing regular Java types for key and values and the corresponding serializers.
-        </p>
-        <pre>
+            <p>
+                The test driver accepts <code>ConsumerRecord</code>s with key and value type <code>byte[]</code>.
+                Because <code>byte[]</code> types can be problematic, you can use the <code>ConsumerRecordFactory</code>
+                to generate those records
+                by providing regular Java types for key and values and the corresponding serializers.
+            </p>
+            <pre>
 ConsumerRecordFactory&lt;String, Integer&gt; factory = new ConsumerRecordFactory&lt;&gt;("input-topic", new StringSerializer(), new IntegerSerializer());
 testDriver.pipe(factory.create("key", 42L));
         </pre>
-        <p>
-        To verify the output, the test driver produces <code>ProducerRecord</code>s with key and value type <code>byte[]</code>.
-        For result verification, you can specify corresponding deserializers when reading the output record from the driver.
-        <pre>
+            <p>
+                To verify the output, the test driver produces <code>ProducerRecord</code>s with key and value type
+                <code>byte[]</code>.
+                For result verification, you can specify corresponding deserializers when reading the output record from
+                the driver.
+            <pre>
 ProducerRecord&lt;String, Integer&gt; outputRecord = testDriver.readOutput("output-topic", new StringDeserializer(), new LongDeserializer());
         </pre>
-        <p>
-        For result verification, you can use <code>OutputVerifier</code>.
-        It offers helper methods to compare only certain parts of the result record:
-        for example, you might only care about the key and value, but not the timestamp of the result record.
-        </p>
-        <pre>
+            <p>
+                For result verification, you can use <code>OutputVerifier</code>.
+                It offers helper methods to compare only certain parts of the result record:
+                for example, you might only care about the key and value, but not the timestamp of the result record.
+            </p>
+            <pre>
 OutputVerifier.compareKeyValue(outputRecord, "key", 42L); // throws AssertionError if key or value does not match
         </pre>
-        <p>
-        <code>TopologyTestDriver</code> supports punctuations, too.
-        Event-time punctuations are triggered automatically based on the processed records' timestamps.
-        Wall-clock-time punctuations can also be triggered by advancing the test driver's wall-clock-time (the driver mocks wall-clock-time internally to give users control over it).
-        </p>
-        <pre>
+            <p>
+                <code>TopologyTestDriver</code> supports punctuations, too.
+                Event-time punctuations are triggered automatically based on the processed records' timestamps.
+                Wall-clock-time punctuations can also be triggered by advancing the test driver's wall-clock-time (the
+                driver mocks wall-clock-time internally to give users control over it).
+            </p>
+            <pre>
 testDriver.advanceWallClockTime(20L);
         </pre>
-        </div>
-        <p>
-        Additionally, you can access state stores via the test driver before or after a test.
-        Accessing stores before a test is useful to pre-populate a store with some initial values.
-        After data was processed, expected updates to the store can be verified.
-        </p>
-        <pre>
+            <p>
+                Additionally, you can access state stores via the test driver before or after a test.
+                Accessing stores before a test is useful to pre-populate a store with some initial values.
+                After data was processed, expected updates to the store can be verified.
+            </p>
+            <pre>
 KeyValueStore store = testDriver.getKeyValueStore("store-name");
         </pre>
-        <p>
-        Note, that you should always close the test driver at the end to make sure all resources are release properly.
-        </p>
-        <pre>
+            <p>
+                Note, that you should always close the test driver at the end to make sure all resources are release
+                properly.
+            </p>
+            <pre>
 testDriver.close();
         </pre>
 
-        <h3>Example</h3>
-        <p>
-        The following example demonstrates how to use the test driver and helper classes.
-        The example creates a topology that computes the maximum value per key using a key-value-store.
-        While processing, no output is generated, but only the store is updated.
-        Output is only sent downstream based on event-time and wall-clock punctuations.
-        </p>
-        <pre>
+            <h3>Example</h3>
+            <p>
+                The following example demonstrates how to use the test driver and helper classes.
+                The example creates a topology that computes the maximum value per key using a key-value-store.
+                While processing, no output is generated, but only the store is updated.
+                Output is only sent downstream based on event-time and wall-clock punctuations.
+            </p>
+            <pre>
 private TopologyTestDriver testDriver;
 private KeyValueStore&lt;String, Long&gt; store;
 
@@ -270,31 +293,146 @@ public class CustomMaxAggregator implements Processor&lt;String, Long&gt; {
     public void close() {}
 }
         </pre>
+        </div>
+        <div class="section" id="unit-testing-processors">
+            <h2>
+                <a class="headerlink" href="#unit-testing-processors"
+                   title="Permalink to this headline">Unit Testing Processors</a>
+            </h2>
+            <p>
+                If you <a href="processor-api.html">write a Processor</a>, you will want to test it.
+            </p>
+            <p>
+                Because the <code>Processor</code> forwards its results to the context rather than returning them,
+                Unit testing requires a mocked context capable of capturing forwarded data for inspection.
+                For this reason, we provide a <code>MockProcessorContext</code> in <a href="#test-utils-artifact"><code>test-utils</code></a>.
+            </p>
+            <b>Construction</b>
+            <p>
+                To begin with, instantiate your processor and initialize it with the mock context:
+            <pre>
+final Processor processorUnderTest = ...;
+final MockProcessorContext context = new MockProcessorContext();
+processorUnderTest.init(context);
+                </pre>
+            If you need to pass configuration to your processor or set the default serdes, you can create the mock with
+            config:
+            <pre>
+final Properties config = new Properties();
+config.put(StreamsConfig.APPLICATION_ID_CONFIG, "unit-test");
+config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
+config.put("some.other.config", "some config value");
+final MockProcessorContext context = new MockProcessorContext(config);
+                </pre>
+            </p>
+            <b>Captured data</b>
+            <p>
+                The mock will capture any values that your processor forwards. You can make assertions on them:
+            <pre>
+processorUnderTest.process("key", "value");
+
+final Iterator&lt;CapturedForward&gt; forwarded = context.forwarded().iterator();
+assertEquals(forwarded.next().keyValue(), new KeyValue&lt;&gt;(..., ...));
+assertFalse(forwarded.hasNext());
+
+// you can reset forwards to clear the captured data. This may be helpful in constructing longer scenarios.
+context.resetForwards();
+
+assertEquals(context.forwarded().size(), 0);
+            </pre>
+            If your processor forwards to specific child processors, you can query the context for captured data by
+            child name:
+            <pre>
+final List&lt;CapturedForward&gt; captures = context.forwarded("childProcessorName");
+            </pre>
+            The mock also captures whether your processor has called <code>commit()</code> on the context:
+            <pre>
+assertTrue(context.committed());
+
+// commit captures can also be reset.
+context.resetCommit();
+
+assertFalse(context.committed());
+            </pre>
+            </p>
+            <b>Setting record metadata</b>
+            <p>
+                In case your processor logic depends on the record metadata (topic, partition, offset, or timestamp),
+                you can set them on the context, either all together or individually:
+            <pre>
+context.setRecordMetadata("topicName", /*partition*/ 0, /*offset*/ 0L, /*timestamp*/ 0L);
+context.setTopic("topicName");
+context.setPartition(0);
+context.setOffset(0L);
+context.setTimestamp(0L);
+                </pre>
+            Once these are set, the context will continue returning the same values, until you set new ones.
+            </p>
+            <b>State stores</b>
+            <p>
+                In case your punctuator is stateful, the mock context allows you to register state stores.
+                You're encouraged to use a simple in-memory store of the appropriate type (KeyValue, Windowed, or
+                Session), since the mock context does <i>not</i> manage changelogs, state directories, etc.
+            </p>
+            <pre>
+final KeyValueStore&lt;String, Integer&gt; store =
+    Stores.keyValueStoreBuilder(
+            Stores.inMemoryKeyValueStore("myStore"),
+            Serdes.String(),
+            Serdes.Integer()
+        )
+        .withLoggingDisabled() // Changelog is not supported by MockProcessorContext.
+        .build();
+store.init(context, store);
+context.register(store, /*deprecated parameter*/ false, /*parameter unused in mock*/ null);
+            </pre>
+            <b>Verifying punctuators</b>
+            <p>
+                Processors can schedule punctuators to handle periodic tasks.
+                The mock context does <i>not</i> automatically execute punctuators, but it does capture them to
+                allow you to unit test them as well:
+            <pre>
+final MockProcessorContext.CapturedPunctuator capturedPunctuator = context.scheduledPunctuators().get(0);
+final long interval = capturedPunctuator.getIntervalMs();
+final PunctuationType type = capturedPunctuator.getType();
+final boolean cancelled = capturedPunctuator.cancelled();
+final Punctuator punctuator = capturedPunctuator.getPunctuator();
+punctuator.punctuate(/*timestamp*/ 0L);
+                </pre>
+            If you need to write tests involving automatic firing of scheduled punctuators, we recommend creating a
+            simple topology with your processor and using the <a href="testing.html#testing-topologytestdriver"><code>TopologyTestDriver</code></a>.
+            </p>
+        </div>
     </div>
     <div class="pagination">
-    <div class="pagination">
-        <a href="/{{version}}/documentation/streams/developer-guide/datatypes" class="pagination__btn pagination__btn__prev">Previous</a>
-        <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries" class="pagination__btn pagination__btn__next">Next</a>
+        <div class="pagination">
+            <a href="/{{version}}/documentation/streams/developer-guide/datatypes"
+               class="pagination__btn pagination__btn__prev">Previous</a>
+            <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries"
+               class="pagination__btn pagination__btn__next">Next</a>
+        </div>
     </div>
 </script>
 
 <!--#include virtual="../../../includes/_header.htm" -->
 <!--#include virtual="../../../includes/_top.htm" -->
 <div class="content documentation documentation--current">
-  <!--#include virtual="../../../includes/_nav.htm" -->
-  <div class="right">
-    <!--#include virtual="../../../includes/_docs_banner.htm" -->
-    <ul class="breadcrumbs">
-      <li><a href="/documentation">Documentation</a></li>
-      <li><a href="/documentation/streams">Kafka Streams</a></li>
-      <li><a href="/documentation/streams/developer-guide/">Developer Guide</a></li>
-    </ul>
-    <div class="p-content"></div>
-  </div>
+    <!--#include virtual="../../../includes/_nav.htm" -->
+    <div class="right">
+        <!--#include virtual="../../../includes/_docs_banner.htm" -->
+        <ul class="breadcrumbs">
+            <li><a href="/documentation">Documentation</a></li>
+            <li><a href="/documentation/streams">Kafka Streams</a></li>
+            <li><a href="/documentation/streams/developer-guide/">Developer Guide</a></li>
+        </ul>
+        <div class="p-content"></div>
+    </div>
 </div>
 <!--#include virtual="../../../includes/_footer.htm" -->
 <script>
-    $(function() {
+    $(function () {
         // Show selected style on nav item
         $('.b-nav__streams').addClass('selected');
 
@@ -303,7 +441,7 @@ public class CustomMaxAggregator implements Processor&lt;String, Long&gt; {
             y_pos = $navbar.offset().top,
             height = $navbar.height();
 
-        $(window).scroll(function() {
+        $(window).scroll(function () {
             var scrollTop = $(window).scrollTop();
 
             if (scrollTop > y_pos - height) {

--- a/docs/streams/developer-guide/write-streams.html
+++ b/docs/streams/developer-guide/write-streams.html
@@ -37,6 +37,7 @@
       <ul class="simple">
           <li><a class="reference internal" href="#libraries-and-maven-artifacts" id="id1">Libraries and Maven artifacts</a></li>
           <li><a class="reference internal" href="#using-kafka-streams-within-your-application-code" id="id2">Using Kafka Streams within your application code</a></li>
+          <li><a class="reference internal" href="#testing-a-streams-app" id="id3">Testing a Streams application</a></li>
       </ul>
     <p>Any Java application that makes use of the Kafka Streams library is considered a Kafka Streams application.
       The computational logic of a Kafka Streams application is defined as a <a class="reference internal" href="../concepts.html#streams-concepts"><span class="std std-ref">processor topology</span></a>,
@@ -196,6 +197,11 @@
       <p>After an application is stopped, Kafka Streams will migrate any tasks that had been running in this instance to available remaining
         instances.</p>
 </div>
+
+      <div class="section" id="testing-a-streams-app">
+          <a class="headerlink" href="#testing-a-streams-app" title="Permalink to this headline"><h2>Testing a Streams application</a></h2>
+          Kafka Streams comes with a <code>test-utils</code> module to help you test your application <a href="testing.html">here</a>.
+      </div>
 </div>
 
 

--- a/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorDemo.java
+++ b/streams/examples/src/main/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorDemo.java
@@ -49,7 +49,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public class WordCountProcessorDemo {
 
-    private static class MyProcessorSupplier implements ProcessorSupplier<String, String> {
+    static class MyProcessorSupplier implements ProcessorSupplier<String, String> {
 
         @Override
         public Processor<String, String> get() {

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorTest.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.examples.wordcount;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.MockProcessorContext;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Demonstrates the use of {@link MockProcessorContext} for testing the {@link Processor} in the {@link WordCountProcessorDemo}.
+ * <p>
+ * In this example, the input stream reads from a topic named "streams-plaintext-input", where the values of messages
+ * represent lines of text; and the histogram output is written to topic "streams-wordcount-processor-output" where each record
+ * is an updated count of a single word.
+ */
+public class WordCountProcessorTest {
+    @Test
+    public void test() {
+        final MockProcessorContext context = new MockProcessorContext();
+
+        // Create, initialize, and register the state store.
+        final KeyValueStore<String, Integer> store = Stores.keyValueStoreBuilder(
+            Stores.inMemoryKeyValueStore("Counts"),
+            Serdes.String(),
+            Serdes.Integer()
+        ).build();
+        store.init(context, store);
+        context.register(store, false, null);
+
+        // Create and initialize the processor under test
+        final Processor<String, String> processor = new WordCountProcessorDemo.MyProcessorSupplier().get();
+        processor.init(context);
+
+        // In this example, we have to set the record metadata, since the state store change-logger makes use of it.
+        // Alternatively, we could construct the state store '.withLoggingDisabled()'.
+        context.setRecordMetadata("input", 0, 0L, 0L);
+        // send a record to the processor
+        processor.process("key", "alpha beta gamma alpha");
+
+        // note that the processor commits, but does not forward, during process()
+        assertTrue(context.committed());
+        assertTrue(context.forwarded().isEmpty());
+
+        // now, we trigger the punctuator, which iterates over the state store and forwards the contents.
+        context.scheduledPunctuators().get(0).getPunctuator().punctuate(0L);
+
+        // finally, we can verify the output.
+        final Iterator<MockProcessorContext.CapturedForward> capturedForwards = context.forwarded().iterator();
+        assertEquals(new KeyValue<>("alpha", "2"), capturedForwards.next().keyValue());
+        assertEquals(new KeyValue<>("beta", "1"), capturedForwards.next().keyValue());
+        assertEquals(new KeyValue<>("gamma", "1"), capturedForwards.next().keyValue());
+        assertFalse(capturedForwards.hasNext());
+    }
+}

--- a/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorTest.java
+++ b/streams/examples/src/test/java/org/apache/kafka/streams/examples/wordcount/WordCountProcessorTest.java
@@ -31,11 +31,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Demonstrates the use of {@link MockProcessorContext} for testing the {@link Processor} in the {@link WordCountProcessorDemo}.
- * <p>
- * In this example, the input stream reads from a topic named "streams-plaintext-input", where the values of messages
- * represent lines of text; and the histogram output is written to topic "streams-wordcount-processor-output" where each record
- * is an updated count of a single word.
+ * Demonstrate the use of {@link MockProcessorContext} for testing the {@link Processor} in the {@link WordCountProcessorDemo}.
  */
 public class WordCountProcessorTest {
     @Test
@@ -43,11 +39,10 @@ public class WordCountProcessorTest {
         final MockProcessorContext context = new MockProcessorContext();
 
         // Create, initialize, and register the state store.
-        final KeyValueStore<String, Integer> store = Stores.keyValueStoreBuilder(
-            Stores.inMemoryKeyValueStore("Counts"),
-            Serdes.String(),
-            Serdes.Integer()
-        ).build();
+        final KeyValueStore<String, Integer> store =
+            Stores.keyValueStoreBuilder(Stores.inMemoryKeyValueStore("Counts"), Serdes.String(), Serdes.Integer())
+                .withLoggingDisabled() // Changelog is not supported by MockProcessorContext.
+                .build();
         store.init(context, store);
         context.register(store, false, null);
 
@@ -55,9 +50,6 @@ public class WordCountProcessorTest {
         final Processor<String, String> processor = new WordCountProcessorDemo.MyProcessorSupplier().get();
         processor.init(context);
 
-        // In this example, we have to set the record metadata, since the state store change-logger makes use of it.
-        // Alternatively, we could construct the state store '.withLoggingDisabled()'.
-        context.setRecordMetadata("input", 0, 0L, 0L);
         // send a record to the processor
         processor.process("key", "alpha beta gamma alpha");
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamJoinTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.test.KStreamTestDriver;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.TestUtils;
@@ -719,6 +719,6 @@ public class KStreamKStreamJoinTest {
     }
 
     private void setRecordContext(final long time, final String topic) {
-        ((MockProcessorContext) driver.context()).setRecordContext(new ProcessorRecordContext(time, 0, 0, topic));
+        ((InternalMockProcessorContext) driver.context()).setRecordContext(new ProcessorRecordContext(time, 0, 0, topic));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamKStreamLeftJoinTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.test.KStreamTestDriver;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockValueJoiner;
 import org.apache.kafka.test.TestUtils;
@@ -304,6 +304,6 @@ public class KStreamKStreamLeftJoinTest {
     }
 
     private void setRecordContext(final long time, final String topic) {
-        ((MockProcessorContext) driver.context()).setRecordContext(new ProcessorRecordContext(time, 0, 0, topic));
+        ((InternalMockProcessorContext) driver.context()).setRecordContext(new ProcessorRecordContext(time, 0, 0, topic));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamSessionWindowAggregateProcessorTest.java
@@ -31,7 +31,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.internals.RocksDBSessionStoreSupplier;
 import org.apache.kafka.streams.state.SessionStore;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -81,13 +81,13 @@ public class KStreamSessionWindowAggregateProcessorTest {
     private final List<KeyValue> results = new ArrayList<>();
     private Processor<String, String> processor = sessionAggregator.get();
     private SessionStore<String, Long> sessionStore;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
 
 
     @Before
     public void initializeStore() {
         final File stateDir = TestUtils.tempDirectory();
-        context = new MockProcessorContext(stateDir,
+        context = new InternalMockProcessorContext(stateDir,
             Serdes.String(), Serdes.String(), new NoOpRecordCollector(), new ThreadCache(new LogContext("testCache "), 100000, new MockStreamsMetrics(new Metrics()))) {
             @Override
             public <K, V> void forward(final K key, final V value) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -31,7 +31,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.test.KStreamTestDriver;
 import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
@@ -143,7 +143,7 @@ public class KStreamWindowAggregateTest {
     }
 
     private void setRecordContext(final long time, final String topic) {
-        ((MockProcessorContext) driver.context()).setRecordContext(new ProcessorRecordContext(time, 0, 0, topic));
+        ((InternalMockProcessorContext) driver.context()).setRecordContext(new ProcessorRecordContext(time, 0, 0, topic));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractTaskTest.java
@@ -32,7 +32,7 @@ import org.apache.kafka.streams.errors.LockException;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockRestoreCallback;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.TestUtils;
@@ -194,7 +194,7 @@ public class AbstractTaskTest {
         testFile4.createNewFile();
         assertTrue(testFile4.exists());
 
-        task.processorContext = new MockProcessorContext(stateDirectory.directoryForTask(task.id), streamsConfig);
+        task.processorContext = new InternalMockProcessorContext(stateDirectory.directoryForTask(task.id), streamsConfig);
 
         task.stateMgr.register(store1, new MockRestoreCallback());
         task.stateMgr.register(store2, new MockRestoreCallback());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -34,7 +34,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.StateRestoreCallback;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.internals.OffsetCheckpoint;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockStateRestoreListener;
 import org.apache.kafka.test.NoOpReadOnlyStore;
 import org.apache.kafka.test.TestUtils;
@@ -86,7 +86,7 @@ public class GlobalStateManagerImplTest {
     private MockConsumer<byte[], byte[]> consumer;
     private File checkpointFile;
     private ProcessorTopology topology;
-    private MockProcessorContext mockProcessorContext;
+    private InternalMockProcessorContext processorContext;
 
     @Before
     public void before() throws IOException {
@@ -120,8 +120,8 @@ public class GlobalStateManagerImplTest {
             stateDirectory,
             stateRestoreListener,
             streamsConfig);
-        mockProcessorContext = new MockProcessorContext(stateDirectory.globalStateDir(), streamsConfig);
-        stateManager.setGlobalProcessorContext(mockProcessorContext);
+        processorContext = new InternalMockProcessorContext(stateDirectory.globalStateDir(), streamsConfig);
+        stateManager.setGlobalProcessorContext(processorContext);
         checkpointFile = new File(stateManager.baseDir(), ProcessorStateManager.CHECKPOINT_FILE_NAME);
     }
 
@@ -631,7 +631,7 @@ public class GlobalStateManagerImplTest {
         assertTrue(testFile4.exists());
 
         // only delete and recreate store 1 and 3 -- 2 and 4 must be untouched
-        stateManager.reinitializeStateStoresForPartitions(Utils.mkList(t1, t3), mockProcessorContext);
+        stateManager.reinitializeStateStoresForPartitions(Utils.mkList(t1, t3), processorContext);
 
         assertFalse(testFile1.exists());
         assertTrue(testFile2.exists());

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ProcessorNodeTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -110,7 +110,7 @@ public class ProcessorNodeTest {
         final StateSerdes anyStateSerde = StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class);
 
         final Metrics metrics = new Metrics();
-        final MockProcessorContext context = new MockProcessorContext(anyStateSerde,  new RecordCollectorImpl(null, null, new LogContext("processnode-test "), new DefaultProductionExceptionHandler()), metrics);
+        final InternalMockProcessorContext context = new InternalMockProcessorContext(anyStateSerde,  new RecordCollectorImpl(null, null, new LogContext("processnode-test "), new DefaultProductionExceptionHandler()), metrics);
         final ProcessorNode node = new ProcessorNode("name", new NoOpProcessor(), Collections.emptySet());
         node.init(context);
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/RecordQueueTest.java
@@ -34,7 +34,7 @@ import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockSourceNode;
 import org.apache.kafka.test.MockTimestampExtractor;
 import org.junit.After;
@@ -54,7 +54,7 @@ public class RecordQueueTest {
     private final TimestampExtractor timestampExtractor = new MockTimestampExtractor();
     private final String[] topics = {"topic"};
 
-    final MockProcessorContext context = new MockProcessorContext(StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class),
+    final InternalMockProcessorContext context = new InternalMockProcessorContext(StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class),
             new RecordCollectorImpl(null, null,  new LogContext("record-queue-test "), new DefaultProductionExceptionHandler()));
     private final MockSourceNode mockSourceNodeWithMetrics = new MockSourceNode<>(topics, intDeserializer, intDeserializer);
     private final RecordQueue queue = new RecordQueue(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/SinkNodeTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +37,7 @@ import static org.junit.Assert.fail;
 public class SinkNodeTest {
     private final Serializer anySerializer = Serdes.Bytes().serializer();
     private final StateSerdes anyStateSerde = StateSerdes.withBuiltinTypes("anyName", Bytes.class, Bytes.class);
-    private final MockProcessorContext context = new MockProcessorContext(anyStateSerde,
+    private final InternalMockProcessorContext context = new InternalMockProcessorContext(anyStateSerde,
         new RecordCollectorImpl(new MockProducer<byte[], byte[]>(true, anySerializer, anySerializer), null, new LogContext("sinknode-test "), new DefaultProductionExceptionHandler()));
     private final SinkNode sink = new SinkNode<>("anyNodeName", "any-output-topic", anySerializer, anySerializer, null);
 

--- a/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/KeyValueStoreTestDriver.java
@@ -34,7 +34,7 @@ import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
 import org.apache.kafka.streams.state.internals.RocksDBKeyValueStoreTest;
 import org.apache.kafka.streams.state.internals.ThreadCache;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.MockTimestampExtractor;
 import org.apache.kafka.test.TestUtils;
 
@@ -179,7 +179,7 @@ public class KeyValueStoreTestDriver<K, V> {
     private final Set<K> flushedRemovals = new HashSet<>();
     private final List<KeyValue<byte[], byte[]>> restorableEntries = new LinkedList<>();
 
-    private final MockProcessorContext context;
+    private final InternalMockProcessorContext context;
     private final StateSerdes<K, V> stateSerdes;
 
     private KeyValueStoreTestDriver(final StateSerdes<K, V> serdes) {
@@ -227,7 +227,7 @@ public class KeyValueStoreTestDriver<K, V> {
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, serdes.valueSerde().getClass());
         props.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, RocksDBKeyValueStoreTest.TheRocksDbConfigSetter.class);
 
-        context = new MockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, null) {
+        context = new InternalMockProcessorContext(stateDir, serdes.keySerde(), serdes.valueSerde(), recordCollector, null) {
             ThreadCache cache = new ThreadCache(new LogContext("testCache "), 1024 * 1024L, metrics());
 
             @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/AbstractKeyValueStoreTest.java
@@ -25,7 +25,7 @@ import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.KeyValueStoreTestDriver;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,14 +48,14 @@ public abstract class AbstractKeyValueStoreTest {
 
     protected abstract <K, V> KeyValueStore<K, V> createKeyValueStore(final ProcessorContext context);
 
-    protected MockProcessorContext context;
+    protected InternalMockProcessorContext context;
     protected KeyValueStore<Integer, String> store;
     protected KeyValueStoreTestDriver<Integer, String> driver;
 
     @Before
     public void before() {
         driver = KeyValueStoreTestDriver.create(Integer.class, String.class);
-        context = (MockProcessorContext) driver.context();
+        context = (InternalMockProcessorContext) driver.context();
         context.setTime(10);
         store = createKeyValueStore(context);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingKeyValueStoreTest.java
@@ -33,7 +33,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +58,7 @@ import static org.junit.Assert.fail;
 public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
 
     private final int maxCacheSizeBytes = 150;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private CachingKeyValueStore<String, String> store;
     private InMemoryKeyValueStore<Bytes, byte[]> underlyingStore;
     private ThreadCache cache;
@@ -73,7 +73,7 @@ public class CachingKeyValueStoreTest extends AbstractKeyValueStoreTest {
         store = new CachingKeyValueStore<>(underlyingStore, Serdes.String(), Serdes.String());
         store.setFlushListener(cacheFlushListener, false);
         cache = new ThreadCache(new LogContext("testCache "), maxCacheSizeBytes, new MockStreamsMetrics(new Metrics()));
-        context = new MockProcessorContext(null, null, null, (RecordCollector) null, cache);
+        context = new InternalMockProcessorContext(null, null, null, (RecordCollector) null, cache);
         topic = "topic";
         context.setRecordContext(new ProcessorRecordContext(10, 0, 0, topic));
         store.init(context, null);

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingSessionStoreTest.java
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertFalse;
 public class CachingSessionStoreTest {
 
     private static final int MAX_CACHE_SIZE_BYTES = 600;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private RocksDBSegmentedBytesStore underlying;
     private CachingSessionStore<String, String> cachingStore;
     private ThreadCache cache;
@@ -75,7 +75,7 @@ public class CachingSessionStoreTest {
                                                  Segments.segmentInterval(retention, numSegments)
                                                  );
         cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
-        context = new MockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
+        context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, null, cache);
         context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, "topic"));
         cachingStore.init(context, cachingStore);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/CachingWindowStoreTest.java
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.WindowStoreIterator;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -56,7 +56,7 @@ public class CachingWindowStoreTest {
     private static final int MAX_CACHE_SIZE_BYTES = 150;
     private static final long DEFAULT_TIMESTAMP = 10L;
     private static final Long WINDOW_SIZE = 10000L;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private RocksDBSegmentedBytesStore underlying;
     private CachingWindowStore<String, String> cachingStore;
     private CachingKeyValueStoreTest.CacheFlushListenerStub<Windowed<String>, String> cacheListener;
@@ -80,7 +80,7 @@ public class CachingWindowStoreTest {
         cachingStore.setFlushListener(cacheListener, false);
         cache = new ThreadCache(new LogContext("testCache "), MAX_CACHE_SIZE_BYTES, new MockStreamsMetrics(new Metrics()));
         topic = "topic";
-        context = new MockProcessorContext(TestUtils.tempDirectory(), null, null, (RecordCollector) null, cache);
+        context = new InternalMockProcessorContext(TestUtils.tempDirectory(), null, null, (RecordCollector) null, cache);
         context.setRecordContext(new ProcessorRecordContext(DEFAULT_TIMESTAMP, 0, 0, topic));
         cachingStore.init(context, cachingStore);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/ChangeLoggingKeyValueBytesStoreTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ChangeLoggingKeyValueBytesStoreTest {
 
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private final InMemoryKeyValueStore<Bytes, byte[]> inner = new InMemoryKeyValueStore<>("kv", Serdes.Bytes(), Serdes.ByteArray());
     private final ChangeLoggingKeyValueBytesStore store = new ChangeLoggingKeyValueBytesStore(inner);
     private final Map sent = new HashMap<>();
@@ -64,7 +64,7 @@ public class ChangeLoggingKeyValueBytesStoreTest {
                 sent.put(key, value);
             }
         };
-        context = new MockProcessorContext(
+        context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
             Serdes.String(),
             Serdes.Long(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/MeteredWindowStoreTest.java
@@ -27,7 +27,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.easymock.EasyMock;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class MeteredWindowStoreTest {
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     @SuppressWarnings("unchecked")
     private final WindowStore<Bytes, byte[]> innerStoreMock = EasyMock.createNiceMock(WindowStore.class);
     private final MeteredWindowStore<String, String> store = new MeteredWindowStore<>(innerStoreMock, "scope", new MockTime(), Serdes.String(), new SerdeThatDoesntHandleNull());
@@ -98,7 +98,7 @@ public class MeteredWindowStoreTest {
 
         };
 
-        context = new MockProcessorContext(
+        context = new InternalMockProcessorContext(
             TestUtils.tempDirectory(),
             Serdes.String(),
             Serdes.Long(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBKeyValueStoreSupplierTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -44,7 +44,7 @@ public class RocksDBKeyValueStoreSupplierTest {
 
     private static final String STORE_NAME = "name";
     private final ThreadCache cache = new ThreadCache(new LogContext("test "), 1024, new MockStreamsMetrics(new Metrics()));
-    private final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+    private final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                                                           Serdes.String(),
                                                                           Serdes.String(),
                                                                           new NoOpRecordCollector(),
@@ -73,7 +73,7 @@ public class RocksDBKeyValueStoreSupplierTest {
                 logged.add(new ProducerRecord<K, V>(topic, partition, timestamp, key, value));
             }
         };
-        final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+        final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                                                       Serdes.String(),
                                                                       Serdes.String(),
                                                                       collector,
@@ -100,7 +100,7 @@ public class RocksDBKeyValueStoreSupplierTest {
                 logged.add(new ProducerRecord<>(topic, partition, timestamp, key, value));
             }
         };
-        final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+        final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                                                       Serdes.String(),
                                                                       Serdes.String(),
                                                                       collector,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -56,7 +56,7 @@ public class RocksDBSegmentedBytesStoreTest {
 
     private final long retention = 60000L;
     private final int numSegments = 3;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private final String storeName = "bytes-store";
     private RocksDBSegmentedBytesStore bytesStore;
     private File stateDir;
@@ -71,7 +71,7 @@ public class RocksDBSegmentedBytesStoreTest {
                                                     schema);
 
         stateDir = TestUtils.tempDirectory();
-        context = new MockProcessorContext(
+        context = new InternalMockProcessorContext(
             stateDir,
             Serdes.String(),
             Serdes.Long(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreSupplierTest.java
@@ -26,7 +26,7 @@ import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.SessionStore;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -47,7 +47,7 @@ public class RocksDBSessionStoreSupplierTest {
     private static final String STORE_NAME = "name";
     private final List<ProducerRecord> logged = new ArrayList<>();
     private final ThreadCache cache = new ThreadCache(new LogContext("test "), 1024, new MockStreamsMetrics(new Metrics()));
-    private final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+    private final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
         Serdes.String(),
         Serdes.String(),
         new NoOpRecordCollector() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSessionStoreTest.java
@@ -25,7 +25,7 @@ import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.SessionStore;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertTrue;
 public class RocksDBSessionStoreTest {
 
     private SessionStore<String, Long> sessionStore;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
 
     @Before
     public void before() {
@@ -59,7 +59,7 @@ public class RocksDBSessionStoreTest {
                                                  Serdes.String(),
                                                  Serdes.Long());
 
-        context = new MockProcessorContext(TestUtils.tempDirectory(),
+        context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                            Serdes.String(),
                                            Serdes.Long(),
                                            new NoOpRecordCollector(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBStoreTest.java
@@ -31,7 +31,7 @@ import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.RocksDBConfigSetter;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -62,14 +62,14 @@ public class RocksDBStoreTest {
     private Serializer<String> stringSerializer = new StringSerializer();
     private Deserializer<String> stringDeserializer = new StringDeserializer();
     private RocksDBStore rocksDBStore;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private File dir;
 
     @Before
     public void setUp() {
         rocksDBStore = new RocksDBStore("test");
         dir = TestUtils.tempDirectory();
-        context = new MockProcessorContext(dir,
+        context = new InternalMockProcessorContext(dir,
             Serdes.String(),
             Serdes.String(),
             new NoOpRecordCollector(),
@@ -115,7 +115,7 @@ public class RocksDBStoreTest {
         configs.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "test-server:9092");
         configs.put(StreamsConfig.ROCKSDB_CONFIG_SETTER_CLASS_CONFIG, MockRocksDbConfigSetter.class);
         MockRocksDbConfigSetter.called = false;
-        rocksDBStore.openDB(new MockProcessorContext(tempDir, new StreamsConfig(configs)));
+        rocksDBStore.openDB(new InternalMockProcessorContext(tempDir, new StreamsConfig(configs)));
 
         assertTrue(MockRocksDbConfigSetter.called);
     }
@@ -123,7 +123,7 @@ public class RocksDBStoreTest {
     @Test(expected = ProcessorStateException.class)
     public void shouldThrowProcessorStateExceptionOnOpeningReadOnlyDir() throws IOException {
         final File tmpDir = TestUtils.tempDirectory();
-        MockProcessorContext tmpContext = new MockProcessorContext(tmpDir,
+        InternalMockProcessorContext tmpContext = new InternalMockProcessorContext(tmpDir,
             Serdes.String(),
             Serdes.Long(),
             new NoOpRecordCollector(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreSupplierTest.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.StreamsMetrics;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.WindowStore;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -45,7 +45,7 @@ public class RocksDBWindowStoreSupplierTest {
     private static final String STORE_NAME = "name";
     private WindowStore<String, String> store;
     private final ThreadCache cache = new ThreadCache(new LogContext("test "), 1024, new MockStreamsMetrics(new Metrics()));
-    private final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+    private final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                                                           Serdes.String(),
                                                                           Serdes.String(),
                                                                           new NoOpRecordCollector(),
@@ -75,7 +75,7 @@ public class RocksDBWindowStoreSupplierTest {
                 logged.add(new ProducerRecord<K, V>(topic, partition, timestamp, key, value));
             }
         };
-        final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+        final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                                                       Serdes.String(),
                                                                       Serdes.String(),
                                                                       collector,
@@ -102,7 +102,7 @@ public class RocksDBWindowStoreSupplierTest {
                 logged.add(new ProducerRecord<K, V>(topic, partition, timestamp, key, value));
             }
         };
-        final MockProcessorContext context = new MockProcessorContext(TestUtils.tempDirectory(),
+        final InternalMockProcessorContext context = new InternalMockProcessorContext(TestUtils.tempDirectory(),
                                                                       Serdes.String(),
                                                                       Serdes.String(),
                                                                       collector,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBWindowStoreTest.java
@@ -37,7 +37,7 @@ import org.apache.kafka.streams.state.StateSerdes;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.state.WindowStoreIterator;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -94,7 +94,7 @@ public class RocksDBWindowStoreTest {
     };
 
     private final File baseDir = TestUtils.tempDirectory("test");
-    private final MockProcessorContext context = new MockProcessorContext(baseDir, Serdes.ByteArray(), Serdes.ByteArray(), recordCollector, cache);
+    private final InternalMockProcessorContext context = new InternalMockProcessorContext(baseDir, Serdes.ByteArray(), Serdes.ByteArray(), recordCollector, cache);
     private WindowStore<Integer, String> windowStore;
 
     private WindowStore<Integer, String> createWindowStore(final ProcessorContext context, final boolean retainDuplicates) {
@@ -842,7 +842,7 @@ public class RocksDBWindowStoreTest {
         assertThat(toList(windowStore.fetch(key3, 0, Long.MAX_VALUE)), equalTo(expectedKey3));
     }
 
-    private void putFirstBatch(final WindowStore<Integer, String> store, final long startTime, final MockProcessorContext context) {
+    private void putFirstBatch(final WindowStore<Integer, String> store, final long startTime, final InternalMockProcessorContext context) {
         context.setRecordContext(createRecordContext(startTime));
         store.put(0, "zero");
         context.setRecordContext(createRecordContext(startTime + 1L));
@@ -855,7 +855,7 @@ public class RocksDBWindowStoreTest {
         store.put(5, "five");
     }
 
-    private void putSecondBatch(final WindowStore<Integer, String> store, final long startTime, MockProcessorContext context) {
+    private void putSecondBatch(final WindowStore<Integer, String> store, final long startTime, InternalMockProcessorContext context) {
         context.setRecordContext(createRecordContext(startTime + 3L));
         store.put(2, "two+1");
         context.setRecordContext(createRecordContext(startTime + 4L));

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentIteratorTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -48,12 +48,12 @@ public class SegmentIteratorTest {
         }
     };
 
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private SegmentIterator iterator = null;
 
     @Before
     public void before() {
-        context = new MockProcessorContext(
+        context = new InternalMockProcessorContext(
                 TestUtils.tempDirectory(),
                 Serdes.String(),
                 Serdes.String(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/SegmentsTest.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
 public class SegmentsTest {
 
     private static final int NUM_SEGMENTS = 5;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private Segments segments;
     private long segmentInterval;
     private File stateDirectory;
@@ -54,7 +54,7 @@ public class SegmentsTest {
     @Before
     public void createContext() {
         stateDirectory = TestUtils.tempDirectory();
-        context = new MockProcessorContext(stateDirectory,
+        context = new InternalMockProcessorContext(stateDirectory,
                                            Serdes.String(),
                                            Serdes.Long(),
                                            new NoOpRecordCollector(),

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StateStoreTestUtils.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 
 import java.util.Collections;
@@ -42,7 +42,7 @@ public class StateStoreTestUtils {
 
         final StateStore stateStore = supplier.get();
         stateStore.init(
-            new MockProcessorContext(
+            new InternalMockProcessorContext(
                 StateSerdes.withBuiltinTypes(
                     ProcessorStateManager.storeChangelogTopic(applicationId, name),
                     keyType,

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreChangeLoggerTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/StoreChangeLoggerTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.streams.errors.DefaultProductionExceptionHandler;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.internals.RecordCollectorImpl;
 import org.apache.kafka.streams.state.StateSerdes;
-import org.apache.kafka.test.MockProcessorContext;
+import org.apache.kafka.test.InternalMockProcessorContext;
 import org.junit.After;
 import org.junit.Test;
 
@@ -39,7 +39,7 @@ public class StoreChangeLoggerTest {
 
     private final Map<Integer, String> logged = new HashMap<>();
 
-    private final MockProcessorContext context = new MockProcessorContext(StateSerdes.withBuiltinTypes(topic, Integer.class, String.class),
+    private final InternalMockProcessorContext context = new InternalMockProcessorContext(StateSerdes.withBuiltinTypes(topic, Integer.class, String.class),
             new RecordCollectorImpl(null, "StoreChangeLoggerTest", new LogContext("StoreChangeLoggerTest "), new DefaultProductionExceptionHandler()) {
                 @Override
                 public <K1, V1> void send(final String topic,

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -48,7 +48,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class MockProcessorContext extends AbstractProcessorContext implements RecordCollector.Supplier {
+public class InternalMockProcessorContext extends AbstractProcessorContext implements RecordCollector.Supplier {
 
     private final File stateDir;
     private final Metrics metrics;
@@ -61,19 +61,19 @@ public class MockProcessorContext extends AbstractProcessorContext implements Re
     private Serde<?> valSerde;
     private long timestamp = -1L;
 
-    public MockProcessorContext(final File stateDir,
-                                final StreamsConfig config) {
+    public InternalMockProcessorContext(final File stateDir,
+                                        final StreamsConfig config) {
         this(stateDir, null, null, new Metrics(), config, null, null);
     }
 
-    public MockProcessorContext(final StateSerdes<?, ?> serdes,
-                                final RecordCollector collector) {
+    public InternalMockProcessorContext(final StateSerdes<?, ?> serdes,
+                                        final RecordCollector collector) {
         this(null, serdes.keySerde(), serdes.valueSerde(), collector, null);
     }
 
-    public MockProcessorContext(final StateSerdes<?, ?> serdes,
-                                final RecordCollector collector,
-                                final Metrics metrics) {
+    public InternalMockProcessorContext(final StateSerdes<?, ?> serdes,
+                                        final RecordCollector collector,
+                                        final Metrics metrics) {
         this(null, serdes.keySerde(), serdes.valueSerde(), metrics, new StreamsConfig(StreamsTestUtils.minimalStreamsConfig()), new RecordCollector.Supplier() {
             @Override
             public RecordCollector recordCollector() {
@@ -82,11 +82,11 @@ public class MockProcessorContext extends AbstractProcessorContext implements Re
         }, null);
     }
 
-    public MockProcessorContext(final File stateDir,
-                                final Serde<?> keySerde,
-                                final Serde<?> valSerde,
-                                final RecordCollector collector,
-                                final ThreadCache cache) {
+    public InternalMockProcessorContext(final File stateDir,
+                                        final Serde<?> keySerde,
+                                        final Serde<?> valSerde,
+                                        final RecordCollector collector,
+                                        final ThreadCache cache) {
         this(stateDir, keySerde, valSerde, new Metrics(), new StreamsConfig(StreamsTestUtils.minimalStreamsConfig()), new RecordCollector.Supplier() {
             @Override
             public RecordCollector recordCollector() {
@@ -95,13 +95,13 @@ public class MockProcessorContext extends AbstractProcessorContext implements Re
         }, cache);
     }
 
-    private MockProcessorContext(final File stateDir,
-                                final Serde<?> keySerde,
-                                final Serde<?> valSerde,
-                                final Metrics metrics,
-                                final StreamsConfig config,
-                                final RecordCollector.Supplier collectorSupplier,
-                                final ThreadCache cache) {
+    private InternalMockProcessorContext(final File stateDir,
+                                         final Serde<?> keySerde,
+                                         final Serde<?> valSerde,
+                                         final Metrics metrics,
+                                         final StreamsConfig config,
+                                         final RecordCollector.Supplier collectorSupplier,
+                                         final ThreadCache cache) {
         super(new TaskId(0, 0),
               config,
               new MockStreamsMetrics(metrics),

--- a/streams/src/test/java/org/apache/kafka/test/KStreamTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/test/KStreamTestDriver.java
@@ -48,7 +48,7 @@ public class KStreamTestDriver extends ExternalResource {
     private static final long DEFAULT_CACHE_SIZE_BYTES = 1 * 1024 * 1024L;
 
     private ProcessorTopology topology;
-    private MockProcessorContext context;
+    private InternalMockProcessorContext context;
     private ProcessorTopology globalTopology;
     private final LogContext logContext = new LogContext("testCache ");
 
@@ -85,7 +85,7 @@ public class KStreamTestDriver extends ExternalResource {
         topology = builder.build(null);
         globalTopology = builder.buildGlobalStateTopology();
         final ThreadCache cache = new ThreadCache(logContext, cacheSize, new MockStreamsMetrics(new Metrics()));
-        context = new MockProcessorContext(stateDir, keySerde, valSerde, new MockRecordCollector(), cache);
+        context = new InternalMockProcessorContext(stateDir, keySerde, valSerde, new MockRecordCollector(), cache);
         context.setRecordContext(new ProcessorRecordContext(0, 0, 0, "topic"));
         // init global topology first as it will add stores to the
         // store map that are required for joins etc.
@@ -126,7 +126,7 @@ public class KStreamTestDriver extends ExternalResource {
         globalTopology = internalTopologyBuilder.buildGlobalStateTopology();
 
         final ThreadCache cache = new ThreadCache(logContext, cacheSize, new MockStreamsMetrics(new Metrics()));
-        context = new MockProcessorContext(stateDir, keySerde, valSerde, new MockRecordCollector(), cache);
+        context = new InternalMockProcessorContext(stateDir, keySerde, valSerde, new MockRecordCollector(), cache);
         context.setRecordContext(new ProcessorRecordContext(0, 0, 0, "topic"));
 
         // init global topology first as it will add stores to the

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -1,0 +1,245 @@
+package org.apache.kafka.streams.processor;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.processor.internals.StreamsMetricsImpl;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * This is a mock of {@link ProcessorContext} provided for authors of {@link Processor},
+ * {@link org.apache.kafka.streams.kstream.Transformer}, and {@link org.apache.kafka.streams.kstream.ValueTransformer}.
+ * <p>
+ * The tests for this class ({@link org.apache.kafka.streams.MockProcessorContextTest}) include several behavioral
+ * tests that serve as example usage.
+ * <p>
+ * Note that this class does not take any automated actions (such as firing scheduled punctuators).
+ * It simply captures any data it witnessess.
+ * If you require more automated tests, we recommend wrapping your {@link Processor} in a dummy
+ * {@link org.apache.kafka.streams.Topology} and using the {@link org.apache.kafka.streams.TopologyTestDriver}.
+ * <p>
+ */
+@SuppressWarnings("JavadocReference")
+@InterfaceStability.Evolving
+public class MockProcessorContext implements ProcessorContext {
+    // Immutable fields ================================================
+    private final StreamsMetricsImpl metrics;
+    private final TaskId taskId;
+    private final StreamsConfig config;
+    private final File stateDir; // default: null
+
+    /**
+     * Create a {@link MockProcessorContext} with dummy taskId and null stateDir.
+     * Most unit tests using this mock won't need to know the taskId,
+     * and most unit tests should be able to get by with the
+     * {@link org.apache.kafka.streams.state.internals.InMemoryKeyValueStore}, so the stateDir won't matter.
+     *
+     * @param config a StreamsConfig Properties object.
+     *               {@link StreamsConfig.BOOTSTRAP_SERVERS_CONFIG} [required] is ignored.
+     *               {@link StreamsConfig.APPLICATION_ID_CONFIG} [required] will set the {@link ProcessorContext#applicationId()} value.
+     *               {@link StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG} will set the {@link ProcessorContext#keySerde()} value.
+     *               {@link StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG} will set the {@link ProcessorContext#valueSerde()} value.
+     *               All properties will be available via {@link ProcessorContext#appConfigs()} and {@link ProcessorContext#appConfigsWithPrefix(String)}.
+     */
+    public MockProcessorContext(final Properties config) {
+        this(config, new TaskId(0, 0), null);
+    }
+
+    public MockProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        this.taskId = taskId;
+        this.config = streamsConfig;
+        this.stateDir = stateDir;
+        this.metrics = new StreamsMetricsImpl(new Metrics(), "mock-processor-context", new HashMap<String, String>());
+    }
+
+    @Override public String applicationId() { return config.getString(StreamsConfig.APPLICATION_ID_CONFIG);}
+
+    @Override public TaskId taskId() { return taskId;}
+
+    @Override public Map<String, Object> appConfigs() {
+        final Map<String, Object> combined = new HashMap<>();
+        combined.putAll(config.originals());
+        combined.putAll(config.values());
+        return combined;
+    }
+
+    @Override public Map<String, Object> appConfigsWithPrefix(final String prefix) {
+        return config.originalsWithPrefix(prefix);
+    }
+
+    @Override public Serde<?> keySerde() { return config.defaultKeySerde();}
+
+    @Override public Serde<?> valueSerde() { return config.defaultValueSerde();}
+
+    @Override public File stateDir() { return stateDir;}
+
+    @Override public StreamsMetrics metrics() { return metrics;}
+
+    // settable record metadata ================================================
+
+    private String topic;
+    private Integer partition;
+    private Long offset;
+    private Long timestamp;
+
+    public void setRecordMetadata(final String topic, final int partition, final long offset, final long timestamp) {
+        this.topic = topic;
+        this.partition = partition;
+        this.offset = offset;
+        this.timestamp = timestamp;
+    }
+    public void setTopic(final String topic) { this.topic = topic;}
+    public void setPartition(final int partition) { this.partition = partition;}
+    public void setOffset(final long offset) { this.offset = offset;}
+    public void setTimestamp(final long timestamp) { this.timestamp = timestamp;}
+
+    @Override public String topic() { return topic;}
+    @Override public int partition() { return partition;}
+    @Override public long offset() { return offset;}
+    @Override public long timestamp() { return timestamp;}
+
+    // mocks ================================================
+
+    // state stores
+    private final Map<String, StateStore> stateStores = new HashMap<>();
+    @Override
+    public void register(final StateStore store, final boolean loggingEnabledIsDeprecatedAndIgnored, final StateRestoreCallback stateRestoreCallbackIsIgnoredInMock) {
+        stateStores.put(store.name(), store);
+    }
+
+    @Override public StateStore getStateStore(final String name) { return stateStores.get(name);}
+
+    // punctuators
+    public static class CapturedPunctuator {
+        private final long intervalMs;
+        private final PunctuationType type;
+        private final Punctuator punctuator;
+
+        private CapturedPunctuator(final long intervalMs, final PunctuationType type, final Punctuator punctuator) {
+            this.intervalMs = intervalMs;
+            this.type = type;
+            this.punctuator = punctuator;
+        }
+
+        public long getIntervalMs() { return intervalMs;}
+        public PunctuationType getType() { return type;}
+        public Punctuator getPunctuator() { return punctuator;}
+    }
+
+    private final List<CapturedPunctuator> punctuators = new LinkedList<>();
+
+    @Override
+    public Cancellable schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) {
+        punctuators.add(new CapturedPunctuator(intervalMs, type, callback));
+        return new Cancellable() {
+            @Override public void cancel() {}
+        };
+    }
+    @Override
+    public void schedule(final long interval) {
+        throw new UnsupportedOperationException("schedule() is deprecated and not supported in Mock. Use schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) instead.");
+    }
+
+    public List<CapturedPunctuator> scheduledPunctuators() {
+        final LinkedList<CapturedPunctuator> capturedPunctuators = new LinkedList<>();
+        capturedPunctuators.addAll(punctuators);
+        return capturedPunctuators;
+    }
+
+    // forwards
+    private class Capture {
+        /*Nullable*/ private final Integer childIndex;
+        /*Nullable*/ private final String childName;
+        private final KeyValue kv;
+
+        private Capture(final KeyValue kv) {
+            this.childIndex = null;
+            this.childName = null;
+            this.kv = kv;
+        }
+
+        private Capture(final Integer childIndex, final KeyValue kv) {
+            this.childIndex = childIndex;
+            this.childName = null;
+            this.kv = kv;
+        }
+
+        private Capture(final String childName, final KeyValue kv) {
+            this.childIndex = null;
+            this.childName = childName;
+            this.kv = kv;
+        }
+    }
+
+    private List<Capture> captured = new LinkedList<>();
+
+    @Override public <FK, FV> void forward(final FK key, final FV value) {
+        captured.add(new Capture(castKV(key, value)));
+    }
+
+    @Override public <FK, FV> void forward(final FK key, final FV value, final To to) {
+        captured.add(new Capture(to.childName, castKV(key, value)));
+    }
+
+    @Override public <FK, FV> void forward(final FK key, final FV value, final int childIndex) {
+        captured.add(new Capture(childIndex, castKV(key, value)));
+    }
+
+    @Override
+    public <FK, FV> void forward(final FK key, final FV value, final String childName) {
+        captured.add(new Capture(childName, castKV(key, value)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <FK, FV> KeyValue castKV(final FK key, final FV value) { return new KeyValue(key, value);}
+
+    public List<KeyValue> forwarded() {
+        final LinkedList<KeyValue> result = new LinkedList<>();
+        for (final Capture capture : captured) {
+            result.add(capture.kv);
+        }
+        return result;
+    }
+
+    public List<KeyValue> forwarded(final int childIndex) {
+        final LinkedList<KeyValue> result = new LinkedList<>();
+        for (final Capture capture : captured) {
+            if (capture.childIndex != null && capture.childIndex == childIndex) {
+                result.add(capture.kv);
+            }
+        }
+        return result;
+    }
+
+    public List<KeyValue> forwarded(final String childName) {
+        final LinkedList<KeyValue> result = new LinkedList<>();
+        for (final Capture capture : captured) {
+            if (capture.childName != null && capture.childName.equals(childName)) {
+                result.add(capture.kv);
+            }
+        }
+        return result;
+    }
+
+    public void resetForwards() { captured = new LinkedList<>();}
+
+    // commits
+
+    private boolean committed = false;
+
+    @Override public void commit() { committed = true; }
+
+    public boolean committed() { return committed;}
+
+    public void resetCommit() {committed = false;}
+}

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -144,10 +144,13 @@ public class MockProcessorContext implements ProcessorContext {
      */
     public MockProcessorContext() {
         //noinspection DoubleBraceInitialization
-        this(new Properties() {{
-                 put(StreamsConfig.APPLICATION_ID_CONFIG, "");
-                 put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
-             }},
+        this(
+            new Properties() {
+                {
+                    put(StreamsConfig.APPLICATION_ID_CONFIG, "");
+                    put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+                }
+            },
             new TaskId(0, 0),
             null);
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -109,7 +109,7 @@ public class MockProcessorContext implements ProcessorContext {
 
     private final List<CapturedPunctuator> punctuators = new LinkedList<>();
 
-    private class CapturedForward {
+    private static class CapturedForward {
         /*Nullable*/ private final Integer childIndex;
         /*Nullable*/ private final String childName;
         private final KeyValue kv;

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -22,7 +22,12 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.ValueTransformer;
 import org.apache.kafka.streams.processor.internals.StreamsMetricsImpl;
+import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
 
 import java.io.File;
 import java.util.HashMap;
@@ -33,16 +38,15 @@ import java.util.Properties;
 
 /**
  * This is a mock of {@link ProcessorContext} provided for authors of {@link Processor},
- * {@link org.apache.kafka.streams.kstream.Transformer}, and {@link org.apache.kafka.streams.kstream.ValueTransformer}.
+ * {@link Transformer}, and {@link ValueTransformer}.
  * <p>
  * The tests for this class (org.apache.kafka.streams.MockProcessorContextTest) include several behavioral
  * tests that serve as example usage.
  * <p>
  * Note that this class does not take any automated actions (such as firing scheduled punctuators).
  * It simply captures any data it witnessess.
- * If you require more automated tests, we recommend wrapping your {@link Processor} in a dummy
- * {@link org.apache.kafka.streams.Topology} and using the {@link org.apache.kafka.streams.TopologyTestDriver}.
- * <p>
+ * If you require more automated tests, we recommend wrapping your {@link Processor} in a minimal source-processor-sink
+ * {@link Topology} and using the {@link TopologyTestDriver}.
  */
 @InterfaceStability.Evolving
 public class MockProcessorContext implements ProcessorContext {
@@ -52,131 +56,26 @@ public class MockProcessorContext implements ProcessorContext {
     private final StreamsConfig config;
     private final File stateDir; // default: null
 
-    /**
-     * Create a {@link MockProcessorContext} with dummy taskId and null stateDir.
-     * Most unit tests using this mock won't need to know the taskId,
-     * and most unit tests should be able to get by with the
-     * {@link org.apache.kafka.streams.state.internals.InMemoryKeyValueStore}, so the stateDir won't matter.
-     *
-     * @param config a StreamsConfig Properties object.
-     *               StreamsConfig.BOOTSTRAP_SERVERS_CONFIG [required] is ignored.
-     *               StreamsConfig.APPLICATION_ID_CONFIG [required] will set the {@link ProcessorContext#applicationId()} value.
-     *               StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG will set the {@link ProcessorContext#keySerde()} value.
-     *               StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG will set the {@link ProcessorContext#valueSerde()} value.
-     *               All properties will be available via {@link ProcessorContext#appConfigs()} and {@link ProcessorContext#appConfigsWithPrefix(String)}.
-     */
-    public MockProcessorContext(final Properties config) {
-        this(config, new TaskId(0, 0), null);
-    }
-
-    public MockProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
-        final StreamsConfig streamsConfig = new StreamsConfig(config);
-        this.taskId = taskId;
-        this.config = streamsConfig;
-        this.stateDir = stateDir;
-        this.metrics = new StreamsMetricsImpl(new Metrics(), "mock-processor-context", new HashMap<String, String>());
-    }
-
-    @Override public String applicationId() {
-        return config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
-    }
-
-    @Override public TaskId taskId() {
-        return taskId;
-    }
-
-    @Override public Map<String, Object> appConfigs() {
-        final Map<String, Object> combined = new HashMap<>();
-        combined.putAll(config.originals());
-        combined.putAll(config.values());
-        return combined;
-    }
-
-    @Override public Map<String, Object> appConfigsWithPrefix(final String prefix) {
-        return config.originalsWithPrefix(prefix);
-    }
-
-    @Override public Serde<?> keySerde() {
-        return config.defaultKeySerde();
-    }
-
-    @Override public Serde<?> valueSerde() {
-        return config.defaultValueSerde();
-    }
-
-    @Override public File stateDir() {
-        return stateDir;
-    }
-
-    @Override public StreamsMetrics metrics() {
-        return metrics;
-    }
-
     // settable record metadata ================================================
-
     private String topic;
     private Integer partition;
     private Long offset;
     private Long timestamp;
 
-    public void setRecordMetadata(final String topic, final int partition, final long offset, final long timestamp) {
-        this.topic = topic;
-        this.partition = partition;
-        this.offset = offset;
-        this.timestamp = timestamp;
-    }
-
-    public void setTopic(final String topic) {
-        this.topic = topic;
-    }
-
-    public void setPartition(final int partition) {
-        this.partition = partition;
-    }
-
-    public void setOffset(final long offset) {
-        this.offset = offset;
-    }
-
-    public void setTimestamp(final long timestamp) {
-        this.timestamp = timestamp;
-    }
-
-    @Override public String topic() {
-        return topic;
-    }
-
-    @Override public int partition() {
-        return partition;
-    }
-
-    @Override public long offset() {
-        return offset;
-    }
-
-    @Override public long timestamp() {
-        return timestamp;
-    }
-
     // mocks ================================================
-
-    // state stores
     private final Map<String, StateStore> stateStores = new HashMap<>();
 
-    @Override
-    public void register(final StateStore store, final boolean loggingEnabledIsDeprecatedAndIgnored, final StateRestoreCallback stateRestoreCallbackIsIgnoredInMock) {
-        stateStores.put(store.name(), store);
-    }
 
-    @Override public StateStore getStateStore(final String name) {
-        return stateStores.get(name);
-    }
-
-    // punctuators
+    /**
+     * A simple class for holding captured punctuators, along with their scheduling information.
+     */
     public static class CapturedPunctuator {
         private final long intervalMs;
         private final PunctuationType type;
         private final Punctuator punctuator;
+
+        // mutable:
+        private boolean cancelled = false;
 
         private CapturedPunctuator(final long intervalMs, final PunctuationType type, final Punctuator punctuator) {
             this.intervalMs = intervalMs;
@@ -195,24 +94,260 @@ public class MockProcessorContext implements ProcessorContext {
         public Punctuator getPunctuator() {
             return punctuator;
         }
+
+        public void cancel() {
+            this.cancelled = true;
+        }
+
+        public boolean cancelled() {
+            return cancelled;
+        }
     }
 
     private final List<CapturedPunctuator> punctuators = new LinkedList<>();
 
+    private class CapturedForward {
+        /*Nullable*/ private final Integer childIndex;
+        /*Nullable*/ private final String childName;
+        private final KeyValue kv;
+
+        private CapturedForward(final KeyValue kv) {
+            this.childIndex = null;
+            this.childName = null;
+            this.kv = kv;
+        }
+
+        private CapturedForward(final Integer childIndex, final KeyValue kv) {
+            this.childIndex = childIndex;
+            this.childName = null;
+            this.kv = kv;
+        }
+
+        private CapturedForward(final String childName, final KeyValue kv) {
+            this.childIndex = null;
+            this.childName = childName;
+            this.kv = kv;
+        }
+    }
+
+    private List<CapturedForward> capturedForwards = new LinkedList<>();
+
+    private boolean committed = false;
+
+    // contructors ================================================
+
+    /**
+     * Create a {@link MockProcessorContext} with dummy {@code config} and {@code taskId} and {@code null} {@code stateDir}.
+     * Most unit tests using this mock won't need to know the taskId,
+     * and most unit tests should be able to get by with the
+     * {@link InMemoryKeyValueStore}, so the stateDir won't matter.
+     */
+    public MockProcessorContext() {
+        //noinspection DoubleBraceInitialization
+        this(new Properties() {{
+                 put(StreamsConfig.APPLICATION_ID_CONFIG, "");
+                 put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+             }},
+            new TaskId(0, 0),
+            null);
+    }
+
+    /**
+     * Create a {@link MockProcessorContext} with dummy {@code taskId} and {@code null} {@code stateDir}.
+     * Most unit tests using this mock won't need to know the taskId,
+     * and most unit tests should be able to get by with the
+     * {@link InMemoryKeyValueStore}, so the stateDir won't matter.
+     *
+     * @param config a Properties object, used to configure the context and the processor.
+     */
+    public MockProcessorContext(final Properties config) {
+        this(config, new TaskId(0, 0), null);
+    }
+
+    /**
+     * Create a {@link MockProcessorContext} with a specified taskId and null stateDir.
+     *
+     * @param config   a {@link Properties} object, used to configure the context and the processor.
+     * @param taskId   a {@link TaskId}, which the context makes available via {@link MockProcessorContext#taskId()}.
+     * @param stateDir a {@link File}, which the context makes available viw {@link MockProcessorContext#stateDir()}.
+     */
+    public MockProcessorContext(final Properties config, final TaskId taskId, final File stateDir) {
+        final StreamsConfig streamsConfig = new StreamsConfig(config);
+        this.taskId = taskId;
+        this.config = streamsConfig;
+        this.stateDir = stateDir;
+        this.metrics = new StreamsMetricsImpl(new Metrics(), "mock-processor-context", new HashMap<String, String>());
+    }
+
+    @Override
+    public String applicationId() {
+        return config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+    }
+
+    @Override
+    public TaskId taskId() {
+        return taskId;
+    }
+
+    @Override
+    public Map<String, Object> appConfigs() {
+        final Map<String, Object> combined = new HashMap<>();
+        combined.putAll(config.originals());
+        combined.putAll(config.values());
+        return combined;
+    }
+
+    @Override
+    public Map<String, Object> appConfigsWithPrefix(final String prefix) {
+        return config.originalsWithPrefix(prefix);
+    }
+
+    @Override
+    public Serde<?> keySerde() {
+        return config.defaultKeySerde();
+    }
+
+    @Override
+    public Serde<?> valueSerde() {
+        return config.defaultValueSerde();
+    }
+
+    @Override
+    public File stateDir() {
+        return stateDir;
+    }
+
+    @Override
+    public StreamsMetrics metrics() {
+        return metrics;
+    }
+
+    // settable record metadata ================================================
+
+    /**
+     * The context exposes these metadata for use in the processor. Normally, they are set by the Kafka Streams framework,
+     * but for the purpose of driving unit tests, you can set them directly.
+     *
+     * @param topic     A topic name
+     * @param partition A partition number
+     * @param offset    A record offset
+     * @param timestamp A record timestamp
+     */
+    public void setRecordMetadata(final String topic, final int partition, final long offset, final long timestamp) {
+        this.topic = topic;
+        this.partition = partition;
+        this.offset = offset;
+        this.timestamp = timestamp;
+    }
+
+
+    /**
+     * The context exposes this metadata for use in the processor. Normally, they are set by the Kafka Streams framework,
+     * but for the purpose of driving unit tests, you can set it directly. Setting this attribute doesn't affect the others.
+     *
+     * @param topic A topic name
+     */
+    public void setTopic(final String topic) {
+        this.topic = topic;
+    }
+
+    /**
+     * The context exposes this metadata for use in the processor. Normally, they are set by the Kafka Streams framework,
+     * but for the purpose of driving unit tests, you can set it directly. Setting this attribute doesn't affect the others.
+     *
+     * @param partition A partition number
+     */
+    public void setPartition(final int partition) {
+        this.partition = partition;
+    }
+
+
+    /**
+     * The context exposes this metadata for use in the processor. Normally, they are set by the Kafka Streams framework,
+     * but for the purpose of driving unit tests, you can set it directly. Setting this attribute doesn't affect the others.
+     *
+     * @param offset A record offset
+     */
+    public void setOffset(final long offset) {
+        this.offset = offset;
+    }
+
+
+    /**
+     * The context exposes this metadata for use in the processor. Normally, they are set by the Kafka Streams framework,
+     * but for the purpose of driving unit tests, you can set it directly. Setting this attribute doesn't affect the others.
+     *
+     * @param timestamp A record timestamp
+     */
+    public void setTimestamp(final long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public String topic() {
+        return topic;
+    }
+
+    @Override
+    public int partition() {
+        return partition;
+    }
+
+    @Override
+    public long offset() {
+        return offset;
+    }
+
+    @Override
+    public long timestamp() {
+        return timestamp;
+    }
+
+    // mocks ================================================
+
+    // state stores
+
+    @Override
+    public void register(final StateStore store,
+                         final boolean loggingEnabledIsDeprecatedAndIgnored,
+                         final StateRestoreCallback stateRestoreCallbackIsIgnoredInMock) {
+        stateStores.put(store.name(), store);
+    }
+
+    @Override
+    public StateStore getStateStore(final String name) {
+        return stateStores.get(name);
+    }
+
+    // punctuators
+
     @Override
     public Cancellable schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) {
-        punctuators.add(new CapturedPunctuator(intervalMs, type, callback));
+        final CapturedPunctuator capturedPunctuator = new CapturedPunctuator(intervalMs, type, callback);
+
+        punctuators.add(capturedPunctuator);
+
         return new Cancellable() {
-            @Override public void cancel() {
+            @Override
+            public void cancel() {
+                capturedPunctuator.cancel();
             }
         };
     }
 
     @Override
     public void schedule(final long interval) {
-        throw new UnsupportedOperationException("schedule() is deprecated and not supported in Mock. Use schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) instead.");
+        throw new UnsupportedOperationException(
+            "schedule() is deprecated and not supported in Mock. " +
+                "Use schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) instead."
+        );
     }
 
+    /**
+     * A method for getting the punctuators sheduled so far. The returned list is not affected by subsequent calls to {@code schedule(...)}.
+     *
+     * @return A list of captured punctuators.
+     */
     public List<CapturedPunctuator> scheduledPunctuators() {
         final LinkedList<CapturedPunctuator> capturedPunctuators = new LinkedList<>();
         capturedPunctuators.addAll(punctuators);
@@ -220,65 +355,59 @@ public class MockProcessorContext implements ProcessorContext {
     }
 
     // forwards
-    private class Capture {
-        /*Nullable*/ private final Integer childIndex;
-        /*Nullable*/ private final String childName;
-        private final KeyValue kv;
 
-        private Capture(final KeyValue kv) {
-            this.childIndex = null;
-            this.childName = null;
-            this.kv = kv;
-        }
-
-        private Capture(final Integer childIndex, final KeyValue kv) {
-            this.childIndex = childIndex;
-            this.childName = null;
-            this.kv = kv;
-        }
-
-        private Capture(final String childName, final KeyValue kv) {
-            this.childIndex = null;
-            this.childName = childName;
-            this.kv = kv;
-        }
+    @Override
+    public <FK, FV> void forward(final FK key, final FV value) {
+        //noinspection unchecked
+        capturedForwards.add(new CapturedForward(new KeyValue(key, value)));
     }
 
-    private List<Capture> captured = new LinkedList<>();
-
-    @Override public <FK, FV> void forward(final FK key, final FV value) {
-        captured.add(new Capture(castKV(key, value)));
+    @Override
+    public <FK, FV> void forward(final FK key, final FV value, final To to) {
+        //noinspection unchecked
+        capturedForwards.add(new CapturedForward(to.childName, new KeyValue(key, value)));
     }
 
-    @Override public <FK, FV> void forward(final FK key, final FV value, final To to) {
-        captured.add(new Capture(to.childName, castKV(key, value)));
-    }
-
-    @Override public <FK, FV> void forward(final FK key, final FV value, final int childIndex) {
-        captured.add(new Capture(childIndex, castKV(key, value)));
+    @Override
+    public <FK, FV> void forward(final FK key, final FV value, final int childIndex) {
+        //noinspection unchecked
+        capturedForwards.add(new CapturedForward(childIndex, new KeyValue(key, value)));
     }
 
     @Override
     public <FK, FV> void forward(final FK key, final FV value, final String childName) {
-        captured.add(new Capture(childName, castKV(key, value)));
+        //noinspection unchecked
+        capturedForwards.add(new CapturedForward(childName, new KeyValue(key, value)));
     }
 
-    @SuppressWarnings("unchecked")
-    private <FK, FV> KeyValue castKV(final FK key, final FV value) {
-        return new KeyValue(key, value);
-    }
-
+    /**
+     * A method for retrieving all the forwarded data this context has observed. The returned list will not be
+     * affected by subsequent interactions with the context. The data in the list is in the same order as the calls to
+     * {@code forward(...)}.
+     *
+     * @return A list of key/value pairs that were previously passed to the context.
+     */
     public List<KeyValue> forwarded() {
         final LinkedList<KeyValue> result = new LinkedList<>();
-        for (final Capture capture : captured) {
-            result.add(capture.kv);
+        for (final CapturedForward capturedForward : capturedForwards) {
+            result.add(capturedForward.kv);
         }
         return result;
     }
 
+    /**
+     * A method for retrieving all the forwarded data this context has observed for a specific child by index.
+     * The returned list will not be affected by subsequent interactions with the context.
+     * The data in the list is in the same order as the calls to {@code forward(...)}.
+     *
+     * @param childIndex The child index to retrieve forwards for
+     * @return A list of key/value pairs that were previously passed to the context.
+     * @deprecated please re-write processors to use {@link #forward(Object, Object, To)} instead
+     */
+    @Deprecated
     public List<KeyValue> forwarded(final int childIndex) {
         final LinkedList<KeyValue> result = new LinkedList<>();
-        for (final Capture capture : captured) {
+        for (final CapturedForward capture : capturedForwards) {
             if (capture.childIndex != null && capture.childIndex == childIndex) {
                 result.add(capture.kv);
             }
@@ -286,9 +415,17 @@ public class MockProcessorContext implements ProcessorContext {
         return result;
     }
 
+    /**
+     * A method for retrieving all the forwarded data this context has observed for a specific child by name.
+     * The returned list will not be affected by subsequent interactions with the context.
+     * The data in the list is in the same order as the calls to {@code forward(...)}.
+     *
+     * @param childName The child name to retrieve forwards for
+     * @return A list of key/value pairs that were previously passed to the context.
+     */
     public List<KeyValue> forwarded(final String childName) {
         final LinkedList<KeyValue> result = new LinkedList<>();
-        for (final Capture capture : captured) {
+        for (final CapturedForward capture : capturedForwards) {
             if (capture.childName != null && capture.childName.equals(childName)) {
                 result.add(capture.kv);
             }
@@ -296,22 +433,32 @@ public class MockProcessorContext implements ProcessorContext {
         return result;
     }
 
+    /**
+     * Clears the captured forwarded data.
+     */
     public void resetForwards() {
-        captured = new LinkedList<>();
+        capturedForwards = new LinkedList<>();
     }
 
     // commits
 
-    private boolean committed = false;
-
-    @Override public void commit() {
+    @Override
+    public void commit() {
         committed = true;
     }
 
+    /**
+     * Whether {@link ProcessorContext#commit()} has been called in this context.
+     *
+     * @return {@code true} iff {@link ProcessorContext#commit()} has been called in this context since construction or reset.
+     */
     public boolean committed() {
         return committed;
     }
 
+    /**
+     * Re-sets the commit capture to {@code false} (whether or not it was previously {@code true}).
+     */
     public void resetCommit() {
         committed = false;
     }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -16,11 +16,9 @@
  */
 package org.apache.kafka.streams.processor;
 
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.StreamsMetrics;
@@ -466,46 +464,11 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
 
     @Override
     public RecordCollector recordCollector() {
-        // This interface is required for state stores that add change logging.
-        // Rather than risking a mysterious ClassCastException during unit tests, just supply a no-op collector.
+        // This interface is assumed by state stores that add change-logging.
+        // Rather than risk a mysterious ClassCastException during unit tests, throw an explanatory exception.
 
-        return new RecordCollector() {
-            @Override
-            public <K, V> void send(final String topic,
-                                    final K key,
-                                    final V value,
-                                    final Integer partition,
-                                    final Long timestamp,
-                                    final Serializer<K> keySerializer,
-                                    final Serializer<V> valueSerializer) {
-
-            }
-
-            @Override
-            public <K, V> void send(final String topic,
-                                    final K key,
-                                    final V value,
-                                    final Long timestamp,
-                                    final Serializer<K> keySerializer,
-                                    final Serializer<V> valueSerializer,
-                                    final StreamPartitioner<? super K, ? super V> partitioner) {
-
-            }
-
-            @Override
-            public void flush() {
-
-            }
-
-            @Override
-            public void close() {
-
-            }
-
-            @Override
-            public Map<TopicPartition, Long> offsets() {
-                return null;
-            }
-        };
+        throw new UnsupportedOperationException("MockProcessorContext does not provide record collection. " +
+            "For processor unit tests, use an in-memory state store with change-logging disabled. " +
+            "Alternatively, use the TopologyTestDriver for testing processor/store/topology integration.");
     }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -37,8 +37,8 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * This is a mock of {@link ProcessorContext} provided for authors of {@link Processor},
- * {@link Transformer}, and {@link ValueTransformer}.
+ * This is a mock of {@link ProcessorContext} for users to test their {@link Processor},
+ * {@link Transformer}, and {@link ValueTransformer} implementations.
  * <p>
  * The tests for this class (org.apache.kafka.streams.MockProcessorContextTest) include several behavioral
  * tests that serve as example usage.
@@ -47,6 +47,9 @@ import java.util.Properties;
  * It simply captures any data it witnessess.
  * If you require more automated tests, we recommend wrapping your {@link Processor} in a minimal source-processor-sink
  * {@link Topology} and using the {@link TopologyTestDriver}.
+ * <p>
+ * See https://kafka.apache.org/11/documentation/streams/developer-guide/testing.html for more documentation on testing
+ * strategies.
  */
 @InterfaceStability.Evolving
 public class MockProcessorContext implements ProcessorContext {

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
@@ -19,7 +35,7 @@ import java.util.Properties;
  * This is a mock of {@link ProcessorContext} provided for authors of {@link Processor},
  * {@link org.apache.kafka.streams.kstream.Transformer}, and {@link org.apache.kafka.streams.kstream.ValueTransformer}.
  * <p>
- * The tests for this class ({@link org.apache.kafka.streams.MockProcessorContextTest}) include several behavioral
+ * The tests for this class (org.apache.kafka.streams.MockProcessorContextTest) include several behavioral
  * tests that serve as example usage.
  * <p>
  * Note that this class does not take any automated actions (such as firing scheduled punctuators).
@@ -28,7 +44,6 @@ import java.util.Properties;
  * {@link org.apache.kafka.streams.Topology} and using the {@link org.apache.kafka.streams.TopologyTestDriver}.
  * <p>
  */
-@SuppressWarnings("JavadocReference")
 @InterfaceStability.Evolving
 public class MockProcessorContext implements ProcessorContext {
     // Immutable fields ================================================
@@ -44,10 +59,10 @@ public class MockProcessorContext implements ProcessorContext {
      * {@link org.apache.kafka.streams.state.internals.InMemoryKeyValueStore}, so the stateDir won't matter.
      *
      * @param config a StreamsConfig Properties object.
-     *               {@link StreamsConfig.BOOTSTRAP_SERVERS_CONFIG} [required] is ignored.
-     *               {@link StreamsConfig.APPLICATION_ID_CONFIG} [required] will set the {@link ProcessorContext#applicationId()} value.
-     *               {@link StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG} will set the {@link ProcessorContext#keySerde()} value.
-     *               {@link StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG} will set the {@link ProcessorContext#valueSerde()} value.
+     *               StreamsConfig.BOOTSTRAP_SERVERS_CONFIG [required] is ignored.
+     *               StreamsConfig.APPLICATION_ID_CONFIG [required] will set the {@link ProcessorContext#applicationId()} value.
+     *               StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG will set the {@link ProcessorContext#keySerde()} value.
+     *               StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG will set the {@link ProcessorContext#valueSerde()} value.
      *               All properties will be available via {@link ProcessorContext#appConfigs()} and {@link ProcessorContext#appConfigsWithPrefix(String)}.
      */
     public MockProcessorContext(final Properties config) {
@@ -62,9 +77,13 @@ public class MockProcessorContext implements ProcessorContext {
         this.metrics = new StreamsMetricsImpl(new Metrics(), "mock-processor-context", new HashMap<String, String>());
     }
 
-    @Override public String applicationId() { return config.getString(StreamsConfig.APPLICATION_ID_CONFIG);}
+    @Override public String applicationId() {
+        return config.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+    }
 
-    @Override public TaskId taskId() { return taskId;}
+    @Override public TaskId taskId() {
+        return taskId;
+    }
 
     @Override public Map<String, Object> appConfigs() {
         final Map<String, Object> combined = new HashMap<>();
@@ -77,13 +96,21 @@ public class MockProcessorContext implements ProcessorContext {
         return config.originalsWithPrefix(prefix);
     }
 
-    @Override public Serde<?> keySerde() { return config.defaultKeySerde();}
+    @Override public Serde<?> keySerde() {
+        return config.defaultKeySerde();
+    }
 
-    @Override public Serde<?> valueSerde() { return config.defaultValueSerde();}
+    @Override public Serde<?> valueSerde() {
+        return config.defaultValueSerde();
+    }
 
-    @Override public File stateDir() { return stateDir;}
+    @Override public File stateDir() {
+        return stateDir;
+    }
 
-    @Override public StreamsMetrics metrics() { return metrics;}
+    @Override public StreamsMetrics metrics() {
+        return metrics;
+    }
 
     // settable record metadata ================================================
 
@@ -98,26 +125,52 @@ public class MockProcessorContext implements ProcessorContext {
         this.offset = offset;
         this.timestamp = timestamp;
     }
-    public void setTopic(final String topic) { this.topic = topic;}
-    public void setPartition(final int partition) { this.partition = partition;}
-    public void setOffset(final long offset) { this.offset = offset;}
-    public void setTimestamp(final long timestamp) { this.timestamp = timestamp;}
 
-    @Override public String topic() { return topic;}
-    @Override public int partition() { return partition;}
-    @Override public long offset() { return offset;}
-    @Override public long timestamp() { return timestamp;}
+    public void setTopic(final String topic) {
+        this.topic = topic;
+    }
+
+    public void setPartition(final int partition) {
+        this.partition = partition;
+    }
+
+    public void setOffset(final long offset) {
+        this.offset = offset;
+    }
+
+    public void setTimestamp(final long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override public String topic() {
+        return topic;
+    }
+
+    @Override public int partition() {
+        return partition;
+    }
+
+    @Override public long offset() {
+        return offset;
+    }
+
+    @Override public long timestamp() {
+        return timestamp;
+    }
 
     // mocks ================================================
 
     // state stores
     private final Map<String, StateStore> stateStores = new HashMap<>();
+
     @Override
     public void register(final StateStore store, final boolean loggingEnabledIsDeprecatedAndIgnored, final StateRestoreCallback stateRestoreCallbackIsIgnoredInMock) {
         stateStores.put(store.name(), store);
     }
 
-    @Override public StateStore getStateStore(final String name) { return stateStores.get(name);}
+    @Override public StateStore getStateStore(final String name) {
+        return stateStores.get(name);
+    }
 
     // punctuators
     public static class CapturedPunctuator {
@@ -131,9 +184,17 @@ public class MockProcessorContext implements ProcessorContext {
             this.punctuator = punctuator;
         }
 
-        public long getIntervalMs() { return intervalMs;}
-        public PunctuationType getType() { return type;}
-        public Punctuator getPunctuator() { return punctuator;}
+        public long getIntervalMs() {
+            return intervalMs;
+        }
+
+        public PunctuationType getType() {
+            return type;
+        }
+
+        public Punctuator getPunctuator() {
+            return punctuator;
+        }
     }
 
     private final List<CapturedPunctuator> punctuators = new LinkedList<>();
@@ -142,9 +203,11 @@ public class MockProcessorContext implements ProcessorContext {
     public Cancellable schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) {
         punctuators.add(new CapturedPunctuator(intervalMs, type, callback));
         return new Cancellable() {
-            @Override public void cancel() {}
+            @Override public void cancel() {
+            }
         };
     }
+
     @Override
     public void schedule(final long interval) {
         throw new UnsupportedOperationException("schedule() is deprecated and not supported in Mock. Use schedule(final long intervalMs, final PunctuationType type, final Punctuator callback) instead.");
@@ -201,7 +264,9 @@ public class MockProcessorContext implements ProcessorContext {
     }
 
     @SuppressWarnings("unchecked")
-    private <FK, FV> KeyValue castKV(final FK key, final FV value) { return new KeyValue(key, value);}
+    private <FK, FV> KeyValue castKV(final FK key, final FV value) {
+        return new KeyValue(key, value);
+    }
 
     public List<KeyValue> forwarded() {
         final LinkedList<KeyValue> result = new LinkedList<>();
@@ -231,15 +296,23 @@ public class MockProcessorContext implements ProcessorContext {
         return result;
     }
 
-    public void resetForwards() { captured = new LinkedList<>();}
+    public void resetForwards() {
+        captured = new LinkedList<>();
+    }
 
     // commits
 
     private boolean committed = false;
 
-    @Override public void commit() { committed = true; }
+    @Override public void commit() {
+        committed = true;
+    }
 
-    public boolean committed() { return committed;}
+    public boolean committed() {
+        return committed;
+    }
 
-    public void resetCommit() {committed = false;}
+    public void resetCommit() {
+        committed = false;
+    }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -300,21 +300,25 @@ public class MockProcessorContext implements ProcessorContext {
 
     @Override
     public String topic() {
+        if (topic == null) throw new IllegalStateException("Topic must be set before use via setRecordMetadata() or setTopic().");
         return topic;
     }
 
     @Override
     public int partition() {
+        if (partition == null) throw new IllegalStateException("Partition must be set before use via setRecordMetadata() or setPartition().");
         return partition;
     }
 
     @Override
     public long offset() {
+        if (offset == null) throw new IllegalStateException("Offset must be set before use via setRecordMetadata() or setOffset().");
         return offset;
     }
 
     @Override
     public long timestamp() {
+        if (timestamp == null) throw new IllegalStateException("Timestamp must be set before use via setRecordMetadata() or setTimestamp().");
         return timestamp;
     }
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/processor/MockProcessorContext.java
@@ -301,29 +301,33 @@ public class MockProcessorContext implements ProcessorContext, RecordCollector.S
 
     @Override
     public String topic() {
-        if (topic == null)
+        if (topic == null) {
             throw new IllegalStateException("Topic must be set before use via setRecordMetadata() or setTopic().");
+        }
         return topic;
     }
 
     @Override
     public int partition() {
-        if (partition == null)
+        if (partition == null) {
             throw new IllegalStateException("Partition must be set before use via setRecordMetadata() or setPartition().");
+        }
         return partition;
     }
 
     @Override
     public long offset() {
-        if (offset == null)
+        if (offset == null) {
             throw new IllegalStateException("Offset must be set before use via setRecordMetadata() or setOffset().");
+        }
         return offset;
     }
 
     @Override
     public long timestamp() {
-        if (timestamp == null)
+        if (timestamp == null) {
             throw new IllegalStateException("Timestamp must be set before use via setRecordMetadata() or setTimestamp().");
+        }
         return timestamp;
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -56,13 +56,13 @@ public class MockProcessorContextTest {
         processor.process("barbaz", 50L);
 
         final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
-        assertEquals(forwarded.next().keyValue(), new KeyValue<>("foo5", 8L));
-        assertEquals(forwarded.next().keyValue(), new KeyValue<>("barbaz50", 56L));
+        assertEquals(new KeyValue<>("foo5", 8L), forwarded.next().keyValue());
+        assertEquals(new KeyValue<>("barbaz50", 56L), forwarded.next().keyValue());
         assertFalse(forwarded.hasNext());
 
         context.resetForwards();
 
-        assertEquals(context.forwarded().size(), 0);
+        assertEquals(0, context.forwarded().size());
     }
 
     @Test
@@ -82,13 +82,13 @@ public class MockProcessorContextTest {
         processor.process("barbaz", 50L);
 
         final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
-        assertEquals(forwarded.next().keyValue(), new KeyValue<>("foo5", 8L));
-        assertEquals(forwarded.next().keyValue(), new KeyValue<>("barbaz50", 56L));
+        assertEquals(new KeyValue<>("foo5", 8L), forwarded.next().keyValue());
+        assertEquals(new KeyValue<>("barbaz50", 56L), forwarded.next().keyValue());
         assertFalse(forwarded.hasNext());
 
         context.resetForwards();
 
-        assertEquals(context.forwarded().size(), 0);
+        assertEquals(0, context.forwarded().size());
     }
 
     @Test
@@ -118,37 +118,37 @@ public class MockProcessorContextTest {
             final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
 
             final CapturedForward forward1 = forwarded.next();
-            assertEquals(forward1.keyValue(), new KeyValue<>("start", -1L));
-            assertEquals(forward1.childName(), null);
+            assertEquals(new KeyValue<>("start", -1L), forward1.keyValue());
+            assertEquals(null, forward1.childName());
 
             final CapturedForward forward2 = forwarded.next();
-            assertEquals(forward2.keyValue(), new KeyValue<>("foo5", 8L));
-            assertEquals(forward2.childName(), "george");
+            assertEquals(new KeyValue<>("foo5", 8L), forward2.keyValue());
+            assertEquals("george", forward2.childName());
 
             final CapturedForward forward3 = forwarded.next();
-            assertEquals(forward3.keyValue(), new KeyValue<>("barbaz50", 56L));
-            assertEquals(forward3.childName(), "pete");
+            assertEquals(new KeyValue<>("barbaz50", 56L), forward3.keyValue());
+            assertEquals("pete", forward3.childName());
 
             assertFalse(forwarded.hasNext());
         }
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded("george").iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("start", -1L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("foo5", 8L));
+            assertEquals(new KeyValue<>("start", -1L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("foo5", 8L), forwarded.next().keyValue());
             assertFalse(forwarded.hasNext());
         }
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded("pete").iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("start", -1L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("barbaz50", 56L));
+            assertEquals(new KeyValue<>("start", -1L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("barbaz50", 56L), forwarded.next().keyValue());
             assertFalse(forwarded.hasNext());
         }
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded("steve").iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("start", -1L));
+            assertEquals(new KeyValue<>("start", -1L), forwarded.next().keyValue());
             assertFalse(forwarded.hasNext());
         }
     }
@@ -291,14 +291,14 @@ public class MockProcessorContextTest {
         {
             processor.process("foo", 5L);
             final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("appId", "testMetadata"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("taskId", new TaskId(0, 0)));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("topic", "t1"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("partition", 0));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("offset", 0L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("timestamp", 0L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("key", "foo"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("value", 5L));
+            assertEquals(new KeyValue<>("appId", "testMetadata"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("taskId", new TaskId(0, 0)), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("topic", "t1"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("partition", 0), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("offset", 0L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("timestamp", 0L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("key", "foo"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("value", 5L), forwarded.next().keyValue());
         }
 
         context.resetForwards();
@@ -310,14 +310,14 @@ public class MockProcessorContextTest {
         {
             processor.process("bar", 50L);
             final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("appId", "testMetadata"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("taskId", new TaskId(0, 0)));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("topic", "t1"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("partition", 0));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("offset", 1L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("timestamp", 10L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("key", "bar"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("value", 50L));
+            assertEquals(new KeyValue<>("appId", "testMetadata"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("taskId", new TaskId(0, 0)), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("topic", "t1"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("partition", 0), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("offset", 1L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("timestamp", 10L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("key", "bar"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("value", 50L), forwarded.next().keyValue());
         }
 
         context.resetForwards();
@@ -328,14 +328,14 @@ public class MockProcessorContextTest {
         {
             processor.process("baz", 500L);
             final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("appId", "testMetadata"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("taskId", new TaskId(0, 0)));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("topic", "t2"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("partition", 30));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("offset", 1L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("timestamp", 10L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("key", "baz"));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("value", 500L));
+            assertEquals(new KeyValue<>("appId", "testMetadata"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("taskId", new TaskId(0, 0)), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("topic", "t2"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("partition", 30), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("offset", 1L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("timestamp", 10L), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("key", "baz"), forwarded.next().keyValue());
+            assertEquals(new KeyValue<>("value", 500L), forwarded.next().keyValue());
         }
     }
 
@@ -395,8 +395,8 @@ public class MockProcessorContextTest {
         final File dummyFile = new File("");
         final MockProcessorContext context = new MockProcessorContext(config, new TaskId(1, 1), dummyFile);
 
-        assertEquals(context.applicationId(), "testFullConstructor");
-        assertEquals(context.taskId(), new TaskId(1, 1));
+        assertEquals("testFullConstructor", context.applicationId());
+        assertEquals(new TaskId(1, 1), context.taskId());
         assertEquals("testFullConstructor", context.appConfigs().get(StreamsConfig.APPLICATION_ID_CONFIG));
         assertEquals("testFullConstructor", context.appConfigsWithPrefix("application.").get("id"));
         assertEquals(Serdes.String().getClass(), context.keySerde().getClass());

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -1,0 +1,373 @@
+package org.apache.kafka.streams;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.MockProcessorContext;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.To;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.internals.InMemoryKeyValueStore;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MockProcessorContextTest {
+    /**
+     * Behavioral test demonstrating the use of the context for capturing forwarded values
+     */
+    @Test public void testForward() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testForward");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
+            @Override public void process(final String key, final Long value) {
+                this.context().forward(key + value, key.length() + value);
+            }
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+
+        processor.init(context);
+
+        processor.process("foo", 5L);
+        processor.process("barbaz", 50L);
+
+        final Iterator<KeyValue> forwarded = context.forwarded().iterator();
+        assertEquals(forwarded.next(), new KeyValue<>("foo5", 8L));
+        assertEquals(forwarded.next(), new KeyValue<>("barbaz50", 56L));
+        Assert.assertFalse(forwarded.hasNext());
+
+        context.resetForwards();
+
+        assertEquals(context.forwarded().size(), 0);
+    }
+
+    /**
+     * Behavioral test demonstrating the use of the context for capturing forwarded values to specific children
+     */
+    @Test public void testForwardTo() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testForwardTo");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
+            private int count = 0;
+            @Override public void process(final String key, final Long value) {
+                final To child = count % 2 == 0 ? To.child("george") : To.child("pete");
+                this.context().forward(key + value, key.length() + value, child);
+                count++;
+            }
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+
+        processor.init(context);
+
+        processor.process("foo", 5L);
+        processor.process("barbaz", 50L);
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded().iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("foo5", 8L));
+            assertEquals(forwarded.next(), new KeyValue<>("barbaz50", 56L));
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded("george").iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("foo5", 8L));
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded("pete").iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("barbaz50", 56L));
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded("steve").iterator();
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        context.resetForwards();
+
+        assertEquals(context.forwarded().size(), 0);
+    }
+
+    /**
+     * Behavioral test demonstrating the use of the context for capturing forwarded values to children by index (deprecated usage)
+     */
+    @Test public void testForwardToIndex() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testForwardTo");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
+            private int count = 0;
+            @Override public void process(final String key, final Long value) {
+                this.context().forward(key + value, key.length() + value, count % 2);
+                count++;
+            }
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+
+        processor.init(context);
+
+        processor.process("foo", 5L);
+        processor.process("barbaz", 50L);
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded().iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("foo5", 8L));
+            assertEquals(forwarded.next(), new KeyValue<>("barbaz50", 56L));
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded(0).iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("foo5", 8L));
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded(1).iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("barbaz50", 56L));
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        {
+            final Iterator<KeyValue> forwarded = context.forwarded(2).iterator();
+            Assert.assertFalse(forwarded.hasNext());
+        }
+
+        context.resetForwards();
+
+        assertEquals(context.forwarded().size(), 0);
+    }
+
+    /**
+     * Behavioral test demonstrating the use of the context for capturing commits
+     */
+    @Test public void testCommit() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testCommit");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
+            private int count = 0;
+            @Override public void process(final String key, final Long value) {
+                if (++count > 2) context().commit();
+            }
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+
+        processor.init(context);
+
+        processor.process("foo", 5L);
+        processor.process("barbaz", 50L);
+
+        Assert.assertFalse(context.committed());
+
+        processor.process("foobar", 500L);
+
+        Assert.assertTrue(context.committed());
+
+        context.resetCommit();
+
+        Assert.assertFalse(context.committed());
+    }
+
+    /**
+     * Behavioral test demonstrating the use of state stores
+     */
+    @Test public void testState() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testForwardTo");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+        final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
+            @Override public void process(final String key, final Long value) {
+                //noinspection unchecked
+                final KeyValueStore<String, Long> stateStore = (KeyValueStore<String, Long>) context().getStateStore("my-state");
+                stateStore.put(key, (stateStore.get(key) == null ? 0 : stateStore.get(key)) + value);
+                stateStore.put("all", (stateStore.get("all") == null ? 0 : stateStore.get("all")) + value);
+            }
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+        final KeyValueStore<String, Long> store = new InMemoryKeyValueStore<>("my-state", Serdes.String(), Serdes.Long());
+        context.register(store, false, null);
+
+        processor.init(context);
+
+        processor.process("foo", 5L);
+        processor.process("bar", 50L);
+
+        Assert.assertEquals(5L, (long) store.get("foo"));
+        Assert.assertEquals(50L, (long) store.get("bar"));
+        Assert.assertEquals(55L, (long) store.get("all"));
+    }
+
+    /**
+     * Behavioral test demonstrating the use of the context with context-aware processors
+     */
+    @Test public void testMetadata() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testMetadata");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+        final AbstractProcessor<String, Object> processor = new AbstractProcessor<String, Object>() {
+            @Override public void process(final String key, final Object value) {
+                context().forward("appId", context().applicationId());
+                context().forward("taskId", context().taskId());
+
+                context().forward("topic", context().topic());
+                context().forward("partition", context().partition());
+                context().forward("offset", context().offset());
+                context().forward("timestamp", context().timestamp());
+
+                context().forward("key", key);
+                context().forward("value", value);
+            }
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+        processor.init(context);
+
+        try {
+            processor.process("foo", 5L);
+            Assert.fail("Should have thrown an NPE.");
+        } catch (final NullPointerException npe) {
+            // expected, since the record metadata isn't initialized
+        }
+
+        context.resetForwards();
+        context.setRecordMetadata("t1", 0, 0L, 0L);
+
+        {
+            processor.process("foo", 5L);
+            final Iterator<KeyValue> forwarded = context.forwarded().iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("appId", "testMetadata"));
+            assertEquals(forwarded.next(), new KeyValue<>("taskId", new TaskId(0, 0)));
+            assertEquals(forwarded.next(), new KeyValue<>("topic", "t1"));
+            assertEquals(forwarded.next(), new KeyValue<>("partition", 0));
+            assertEquals(forwarded.next(), new KeyValue<>("offset", 0L));
+            assertEquals(forwarded.next(), new KeyValue<>("timestamp", 0L));
+            assertEquals(forwarded.next(), new KeyValue<>("key", "foo"));
+            assertEquals(forwarded.next(), new KeyValue<>("value", 5L));
+        }
+
+        context.resetForwards();
+
+        // record metadata should be "sticky"
+        context.setOffset(1L);
+        context.setTimestamp(10L);
+
+        {
+            processor.process("bar", 50L);
+            final Iterator<KeyValue> forwarded = context.forwarded().iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("appId", "testMetadata"));
+            assertEquals(forwarded.next(), new KeyValue<>("taskId", new TaskId(0, 0)));
+            assertEquals(forwarded.next(), new KeyValue<>("topic", "t1"));
+            assertEquals(forwarded.next(), new KeyValue<>("partition", 0));
+            assertEquals(forwarded.next(), new KeyValue<>("offset", 1L));
+            assertEquals(forwarded.next(), new KeyValue<>("timestamp", 10L));
+            assertEquals(forwarded.next(), new KeyValue<>("key", "bar"));
+            assertEquals(forwarded.next(), new KeyValue<>("value", 50L));
+        }
+
+        context.resetForwards();
+        // record metadata should be "sticky"
+        context.setTopic("t2");
+        context.setPartition(30);
+
+        {
+            processor.process("baz", 500L);
+            final Iterator<KeyValue> forwarded = context.forwarded().iterator();
+            assertEquals(forwarded.next(), new KeyValue<>("appId", "testMetadata"));
+            assertEquals(forwarded.next(), new KeyValue<>("taskId", new TaskId(0, 0)));
+            assertEquals(forwarded.next(), new KeyValue<>("topic", "t2"));
+            assertEquals(forwarded.next(), new KeyValue<>("partition", 30));
+            assertEquals(forwarded.next(), new KeyValue<>("offset", 1L));
+            assertEquals(forwarded.next(), new KeyValue<>("timestamp", 10L));
+            assertEquals(forwarded.next(), new KeyValue<>("key", "baz"));
+            assertEquals(forwarded.next(), new KeyValue<>("value", 500L));
+        }
+    }
+
+    /**
+     * Behavioral test demonstrating testing captured punctuator behavior
+     */
+    @Test public void testPunctuatorCapture() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testPunctuatorCapture");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+
+
+        final Processor<String, Long> processor = new Processor<String, Long>() {
+            @Override public void init(final ProcessorContext context) {
+                context.schedule(
+                    1000L,
+                    PunctuationType.WALL_CLOCK_TIME,
+                    new Punctuator() {
+                        @Override public void punctuate(final long timestamp) {
+                            context.commit();
+                        }
+                    }
+                );
+            }
+            @Override public void process(final String key, final Long value) {}
+            @Override public void punctuate(final long timestamp) {}
+            @Override public void close() {}
+        };
+
+        final MockProcessorContext context = new MockProcessorContext(config);
+
+        processor.init(context);
+
+        assertEquals(1000L, context.scheduledPunctuators().get(0).getIntervalMs());
+        assertEquals(PunctuationType.WALL_CLOCK_TIME, context.scheduledPunctuators().get(0).getType());
+        final Punctuator punctuator = context.scheduledPunctuators().get(0).getPunctuator();
+        assertFalse(context.committed());
+        punctuator.punctuate(1234L);
+        assertTrue(context.committed());
+    }
+
+    /**
+     * Unit test verifying the full MockProcessorContext constructor
+     */
+    @Test public void testFullConstructor() {
+        final Properties config = new Properties();
+        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "testFullConstructor");
+        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "");
+        config.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+        config.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Long().getClass());
+
+        final File dummyFile = new File("");
+        final MockProcessorContext context = new MockProcessorContext(config, new TaskId(1, 1), dummyFile);
+
+        assertEquals(context.applicationId(), "testFullConstructor");
+        assertEquals(context.taskId(), new TaskId(1, 1));
+        assertEquals(context.taskId(), new TaskId(1, 1));
+        assertEquals("testFullConstructor", context.appConfigs().get(StreamsConfig.APPLICATION_ID_CONFIG));
+        assertEquals("testFullConstructor", context.appConfigsWithPrefix("application.").get("id"));
+        assertEquals(Serdes.String().getClass(), context.keySerde().getClass());
+        assertEquals(Serdes.Long().getClass(), context.valueSerde().getClass());
+        assertEquals(dummyFile, context.stateDir());
+    }
+}

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -232,6 +232,7 @@ public class MockProcessorContextTest {
         final KeyValueStore<String, Long> store = new InMemoryKeyValueStore<>("my-state", Serdes.String(), Serdes.Long());
         context.register(store, false, null);
 
+        store.init(context, store);
         processor.init(context);
 
         processor.process("foo", 5L);

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -40,9 +40,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class MockProcessorContextTest {
-    /**
-     * Behavioral test demonstrating the use of the context for capturing forwarded values
-     */
     @Test
     public void shouldCaptureOutputRecords() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -68,9 +65,6 @@ public class MockProcessorContextTest {
         assertEquals(context.forwarded().size(), 0);
     }
 
-    /**
-     * Behavioral test demonstrating the use of the context for capturing forwarded values using the To API
-     */
     @Test
     public void shouldCaptureOutputRecordsUsingTo() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -97,9 +91,6 @@ public class MockProcessorContextTest {
         assertEquals(context.forwarded().size(), 0);
     }
 
-    /**
-     * Behavioral test demonstrating the use of the context for capturing forwarded values to specific children
-     */
     @Test
     public void shouldCaptureRecordsOutputToChildByName() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -152,9 +143,6 @@ public class MockProcessorContextTest {
         }
     }
 
-    /**
-     * Unit test verifying that forwarding to child by index is not supported. This usage is deprecated.
-     */
     @Test
     public void shouldThrowIfForwardedWithDeprecatedChildIndex() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -177,9 +165,6 @@ public class MockProcessorContextTest {
         }
     }
 
-    /**
-     * Unit test verifying that forwarding to child by name is not supported. This usage is deprecated.
-     */
     @Test
     public void shouldThrowIfForwardedWithDeprecatedChildName() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -202,9 +187,6 @@ public class MockProcessorContextTest {
         }
     }
 
-    /**
-     * Behavioral test demonstrating the use of the context for capturing commits
-     */
     @Test
     public void shouldCaptureCommitsAndAllowReset() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -234,9 +216,6 @@ public class MockProcessorContextTest {
         assertFalse(context.committed());
     }
 
-    /**
-     * Behavioral test demonstrating the use of state stores
-     */
     @Test
     public void shouldStoreAndReturnStateStores() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
@@ -263,9 +242,6 @@ public class MockProcessorContextTest {
         assertEquals(55L, (long) store.get("all"));
     }
 
-    /**
-     * Behavioral test demonstrating the use of the context with context-aware processors
-     */
     @Test
     public void shouldCaptureApplicationAndRecordMetadata() {
         final Properties config = new Properties();
@@ -352,9 +328,6 @@ public class MockProcessorContextTest {
         }
     }
 
-    /**
-     * Behavioral test demonstrating testing captured punctuator behavior
-     */
     @Test
     public void shouldCapturePunctuator() {
         final Processor<String, Long> processor = new Processor<String, Long>() {
@@ -400,9 +373,6 @@ public class MockProcessorContextTest {
         assertTrue(context.committed());
     }
 
-    /**
-     * Unit test verifying the full MockProcessorContext constructor
-     */
     @Test
     public void fullConstructorShouldSetAllExpectedAttributes() {
         final Properties config = new Properties();

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -116,9 +116,19 @@ public class MockProcessorContextTest {
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("start", -1L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("foo5", 8L));
-            assertEquals(forwarded.next().keyValue(), new KeyValue<>("barbaz50", 56L));
+
+            final CapturedForward forward1 = forwarded.next();
+            assertEquals(forward1.keyValue(), new KeyValue<>("start", -1L));
+            assertEquals(forward1.childName(), null);
+
+            final CapturedForward forward2 = forwarded.next();
+            assertEquals(forward2.keyValue(), new KeyValue<>("foo5", 8L));
+            assertEquals(forward2.childName(), "george");
+
+            final CapturedForward forward3 = forwarded.next();
+            assertEquals(forward3.keyValue(), new KeyValue<>("barbaz50", 56L));
+            assertEquals(forward3.childName(), "pete");
+
             assertFalse(forwarded.hasNext());
         }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -269,8 +269,8 @@ public class MockProcessorContextTest {
 
         try {
             processor.process("foo", 5L);
-            fail("Should have thrown an NPE.");
-        } catch (final NullPointerException expected) {
+            fail("Should have thrown an exception.");
+        } catch (final IllegalStateException expected) {
             // expected, since the record metadata isn't initialized
         }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -64,6 +64,7 @@ public class MockProcessorContextTest {
 
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
             private int count = 0;
+
             @Override public void process(final String key, final Long value) {
                 final To child = count % 2 == 0 ? To.child("george") : To.child("pete");
                 this.context().forward(key + value, key.length() + value, child);
@@ -117,6 +118,7 @@ public class MockProcessorContextTest {
 
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
             private int count = 0;
+
             @Override public void process(final String key, final Long value) {
                 this.context().forward(key + value, key.length() + value, count % 2);
                 count++;
@@ -169,6 +171,7 @@ public class MockProcessorContextTest {
 
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
             private int count = 0;
+
             @Override public void process(final String key, final Long value) {
                 if (++count > 2) context().commit();
             }
@@ -331,9 +334,15 @@ public class MockProcessorContextTest {
                     }
                 );
             }
-            @Override public void process(final String key, final Long value) {}
-            @Override public void punctuate(final long timestamp) {}
-            @Override public void close() {}
+
+            @Override public void process(final String key, final Long value) {
+            }
+
+            @Override public void punctuate(final long timestamp) {
+            }
+
+            @Override public void close() {
+            }
         };
 
         final MockProcessorContext context = new MockProcessorContext(config);

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/MockProcessorContextTest.java
@@ -54,7 +54,6 @@ public class MockProcessorContextTest {
         };
 
         final MockProcessorContext context = new MockProcessorContext();
-
         processor.init(context);
 
         processor.process("foo", 5L);
@@ -63,7 +62,7 @@ public class MockProcessorContextTest {
         final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
         assertEquals(forwarded.next().kv(), new KeyValue<>("foo5", 8L));
         assertEquals(forwarded.next().kv(), new KeyValue<>("barbaz50", 56L));
-        Assert.assertFalse(forwarded.hasNext());
+        assertFalse(forwarded.hasNext());
 
         context.resetForwards();
 
@@ -92,7 +91,7 @@ public class MockProcessorContextTest {
         final Iterator<CapturedForward> forwarded = context.forwarded().iterator();
         assertEquals(forwarded.next().kv(), new KeyValue<>("foo5", 8L));
         assertEquals(forwarded.next().kv(), new KeyValue<>("barbaz50", 56L));
-        Assert.assertFalse(forwarded.hasNext());
+        assertFalse(forwarded.hasNext());
 
         context.resetForwards();
 
@@ -130,27 +129,27 @@ public class MockProcessorContextTest {
             assertEquals(forwarded.next().kv(), new KeyValue<>("start", -1L));
             assertEquals(forwarded.next().kv(), new KeyValue<>("foo5", 8L));
             assertEquals(forwarded.next().kv(), new KeyValue<>("barbaz50", 56L));
-            Assert.assertFalse(forwarded.hasNext());
+            assertFalse(forwarded.hasNext());
         }
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded("george").iterator();
             assertEquals(forwarded.next().kv(), new KeyValue<>("start", -1L));
             assertEquals(forwarded.next().kv(), new KeyValue<>("foo5", 8L));
-            Assert.assertFalse(forwarded.hasNext());
+            assertFalse(forwarded.hasNext());
         }
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded("pete").iterator();
             assertEquals(forwarded.next().kv(), new KeyValue<>("start", -1L));
             assertEquals(forwarded.next().kv(), new KeyValue<>("barbaz50", 56L));
-            Assert.assertFalse(forwarded.hasNext());
+            assertFalse(forwarded.hasNext());
         }
 
         {
             final Iterator<CapturedForward> forwarded = context.forwarded("steve").iterator();
             assertEquals(forwarded.next().kv(), new KeyValue<>("start", -1L));
-            Assert.assertFalse(forwarded.hasNext());
+            assertFalse(forwarded.hasNext());
         }
 
         context.resetForwards();
@@ -159,18 +158,15 @@ public class MockProcessorContextTest {
     }
 
     /**
-     * Behavioral test demonstrating the use of the context for capturing forwarded values to children by index (deprecated usage)
+     * Unit test verifying that forwarding to child by index is not supported. This usage is deprecated.
      */
     @Test
-    public void shouldCaptureRecordsOutputToChildByIndex() {
+    public void shouldThrowInsteadOfCaptureRecordsOutputToChildByIndex() {
         final AbstractProcessor<String, Long> processor = new AbstractProcessor<String, Long>() {
-            private int count = 0;
-
             @Override
             public void process(final String key, final Long value) {
                 //noinspection deprecation
-                this.context().forward(key + value, key.length() + value, count % 2);
-                count++;
+                this.context().forward(key, value, 0);
             }
         };
 
@@ -207,15 +203,15 @@ public class MockProcessorContextTest {
         processor.process("foo", 5L);
         processor.process("barbaz", 50L);
 
-        Assert.assertFalse(context.committed());
+        assertFalse(context.committed());
 
         processor.process("foobar", 500L);
 
-        Assert.assertTrue(context.committed());
+        assertTrue(context.committed());
 
         context.resetCommit();
 
-        Assert.assertFalse(context.committed());
+        assertFalse(context.committed());
     }
 
     /**
@@ -242,9 +238,9 @@ public class MockProcessorContextTest {
         processor.process("foo", 5L);
         processor.process("bar", 50L);
 
-        Assert.assertEquals(5L, (long) store.get("foo"));
-        Assert.assertEquals(50L, (long) store.get("bar"));
-        Assert.assertEquals(55L, (long) store.get("all"));
+        assertEquals(5L, (long) store.get("foo"));
+        assertEquals(50L, (long) store.get("bar"));
+        assertEquals(55L, (long) store.get("all"));
     }
 
     /**


### PR DESCRIPTION
We are adding a public testing utility to make it easier to unit test Processor implementations.

See KIP-267 (https://cwiki.apache.org/confluence/display/KAFKA/KIP-267%3A+Add+Processor+Unit+Test+Support+to+Kafka+Streams+Test+Utils).

The testing for this change is in this commit. There are behavioral and unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
