### PR TITLE
MINOR: Downgrade to Gradle 4.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.6"
+  gradleVersion = "4.5.1"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []


### PR DESCRIPTION
There is a regression in Gradle 4.6 that causes
`testAll` (but not `test`) to fail:

https://github.com/gradle/gradle/pull/4680

`./gradlew testAll` works after this change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
