### PR TITLE
MINOR: Add line break so example command is readable without scrolling

### DIFF
--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -209,7 +209,8 @@
 
   To remove an override you can do
   <pre class="brush: bash;">
-  &gt; bin/kafka-configs.sh --zookeeper localhost:2181  --entity-type topics --entity-name my-topic --alter --delete-config max.message.bytes
+  &gt; bin/kafka-configs.sh --zookeeper localhost:2181  --entity-type topics --entity-name my-topic
+      --alter --delete-config max.message.bytes
   </pre>
 
   The following are the topic-level configurations. The server's default configuration for this property is given under the Server Default Property heading. A given server default config value only applies to a topic if it does not have an explicit topic config override.


### PR DESCRIPTION
Line explaining how to remove topic level config is too long, thus the containing div becomes scrollable.
Depending on browser this is either clumsy or invisible.

Change-Id: If79515da36df6fcb24b6429ab325aaede0e589e3

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
