### PR TITLE
KAFKA-5034: Enable plugins to be added to the plugin path at runtime

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -246,7 +246,7 @@ public class WorkerConfig extends AbstractConfig {
 
     public static List<String> pluginLocations(Map<String, String> props) {
         String locationList = props.get(WorkerConfig.PLUGIN_PATH_CONFIG);
-        return locationList == null
+        return locationList == null || locationList.trim().isEmpty()
                          ? new ArrayList<String>()
                          : Arrays.asList(locationList.trim().split("\\s*,\\s*", -1));
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginPathDirectoryListener.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginPathDirectoryListener.java
@@ -66,9 +66,14 @@ class PluginPathDirectoryListener implements Runnable {
         // Have to track which entries in the plugin path directory are directories; after a
         // file/directory is deleted, it's impossible to determine whether or not it used to be a
         // directory.
-        for (File file : pluginPathDirectory.toFile().listFiles()) {
-            if (file.isDirectory()) {
-                pluginDirectories.add(file.toPath().toAbsolutePath());
+        File[] files = pluginPathDirectory.toFile().listFiles();
+        // Should always be true, given the check at the beginning of the method. Still, check for
+        // null here just to be safe.
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    pluginDirectories.add(file.toPath().toAbsolutePath());
+                }
             }
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginPathDirectoryListener.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginPathDirectoryListener.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.isolation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class PluginPathDirectoryListener implements Runnable {
+
+    private static final Logger log = LoggerFactory.getLogger(PluginPathDirectoryListener.class);
+
+    private final PluginReceiver pluginReceiver;
+    private final WatchService watchService;
+    private final Set<Path> pluginDirectories;
+
+    PluginPathDirectoryListener(
+            PluginReceiver pluginReceiver,
+            Iterable<Path> pluginDirectories
+    ) throws IOException {
+        this.pluginReceiver = pluginReceiver;
+        this.pluginDirectories = new HashSet<>();
+
+        watchService = FileSystems.getDefault().newWatchService();
+        for (Path pluginDirectory : pluginDirectories) {
+            registerDirectory(pluginDirectory);
+        }
+    }
+
+    private void registerDirectory(Path pluginPathDirectory) throws IOException {
+        if (!pluginPathDirectory.toFile().isDirectory()) {
+            throw new IllegalArgumentException("Not a directory: " + pluginPathDirectory);
+        }
+        pluginPathDirectory.register(
+                watchService,
+                StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_DELETE
+        );
+
+        // Have to track which entries in the plugin path directory are directories; after a
+        // file/directory is deleted, it's impossible to determine whether or not it used to be a
+        // directory.
+        for (File file : pluginPathDirectory.toFile().listFiles()) {
+            if (file.isDirectory()) {
+                pluginDirectories.add(file.toPath().toAbsolutePath());
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        for (;;) {
+            try {
+                WatchKey watchKey = watchService.take();
+                List<WatchEvent<?>> events = watchKey.pollEvents();
+                Path pluginPath = watchKeyPath(watchKey);
+                for (WatchEvent<?> event : events) {
+                    handleEvent(pluginPath, pathWatchEvent(event));
+                }
+                if (!watchKey.reset()) {
+                    log.warn("No longer monitoring directory {} on plugin path", pluginPath);
+                }
+            } catch (InterruptedException e) {
+                log.warn("Interrupted while polling for plugin path file system changes; polling will cease");
+                return;
+            } catch (Throwable t) {
+                log.error("Error while monitoring file system for plugin path changes", t);
+                t.printStackTrace(System.out);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private WatchEvent<Path> pathWatchEvent(WatchEvent<?> watchEvent) {
+        return (WatchEvent<Path>) watchEvent;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Path watchKeyPath(WatchKey watchKey) {
+        return (Path) watchKey.watchable();
+    }
+
+    private void handleEvent(Path pluginPath, WatchEvent<Path> event) {
+        Path pluginLocation = pluginPath.resolve(event.context()).toAbsolutePath();
+        if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())) {
+            boolean isDirectory = Files.isDirectory(pluginLocation);
+            if (isDirectory) {
+                pluginDirectories.add(pluginLocation);
+            }
+            if (isDirectory || PluginUtils.isArchive(pluginLocation)) {
+                pluginReceiver.onCreate(pluginLocation);
+            }
+        } else if (StandardWatchEventKinds.ENTRY_DELETE.equals(event.kind())) {
+            boolean wasDirectory = pluginDirectories.remove(pluginLocation);
+            if (wasDirectory || PluginUtils.isArchive(pluginLocation)) {
+                pluginReceiver.onDelete(pluginLocation);
+            }
+        } else {
+            log.warn(
+                    "Received unexpected event kind while monitoring file system for changes: {}",
+                    event.kind()
+            );
+        }
+    }
+
+    interface PluginReceiver {
+
+        /**
+          * Called when an entry that could be a plugin (either a directory or an archive file) is
+          * created.
+          * @param pluginLocation The absolute path to the newly-created directory/file
+          */
+        void onCreate(Path pluginLocation);
+
+        /**
+          * Called when an entry that could have been a plugin (either a directory or an archive file) is
+          * deleted.
+          * @param pluginLocation The absolute path to the recently-deleted directory/file
+          */
+        void onDelete(Path pluginLocation);
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginPathDirectoryListenerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginPathDirectoryListenerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.isolation;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PluginPathDirectoryListenerTest {
+
+    // How long to wait for every plugin creation to be registered before failing the test, in ms
+    private static final long CREATE_WAIT_TIMEOUT = 15000;
+
+    // How long to wait for every plugin deletion to be registered before failing the test, in ms
+    private static final long DELETE_WAIT_TIMEOUT = 15000;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testPluginDirectoryListener() throws IOException, InterruptedException {
+        File testPluginDirectory = folder.newFolder("test-plugin-directory");
+
+        Path pluginDir1 = Paths.get(testPluginDirectory.toString(), "pluginDir1");
+        Path pluginDir2 = Paths.get(testPluginDirectory.toString(), "pluginDir2");
+        Path pluginDir3 = Paths.get(testPluginDirectory.toString(), "pluginDir3");
+        Path pluginDir4 = Paths.get(testPluginDirectory.toString(), "pluginDir4");
+
+        Path pluginJar1 = Paths.get(testPluginDirectory.toString(), "pluginJar1.jar");
+        Path pluginJar2 = Paths.get(testPluginDirectory.toString(), "pluginJar2.jar");
+        Path pluginJar3 = Paths.get(testPluginDirectory.toString(), "pluginJar3.jar");
+        Path pluginJar4 = Paths.get(testPluginDirectory.toString(), "pluginJar4.jar");
+
+        Path pluginZip1 = Paths.get(testPluginDirectory.toString(), "pluginZip1.zip");
+        Path pluginZip2 = Paths.get(testPluginDirectory.toString(), "pluginZip2.zip");
+        Path pluginZip3 = Paths.get(testPluginDirectory.toString(), "pluginZip3.zip");
+        Path pluginZip4 = Paths.get(testPluginDirectory.toString(), "pluginZip4.zip");
+
+        Path irrelevantFile = Paths.get(testPluginDirectory.toString(), "irrelevantFile");
+
+        createDirectory(pluginDir4);
+        createFile(pluginJar4);
+        createFile(pluginZip4);
+
+        final Set<Path> expectedDirCreates = new HashSet<>(Arrays.asList(
+                pluginDir1, pluginDir2, pluginDir3
+        ));
+        final Set<Path> expectedFileCreates = new HashSet<>(Arrays.asList(
+                pluginJar1, pluginJar2, pluginJar3, pluginZip1, pluginZip2, pluginZip3
+        ));
+
+        final Set<Path> expectedCreates = new HashSet<>();
+        expectedCreates.addAll(expectedDirCreates);
+        expectedCreates.addAll(expectedFileCreates);
+
+        final Set<Path> expectedDeletes = new HashSet<>(Arrays.asList(
+                pluginDir2, pluginDir4,
+                pluginJar2, pluginJar4,
+                pluginZip2, pluginZip4
+        ));
+
+        final Set<Path> actualCreates = new HashSet<>();
+        final Set<Path> actualDeletes = new HashSet<>();
+
+        PluginPathDirectoryListener.PluginReceiver pluginReceiver = new PluginPathDirectoryListener.PluginReceiver() {
+            @Override
+            public void onCreate(Path pluginLocation) {
+                actualCreates.add(pluginLocation);
+                if (actualCreates.equals(expectedCreates)) {
+                    synchronized (expectedCreates) {
+                        expectedCreates.notify();
+                    }
+                }
+            }
+
+            @Override
+            public void onDelete(Path pluginLocation) {
+                actualDeletes.add(pluginLocation);
+                if (actualDeletes.equals(expectedDeletes)) {
+                    synchronized (expectedDeletes) {
+                        expectedDeletes.notify();
+                    }
+                }
+            }
+        };
+
+        PluginPathDirectoryListener testListener =
+                new PluginPathDirectoryListener(pluginReceiver, Collections.singleton(testPluginDirectory.toPath()));
+        new Thread(testListener).start();
+
+        for (Path directory : expectedDirCreates) {
+            createDirectory(directory);
+        }
+        for (Path file : expectedFileCreates) {
+            createFile(file);
+        }
+        createFile(irrelevantFile);
+        synchronized (expectedCreates) {
+            expectedCreates.wait(CREATE_WAIT_TIMEOUT);
+        }
+        assertEquals(
+                "Not all expected plugin directory creates were observed during testing",
+                expectedCreates,
+                actualCreates
+        );
+
+        for (Path directory : expectedDeletes) {
+            deleteFileOrDirectory(directory);
+        }
+        deleteFileOrDirectory(irrelevantFile);
+        synchronized (expectedDeletes) {
+            expectedDeletes.wait(DELETE_WAIT_TIMEOUT);
+        }
+        assertEquals(
+                "Not all expected plugin directory deletes were observed during testing",
+                expectedDeletes,
+                actualDeletes
+        );
+    }
+
+    private void createFile(Path path) throws IOException {
+        if (!path.toFile().createNewFile()) {
+            fail("Failed to create test file " + path.toString());
+        }
+    }
+
+    private void createDirectory(Path path) {
+        if (!path.toFile().mkdir()) {
+            fail("Failed to create test directory " + path.toString());
+        }
+    }
+
+    private void deleteFileOrDirectory(Path path) {
+        if (!path.toFile().delete()) {
+            fail("Failed to delete test directory " + path.toString());
+        }
+    }
+}


### PR DESCRIPTION
Each directory in the plugin.path is monitored for file system changes via a daemon thread, and when a change is detected that appears to correspond to a plugin creation (e.g., a directory or archive file is created), the DelegatingClassLoader is alerted and scans the location for new plugins to register.

Plugin removals currently only result in a warning, since once they are loaded by the DelegatingClassLoader, deletion of the corresponding .class, .zip, or .jar files does not remove them from the class loader.

Testing involves creating a directory, populating it with several fake plugins, and watching it with a `PluginPathDirectoryListener`. At that point, several more fake plugins are created, and it is verified that their creation has been detected by the listener. Afterward, some fake plugins are deleted, and it is verified that their deletion has been detected by the listener. A "red herring" file is also created and deleted during the test, and it is verified that that file is not acknowledged by the listener. All current plugin formats are included in the test (directory, JAR file, and ZIP file).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
