### PR TITLE
Make [Config]Resource.toString() consistent with existing code

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigResource.java
@@ -90,6 +90,6 @@ public final class ConfigResource {
 
     @Override
     public String toString() {
-        return "ConfigResource{type=" + type + ", name='" + name + "'}";
+        return "ConfigResource(type=" + type + ", name='" + name + "')";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/Resource.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/Resource.java
@@ -55,6 +55,6 @@ public final class Resource {
 
     @Override
     public String toString() {
-        return "Resource(type=" + type + ", name='" + name + "'}";
+        return "Resource(type=" + type + ", name='" + name + "')";
     }
 }


### PR DESCRIPTION
The toString() for ConfigResource was using { } instead of ( ) which is inconsistent with the existing toStrings in the code,
while toString for Resource was using a mix of ( and }.