### PR TITLE
MINOR: Build and code sample updates for Kafka Streams DSL for Scala

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -991,7 +991,6 @@ project(':streams:streams-scala') {
     testCompile project(':core').sourceSets.test.output
     testCompile project(':streams').sourceSets.test.output
     testCompile project(':clients').sourceSets.test.output
-    testCompile libs.scalaLogging
 
     testCompile libs.junit
     testCompile libs.scalatest

--- a/build.gradle
+++ b/build.gradle
@@ -980,7 +980,7 @@ project(':streams') {
 project(':streams:streams-scala') {
   println "Building project 'streams-scala' with Scala version ${versions.scala}"
   apply plugin: 'scala'
-  archivesBaseName = "kafka-streams-scala"
+  archivesBaseName = "kafka-streams-scala_${versions.baseScala}"
 
   dependencies {
     compile project(':streams')

--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -3191,11 +3191,13 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 
 import org.apache.kafka.streams.kstream.Materialized
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala._
+import org.apache.kafka.streams.scala.kstream._
 import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
 
 object WordCountApplication extends App {
   import DefaultSerdes._
-  import ImplicitConversions._
 
   val config: Properties = {
     val p = new Properties()
@@ -3204,19 +3206,19 @@ object WordCountApplication extends App {
     p
   }
 
-  val builder = new StreamsBuilder()
-  val textLines = builder.stream[String, String]("TextLinesTopic")
-  val wordCounts = textLines
+  val builder: StreamsBuilder = new StreamsBuilder
+  val textLines: KStream[String, String] = builder.stream[String, String]("TextLinesTopic")
+  val wordCounts: KTable[String, Long] = textLines
     .flatMapValues(textLine => textLine.toLowerCase.split("\\W+"))
     .groupBy((_, word) => word)
-    .count(Materialized.as("counts-store"))
+    .count(Materialized.as("counts-store").withKeySerde(DefaultSerdes.stringSerde))
   wordCounts.toStream.to("WordsWithCountsTopic")
 
   val streams: KafkaStreams = new KafkaStreams(builder.build(), config)
   streams.start()
 
   sys.ShutdownHookThread {
-    streams.close(10, TimeUnit.SECONDS)
+     streams.close(10, TimeUnit.SECONDS)
   }
 }
               </pre>
@@ -3290,7 +3292,7 @@ val clicksPerRegion: KTable[String, Long] =
    // Join the stream against the table.
    .leftJoin(userRegionsTable, (clicks: UserClicks, region: String) => (if (region == null) "UNKNOWN" else region, clicks.clicks))
 
-   // Change the stream from <user> -> <region, clicks> to <region> -> <clicks>
+   // Change the stream from &lt;user&gt; -&gt; &lt;region, clicks&gt; to &lt;region&gt; -&gt; &lt;clicks&gt;
    .map((_, regionWithClicks) => regionWithClicks)
 
    // Compute the total per region by summing the individual click counts per region.

--- a/docs/streams/developer-guide/dsl-api.html
+++ b/docs/streams/developer-guide/dsl-api.html
@@ -3211,7 +3211,7 @@ object WordCountApplication extends App {
   val wordCounts: KTable[String, Long] = textLines
     .flatMapValues(textLine => textLine.toLowerCase.split("\\W+"))
     .groupBy((_, word) => word)
-    .count(Materialized.as("counts-store").withKeySerde(DefaultSerdes.stringSerde))
+    .count(Materialized.as("counts-store"))
   wordCounts.toStream.to("WordsWithCountsTopic")
 
   val streams: KafkaStreams = new KafkaStreams(builder.build(), config)

--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -275,7 +275,7 @@ object WordCountApplication extends App {
   val wordCounts: KTable[String, Long] = textLines
     .flatMapValues(textLine => textLine.toLowerCase.split("\\W+"))
     .groupBy((_, word) => word)
-    .count(Materialized.as("counts-store").withKeySerde(DefaultSerdes.stringSerde))
+    .count(Materialized.as("counts-store"))
   wordCounts.toStream.to("WordsWithCountsTopic")
 
   val streams: KafkaStreams = new KafkaStreams(builder.build(), config)

--- a/docs/streams/index.html
+++ b/docs/streams/index.html
@@ -255,12 +255,13 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 
 import org.apache.kafka.streams.kstream.Materialized
+import org.apache.kafka.streams.scala.ImplicitConversions._
+import org.apache.kafka.streams.scala._
 import org.apache.kafka.streams.scala.kstream._
 import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
 
 object WordCountApplication extends App {
   import DefaultSerdes._
-  import ImplicitConversions._
 
   val config: Properties = {
     val p = new Properties()
@@ -269,19 +270,19 @@ object WordCountApplication extends App {
     p
   }
 
-  val builder: StreamsBuilder = new StreamsBuilder()
+  val builder: StreamsBuilder = new StreamsBuilder
   val textLines: KStream[String, String] = builder.stream[String, String]("TextLinesTopic")
   val wordCounts: KTable[String, Long] = textLines
     .flatMapValues(textLine => textLine.toLowerCase.split("\\W+"))
     .groupBy((_, word) => word)
-    .count(Materialized.as("counts-store"))
+    .count(Materialized.as("counts-store").withKeySerde(DefaultSerdes.stringSerde))
   wordCounts.toStream.to("WordsWithCountsTopic")
 
   val streams: KafkaStreams = new KafkaStreams(builder.build(), config)
   streams.start()
 
   sys.ShutdownHookThread {
-    streams.close(10, TimeUnit.SECONDS)
+     streams.close(10, TimeUnit.SECONDS)
   }
 }
                </pre>

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
@@ -34,7 +34,6 @@ import org.apache.kafka.streams._
 import org.apache.kafka.streams.scala.kstream._
 
 import ImplicitConversions._
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * Test suite that does an example to demonstrate stream-table joins in Kafka Streams
@@ -46,7 +45,7 @@ import com.typesafe.scalalogging.LazyLogging
  * Hence the native Java API based version is more verbose.
  */ 
 class StreamToTableJoinScalaIntegrationTestImplicitSerdes extends JUnitSuite
-  with StreamToTableJoinTestData with LazyLogging {
+  with StreamToTableJoinTestData {
 
   private val privateCluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)
 

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/TopologyTest.scala
@@ -31,7 +31,6 @@ import org.apache.kafka.streams.scala.kstream._
 import org.apache.kafka.common.serialization._
 
 import ImplicitConversions._
-import com.typesafe.scalalogging.LazyLogging
 
 import org.apache.kafka.streams.{KafkaStreams => KafkaStreamsJ, StreamsBuilder => StreamsBuilderJ, _}
 import org.apache.kafka.streams.kstream.{KTable => KTableJ, KStream => KStreamJ, KGroupedStream => KGroupedStreamJ, _}
@@ -40,7 +39,7 @@ import collection.JavaConverters._
 /**
  * Test suite that verifies that the topology built by the Java and Scala APIs match.
  */ 
-class TopologyTest extends JUnitSuite with LazyLogging {
+class TopologyTest extends JUnitSuite {
 
   val inputTopic = "input-topic"
   val userClicksTopic = "user-clicks-topic"

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
@@ -40,7 +40,6 @@ import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.test.TestUtils
 
 import ImplicitConversions._
-import com.typesafe.scalalogging.LazyLogging
 
 /**
  * Test suite that does a classic word count example.
@@ -51,7 +50,7 @@ import com.typesafe.scalalogging.LazyLogging
  * Note: In the current project settings SAM type conversion is turned off as it's experimental in Scala 2.11.
  * Hence the native Java API based version is more verbose.
  */ 
-class WordCountTest extends JUnitSuite with WordCountTestData with LazyLogging {
+class WordCountTest extends JUnitSuite with WordCountTestData {
 
   private val privateCluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)
 


### PR DESCRIPTION
Several build and documentation updates were required after the merge of [KAFKA-6670: Implement a Scala wrapper library for Kafka Streams](https://github.com/apache/kafka/pull/4756).

## Encode Scala major version into `streams-scala` artifacts.

To differentiate versions of the `kafka-streams-scala` artifact across Scala major versions it's required to encode the version into the artifact name before its published to a maven repository.  This is accomplished by following a similar release process as kafka core, which encodes the Scala major version and then runs the build for each major version of Scala supported.  **This is considered standard practice when releasing Scala libraries**, but is not handled for us automatically with the basic Scala for Gradle support.

After this change you can generate and install the `kafka-streams-scala` artifact into the local maven repository:

```
$ ./gradlew -PscalaVersion=2.11 install
$ ./gradlew -PscalaVersion=2.12 install
```

Which results in the following files generated:

```
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/maven-metadata-local.xml
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT-sources.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/maven-metadata-local.xml
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT-test-sources.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT.pom
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT-test.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT-javadoc.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT-scaladoc.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.12/2.0.0-SNAPSHOT/kafka-streams-scala_2.12-2.0.0-SNAPSHOT.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/maven-metadata-local.xml
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT-test.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/maven-metadata-local.xml
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT-sources.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT-scaladoc.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT-test-sources.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT-javadoc.jar
/home/seglo/.m2/repository/org/apache/kafka/kafka-streams-scala_2.11/2.0.0-SNAPSHOT/kafka-streams-scala_2.11-2.0.0-SNAPSHOT.pom
```

## Review Code Samples

I reviewed all the code samples introduced by the main PR.  [I created a sample project which validates the main WordCount example](https://github.com/seglo/kafka-streams-scala-example).  The other examples are code snippets instead of whole programs, but are equivalent to existing tests found in the `apache/kafka` `streams-scala` project, or the original `lightbend/kafka-streams-scala` project.

Code sample / documentation references

#### WordCountApplication example

Docs location:

* `/documentation/streams/` (Scala Example)
* `/documentation/streams/developer-guide/dsl-api.html#scala-dsl-sample-usage`

See [`WordCountApplication`](https://github.com/seglo/kafka-streams-scala-example/blob/master/src/main/scala/seglo/WordCountApplication.scala#L3..L38) in sample project.

> **NOTE**: The `WordCountApplication` usage of `count` reveals how using the `Materialized` does not take advantage of implicit SerDes as other Kafka Streams operators do (operators that accept a `Serialized`, `Consumed`, `Produced` etc).  This is not an issue when you do not want to provide a user-defined and named state store, but to make this example consistent with the Java examples we use the overload of the `count` API which takes the `Materialized` parameter.  It's required to pass the key SerDes in this example because a global serializer is not defined in the Kafka Streams config.  @debasishg is going to follow up with a proposal to amend this API in a separate thread.

#### Implicit SerDes Example

Docs location:

* `/documentation/streams/developer-guide/dsl-api.html#scala-dsl-implicit-serdes`

See `StreamToTableJoinScalaIntegrationTestImplicitSerdes` test in [`apache/kafka`](https://github.com/apache/kafka/)

https://github.com/apache/kafka/blob/trunk/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala#L77..L102


#### User-defined SerDes Example

Docs location:

* `/documentation/streams/developer-guide/dsl-api.html#scala-dsl-user-defined-serdes`

See `StreamToTableJoinScalaIntegrationTestImplicitSerdesWithAvro` integration test in [`lightbend/kafka-streams-scala`](https://github.com/lightbend/kafka-streams-scala/).  This test doesn't exist in `apache/kafka` because we didn't want to add the Avro dep.

https://github.com/lightbend/kafka-streams-scala/blob/v0.2.1/src/test/scala/com/lightbend/kafka/scala/streams/StreamToTableJoinScalaIntegrationTestImplicitSerdesWithAvro.scala#L61..L142

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
