### PR TITLE
KAFKA-6742: TopologyTestDriver error when dealing with stores from GlobalKTable

### DIFF
--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -173,7 +173,7 @@ public class TopologyTestDriver implements Closeable {
     private final static TaskId TASK_ID = new TaskId(0, PARTITION_ID);
     private StreamTask task;
     private GlobalStateUpdateTask globalStateTask;
-    private GlobalStateManager    globalStateManager;
+    private GlobalStateManager globalStateManager;
 
     private final StateDirectory stateDirectory;
     private final ProcessorTopology processorTopology;
@@ -376,7 +376,7 @@ public class TopologyTestDriver implements Closeable {
             // Forward back into the topology if the produced record is to an internal or a source topic ...
             final String outputTopicName = record.topic();
             if (internalTopics.contains(outputTopicName) || processorTopology.sourceTopics().contains(outputTopicName)
-            		|| globalPartitionsByTopic.containsKey(outputTopicName)) {
+                    || globalPartitionsByTopic.containsKey(outputTopicName)) {
                 final byte[] serializedKey = record.key();
                 final byte[] serializedValue = record.value();
 
@@ -460,13 +460,13 @@ public class TopologyTestDriver implements Closeable {
     /**
      * Records sent with this {@link Producer} are streamed to the topology.
      * <p>
-     * This is useful when testing processes that are also using "normal" kafka producer, tipically in
-     * a different thread. 
+     * This is useful when testing processes that are also using "normal" kafka producer, typically in
+     * a different thread.
      * 
      * @return the producer.
      */
     public final Producer<byte[], byte[]> getProducer() {
-    	return producer;
+        return producer;
     }
 
     /**
@@ -485,8 +485,7 @@ public class TopologyTestDriver implements Closeable {
     public Map<String, StateStore> getAllStateStores() {
         final Map<String, StateStore> allStores = new HashMap<>();
         for (final String storeName : internalTopologyBuilder.allStateStoreName()) {
-            StateStore res = getStateStore(storeName);
-            allStores.put(storeName, res);
+            allStores.put(storeName, getStateStore(storeName));
         }
         return allStores;
     }
@@ -507,9 +506,9 @@ public class TopologyTestDriver implements Closeable {
      */
     public StateStore getStateStore(final String name) {
         StateStore res = task == null ? null : 
-        	((ProcessorContextImpl) task.context()).getStateMgr().getStore(name);
+            ((ProcessorContextImpl) task.context()).getStateMgr().getStore(name);
         if (res == null && globalStateManager != null)
-        	res = globalStateManager.getGlobalStore(name);
+            res = globalStateManager.getGlobalStore(name);
         return res;
     }
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -171,9 +171,9 @@ public class TopologyTestDriver implements Closeable {
 
     private final static int PARTITION_ID = 0;
     private final static TaskId TASK_ID = new TaskId(0, PARTITION_ID);
-    private StreamTask task;
-    private GlobalStateUpdateTask globalStateTask;
-    private GlobalStateManager globalStateManager;
+    private final StreamTask task;
+    private final GlobalStateUpdateTask globalStateTask;
+    private final GlobalStateManager globalStateManager;
 
     private final StateDirectory stateDirectory;
     private final ProcessorTopology processorTopology;
@@ -287,6 +287,10 @@ public class TopologyTestDriver implements Closeable {
                 new LogContext());
             globalStateTask.initialize();
         }
+        else {
+            globalStateManager = null;
+            globalStateTask = null;
+        }
 
         if (!partitionsByTopic.isEmpty()) {
             task = new StreamTask(
@@ -306,6 +310,9 @@ public class TopologyTestDriver implements Closeable {
                 producer);
             task.initializeStateStores();
             task.initializeTopology();
+        }
+        else {
+            task = null;
         }
     }
 
@@ -463,8 +470,9 @@ public class TopologyTestDriver implements Closeable {
      * This is useful when testing processes that are also using "normal" kafka producer, typically in
      * a different thread.<br>
      * The main difference between using it instead of the {@link #pipeInput(ConsumerRecord)} method is 
-     * that with the producer we both feed the stream and get a topic output (see: {@link #readOutput(String)})
-     * while with {@link #pipeInput(ConsumerRecord)} we only collect output from the topology sinks. 
+     * that with the producer we push data to a topic and eventually feed the stream
+     * while with {@link #pipeInput(ConsumerRecord)} we feed the stream but we only collect output from 
+     * the topology sinks. 
      * 
      * @return the producer.
      */

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -178,17 +178,7 @@ public class TopologyTestDriver implements Closeable {
     private final StateDirectory stateDirectory;
     private final ProcessorTopology processorTopology;
     
-    /**
-     * Records sent with this {@link Producer} are streamed to the topology.
-     * <p>
-     * This is useful when testing processes that are also using "normal" kafka producer, typically in
-     * a different thread.<br>
-     * The main difference between using it instead of the {@link #pipeInput(ConsumerRecord)} method is 
-     * that with the producer we push data to a topic and eventually feed the stream
-     * while with {@link #pipeInput(ConsumerRecord)} we feed the stream but we only collect output from 
-     * the topology sinks. 
-     */
-    protected final MockProducer<byte[], byte[]> producer;
+    private final MockProducer<byte[], byte[]> producer;
 
     private final Set<String> internalTopics = new HashSet<>();
     private final Map<String, TopicPartition> partitionsByTopic = new HashMap<>();

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -177,7 +177,18 @@ public class TopologyTestDriver implements Closeable {
 
     private final StateDirectory stateDirectory;
     private final ProcessorTopology processorTopology;
-    private final MockProducer<byte[], byte[]> producer;
+    
+    /**
+     * Records sent with this {@link Producer} are streamed to the topology.
+     * <p>
+     * This is useful when testing processes that are also using "normal" kafka producer, typically in
+     * a different thread.<br>
+     * The main difference between using it instead of the {@link #pipeInput(ConsumerRecord)} method is 
+     * that with the producer we push data to a topic and eventually feed the stream
+     * while with {@link #pipeInput(ConsumerRecord)} we feed the stream but we only collect output from 
+     * the topology sinks. 
+     */
+    protected final MockProducer<byte[], byte[]> producer;
 
     private final Set<String> internalTopics = new HashSet<>();
     private final Map<String, TopicPartition> partitionsByTopic = new HashMap<>();
@@ -462,22 +473,6 @@ public class TopologyTestDriver implements Closeable {
         return new ProducerRecord<>(record.topic(), record.partition(), record.timestamp(), key, value);
     }
     
-    /**
-     * Records sent with this {@link Producer} are streamed to the topology.
-     * <p>
-     * This is useful when testing processes that are also using "normal" kafka producer, typically in
-     * a different thread.<br>
-     * The main difference between using it instead of the {@link #pipeInput(ConsumerRecord)} method is 
-     * that with the producer we push data to a topic and eventually feed the stream
-     * while with {@link #pipeInput(ConsumerRecord)} we feed the stream but we only collect output from 
-     * the topology sinks. 
-     * 
-     * @return the producer.
-     */
-    public final Producer<byte[], byte[]> getProducer() {
-        return producer;
-    }
-
     /**
      * Get all {@link StateStore StateStores} from the topology.
      * The stores can be a "regular" or global stores.

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -461,7 +461,10 @@ public class TopologyTestDriver implements Closeable {
      * Records sent with this {@link Producer} are streamed to the topology.
      * <p>
      * This is useful when testing processes that are also using "normal" kafka producer, typically in
-     * a different thread.
+     * a different thread.<br>
+     * The main difference between using it instead of the {@link #pipeInput(ConsumerRecord)} method is 
+     * that with the producer we both feed the stream and get a topic output (see: {@link #readOutput(String)})
+     * while with {@link #pipeInput(ConsumerRecord)} we only collect output from the topology sinks. 
      * 
      * @return the producer.
      */

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -286,8 +286,7 @@ public class TopologyTestDriver implements Closeable {
                 new LogAndContinueExceptionHandler(),
                 new LogContext());
             globalStateTask.initialize();
-        }
-        else {
+        } else {
             globalStateManager = null;
             globalStateTask = null;
         }
@@ -310,8 +309,7 @@ public class TopologyTestDriver implements Closeable {
                 producer);
             task.initializeStateStores();
             task.initializeTopology();
-        }
-        else {
+        } else {
             task = null;
         }
     }
@@ -518,8 +516,9 @@ public class TopologyTestDriver implements Closeable {
     public StateStore getStateStore(final String name) {
         StateStore res = task == null ? null : 
             ((ProcessorContextImpl) task.context()).getStateMgr().getStore(name);
-        if (res == null && globalStateManager != null)
+        if (res == null && globalStateManager != null) {
             res = globalStateManager.getGlobalStore(name);
+        }
         return res;
     }
 

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -910,7 +910,7 @@ public class TopologyTestDriverTest {
             Consumed.with(Serdes.String(), Serdes.String()),
             Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("globalStore"));
         try (final TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
-            final KeyValueStore<String,String> globalStore = testDriver.getKeyValueStore("globalStore");
+            final KeyValueStore<String, String> globalStore = testDriver.getKeyValueStore("globalStore");
             Assert.assertNotNull(globalStore);
             Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
             final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -915,29 +915,8 @@ public class TopologyTestDriverTest {
             Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
             final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
             testDriver.pipeInput(recordFactory.create("topic", "k1", "value1"));
-            // just to serialize keys and values
-            final ConsumerRecord<byte[], byte[]> record = recordFactory.create("dummy", "k2", "value2"); 
-            // send data using the producer
-            testDriver.producer.send(new ProducerRecord<>("topic", null, record.timestamp(), 
-                    record.key(), record.value()));
-            testDriver.advanceWallClockTime(0);
             // we expect to have both in the global store, the one from pipeInput and the one from the producer
             Assert.assertEquals("value1", globalStore.get("k1"));
-            Assert.assertEquals("value2", globalStore.get("k2"));
-            // read back data sent via the producer
-            ProducerRecord<String, String> pr = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
-            Assert.assertEquals("k2", pr.key());
-            Assert.assertEquals("value2", pr.value());
-            // no data from pipeInput should be present here since the topology has no sink
-            ProducerRecord<String, String> pr2 = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
-            Assert.assertNull(pr2);
-            // send data using the producer to a topic not used in the topology
-            testDriver.producer.send(new ProducerRecord<>("notInTopologytopic", null, 
-                    record.timestamp(), record.key(), record.value()));
-            testDriver.advanceWallClockTime(0);
-            ProducerRecord<String, String> pr3 = testDriver.readOutput("notInTopologytopic", new StringDeserializer(), new StringDeserializer());
-            Assert.assertEquals("k2", pr3.key());
-            Assert.assertEquals("value2", pr3.value());
         }
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -948,6 +948,8 @@ public class TopologyTestDriverTest {
             ProducerRecord<String,String> pr = testDriver.readOutput("local", new StringDeserializer(), new StringDeserializer());
             Assert.assertEquals("two", pr.key());
             Assert.assertEquals("Second", pr.value());
+            ProducerRecord<String,String> pr2 = testDriver.readOutput("local", new StringDeserializer(), new StringDeserializer());
+            Assert.assertNull(pr2);
         }
     }
 
@@ -998,6 +1000,8 @@ public class TopologyTestDriverTest {
             ProducerRecord<String,String> pr = testDriver.readOutput("global", new StringDeserializer(), new StringDeserializer());
             Assert.assertEquals("two", pr.key());
             Assert.assertEquals("Second", pr.value());
+            ProducerRecord<String,String> pr2 = testDriver.readOutput("global", new StringDeserializer(), new StringDeserializer());
+            Assert.assertNull(pr2);
         }
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -903,117 +903,101 @@ public class TopologyTestDriverTest {
     
     @Test
     public void shouldFeedStoreFromKTable() {
-		StreamsBuilder builder = new StreamsBuilder();
-		@SuppressWarnings("unused")
-		final KTable<String,String> localTable = builder
-		.table("local",  
-			Consumed.with(Serdes.String(), Serdes.String()),
-			Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("localStore"))
-		;
-        final Properties config = new Properties();
-        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver-cleanup");
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-    	try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
-    		final KeyValueStore<String,String> localStore = testDriver.getKeyValueStore("localStore");
-    		Assert.assertNotNull(localStore);
-    		Assert.assertNotNull(testDriver.getAllStateStores().get("localStore"));
-    		//
-        	final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
-    		testDriver.pipeInput(crf.create("local", "one", "TheOne"));
-    		//
-    		Assert.assertEquals("TheOne", localStore.get("one"));
-    	}
+        final StreamsBuilder builder = new StreamsBuilder();
+        @SuppressWarnings("unused")
+        final KTable<String,String> localTable = builder
+        .table("local",  
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("localStore"))
+        ;
+        try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
+            final KeyValueStore<String,String> localStore = testDriver.getKeyValueStore("localStore");
+            Assert.assertNotNull(localStore);
+            Assert.assertNotNull(testDriver.getAllStateStores().get("localStore"));
+            //
+            final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            testDriver.pipeInput(crf.create("local", "one", "TheOne"));
+            //
+            Assert.assertEquals("TheOne", localStore.get("one"));
+        }
     }
 
     @Test
     public void shouldFeedStoreViaProducerFromKTable() {
-		StreamsBuilder builder = new StreamsBuilder();
-		@SuppressWarnings("unused")
-		final KTable<String,String> localTable = builder
-		.table("local",  
-			Consumed.with(Serdes.String(), Serdes.String()),
-			Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("localStore"))
-		;
-        final Properties config = new Properties();
-        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver-cleanup");
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-    	try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
-    		final KeyValueStore<String,String> localStore = testDriver.getKeyValueStore("localStore");
-    		Assert.assertNotNull(localStore);
-    		Assert.assertNotNull(testDriver.getAllStateStores().get("localStore"));
-    		//
-    	   	final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
-    		testDriver.pipeInput(crf.create("local", "one", "TheOne"));
-    		// just to serialize keys and values
-    		ConsumerRecord<byte[],byte[]> cr = crf.create("dummy", "two", "Second"); 
-    		testDriver.getProducer().send(new ProducerRecord<>("local", null, cr.timestamp(), cr.key(), cr.value()));
-    		testDriver.advanceWallClockTime(0);
-    		Assert.assertEquals("TheOne", localStore.get("one"));
-    		Assert.assertEquals("Second", localStore.get("two"));
-    		//
-    		ProducerRecord<String,String> pr = testDriver.readOutput("local", new StringDeserializer(), new StringDeserializer());
-    		Assert.assertEquals("two", pr.key());
-    		Assert.assertEquals("Second", pr.value());
-    	}
+        final StreamsBuilder builder = new StreamsBuilder();
+        @SuppressWarnings("unused")
+        final KTable<String,String> localTable = builder
+        .table("local",  
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("localStore"))
+        ;
+        try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
+            final KeyValueStore<String,String> localStore = testDriver.getKeyValueStore("localStore");
+            Assert.assertNotNull(localStore);
+            Assert.assertNotNull(testDriver.getAllStateStores().get("localStore"));
+            //
+            final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            testDriver.pipeInput(crf.create("local", "one", "TheOne"));
+            // just to serialize keys and values
+            ConsumerRecord<byte[],byte[]> cr = crf.create("dummy", "two", "Second"); 
+            testDriver.getProducer().send(new ProducerRecord<>("local", null, cr.timestamp(), cr.key(), cr.value()));
+            testDriver.advanceWallClockTime(0);
+            Assert.assertEquals("TheOne", localStore.get("one"));
+            Assert.assertEquals("Second", localStore.get("two"));
+            //
+            ProducerRecord<String,String> pr = testDriver.readOutput("local", new StringDeserializer(), new StringDeserializer());
+            Assert.assertEquals("two", pr.key());
+            Assert.assertEquals("Second", pr.value());
+        }
     }
 
     @Test
     public void shouldFeedStoreFromGlobalKTable() {
-		StreamsBuilder builder = new StreamsBuilder();
-		@SuppressWarnings("unused")
-		final GlobalKTable<String,String> globalTable = builder
-		.globalTable("global",  
-			Consumed.with(Serdes.String(), Serdes.String()),
-			Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("globalStore"))
-		;
-        final Properties config = new Properties();
-        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver-cleanup");
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-    	try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
-    		final KeyValueStore<String,String> globalStore = testDriver.getKeyValueStore("globalStore");
-    		Assert.assertNotNull(globalStore);
-    		Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
-    		//
-        	final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
-    		testDriver.pipeInput(crf.create("global", "one", "TheOne"));
-    		//
-    		Assert.assertEquals("TheOne", globalStore.get("one"));
-    	}
+        final StreamsBuilder builder = new StreamsBuilder();
+        @SuppressWarnings("unused")
+        final GlobalKTable<String,String> globalTable = builder
+        .globalTable("global",  
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("globalStore"))
+        ;
+        try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
+            final KeyValueStore<String,String> globalStore = testDriver.getKeyValueStore("globalStore");
+            Assert.assertNotNull(globalStore);
+            Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
+            //
+            final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            testDriver.pipeInput(crf.create("global", "one", "TheOne"));
+            //
+            Assert.assertEquals("TheOne", globalStore.get("one"));
+        }
     }
 
     @Test
     public void shouldFeedStoreViaProducerFromGlobalKTable() {
-		StreamsBuilder builder = new StreamsBuilder();
-		@SuppressWarnings("unused")
-		final GlobalKTable<String,String> globalTable = builder
-		.globalTable("global",  
-			Consumed.with(Serdes.String(), Serdes.String()),
-			Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("globalStore"))
-		;
-        final Properties config = new Properties();
-        config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver-cleanup");
-        config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-        config.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-    	try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
-    		final KeyValueStore<String,String> globalStore = testDriver.getKeyValueStore("globalStore");
-    		Assert.assertNotNull(globalStore);
-    		Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
-    		//
-    	   	final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
-    		testDriver.pipeInput(crf.create("global", "one", "TheOne"));
-    		// just to serialize keys and values
-    		ConsumerRecord<byte[],byte[]> cr = crf.create("dummy", "two", "Second"); 
-    		testDriver.getProducer().send(new ProducerRecord<>("global", null, cr.timestamp(), cr.key(), cr.value()));
-    		testDriver.advanceWallClockTime(0);
-    		Assert.assertEquals("TheOne", globalStore.get("one"));
-    		Assert.assertEquals("Second", globalStore.get("two"));
-    		//
-    		ProducerRecord<String,String> pr = testDriver.readOutput("global", new StringDeserializer(), new StringDeserializer());
-    		Assert.assertEquals("two", pr.key());
-    		Assert.assertEquals("Second", pr.value());
-    	}
+        final StreamsBuilder builder = new StreamsBuilder();
+        @SuppressWarnings("unused")
+        final GlobalKTable<String,String> globalTable = builder
+        .globalTable("global",  
+            Consumed.with(Serdes.String(), Serdes.String()),
+            Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("globalStore"))
+        ;
+        try (TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
+            final KeyValueStore<String,String> globalStore = testDriver.getKeyValueStore("globalStore");
+            Assert.assertNotNull(globalStore);
+            Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
+            //
+            final ConsumerRecordFactory<String,String> crf = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            testDriver.pipeInput(crf.create("global", "one", "TheOne"));
+            // just to serialize keys and values
+            ConsumerRecord<byte[],byte[]> cr = crf.create("dummy", "two", "Second"); 
+            testDriver.getProducer().send(new ProducerRecord<>("global", null, cr.timestamp(), cr.key(), cr.value()));
+            testDriver.advanceWallClockTime(0);
+            Assert.assertEquals("TheOne", globalStore.get("one"));
+            Assert.assertEquals("Second", globalStore.get("two"));
+            //
+            ProducerRecord<String,String> pr = testDriver.readOutput("global", new StringDeserializer(), new StringDeserializer());
+            Assert.assertEquals("two", pr.key());
+            Assert.assertEquals("Second", pr.value());
+        }
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -585,7 +585,7 @@ public class TopologyTestDriverTest {
     public void shouldPopulateGlobalStore() {
         testDriver = new TopologyTestDriver(setupGlobalStoreTopology(SOURCE_TOPIC_1), config);
 
-        final KeyValueStore<byte[],byte[]> globalStore = testDriver.getKeyValueStore(SOURCE_TOPIC_1 + "-globalStore");
+        final KeyValueStore<byte[], byte[]> globalStore = testDriver.getKeyValueStore(SOURCE_TOPIC_1 + "-globalStore");
         Assert.assertNotNull(globalStore);
         Assert.assertNotNull(testDriver.getAllStateStores().get(SOURCE_TOPIC_1 + "-globalStore"));
 
@@ -908,16 +908,15 @@ public class TopologyTestDriverTest {
         final StreamsBuilder builder = new StreamsBuilder();
         builder.globalTable("topic",  
             Consumed.with(Serdes.String(), Serdes.String()),
-            Materialized.<String,String,KeyValueStore<Bytes,byte[]>>as("globalStore"))
-        ;
+            Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("globalStore"));
         try (final TopologyTestDriver testDriver = new TopologyTestDriver(builder.build(), config)) {
             final KeyValueStore<String,String> globalStore = testDriver.getKeyValueStore("globalStore");
             Assert.assertNotNull(globalStore);
             Assert.assertNotNull(testDriver.getAllStateStores().get("globalStore"));
-            final ConsumerRecordFactory<String,String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+            final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
             testDriver.pipeInput(recordFactory.create("topic", "k1", "value1"));
             // just to serialize keys and values
-            final ConsumerRecord<byte[],byte[]> record = recordFactory.create("dummy", "k2", "value2"); 
+            final ConsumerRecord<byte[], byte[]> record = recordFactory.create("dummy", "k2", "value2"); 
             // send data using the producer
             testDriver.getProducer().send(new ProducerRecord<>("topic", null, record.timestamp(), 
                     record.key(), record.value()));
@@ -926,17 +925,17 @@ public class TopologyTestDriverTest {
             Assert.assertEquals("value1", globalStore.get("k1"));
             Assert.assertEquals("value2", globalStore.get("k2"));
             // read back data sent via the producer
-            ProducerRecord<String,String> pr = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
+            ProducerRecord<String, String> pr = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
             Assert.assertEquals("k2", pr.key());
             Assert.assertEquals("value2", pr.value());
             // no data from pipeInput should be present here since the topology has no sink
-            ProducerRecord<String,String> pr2 = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
+            ProducerRecord<String, String> pr2 = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
             Assert.assertNull(pr2);
             // send data using the producer to a topic not used in the topology
             testDriver.getProducer().send(new ProducerRecord<>("notInTopologytopic", null, 
                     record.timestamp(), record.key(), record.value()));
             testDriver.advanceWallClockTime(0);
-            ProducerRecord<String,String> pr3 = testDriver.readOutput("notInTopologytopic", new StringDeserializer(), new StringDeserializer());
+            ProducerRecord<String, String> pr3 = testDriver.readOutput("notInTopologytopic", new StringDeserializer(), new StringDeserializer());
             Assert.assertEquals("k2", pr3.key());
             Assert.assertEquals("value2", pr3.value());
         }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -919,7 +919,8 @@ public class TopologyTestDriverTest {
             // just to serialize keys and values
             final ConsumerRecord<byte[],byte[]> record = recordFactory.create("dummy", "k2", "value2"); 
             // send data using the producer
-            testDriver.getProducer().send(new ProducerRecord<>("topic", null, record.timestamp(), record.key(), record.value()));
+            testDriver.getProducer().send(new ProducerRecord<>("topic", null, record.timestamp(), 
+                    record.key(), record.value()));
             testDriver.advanceWallClockTime(0);
             // we expect to have both in the global store, the one from pipeInput and the one from the producer
             Assert.assertEquals("value1", globalStore.get("k1"));
@@ -931,6 +932,13 @@ public class TopologyTestDriverTest {
             // no data from pipeInput should be present here since the topology has no sink
             ProducerRecord<String,String> pr2 = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
             Assert.assertNull(pr2);
+            // send data using the producer to a topic not used in the topology
+            testDriver.getProducer().send(new ProducerRecord<>("notInTopologytopic", null, 
+                    record.timestamp(), record.key(), record.value()));
+            testDriver.advanceWallClockTime(0);
+            ProducerRecord<String,String> pr3 = testDriver.readOutput("notInTopologytopic", new StringDeserializer(), new StringDeserializer());
+            Assert.assertEquals("k2", pr3.key());
+            Assert.assertEquals("value2", pr3.value());
         }
     }
 }

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -918,7 +918,7 @@ public class TopologyTestDriverTest {
             // just to serialize keys and values
             final ConsumerRecord<byte[], byte[]> record = recordFactory.create("dummy", "k2", "value2"); 
             // send data using the producer
-            testDriver.getProducer().send(new ProducerRecord<>("topic", null, record.timestamp(), 
+            testDriver.producer.send(new ProducerRecord<>("topic", null, record.timestamp(), 
                     record.key(), record.value()));
             testDriver.advanceWallClockTime(0);
             // we expect to have both in the global store, the one from pipeInput and the one from the producer
@@ -932,7 +932,7 @@ public class TopologyTestDriverTest {
             ProducerRecord<String, String> pr2 = testDriver.readOutput("topic", new StringDeserializer(), new StringDeserializer());
             Assert.assertNull(pr2);
             // send data using the producer to a topic not used in the topology
-            testDriver.getProducer().send(new ProducerRecord<>("notInTopologytopic", null, 
+            testDriver.producer.send(new ProducerRecord<>("notInTopologytopic", null, 
                     record.timestamp(), record.key(), record.value()));
             testDriver.advanceWallClockTime(0);
             ProducerRecord<String, String> pr3 = testDriver.readOutput("notInTopologytopic", new StringDeserializer(), new StringDeserializer());


### PR DESCRIPTION
@guozhangwang
 
While TopologyTestDriver works well with stores created from KTable it does not with stores from GlobalKTable.
Moreover, for my testing purposes but I think it can be useful to others, I need to get access to the MockProducer inside TopologyTestDriver.

I have added 4 new tests to TopologyTestDriverTest, two for stores from KTable and two for stores from GlobalKTable.

While I was changing the TopologyTestDriver I've also make it implement java.io.Closeable.