### PR TITLE
[MINOR] ConsumerGroupCommand does not print cause of failure

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -87,7 +87,8 @@ object ConsumerGroupCommand extends Logging {
       }
     } catch {
       case e: Throwable =>
-        printError(s"Executing consumer group command failed due to ${e.getMessage}", Some(e))
+        printError(s"Executing consumer group command failed (${e.getMessage}) ${System.lineSeparator()}" +
+          s"${if (e.getCause != null) e.getCause}", Some(e))
     } finally {
       consumerGroupService.close()
     }
@@ -97,7 +98,7 @@ object ConsumerGroupCommand extends Logging {
 
   def printError(msg: String, e: Option[Throwable] = None): Unit = {
     println(s"Error: $msg")
-    e.foreach(debug("Exception in consumer group command", _))
+    e.foreach(error("Exception in consumer group command", _))
   }
 
   def convertTimestamp(timeString: String): java.lang.Long = {

--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -87,8 +87,7 @@ object ConsumerGroupCommand extends Logging {
       }
     } catch {
       case e: Throwable =>
-        printError(s"Executing consumer group command failed (${e.getMessage}) ${System.lineSeparator()}" +
-          s"${if (e.getCause != null) e.getCause}", Some(e))
+        printError(s"Executing consumer group command failed due to ${e.getMessage}", Some(e))
     } finally {
       consumerGroupService.close()
     }
@@ -96,9 +95,13 @@ object ConsumerGroupCommand extends Logging {
 
   val MISSING_COLUMN_VALUE = "-"
 
-  def printError(msg: String, e: Option[Throwable] = None): Unit = {
+  def printError(msg: String, t: Option[Throwable] = None): Unit = {
     println(s"Error: $msg")
-    e.foreach(error("Exception in consumer group command", _))
+    t.foreach(e => {
+      val errorMessage = "Exception in consumer group command"
+      error(errorMessage, e)
+      System.err.println(errorMessage + System.lineSeparator() + Utils.stackTrace(e))
+    })
   }
 
   def convertTimestamp(timeString: String): java.lang.Long = {


### PR DESCRIPTION
When kafka-consumer-groups.sh fails to execute a command (for example, because of a configuration problem), it does not print the cause of failure which could make it hard to debug the root cause. This patch includes a minor change to print the actual cause of the exception.

Example error output with the patch:
```
Error: Executing consumer group command failed (Failed to construct kafka consumer)
org.apache.kafka.common.config.ConfigException: request.timeout.ms should be greater than session.timeout.ms and fetch.max.wait.ms
```