### PR TITLE
KAFKA-6770: Add New Protocol Versions to 1.1.0 documentation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/FetchRequest.java
@@ -52,7 +52,7 @@ public class FetchRequest extends AbstractRequest {
     private static final String MIN_BYTES_KEY_NAME = "min_bytes";
     private static final String ISOLATION_LEVEL_KEY_NAME = "isolation_level";
     private static final String TOPICS_KEY_NAME = "topics";
-    private static final String FORGOTTEN_TOPICS_DATA = "forgetten_topics_data";
+    private static final String FORGOTTEN_TOPICS_DATA = "forgotten_topics_data";
 
     // request and partition level name
     private static final String MAX_BYTES_KEY_NAME = "max_bytes";

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -151,7 +151,12 @@
 </ul>
 
 <h5><a id="upgrade_110_new_protocols" href="#upgrade_110_new_protocols">New Protocol Versions</a></h5>
-<ul></ul>
+<ul>
+    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">KIP-226</a>: DescribeConfigsRequest v1 introduces a <code>include_synonyms</code> field. </li>
+    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">KIP-226</a>: DescribeConfigsResponse v1 introduces a <code>config_synonyms</code> field. </li>
+    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability">KIP-227</a>: FetchRequest v7 introduces 3 new fields: <code>session_id</code>, <code>epoch</code> and <code>forgetten_topics_data</code>. </li>
+    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability">KIP-227</a>: FetchResponse v7 introduces a <code>session_id</code> field. </li>
+</ul>
 
 <h5><a id="upgrade_110_streams" href="#upgrade_110_streams">Upgrading a 1.1.0 Kafka Streams Application</a></h5>
 <ul>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -152,10 +152,8 @@
 
 <h5><a id="upgrade_110_new_protocols" href="#upgrade_110_new_protocols">New Protocol Versions</a></h5>
 <ul>
-    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">KIP-226</a>: DescribeConfigsRequest v1 introduces a <code>include_synonyms</code> field. </li>
-    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">KIP-226</a>: DescribeConfigsResponse v1 introduces a <code>config_synonyms</code> field. </li>
-    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability">KIP-227</a>: FetchRequest v7 introduces 3 new fields: <code>session_id</code>, <code>epoch</code> and <code>forgetten_topics_data</code>. </li>
-    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability">KIP-227</a>: FetchResponse v7 introduces a <code>session_id</code> field. </li>
+    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration">KIP-226</a> introduced DescribeConfigs Request/Response v1.</li>
+    <li> <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-227%3A+Introduce+Incremental+FetchRequests+to+Increase+Partition+Scalability">KIP-227</a> introduced Fetch Request/Response v7.</li>
 </ul>
 
 <h5><a id="upgrade_110_streams" href="#upgrade_110_streams">Upgrading a 1.1.0 Kafka Streams Application</a></h5>


### PR DESCRIPTION
1.1 introduced 2 new versions to existing API keys:
- DescribeConfigs v1
- Fetch v7

The 3rd new field of FetchRequest v7 is called `forgetten_topics_data`. Can we fix the typo in the field name or is it considered public API now ?

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
