### PR TITLE
KAFKA-6757 Log runtime exception in case of server startup errors

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServerStartable.scala
+++ b/core/src/main/scala/kafka/server/KafkaServerStartable.scala
@@ -37,9 +37,9 @@ class KafkaServerStartable(val staticServerConfig: KafkaConfig, reporters: Seq[K
   def startup() {
     try server.startup()
     catch {
-      case _: Throwable =>
+        case e: Throwable =>
         // KafkaServer.startup() calls shutdown() in case of exceptions, so we invoke `exit` to set the status code
-        fatal("Exiting Kafka.")
+        fatal("Exiting Kafka.", e)
         Exit.exit(1)
     }
   }


### PR DESCRIPTION
Sometimes while running Kafka server inside tests of an upstream application it can happen that the server cannot start due to a bad runtime error, like a missing jar on the classpath, see KAFKA-6757 for examples .

I would like KafkaServerStartable to log any 'Throwable' in order to catch these unpredictable error

Testing strategy: no test case is needed or it is worth to add

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
