### PR TITLE
KAFKA-6724 ConsumerPerformance resets offsets on every startup

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -157,8 +157,6 @@ object ConsumerPerformance extends LazyLogging {
       def onPartitionsRevoked(partitions: util.Collection[TopicPartition]) {
         joinStart = System.currentTimeMillis
       }})
-    consumer.poll(0)
-    consumer.seekToBeginning(Collections.emptyList())
 
     // Now start the benchmark
     val startMs = System.currentTimeMillis


### PR DESCRIPTION
### Remove consumer offset reset on startup

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
