### PR TITLE
KAFKA-6716: Should close the `discardChannel` in completeSend

### DIFF
--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -124,11 +124,12 @@ public class MockSelector implements Selectable {
 
     private void completeSend(Send send) throws IOException {
         // Consume the send so that we will be able to send more requests to the destination
-        ByteBufferChannel discardChannel = new ByteBufferChannel(send.size());
-        while (!send.completed()) {
-            send.writeTo(discardChannel);
+        try (ByteBufferChannel discardChannel = new ByteBufferChannel(send.size())) {
+            while (!send.completed()) {
+                send.writeTo(discardChannel);
+            }
+            completedSends.add(send);
         }
-        completedSends.add(send);
     }
 
     private void completeDelayedReceives() {


### PR DESCRIPTION
KAFKA-6716: Should close the `discardChannel` in completeSend
https://issues.apache.org/jira/browse/KAFKA-6716

Should close the `discardChannel` in MockSelector#completeSend

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
