### PR TITLE
MINOR: Removed unused imports in a few tests

### DIFF
--- a/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
+++ b/core/src/test/scala/unit/kafka/network/SocketServerTest.scala
@@ -20,7 +20,7 @@ package kafka.network
 import java.io._
 import java.net._
 import java.nio.ByteBuffer
-import java.util.{HashMap, Properties, Random}
+import java.util.{HashMap, Random}
 import java.nio.channels.SocketChannel
 import javax.net.ssl._
 

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
@@ -16,7 +16,6 @@
   */
 package kafka.server
 
-import java.nio.ByteBuffer
 import java.util
 
 import kafka.utils.TestUtils

--- a/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala
@@ -16,7 +16,6 @@
   */
 package kafka.server
 
-import java.nio.ByteBuffer
 import java.util
 
 import kafka.api.{KafkaSasl, SaslSetup}


### PR DESCRIPTION
Removed unused imports in:
- core/src/test/scala/unit/kafka/network/SocketServerTest.scala
- core/src/test/scala/unit/kafka/server/DelegationTokenRequestsOnPlainTextTest.scala
- core/src/test/scala/unit/kafka/server/DelegationTokenRequestsWithDisableTokenFeatureTest.scala

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
