### PR TITLE
ConnectorConfig could override Producer's config

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -455,6 +455,15 @@ public class Worker {
                     internalKeyConverter, internalValueConverter);
             OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetBackingStore, id.connector(),
                     internalKeyConverter, internalValueConverter);
+            
+            // Why do you use only producerProps
+            // Could we merge producerProps and connectorConfig (producer's config properties)?
+            // Use-case: have different sasl.jaas.config function of Connector "instances"
+            // So different credentials (to bridge with ACLs)
+            // KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps);
+            // must define how to merge producerProps + connConfig
+            // KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(mergedProducerProps);
+            
             KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps);
             return new WorkerSourceTask(id, (SourceTask) task, statusListener, initialState, keyConverter, valueConverter,
                     headerConverter, transformationChain, producer, offsetReader, offsetWriter, config, metrics, loader, time);


### PR DESCRIPTION
Could we improve Worker to be able to override producer configuration properties from ConnectorConfig.
It would be able to override for example sasl.jaas.config (credentials)

Is there another way to handle this case?

Thank you

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
