### PR TITLE
KAFKA-6864: Pass null key and value to deserializer

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -987,10 +987,10 @@ public class Fetcher<K, V> implements SubscriptionState.Listener, Closeable {
             Headers headers = new RecordHeaders(record.headers());
             ByteBuffer keyBytes = record.key();
             byte[] keyByteArray = keyBytes == null ? null : Utils.toArray(keyBytes);
-            K key = keyBytes == null ? null : this.keyDeserializer.deserialize(partition.topic(), headers, keyByteArray);
+            K key = this.keyDeserializer.deserialize(partition.topic(), headers, keyByteArray);
             ByteBuffer valueBytes = record.value();
             byte[] valueByteArray = valueBytes == null ? null : Utils.toArray(valueBytes);
-            V value = valueBytes == null ? null : this.valueDeserializer.deserialize(partition.topic(), headers, valueByteArray);
+            V value = this.valueDeserializer.deserialize(partition.topic(), headers, valueByteArray);
             return new ConsumerRecord<>(partition.topic(), partition.partition(), offset,
                                         timestamp, timestampType, record.checksumOrNull(),
                                         keyByteArray == null ? ConsumerRecord.NULL_SIZE : keyByteArray.length,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CallTrackingDeserializer.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/CallTrackingDeserializer.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.clients.consumer.internals;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+/**
+ * Deserialization always returns null.
+ */
+public class CallTrackingDeserializer<T> implements Deserializer<T> {
+
+    public int numberOfDeserializations = 0;
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {}
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        numberOfDeserializations++;
+        return null;
+    }
+
+    @Override
+    public void close() {}
+}


### PR DESCRIPTION
currently null values are not passed to the keyDeserializer and valueDeserializer in the Fetcher class. This prevents custom deserialization of null values.