### PR TITLE
MINOR: Remove unnecessary registerGlobalStateStores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorStateManager.java
@@ -328,13 +328,6 @@ public class ProcessorStateManager extends AbstractStateManager {
         return partition == null ? taskId.partition : partition.partition();
     }
 
-    void registerGlobalStateStores(final List<StateStore> stateStores) {
-        log.debug("Register global stores {}", stateStores);
-        for (final StateStore stateStore : stateStores) {
-            globalStores.put(stateStore.name(), stateStore);
-        }
-    }
-
     @Override
     public StateStore getGlobalStore(final String name) {
         return globalStores.get(name);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -147,8 +147,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
         recordInfo = new PartitionGroup.RecordInfo();
         partitionGroup = new PartitionGroup(partitionQueues);
 
-        stateMgr.registerGlobalStateStores(topology.globalStateStores());
-
         // initialize transactions if eos is turned on, which will block if the previous transaction has not
         // completed yet; do not start the first transaction until the topology has been initialized later
         if (eosEnabled) {


### PR DESCRIPTION
While reviewing another PR I realize that registerGlobalStateStores is no longer needed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
