### PR TITLE
KAFKA-6868: Fix buffer underflow and expose group state in the consumer groups API

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -37,50 +37,7 @@ public class ConsumerGroupDescription {
     private final ConsumerGroupState state;
     private final Node coordinator;
 
-    public static class Builder {
-        private final String groupId;
-        private boolean isSimpleConsumerGroup = true;
-        private Collection<MemberDescription> members = null;
-        private String partitionAssignor = "";
-        private ConsumerGroupState state = ConsumerGroupState.UNKNOWN;
-        private Node coordinator = null;
-
-        public Builder(String groupId) {
-            this.groupId = groupId;
-        }
-
-        public Builder isSimpleConsumerGroup(boolean isSimpleConsumerGroup) {
-            this.isSimpleConsumerGroup = isSimpleConsumerGroup;
-            return this;
-        }
-
-        public Builder members(Collection<MemberDescription> members) {
-            this.members = members;
-            return this;
-        }
-
-        public Builder partitionAssignor(String partitionAssignor) {
-            this.partitionAssignor = partitionAssignor;
-            return this;
-        }
-
-        public Builder state(ConsumerGroupState state) {
-            this.state = state;
-            return this;
-        }
-
-        public Builder coordinator(Node coordinator) {
-            this.coordinator = coordinator;
-            return this;
-        }
-
-        public ConsumerGroupDescription build() {
-            return new ConsumerGroupDescription(groupId, isSimpleConsumerGroup,
-                members, partitionAssignor, state, coordinator);
-        }
-    }
-
-    private ConsumerGroupDescription(String groupId, boolean isSimpleConsumerGroup,
+    ConsumerGroupDescription(String groupId, boolean isSimpleConsumerGroup,
             Collection<MemberDescription> members, String partitionAssignor, ConsumerGroupState state,
             Node coordinator) {
         this.groupId = groupId == null ? "" : groupId;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -37,8 +37,11 @@ public class ConsumerGroupDescription {
     private final ConsumerGroupState state;
     private final Node coordinator;
 
-    ConsumerGroupDescription(String groupId, boolean isSimpleConsumerGroup,
-            Collection<MemberDescription> members, String partitionAssignor, ConsumerGroupState state,
+    ConsumerGroupDescription(String groupId,
+            boolean isSimpleConsumerGroup,
+            Collection<MemberDescription> members,
+            String partitionAssignor,
+            ConsumerGroupState state,
             Node coordinator) {
         this.groupId = groupId == null ? "" : groupId;
         this.isSimpleConsumerGroup = isSimpleConsumerGroup;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -21,7 +21,9 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.annotation.InterfaceStability;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 
 /**
@@ -39,16 +41,32 @@ public class DescribeConsumerGroupsResult {
     }
 
     /**
-     * Return a map from group id to futures which can be used to check the description of a consumer group.
+     * Return a map from group id to futures which yield group descriptions.
      */
     public Map<String, KafkaFuture<ConsumerGroupDescription>> describedGroups() {
         return futures;
     }
 
     /**
-     * Return a future which succeeds only if all the consumer group description succeed.
+     * Return a future which yields all ConsumerGroupDescription objects, if all the describes succeed.
      */
-    public KafkaFuture<Void> all() {
-        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0]));
+    public KafkaFuture<Map<String, ConsumerGroupDescription>> all() {
+        return KafkaFuture.allOf(futures.values().toArray(new KafkaFuture[0])).thenApply(
+            new KafkaFuture.BaseFunction<Void, Map<String, ConsumerGroupDescription>>() {
+                @Override
+                public Map<String, ConsumerGroupDescription> apply(Void v) {
+                    try {
+                        HashMap<String, ConsumerGroupDescription> map = new HashMap<>();
+                        for (Map.Entry<String, KafkaFuture<ConsumerGroupDescription>> entry : futures.entrySet()) {
+                            map.put(entry.getKey(), entry.getValue().get());
+                        }
+                        return map;
+                    } catch (InterruptedException | ExecutionException e) {
+                        // This should be unreachable, since the KafkaFuture#allOf already ensured
+                        // that all of the futures completed successfully.
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -56,7 +56,7 @@ public class DescribeConsumerGroupsResult {
                 @Override
                 public Map<String, ConsumerGroupDescription> apply(Void v) {
                     try {
-                        Map<String, ConsumerGroupDescription> descriptions = new HashMap<>();
+                        Map<String, ConsumerGroupDescription> descriptions = new HashMap<>(futures.size());
                         for (Map.Entry<String, KafkaFuture<ConsumerGroupDescription>> entry : futures.entrySet()) {
                             descriptions.put(entry.getKey(), entry.getValue().get());
                         }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConsumerGroupsResult.java
@@ -56,11 +56,11 @@ public class DescribeConsumerGroupsResult {
                 @Override
                 public Map<String, ConsumerGroupDescription> apply(Void v) {
                     try {
-                        HashMap<String, ConsumerGroupDescription> map = new HashMap<>();
+                        Map<String, ConsumerGroupDescription> descriptions = new HashMap<>();
                         for (Map.Entry<String, KafkaFuture<ConsumerGroupDescription>> entry : futures.entrySet()) {
-                            map.put(entry.getKey(), entry.getValue().get());
+                            descriptions.put(entry.getKey(), entry.getValue().get());
                         }
-                        return map;
+                        return descriptions;
                     } catch (InterruptedException | ExecutionException e) {
                         // This should be unreachable, since the KafkaFuture#allOf already ensured
                         // that all of the futures completed successfully.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -136,7 +136,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -2385,11 +2384,11 @@ public class KafkaAdminClient extends AdminClient {
                                     final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
 
                                     for (DescribeGroupsResponse.GroupMember groupMember : members) {
-                                        Set<TopicPartition> partitions = Collections.<TopicPartition>emptySet();
+                                        Set<TopicPartition> partitions = Collections.emptySet();
                                         if (groupMember.memberAssignment().remaining() > 0) {
                                             final PartitionAssignor.Assignment assignment = ConsumerProtocol.
                                                 deserializeAssignment(groupMember.memberAssignment().duplicate());
-                                            partitions = new TreeSet<>(assignment.partitions());
+                                            partitions = new HashSet<>(assignment.partitions());
                                         }
                                         final MemberDescription memberDescription =
                                             new MemberDescription(groupMember.memberId(),

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2379,18 +2379,19 @@ public class KafkaAdminClient extends AdminClient {
                                     final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
 
                                     for (DescribeGroupsResponse.GroupMember groupMember : members) {
+                                        List<TopicPartition> partitions = Collections.<TopicPartition>emptyList();
                                         if (groupMember.memberAssignment().remaining() > 0) {
                                             final PartitionAssignor.Assignment assignment =
                                                 ConsumerProtocol.deserializeAssignment(
                                                     ByteBuffer.wrap(Utils.readBytes(groupMember.memberAssignment())));
-
-                                            final MemberDescription memberDescription =
-                                                new MemberDescription.Builder(groupMember.memberId()).
-                                                    clientId(groupMember.clientId()).
-                                                    host(groupMember.clientHost()).
-                                                    assignment(new MemberAssignment(assignment.partitions())).build();
-                                            memberDescriptions.add(memberDescription);
+                                            partitions = assignment.partitions();
                                         }
+                                        final MemberDescription memberDescription =
+                                            new MemberDescription.Builder(groupMember.memberId()).
+                                                clientId(groupMember.clientId()).
+                                                host(groupMember.clientHost()).
+                                                assignment(new MemberAssignment(partitions)).build();
+                                        memberDescriptions.add(memberDescription);
                                     }
                                     final ConsumerGroupDescription consumerGroupDescription =
                                             new ConsumerGroupDescription.Builder(groupId).

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
@@ -19,25 +19,24 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * A description of the assignments of a specific group member.
  */
 public class MemberAssignment {
-    private final Collection<TopicPartition> topicPartitions;
+    private final Set<TopicPartition> topicPartitions;
 
     /**
      * Creates an instance with the specified parameters.
      *
      * @param topicPartitions List of topic partitions
      */
-    public MemberAssignment(List<TopicPartition> topicPartitions) {
-        this.topicPartitions = topicPartitions == null ? Collections.<TopicPartition>emptyList() :
-            Collections.unmodifiableList(new ArrayList<TopicPartition>(topicPartitions));
+    MemberAssignment(Set<TopicPartition> topicPartitions) {
+        this.topicPartitions = topicPartitions == null ? Collections.<TopicPartition>emptySet() :
+            Collections.unmodifiableSet(new TreeSet<TopicPartition>(topicPartitions));
     }
 
     @Override
@@ -58,7 +57,7 @@ public class MemberAssignment {
     /**
      * The topic partitions assigned to a group member.
      */
-    public Collection<TopicPartition> topicPartitions() {
+    public Set<TopicPartition> topicPartitions() {
         return topicPartitions;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
@@ -20,8 +20,8 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * A description of the assignments of a specific group member.
@@ -36,7 +36,7 @@ public class MemberAssignment {
      */
     MemberAssignment(Set<TopicPartition> topicPartitions) {
         this.topicPartitions = topicPartitions == null ? Collections.<TopicPartition>emptySet() :
-            Collections.unmodifiableSet(new TreeSet<TopicPartition>(topicPartitions));
+            Collections.unmodifiableSet(new HashSet<>(topicPartitions));
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
@@ -19,13 +19,16 @@ package org.apache.kafka.clients.admin;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Utils;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * A description of the assignments of a specific group member.
  */
 public class MemberAssignment {
-    private final List<TopicPartition> topicPartitions;
+    private final Collection<TopicPartition> topicPartitions;
 
     /**
      * Creates an instance with the specified parameters.
@@ -33,7 +36,8 @@ public class MemberAssignment {
      * @param topicPartitions List of topic partitions
      */
     public MemberAssignment(List<TopicPartition> topicPartitions) {
-        this.topicPartitions = topicPartitions;
+        this.topicPartitions = topicPartitions == null ? Collections.<TopicPartition>emptyList() :
+            Collections.unmodifiableList(new ArrayList<TopicPartition>(topicPartitions));
     }
 
     @Override
@@ -54,7 +58,7 @@ public class MemberAssignment {
     /**
      * The topic partitions assigned to a group member.
      */
-    public List<TopicPartition> topicPartitions() {
+    public Collection<TopicPartition> topicPartitions() {
         return topicPartitions;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
@@ -17,49 +17,72 @@
 
 package org.apache.kafka.clients.admin;
 
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collections;
+import java.util.Objects;
+
 /**
  * A detailed description of a single group instance in the cluster.
  */
 public class MemberDescription {
-
     private final String memberId;
     private final String clientId;
     private final String host;
     private final MemberAssignment assignment;
 
-    /**
-     * Creates an instance with the specified parameters.
-     *
-     * @param memberId The consumer id
-     * @param clientId   The client id
-     * @param host       The host
-     * @param assignment The assignment
-     */
-    public MemberDescription(String memberId, String clientId, String host, MemberAssignment assignment) {
-        this.memberId = memberId;
-        this.clientId = clientId;
-        this.host = host;
-        this.assignment = assignment;
+    public static class Builder {
+        private final String memberId;
+        private String clientId;
+        private String host;
+        private MemberAssignment assignment;
+
+        public Builder(String memberId) {
+            this.memberId = memberId;
+        }
+
+        public Builder clientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public Builder assignment(MemberAssignment assignment) {
+            this.assignment = assignment;
+            return this;
+        }
+
+        public MemberDescription build() {
+            return new MemberDescription(memberId, clientId, host, assignment);
+        }
+    }
+
+    private MemberDescription(String memberId, String clientId, String host, MemberAssignment assignment) {
+        this.memberId = memberId == null ? "" : memberId;
+        this.clientId = clientId == null ? "" : clientId;
+        this.host = host == null ? "" : host;
+        this.assignment = assignment == null ?
+            new MemberAssignment(Collections.<TopicPartition>emptyList()) : assignment;
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         MemberDescription that = (MemberDescription) o;
-
-        if (memberId != null ? !memberId.equals(that.memberId) : that.memberId != null) return false;
-        if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
-        return assignment != null ? assignment.equals(that.assignment) : that.assignment == null;
+        return memberId.equals(that.memberId) &&
+            clientId.equals(that.clientId) &&
+            host.equals(that.host) &&
+            assignment.equals(that.assignment);
     }
 
     @Override
     public int hashCode() {
-        int result = memberId != null ? memberId.hashCode() : 0;
-        result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
-        result = 31 * result + (assignment != null ? assignment.hashCode() : 0);
-        return result;
+        return Objects.hash(memberId, clientId, host, assignment);
     }
 
     /**
@@ -92,7 +115,9 @@ public class MemberDescription {
 
     @Override
     public String toString() {
-        return "(memberId=" + memberId + ", clientId=" + clientId + ", host=" + host + ", assignment=" +
-            assignment + ")";
+        return "(memberId=" + memberId +
+            ", clientId=" + clientId +
+            ", host=" + host +
+            ", assignment=" + assignment + ")";
     }
 }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
@@ -31,42 +31,12 @@ public class MemberDescription {
     private final String host;
     private final MemberAssignment assignment;
 
-    public static class Builder {
-        private final String memberId;
-        private String clientId;
-        private String host;
-        private MemberAssignment assignment;
-
-        public Builder(String memberId) {
-            this.memberId = memberId;
-        }
-
-        public Builder clientId(String clientId) {
-            this.clientId = clientId;
-            return this;
-        }
-
-        public Builder host(String host) {
-            this.host = host;
-            return this;
-        }
-
-        public Builder assignment(MemberAssignment assignment) {
-            this.assignment = assignment;
-            return this;
-        }
-
-        public MemberDescription build() {
-            return new MemberDescription(memberId, clientId, host, assignment);
-        }
-    }
-
-    private MemberDescription(String memberId, String clientId, String host, MemberAssignment assignment) {
+    MemberDescription(String memberId, String clientId, String host, MemberAssignment assignment) {
         this.memberId = memberId == null ? "" : memberId;
         this.clientId = clientId == null ? "" : clientId;
         this.host = host == null ? "" : host;
         this.assignment = assignment == null ?
-            new MemberAssignment(Collections.<TopicPartition>emptyList()) : assignment;
+            new MemberAssignment(Collections.<TopicPartition>emptySet()) : assignment;
     }
 
     @Override

--- a/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java
@@ -27,7 +27,8 @@ public enum ConsumerGroupState {
     PREPARING_REBALANCE("PreparingRebalance"),
     COMPLETING_REBALANCE("CompletingRebalance"),
     STABLE("Stable"),
-    DEAD("Dead");
+    DEAD("Dead"),
+    EMPTY("Empty");
 
     private final static HashMap<String, ConsumerGroupState> NAME_TO_ENUM;
 

--- a/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java
+++ b/clients/src/main/java/org/apache/kafka/common/ConsumerGroupState.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common;
+
+import java.util.HashMap;
+
+/**
+ * The consumer group state.
+ */
+public enum ConsumerGroupState {
+    UNKNOWN("Unknown"),
+    PREPARING_REBALANCE("PreparingRebalance"),
+    COMPLETING_REBALANCE("CompletingRebalance"),
+    STABLE("Stable"),
+    DEAD("Dead");
+
+    private final static HashMap<String, ConsumerGroupState> NAME_TO_ENUM;
+
+    static {
+        NAME_TO_ENUM = new HashMap<>();
+        for (ConsumerGroupState state : ConsumerGroupState.values()) {
+            NAME_TO_ENUM.put(state.name, state);
+        }
+    }
+
+    private final String name;
+
+    ConsumerGroupState(String name) {
+        this.name = name;
+    }
+
+
+    /**
+     * Parse a string into a consumer group state.
+     */
+    public static ConsumerGroupState parse(String name) {
+        ConsumerGroupState state = NAME_TO_ENUM.get(name);
+        return state == null ? UNKNOWN : state;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/errors/GroupIdNotFoundException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/GroupIdNotFoundException.java
@@ -17,15 +17,7 @@
 package org.apache.kafka.common.errors;
 
 public class GroupIdNotFoundException extends ApiException {
-    private final String groupId;
-
-    public GroupIdNotFoundException(String groupId) {
-        super("The group id " + groupId + " was not found");
-        this.groupId = groupId;
+    public GroupIdNotFoundException(String message) {
+        super(message);
     }
-
-    public String groupId() {
-        return groupId;
-    }
-
 }

--- a/clients/src/main/java/org/apache/kafka/common/errors/GroupNotEmptyException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/GroupNotEmptyException.java
@@ -17,15 +17,7 @@
 package org.apache.kafka.common.errors;
 
 public class GroupNotEmptyException extends ApiException {
-    private final String groupId;
-
-    public GroupNotEmptyException(String groupId) {
-        super("The group " + groupId + " is not empty");
-        this.groupId = groupId;
+    public GroupNotEmptyException(String message) {
+        super(message);
     }
-
-    public String groupId() {
-        return groupId;
-    }
-
 }

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -157,7 +157,8 @@ public class StreamsResetter {
                                            final AdminClient adminClient) throws ExecutionException, InterruptedException {
         final DescribeConsumerGroupsResult describeResult = adminClient.describeConsumerGroups(Arrays.asList(groupId),
                 (new DescribeConsumerGroupsOptions()).timeoutMs(10 * 1000));
-        final List<MemberDescription> members = describeResult.describedGroups().get(groupId).get().members();
+        final List<MemberDescription> members =
+            new ArrayList<MemberDescription>(describeResult.describedGroups().get(groupId).get().members());
         if (!members.isEmpty()) {
             throw new IllegalStateException("Consumer group '" + groupId + "' is still active "
                     + "and has following members: " + members + ". "

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -31,7 +31,7 @@ import org.apache.kafka.clients.admin._
 import kafka.utils.{Logging, TestUtils}
 import kafka.utils.Implicits._
 import org.apache.kafka.clients.admin.NewTopic
-import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.{KafkaFuture, TopicPartition, TopicPartitionReplica}
@@ -49,6 +49,7 @@ import scala.collection.JavaConverters._
 import java.lang.{Long => JLong}
 
 import kafka.zk.KafkaZkClient
+import org.apache.kafka.common.internals.Topic
 import org.scalatest.Assertions.intercept
 
 import scala.concurrent.duration.Duration
@@ -98,6 +99,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       config.setProperty(KafkaConfig.InterBrokerListenerNameProp, listenerName.value)
       config.setProperty(KafkaConfig.ListenerSecurityProtocolMapProp, s"${listenerName.value}:${securityProtocol.name}")
       config.setProperty(KafkaConfig.DeleteTopicEnableProp, "true")
+      config.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
       // We set this in order to test that we don't expose sensitive data via describe configs. This will already be
       // set for subclasses with security enabled and we don't want to overwrite it.
       if (!config.containsKey(KafkaConfig.SslTruststorePasswordProp))
@@ -958,6 +960,120 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     future2.get
     client.close()
     assertEquals(1, factory.failuresInjected)
+  }
+
+  /**
+    * Test the consumer group APIs.
+    */
+  @Test
+  def testConsumerGroups(): Unit = {
+    val config = createConfig()
+    val client = AdminClient.create(config)
+    try {
+      // Verify that initially there are no consumer groups to list.
+      val list1 = client.listConsumerGroups()
+      assertTrue(0 == list1.all().get().size())
+      assertTrue(0 == list1.errors().get().size())
+      assertTrue(0 == list1.valid().get().size())
+      val testTopicName = "test_topic"
+      val testNumPartitions = 2
+      client.createTopics(Collections.singleton(
+        new NewTopic(testTopicName, testNumPartitions, 1))).all().get()
+      val producer = createNewProducer
+      try {
+        producer.send(new ProducerRecord(testTopicName, 0, null, null)).get()
+      } finally {
+        Utils.closeQuietly(producer, "producer")
+      }
+      val testGroupId = "test_group_id"
+      val testClientId = "test_client_id"
+      val fakeGroupId = "fake_group_id"
+      val newConsumerConfig = new Properties(consumerConfig)
+      newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
+      newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
+      val consumer = TestUtils.createNewConsumer(brokerList,
+        securityProtocol = this.securityProtocol,
+        trustStoreFile = this.trustStoreFile,
+        saslProperties = this.clientSaslProperties,
+        props = Some(newConsumerConfig))
+      try {
+        // Start a consumer in a thread that will subscribe to a new group.
+        val consumerThread = new Thread {
+          override def run {
+            consumer.subscribe(Collections.singleton(testTopicName))
+            while (true) {
+              consumer.poll(5000)
+              consumer.commitSync()
+            }
+          }
+        }
+        try {
+          consumerThread.start
+          // Test that we can list the new group.
+          TestUtils.waitUntilTrue(() => {
+            val matching = client.listConsumerGroups().all().get().asScala.
+              filter(listing => listing.groupId().equals(testGroupId))
+            !matching.isEmpty
+          }, s"Expected to be able to list $testGroupId")
+
+          val result = client.describeConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
+          assertEquals(2, result.describedGroups().size())
+
+          // Test that we can get information about the test consumer group.
+          assertTrue(result.describedGroups().containsKey(testGroupId))
+          val testGroupDescription = result.describedGroups().get(testGroupId).get()
+          assertEquals(testGroupId, testGroupDescription.groupId())
+          assertFalse(testGroupDescription.isSimpleConsumerGroup())
+          assertEquals(1, testGroupDescription.members().size())
+          val member = testGroupDescription.members().iterator().next()
+          assertEquals(testClientId, member.clientId())
+          val topicPartitions = member.assignment().topicPartitions()
+          assertEquals(testNumPartitions, topicPartitions.size())
+          assertEquals(testNumPartitions, topicPartitions.asScala.
+            count(tp => tp.topic().equals(testTopicName)))
+
+          // Test that the fake group is listed as dead.
+          assertTrue(result.describedGroups().containsKey(fakeGroupId))
+          val fakeGroupDescription = result.describedGroups().get(fakeGroupId).get()
+          assertEquals(fakeGroupId, fakeGroupDescription.groupId())
+          assertEquals(0, fakeGroupDescription.members().size())
+          assertEquals("", fakeGroupDescription.partitionAssignor())
+          assertTrue(fakeGroupDescription.isDead())
+
+          // Test that all() returns 2 results
+          assertEquals(2, result.all().get().size())
+
+          // Test listConsumerGroupOffsets
+          val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+          TestUtils.waitUntilTrue(() => {
+            val parts = client.listConsumerGroupOffsets(testGroupId).partitionsToOffsetAndMetadata().get()
+            val part = new TopicPartition(testTopicName, 0)
+            parts.containsKey(part) && (parts.get(part).offset() == 1)
+          }, s"Expected the offset for partition 0 to eventually become 1.")
+
+          // Test consumer group deletion
+          val deleteResult = client.deleteConsumerGroups(Seq(testGroupId, fakeGroupId).asJava)
+          assertEquals(2, deleteResult.deletedGroups().size())
+
+          // Deleting the fake group ID should get GroupIdNotFoundException.
+          assertTrue(deleteResult.deletedGroups().containsKey(fakeGroupId))
+          assertFutureExceptionTypeEquals(deleteResult.deletedGroups().get(fakeGroupId),
+            classOf[GroupIdNotFoundException])
+
+          // Deleting the real group ID should get GroupNotEmptyException
+          assertTrue(deleteResult.deletedGroups().containsKey(testGroupId))
+          assertFutureExceptionTypeEquals(deleteResult.deletedGroups().get(testGroupId),
+            classOf[GroupNotEmptyException])
+        } finally {
+          consumerThread.interrupt()
+          consumerThread.join()
+        }
+      } finally {
+        Utils.closeQuietly(consumer, "consumer")
+      }
+    } finally {
+      Utils.closeQuietly(client, "adminClient")
+    }
   }
 }
 

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.{KafkaFuture, TopicPartition, TopicPartitionReplica}
+import org.apache.kafka.common.{ConsumerGroupState, KafkaFuture, TopicPartition, TopicPartitionReplica}
 import org.apache.kafka.common.acl._
 import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors._
@@ -1038,7 +1038,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
           assertEquals(fakeGroupId, fakeGroupDescription.groupId())
           assertEquals(0, fakeGroupDescription.members().size())
           assertEquals("", fakeGroupDescription.partitionAssignor())
-          assertTrue(fakeGroupDescription.isDead())
+          assertEquals(ConsumerGroupState.DEAD, fakeGroupDescription.state())
 
           // Test that all() returns 2 results
           assertEquals(2, result.all().get().size())


### PR DESCRIPTION
* The consumer groups API should expose group state.  This information is needed by administrative tools and scripts that access consume groups.

* The partition assignment will be empty when the group is rebalancing. Fix an issue where the adminclient attempted to deserialize this empty buffer.

* Remove nulls from the API and make all collections immutable.

* DescribeConsumerGroupsResult#all should return a result as expected, rather than Void

* Add Builder classes for MemberDescription and ConsumerGroupDescription, so that we can easily add new fields later without having a large number of constructors.

* Fix exception text for GroupIdNotFoundException, GroupNotEmptyException. It was being filled in as
"The group id The group id does not exist was not found" and similar.

* Add integration test