### PR TITLE
KAFKA-6711: GlobalStateManagerImpl should not write offsets

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -267,7 +267,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         for (final Map.Entry<TopicPartition, Long> topicPartitionOffset : checkpointableOffsets.entrySet()) {
             final String topic = topicPartitionOffset.getKey().topic();
             if (globalNonPersistentStoresTopics.contains(topic)) {
-                log.debug("Skipping global store' topic {}", topic);
+                filteredOffsets.put(topicPartitionOffset.getKey(), (long) StateRestorer.NO_CHECKPOINT);
             } else {
                 filteredOffsets.put(topicPartitionOffset.getKey(), topicPartitionOffset.getValue());
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -251,9 +251,9 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
     public void checkpoint(final Map<TopicPartition, Long> offsets) {
 
         // Find non persistent store's topics
-        Map<String, String> storeToChangelogTopic = topology.storeToChangelogTopic();
-        Set<String> globalNonPersistentStoresTopics = new HashSet<>();
-        for (StateStore store : topology.globalStateStores()) {
+        final Map<String, String> storeToChangelogTopic = topology.storeToChangelogTopic();
+        final Set<String> globalNonPersistentStoresTopics = new HashSet<>();
+        for (final StateStore store : topology.globalStateStores()) {
             if (!store.persistent() && storeToChangelogTopic.containsKey(store.name())) {
                 globalNonPersistentStoresTopics.add(storeToChangelogTopic.get(store.name()));
             }
@@ -264,8 +264,8 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         final Map<TopicPartition, Long> filteredOffsets = new HashMap<>();
 
         // Skip non persistent store
-        for (Map.Entry<TopicPartition, Long> topicPartitionOffset : checkpointableOffsets.entrySet()) {
-            String topic = topicPartitionOffset.getKey().topic();
+        for (final Map.Entry<TopicPartition, Long> topicPartitionOffset : checkpointableOffsets.entrySet()) {
+            final String topic = topicPartitionOffset.getKey().topic();
             if (globalNonPersistentStoresTopics.contains(topic)) {
                 log.debug("Skipping global store' topic {}", topic);
             } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImpl.java
@@ -167,7 +167,7 @@ public class GlobalStateManagerImpl implements GlobalStateManager {
         for (final TopicPartition topicPartition : topicPartitions) {
             consumer.assign(Collections.singletonList(topicPartition));
             final Long checkpoint = checkpointableOffsets.get(topicPartition);
-            if (checkpoint != null) {
+            if (checkpoint != null && checkpoint > StateRestorer.NO_CHECKPOINT) {
                 consumer.seek(topicPartition, checkpoint);
             } else {
                 consumer.seekToBeginning(Collections.singletonList(topicPartition));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -469,21 +469,7 @@ public class GlobalStateManagerImplTest {
         stateManager.register(store3, stateRestoreCallback);
         stateManager.close(Collections.<TopicPartition, Long>emptyMap());
 
-        final OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkpointFile);
-
-        assertThat(checkpoint.read(), equalTo(Collections.<TopicPartition, Long>emptyMap()));
-    }
-
-    @Test
-    public void shouldNotSkipGlobalInMemoryStoreOffsetsToFile() throws IOException {
-        stateManager.initialize();
-        initializeConsumer(10, 1, t1);
-        stateManager.register(store1, stateRestoreCallback);
-        stateManager.close(Collections.<TopicPartition, Long>emptyMap());
-
-        final OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkpointFile);
-
-        assertThat(checkpoint.read(), equalTo(Collections.singletonMap(t1, 11L)));
+        assertThat(readOffsetsCheckpoint(), equalTo(Collections.<TopicPartition, Long>emptyMap()));
     }
 
     private Map<TopicPartition, Long> readOffsetsCheckpoint() throws IOException {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -462,6 +462,30 @@ public class GlobalStateManagerImplTest {
         assertThat(readOffsetsCheckpoint(), equalTo(checkpointMap));
     }
 
+    @Test
+    public void shouldSkipGlobalInMemoryStoreOffsetsToFile() throws IOException {
+        stateManager.initialize();
+        initializeConsumer(10, 1, t3);
+        stateManager.register(store3, stateRestoreCallback);
+        stateManager.close(Collections.<TopicPartition, Long>emptyMap());
+
+        final OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkpointFile);
+
+        assertThat(checkpoint.read(), equalTo(Collections.<TopicPartition, Long>emptyMap()));
+    }
+
+    @Test
+    public void shouldNotSkipGlobalInMemoryStoreOffsetsToFile() throws IOException {
+        stateManager.initialize();
+        initializeConsumer(10, 1, t1);
+        stateManager.register(store1, stateRestoreCallback);
+        stateManager.close(Collections.<TopicPartition, Long>emptyMap());
+
+        final OffsetCheckpoint checkpoint = new OffsetCheckpoint(checkpointFile);
+
+        assertThat(checkpoint.read(), equalTo(Collections.singletonMap(t1, 11L)));
+    }
+
     private Map<TopicPartition, Long> readOffsetsCheckpoint() throws IOException {
         final OffsetCheckpoint offsetCheckpoint = new OffsetCheckpoint(new File(stateManager.baseDir(),
                                                                                 ProcessorStateManager.CHECKPOINT_FILE_NAME));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStateManagerImplTest.java
@@ -469,7 +469,7 @@ public class GlobalStateManagerImplTest {
         stateManager.register(store3, stateRestoreCallback);
         stateManager.close(Collections.<TopicPartition, Long>emptyMap());
 
-        assertThat(readOffsetsCheckpoint(), equalTo(Collections.<TopicPartition, Long>emptyMap()));
+        assertThat(readOffsetsCheckpoint(), equalTo(Collections.singletonMap(t3, (long) StateRestorer.NO_CHECKPOINT)));
     }
 
     private Map<TopicPartition, Long> readOffsetsCheckpoint() throws IOException {

--- a/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
@@ -80,7 +80,7 @@ public class NoOpReadOnlyStore<K, V>
 
     @Override
     public boolean persistent() {
-        return false;
+        return rocksdbStore;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpReadOnlyStore.java
@@ -28,14 +28,21 @@ public class NoOpReadOnlyStore<K, V>
     private boolean open = true;
     public boolean initialized;
     public boolean flushed;
+    public boolean rocksdbStore;
 
 
     public NoOpReadOnlyStore() {
-        this("");
+        this("", false);
     }
 
+
     public NoOpReadOnlyStore(final String name) {
+        this(name, false);
+    }
+
+    public NoOpReadOnlyStore(final String name, final boolean rocksdbStore) {
         this.name = name;
+        this.rocksdbStore = rocksdbStore;
     }
 
     @Override


### PR DESCRIPTION
Backport KAFKA-6711 to 1.0.x which is actually affected codes

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
