### PR TITLE
KAFKA-6760: Responses not logged properly in controller

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/LeaderAndIsrResponse.java
@@ -119,4 +119,13 @@ public class LeaderAndIsrResponse extends AbstractResponse {
 
         return struct;
     }
+
+    @Override
+    public String toString() {
+        return "LeaderAndIsrResponse(" +
+                "responses=" + responses +
+                ", error=" + error +
+                ")";
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/StopReplicaResponse.java
@@ -115,4 +115,13 @@ public class StopReplicaResponse extends AbstractResponse {
         struct.set(ERROR_CODE, error.code());
         return struct;
     }
+
+    @Override
+    public String toString() {
+        return "StopReplicaResponse(" +
+                "responses=" + responses +
+                ", error=" + error +
+                ")";
+    }
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/LeaderAndIsrResponseTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LeaderAndIsrResponseTest {
 
@@ -62,6 +63,18 @@ public class LeaderAndIsrResponseTest {
         assertEquals(2, errorCounts.size());
         assertEquals(1, errorCounts.get(Errors.NONE).intValue());
         assertEquals(1, errorCounts.get(Errors.CLUSTER_AUTHORIZATION_FAILED).intValue());
+    }
+
+    @Test
+    public void testToString() {
+        Map<TopicPartition, Errors> errors = new HashMap<>();
+        errors.put(new TopicPartition("foo", 0), Errors.NONE);
+        errors.put(new TopicPartition("foo", 1), Errors.CLUSTER_AUTHORIZATION_FAILED);
+        LeaderAndIsrResponse response = new LeaderAndIsrResponse(Errors.NONE, errors);
+        String responseStr = response.toString();
+        assertTrue(responseStr.contains(LeaderAndIsrResponse.class.getSimpleName()));
+        assertTrue(responseStr.contains(errors.toString()));
+        assertTrue(responseStr.contains(Errors.NONE.name()));
     }
 
 }

--- a/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/StopReplicaResponseTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StopReplicaResponseTest {
 
@@ -56,6 +57,18 @@ public class StopReplicaResponseTest {
         assertEquals(2, errorCounts.size());
         assertEquals(1, errorCounts.get(Errors.NONE).intValue());
         assertEquals(1, errorCounts.get(Errors.CLUSTER_AUTHORIZATION_FAILED).intValue());
+    }
+
+    @Test
+    public void testToString() {
+        Map<TopicPartition, Errors> errors = new HashMap<>();
+        errors.put(new TopicPartition("foo", 0), Errors.NONE);
+        errors.put(new TopicPartition("foo", 1), Errors.CLUSTER_AUTHORIZATION_FAILED);
+        StopReplicaResponse response = new StopReplicaResponse(Errors.NONE, errors);
+        String responseStr = response.toString();
+        assertTrue(responseStr.contains(StopReplicaResponse.class.getSimpleName()));
+        assertTrue(responseStr.contains(errors.toString()));
+        assertTrue(responseStr.contains(Errors.NONE.name()));
     }
 
 }


### PR DESCRIPTION
Added toString() to LeaderAndIsrResponse and StopReplicaResponse

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
