### PR TITLE
MINOR: Make kafka-streams-test-utils dependencies work with releases tarballs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -968,9 +968,18 @@ project(':streams:test-utils') {
   archivesBaseName = "kafka-streams-test-utils"
 
   dependencies {
-    compile project(':streams').sourceSets.main.output
+    // streams and streams-test-utils have a circular dependency that needs to be broken. Making streams a regular
+    // compile dependency here is a circular dependency. Making the streams project's main sourceSet output a dependency
+    // incorrectly includes raw class files as dependencies and ends up including them in output like the release tgz.
+    // Making the main sourceSet's output a compileOnly (provided) dependency resolves the circular dependency in gradle
+    // and also leaves the raw class files out of the output. This does require that users of this jar specify the
+    // streams dependency separately, but they wouldn't be using this module in tests unless they already had a
+    // compile dependency on streams. For this module, however, we need to also include streams as a separate test
+    // dependency since it is compileOnly/provided for the compile phase.
+    compileOnly project(':streams').sourceSets.main.output
     compile project(':clients')
 
+    testCompile project(':streams')
     testCompile project(':clients').sourceSets.test.output
     testCompile libs.junit
     testCompile libs.rocksDBJni


### PR DESCRIPTION
https://github.com/apache/kafka/pull/4760 unintentionally included extra raw class files in the release tarballs by making the .class file output (instead of the jar) for a streams a dependency of the streams-test-utils. This fixes that issue by instead breaking the circular dependency by using a `compileOnly`/`provided` dependency on those sources and also including the dependency as a test dependency.

I verified by using `gradlew clean installAll releaseTarGzAll`, then checking that the release tarball doesn't have the extraneous files and the installed pom file has the expected dependencies. The dependency on kafka-streams is now in the `test` scope, but that should be fine since a streams application would only use this dependency if it already had a dependency on streams in `compile` (or in weird edge cases the user could handle specifying the right dependencies). This actually seems to even be an improvement over the previous situation where the actual dependency was not expressed in the pom at all (since the dependency was on the sourceSet output rather than the actual project).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
