### PR TITLE
[KAFKA-6702]Wrong className in LoggerFactory.getLogger method

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/JaasContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/JaasContext.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 public class JaasContext {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JaasUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JaasContext.class);
 
     private static final String GLOBAL_CONTEXT_NAME_SERVER = "KafkaServer";
     private static final String GLOBAL_CONTEXT_NAME_CLIENT = "KafkaClient";

--- a/streams/src/main/java/org/apache/kafka/streams/errors/LogAndContinueExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/LogAndContinueExceptionHandler.java
@@ -19,7 +19,6 @@ package org.apache.kafka.streams.errors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +29,7 @@ import java.util.Map;
  * signals the processing pipeline to continue processing more records.
  */
 public class LogAndContinueExceptionHandler implements DeserializationExceptionHandler {
-    private static final Logger log = LoggerFactory.getLogger(StreamThread.class);
+    private static final Logger log = LoggerFactory.getLogger(LogAndContinueExceptionHandler.class);
 
     @Override
     public DeserializationHandlerResponse handle(final ProcessorContext context,

--- a/streams/src/main/java/org/apache/kafka/streams/errors/LogAndFailExceptionHandler.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/LogAndFailExceptionHandler.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.errors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.internals.StreamThread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +29,7 @@ import java.util.Map;
  * signals the processing pipeline to stop processing more records and fail.
  */
 public class LogAndFailExceptionHandler implements DeserializationExceptionHandler {
-    private static final Logger log = LoggerFactory.getLogger(StreamThread.class);
+    private static final Logger log = LoggerFactory.getLogger(LogAndFailExceptionHandler.class);
 
     @Override
     public DeserializationHandlerResponse handle(final ProcessorContext context,


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/KAFKA-6702](https://issues.apache.org/jira/browse/KAFKA-6702)
[KAFKA-6702]Wrong className in LoggerFactory.getLogger method