### PR TITLE
KAFKA-6807: Inconsistent method name.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateRestorer.java
@@ -100,7 +100,7 @@ public class StateRestorer {
     }
 
     boolean hasCompleted(final long recordOffset, final long endOffset) {
-        return endOffset == 0 || recordOffset >= readTo(endOffset);
+        return endOffset == 0 || recordOffset >= lesser(endOffset);
     }
 
     Long restoredOffset() {
@@ -115,7 +115,7 @@ public class StateRestorer {
         return offsetLimit;
     }
 
-    private Long readTo(final long endOffset) {
+    private Long lesser(final long endOffset) {
         return endOffset < offsetLimit ? endOffset : offsetLimit;
     }
 


### PR DESCRIPTION
Change the method name "readTo" to "lesser".
The method is named as "readTo", but the method will return the variable with lesses value. Thus, the name "readTo" is inconsistent with the method body code.
Rename the method as "lesser" should be better.
