### PR TITLE
Minor: Empty list returned by poll() destroys the source task when assert is enabled

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -46,7 +46,7 @@ public abstract class SourceTask implements Task {
     /**
      * <p>
      * Poll this source task for new records. If no data is currently available, this method
-     * should block but return control to the caller regularly (by returning {@code null}) in
+     * should block but return control to the caller regularly (by returning {@code null} or empty list) in
      * order for the task to transition to the {@code PAUSED} state if requested to do so.
      * </p>
      * <p>

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -231,15 +231,15 @@ class WorkerSourceTask extends WorkerTask {
 
                 maybeThrowProducerSendException();
 
-                if (toSend == null) {
+                if (toSend == null || toSend.isEmpty()) {
                     log.trace("{} Nothing to send to Kafka. Polling source for additional records", this);
                     long start = time.milliseconds();
                     toSend = poll();
-                    if (toSend != null) {
+                    if (toSend != null && !toSend.isEmpty()) {
                         recordPollReturned(toSend.size(), time.milliseconds() - start);
                     }
                 }
-                if (toSend == null)
+                if (toSend == null || toSend.isEmpty())
                     continue;
                 log.trace("{} About to send {} records to Kafka", this, toSend.size());
                 if (!sendRecords())


### PR DESCRIPTION
I noticed this issue when running the embedded connectors. There is a assert in SourceRecordWriteCounter.
```
        public SourceRecordWriteCounter(int batchSize, SourceTaskMetricsGroup metricsGroup) {
            assert batchSize > 0;   // this one
            assert metricsGroup != null;
            this.batchSize = batchSize;
            counter = batchSize;
            this.metricsGroup = metricsGroup;
        }
```
Hence, the empty list will cease the source task. By contrast, empty list is not a issue in production since the assert is usually disabled in production. It seems to me making the behavior consistent is necessary. A simple fix is to remove the assert. Or empty list should be handled as null list. I prefer later since both of them mean "no data can be processed".

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
