### PR TITLE
MINOR: Depend on streams:test-utils for streams and examples tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -923,6 +923,7 @@ project(':streams') {
     testCompile project(':clients').sourceSets.test.output
     testCompile project(':core')
     testCompile project(':core').sourceSets.test.output
+    testCompile project(':streams:test-utils').sourceSets.main.output
     testCompile libs.junit
     testCompile libs.easymock
     testCompile libs.bcpkix
@@ -967,11 +968,12 @@ project(':streams:test-utils') {
   archivesBaseName = "kafka-streams-test-utils"
 
   dependencies {
-    compile project(':streams')
+    compile project(':streams').sourceSets.main.output
     compile project(':clients')
 
     testCompile project(':clients').sourceSets.test.output
     testCompile libs.junit
+    testCompile libs.rocksDBJni
 
     testRuntime libs.slf4jlog4j
   }


### PR DESCRIPTION
Link :streams:test-utils as a test dependency for :streams and :streams:examples, avoiding a circular dependency.

Testing strategy: the project should build.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
