### PR TITLE
KAFKA-6830: Add consumer fetch request metric for topics

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
+++ b/core/src/main/scala/kafka/server/KafkaRequestHandler.scala
@@ -157,6 +157,7 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
   val failedProduceRequestRate = newMeter(BrokerTopicStats.FailedProduceRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
   val failedFetchRequestRate = newMeter(BrokerTopicStats.FailedFetchRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
   val totalProduceRequestRate = newMeter(BrokerTopicStats.TotalProduceRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
+  val consumerFetchRequestRate = newMeter(BrokerTopicStats.ConsumerFetchRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
   val totalFetchRequestRate = newMeter(BrokerTopicStats.TotalFetchRequestsPerSec, "requests", TimeUnit.SECONDS, tags)
   val fetchMessageConversionsRate = newMeter(BrokerTopicStats.FetchMessageConversionsPerSec, "requests", TimeUnit.SECONDS, tags)
   val produceMessageConversionsRate = newMeter(BrokerTopicStats.ProduceMessageConversionsPerSec, "requests", TimeUnit.SECONDS, tags)
@@ -173,6 +174,7 @@ class BrokerTopicMetrics(name: Option[String]) extends KafkaMetricsGroup {
     removeMetric(BrokerTopicStats.FailedProduceRequestsPerSec, tags)
     removeMetric(BrokerTopicStats.FailedFetchRequestsPerSec, tags)
     removeMetric(BrokerTopicStats.TotalProduceRequestsPerSec, tags)
+    removeMetric(BrokerTopicStats.ConsumerFetchRequestsPerSec, tags)
     removeMetric(BrokerTopicStats.TotalFetchRequestsPerSec, tags)
     removeMetric(BrokerTopicStats.FetchMessageConversionsPerSec, tags)
     removeMetric(BrokerTopicStats.ProduceMessageConversionsPerSec, tags)
@@ -189,6 +191,7 @@ object BrokerTopicStats {
   val FailedProduceRequestsPerSec = "FailedProduceRequestsPerSec"
   val FailedFetchRequestsPerSec = "FailedFetchRequestsPerSec"
   val TotalProduceRequestsPerSec = "TotalProduceRequestsPerSec"
+  val ConsumerFetchRequestsPerSec = "ConsumerFetchRequestsPerSec"
   val TotalFetchRequestsPerSec = "TotalFetchRequestsPerSec"
   val FetchMessageConversionsPerSec = "FetchMessageConversionsPerSec"
   val ProduceMessageConversionsPerSec = "ProduceMessageConversionsPerSec"

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -872,8 +872,13 @@ class ReplicaManager(val config: KafkaConfig,
       val partitionFetchSize = fetchInfo.maxBytes
       val followerLogStartOffset = fetchInfo.logStartOffset
 
-      brokerTopicStats.topicStats(tp.topic).totalFetchRequestRate.mark()
+      val topicStats = brokerTopicStats.topicStats(tp.topic)
+      topicStats.totalFetchRequestRate.mark()
       brokerTopicStats.allTopicsStats.totalFetchRequestRate.mark()
+      if (-1 == replicaId) {
+        topicStats.consumerFetchRequestRate.mark()
+        brokerTopicStats.allTopicsStats.consumerFetchRequestRate.mark()
+      }
 
       try {
         trace(s"Fetching log segment for partition $tp, offset $offset, partition fetch size $partitionFetchSize, " +


### PR DESCRIPTION
**Description:**
Introduce new metric (`ConsumerFetchRequestsPerSec`) for each topic. It is used to count only fetch requests received by broker instance that originated from clients (and not from replicas). This allows us to tell whether the topic is being actively consumed (not only synchronized from replicas).

**Testing strategy:**
We want to verify that correct metric is growing depending on whether the partitions hosted by given broker instance are being read from (by clients).

Have a cluster with 2+ nodes (needed for replication).

a1) Create a topic with replication factor = 1.
a2) Observe that `ConsumerFetchRequestsPerSec` does not change value (noone is consuming).
a3) Start a consumer reading from that topic. Observe that `ConsumerFetchRequestsPerSec` grows.
a4) Stop the consumer. Observe that `ConsumerFetchRequestsPerSec` is no longer growing.

b1) Create a topic with replication factor >= 2.
b2) Observe that `ConsumerFetchRequestsPerSec` is not changing value. Observe that `TotalFetchRequestsPerSec` is growing.
b3) Start a consumer reading from that topic. Observe that `ConsumerFetchRequestsPerSec` is growing.
b4) Stop the consumer. Observe that `ConsumerFetchRequestsPerSec` is no longer growing. Observe that `TotalFetchRequestsPerSec` is still growing (replication is still going on).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
