### PR TITLE
MINOR: Fix formatting in --new-consumer deprecation warning

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -1017,8 +1017,8 @@ object ConsumerGroupCommand extends Logging {
         CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 
         if (options.has(newConsumerOpt)) {
-          Console.err.println(s"The $newConsumerOpt option is deprecated and will be removed in a future major release." +
-            s"The new consumer is used by default if the $bootstrapServerOpt option is provided.")
+          Console.err.println(s"The --new-consumer option is deprecated and will be removed in a future major release. " +
+            s"The new consumer is used by default if the --bootstrap-server option is provided.")
         }
 
         if (options.has(deleteOpt) && options.has(topicOpt))

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -453,7 +453,7 @@ object ConsoleConsumer extends Logging {
       CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServerOpt)
 
       if (options.has(newConsumerOpt)) {
-        Console.err.println("The --new-consumer option is deprecated and will be removed in a future major release." +
+        Console.err.println("The --new-consumer option is deprecated and will be removed in a future major release. " +
           "The new consumer is used by default if the --bootstrap-server option is provided.")
       }
     }

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -318,7 +318,7 @@ object ConsumerPerformance extends LazyLogging {
       CommandLineUtils.checkRequiredArgs(parser, options, bootstrapServersOpt)
 
       if (options.has(newConsumerOpt)) {
-        Console.err.println("The --new-consumer option is deprecated and will be removed in a future major release." +
+        Console.err.println("The --new-consumer option is deprecated and will be removed in a future major release. " +
           "The new consumer is used by default if the --bootstrap-server option is provided.")
       }
 

--- a/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
+++ b/core/src/main/scala/kafka/tools/ConsumerPerformance.scala
@@ -319,7 +319,7 @@ object ConsumerPerformance extends LazyLogging {
 
       if (options.has(newConsumerOpt)) {
         Console.err.println("The --new-consumer option is deprecated and will be removed in a future major release. " +
-          "The new consumer is used by default if the --bootstrap-server option is provided.")
+          "The new consumer is used by default if the --broker-list option is provided.")
       }
 
       import org.apache.kafka.clients.consumer.ConsumerConfig


### PR DESCRIPTION
Added space between sentences, to make the text look nicer. All unit tests and integrations tests pass after the change.

**Before:**
```
$ bin/kafka-consumer-groups.sh --new-consumer --bootstrap-server localhost:9092 --list
The [new-consumer] option is deprecated and will be removed in a future major release.The new consumer is used by default if the [bootstrap-server] option is provided.
Note: This will not show information about old Zookeeper-based consumers.
```

**After:**
```
$ bin/kafka-consumer-groups.sh --new-consumer --bootstrap-server localhost:9092 --list
The [new-consumer] option is deprecated and will be removed in a future major release. The new consumer is used by default if the [bootstrap-server] option is provided.
Note: This will not show information about old Zookeeper-based consumers.
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
