### PR TITLE
MINOR: use jdk8 to build/run system tests

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,7 +80,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # share to a temporary location and the provisioning scripts symlink data
       # to the right location.
       override.cache.enable :generic, {
-        "oracle-jdk7" => { cache_dir: "/tmp/oracle-jdk7-installer-cache" },
+        "oracle-jdk8" => { cache_dir: "/tmp/oracle-jdk8-installer-cache" },
       }
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ ec2_keypair_file = nil
 
 ec2_region = "us-east-1"
 ec2_az = nil # Uses set by AWS
-ec2_ami = "ami-9eaa1cf6"
+ec2_ami = "ami-905730e8"
 ec2_instance_type = "m3.medium"
 ec2_user = "ubuntu"
 ec2_instance_name_prefix = "kafka-vagrant"

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -27,13 +27,9 @@ if [ -z `which javac` ]; then
     apt-get -y update
 
     # Try to share cache. See Vagrantfile for details
-    mkdir -p /var/cache/oracle-jdk7-installer
-    if [ -e "/tmp/oracle-jdk7-installer-cache/" ]; then
-        find /tmp/oracle-jdk7-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk7-installer/ \;
-    fi
-    if [ ! -e "/var/cache/oracle-jdk7-installer/jdk-7u80-linux-x64.tar.gz" ]; then
-        # Grab a copy of the JDK since it has moved and original downloader won't work
-        curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-7u80-linux-x64.tar.gz" -o /var/cache/oracle-jdk7-installer/jdk-7u80-linux-x64.tar.gz
+    mkdir -p /var/cache/oracle-jdk8-installer
+    if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
+        find /tmp/oracle-jdk8-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk8-installer/ \;
     fi
 
     /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
@@ -42,15 +38,15 @@ if [ -z `which javac` ]; then
     # as one line per dot in the build logs.
     # To avoid this noise we redirect all output to a file that we only show if apt-get fails.
     echo "Installing JDK..."
-    if ! apt-get -y install oracle-java7-installer oracle-java7-set-default >/tmp/jdk_install.log 2>&1 ; then
+    if ! apt-get -y install oracle-java8-installer oracle-java8-set-default >/tmp/jdk_install.log 2>&1 ; then
         cat /tmp/jdk_install.log
         echo "ERROR: JDK install failed"
         exit 1
     fi
     echo "JDK installed: $(javac -version 2>&1)"
 
-    if [ -e "/tmp/oracle-jdk7-installer-cache/" ]; then
-        cp -R /var/cache/oracle-jdk7-installer/* /tmp/oracle-jdk7-installer-cache
+    if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
+        cp -R /var/cache/oracle-jdk8-installer/* /tmp/oracle-jdk8-installer-cache
     fi
 fi
 

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -31,9 +31,9 @@ if [ -z `which javac` ]; then
     if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
         find /tmp/oracle-jdk8-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk8-installer/ \;
     fi
-    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u161-linux-x64.tar.gz" ]; then
+    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz" ]; then
       # Grab a copy of the JDK since it has moved and original downloader won't work
-      curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-8u161-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u161-linux-x64.tar.gz
+      curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-8u171-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u171-linux-x64.tar.gz
     fi
 
     /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -31,6 +31,10 @@ if [ -z `which javac` ]; then
     if [ -e "/tmp/oracle-jdk8-installer-cache/" ]; then
         find /tmp/oracle-jdk8-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk8-installer/ \;
     fi
+    if [ ! -e "/var/cache/oracle-jdk8-installer/jdk-8u161-linux-x64.tar.gz" ]; then
+      # Grab a copy of the JDK since it has moved and original downloader won't work
+      curl -s -L "https://s3-us-west-2.amazonaws.com/kafka-packages/jdk-8u161-linux-x64.tar.gz" -o /var/cache/oracle-jdk8-installer/jdk-8u161-linux-x64.tar.gz
+    fi
 
     /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 


### PR DESCRIPTION
java 7 is way past expired and the debian installer packages
are no longer available.

Also upgrade ami to latest ubuntu/trusty 14 amd64 as old one is not available.

Tested by running ./vagrant/vagrant-up.sh successfully.