### PR TITLE
KAFKA-6732

### DIFF
--- a/docs/streams/developer-guide/write-streams.html
+++ b/docs/streams/developer-guide/write-streams.html
@@ -40,7 +40,7 @@
           <li><a class="reference internal" href="#testing-a-streams-app" id="id3">Testing a Streams application</a></li>
       </ul>
     <p>Any Java application that makes use of the Kafka Streams library is considered a Kafka Streams application.
-      The computational logic of a Kafka Streams application is defined as a <a class="reference internal" href="../concepts.html#streams-concepts"><span class="std std-ref">processor topology</span></a>,
+      The computational logic of a Kafka Streams application is defined as a <a class="reference internal" href="../core-concepts#streams_topology"><span class="std std-ref">processor topology</span></a>,
       which is a graph of stream processors (nodes) and streams (edges).</p>
     <p>You can define the processor topology with the Kafka Streams APIs:</p>
     <dl class="docutils">


### PR DESCRIPTION
The link to processor topology on write-streams.html is redirecting to 404 error.
Links which result in 404 : referred from https://kafka.apache.org/11/documentation/streams/developer-guide/write-streams.html

Broken :
https://kafka.apache.org/11/documentation/streams/concepts.html#streams-concepts 

https://kafka.apache.org/documentation/streams/concepts.html#streams-concepts 