### PR TITLE
KAFKA-6765: Handle exception while reading throttle metric value in test

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Metrics.java
@@ -487,7 +487,8 @@ public class Metrics implements Closeable {
 
     /**
      * Add a metric to monitor an object that implements MetricValueProvider. This metric won't be associated with any
-     * sensor. This is a way to expose existing values as metrics.
+     * sensor. This is a way to expose existing values as metrics. User is expected to add any additional
+     * synchronization to update and access metric values, if required.
      *
      * @param metricName The name of the metric
      * @param metricValueProvider The metric value provider associated with this metric
@@ -503,7 +504,8 @@ public class Metrics implements Closeable {
 
     /**
      * Add a metric to monitor an object that implements MetricValueProvider. This metric won't be associated with any
-     * sensor. This is a way to expose existing values as metrics.
+     * sensor. This is a way to expose existing values as metrics. User is expected to add any additional
+     * synchronization to update and access metric values, if required.
      *
      * @param metricName The name of the metric
      * @param metricValueProvider The metric value provider associated with this metric

--- a/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/Sensor.java
@@ -18,8 +18,6 @@ package org.apache.kafka.common.metrics;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.CompoundStat.NamedMeasurable;
-import org.apache.kafka.common.metrics.stats.Rate;
-import org.apache.kafka.common.metrics.stats.SampledStat;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 
@@ -292,17 +290,11 @@ public final class Sensor {
         return Collections.unmodifiableList(new LinkedList<>(this.metrics.values()));
     }
 
+    /**
+     * KafkaMetrics of sensors which use SampledStat should be synchronized on the Sensor object
+     * to allow concurrent reads and updates. For simplicity, all sensors are synchronized on Sensor.
+     */
     private Object metricLock(Stat stat) {
-        boolean requiresSensorLockForAccess = stat instanceof SampledStat || stat instanceof Rate;
-        if (stat instanceof CompoundStat) {
-            for (NamedMeasurable namedStat : ((CompoundStat) stat).stats()) {
-                Measurable measurable = namedStat.stat();
-                if (measurable instanceof SampledStat || measurable instanceof Rate) {
-                    requiresSensorLockForAccess = true;
-                    break;
-                }
-            }
-        }
-        return requiresSensorLockForAccess ? this : new Object();
+        return this;
     }
 }

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -160,26 +160,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 }
 
 object QuotaTestClients {
-  // This method may be invoked when metrics are being updated. Reading metricValue
-  // during an update may cause ConcurrentModificationException or NullPointerException.
-  // Retry a few times with a very small delay. We want to allow reading throttle metrics
-  // without waiting for request to complete to avoid waiting for potentially large
-  // throttle times.
-  def metricValue(metric: Metric): Double = {
-    val maxRetries = 10
-    (1 to maxRetries).foreach { i =>
-      try {
-        return metric.metricValue().asInstanceOf[Double]
-      } catch {
-        case e: Exception =>
-          if (i == maxRetries)
-            throw e
-          else
-            Thread.sleep(1)
-      }
-    }
-    throw new IllegalStateException("Should not get here")
-  }
+  def metricValue(metric: Metric): Double = metric.metricValue().asInstanceOf[Double]
 }
 
 abstract class QuotaTestClients(topic: String,


### PR DESCRIPTION
Quota tests wait for throttle metric to be updated without waiting for requests to complete to avoid waiting for potentially large throttle times. This requires the test to read metric values while a broker may be updating the value, resulting in exception in the test. Since this issue can also occur with JMX metrics reporter, change synchronization on metrics with sensors to use the sensor as lock.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
