### PR TITLE
KAFKA-6845: Shrink size of docker image

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -32,7 +32,7 @@ LABEL ducker.creator=$ducker_creator
 
 # Update Linux and install necessary utilities.
 RUN apt update && apt install -y sudo netcat iptables rsync unzip wget curl jq coreutils openssh-server net-tools vim python-pip python-dev libffi-dev libssl-dev cmake pkg-config libfuse-dev && apt-get -y clean
-RUN pip install -U pip==9.0.3 setuptools && pip install --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --upgrade ducktape==0.7.1
+RUN pip install --no-cache-dir -U pip==9.0.3 setuptools && pip install --no-cache-dir --upgrade cffi virtualenv pyasn1 boto3 pycrypto pywinrm ipaddress enum34 && pip install --no-cache-dir --upgrade ducktape==0.7.1
 
 # Set up ssh
 COPY ./ssh-config /root/.ssh/config


### PR DESCRIPTION
Jira issue: https://issues.apache.org/jira/browse/KAFKA-6845

Proposing a very small change to slightly reduce the size of the Docker image:

- Adding `--no-cache-dir` flag to all `pip install` commands to prevent caching of build artifacts

When building, I'm seeing an ~20 MB reduction in image size. (1.76 GB -> 1.74 GB)