### PR TITLE
KAFKA-6697; JBOD configured broker should not die if log directory is invalid

### DIFF
--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -153,17 +153,18 @@ class LogManager(logDirs: Seq[File],
           throw new IOException(s"Failed to load ${dir.getAbsolutePath} during broker startup")
 
         if (!dir.exists) {
-          info("Log directory '" + dir.getAbsolutePath + "' not found, creating it.")
+          info(s"Log directory ${dir.getAbsolutePath} not found, creating it.")
           val created = dir.mkdirs()
           if (!created)
-            throw new IOException("Failed to create data directory " + dir.getAbsolutePath)
+            throw new IOException(s"Failed to create data directory ${dir.getAbsolutePath}")
         }
         if (!dir.isDirectory || !dir.canRead)
-          throw new IOException(dir.getAbsolutePath + " is not a readable log directory.")
+          throw new IOException(s"${dir.getAbsolutePath} is not a readable log directory.")
 
-        if (canonicalPaths.contains(dir.getCanonicalPath))
-          throw new KafkaException("Duplicate log directory found: " + dirs.mkString(", "))
-        canonicalPaths.add(dir.getCanonicalPath)
+        // getCanonicalPath can throw IOException if the disk is bad
+        if (!canonicalPaths.add(dir.getCanonicalPath))
+          throw new KafkaException(s"Duplicate log directory found: ${dirs.mkString(", ")}")
+
 
         liveLogDirs.add(dir)
       } catch {
@@ -172,7 +173,7 @@ class LogManager(logDirs: Seq[File],
       }
     }
     if (liveLogDirs.isEmpty) {
-      fatal(s"Shutdown broker because none of the specified log dirs from " + dirs.mkString(", ") + " can be created or validated")
+      fatal(s"Shutdown broker because none of the specified log dirs from ${dirs.mkString(", ")} can be created or validated")
       Exit.halt(1)
     }
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -161,8 +161,9 @@ class LogManager(logDirs: Seq[File],
         if (!dir.isDirectory || !dir.canRead)
           throw new IOException(s"${dir.getAbsolutePath} is not a readable log directory.")
 
-        // getCanonicalPath() can throw IOException if the disk is not properly mounted or if the path is invalid (e.g. contains Nul character)
-        // We treat both cases the same and mark the log directory as offline in either case
+        // getCanonicalPath() throws IOException if a file system query fails or if the path is invalid (e.g. contains
+        // the Nul character). Since there's no easy way to distinguish between the two cases, we treat them the same
+        // and mark the log directory as offline.
         if (!canonicalPaths.add(dir.getCanonicalPath))
           throw new KafkaException(s"Duplicate log directory found: ${dirs.mkString(", ")}")
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -161,7 +161,8 @@ class LogManager(logDirs: Seq[File],
         if (!dir.isDirectory || !dir.canRead)
           throw new IOException(s"${dir.getAbsolutePath} is not a readable log directory.")
 
-        // getCanonicalPath can throw IOException if the disk is bad
+        // getCanonicalPath() can throw IOException if the disk is not properly mounted or if the path is invalid (e.g. contains Nul character)
+        // We treat both cases the same and mark the log directory as offline in either case
         if (!canonicalPaths.add(dir.getCanonicalPath))
           throw new KafkaException(s"Duplicate log directory found: ${dirs.mkString(", ")}")
 

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -80,6 +80,9 @@ class LogManagerTest {
    */
   @Test
   def testCreateLogWithInvalidLogDir() {
+    // We would like to simulate the scenario that the disk is not properly mounted. But it is not easy to achieve in the unit test.
+    // Thus we configure a log dir path with Nul character which can cause dir.getCanonicalPath() to throw IOException
+    // as an alternative approach to simulate the scenario that the disk is that not properly mounted
     val dirs = Seq(logDir, new File("\u0000"))
 
     logManager.shutdown()

--- a/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogManagerTest.scala
@@ -76,13 +76,13 @@ class LogManagerTest {
 
   /**
    * Test that getOrCreateLog on a non-existent log creates a new log and that we can append to the new log.
-   * The LogManager is configured with one invalid log directory which should be marked as offline
+   * The LogManager is configured with one invalid log directory which should be marked as offline.
    */
   @Test
   def testCreateLogWithInvalidLogDir() {
-    // We would like to simulate the scenario that the disk is not properly mounted. But it is not easy to achieve in the unit test.
-    // Thus we configure a log dir path with Nul character which can cause dir.getCanonicalPath() to throw IOException
-    // as an alternative approach to simulate the scenario that the disk is that not properly mounted
+    // Configure the log dir with the Nul character as the path, which causes dir.getCanonicalPath() to throw an
+    // IOException. This simulates the scenario where the disk is not properly mounted (which is hard to achieve in
+    // a unit test)
     val dirs = Seq(logDir, new File("\u0000"))
 
     logManager.shutdown()


### PR DESCRIPTION
Currently JBOD configured broker will still die on startup if dir.getCanonicalPath() throws IOException. We should mark such log directory as offline and broker should still run if there is good disk.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
