### PR TITLE
KAFKA-6538: Fixed RocksDBStore to enhance processor state  exceptions with more context

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -225,7 +225,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         try {
             return this.db.get(rawKey);
         } catch (final RocksDBException e) {
-            throw new ProcessorStateException("Error while getting value for key from store " + this.name, e);
+            throw new ProcessorStateException("Error while getting value for key" + wrapToBytes(rawKey) + "from store " + this.name, e);
         }
     }
 
@@ -301,13 +301,15 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
             try {
                 db.delete(wOptions, rawKey);
             } catch (final RocksDBException e) {
-                throw new ProcessorStateException("Error while removing key from store " + this.name, e);
+                throw new ProcessorStateException("Error while removing key" + wrapToBytes(rawValue) + "from store " + this.name, e);
             }
         } else {
             try {
                 db.put(wOptions, rawKey, rawValue);
             } catch (final RocksDBException e) {
-                throw new ProcessorStateException("Error while executing putting key/value into store " + this.name, e);
+                String str = String.format("Error while executing putting key %s value %s into store %s", wrapToBytes(rawKey),
+                        wrapToBytes(rawValue), this.name);
+                throw new ProcessorStateException(str, e);
             }
         }
     }
@@ -463,6 +465,10 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         for (final KeyValueIterator iterator : iterators) {
             iterator.close();
         }
+    }
+
+    private Bytes wrapToBytes(byte... rawValue) {
+        return Bytes.wrap(rawValue);
     }
 
     private class RocksDbIterator implements KeyValueIterator<Bytes, byte[]> {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6538
Fixed against `Base:1.1` version.
Fixed Class:`RocksDBStore` to enhance Processor State Exception containing Key/Value values as Bytes/byte[] to Bytes/Bytes form in the error message for displaying more useful context .

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
