### PR TITLE
MINOR: Java 10 fixes so that the build passes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ allprojects {
   }
   
   apply plugin: 'idea'
-  apply plugin: "jacoco"
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'com.github.ben-manes.versions'
 
@@ -384,6 +383,7 @@ subprojects {
 
   // Ignore core since its a scala project
   if (it.path != ':core') {
+    apply plugin: "jacoco"
 
     jacoco {
       toolVersion = "0.8.1"
@@ -591,8 +591,7 @@ project(':core') {
     scoverage libs.scoveragePlugin
     scoverage libs.scoverageRuntime
   }
-
-  jacocoTestReport.enabled = false
+  
   scoverage {
     reportDir = file("${rootProject.buildDir}/scoverage")
     highlighting = false

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ versions += [
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.59",
-  easymock: "3.5.1",
+  easymock: "3.6",
   jackson: "2.9.5",
   jetty: "9.2.24.v20180105",
   jersey: "2.25.1",


### PR DESCRIPTION
* Upgrade EasyMock to 3.6 which adds support for Java 10
by upgrading to ASM 6.1.1.

* Ensure that Jacoco is truly disabled for the `core` project.
This was the original intent, since it's in Scala, but it had not
been achieved. This is important because the Jacoco agent
fails when it tries to instrument the classes compiled by
scalac with Java 10.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
