### PR TITLE
KAFKA-6718: Rack Aware Replica Task Assignment

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsConfig.java
@@ -185,6 +185,10 @@ public class StreamsConfig extends AbstractConfig {
     public static final String APPLICATION_SERVER_CONFIG = "application.server";
     private static final String APPLICATION_SERVER_DOC = "A host:port pair pointing to an embedded user defined endpoint that can be used for discovering the locations of state stores within a single KafkaStreams application";
 
+    /**{@code rack.id} */
+    public static final String RACK_ID_CONFIG = "rack.id";
+    private static final String RACK_ID_DOC = "An identifier for the rack of a node for rack-aware replication.";
+
     /** {@code bootstrap.servers} */
     public static final String BOOTSTRAP_SERVERS_CONFIG = CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 
@@ -418,6 +422,11 @@ public class StreamsConfig extends AbstractConfig {
                     0,
                     Importance.MEDIUM,
                     NUM_STANDBY_REPLICAS_DOC)
+            .define(RACK_ID_CONFIG,
+                    Type.STRING,
+                    "",
+                    Importance.LOW,
+                    RACK_ID_DOC)
             .define(NUM_STREAM_THREADS_CONFIG,
                     Type.INT,
                     1,
@@ -781,6 +790,7 @@ public class StreamsConfig extends AbstractConfig {
         // add configs required for stream partition assignor
         consumerProps.put(REPLICATION_FACTOR_CONFIG, getInt(REPLICATION_FACTOR_CONFIG));
         consumerProps.put(APPLICATION_SERVER_CONFIG, getString(APPLICATION_SERVER_CONFIG));
+        consumerProps.put(RACK_ID_CONFIG, getString(RACK_ID_CONFIG));
         consumerProps.put(NUM_STANDBY_REPLICAS_CONFIG, getInt(NUM_STANDBY_REPLICAS_CONFIG));
         consumerProps.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, StreamPartitionAssignor.class.getName());
         consumerProps.put(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG, getLong(WINDOW_STORE_CHANGE_LOG_ADDITIONAL_RETENTION_MS_CONFIG));

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamPartitionAssignor.java
@@ -124,6 +124,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             state.addPreviousActiveTasks(info.prevTasks);
             state.addPreviousStandbyTasks(info.standbyTasks);
             state.incrementCapacity();
+            state.updateRackId(info.rackId);
         }
 
         @Override
@@ -169,6 +170,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
     };
 
     private String userEndPoint;
+    private String rackId;
     private int numStandbyReplicas;
 
     private TaskManager taskManager;
@@ -229,6 +231,8 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
             this.userEndPoint = userEndPoint;
         }
 
+        rackId = streamsConfig.getString(StreamsConfig.RACK_ID_CONFIG);
+
         internalTopicManager = new InternalTopicManager(taskManager.adminClient, streamsConfig);
 
         copartitionedTopicsValidator = new CopartitionedTopicsValidator(logPrefix);
@@ -249,7 +253,7 @@ public class StreamPartitionAssignor implements PartitionAssignor, Configurable 
         final Set<TaskId> previousActiveTasks = taskManager.prevActiveTaskIds();
         final Set<TaskId> standbyTasks = taskManager.cachedTasksIds();
         standbyTasks.removeAll(previousActiveTasks);
-        final SubscriptionInfo data = new SubscriptionInfo(taskManager.processId(), previousActiveTasks, standbyTasks, this.userEndPoint);
+        final SubscriptionInfo data = new SubscriptionInfo(taskManager.processId(), previousActiveTasks, standbyTasks, this.userEndPoint, this.rackId);
 
         taskManager.updateSubscriptionsFromMetadata(topics);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/ClientState.java
@@ -28,29 +28,34 @@ public class ClientState {
     private final Set<TaskId> prevActiveTasks;
     private final Set<TaskId> prevAssignedTasks;
 
+    private String rackId;
     private int capacity;
-
 
     public ClientState() {
         this(0);
     }
 
-    ClientState(final int capacity) {
-        this(new HashSet<TaskId>(), new HashSet<TaskId>(), new HashSet<TaskId>(), new HashSet<TaskId>(), new HashSet<TaskId>(), capacity);
+    public ClientState(int capacity) {
+        this(0, "");
     }
 
-    private ClientState(Set<TaskId> activeTasks, Set<TaskId> standbyTasks, Set<TaskId> assignedTasks, Set<TaskId> prevActiveTasks, Set<TaskId> prevAssignedTasks, int capacity) {
+    ClientState(final int capacity, final String rackId) {
+        this(new HashSet<TaskId>(), new HashSet<TaskId>(), new HashSet<TaskId>(), new HashSet<TaskId>(), new HashSet<TaskId>(), capacity, rackId);
+    }
+
+    private ClientState(Set<TaskId> activeTasks, Set<TaskId> standbyTasks, Set<TaskId> assignedTasks, Set<TaskId> prevActiveTasks, Set<TaskId> prevAssignedTasks, int capacity, String rackId) {
         this.activeTasks = activeTasks;
         this.standbyTasks = standbyTasks;
         this.assignedTasks = assignedTasks;
         this.prevActiveTasks = prevActiveTasks;
         this.prevAssignedTasks = prevAssignedTasks;
         this.capacity = capacity;
+        this.rackId = rackId;
     }
 
     public ClientState copy() {
         return new ClientState(new HashSet<>(activeTasks), new HashSet<>(standbyTasks), new HashSet<>(assignedTasks),
-                new HashSet<>(prevActiveTasks), new HashSet<>(prevAssignedTasks), capacity);
+                new HashSet<>(prevActiveTasks), new HashSet<>(prevAssignedTasks), capacity, rackId);
     }
 
     public void assign(final TaskId taskId, final boolean active) {
@@ -79,6 +84,10 @@ public class ClientState {
         capacity++;
     }
 
+    public void updateRackId(final String rackId){
+        this.rackId = rackId;
+    }
+
     public int activeTaskCount() {
         return activeTasks.size();
     }
@@ -100,6 +109,7 @@ public class ClientState {
                 ") prevActiveTasks: (" + prevActiveTasks +
                 ") prevAssignedTasks: (" + prevAssignedTasks +
                 ") capacity: " + capacity +
+                " rackId: " + rackId +
                 "]";
     }
 
@@ -139,6 +149,10 @@ public class ClientState {
 
     boolean hasAssignedTask(final TaskId taskId) {
         return assignedTasks.contains(taskId);
+    }
+
+    String getRackId(){
+        return rackId;
     }
 
     // Visible for testing


### PR DESCRIPTION
Machines in data centre are sometimes grouped in racks. Racks provide isolation as each rack may be in a different physical location and has its own power source. When tasks are properly replicated across racks, it provides fault tolerance in that if a rack goes down, the remaining racks can continue to serve traffic.
 
This feature is already implemented at Kafka KIP-36 but we needed similar for task assignments at Kafka Streams Application layer. 
 
This features enables replica tasks to be assigned on different racks for fault-tolerance.
NUM_STANDBY_REPLICAS = x
totalTasks = x+1 (replica + active)

1. If there are no rackID provided: Cluster will behave rack-unaware
2. If same rackId is given to all the nodes: Cluster will behave rack-unaware
3. If (totalTasks >= number of racks), then Cluster will be rack aware i.e. each replica task is each assigned to a different rack. Among the available racks, it'll further preserve stickiness as well as select least loaded if not stiky. 
4. If (totalTasks < number of racks), then it will first assign tasks on different racks, further tasks will be assigned to least loaded node, cluster wide.