### PR TITLE
Minor: Fix MetadataTest.testMetadata

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/Cluster.java
+++ b/clients/src/main/java/org/apache/kafka/common/Cluster.java
@@ -85,7 +85,7 @@ public final class Cluster {
         List<Node> copy = new ArrayList<>(nodes);
         Collections.shuffle(copy);
         this.nodes = Collections.unmodifiableList(copy);
-        this.nodesById = new HashMap<>();
+        this.nodesById = new HashMap<>(nodes.size());
         for (Node node : nodes)
             this.nodesById.put(node.id(), node);
 
@@ -97,8 +97,8 @@ public final class Cluster {
         // index the partitions by topic and node respectively, and make the lists
         // unmodifiable so we can hand them out in user-facing apis without risk
         // of the client modifying the contents
-        HashMap<String, List<PartitionInfo>> partsForTopic = new HashMap<>();
-        HashMap<Integer, List<PartitionInfo>> partsForNode = new HashMap<>();
+        HashMap<String, List<PartitionInfo>> partsForTopic = new HashMap<>(partitions.size());
+        HashMap<Integer, List<PartitionInfo>> partsForNode = new HashMap<>(this.nodes.size());
         for (Node n : this.nodes) {
             partsForNode.put(n.id(), new ArrayList<PartitionInfo>());
         }
@@ -172,7 +172,7 @@ public final class Cluster {
     public List<Node> nodes() {
         return this.nodes;
     }
-    
+
     /**
      * Get the node by the node id (or null if no such node exists)
      * @param id The id of the node

--- a/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/MetadataTest.java
@@ -63,6 +63,7 @@ public class MetadataTest {
         time += refreshBackoffMs;
         assertTrue("Update needed now that backoff time expired", metadata.timeToNextUpdate(time) == 0);
         String topic = "my-topic";
+        Cluster cluster = TestUtils.singletonCluster(topic, 1);
         Thread t1 = asyncFetch(topic, 500);
         Thread t2 = asyncFetch(topic, 500);
         assertTrue("Awaiting update", t1.isAlive());
@@ -71,7 +72,7 @@ public class MetadataTest {
         // This simulates the metadata update sequence in KafkaProducer
         while (t1.isAlive() || t2.isAlive()) {
             if (metadata.timeToNextUpdate(time) == 0) {
-                metadata.update(TestUtils.singletonCluster(topic, 1), Collections.<String>emptySet(), time);
+                metadata.update(cluster, Collections.<String>emptySet(), time);
                 time += refreshBackoffMs;
             }
             Thread.sleep(1);


### PR DESCRIPTION
MetadataTest.testMetadata fails frequently on our jenkins. The error message is shown below.

`java.lang.AssertionError: Exception in background thread : org.apache.kafka.common.errors.TimeoutException: Failed to update metadata after 500 ms. expected null, but was:<org.apache.kafka.common.errors.TimeoutException: Failed to update metadata after 500 ms.>`

The failure is caused by taking too much time to create the Cluster. Given the test always uses the identical cluster object, moving the creation out of loop shouldn't break the previous behavior. This PR also makes some collection have precise initial size.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
