### PR TITLE
MINOR: Bump version to 2.0.0-SNAPSHOT

### DIFF
--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -210,6 +210,6 @@ case object KAFKA_1_1_IV0 extends ApiVersion {
 
 case object KAFKA_2_0_IV0 extends ApiVersion {
   val version: String = "2.0-IV0"
-  val messageFormatVersion: Byte = RecordBatch.MAGIC_VALUE_V2
+  val messageFormatVersion = RecordFormat.V2
   val id: Int = 15
 }

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -76,7 +76,9 @@ object ApiVersion {
     // Introduced DeleteGroupsRequest V0 via KIP-229, plus KIP-227 incremental fetch requests,
     // and KafkaStorageException for fetch requests.
     "1.1-IV0" -> KAFKA_1_1_IV0,
-    "1.1" -> KAFKA_1_1_IV0
+    "1.1" -> KAFKA_1_1_IV0,
+    "2.0-IV0" -> KAFKA_2_0_IV0,
+    "2.0" -> KAFKA_2_0_IV0
   )
 
   private val versionPattern = "\\.".r
@@ -204,4 +206,10 @@ case object KAFKA_1_1_IV0 extends ApiVersion {
   val version: String = "1.1-IV0"
   val messageFormatVersion = RecordFormat.V2
   val id: Int = 14
+}
+
+case object KAFKA_2_0_IV0 extends ApiVersion {
+  val version: String = "2.0-IV0"
+  val messageFormatVersion: Byte = RecordBatch.MAGIC_VALUE_V2
+  val id: Int = 15
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 group=org.apache.kafka
 # NOTE: When you change this version number, you should also make sure to update
 # the version numbers in tests/kafkatest/__init__.py and kafka-merge-pr.py.
-version=1.2.0-SNAPSHOT
+version=2.0.0-SNAPSHOT
 scalaVersion=2.11.12
 task=build
 org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m -Xss2m

--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -70,7 +70,7 @@ TEMP_BRANCH_PREFIX = "PR_TOOL"
 
 DEV_BRANCH_NAME = "trunk"
 
-DEFAULT_FIX_VERSION = os.environ.get("DEFAULT_FIX_VERSION", "1.2.0")
+DEFAULT_FIX_VERSION = os.environ.get("DEFAULT_FIX_VERSION", "2.0.0")
 
 def get_json(url):
     try:

--- a/tests/kafkatest/__init__.py
+++ b/tests/kafkatest/__init__.py
@@ -22,4 +22,4 @@
 # Instead, in development branches, the version should have a suffix of the form ".devN"
 #
 # For example, when Kafka is at version 1.0.0-SNAPSHOT, this should be something like "1.0.0.dev0"
-__version__ = '1.2.0.dev0'
+__version__ = '2.0.0.dev0'


### PR DESCRIPTION
I proposed last year that the June/July release should be 2.0.0 to allow us to:

* Bump the minimum Java version to 8
* Remove the deprecated Scala clients

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
