### PR TITLE
KAFKA-6727 fix broken Config hashCode() and equals()

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
@@ -19,8 +19,8 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class Config {
      * Configuration entries for a resource.
      */
     public Collection<ConfigEntry> entries() {
-        return new ArrayList<>(entries.values());
+        return Collections.unmodifiableCollection(entries.values());
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * A configuration object containing the configuration entries for a resource.
@@ -36,14 +37,14 @@ public class Config {
      * Create a configuration instance with the provided entries.
      */
     public Config(Collection<ConfigEntry> entries) {
-        this.entries = Collections.unmodifiableCollection(entries);
+        this.entries = Objects.requireNonNull(entries);
     }
 
     /**
      * Configuration entries for a resource.
      */
     public Collection<ConfigEntry> entries() {
-        return entries;
+        return Collections.unmodifiableCollection(entries);
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
@@ -21,40 +21,40 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A configuration object containing the configuration entries for a resource.
- *
+ * <p>
  * The API of this class is evolving, see {@link AdminClient} for details.
  */
 @InterfaceStability.Evolving
 public class Config {
 
-    private final Collection<ConfigEntry> entries;
+    private final Map<String, ConfigEntry> entries = new HashMap<>();
 
     /**
      * Create a configuration instance with the provided entries.
      */
     public Config(Collection<ConfigEntry> entries) {
-        this.entries = Objects.requireNonNull(entries);
+        for (ConfigEntry entry : entries) {
+            this.entries.put(entry.name(), entry);
+        }
     }
 
     /**
      * Configuration entries for a resource.
      */
     public Collection<ConfigEntry> entries() {
-        return Collections.unmodifiableCollection(entries);
+        return Collections.unmodifiableCollection(entries.values());
     }
 
     /**
      * Get the configuration entry with the provided name or null if there isn't one.
      */
     public ConfigEntry get(String name) {
-        for (ConfigEntry entry : entries)
-            if (entry.name().equals(name))
-                return entry;
-        return null;
+        return entries.get(name);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/Config.java
@@ -19,8 +19,8 @@ package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,7 +47,7 @@ public class Config {
      * Configuration entries for a resource.
      */
     public Collection<ConfigEntry> entries() {
-        return Collections.unmodifiableCollection(entries.values());
+        return new ArrayList<>(entries.values());
     }
 
     /**
@@ -76,6 +76,6 @@ public class Config {
 
     @Override
     public String toString() {
-        return "Config(entries=" + entries + ")";
+        return "Config(entries=" + entries.values() + ")";
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -62,6 +63,11 @@ public class ConfigTest {
     }
 
     @Test
+    public void shouldReturnComparableEntities() {
+        assertThat(new Config(config.entries()).entries(), is(equalTo(config.entries())));
+    }
+
+    @Test
     public void shouldImplementEqualsProperly() {
         final Collection<ConfigEntry> entries = new ArrayList<>();
         entries.add(E1);
@@ -80,5 +86,11 @@ public class ConfigTest {
         assertThat(config.hashCode(), is(config.hashCode()));
         assertThat(config.hashCode(), is(new Config(config.entries()).hashCode()));
         assertThat(config.hashCode(), is(not(new Config(entries).hashCode())));
+    }
+
+    @Test
+    public void shouldImplementToStringProperly() {
+        assertThat(config.toString(), containsString(E1.toString()));
+        assertThat(config.toString(), containsString(E2.toString()));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -17,47 +17,68 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConfigTest {
+    private static final ConfigEntry E1 = new ConfigEntry("a", "b");
+    private static final ConfigEntry E2 = new ConfigEntry("c", "d");
+    private Config config;
+
+    @Before
+    public void setUp() {
+        final Collection<ConfigEntry> entries = new ArrayList<>();
+        entries.add(E1);
+        entries.add(E2);
+
+        config = new Config(entries);
+    }
+
+    @Test
+    public void shouldGetEntry() {
+        assertThat(config.get("a"), is(E1));
+        assertThat(config.get("c"), is(E2));
+    }
+
+    @Test
+    public void shouldReturnNullOnGetUnknownEntry() {
+        assertThat(config.get("unknown"), is(nullValue()));
+    }
+
+    @Test
+    public void shouldGetAllEntries() {
+        assertThat(config.entries().size(), is(2));
+        assertThat(config.entries(), hasItems(E1, E2));
+    }
 
     @Test
     public void shouldImplementEqualsProperly() {
-        final ConfigEntry e1 = new ConfigEntry("a", "b");
-        final ConfigEntry e2 = new ConfigEntry("c", "d");
+        final Collection<ConfigEntry> entries = new ArrayList<>();
+        entries.add(E1);
 
-        final Collection<ConfigEntry> entries1 = new ArrayList<>();
-        entries1.add(e1);
-
-        final Collection<ConfigEntry> entries2 = new ArrayList<>();
-        entries2.add(e1);
-        entries2.add(e2);
-
-        assertThat(new Config(entries1), is(equalTo(new Config(entries1))));
-        assertThat(new Config(entries1), is(not(equalTo(new Config(entries2)))));
+        assertThat(config, is(equalTo(config)));
+        assertThat(config, is(equalTo(new Config(config.entries()))));
+        assertThat(config, is(not(equalTo(new Config(entries)))));
+        assertThat(config, is(not(equalTo((Object)"this"))));
     }
 
     @Test
     public void shouldImplementHashCodeProperly() {
-        final ConfigEntry e1 = new ConfigEntry("a", "b");
-        final ConfigEntry e2 = new ConfigEntry("c", "d");
+        final Collection<ConfigEntry> entries = new ArrayList<>();
+        entries.add(E1);
 
-        final Collection<ConfigEntry> entries1 = new ArrayList<>();
-        entries1.add(e1);
-
-        final Collection<ConfigEntry> entries2 = new ArrayList<>();
-        entries2.add(e1);
-        entries2.add(e2);
-
-        assertThat(new Config(entries1).hashCode(), is(new Config(entries1).hashCode()));
-        assertThat(new Config(entries1).hashCode(), is(not(new Config(entries2).hashCode())));
+        assertThat(config.hashCode(), is(config.hashCode()));
+        assertThat(config.hashCode(), is(new Config(config.entries()).hashCode()));
+        assertThat(config.hashCode(), is(not(new Config(entries).hashCode())));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -63,11 +63,6 @@ public class ConfigTest {
     }
 
     @Test
-    public void shouldReturnComparableEntities() {
-        assertThat(new Config(config.entries()).entries(), is(equalTo(config.entries())));
-    }
-
-    @Test
     public void shouldImplementEqualsProperly() {
         final Collection<ConfigEntry> entries = new ArrayList<>();
         entries.add(E1);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -69,7 +69,7 @@ public class ConfigTest {
         assertThat(config, is(equalTo(config)));
         assertThat(config, is(equalTo(new Config(config.entries()))));
         assertThat(config, is(not(equalTo(new Config(entries)))));
-        assertThat(config, is(not(equalTo((Object)"this"))));
+        assertThat(config, is(not(equalTo((Object) "this"))));
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/ConfigTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.clients.admin;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ConfigTest {
+
+    @Test
+    public void shouldImplementEqualsProperly() {
+        final ConfigEntry e1 = new ConfigEntry("a", "b");
+        final ConfigEntry e2 = new ConfigEntry("c", "d");
+
+        final Collection<ConfigEntry> entries1 = new ArrayList<>();
+        entries1.add(e1);
+
+        final Collection<ConfigEntry> entries2 = new ArrayList<>();
+        entries2.add(e1);
+        entries2.add(e2);
+
+        assertThat(new Config(entries1), is(equalTo(new Config(entries1))));
+        assertThat(new Config(entries1), is(not(equalTo(new Config(entries2)))));
+    }
+
+    @Test
+    public void shouldImplementHashCodeProperly() {
+        final ConfigEntry e1 = new ConfigEntry("a", "b");
+        final ConfigEntry e2 = new ConfigEntry("c", "d");
+
+        final Collection<ConfigEntry> entries1 = new ArrayList<>();
+        entries1.add(e1);
+
+        final Collection<ConfigEntry> entries2 = new ArrayList<>();
+        entries2.add(e1);
+        entries2.add(e2);
+
+        assertThat(new Config(entries1).hashCode(), is(new Config(entries1).hashCode()));
+        assertThat(new Config(entries1).hashCode(), is(not(new Config(entries2).hashCode())));
+    }
+}


### PR DESCRIPTION
Fix for [KAFKA-6727](https://issues.apache.org/jira/browse/KAFKA-6727).

Current implementation stores reference to `entries` wrapped in `Collections.unmodifiableCollection`, which breaks `hashCode` and `equals`.

From [Java docs](https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#unmodifiableCollection\(java.util.Collection\))

> The returned collection does not pass the hashCode and equals operations through to the backing collection, but relies on Object's equals and hashCode methods.

Contribution is my own original work and I license the work to the project under the project's open source license.

