### PR TITLE
KAFKA-6743 ConsumerPerformance fails to consume all messages 

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -186,11 +186,11 @@ object ConsumerPerformance extends LazyLogging {
           lastBytesRead = bytesRead
         }
       }
-      if (messagesRead < count)
-        println(s"WARNING: Exiting before consuming the expected number of messages: timeout ($timeout ms) exceeded. " +
-          s"Probably too much time spent on processing a polled list of records. Be sure to increase the --timeout option")
     }
 
+    if (messagesRead < count)
+      println(s"WARNING: Exiting before consuming the expected number of messages: timeout ($timeout ms) exceeded. " +
+        s"Probably too much time spent on processing a polled list of records. Be sure to increase the --timeout option.")
     totalMessagesRead.set(messagesRead)
     totalBytesRead.set(bytesRead)
   }

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -65,7 +65,7 @@ object ConsumerPerformance extends LazyLogging {
       val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](config.props)
       consumer.subscribe(Collections.singletonList(config.topic))
       startMs = System.currentTimeMillis
-      consume(consumer, List(config.topic), config.numMessages, 1000, config, totalMessagesRead, totalBytesRead, joinGroupTimeInMs, startMs)
+      consume(consumer, List(config.topic), config.numMessages, config.pollLoopTimeout, config, totalMessagesRead, totalBytesRead, joinGroupTimeInMs, startMs)
       endMs = System.currentTimeMillis
 
       if (config.printMetrics) {
@@ -302,6 +302,11 @@ object ConsumerPerformance extends LazyLogging {
     val printMetricsOpt = parser.accepts("print-metrics", "Print out the metrics. This only applies to new consumer.")
     val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
       "interval as configured by reporting-interval")
+    val pollLoopTimeoutOpt = parser.accepts("polling-loop-timeout", "Consumer polling loop timeout.")
+      .withOptionalArg()
+      .describedAs("count")
+      .ofType(classOf[Long])
+      .defaultsTo(1000)
 
     val options = parser.parse(args: _*)
 
@@ -354,6 +359,7 @@ object ConsumerPerformance extends LazyLogging {
     val showDetailedStats = options.has(showDetailedStatsOpt)
     val dateFormat = new SimpleDateFormat(options.valueOf(dateFormatOpt))
     val hideHeader = options.has(hideHeaderOpt)
+    val pollLoopTimeout = options.valueOf(pollLoopTimeoutOpt).longValue()
   }
 
   class ConsumerPerfThread(threadId: Int,

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -187,7 +187,8 @@ object ConsumerPerformance extends LazyLogging {
         }
       }
       if (messagesRead < count)
-        println(s"Exiting before consuming all messages: polling-loop-timeout ($timeout ms) exceeded. Check --polling-loop-timeout option")
+        println(s"WARNING: Exiting before consuming the expected number of messages: timeout ($timeout ms) exceeded. " +
+          s"Probably too much time spent on processing a polled list of records. Be sure to increase the --timeout option")
     }
 
     totalMessagesRead.set(messagesRead)
@@ -304,11 +305,11 @@ object ConsumerPerformance extends LazyLogging {
     val printMetricsOpt = parser.accepts("print-metrics", "Print out the metrics. This only applies to new consumer.")
     val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
       "interval as configured by reporting-interval")
-    val pollLoopTimeoutOpt = parser.accepts("polling-loop-timeout", "Consumer polling loop timeout.")
+    val pollLoopTimeoutOpt = parser.accepts("timeout", "Consumer polling loop timeout.")
       .withOptionalArg()
       .describedAs("count")
       .ofType(classOf[Long])
-      .defaultsTo(60000)
+      .defaultsTo(10000)
 
     val options = parser.parse(args: _*)
 

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -186,6 +186,8 @@ object ConsumerPerformance extends LazyLogging {
           lastBytesRead = bytesRead
         }
       }
+      if (messagesRead < count)
+        println(s"Exiting before consuming all messages: polling-loop-timeout ($timeout ms) exceeded. Check --polling-loop-timeout option")
     }
 
     totalMessagesRead.set(messagesRead)
@@ -306,7 +308,7 @@ object ConsumerPerformance extends LazyLogging {
       .withOptionalArg()
       .describedAs("count")
       .ofType(classOf[Long])
-      .defaultsTo(1000)
+      .defaultsTo(60000)
 
     val options = parser.parse(args: _*)
 

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -65,7 +65,7 @@ object ConsumerPerformance extends LazyLogging {
       val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](config.props)
       consumer.subscribe(Collections.singletonList(config.topic))
       startMs = System.currentTimeMillis
-      consume(consumer, List(config.topic), config.numMessages, config.pollLoopTimeout, config, totalMessagesRead, totalBytesRead, joinGroupTimeInMs, startMs)
+      consume(consumer, List(config.topic), config.numMessages, config.recordFetchTimeoutMs, config, totalMessagesRead, totalBytesRead, joinGroupTimeInMs, startMs)
       endMs = System.currentTimeMillis
 
       if (config.printMetrics) {
@@ -305,9 +305,9 @@ object ConsumerPerformance extends LazyLogging {
     val printMetricsOpt = parser.accepts("print-metrics", "Print out the metrics. This only applies to new consumer.")
     val showDetailedStatsOpt = parser.accepts("show-detailed-stats", "If set, stats are reported for each reporting " +
       "interval as configured by reporting-interval")
-    val pollLoopTimeoutOpt = parser.accepts("timeout", "Consumer polling loop timeout.")
+    val recordFetchTimeoutOpt = parser.accepts("timeout", "The maximum allowed time in milliseconds between returned records.")
       .withOptionalArg()
-      .describedAs("count")
+      .describedAs("milliseconds")
       .ofType(classOf[Long])
       .defaultsTo(10000)
 
@@ -362,7 +362,7 @@ object ConsumerPerformance extends LazyLogging {
     val showDetailedStats = options.has(showDetailedStatsOpt)
     val dateFormat = new SimpleDateFormat(options.valueOf(dateFormatOpt))
     val hideHeader = options.has(hideHeaderOpt)
-    val pollLoopTimeout = options.valueOf(pollLoopTimeoutOpt).longValue()
+    val recordFetchTimeoutMs = options.valueOf(recordFetchTimeoutOpt).longValue()
   }
 
   class ConsumerPerfThread(threadId: Int,

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -33,11 +33,11 @@ import java.util.{Collections, Properties, Random}
 import kafka.consumer.Consumer
 import kafka.consumer.ConsumerConnector
 import kafka.consumer.KafkaStream
+import kafka.consumer.ConsumerTimeoutException
 import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.common.errors.TimeoutException
 
 import scala.collection.mutable
 
@@ -401,7 +401,7 @@ object ConsumerPerformance extends LazyLogging {
       } catch {
         case _: InterruptedException =>
         case _: ClosedByInterruptException =>
-        case _: TimeoutException =>
+        case _: ConsumerTimeoutException =>
           consumerTimeout.set(true)
         case e: Throwable => e.printStackTrace()
       }

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -190,7 +190,7 @@ object ConsumerPerformance extends LazyLogging {
 
     if (messagesRead < count)
       println(s"WARNING: Exiting before consuming the expected number of messages: timeout ($timeout ms) exceeded. " +
-        s"Probably too much time spent on processing a polled list of records. Be sure to increase the --timeout option.")
+        "You can use the --timeout option to increase the timeout."))
     totalMessagesRead.set(messagesRead)
     totalBytesRead.set(bytesRead)
   }

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -38,6 +38,7 @@ import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.kafka.common.errors.TimeoutException
 
 import scala.collection.mutable
 
@@ -401,7 +402,7 @@ object ConsumerPerformance extends LazyLogging {
       } catch {
         case _: InterruptedException =>
         case _: ClosedByInterruptException =>
-        case _: ConsumerTimeoutException =>
+        case _: TimeoutException =>
           consumerTimeout.set(true)
         case e: Throwable => e.printStackTrace()
       }

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -33,7 +33,6 @@ import java.util.{Collections, Properties, Random}
 import kafka.consumer.Consumer
 import kafka.consumer.ConsumerConnector
 import kafka.consumer.KafkaStream
-import kafka.consumer.ConsumerTimeoutException
 import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicBoolean
 


### PR DESCRIPTION
## ConsumerPerformance fails to consume all messages 
on topics with large number of partitions due to a relatively short default polling loop timeout (1000 ms) that is not reachable and modifiable by the end user. 

### Demo
Create a topic of 10 000 partitions, send a 50 000 000 of 100 byte records using kafka-producer-perf-test and consume them using kafka-consumer-perf-test (ConsumerPerformance). You will likely notice that the number of records returned by the kafka-consumer-perf-test is many times less than expected 50 000 000. 

This happens due to specific ConsumerPerformance implementation. As the result, in some rough cases it may take a long enough time to process/iterate through the records polled in batches, thus, the time may exceed the default hardcoded polling loop timeout and this is probably not what we want from this utility. 

### Possible options
1) Increasing polling loop timeout in ConsumerPerformance implementation. It defaults to 1000 ms and is hardcoded, thus cannot be changed but we could export it as an OPTIONAL kafka-consumer-perf-test parameter to enable it on a script level configuration and available to the end user.
2) Decreasing max.poll.records on a Consumer config level. This is not a fine option though since we do not want to touch the default settings.

[KAFKA-6743: ConsumerPerformance fails to consume all messages on topics with large number of partitions](https://issues.apache.org/jira/browse/KAFKA-6743)
[KIP-281: ConsumerPerformance: Increase Polling Loop Timeout and Make It Reachable by the End User](https://cwiki.apache.org/confluence/display/KAFKA/KIP-281%3A+ConsumerPerformance%3A+Increase+Polling+Loop+Timeout+and+Make+It+Reachable+by+the+End+User)

### Result
`bin/kafka-consumer-perf-test.sh... --polling-loop-timeout <TIME_IN_MS> ` 

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
