### PR TITLE
KAFKA-6652: The controller should log failed attempts to transition a replica to OfflineReplica state if there is no leadership info

### DIFF
--- a/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
+++ b/core/src/main/scala/kafka/controller/ReplicaStateMachine.scala
@@ -202,6 +202,9 @@ class ReplicaStateMachine(config: KafkaConfig,
             deletePartition = false, (_, _) => ())
         }
         val replicasToRemoveFromIsr = validReplicas.filter(replica => controllerContext.partitionLeadershipInfo.contains(replica.topicPartition))
+        validReplicas.filterNot(replica => controllerContext.partitionLeadershipInfo.contains(replica.topicPartition)).foreach { replica =>
+          logFailedStateChange(replica, replicaState(replica), targetState, new IllegalStateException(s"No leadership info found for the replica $replica"))
+        }
         val updatedLeaderIsrAndControllerEpochs = removeReplicasFromIsr(replicaId, replicasToRemoveFromIsr.map(_.topicPartition))
         updatedLeaderIsrAndControllerEpochs.foreach { case (partition, leaderIsrAndControllerEpoch) =>
           if (!topicDeletionManager.isPartitionToBeDeleted(partition)) {


### PR DESCRIPTION
A controller can pick up a partially deleted topic where some partition znodes
have been deleted by the previous controller. In that case, there will be no leadership
info for the replica's partition, and hence trying to change the state of the replica to OfflineReplica
will fail. This patch adds logs to indicate the failed attempts to change the state.
There will be a separate PR to address the partially deleted topic issue.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
