### PR TITLE
KAFKA-6815 "default.production.exception.handler" default value is not specified in doc

### DIFF
--- a/docs/streams/developer-guide/config-streams.html
+++ b/docs/streams/developer-guide/config-streams.html
@@ -215,7 +215,7 @@
           <tr class="row-odd"><td>default.deserialization.exception.handler</td>
             <td>Medium</td>
             <td colspan="2">Exception handling class that implements the <code class="docutils literal"><span class="pre">DeserializationExceptionHandler</span></code> interface.</td>
-            <td>30000 milliseconds</td>
+            <td><code class="docutils literal"><span class="pre">LogAndContinueExceptionHandler</span></code></td>
           </tr>
           <tr class="row-even"><td>default.production.exception.handler</td>
             <td>Medium</td>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6815

in KafkaStreams config, 
default.deserialization.exception.handler is LogAndFailExceptionHandler 
but, document has 30000ms 
