### PR TITLE
KAFKA-6814: Refine shown message when failing to delete groups

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -46,6 +46,8 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
 import org.apache.kafka.common.errors.DisconnectException;
+import org.apache.kafka.common.errors.GroupIdNotFoundException;
+import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.InvalidGroupIdException;
 import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.errors.InvalidTopicException;
@@ -2587,7 +2589,12 @@ public class KafkaAdminClient extends AdminClient {
                             final Errors groupError = response.get(groupId);
 
                             if (groupError != Errors.NONE) {
-                                future.completeExceptionally(groupError.exception());
+                                ApiException exception = groupError.exception();
+                                if (exception instanceof GroupIdNotFoundException || exception instanceof GroupNotEmptyException) {
+                                    future.completeExceptionally(groupError.exception(groupId));
+                                } else {
+                                    future.completeExceptionally(groupError.exception());
+                                }
                             } else {
                                 future.complete(null);
                             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6814

When deleting a nonexistent group, exception message is as below:
`The group id The group id does not exist was not found` which is very unfriendly. This patch will fix this misleading message in this case, and also cover deleting-not-empty-group as well.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
