### PR TITLE
Trogdor: Added commonClientConf and adminClientConf to workload specs

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.kafka.trogdor.common;
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
@@ -50,7 +49,7 @@ import java.util.concurrent.Future;
 public final class WorkerUtils {
 
     private static final List<String> CLIENT_SECURITY_KEYS = Arrays.asList(
-        CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+        AdminClientConfig.SECURITY_PROTOCOL_CONFIG,
         SaslConfigs.SASL_MECHANISM,
         SaslConfigs.SASL_JAAS_CONFIG,
         SaslConfigs.SASL_KERBEROS_SERVICE_NAME,

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.config.ConfigDef;
 
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.TimeoutException;
@@ -37,20 +36,15 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.Future;
 
 /**
  * Utilities for Trogdor TaskWorkers.
  */
 public final class WorkerUtils {
-
-    private static final ConfigDef SASL_AND_SSL_CONFIG = new ConfigDef()
-        .withClientSaslSupport().withClientSslSupport();
 
     /**
      * Handle an exception in a TaskWorker.
@@ -240,14 +234,8 @@ public final class WorkerUtils {
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, CREATE_TOPICS_REQUEST_TIMEOUT);
-
-        // copy security related props
-        Set<String> clientSecurityKeys = new HashSet<>(SASL_AND_SSL_CONFIG.configKeys().keySet());
-        clientSecurityKeys.add(AdminClientConfig.SECURITY_PROTOCOL_CONFIG);
-        for (Map.Entry<String, String> clientPropsEntry: clientConf.entrySet()) {
-            if (clientSecurityKeys.contains(clientPropsEntry.getKey())) {
-                props.put(clientPropsEntry.getKey(), clientPropsEntry.getValue());
-            }
+        for (Map.Entry<String, String> entry : clientConf.entrySet()) {
+            props.setProperty(entry.getKey(), entry.getValue());
         }
         return AdminClient.create(props);
     }

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -75,6 +75,23 @@ public final class WorkerUtils {
         return (int) perPeriod;
     }
 
+    /**
+     * Adds all properties from commonConf and then from clientConf to given 'props' (in
+     * that order, over-writing properties with the same keys).
+     * @param props              Properties object that may contain zero or more properties
+     * @param commonConf         Map with common client properties
+     * @param clientConf         Map with client properties
+     */
+    public static void addConfigsToProperties(
+        Properties props, Map<String, String> commonConf, Map<String, String> clientConf) {
+        for (Map.Entry<String, String> commonEntry : commonConf.entrySet()) {
+            props.setProperty(commonEntry.getKey(), commonEntry.getValue());
+        }
+        for (Map.Entry<String, String> entry : clientConf.entrySet()) {
+            props.setProperty(entry.getKey(), entry.getValue());
+        }
+    }
+
     private static final int CREATE_TOPICS_REQUEST_TIMEOUT = 25000;
     private static final int CREATE_TOPICS_CALL_TIMEOUT = 180000;
     private static final int MAX_CREATE_TOPICS_BATCH_SIZE = 10;
@@ -239,13 +256,9 @@ public final class WorkerUtils {
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, CREATE_TOPICS_REQUEST_TIMEOUT);
-        for (Map.Entry<String, String> entry : commonClientConf.entrySet()) {
-            props.setProperty(entry.getKey(), entry.getValue());
-        }
-        // admin client conf will override same fields in common client config
-        for (Map.Entry<String, String> entry : adminClientConf.entrySet()) {
-            props.setProperty(entry.getKey(), entry.getValue());
-        }
+        // first add common client config, and then admin client config to properties, possibly
+        // over-writing default or common properties.
+        addConfigsToProperties(props, commonClientConf, adminClientConf);
         return AdminClient.create(props);
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaException;
-
 import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicExistsException;

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -45,7 +45,6 @@ import java.util.concurrent.Future;
  * Utilities for Trogdor TaskWorkers.
  */
 public final class WorkerUtils {
-
     /**
      * Handle an exception in a TaskWorker.
      *

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -87,6 +87,9 @@ public final class WorkerUtils {
      *
      * @param log               The logger to use.
      * @param bootstrapServers  The bootstrap server list.
+     * @param commonClientConf  Common client config
+     * @param adminClientConf   AdminClient config. This config has precedence over fields in
+     *                          common client config.
      * @param topics            Maps topic names to partition assignments.
      * @param failOnExisting    If true, the method will throw TopicExistsException if one or
      *                          more topics already exist. Otherwise, the existing topics are
@@ -95,12 +98,14 @@ public final class WorkerUtils {
      *                          number of partitions, the method throws RuntimeException.
      */
     public static void createTopics(
-        Logger log, String bootstrapServers, Map<String, String> clientConf,
+        Logger log, String bootstrapServers, Map<String, String> commonClientConf,
+        Map<String, String> adminClientConf,
         Map<String, NewTopic> topics, boolean failOnExisting) throws Throwable {
         // this method wraps the call to createTopics() that takes admin client, so that we can
         // unit test the functionality with MockAdminClient. The exception is caught and
         // re-thrown so that admin client is closed when the method returns.
-        try (AdminClient adminClient = createAdminClient(bootstrapServers, clientConf)) {
+        try (AdminClient adminClient
+                 = createAdminClient(bootstrapServers, commonClientConf, adminClientConf)) {
             createTopics(log, adminClient, topics, failOnExisting);
         } catch (Exception e) {
             log.warn("Failed to create or verify topics {}", topics, e);
@@ -230,11 +235,16 @@ public final class WorkerUtils {
     }
 
     private static AdminClient createAdminClient(
-        String bootstrapServers, Map<String, String> clientConf) {
+        String bootstrapServers, Map<String, String> commonClientConf,
+        Map<String, String> adminClientConf) {
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, CREATE_TOPICS_REQUEST_TIMEOUT);
-        for (Map.Entry<String, String> entry : clientConf.entrySet()) {
+        for (Map.Entry<String, String> entry : commonClientConf.entrySet()) {
+            props.setProperty(entry.getKey(), entry.getValue());
+        }
+        // admin client conf will override same fields in common client config
+        for (Map.Entry<String, String> entry : adminClientConf.entrySet()) {
             props.setProperty(entry.getKey(), entry.getValue());
         }
         return AdminClient.create(props);

--- a/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.kafka.trogdor.common.JsonUtil;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
-import java.util.TreeMap;
 
 
 /**
@@ -106,6 +106,6 @@ public abstract class TaskSpec {
     }
 
     protected Map<String, String> configOrEmptyMap(Map<String, String> config) {
-        return (config == null) ? new TreeMap<String, String>() : config;
+        return (config == null) ? Collections.<String, String>emptyMap() : config;
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/task/TaskSpec.java
@@ -21,7 +21,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.kafka.trogdor.common.JsonUtil;
 
+import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 
 /**
@@ -101,5 +103,9 @@ public abstract class TaskSpec {
     @Override
     public String toString() {
         return JsonUtil.toJsonString(this);
+    }
+
+    protected Map<String, String> configOrEmptyMap(Map<String, String> config) {
+        return (config == null) ? new TreeMap<String, String>() : config;
     }
 }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -26,7 +26,6 @@ import org.apache.kafka.trogdor.task.TaskWorker;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.Set;
 
 /**
@@ -89,10 +88,6 @@ public class ProduceBenchSpec extends TaskSpec {
                              ? DEFAULT_NUM_PARTITIONS : partitionsPerTopic;
         this.replicationFactor = (replicationFactor == 0)
                                  ? DEFAULT_REPLICATION_FACTOR : replicationFactor;
-    }
-
-    private Map<String, String> configOrEmptyMap(Map<String, String> config) {
-        return (config == null) ? new TreeMap<String, String>() : config;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -45,6 +45,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final PayloadGenerator keyGenerator;
     private final PayloadGenerator valueGenerator;
     private final Map<String, String> producerConf;
+    private final Map<String, String> adminClientConf;
     private final Map<String, String> commonClientConf;
     private final int totalTopics;
     private final int activeTopics;
@@ -63,6 +64,7 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
                          @JsonProperty("producerConf") Map<String, String> producerConf,
                          @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
+                         @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
                          @JsonProperty("totalTopics") int totalTopics,
                          @JsonProperty("activeTopics") int activeTopics,
                          @JsonProperty("topicPrefix") String topicPrefix,
@@ -79,6 +81,7 @@ public class ProduceBenchSpec extends TaskSpec {
             new ConstantPayloadGenerator(512, new byte[0]) : valueGenerator;
         this.producerConf = configOrEmptyMap(producerConf);
         this.commonClientConf = configOrEmptyMap(commonClientConf);
+        this.adminClientConf = configOrEmptyMap(adminClientConf);
         this.totalTopics = totalTopics;
         this.activeTopics = activeTopics;
         this.topicPrefix = (topicPrefix == null) ? DEFAULT_TOPIC_PREFIX : topicPrefix;
@@ -130,6 +133,11 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public Map<String, String> commonClientConf() {
         return commonClientConf;
+    }
+
+    @JsonProperty
+    public Map<String, String> adminClientConf() {
+        return adminClientConf;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchSpec.java
@@ -45,6 +45,7 @@ public class ProduceBenchSpec extends TaskSpec {
     private final PayloadGenerator keyGenerator;
     private final PayloadGenerator valueGenerator;
     private final Map<String, String> producerConf;
+    private final Map<String, String> commonClientConf;
     private final int totalTopics;
     private final int activeTopics;
     private final String topicPrefix;
@@ -61,6 +62,7 @@ public class ProduceBenchSpec extends TaskSpec {
                          @JsonProperty("keyGenerator") PayloadGenerator keyGenerator,
                          @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
                          @JsonProperty("producerConf") Map<String, String> producerConf,
+                         @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
                          @JsonProperty("totalTopics") int totalTopics,
                          @JsonProperty("activeTopics") int activeTopics,
                          @JsonProperty("topicPrefix") String topicPrefix,
@@ -75,7 +77,8 @@ public class ProduceBenchSpec extends TaskSpec {
             new SequentialPayloadGenerator(4, 0) : keyGenerator;
         this.valueGenerator = valueGenerator == null ?
             new ConstantPayloadGenerator(512, new byte[0]) : valueGenerator;
-        this.producerConf = (producerConf == null) ? new TreeMap<String, String>() : producerConf;
+        this.producerConf = configOrEmptyMap(producerConf);
+        this.commonClientConf = configOrEmptyMap(commonClientConf);
         this.totalTopics = totalTopics;
         this.activeTopics = activeTopics;
         this.topicPrefix = (topicPrefix == null) ? DEFAULT_TOPIC_PREFIX : topicPrefix;
@@ -83,6 +86,10 @@ public class ProduceBenchSpec extends TaskSpec {
                              ? DEFAULT_NUM_PARTITIONS : partitionsPerTopic;
         this.replicationFactor = (replicationFactor == 0)
                                  ? DEFAULT_REPLICATION_FACTOR : replicationFactor;
+    }
+
+    private Map<String, String> configOrEmptyMap(Map<String, String> config) {
+        return (config == null) ? new TreeMap<String, String>() : config;
     }
 
     @JsonProperty
@@ -118,6 +125,11 @@ public class ProduceBenchSpec extends TaskSpec {
     @JsonProperty
     public Map<String, String> producerConf() {
         return producerConf;
+    }
+
+    @JsonProperty
+    public Map<String, String> commonClientConf() {
+        return commonClientConf;
     }
 
     @JsonProperty

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -109,9 +109,10 @@ public class ProduceBenchWorker implements TaskWorker {
                 Map<String, NewTopic> newTopics = new HashMap<>();
                 for (int i = 0; i < spec.totalTopics(); i++) {
                     String name = topicIndexToName(i);
-                    newTopics.put(name, new NewTopic(name, spec.numPartitions(), spec.replicationFactor()));
+                    newTopics.put(name, new NewTopic(name, spec.numPartitions(),
+                                                     spec.replicationFactor()));
                 }
-                WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.producerConf(),
+                WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
                                          newTopics, false);
 
                 executor.submit(new SendRecords());
@@ -183,6 +184,9 @@ public class ProduceBenchWorker implements TaskWorker {
                 new StatusUpdater(histogram), 1, 1, TimeUnit.MINUTES);
             Properties props = new Properties();
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.bootstrapServers());
+            for (Map.Entry<String, String> commonEntry : spec.commonClientConf().entrySet()) {
+                props.setProperty(commonEntry.getKey(), commonEntry.getValue());
+            }
             for (Map.Entry<String, String> entry : spec.producerConf().entrySet()) {
                 props.setProperty(entry.getKey(), entry.getValue());
             }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -111,7 +111,8 @@ public class ProduceBenchWorker implements TaskWorker {
                     String name = topicIndexToName(i);
                     newTopics.put(name, new NewTopic(name, spec.numPartitions(), spec.replicationFactor()));
                 }
-                WorkerUtils.createTopics(log, spec.bootstrapServers(), newTopics, false);
+                WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.producerConf(),
+                                         newTopics, false);
 
                 executor.submit(new SendRecords());
             } catch (Throwable e) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -113,7 +113,7 @@ public class ProduceBenchWorker implements TaskWorker {
                                                      spec.replicationFactor()));
                 }
                 WorkerUtils.createTopics(log, spec.bootstrapServers(), spec.commonClientConf(),
-                                         newTopics, false);
+                                         spec.adminClientConf(), newTopics, false);
 
                 executor.submit(new SendRecords());
             } catch (Throwable e) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ProduceBenchWorker.java
@@ -184,12 +184,9 @@ public class ProduceBenchWorker implements TaskWorker {
                 new StatusUpdater(histogram), 1, 1, TimeUnit.MINUTES);
             Properties props = new Properties();
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, spec.bootstrapServers());
-            for (Map.Entry<String, String> commonEntry : spec.commonClientConf().entrySet()) {
-                props.setProperty(commonEntry.getKey(), commonEntry.getValue());
-            }
-            for (Map.Entry<String, String> entry : spec.producerConf().entrySet()) {
-                props.setProperty(entry.getKey(), entry.getValue());
-            }
+            // add common client configs to producer properties, and then user-specified producer
+            // configs
+            WorkerUtils.addConfigsToProperties(props, spec.commonClientConf(), spec.producerConf());
             this.producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
             this.keys = new PayloadIterator(spec.keyGenerator());
             this.values = new PayloadIterator(spec.valueGenerator());

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -124,7 +124,7 @@ public class RoundTripWorker implements TaskWorker {
                     throw new ConfigException("Invalid null or empty partitionAssignments.");
                 }
                 WorkerUtils.createTopics(
-                    log, spec.bootstrapServers(),
+                    log, spec.bootstrapServers(), Collections.<String, String>emptyMap(),
                     Collections.singletonMap(TOPIC_NAME,
                                              new NewTopic(TOPIC_NAME, spec.partitionAssignments())),
                     true);

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -124,7 +124,7 @@ public class RoundTripWorker implements TaskWorker {
                     throw new ConfigException("Invalid null or empty partitionAssignments.");
                 }
                 WorkerUtils.createTopics(
-                    log, spec.bootstrapServers(), Collections.<String, String>emptyMap(),
+                    log, spec.bootstrapServers(), spec.commonClientConf(),
                     Collections.singletonMap(TOPIC_NAME,
                                              new NewTopic(TOPIC_NAME, spec.partitionAssignments())),
                     true);

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -184,6 +185,10 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "producer." + id);
             props.put(ProducerConfig.ACKS_CONFIG, "all");
             props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
+            // or entries can be overridden by the user via producerConf field in the spec
+            for (Map.Entry<String, String> entry : spec.producerConf().entrySet()) {
+                props.setProperty(entry.getKey(), entry.getValue());
+            }
             producer = new KafkaProducer<>(props, new ByteArraySerializer(),
                 new ByteArraySerializer());
             int perPeriod = WorkerUtils.
@@ -275,6 +280,10 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
             props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
             props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 100000);
+            // or entries can be overridden by the user via consumerConf field in the spec
+            for (Map.Entry<String, String> entry : spec.consumerConf().entrySet()) {
+                props.setProperty(entry.getKey(), entry.getValue());
+            }
             consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(),
                 new ByteArrayDeserializer());
             consumer.subscribe(Collections.singleton(TOPIC_NAME));

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -124,7 +124,7 @@ public class RoundTripWorker implements TaskWorker {
                     throw new ConfigException("Invalid null or empty partitionAssignments.");
                 }
                 WorkerUtils.createTopics(
-                    log, spec.bootstrapServers(), spec.commonClientConf(),
+                    log, spec.bootstrapServers(), spec.commonClientConf(), spec.adminClientConf(),
                     Collections.singletonMap(TOPIC_NAME,
                                              new NewTopic(TOPIC_NAME, spec.partitionAssignments())),
                     true);

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -185,12 +184,8 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "producer." + id);
             props.put(ProducerConfig.ACKS_CONFIG, "all");
             props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
-            for (Map.Entry<String, String> commonEntry : spec.commonClientConf().entrySet()) {
-                props.setProperty(commonEntry.getKey(), commonEntry.getValue());
-            }
-            for (Map.Entry<String, String> entry : spec.producerConf().entrySet()) {
-                props.setProperty(entry.getKey(), entry.getValue());
-            }
+            // user may over-write the defaults with common client config and consumer config
+            WorkerUtils.addConfigsToProperties(props, spec.commonClientConf(), spec.producerConf());
             producer = new KafkaProducer<>(props, new ByteArraySerializer(),
                 new ByteArraySerializer());
             int perPeriod = WorkerUtils.
@@ -282,12 +277,8 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
             props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
             props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 100000);
-            for (Map.Entry<String, String> commonEntry : spec.commonClientConf().entrySet()) {
-                props.setProperty(commonEntry.getKey(), commonEntry.getValue());
-            }
-            for (Map.Entry<String, String> entry : spec.consumerConf().entrySet()) {
-                props.setProperty(entry.getKey(), entry.getValue());
-            }
+            // user may over-write the defaults with common client config and consumer config
+            WorkerUtils.addConfigsToProperties(props, spec.commonClientConf(), spec.consumerConf());
             consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(),
                 new ByteArrayDeserializer());
             consumer.subscribe(Collections.singleton(TOPIC_NAME));

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -185,7 +185,9 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "producer." + id);
             props.put(ProducerConfig.ACKS_CONFIG, "all");
             props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
-            // or entries can be overridden by the user via producerConf field in the spec
+            for (Map.Entry<String, String> commonEntry : spec.commonClientConf().entrySet()) {
+                props.setProperty(commonEntry.getKey(), commonEntry.getValue());
+            }
             for (Map.Entry<String, String> entry : spec.producerConf().entrySet()) {
                 props.setProperty(entry.getKey(), entry.getValue());
             }
@@ -280,7 +282,9 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
             props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
             props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 100000);
-            // or entries can be overridden by the user via consumerConf field in the spec
+            for (Map.Entry<String, String> commonEntry : spec.commonClientConf().entrySet()) {
+                props.setProperty(commonEntry.getKey(), commonEntry.getValue());
+            }
             for (Map.Entry<String, String> entry : spec.consumerConf().entrySet()) {
                 props.setProperty(entry.getKey(), entry.getValue());
             }

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorker.java
@@ -184,7 +184,7 @@ public class RoundTripWorker implements TaskWorker {
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "producer." + id);
             props.put(ProducerConfig.ACKS_CONFIG, "all");
             props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 105000);
-            // user may over-write the defaults with common client config and consumer config
+            // user may over-write the defaults with common client config and producer config
             WorkerUtils.addConfigsToProperties(props, spec.commonClientConf(), spec.producerConf());
             producer = new KafkaProducer<>(props, new ByteArraySerializer(),
                 new ByteArraySerializer());

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -43,6 +43,7 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     private final PayloadGenerator valueGenerator;
     private final int maxMessages;
     private final Map<String, String> commonClientConf;
+    private final Map<String, String> adminClientConf;
 
     @JsonCreator
     public RoundTripWorkloadSpec(@JsonProperty("startMs") long startMs,
@@ -50,6 +51,7 @@ public class RoundTripWorkloadSpec extends TaskSpec {
              @JsonProperty("clientNode") String clientNode,
              @JsonProperty("bootstrapServers") String bootstrapServers,
              @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
+             @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
              @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
              @JsonProperty("partitionAssignments") NavigableMap<Integer, List<Integer>> partitionAssignments,
              @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
@@ -65,6 +67,8 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         this.maxMessages = maxMessages;
         this.commonClientConf = (commonClientConf == null)
                                 ? new TreeMap<String, String>() : commonClientConf;
+        this.adminClientConf = (adminClientConf == null)
+                               ? new TreeMap<String, String>() : adminClientConf;
     }
 
     @JsonProperty
@@ -100,6 +104,11 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     @JsonProperty
     public Map<String, String> commonClientConf() {
         return commonClientConf;
+    }
+
+    @JsonProperty
+    public Map<String, String> adminClientConf() {
+        return adminClientConf;
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -75,10 +75,6 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         this.consumerConf = configOrEmptyMap(consumerConf);
     }
 
-    private Map<String, String> configOrEmptyMap(Map<String, String> config) {
-        return (config == null) ? new TreeMap<String, String>() : config;
-    }
-
     @JsonProperty
     public String clientNode() {
         return clientNode;

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -26,6 +26,7 @@ import org.apache.kafka.trogdor.task.TaskWorker;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
@@ -41,12 +42,14 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     private final NavigableMap<Integer, List<Integer>> partitionAssignments;
     private final PayloadGenerator valueGenerator;
     private final int maxMessages;
+    private final Map<String, String> commonClientConf;
 
     @JsonCreator
     public RoundTripWorkloadSpec(@JsonProperty("startMs") long startMs,
              @JsonProperty("durationMs") long durationMs,
              @JsonProperty("clientNode") String clientNode,
              @JsonProperty("bootstrapServers") String bootstrapServers,
+             @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
              @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
              @JsonProperty("partitionAssignments") NavigableMap<Integer, List<Integer>> partitionAssignments,
              @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
@@ -60,6 +63,8 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         this.valueGenerator = valueGenerator == null ?
             new UniformRandomPayloadGenerator(32, 123, 10) : valueGenerator;
         this.maxMessages = maxMessages;
+        this.commonClientConf = (commonClientConf == null)
+                                ? new TreeMap<String, String>() : commonClientConf;
     }
 
     @JsonProperty
@@ -90,6 +95,11 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     @JsonProperty
     public int maxMessages() {
         return maxMessages;
+    }
+
+    @JsonProperty
+    public Map<String, String> commonClientConf() {
+        return commonClientConf;
     }
 
     @Override

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/RoundTripWorkloadSpec.java
@@ -43,6 +43,8 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     private final PayloadGenerator valueGenerator;
     private final int maxMessages;
     private final Map<String, String> commonClientConf;
+    private final Map<String, String> producerConf;
+    private final Map<String, String> consumerConf;
     private final Map<String, String> adminClientConf;
 
     @JsonCreator
@@ -52,6 +54,8 @@ public class RoundTripWorkloadSpec extends TaskSpec {
              @JsonProperty("bootstrapServers") String bootstrapServers,
              @JsonProperty("commonClientConf") Map<String, String> commonClientConf,
              @JsonProperty("adminClientConf") Map<String, String> adminClientConf,
+             @JsonProperty("consumerConf") Map<String, String> consumerConf,
+             @JsonProperty("producerConf") Map<String, String> producerConf,
              @JsonProperty("targetMessagesPerSec") int targetMessagesPerSec,
              @JsonProperty("partitionAssignments") NavigableMap<Integer, List<Integer>> partitionAssignments,
              @JsonProperty("valueGenerator") PayloadGenerator valueGenerator,
@@ -65,10 +69,14 @@ public class RoundTripWorkloadSpec extends TaskSpec {
         this.valueGenerator = valueGenerator == null ?
             new UniformRandomPayloadGenerator(32, 123, 10) : valueGenerator;
         this.maxMessages = maxMessages;
-        this.commonClientConf = (commonClientConf == null)
-                                ? new TreeMap<String, String>() : commonClientConf;
-        this.adminClientConf = (adminClientConf == null)
-                               ? new TreeMap<String, String>() : adminClientConf;
+        this.commonClientConf = configOrEmptyMap(commonClientConf);
+        this.adminClientConf = configOrEmptyMap(adminClientConf);
+        this.producerConf = configOrEmptyMap(producerConf);
+        this.consumerConf = configOrEmptyMap(consumerConf);
+    }
+
+    private Map<String, String> configOrEmptyMap(Map<String, String> config) {
+        return (config == null) ? new TreeMap<String, String>() : config;
     }
 
     @JsonProperty
@@ -109,6 +117,16 @@ public class RoundTripWorkloadSpec extends TaskSpec {
     @JsonProperty
     public Map<String, String> adminClientConf() {
         return adminClientConf;
+    }
+
+    @JsonProperty
+    public Map<String, String> producerConf() {
+        return producerConf;
+    }
+
+    @JsonProperty
+    public Map<String, String> consumerConf() {
+        return consumerConf;
     }
 
     @Override

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -49,8 +49,8 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, 0, null));
         verify(new WorkerStopping(null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, null, 0, 0, "test-topic", 1, (short) 3));
-        verify(new RoundTripWorkloadSpec(0, 0, null, null,
+            0, 0, null, null, null, null, 0, 0, "test-topic", 1, (short) 3));
+        verify(new RoundTripWorkloadSpec(0, 0, null, null, null,
             0, null, null, 0));
         verify(new SampleTaskSpec(0, 0, 0, null));
     }

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -50,7 +50,7 @@ public class JsonSerializationTest {
         verify(new WorkerStopping(null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
             0, 0, null, null, null, null, null, 0, 0, "test-topic", 1, (short) 3));
-        verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null,
+        verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null, null, null,
             0, null, null, 0));
         verify(new SampleTaskSpec(0, 0, 0, null));
     }

--- a/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
+++ b/tools/src/test/java/org/apache/kafka/trogdor/common/JsonSerializationTest.java
@@ -49,8 +49,8 @@ public class JsonSerializationTest {
         verify(new WorkerRunning(null, 0, null));
         verify(new WorkerStopping(null, 0, null));
         verify(new ProduceBenchSpec(0, 0, null, null,
-            0, 0, null, null, null, null, 0, 0, "test-topic", 1, (short) 3));
-        verify(new RoundTripWorkloadSpec(0, 0, null, null, null,
+            0, 0, null, null, null, null, null, 0, 0, "test-topic", 1, (short) 3));
+        verify(new RoundTripWorkloadSpec(0, 0, null, null, null, null,
             0, null, null, 0));
         verify(new SampleTaskSpec(0, 0, 0, null));
     }


### PR DESCRIPTION
Currently, WorkerUtils will be able to create topics when there is no security. To be able to work with secure kafka, WorkerUtils.createTopic() needs to be able to take security configs. This PR adds commonClientConf field to both producer bench and roundtrip workload specs so that users can specify security and other common configs once for producer/consumer and adminClient. Also added adminClientConf field to workload specs so that users can specify adminClient specific configs if they want to. For completeness, added consumerConf and producerConf to roundtrip workload spec.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
