### PR TITLE
Minor: Remove the unused field in DelegatingClassLoader

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -65,14 +65,12 @@ public class DelegatingClassLoader extends URLClassLoader {
     private final SortedSet<PluginDesc<HeaderConverter>> headerConverters;
     private final SortedSet<PluginDesc<Transformation>> transformations;
     private final List<String> pluginPaths;
-    private final Map<Path, PluginClassLoader> activePaths;
 
     public DelegatingClassLoader(List<String> pluginPaths, ClassLoader parent) {
         super(new URL[0], parent);
         this.pluginPaths = pluginPaths;
         this.pluginLoaders = new HashMap<>();
         this.aliases = new HashMap<>();
-        this.activePaths = new HashMap<>();
         this.connectors = new TreeSet<>();
         this.converters = new TreeSet<>();
         this.headerConverters = new TreeSet<>();
@@ -216,10 +214,6 @@ public class DelegatingClassLoader extends URLClassLoader {
         PluginScanResult plugins = scanPluginPath(loader, urls);
         log.info("Registered loader: {}", loader);
         if (!plugins.isEmpty()) {
-            if (loader instanceof PluginClassLoader) {
-                activePaths.put(pluginLocation, (PluginClassLoader) loader);
-            }
-
             addPlugins(plugins.connectors(), loader);
             connectors.addAll(plugins.connectors());
             addPlugins(plugins.converters(), loader);


### PR DESCRIPTION
After [3173](https://github.com/apache/kafka/commit/e0150a25e8), the field "activePaths" is not used anymore.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
