### PR TITLE
KAFKA-6733: Support of printing additional ConsumerRecord fields in DefaultMessageFormatter

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -223,16 +223,22 @@ object ConsoleConsumer extends Logging {
       .ofType(classOf[String])
       .defaultsTo(classOf[DefaultMessageFormatter].getName)
     val messageFormatterArgOpt = parser.accepts("property",
-      "The properties to initialize the message formatter. Default properties include:\n" +
-        "\tprint.timestamp=true|false\n" +
-        "\tprint.key=true|false\n" +
-        "\tprint.value=true|false\n" +
-        "\tkey.separator=<key.separator>\n" +
-        "\tline.separator=<line.separator>\n" +
-        "\tkey.deserializer=<key.deserializer>\n" +
-        "\tvalue.deserializer=<value.deserializer>\n" +
-        "\nUsers can also pass in customized properties for their formatter; more specifically, users " +
-        "can pass in properties keyed with \'key.deserializer.\' and \'value.deserializer.\' prefixes to configure their deserializers.")
+      """The properties to initialize the message formatter. Default properties include:
+        |	print.timestamp=true|false
+        |	print.key=true|false
+        |	print.offset=true|false
+        |	print.partition=true|false
+        |	print.headers=true|false
+        |	print.value=true|false
+        |	key.separator=<key.separator>
+        |	line.separator=<line.separator>
+        |	headers.separator=<line.separator>
+        |	key.deserializer=<key.deserializer>
+        |	value.deserializer=<value.deserializer>
+        |	header.deserializer=<header.deserializer>
+        |
+        |Users can also pass in customized properties for their formatter; more specifically, users can pass in properties keyed with 'key.deserializer.', 'value.deserializer.' and 'headers.deserializer.' prefixes to configure their deserializers."""
+        .stripMargin)
       .withRequiredArg
       .describedAs("prop")
       .ofType(classOf[String])
@@ -464,7 +470,7 @@ class DefaultMessageFormatter extends MessageFormatter {
   var printHeaders = false
   var printValue = true
   var keySeparator = utfBytes("\t")
-  var headerSeparator = utfBytes(",")
+  var headersSeparator = utfBytes(",")
   var lineSeparator = utfBytes("\n")
 
   var keyDeserializer: Option[Deserializer[_]] = None
@@ -480,7 +486,7 @@ class DefaultMessageFormatter extends MessageFormatter {
     getPropertyIfExists(props, "print.value", getBoolProperty).foreach(printValue = _)
     getPropertyIfExists(props, "key.separator", getByteProperty).foreach(keySeparator = _)
     getPropertyIfExists(props, "line.separator", getByteProperty).foreach(lineSeparator = _)
-    getPropertyIfExists(props, "header.separator", getByteProperty).foreach(headerSeparator = _)
+    getPropertyIfExists(props, "headers.separator", getByteProperty).foreach(headersSeparator = _)
 
     keyDeserializer = getPropertyIfExists(props, "key.deserializer", getDeserializerProperty(true))
     valueDeserializer = getPropertyIfExists(props, "value.deserializer", getDeserializerProperty(false))
@@ -532,7 +538,7 @@ class DefaultMessageFormatter extends MessageFormatter {
           output.write(utfBytes(header.key() + ":"))
           output.write(deserialize(headersDeserializer, header.value(), topic))
           if(headersIt.hasNext) {
-            output.write(headerSeparator)
+            output.write(headersSeparator)
           }
         }
       } else {

--- a/core/src/test/scala/unit/kafka/tools/DefaultMessageFormatterTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DefaultMessageFormatterTest.scala
@@ -1,0 +1,226 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.tools
+
+import java.io.{ByteArrayOutputStream, Closeable, PrintStream}
+import java.nio.charset.StandardCharsets
+import java.util
+import java.util.Properties
+
+import kafka.tools.DefaultMessageFormatter
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.header.Header
+import org.apache.kafka.common.header.internals.{RecordHeader, RecordHeaders}
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.common.serialization.Deserializer
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+
+import scala.collection.JavaConverters._
+
+@RunWith(value = classOf[Parameterized])
+class DefaultMessageFormatterTest(name: String, record: ConsumerRecord[Array[Byte], Array[Byte]], properties: Map[String, String], expected: String) {
+  import DefaultMessageFormatterTest._
+
+  @Test
+  def testWriteRecord() {
+    withResource(new ByteArrayOutputStream()) { baos =>
+      withResource(new PrintStream(baos)) { ps =>
+        val formatter = buildFormatter(properties)
+        formatter.writeTo(record, ps)
+        val actual = new String(baos.toByteArray(), StandardCharsets.UTF_8)
+        assertEquals(expected, actual)
+
+      }
+    }
+  }
+}
+
+object DefaultMessageFormatterTest {
+  @Parameters(name = "Test {index} - {0}")
+  def parameters: java.util.Collection[Array[Object]] = {
+    Seq(
+      Array(
+        "print nothing",
+        consumerRecord(),
+        Map("print.value" -> "false"),
+        ""),
+      Array(
+        "print key",
+        consumerRecord(),
+        Map("print.key" -> "true", "print.value" -> "false"),
+        "someKey\n"),
+      Array(
+        "print value",
+        consumerRecord(),
+        Map(),
+        "someValue\n"),
+      Array(
+        "print empty timestamp",
+        consumerRecord(timestampType = TimestampType.NO_TIMESTAMP_TYPE),
+        Map("print.timestamp" -> "true", "print.value" -> "false"),
+        "NO_TIMESTAMP\n"),
+      Array(
+        "print log append time timestamp",
+        consumerRecord(timestampType = TimestampType.LOG_APPEND_TIME),
+        Map("print.timestamp" -> "true", "print.value" -> "false"),
+        "LogAppendTime:1234\n"),
+      Array(
+        "print create time timestamp",
+        consumerRecord(timestampType = TimestampType.CREATE_TIME),
+        Map("print.timestamp" -> "true", "print.value" -> "false"),
+        "CreateTime:1234\n"),
+      Array(
+        "print partition",
+        consumerRecord(),
+        Map("print.partition" -> "true", "print.value" -> "false"),
+        "9\n"),
+      Array(
+        "print offset",
+        consumerRecord(),
+        Map("print.offset" -> "true", "print.value" -> "false"),
+        "9876\n"),
+      Array(
+        "print headers",
+        consumerRecord(),
+        Map("print.headers" -> "true", "print.value" -> "false"),
+        "h1:v1,h2:v2\n"),
+      Array(
+        "print empty headers",
+        consumerRecord(headers = Nil),
+        Map("print.headers" -> "true", "print.value" -> "false"),
+        "NO_HEADERS\n"),
+      Array(
+        "print all possible fields with default delimiters",
+        consumerRecord(),
+        Map("print.key" -> "true",
+          "print.timestamp" -> "true",
+          "print.partition" -> "true",
+          "print.offset" -> "true",
+          "print.headers" -> "true",
+          "print.value" -> "true"),
+        "CreateTime:1234\tsomeKey\t9876\t9\th1:v1,h2:v2\tsomeValue\n"),
+      Array(
+        "print all possible fields with custom delimiters",
+        consumerRecord(),
+        Map(
+          "key.separator" -> "|",
+          "line.separator" -> "^",
+          "header.separator" -> "#",
+          "print.key" -> "true",
+          "print.timestamp" -> "true",
+          "print.partition" -> "true",
+          "print.offset" -> "true",
+          "print.headers" -> "true",
+          "print.value" -> "true"),
+        "CreateTime:1234|someKey|9876|9|h1:v1#h2:v2|someValue^"),
+      Array(
+        "print key with custom deserializer",
+        consumerRecord(),
+        Map(
+          "print.key" -> "true",
+          "print.headers" -> "true",
+          "print.value" -> "true",
+          "key.deserializer" -> "unit.kafka.tools.UpperCaseDeserializer"),
+        "SOMEKEY\th1:v1,h2:v2\tsomeValue\n"),
+      Array(
+        "print value with custom deserializer",
+        consumerRecord(),
+        Map(
+          "print.key" -> "true",
+          "print.headers" -> "true",
+          "print.value" -> "true",
+          "value.deserializer" -> "unit.kafka.tools.UpperCaseDeserializer"),
+        "someKey\th1:v1,h2:v2\tSOMEVALUE\n"),
+      Array(
+        "print headers with custom deserializer",
+        consumerRecord(),
+        Map(
+          "print.key" -> "true",
+          "print.headers" -> "true",
+          "print.value" -> "true",
+          "headers.deserializer" -> "unit.kafka.tools.UpperCaseDeserializer"),
+        "someKey\th1:V1,h2:V2\tsomeValue\n"),
+      Array(
+        "print key and value",
+        consumerRecord(),
+        Map("print.key" -> "true", "print.value" -> "true"),
+        "someKey\tsomeValue\n"),
+      Array(
+        "print fields in the beginning, middle and the end",
+        consumerRecord(),
+        Map("print.key" -> "true", "print.value" -> "true", "print.partition" -> "true"),
+        "someKey\t9\tsomeValue\n")
+    ).asJava
+  }
+
+  private def buildFormatter(propsToSet: Map[String, String]): DefaultMessageFormatter = {
+    val properties = new Properties()
+    //putAll doesn't work on java 9 - https://github.com/scala/bug/issues/10418
+    propsToSet.foreach { case (k, v) =>
+      properties.setProperty(k, v)
+    }
+    val formatter = new DefaultMessageFormatter()
+    formatter.init(properties)
+    formatter
+  }
+
+
+  private def header(key: String, value: String) = {
+    new RecordHeader(key, value.getBytes(StandardCharsets.UTF_8))
+  }
+
+  private def consumerRecord(key: String = "someKey",
+                             value: String = "someValue",
+                             headers: Iterable[Header] = Seq(header("h1", "v1"), header("h2", "v2")),
+                             partition: Int = 9,
+                             offset: Long = 9876,
+                             timestamp: Long = 1234,
+                             timestampType: TimestampType = TimestampType.CREATE_TIME) = {
+    new ConsumerRecord[Array[Byte], Array[Byte]](
+      "someTopic",
+      partition,
+      offset,
+      timestamp,
+      timestampType,
+      0L,
+      0,
+      0,
+      key.getBytes(StandardCharsets.UTF_8),
+      value.getBytes(StandardCharsets.UTF_8),
+      new RecordHeaders(headers.asJava))
+
+  }
+
+  private def withResource[Resource <: Closeable, Result](resource: Resource)(handler: Resource => Result): Result = {
+    try {
+      handler(resource)
+    } finally {
+      resource.close()
+    }
+  }
+}
+
+class UpperCaseDeserializer extends Deserializer[String] {
+  override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}
+  override def deserialize(topic: String, data: Array[Byte]): String = new String(data, StandardCharsets.UTF_8).toUpperCase
+  override def close(): Unit = {}
+}

--- a/core/src/test/scala/unit/kafka/tools/DefaultMessageFormatterTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DefaultMessageFormatterTest.scala
@@ -124,7 +124,7 @@ object DefaultMessageFormatterTest {
         Map(
           "key.separator" -> "|",
           "line.separator" -> "^",
-          "header.separator" -> "#",
+          "headers.separator" -> "#",
           "print.key" -> "true",
           "print.timestamp" -> "true",
           "print.partition" -> "true",


### PR DESCRIPTION
New supported fields: offset, partition and headers. Code is backward compatible, so output will remain the same if user won't specify new configuration properties.
Added unit tests to DefaultMessageFormatter which cover previous and new properties.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
