### PR TITLE
KAFKA-6728 Kafka Connect Header Null Pointer Exception

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -498,6 +498,7 @@ class WorkerSinkTask extends WorkerTask {
         if (recordHeaders != null) {
             String topic = record.topic();
             for (org.apache.kafka.common.header.Header recordHeader : recordHeaders) {
+                if (recordHeader == null) continue;
                 SchemaAndValue schemaAndValue = headerConverter.toConnectHeader(topic, recordHeader.key(), recordHeader.value());
                 result.add(recordHeader.key(), schemaAndValue);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -292,6 +292,7 @@ class WorkerSourceTask extends WorkerTask {
         if (headers != null) {
             String topic = record.topic();
             for (Header header : headers) {
+                if (header == null) continue;
                 String key = header.key();
                 byte[] rawHeader = headerConverter.fromConnectHeader(topic, key, header.schema(), header.value());
                 result.add(key, rawHeader);


### PR DESCRIPTION
Guard against potential null recordHeader in WorkerSinkTask#convertHeadersFor

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
