### PR TITLE
KAFKA-6058: Refactor consumer API result return types

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -29,13 +29,13 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class DeleteConsumerGroupsResult {
-    final KafkaFuture<Map<String, KafkaFuture<Void>>> futures;
+    final Map<String, KafkaFuture<Void>> futures;
 
-    DeleteConsumerGroupsResult(KafkaFuture<Map<String, KafkaFuture<Void>>> futures) {
+    DeleteConsumerGroupsResult(Map<String, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 
-    public KafkaFuture<Map<String, KafkaFuture<Void>>> deletedGroups() {
+    public Map<String, KafkaFuture<Void>> deletedGroups() {
         return futures;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -35,7 +35,18 @@ public class DeleteConsumerGroupsResult {
         this.futures = futures;
     }
 
+    /**
+     * Return a map from group id to futures which can be used to check the status of
+     * individual deletions.
+     */
     public Map<String, KafkaFuture<Void>> deletedGroups() {
         return futures;
+    }
+
+    /**
+     * Return a future which succeeds only if all the consumer group deletions succeed.
+     */
+    public KafkaFuture<Void> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class DeleteConsumerGroupsResult {
     final Map<String, KafkaFuture<Void>> futures;
 
-    DeleteConsumerGroupsResult(Map<String, KafkaFuture<Void>> futures) {
+    DeleteConsumerGroupsResult(final Map<String, KafkaFuture<Void>> futures) {
         this.futures = futures;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteConsumerGroupsResult.java
@@ -29,7 +29,7 @@ import java.util.Map;
  */
 @InterfaceStability.Evolving
 public class DeleteConsumerGroupsResult {
-    final Map<String, KafkaFuture<Void>> futures;
+    private final Map<String, KafkaFuture<Void>> futures;
 
     DeleteConsumerGroupsResult(final Map<String, KafkaFuture<Void>> futures) {
         this.futures = futures;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -32,16 +32,16 @@ import java.util.Map;
 @InterfaceStability.Evolving
 public class DescribeConsumerGroupsResult {
 
-    private final KafkaFuture<Map<String, KafkaFuture<ConsumerGroupDescription>>> futures;
+    private final Map<String, KafkaFuture<ConsumerGroupDescription>> futures;
 
-    public DescribeConsumerGroupsResult(KafkaFuture<Map<String, KafkaFuture<ConsumerGroupDescription>>> futures) {
+    public DescribeConsumerGroupsResult(final Map<String, KafkaFuture<ConsumerGroupDescription>> futures) {
         this.futures = futures;
     }
 
     /**
      * Return a map from group name to futures which can be used to check the description of a consumer group.
      */
-    public KafkaFuture<Map<String, KafkaFuture<ConsumerGroupDescription>>> describedGroups() {
+    public Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups() {
         return futures;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -39,9 +39,16 @@ public class DescribeConsumerGroupsResult {
     }
 
     /**
-     * Return a map from group name to futures which can be used to check the description of a consumer group.
+     * Return a map from group id to futures which can be used to check the description of a consumer group.
      */
     public Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups() {
         return futures;
+    }
+
+    /**
+     * Return a future which succeeds only if all the consumer group description succeed.
+     */
+    public KafkaFuture<Void> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2254,10 +2254,12 @@ public class KafkaAdminClient extends AdminClient {
 
         // TODO: KAFKA-6788, we should consider grouping the request per coordinator and send one request with a list of
         // all consumer groups this coordinator host
-        for (final String groupId : groupIds) {
+        for (final Map.Entry<String, KafkaFutureImpl<ConsumerGroupDescription>> entry : futures.entrySet()) {
             // skip sending request for those futures that already failed.
-            if (futures.get(groupId).isCompletedExceptionally())
+            if (entry.getValue().isCompletedExceptionally())
                 continue;
+
+            final String groupId = entry.getKey();
 
             final long startFindCoordinatorMs = time.milliseconds();
             final long deadline = calcDeadlineMs(startFindCoordinatorMs, options.timeoutMs());
@@ -2456,7 +2458,7 @@ public class KafkaAdminClient extends AdminClient {
 
             @Override
             void handleFailure(Throwable throwable) {
-                listFuture.completeExceptionally(new ApiException("Cannot find the brokers to query consumer listings."));
+                listFuture.completeExceptionally(throwable);
             }
         }, nowMetadata);
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2356,12 +2356,12 @@ public class KafkaAdminClient extends AdminClient {
                                     Collection<ConsumerGroupListing> results;
                                     try {
                                         results = entry.getValue().get();
+                                        listings.addAll(results);
                                     } catch (Throwable e) {
-                                        // This should be unreachable, since the future returned by KafkaFuture#allOf should
-                                        // have failed if any Future failed.
-                                        throw new KafkaException("ListConsumerGroupsResult#listings(): internal error", e);
+                                        // This is possible if some of the node returns error, in this case we just log it and move on.
+                                        log.debug("{} returns error {} for ListConsumerRequest, skipping its results in the returned list of consumer groups",
+                                                entry.getKey(), e);
                                     }
-                                    listings.addAll(results);
                                 }
                                 return listings;
                             }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2371,7 +2371,8 @@ public class KafkaAdminClient extends AdminClient {
 
                 // we have to flatten the future here instead in the result, because we need to wait until the map of nodes
                 // are known from the listNode request.
-                flattenFuture.copyWith(KafkaFuture.allOf(futuresMap.values().toArray(new KafkaFuture[0])),
+                flattenFuture.copyWith(
+                        KafkaFuture.allOf(futuresMap.values().toArray(new KafkaFuture[0])),
                         new KafkaFuture.BaseFunction<Void, Collection<ConsumerGroupListing>>() {
                             @Override
                             public Collection<ConsumerGroupListing> apply(Void v) {
@@ -2389,8 +2390,7 @@ public class KafkaAdminClient extends AdminClient {
                                 }
                                 return listings;
                             }
-                        }
-                        );
+                        });
 
                 for (final Map.Entry<Node, KafkaFutureImpl<Collection<ConsumerGroupListing>>> entry : futuresMap.entrySet()) {
                     final long nowList = time.milliseconds();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2369,11 +2369,11 @@ public class KafkaAdminClient extends AdminClient {
                                 // TODO: KAFKA-6789, retry based on the error code
                                 KafkaFutureImpl<Collection<ConsumerGroupListing>> future = new KafkaFutureImpl<>();
                                 future.completeExceptionally(partitionMetadata.error().exception());
-                                futuresMap.put(leader, future);
-                            } else {
                                 // if it is the leader not found error, then the leader might be NoNode; if there are more than
                                 // one such error, we will only have one entry in the map. For now it is okay since we are not
                                 // guaranteeing to return the full list of consumers still.
+                                futuresMap.put(leader, future);
+                            } else {
                                 futuresMap.put(leader, new KafkaFutureImpl<Collection<ConsumerGroupListing>>());
                             }
                         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
@@ -51,23 +51,18 @@ public class ListConsumerGroupsResult {
         private Iterator<ConsumerGroupListing> innerIter;
 
         @Override
-        public boolean hasNext() {
+        protected KafkaFuture<ConsumerGroupListing> makeNext() {
             if (futuresIter == null) {
                 try {
                     listFuture.get();
                 } catch (Exception e) {
-                    // the list future has failed, there will be no listings to show at all;
-                    return false;
+                    // the list future has failed, there will be no listings to show at all
+                    return allDone();
                 }
 
                 futuresIter = futuresMap.values().iterator();
             }
 
-            return super.hasNext();
-        }
-
-        @Override
-        protected KafkaFuture<ConsumerGroupListing> makeNext() {
             while (innerIter == null || !innerIter.hasNext()) {
                 if (futuresIter.hasNext()) {
                     KafkaFuture<Collection<ConsumerGroupListing>> collectionFuture = futuresIter.next();

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 public class ListConsumerGroupsResult {
     private final KafkaFuture<Collection<ConsumerGroupListing>> future;
 
-    ListConsumerGroupsResult(KafkaFuture<Collection<ConsumerGroupListing>> future) {
+    ListConsumerGroupsResult(final KafkaFuture<Collection<ConsumerGroupListing>> future) {
         this.future = future;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListConsumerGroupsResult.java
@@ -18,9 +18,14 @@
 package org.apache.kafka.clients.admin;
 
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.utils.AbstractIterator;
 
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * The result of the {@link AdminClient#listConsumerGroups()} call.
@@ -29,16 +34,75 @@ import java.util.Collection;
  */
 @InterfaceStability.Evolving
 public class ListConsumerGroupsResult {
-    private final KafkaFuture<Collection<ConsumerGroupListing>> future;
+    private final Map<Node, KafkaFutureImpl<Collection<ConsumerGroupListing>>> futuresMap;
+    private final KafkaFuture<Collection<ConsumerGroupListing>> flattenFuture;
+    private final KafkaFuture<Void> listFuture;
 
-    ListConsumerGroupsResult(final KafkaFuture<Collection<ConsumerGroupListing>> future) {
-        this.future = future;
+    ListConsumerGroupsResult(final KafkaFuture<Void> listFuture,
+                             final KafkaFuture<Collection<ConsumerGroupListing>> flattenFuture,
+                             final Map<Node, KafkaFutureImpl<Collection<ConsumerGroupListing>>> futuresMap) {
+        this.flattenFuture = flattenFuture;
+        this.listFuture = listFuture;
+        this.futuresMap = futuresMap;
+    }
+
+    private class FutureConsumerGroupListingIterator extends AbstractIterator<KafkaFuture<ConsumerGroupListing>> {
+        private Iterator<KafkaFutureImpl<Collection<ConsumerGroupListing>>> futuresIter;
+        private Iterator<ConsumerGroupListing> innerIter;
+
+        @Override
+        public boolean hasNext() {
+            if (futuresIter == null) {
+                try {
+                    listFuture.get();
+                } catch (Exception e) {
+                    // the list future has failed, there will be no listings to show at all;
+                    return false;
+                }
+
+                futuresIter = futuresMap.values().iterator();
+            }
+
+            return super.hasNext();
+        }
+
+        @Override
+        protected KafkaFuture<ConsumerGroupListing> makeNext() {
+            while (innerIter == null || !innerIter.hasNext()) {
+                if (futuresIter.hasNext()) {
+                    KafkaFuture<Collection<ConsumerGroupListing>> collectionFuture = futuresIter.next();
+                    try {
+                        Collection<ConsumerGroupListing> collection = collectionFuture.get();
+                        innerIter = collection.iterator();
+                    } catch (Exception e) {
+                        KafkaFutureImpl<ConsumerGroupListing> future = new KafkaFutureImpl<>();
+                        future.completeExceptionally(e);
+                        return future;
+                    }
+                } else {
+                    return allDone();
+                }
+            }
+
+            KafkaFutureImpl<ConsumerGroupListing> future = new KafkaFutureImpl<>();
+            future.complete(innerIter.next());
+            return future;
+        }
     }
 
     /**
-     * Return a future which yields a collection of ConsumerGroupListing objects.
+     * Return an iterator of futures for ConsumerGroupListing objects; the returned future will throw exception
+     * if we cannot get a complete collection of consumer listings.
      */
-    public KafkaFuture<Collection<ConsumerGroupListing>> listings() {
-        return future;
+    public Iterator<KafkaFuture<ConsumerGroupListing>> iterator() {
+        return new FutureConsumerGroupListingIterator();
+    }
+
+    /**
+     * Return a future which yields a full collection of ConsumerGroupListing objects; will throw exception
+     * if we cannot get a complete collection of consumer listings.
+     */
+    public KafkaFuture<Collection<ConsumerGroupListing>> all() {
+        return flattenFuture;
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -83,6 +83,46 @@ public abstract class KafkaFuture<T> implements Future<T> {
         }
     }
 
+    private static class AnyOfAdapter<R> implements BiConsumer<R, Throwable> {
+        private Throwable exceptionToReturn;
+        private boolean returnException;
+        private int remainingResponses;
+        private KafkaFuture<?> future;
+
+        public AnyOfAdapter(int remainingResponses, KafkaFuture<?> future) {
+            this.remainingResponses = remainingResponses;
+            this.exceptionToReturn = null;
+            this.returnException = true;
+            this.future = future;
+            maybeComplete();
+        }
+
+        @Override
+        public synchronized void accept(R newValue, Throwable exception) {
+            if (remainingResponses <= 0)
+                return;
+
+            remainingResponses--;
+
+            if (exception != null) {
+                exceptionToReturn = exception;
+            } else {
+                returnException = false;
+            }
+
+            maybeComplete();
+        }
+
+        private void maybeComplete() {
+            if (remainingResponses <= 0) {
+                if (exceptionToReturn != null && returnException)
+                    future.completeExceptionally(exceptionToReturn);
+                else
+                    future.complete(null);
+            }
+        }
+    }
+
     /** 
      * Returns a new KafkaFuture that is already completed with the given value.
      */
@@ -106,13 +146,18 @@ public abstract class KafkaFuture<T> implements Future<T> {
         return allOfFuture;
     }
 
-    public KafkaFuture<T> combine(KafkaFuture<?>... futures) {
-        AllOfAdapter<Object> allOfWaiter = new AllOfAdapter<>(futures.length, this);
+    /**
+     * Returns a new KafkaFuture that is completed when all the given futures have completed or has failed.
+     * Only if all futures have failed then one exception gets chosen arbitrarily to return; otherwise
+     * the future will be completed successfully
+     */
+    public static KafkaFuture<Void> anyOf(KafkaFuture<?>... futures) {
+        KafkaFuture<Void> anyOfFuture = new KafkaFutureImpl<>();
+        AnyOfAdapter<Object> anyOfWaiter = new AnyOfAdapter<>(futures.length, anyOfFuture);
         for (KafkaFuture<?> future : futures) {
-            future.addWaiter(allOfWaiter);
+            future.addWaiter(anyOfWaiter);
         }
-
-        return this;
+        return anyOfFuture;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
+++ b/clients/src/main/java/org/apache/kafka/common/internals/KafkaFutureImpl.java
@@ -141,11 +141,15 @@ public class KafkaFutureImpl<T> extends KafkaFuture<T> {
      */
     @Override
     public <R> KafkaFuture<R> thenApply(BaseFunction<T, R> function) {
-        KafkaFutureImpl<R> future = new KafkaFutureImpl<R>();
+        KafkaFutureImpl<R> future = new KafkaFutureImpl<>();
         addWaiter(new Applicant<>(function, future));
         return future;
     }
 
+    public <R> void copyWith(KafkaFuture<R> future, BaseFunction<R, T> function) {
+        KafkaFutureImpl<R> futureImpl = (KafkaFutureImpl<R>) future;
+        futureImpl.addWaiter(new Applicant<>(function, this));
+    }
 
     /**
      * @See KafkaFutureImpl#thenApply(BaseFunction)

--- a/clients/src/test/java/org/apache/kafka/clients/MockClient.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MockClient.java
@@ -73,6 +73,7 @@ public class MockClient implements KafkaClient {
 
     }
 
+    private int correlation;
     private final Time time;
     private final Metadata metadata;
     private Set<String> unavailableTopics;
@@ -464,7 +465,7 @@ public class MockClient implements KafkaClient {
     public ClientRequest newClientRequest(String nodeId, AbstractRequest.Builder<?> requestBuilder, long createdTimeMs,
                                           boolean expectResponse, RequestCompletionHandler callback) {
         totalRequestCount.incrementAndGet();
-        return new ClientRequest(nodeId, requestBuilder, 0, "mockClientId", createdTimeMs,
+        return new ClientRequest(nodeId, requestBuilder, correlation++, "mockClientId", createdTimeMs,
                 expectResponse, callback);
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -801,12 +801,12 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(new OffsetFetchResponse(Errors.NONE, responseData));
 
             final ListConsumerGroupOffsetsResult result = env.adminClient().listConsumerGroupOffsets("group-0");
+            final Map<TopicPartition, OffsetAndMetadata> partitionToOffsetAndMetadata = result.partitionsToOffsetAndMetadata().get();
 
-            assertEquals(3, result.partitionsToOffsetAndMetadata().get().size());
-            final TopicPartition topicPartition = result.partitionsToOffsetAndMetadata().get().keySet().iterator().next();
-            assertEquals("my_topic", topicPartition.topic());
-            final OffsetAndMetadata offsetAndMetadata = result.partitionsToOffsetAndMetadata().get().values().iterator().next();
-            assertEquals(10, offsetAndMetadata.offset());
+            assertEquals(3, partitionToOffsetAndMetadata.size());
+            assertEquals(10, partitionToOffsetAndMetadata.get(myTopicPartition0).offset());
+            assertEquals(0, partitionToOffsetAndMetadata.get(myTopicPartition1).offset());
+            assertEquals(20, partitionToOffsetAndMetadata.get(myTopicPartition2).offset());
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -28,9 +28,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * A unit test for KafkaFuture.
@@ -149,6 +151,31 @@ public class KafkaFutureTest {
         }
     }
 
+    private static class ThrowThread<T> extends Thread {
+
+        private final KafkaFutureImpl<T> future;
+        private final T value;
+        Throwable testException = null;
+
+        ThrowThread(KafkaFutureImpl<T> future, T value) {
+            this.future = future;
+            this.value = value;
+        }
+
+        @Override
+        public void run() {
+            try {
+                try {
+                    Thread.sleep(0, 200);
+                } catch (InterruptedException e) {
+                }
+                future.completeExceptionally(new Exception());
+            } catch (Throwable testException) {
+                this.testException = testException;
+            }
+        }
+    }
+
     private static class WaiterThread<T> extends Thread {
 
         private final KafkaFutureImpl<T> future;
@@ -210,6 +237,62 @@ public class KafkaFutureTest {
     @Test
     public void testAllOfFuturesHandlesZeroFutures() throws Exception {
         KafkaFuture<Void> allFuture = KafkaFuture.allOf();
+        assertTrue(allFuture.isDone());
+        assertFalse(allFuture.isCancelled());
+        assertFalse(allFuture.isCompletedExceptionally());
+        allFuture.get();
+    }
+
+    @Test
+    public void testAnyOfFutures() throws Exception {
+        final int numThreads = 5;
+        final List<KafkaFutureImpl<Integer>> futures = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            futures.add(new KafkaFutureImpl<Integer>());
+        }
+        KafkaFuture<Void> allFuture = KafkaFuture.anyOf(futures.toArray(new KafkaFuture[0]));
+        final List<ThrowThread> throwThreads = new ArrayList<>();
+        final List<WaiterThread> waiterThreads = new ArrayList<>();
+        for (int i = 0; i < numThreads - 1; i++) {
+            throwThreads.add(new ThrowThread<>(futures.get(i), i));
+            waiterThreads.add(new WaiterThread<>(futures.get(i), i));
+        }
+        final CompleterThread completerThread = new CompleterThread<>(futures.get(numThreads - 1), numThreads - 1);
+        waiterThreads.add(new WaiterThread<>(futures.get(numThreads - 1), numThreads - 1));
+
+        assertFalse(allFuture.isDone());
+        for (int i = 0; i < numThreads; i++) {
+            waiterThreads.get(i).start();
+        }
+        for (int i = 0; i < numThreads - 1; i++) {
+            throwThreads.get(i).start();
+        }
+        assertFalse(allFuture.isDone());
+        completerThread.start();
+        allFuture.get();
+        assertTrue(allFuture.isDone());
+        for (int i = 0; i < numThreads - 1; i++) {
+            try {
+                futures.get(i).get();
+                fail("Except an exception to be thrown");
+            } catch (Exception e) {
+                // this is good
+            }
+        }
+        assertEquals(Integer.valueOf(numThreads - 1), futures.get(numThreads - 1).get());
+        for (int i = 0; i < numThreads - 1; i++) {
+            throwThreads.get(i).join();
+            waiterThreads.get(i).join();
+            assertEquals(null, throwThreads.get(i).testException);
+            assertNotNull(waiterThreads.get(i).testException);
+        }
+        assertEquals(null, completerThread.testException);
+        assertEquals(null, waiterThreads.get(numThreads - 1).testException);
+    }
+
+    @Test
+    public void testAnyOfFuturesHandlesZeroFutures() throws Exception {
+        KafkaFuture<Void> allFuture = KafkaFuture.anyOf();
         assertTrue(allFuture.isDone());
         assertFalse(allFuture.isCancelled());
         assertFalse(allFuture.isCompletedExceptionally());

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -149,31 +149,6 @@ public class KafkaFutureTest {
         }
     }
 
-    private static class ThrowThread<T> extends Thread {
-
-        private final KafkaFutureImpl<T> future;
-        private final T value;
-        Throwable testException = null;
-
-        ThrowThread(KafkaFutureImpl<T> future, T value) {
-            this.future = future;
-            this.value = value;
-        }
-
-        @Override
-        public void run() {
-            try {
-                try {
-                    Thread.sleep(0, 200);
-                } catch (InterruptedException e) {
-                }
-                future.completeExceptionally(new Exception());
-            } catch (Throwable testException) {
-                this.testException = testException;
-            }
-        }
-    }
-
     private static class WaiterThread<T> extends Thread {
 
         private final KafkaFutureImpl<T> future;

--- a/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/KafkaFutureTest.java
@@ -28,11 +28,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /**
  * A unit test for KafkaFuture.


### PR DESCRIPTION
Refactored the return types in consumer group APIs the following way:

```
Map<TopicPartition, KafkaFuture<Void>> DeleteConsumerGroupsResult#deletedGroups()

Map<TopicPartition, KafkaFuture<ConsumerGroupDescription>> DescribeConsumerGroupsResult#describedGroups()

KafkaFuture<Collection<ConsumerGroupListing>> ListConsumerGroupsResult#listings()

KafkaFuture<Map<TopicPartition, OffsetAndMetadata>> ListConsumerGroupOffsetsResult#partitionsToOffsetAndMetadata()
```

1. For DeleteConsumerGroupsResult and DescribeConsumerGroupsResult, for each group id we have two round-trips to get the coordinator, and then send the delete / describe request; I leave the potential optimization of batching requests for future work.

2. For ListConsumerGroupOffsetsResult, it is a simple single round-trip and hence the whole map is wrapped as a Future.

3. ListConsumerGroupsResult, it is the most tricky one: we would only know how many futures we should wait for after the first listNode returns, and hence I constructed the flattened future in the middle wrapped with the underlying map of futures.

3.a Another big change I made is, we do not return the exception in the flattened future if only a few of the nodes returns ERROR code, and instead just return the rest of the listings; to use that I added a new `anyOf` function in `KafkaFuture`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
