### PR TITLE
MINOR: Retry setting aligned time until set

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -16,15 +16,13 @@
  */
 package org.apache.kafka.streams.integration;
 
-import kafka.admin.AdminClient;
-import kafka.tools.StreamsResetter;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
@@ -64,6 +62,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import kafka.admin.AdminClient;
+import kafka.tools.StreamsResetter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -106,10 +107,19 @@ public abstract class AbstractResetIntegrationTest {
             kafkaAdminClient = (KafkaAdminClient) org.apache.kafka.clients.admin.AdminClient.create(commonClientConfig);
         }
 
+        try {
+            setCurrentTime();
+        } catch (IllegalArgumentException e) {
+            System.err.println("New time less than previous time, will re-try setting time once");
+            setCurrentTime();
+        }
+    }
+
+    private void setCurrentTime() {
+        mockTime = cluster.time;
         // we align time to seconds to get clean window boundaries and thus ensure the same result for each run
         // otherwise, input records could fall into different windows for different runs depending on the initial mock time
         final long alignedTime = (System.currentTimeMillis() / 1000 + 1) * 1000;
-        mockTime = cluster.time;
         mockTime.setCurrentTimeMs(alignedTime);
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractResetIntegrationTest.java
@@ -122,7 +122,7 @@ public abstract class AbstractResetIntegrationTest {
             final long alignedTime = (System.currentTimeMillis() / 1000 + 1) * 1000;
             mockTime.setCurrentTimeMs(alignedTime);
             currentTimeSet = true;
-        } catch (IllegalArgumentException e) {
+        } catch (final IllegalArgumentException e) {
             // don't care will retry until set
         }
         return currentTimeSet;


### PR DESCRIPTION
In the `AbstractResetIntegrationTest` we can have a transient error when setting the time for the test where the new time is less than the original time, for those cases we should catch the exception and re-try setting the time once versus letting the test fail.

For testing, ran the entire streams test suite.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
