### PR TITLE
KIP-81: KAFKA-4133: Bound memory usage of the Consumer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java
@@ -638,7 +638,7 @@ public class NetworkClient implements KafkaClient {
         return found;
     }
 
-    public static AbstractResponse parseResponse(ByteBuffer responseBuffer, RequestHeader requestHeader) {
+    public static AbstractResponse parseSaslResponse(ByteBuffer responseBuffer, RequestHeader requestHeader) {
         Struct responseStruct = parseStructMaybeUpdateThrottleTimeMetrics(responseBuffer, requestHeader, null, 0);
         // Sasl authentication does not use a MemoryPool, hence null Closeable
         return AbstractResponse.parseResponse(requestHeader.apiKey(), responseStruct, null);

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -58,6 +58,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -356,7 +357,7 @@ public class KafkaAdminClient extends AdminClient {
             String metricGrpPrefix = "admin-client";
             channelBuilder = ClientUtils.createChannelBuilder(config, time);
             selector = new Selector(config.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                    metrics, time, metricGrpPrefix, channelBuilder, logContext);
+                    metrics, time, metricGrpPrefix, channelBuilder, MemoryPool.NONE, logContext);
             networkClient = new NetworkClient(
                 selector,
                 metadataManager.updater(),

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -131,7 +131,7 @@ public class ConsumerConfig extends AbstractConfig {
             "Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than " +
             "this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. " +
             "The maximum record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
-            "<code>max.message.bytes</code> (topic config). Note that the consumer performs multiple fetches in parallel.";
+            "<code>max.message.bytes</code> (topic config). Note that the consumer performs multiple fetches in parallel. It should be lower than <code>buffer.memory</code>.";
     public static final int DEFAULT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
 
     /**
@@ -262,6 +262,12 @@ public class ConsumerConfig extends AbstractConfig {
 
     public static final String DEFAULT_ISOLATION_LEVEL = IsolationLevel.READ_UNCOMMITTED.toString().toLowerCase(Locale.ROOT);
 
+    /** <code>buffer.memory</code> */
+    public static final String BUFFER_MEMORY_CONFIG = "buffer.memory";
+    public static final String BUFFER_MEMORY_DOC = "The total bytes of memory the consumer can use to buffer records received from the server while waiting to be processed (decompressed and deserialized)." +
+           " This setting slightly differs from the total memory the consumer will use because some additional memory will be used for decompression (if compression is enabled), deserialization as" +
+           " well as for maintaining in-flight requests. Note that this setting must be at least as big as <code>max.fetch.bytes</code>.";
+
     static {
         CONFIG = new ConfigDef().define(BOOTSTRAP_SERVERS_CONFIG,
                                         Type.LIST,
@@ -320,7 +326,7 @@ public class ConsumerConfig extends AbstractConfig {
                                         Type.INT,
                                         DEFAULT_MAX_PARTITION_FETCH_BYTES,
                                         atLeast(0),
-                                        Importance.HIGH,
+                                        Importance.LOW,
                                         MAX_PARTITION_FETCH_BYTES_DOC)
                                 .define(SEND_BUFFER_CONFIG,
                                         Type.INT,
@@ -464,6 +470,12 @@ public class ConsumerConfig extends AbstractConfig {
                                         in(IsolationLevel.READ_COMMITTED.toString().toLowerCase(Locale.ROOT), IsolationLevel.READ_UNCOMMITTED.toString().toLowerCase(Locale.ROOT)),
                                         Importance.MEDIUM,
                                         ISOLATION_LEVEL_DOC)
+                                .define(BUFFER_MEMORY_CONFIG,
+                                        Type.LONG,
+                                        Long.MAX_VALUE,
+                                        atLeast(1),
+                                        Importance.HIGH,
+                                        BUFFER_MEMORY_DOC)
                                 // security support
                                 .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
                                         Type.STRING,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -131,7 +131,7 @@ public class ConsumerConfig extends AbstractConfig {
             "Records are fetched in batches by the consumer, and if the first record batch in the first non-empty partition of the fetch is larger than " +
             "this value, the record batch will still be returned to ensure that the consumer can make progress. As such, this is not a absolute maximum. " +
             "The maximum record batch size accepted by the broker is defined via <code>message.max.bytes</code> (broker config) or " +
-            "<code>max.message.bytes</code> (topic config). Note that the consumer performs multiple fetches in parallel. It should be lower than <code>buffer.memory</code>.";
+            "<code>max.message.bytes</code> (topic config). Note that the consumer performs multiple fetches in parallel. The value must be lower than <code>buffer.memory</code>.";
     public static final int DEFAULT_FETCH_MAX_BYTES = 50 * 1024 * 1024;
 
     /**
@@ -474,7 +474,7 @@ public class ConsumerConfig extends AbstractConfig {
                                         Type.LONG,
                                         Long.MAX_VALUE,
                                         atLeast(1),
-                                        Importance.HIGH,
+                                        Importance.MEDIUM,
                                         BUFFER_MEMORY_DOC)
                                 // security support
                                 .define(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,

--- a/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java
@@ -65,6 +65,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -443,7 +444,7 @@ public class KafkaProducer<K, V> implements Producer<K, V> {
         Sensor throttleTimeSensor = Sender.throttleTimeSensor(metricsRegistry.senderMetrics);
         KafkaClient client = kafkaClient != null ? kafkaClient : new NetworkClient(
                 new Selector(producerConfig.getLong(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                        this.metrics, time, "producer", channelBuilder, logContext),
+                        this.metrics, time, "producer", channelBuilder, MemoryPool.NONE, logContext),
                 metadata,
                 clientId,
                 maxInflightRequests,

--- a/clients/src/main/java/org/apache/kafka/common/Node.java
+++ b/clients/src/main/java/org/apache/kafka/common/Node.java
@@ -28,20 +28,60 @@ public class Node {
     private final String host;
     private final int port;
     private final String rack;
+    private final boolean privileged;
 
     // Cache hashCode as it is called in performance sensitive parts of the code (e.g. RecordAccumulator.ready)
     private Integer hash;
 
+    /**
+     * Creates a new Node representing a Kafka broker
+     * @param id Identifier of the Node
+     * @param host Hostname used to connect
+     * @param port Port used to connect
+     */
     public Node(int id, String host, int port) {
-        this(id, host, port, null);
+        this(id, host, port, null, false);
     }
 
+    /**
+     * Creates a new Node representing a Kafka broker
+     * @param id Identifier of the Node
+     * @param host Hostname used to connect
+     * @param port Port used to connect
+     * @param rack Rack name
+     */
     public Node(int id, String host, int port, String rack) {
+        this(id, host, port, rack, false);
+    }
+
+    /**
+     * Creates a new Node representing a Kafka broker
+     * @param id Identifier of the Node
+     * @param host Hostname used to connect
+     * @param port Port used to connect
+     * @param privileged If true, messages from this node will be allocated directly on the heap when the MemoryPool 
+     * is full
+     */
+    public Node(int id, String host, int port, boolean privileged) {
+        this(id, host, port, null, privileged);
+    }
+
+    /**
+     * Creates a new Node representing a Kafka broker
+     * @param id Identifier of the Node
+     * @param host Hostname used to connect
+     * @param port Port used to connect
+     * @param rack Rack name
+     * @param privileged If true, messages from this node will be allocated directly on the heap when the MemoryPool 
+     * is full
+     */
+    public Node(int id, String host, int port, String rack, boolean privileged) {
         this.id = id;
-        this.idString = Integer.toString(id);
+        this.idString = Integer.toString(id) + (privileged ? "-privileged" : "");
         this.host = host;
         this.port = port;
         this.rack = rack;
+        this.privileged = privileged;
     }
 
     public static Node noNode() {
@@ -100,6 +140,13 @@ public class Node {
         return rack;
     }
 
+    /**
+     * True if this node is privileged
+     */
+    public boolean privileged() {
+        return privileged;
+    }
+
     @Override
     public int hashCode() {
         Integer h = this.hash;
@@ -108,6 +155,7 @@ public class Node {
             result = 31 * result + id;
             result = 31 * result + port;
             result = 31 * result + ((rack == null) ? 0 : rack.hashCode());
+            result = 31 * result + (privileged ? 1231 : 1237);
             this.hash = result;
             return result;
         } else {
@@ -123,9 +171,10 @@ public class Node {
             return false;
         Node other = (Node) obj;
         return (host == null ? other.host == null : host.equals(other.host)) &&
-            id == other.id &&
-            port == other.port &&
-            (rack == null ? other.rack == null : rack.equals(other.rack));
+                id == other.id &&
+                port == other.port &&
+                (rack == null ? other.rack == null : rack.equals(other.rack)) &&
+                privileged == other.privileged;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/ChannelBuilder.java
@@ -34,9 +34,10 @@ public interface ChannelBuilder extends AutoCloseable, Configurable {
      * @param  key SelectionKey
      * @param  maxReceiveSize max size of a single receive buffer to allocate
      * @param  memoryPool memory pool from which to allocate buffers, or null for none
+     * @param  privileged True if the channel should be privileged
      * @return KafkaChannel
      */
-    KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool) throws KafkaException;
+    KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool, boolean privileged) throws KafkaException;
 
     /**
      * Closes ChannelBuilder

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -121,6 +121,7 @@ public class KafkaChannel {
     private long networkThreadTimeNanos;
     private final int maxReceiveSize;
     private final MemoryPool memoryPool;
+    private final boolean privileged;
     private NetworkReceive receive;
     private Send send;
     // Track connection and mute state of channels to enable outstanding requests on channels to be
@@ -133,7 +134,7 @@ public class KafkaChannel {
     private boolean midWrite;
     private long lastReauthenticationStartNanos;
 
-    public KafkaChannel(String id, TransportLayer transportLayer, Supplier<Authenticator> authenticatorCreator, int maxReceiveSize, MemoryPool memoryPool) {
+    public KafkaChannel(String id, TransportLayer transportLayer, Supplier<Authenticator> authenticatorCreator, int maxReceiveSize, MemoryPool memoryPool, boolean privileged) {
         this.id = id;
         this.transportLayer = transportLayer;
         this.authenticatorCreator = authenticatorCreator;
@@ -144,6 +145,7 @@ public class KafkaChannel {
         this.disconnected = false;
         this.muteState = ChannelMuteState.NOT_MUTED;
         this.state = ChannelState.NOT_CONNECTED;
+        this.privileged = privileged;
     }
 
     public void close() throws IOException {
@@ -379,7 +381,7 @@ public class KafkaChannel {
         NetworkReceive result = null;
 
         if (receive == null) {
-            receive = new NetworkReceive(maxReceiveSize, id, memoryPool);
+            receive = new NetworkReceive(maxReceiveSize, id, memoryPool, privileged);
         }
 
         receive(receive);

--- a/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/PlaintextChannelBuilder.java
@@ -49,12 +49,12 @@ public class PlaintextChannelBuilder implements ChannelBuilder {
     }
 
     @Override
-    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool) throws KafkaException {
+    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool, boolean privileged) throws KafkaException {
         try {
             PlaintextTransportLayer transportLayer = new PlaintextTransportLayer(key);
             Supplier<Authenticator> authenticatorCreator = () -> new PlaintextAuthenticator(configs, transportLayer, listenerName);
             return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
-                    memoryPool != null ? memoryPool : MemoryPool.NONE);
+                    memoryPool != null ? memoryPool : MemoryPool.NONE, privileged);
         } catch (Exception e) {
             log.warn("Failed to create channel due to ", e);
             throw new KafkaException(e);

--- a/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SaslChannelBuilder.java
@@ -184,7 +184,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
     }
 
     @Override
-    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool) throws KafkaException {
+    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool, boolean privileged) throws KafkaException {
         try {
             SocketChannel socketChannel = (SocketChannel) key.channel();
             Socket socket = socketChannel.socket();
@@ -207,7 +207,7 @@ public class SaslChannelBuilder implements ChannelBuilder, ListenerReconfigurabl
                         transportLayer,
                         subjects.get(clientSaslMechanism));
             }
-            return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize, memoryPool != null ? memoryPool : MemoryPool.NONE);
+            return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize, memoryPool != null ? memoryPool : MemoryPool.NONE, privileged);
         } catch (Exception e) {
             log.info("Failed to create channel due to ", e);
             throw new KafkaException(e);

--- a/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selectable.java
@@ -22,6 +22,8 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.kafka.common.Node;
+
 /**
  * An interface for asynchronous, multi-channel network I/O
  */
@@ -34,13 +36,13 @@ public interface Selectable {
 
     /**
      * Begin establishing a socket connection to the given address identified by the given address
-     * @param id The id for this connection
+     * @param node The node to connect to
      * @param address The address to connect to
      * @param sendBufferSize The send buffer for the socket
      * @param receiveBufferSize The receive buffer for the socket
      * @throws IOException If we cannot begin connecting
      */
-    void connect(String id, InetSocketAddress address, int sendBufferSize, int receiveBufferSize) throws IOException;
+    void connect(Node node, InetSocketAddress address, int sendBufferSize, int receiveBufferSize) throws IOException;
 
     /**
      * Wakeup this selector if it is blocked on I/O

--- a/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslChannelBuilder.java
@@ -95,12 +95,12 @@ public class SslChannelBuilder implements ChannelBuilder, ListenerReconfigurable
     }
 
     @Override
-    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool) throws KafkaException {
+    public KafkaChannel buildChannel(String id, SelectionKey key, int maxReceiveSize, MemoryPool memoryPool, boolean privileged) throws KafkaException {
         try {
             SslTransportLayer transportLayer = buildTransportLayer(sslFactory, id, key, peerHost(key));
             Supplier<Authenticator> authenticatorCreator = () -> new SslAuthenticator(configs, transportLayer, listenerName, sslPrincipalMapper);
             return new KafkaChannel(id, transportLayer, authenticatorCreator, maxReceiveSize,
-                    memoryPool != null ? memoryPool : MemoryPool.NONE);
+                    memoryPool != null ? memoryPool : MemoryPool.NONE, privileged);
         } catch (Exception e) {
             log.info("Failed to create channel due to ", e);
             throw new KafkaException(e);

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -217,7 +217,8 @@ public enum ApiKeys {
 
     public final Schema[] requestSchemas;
     public final Schema[] responseSchemas;
-    public final boolean requiresDelayedAllocation;
+    public final boolean requestRequiresDelayedAllocation;
+    public final boolean responseRequiresDelayedAllocation;
 
     ApiKeys(int id, String name, Schema[] requestSchemas, Schema[] responseSchemas) {
         this(id, name, false, requestSchemas, responseSchemas);
@@ -254,7 +255,15 @@ public enum ApiKeys {
                 break;
             }
         }
-        this.requiresDelayedAllocation = requestRetainsBufferReference;
+        boolean responseRetainsBufferReference = false;
+        for (Schema responseVersionSchema : responseSchemas) {
+            if (retainsBufferReference(responseVersionSchema)) {
+                responseRetainsBufferReference = true;
+                break;
+            }
+        }
+        this.requestRequiresDelayedAllocation = requestRetainsBufferReference;
+        this.responseRequiresDelayedAllocation = responseRetainsBufferReference;
         this.requestSchemas = requestSchemas;
         this.responseSchemas = responseSchemas;
     }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AbstractResponse.java
@@ -185,6 +185,7 @@ public abstract class AbstractResponse extends AbstractRequestResponse implement
         return toStruct(version).toString();
     }
 
+    @Override
     public void close() {
         if (closeable != null) {
             try {

--- a/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/JoinGroupResponse.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.utils.Utils;
 
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -127,7 +128,7 @@ public class JoinGroupResponse extends AbstractResponse {
         this.members = groupMembers;
     }
 
-    public JoinGroupResponse(Struct struct) {
+    public JoinGroupResponse(Struct struct, Closeable closeable) {
         this.throttleTimeMs = struct.getOrElse(THROTTLE_TIME_MS, DEFAULT_THROTTLE_TIME);
         members = new HashMap<>();
 
@@ -142,6 +143,7 @@ public class JoinGroupResponse extends AbstractResponse {
         groupProtocol = struct.getString(GROUP_PROTOCOL_KEY_NAME);
         memberId = struct.get(MEMBER_ID);
         leaderId = struct.getString(LEADER_ID_KEY_NAME);
+        this.closeable = closeable;
     }
 
     @Override
@@ -182,8 +184,9 @@ public class JoinGroupResponse extends AbstractResponse {
         return members;
     }
 
+    // Used by tests
     public static JoinGroupResponse parse(ByteBuffer buffer, short version) {
-        return new JoinGroupResponse(ApiKeys.JOIN_GROUP.parseResponse(version, buffer));
+        return new JoinGroupResponse(ApiKeys.JOIN_GROUP.parseResponse(version, buffer), null);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/SyncGroupResponse.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.protocol.types.Struct;
 
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
@@ -79,10 +80,11 @@ public class SyncGroupResponse extends AbstractResponse {
         this.memberState = memberState;
     }
 
-    public SyncGroupResponse(Struct struct) {
+    public SyncGroupResponse(Struct struct, Closeable closeable) {
         this.throttleTimeMs = struct.getOrElse(THROTTLE_TIME_MS, DEFAULT_THROTTLE_TIME);
         this.error = Errors.forCode(struct.get(ERROR_CODE));
         this.memberState = struct.getBytes(MEMBER_ASSIGNMENT_KEY_NAME);
+        this.closeable = closeable;
     }
 
     @Override
@@ -112,8 +114,9 @@ public class SyncGroupResponse extends AbstractResponse {
         return struct;
     }
 
+    // Used by tests
     public static SyncGroupResponse parse(ByteBuffer buffer, short version) {
-        return new SyncGroupResponse(ApiKeys.SYNC_GROUP.parseResponse(version, buffer));
+        return new SyncGroupResponse(ApiKeys.SYNC_GROUP.parseResponse(version, buffer), null);
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -497,7 +497,7 @@ public class SaslClientAuthenticator implements Authenticator {
             if (responseBytes == null)
                 return null;
             else {
-                AbstractResponse response = NetworkClient.parseResponse(ByteBuffer.wrap(responseBytes), currentRequestHeader);
+                AbstractResponse response = NetworkClient.parseSaslResponse(ByteBuffer.wrap(responseBytes), currentRequestHeader);
                 currentRequestHeader = null;
                 return response;
             }

--- a/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java
@@ -402,7 +402,7 @@ public class SaslClientAuthenticator implements Authenticator {
     }
 
     private byte[] receiveResponseOrToken() throws IOException {
-        if (netInBuffer == null) netInBuffer = new NetworkReceive(node);
+        if (netInBuffer == null) netInBuffer = new NetworkReceive(NetworkReceive.UNLIMITED, node);
         netInBuffer.readFrom(transportLayer);
         byte[] serverPacket = null;
         if (netInBuffer.complete()) {
@@ -490,7 +490,7 @@ public class SaslClientAuthenticator implements Authenticator {
 
     private AbstractResponse receiveKafkaResponse() throws IOException {
         if (netInBuffer == null)
-            netInBuffer = new NetworkReceive(node);
+            netInBuffer = new NetworkReceive(NetworkReceive.UNLIMITED, node);
         NetworkReceive receive = netInBuffer;
         try {
             byte[] responseBytes = receiveResponseOrToken();

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -96,7 +96,7 @@ public class AbstractCoordinatorTest {
 
         mockClient.updateMetadata(TestUtils.metadataUpdateWith(1, emptyMap()));
         this.node = metadata.fetch().nodes().get(0);
-        this.coordinatorNode = new Node(Integer.MAX_VALUE - node.id(), node.host(), node.port());
+        this.coordinatorNode = new Node(node.id(), node.host(), node.port(), true);
         this.coordinator = new DummyCoordinator(consumerClient, metrics, mockTime, rebalanceTimeoutMs, retryBackoffMs);
     }
 
@@ -104,8 +104,8 @@ public class AbstractCoordinatorTest {
     public void testCoordinatorDiscoveryBackoff() {
         setupCoordinator();
 
-        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
-        mockClient.prepareResponse(groupCoordinatorResponse(node, Errors.NONE));
+        mockClient.prepareResponse(groupCoordinatorResponse(coordinatorNode, Errors.NONE));
+        mockClient.prepareResponse(groupCoordinatorResponse(coordinatorNode, Errors.NONE));
 
         // blackout the coordinator for 10 milliseconds to simulate a disconnect.
         // after backing off, we should be able to connect.

--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
@@ -61,16 +62,15 @@ public class NetworkTestUtils {
     }
 
     public static Selector createSelector(ChannelBuilder channelBuilder, Time time) {
-        return new Selector(5000, new Metrics(), time, "MetricGroup", channelBuilder, new LogContext());
+        return new Selector(5000L, new Metrics(), time, "MetricGroup", channelBuilder, MemoryPool.NONE, new LogContext());
     }
 
-    public static void checkClientConnection(Selector selector, String node, int minMessageSize, int messageCount) throws Exception {
-
-        waitForChannelReady(selector, node);
+    public static void checkClientConnection(Selector selector, String nodeId, int minMessageSize, int messageCount) throws Exception {
+        waitForChannelReady(selector, nodeId);
         String prefix = TestUtils.randomString(minMessageSize);
         int requests = 0;
         int responses = 0;
-        selector.send(new NetworkSend(node, ByteBuffer.wrap((prefix + "-0").getBytes())));
+        selector.send(new NetworkSend(nodeId, ByteBuffer.wrap((prefix + "-0").getBytes())));
         requests++;
         while (responses < messageCount) {
             selector.poll(0L);
@@ -81,8 +81,8 @@ public class NetworkTestUtils {
                 responses++;
             }
 
-            for (int i = 0; i < selector.completedSends().size() && requests < messageCount && selector.isChannelReady(node); i++, requests++) {
-                selector.send(new NetworkSend(node, ByteBuffer.wrap((prefix + "-" + requests).getBytes())));
+            for (int i = 0; i < selector.completedSends().size() && requests < messageCount && selector.isChannelReady(nodeId); i++, requests++) {
+                selector.send(new NetworkSend(nodeId, ByteBuffer.wrap((prefix + "-" + requests).getBytes())));
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -119,7 +119,7 @@ public class NioEchoServer extends Thread {
         if (channelBuilder == null)
             channelBuilder = ChannelBuilders.serverChannelBuilder(listenerName, false, securityProtocol, config, credentialCache, tokenCache, time);
         this.metrics = new Metrics();
-        this.selector = new Selector(10000, failedAuthenticationDelayMs, metrics, time, "MetricGroup", channelBuilder, new LogContext());
+        this.selector = new Selector(NetworkReceive.UNLIMITED, 10000, failedAuthenticationDelayMs, metrics, time, "MetricGroup", Collections.<String, String>emptyMap(), true, channelBuilder, new LogContext());
         acceptorThread = new AcceptorThread();
         this.time = time;
     }
@@ -200,7 +200,7 @@ public class NioEchoServer extends Thread {
         try {
             acceptorThread.start();
             while (serverSocketChannel.isOpen()) {
-                selector.poll(100);
+                selector.poll(100L);
                 synchronized (newChannels) {
                     for (SocketChannel socketChannel : newChannels) {
                         String id = id(socketChannel);
@@ -315,7 +315,7 @@ public class NioEchoServer extends Thread {
                 java.nio.channels.Selector acceptSelector = java.nio.channels.Selector.open();
                 serverSocketChannel.register(acceptSelector, SelectionKey.OP_ACCEPT);
                 while (serverSocketChannel.isOpen()) {
-                    if (acceptSelector.select(1000) > 0) {
+                    if (acceptSelector.select(1000L) > 0) {
                         Iterator<SelectionKey> it = acceptSelector.selectedKeys().iterator();
                         while (it.hasNext()) {
                             SelectionKey key = it.next();

--- a/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/protocol/ProtoUtilsTest.java
@@ -21,16 +21,44 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.EnumSet;
+
 public class ProtoUtilsTest {
     @Test
-    public void testDelayedAllocationSchemaDetection() throws Exception {
-        //verifies that schemas known to retain a reference to the underlying byte buffer are correctly detected.
+    public void testRequestDelayedAllocationSchemaDetection() throws Exception {
+        //verifies that request schemas known to retain a reference to the underlying byte buffer are correctly detected.
+        EnumSet<ApiKeys> requestRequiresDelayedAllocation = EnumSet.of(
+                ApiKeys.PRODUCE,
+                ApiKeys.JOIN_GROUP,
+                ApiKeys.SYNC_GROUP,
+                ApiKeys.SASL_AUTHENTICATE,
+                ApiKeys.EXPIRE_DELEGATION_TOKEN,
+                ApiKeys.RENEW_DELEGATION_TOKEN);
         for (ApiKeys key : ApiKeys.values()) {
-            if (key == ApiKeys.PRODUCE || key == ApiKeys.JOIN_GROUP || key == ApiKeys.SYNC_GROUP || key == ApiKeys.SASL_AUTHENTICATE
-                || key == ApiKeys.EXPIRE_DELEGATION_TOKEN || key == ApiKeys.RENEW_DELEGATION_TOKEN) {
-                assertTrue(key + " should require delayed allocation", key.requiresDelayedAllocation);
+            if (requestRequiresDelayedAllocation.contains(key)) {
+                assertTrue(key + " should require delayed allocation", key.requestRequiresDelayedAllocation);
             } else {
-                assertFalse(key + " should not require delayed allocation", key.requiresDelayedAllocation);
+                assertFalse(key + " should not require delayed allocation", key.requestRequiresDelayedAllocation);
+            }
+        }
+    }
+
+    @Test
+    public void testResponseDelayedAllocationSchemaDetection() throws Exception {
+        //verifies that response schemas known to retain a reference to the underlying byte buffer are correctly detected.
+        EnumSet<ApiKeys> responseRequiresDelayedAllocation = EnumSet.of(
+                ApiKeys.FETCH,
+                ApiKeys.JOIN_GROUP,
+                ApiKeys.SYNC_GROUP,
+                ApiKeys.DESCRIBE_GROUPS,
+                ApiKeys.SASL_AUTHENTICATE,
+                ApiKeys.CREATE_DELEGATION_TOKEN,
+                ApiKeys.DESCRIBE_DELEGATION_TOKEN);
+        for (ApiKeys key : ApiKeys.values()) {
+            if (responseRequiresDelayedAllocation.contains(key)) {
+                assertTrue(key + " should require delayed allocation", key.responseRequiresDelayedAllocation);
+            } else {
+                assertFalse(key + " should not require delayed allocation", key.responseRequiresDelayedAllocation);
             }
         }
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestContextTest.java
@@ -68,7 +68,8 @@ public class RequestContextTest {
         assertEquals(correlationId, responseHeader.correlationId());
 
         Struct struct = ApiKeys.API_VERSIONS.parseResponse((short) 0, responseBuffer);
-        ApiVersionsResponse response = (ApiVersionsResponse) AbstractResponse.parseResponse(ApiKeys.API_VERSIONS, struct);
+        // No MemoryPool used hence null Closeable
+        ApiVersionsResponse response = (ApiVersionsResponse) AbstractResponse.parseResponse(ApiKeys.API_VERSIONS, struct, null);
         assertEquals(Errors.UNSUPPORTED_VERSION, response.error());
         assertTrue(response.apiVersions().isEmpty());
     }

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -448,8 +448,9 @@ public class RequestResponseTest {
 
         Struct deserializedStruct = ApiKeys.PRODUCE.parseResponse(version, buffer);
 
+        // No MemoryPool used hence null Closeable
         ProduceResponse v5FromBytes = (ProduceResponse) AbstractResponse.parseResponse(ApiKeys.PRODUCE,
-                deserializedStruct);
+                deserializedStruct, null);
 
         assertEquals(1, v5FromBytes.responses().size());
         assertTrue(v5FromBytes.responses().containsKey(tp0));
@@ -520,7 +521,9 @@ public class RequestResponseTest {
                 6, FetchResponse.INVALID_LOG_START_OFFSET, Collections.emptyList(), records));
 
         FetchResponse<MemoryRecords> response = new FetchResponse<>(Errors.NONE, responseData, 10, INVALID_SESSION_ID);
-        FetchResponse deserialized = FetchResponse.parse(toBuffer(response.toStruct((short) 4)), (short) 4);
+        FetchResponse deserialized = FetchResponse.parse(
+                ApiKeys.FETCH.responseSchema((short) 4).read(toBuffer(response.toStruct((short) 4))), null);
+
         assertEquals(responseData, deserialized.responseData());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.common.security.authenticator;
 
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
@@ -201,9 +202,10 @@ public class SaslAuthenticatorFailureDelayTest {
                     new TestSecurityConfig(saslServerConfigs), credentialCache, time);
     }
 
-    private void createClientConnection(SecurityProtocol securityProtocol, String node) throws Exception {
+    private void createClientConnection(SecurityProtocol securityProtocol, String nodeId) throws Exception {
         createSelector(securityProtocol, saslClientConfigs);
-        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", server.port());
+        Node node = new Node(Integer.parseInt(nodeId), "127.0.0.1", server.port());
+        InetSocketAddress addr = new InetSocketAddress(node.host(), node.port());
         selector.connect(node, addr, BUFFER_SIZE, BUFFER_SIZE);
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorTest.java
@@ -1876,7 +1876,7 @@ public class SaslAuthenticatorTest {
         Send send = request.toSend(node, header);
         selector.send(send);
         ByteBuffer responseBuffer = waitForResponse();
-        return NetworkClient.parseResponse(responseBuffer, header);
+        return NetworkClient.parseSaslResponse(responseBuffer, header);
     }
 
     private SaslHandshakeResponse sendHandshakeRequestReceiveResponse(String node, short version) throws Exception {

--- a/clients/src/test/java/org/apache/kafka/test/MockSelector.java
+++ b/clients/src/test/java/org/apache/kafka/test/MockSelector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.test;
 
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.network.ChannelState;
 import org.apache.kafka.common.network.NetworkReceive;
 import org.apache.kafka.common.network.NetworkSend;
@@ -51,8 +52,8 @@ public class MockSelector implements Selectable {
     }
 
     @Override
-    public void connect(String id, InetSocketAddress address, int sendBufferSize, int receiveBufferSize) throws IOException {
-        this.connected.add(id);
+    public void connect(Node node, InetSocketAddress address, int sendBufferSize, int receiveBufferSize) throws IOException {
+        this.connected.add(node.idString());
     }
 
     @Override

--- a/clients/src/test/java/org/apache/kafka/test/TestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/test/TestUtils.java
@@ -244,8 +244,8 @@ public class TestUtils {
     }
 
     public static Properties producerConfig(final String bootstrapServers,
-                                            final Class keySerializer,
-                                            final Class valueSerializer,
+                                            final Class<?> keySerializer,
+                                            final Class<?> valueSerializer,
                                             final Properties additional) {
         final Properties properties = new Properties();
         properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -257,14 +257,14 @@ public class TestUtils {
         return properties;
     }
 
-    public static Properties producerConfig(final String bootstrapServers, final Class keySerializer, final Class valueSerializer) {
+    public static Properties producerConfig(final String bootstrapServers, final Class<?> keySerializer, final Class<?> valueSerializer) {
         return producerConfig(bootstrapServers, keySerializer, valueSerializer, new Properties());
     }
 
     public static Properties consumerConfig(final String bootstrapServers,
                                             final String groupId,
-                                            final Class keyDeserializer,
-                                            final Class valueDeserializer,
+                                            final Class<?> keyDeserializer,
+                                            final Class<?> valueDeserializer,
                                             final Properties additional) {
 
         final Properties consumerConfig = new Properties();
@@ -279,8 +279,8 @@ public class TestUtils {
 
     public static Properties consumerConfig(final String bootstrapServers,
                                             final String groupId,
-                                            final Class keyDeserializer,
-                                            final Class valueDeserializer) {
+                                            final Class<?> keyDeserializer,
+                                            final Class<?> valueDeserializer) {
         return consumerConfig(bootstrapServers,
             groupId,
             keyDeserializer,
@@ -291,7 +291,7 @@ public class TestUtils {
     /**
      * returns consumer config with random UUID for the Group ID
      */
-    public static Properties consumerConfig(final String bootstrapServers, final Class keyDeserializer, final Class valueDeserializer) {
+    public static Properties consumerConfig(final String bootstrapServers, final Class<?> keyDeserializer, final Class<?> valueDeserializer) {
         return consumerConfig(bootstrapServers,
             UUID.randomUUID().toString(),
             keyDeserializer,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerGroupMember.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.Metadata;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
@@ -102,7 +103,7 @@ public class WorkerGroupMember {
             String metricGrpPrefix = "connect";
             ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(config, time);
             NetworkClient netClient = new NetworkClient(
-                    new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, logContext),
+                    new Selector(config.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG), metrics, time, metricGrpPrefix, channelBuilder, MemoryPool.NONE, logContext),
                     this.metadata,
                     clientId,
                     100, // a fixed large enough value will suffice

--- a/core/src/main/scala/kafka/admin/AdminClient.scala
+++ b/core/src/main/scala/kafka/admin/AdminClient.scala
@@ -40,6 +40,7 @@ import org.apache.kafka.common.{Cluster, Node, TopicPartition}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
+import org.apache.kafka.common.memory.MemoryPool
 
 /**
   * A Scala administrative client for Kafka which supports managing and inspecting topics, brokers,
@@ -449,6 +450,7 @@ object AdminClient {
       time,
       "admin",
       channelBuilder,
+      MemoryPool.NONE,
       new LogContext(String.format("[Producer clientId=%s] ", clientId)))
 
     val networkClient = new NetworkClient(

--- a/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
+++ b/core/src/main/scala/kafka/controller/ControllerChannelManager.scala
@@ -120,13 +120,11 @@ class ControllerChannelManager(controllerContext: ControllerContext, config: Kaf
         config.saslInterBrokerHandshakeRequestEnable
       )
       val selector = new Selector(
-        NetworkReceive.UNLIMITED,
         Selector.NO_IDLE_TIMEOUT_MS,
         metrics,
         time,
         "controller-channel",
         Map("broker-id" -> brokerNode.idString).asJava,
-        false,
         channelBuilder,
         logContext
       )

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionMarkerChannelManager.scala
@@ -55,13 +55,11 @@ object TransactionMarkerChannelManager {
       config.saslInterBrokerHandshakeRequestEnable
     )
     val selector = new Selector(
-      NetworkReceive.UNLIMITED,
       config.connectionsMaxIdleMs,
       metrics,
       time,
       "txn-marker-channel",
       Map.empty[String, String].asJava,
-      false,
       channelBuilder,
       logContext
     )

--- a/core/src/main/scala/kafka/network/RequestChannel.scala
+++ b/core/src/main/scala/kafka/network/RequestChannel.scala
@@ -94,7 +94,7 @@ object RequestChannel extends Logging {
     //most request types are parsed entirely into objects at this point. for those we can release the underlying buffer.
     //some (like produce, or any time the schema contains fields of types BYTES or NULLABLE_BYTES) retain a reference
     //to the buffer. for those requests we cannot release the buffer early, but only when request processing is done.
-    if (!header.apiKey.requiresDelayedAllocation) {
+    if (!header.apiKey.requestRequiresDelayedAllocation) {
       releaseBuffer()
     }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -67,7 +67,7 @@ class SocketServer(val config: KafkaConfig, val metrics: Metrics, val time: Time
   private val memoryPoolDepletedPercentMetricName = metrics.metricName("MemoryPoolAvgDepletedPercent", "socket-server-metrics")
   private val memoryPoolDepletedTimeMetricName = metrics.metricName("MemoryPoolDepletedTimeTotal", "socket-server-metrics")
   memoryPoolSensor.add(new Meter(TimeUnit.MILLISECONDS, memoryPoolDepletedPercentMetricName, memoryPoolDepletedTimeMetricName))
-  private val memoryPool = if (config.queuedMaxBytes > 0) new SimpleMemoryPool(config.queuedMaxBytes, config.socketRequestMaxBytes, false, memoryPoolSensor) else MemoryPool.NONE
+  private val memoryPool = SimpleMemoryPool.create(config.queuedMaxBytes, config.socketRequestMaxBytes, memoryPoolSensor)
   val requestChannel = new RequestChannel(maxQueuedRequests)
   private val processors = new ConcurrentHashMap[Int, Processor]()
   private var nextProcessorId = 0

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -424,13 +424,11 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
           time,
           config.saslInterBrokerHandshakeRequestEnable)
         val selector = new Selector(
-          NetworkReceive.UNLIMITED,
-          config.connectionsMaxIdleMs,
+          config.connectionsMaxIdleMs.longValue,
           metrics,
           time,
           "kafka-server-controlled-shutdown",
-          Map.empty.asJava,
-          false,
+          Map.empty[String, String].asJava,
           channelBuilder,
           logContext
         )

--- a/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherBlockingSend.scala
@@ -60,13 +60,11 @@ class ReplicaFetcherBlockingSend(sourceBroker: BrokerEndPoint,
       brokerConfig.saslInterBrokerHandshakeRequestEnable
     )
     val selector = new Selector(
-      NetworkReceive.UNLIMITED,
       brokerConfig.connectionsMaxIdleMs,
       metrics,
       time,
       "replica-fetcher",
       Map("broker-id" -> sourceBroker.id.toString, "fetcher-id" -> fetcherId.toString).asJava,
-      false,
       channelBuilder,
       logContext
     )

--- a/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
+++ b/core/src/main/scala/kafka/tools/ReplicaVerificationTool.scala
@@ -43,6 +43,7 @@ import org.apache.kafka.common.utils.{LogContext, Time}
 import org.apache.kafka.common.{Node, TopicPartition}
 
 import scala.collection.JavaConverters._
+import org.apache.kafka.common.memory.MemoryPool
 
 /**
  * For verifying the consistency among replicas.
@@ -459,7 +460,9 @@ private class ReplicaFetcherBlockingSend(sourceNode: Node,
       "replica-fetcher",
       Map("broker-id" -> sourceNode.id.toString, "fetcher-id" -> fetcherId.toString).asJava,
       false,
+      false,
       channelBuilder,
+      MemoryPool.NONE,
       new LogContext
     )
     new NetworkClient(

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -14,6 +14,7 @@ package kafka.api
 
 import java.time.Duration
 import java.util
+import java.util.{Collections, Properties}
 
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}

--- a/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
@@ -35,8 +35,10 @@ import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.MockTime
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
+import org.apache.kafka.common.Node
 
 import scala.collection.JavaConverters._
+import org.apache.kafka.common.Node
 
 class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
   override val serverCount = 1
@@ -147,20 +149,20 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
     try {
       var actualSuccessfulAuths = 0
       while (actualSuccessfulAuths < numSuccessfulAuths) {
-        val nodeId = actualSuccessfulAuths.toString
-        selector.connect(nodeId, serverAddr, 1024, 1024)
+        val node = new Node(actualSuccessfulAuths, serverAddr.getHostName, serverAddr.getPort)
+        selector.connect(node, serverAddr, 1024, 1024)
         TestUtils.waitUntilTrue(() => {
           selector.poll(100)
-          val disconnectState = selector.disconnected().get(nodeId)
+          val disconnectState = selector.disconnected().get(node.idString)
           // Verify that disconnect state is not AUTHENTICATION_FAILED
           if (disconnectState != null)
             assertEquals(s"Authentication failed with exception ${disconnectState.exception()}",
               ChannelState.State.AUTHENTICATE, disconnectState.state())
-          selector.isChannelReady(nodeId) || disconnectState != null
+          selector.isChannelReady(node.idString) || disconnectState != null
         }, "Client not ready or disconnected within timeout")
-        if (selector.isChannelReady(nodeId))
+        if (selector.isChannelReady(node.idString))
           actualSuccessfulAuths += 1
-        selector.close(nodeId)
+        selector.close(node.idString)
       }
     } finally {
       selector.close()
@@ -175,11 +177,11 @@ class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
    */
   private def verifyNonRetriableAuthenticationFailure(): Unit = {
     val selector = createSelector()
-    val nodeId = "1"
-    selector.connect(nodeId, serverAddr, 1024, 1024)
+    val node = new Node(1, serverAddr.getHostName, serverAddr.getPort)
+    selector.connect(node, serverAddr, 1024, 1024)
     TestUtils.waitUntilTrue(() => {
       selector.poll(100)
-      val disconnectState = selector.disconnected().get(nodeId)
+      val disconnectState = selector.disconnected().get(node.idString)
       if (disconnectState != null)
         assertEquals(ChannelState.State.AUTHENTICATION_FAILED, disconnectState.state())
       disconnectState != null

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -516,7 +516,7 @@ class KafkaApisTest {
     channel.buffer.getInt() // read the size
     ResponseHeader.parse(channel.buffer)
     val struct = api.responseSchema(request.version).read(channel.buffer)
-    AbstractResponse.parseResponse(api, struct)
+    AbstractResponse.parseResponse(api, struct, null)  //no memory pool, null Closeable
   }
 
   private def expectNoThrottling(): Capture[RequestChannel.Response] = {

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -415,16 +415,16 @@ class RequestQuotaTest extends BaseRequestTest {
   private def responseThrottleTime(apiKey: ApiKeys, response: Struct): Int = {
     apiKey match {
       case ApiKeys.PRODUCE => new ProduceResponse(response).throttleTimeMs
-      case ApiKeys.FETCH => FetchResponse.parse(response).throttleTimeMs
+      case ApiKeys.FETCH => FetchResponse.parse(response, null).throttleTimeMs
       case ApiKeys.LIST_OFFSETS => new ListOffsetResponse(response).throttleTimeMs
       case ApiKeys.METADATA => new MetadataResponse(response).throttleTimeMs
       case ApiKeys.OFFSET_COMMIT => new OffsetCommitResponse(response).throttleTimeMs
       case ApiKeys.OFFSET_FETCH => new OffsetFetchResponse(response).throttleTimeMs
       case ApiKeys.FIND_COORDINATOR => new FindCoordinatorResponse(response).throttleTimeMs
-      case ApiKeys.JOIN_GROUP => new JoinGroupResponse(response).throttleTimeMs
+      case ApiKeys.JOIN_GROUP => new JoinGroupResponse(response, null).throttleTimeMs
       case ApiKeys.HEARTBEAT => new HeartbeatResponse(response).throttleTimeMs
       case ApiKeys.LEAVE_GROUP => new LeaveGroupResponse(response).throttleTimeMs
-      case ApiKeys.SYNC_GROUP => new SyncGroupResponse(response).throttleTimeMs
+      case ApiKeys.SYNC_GROUP => new SyncGroupResponse(response, null).throttleTimeMs
       case ApiKeys.DESCRIBE_GROUPS => new DescribeGroupsResponse(response).throttleTimeMs
       case ApiKeys.LIST_GROUPS => new ListGroupsResponse(response).throttleTimeMs
       case ApiKeys.API_VERSIONS => new ApiVersionsResponse(response).throttleTimeMs

--- a/gradle/spotbugs-exclude.xml
+++ b/gradle/spotbugs-exclude.xml
@@ -198,6 +198,12 @@ For a detailed description of spotbugs bug categories, see https://spotbugs.read
     </Match>
 
     <Match>
+        <!-- Suppress a warning about intentional mutable static field. -->
+        <Class name="org.apache.kafka.common.memory.GarbageCollectedMemoryPool"/>
+        <Bug pattern="MS_SHOULD_BE_FINAL"/>
+    </Match>
+
+    <Match>
         <!-- Suppress a spurious warning about locks not being released on all paths.
              This happens because there is an 'if' statement that checks if we have the lock before
              releasing it. -->

--- a/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/workload/ConnectionStressWorker.java
@@ -31,6 +31,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
@@ -173,7 +174,7 @@ public class ConnectionStressWorker implements TaskWorker {
                     try (Metrics metrics = new Metrics()) {
                         LogContext logContext = new LogContext();
                         try (Selector selector = new Selector(conf.getLong(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG),
-                            metrics, TIME, "", channelBuilder, logContext)) {
+                            metrics, TIME, "", channelBuilder, MemoryPool.NONE, logContext)) {
                             try (NetworkClient client = new NetworkClient(selector,
                                     updater,
                                     "ConnectionStressWorker",


### PR DESCRIPTION
Introduce new Consumer config 'buffer.memory'
Allocate MemoryPool based on 'buffer.memory'
Allocate NetworkReceive through the MemoryPool
Communication between client and Coordinator node skips MemoryPool
Expose MemoryPool metrics in consumer-metrics group

https://cwiki.apache.org/confluence/display/KAFKA/KIP-81%3A+Bound+Fetch+memory+usage+in+the+consumer

Co-authored-by: Mickael Maison <mickael.maison@gmail.com>
Co-authored-by: Edoardo Comar <ecomar@uk.ibm.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
