### PR TITLE
KAFKA-6802: Improved logging for missing topics during task assignment

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
@@ -86,7 +86,7 @@ public class DefaultPartitionGrouper implements PartitionGrouper {
                 log.warn("Skipping creating tasks for the topic group {} since topic {}'s metadata is not available yet;"
                          + " no tasks for this topic group will be assigned to any client.\n"
                          + " Make sure all supplied topics in the topology are created before starting"
-                         + " as this could lead to unexpected results", topic);
+                         + " as this could lead to unexpected results", topics, topic);
                 return StreamsPartitionAssignor.NOT_AVAILABLE;
             } else {
                 int numPartitions = partitions.size();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
@@ -82,7 +82,10 @@ public class DefaultPartitionGrouper implements PartitionGrouper {
             List<PartitionInfo> partitions = metadata.partitionsForTopic(topic);
 
             if (partitions.isEmpty()) {
-                log.info("Skipping assigning topic {} to tasks since its metadata is not available yet", topic);
+
+                log.warn("Skipping assigning topic {} to tasks since its metadata is not available yet"
+                         + " Make sure all supplied topics in the topology are created before starting"
+                         + " as this could lead to unexpected results", topic);
                 return StreamsPartitionAssignor.NOT_AVAILABLE;
             } else {
                 int numPartitions = partitions.size();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/DefaultPartitionGrouper.java
@@ -83,7 +83,8 @@ public class DefaultPartitionGrouper implements PartitionGrouper {
 
             if (partitions.isEmpty()) {
 
-                log.warn("Skipping assigning topic {} to tasks since its metadata is not available yet"
+                log.warn("Skipping creating tasks for the topic group {} since topic {}'s metadata is not available yet;"
+                         + " no tasks for this topic group will be assigned to any client.\n"
                          + " Make sure all supplied topics in the topology are created before starting"
                          + " as this could lead to unexpected results", topic);
                 return StreamsPartitionAssignor.NOT_AVAILABLE;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -470,7 +470,10 @@ public class StreamsPartitionAssignor implements PartitionAssignor, Configurable
                 for (final PartitionInfo partitionInfo : partitionInfoList) {
                     final TopicPartition partition = new TopicPartition(partitionInfo.topic(), partitionInfo.partition());
                     if (!allAssignedPartitions.contains(partition)) {
-                        log.warn("Partition {} is not assigned to any tasks: {}", partition, partitionsForTask);
+                        log.warn("Partition {} is not assigned to any tasks: {}"
+                                 + " Possible causes of a partition not getting assigned"
+                                 + " is that a topic defined in the topology has not been"
+                                 + " created when starting your streams application", partition, partitionsForTask);
                     }
                 }
             } else {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsPartitionAssignor.java
@@ -472,8 +472,9 @@ public class StreamsPartitionAssignor implements PartitionAssignor, Configurable
                     if (!allAssignedPartitions.contains(partition)) {
                         log.warn("Partition {} is not assigned to any tasks: {}"
                                  + " Possible causes of a partition not getting assigned"
-                                 + " is that a topic defined in the topology has not been"
-                                 + " created when starting your streams application", partition, partitionsForTask);
+                                 + " is that another topic defined in the topology has not been"
+                                 + " created when starting your streams application,"
+                                 + " resulting in no tasks created for this topology at all.", partition, partitionsForTask);
                     }
                 }
             } else {


### PR DESCRIPTION
If users don't create all topics before starting a streams application, they could get unexpected results.  For example, sharing a state store between sub-topologies where one input topic is not created ahead time results in log message that that "Partition X is not assigned to any tasks" does not give any clues as to how this could have occurred.

Also, this PR changes the log level from `INFO` to `WARN` when metadata does not have partitions for a given topic.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
