### PR TITLE
KAFKA-6731: waitOnState should check the state to be the target start.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -215,7 +215,7 @@ public class KafkaStreams {
         long begin = time.milliseconds();
         synchronized (stateLock) {
             long elapsedMs = 0L;
-            while (state != State.NOT_RUNNING) {
+            while (state != targetState) {
                 if (waitMs == 0) {
                     try {
                         stateLock.wait();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6731

KafkaStreams.waitOnState() should check the state to be the given one instead of the hard-coded `NOT_RUNNING`.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
