### PR TITLE
KAFKA-6474: Rewrite tests to use new public TopologyTestDriver [part 2]

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -71,7 +71,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
             return global;
         }
 
-        if (!currentNode().stateStores.contains(name)) {
+        if (currentNode.stateStores != null && !currentNode().stateStores.contains(name)) {
             throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name +
                     " as the store is not connected to the processor. If you add stores manually via '.addStateStore()' " +
                     "make sure to connect the added store to the processor by providing the processor name to " +

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -71,7 +71,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
             return global;
         }
 
-        if (currentNode.stateStores != null && !currentNode().stateStores.contains(name)) {
+        if (!currentNode().stateStores.contains(name)) {
             throw new StreamsException("Processor " + currentNode().name() + " has no access to StateStore " + name +
                     " as the store is not connected to the processor. If you add stores manually via '.addStateStore()' " +
                     "make sure to connect the added store to the processor by providing the processor name to " +

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTestDriverWrapper.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTestDriverWrapper.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+/**
+ * This class provides access to {@link TopologyTestDriver} protected methods.
+ * It should only be used for internal testing, in the rare occasions where the
+ * necessary functionality is not supported by {@link TopologyTestDriver}.
+ */
+public class TopologyTestDriverWrapper extends TopologyTestDriver {
+
+
+    public TopologyTestDriverWrapper(final Topology topology,
+                                     final Properties config) {
+        super(topology, config);
+    }
+
+    public TopologyTestDriverWrapper(final Topology topology,
+                                     final Properties config,
+                                     final long initialWallClockTimeMs) {
+        super(topology, config, initialWallClockTimeMs);
+    }
+
+    /**
+     * Get the processor context
+     *
+     * @param topicName the topic name is used to identify the source node, which is set as current node
+     * @return the processor context
+     */
+    public ProcessorContext getProcessorContext(final String topicName) {
+        final ProcessorContext context = task.context();
+        ((ProcessorContextImpl) context).setCurrentNode(sourceNodeByTopicName(topicName));
+        return context;
+    }
+
+    /**
+     * Identify the source node for a given topic
+     *
+     * @param topicName the topic name to search for
+     * @return the source node
+     */
+    private ProcessorNode sourceNodeByTopicName(final String topicName) {
+        ProcessorNode topicNode = processorTopology.source(topicName);
+        if (topicNode == null) {
+            for (final String sourceTopic : processorTopology.sourceTopics()) {
+                if (Pattern.compile(sourceTopic).matcher(topicName).matches()) {
+                    return processorTopology.source(sourceTopic);
+                }
+            }
+            if (globalTopology != null) {
+                topicNode = globalTopology.source(topicName);
+            }
+        }
+        return topicNode;
+    }
+
+    /**
+     * Get a processor by name
+     *
+     * @param name the name to search for
+     * @return the processor matching the search name
+     */
+    public ProcessorNode getProcessor(final String name) {
+        final List<ProcessorNode> nodes = processorTopology.processors();
+
+        for (final ProcessorNode node : nodes) {
+            if (node.name().equals(name)) {
+                return node;
+            }
+        }
+
+        return null;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTestDriverWrapper.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTestDriverWrapper.java
@@ -37,12 +37,12 @@ public class TopologyTestDriverWrapper extends TopologyTestDriver {
     }
 
     /**
-     * Get the processor context
+     * Get the processor context, setting the processor whose name is given as current node
      *
-     * @param processorName used to search for a processor connected to this StateStore, which is set as current node
+     * @param processorName processor name to set as current node
      * @return the processor context
      */
-    public ProcessorContext getProcessorContext(final String processorName) {
+    public ProcessorContext setCurrentNodeForProcessorContext(final String processorName) {
         final ProcessorContext context = task.context();
         ((ProcessorContextImpl) context).setCurrentNode(getProcessor(processorName));
         return context;
@@ -56,6 +56,11 @@ public class TopologyTestDriverWrapper extends TopologyTestDriver {
      */
     public ProcessorNode getProcessor(final String name) {
         for (final ProcessorNode node : processorTopology.processors()) {
+            if (node.name().equals(name)) {
+                return node;
+            }
+        }
+        for (final ProcessorNode node : globalTopology.processors()) {
             if (node.name().equals(name)) {
                 return node;
             }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -20,11 +20,11 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyTestDriverWrapper;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Predicate;
@@ -126,7 +126,9 @@ public class KTableFilterTest {
     private void doTestValueGetter(final StreamsBuilder builder,
                                    final KTableImpl<String, Integer, Integer> table2,
                                    final KTableImpl<String, Integer, Integer> table3,
-                                   final String topic1) {
+                                   final String topic1,
+                                   final String procName2,
+                                   final String procName3) {
 
         KTableValueGetterSupplier<String, Integer> getterSupplier2 = table2.valueGetterSupplier();
         KTableValueGetterSupplier<String, Integer> getterSupplier3 = table3.valueGetterSupplier();
@@ -136,8 +138,8 @@ public class KTableFilterTest {
             KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
             KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
 
-            getter2.init(driver.getProcessorContext(topic1));
-            getter3.init(driver.getProcessorContext(topic1));
+            getter2.init(driver.getProcessorContext(procName2));
+            getter3.init(driver.getProcessorContext(procName3));
 
             driver.pipeInput(recordFactory.create(topic1, "A", 1));
             driver.pipeInput(recordFactory.create(topic1, "B", 1));
@@ -208,7 +210,7 @@ public class KTableFilterTest {
                     }
                 });
 
-        doTestValueGetter(builder, table2, table3, topic1);
+        doTestValueGetter(builder, table2, table3, topic1, "KTABLE-SOURCE-0000000002", "KTABLE-SOURCE-0000000002");
     }
 
     @Test
@@ -237,7 +239,7 @@ public class KTableFilterTest {
         assertEquals("anyStoreNameFilter", table2.queryableStoreName());
         assertNull(table3.queryableStoreName());
 
-        doTestValueGetter(builder, table2, table3, topic1);
+        doTestValueGetter(builder, table2, table3, topic1, "KTABLE-FILTER-0000000003", "KTABLE-SOURCE-0000000002");
     }
 
     private void doTestNotSendingOldValue(final StreamsBuilder builder,

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableFilterTest.java
@@ -16,45 +16,38 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.TopologyTestDriverWrapper;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.test.KStreamTestDriver;
+import org.apache.kafka.streams.test.ConsumerRecordFactory;
+import org.apache.kafka.test.MockMapper;
 import org.apache.kafka.test.MockProcessor;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockReducer;
-import org.apache.kafka.test.MockMapper;
-import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Rule;
+import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
-import java.io.File;
 import java.util.List;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class KTableFilterTest {
 
-    final private Serde<Integer> intSerde = Serdes.Integer();
-    final private Serde<String> stringSerde = Serdes.String();
-    private final Consumed<String, Integer> consumed = Consumed.with(stringSerde, intSerde);
-    @Rule
-    public final KStreamTestDriver driver = new KStreamTestDriver();
-    private File stateDir = null;
-
-    @Before
-    public void setUp() {
-        stateDir = TestUtils.tempDirectory("kafka-test");
-    }
+    private final Consumed<String, Integer> consumed = Consumed.with(Serdes.String(), Serdes.Integer());
+    private final ConsumerRecordFactory<String, Integer> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new IntegerSerializer());
+    private final Properties props = StreamsTestUtils.topologyTestConfig(Serdes.String(), Serdes.Integer());
 
     private void doTestKTable(final StreamsBuilder builder,
                               final KTable<String, Integer> table2,
@@ -64,16 +57,14 @@ public class KTableFilterTest {
         table2.toStream().process(supplier);
         table3.toStream().process(supplier);
 
-        driver.setUp(builder, stateDir, Serdes.String(), Serdes.Integer());
-
-        driver.process(topic, "A", 1);
-        driver.process(topic, "B", 2);
-        driver.process(topic, "C", 3);
-        driver.process(topic, "D", 4);
-        driver.flushState();
-        driver.process(topic, "A", null);
-        driver.process(topic, "B", null);
-        driver.flushState();
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            driver.pipeInput(recordFactory.create(topic, "A", 1));
+            driver.pipeInput(recordFactory.create(topic, "B", 2));
+            driver.pipeInput(recordFactory.create(topic, "C", 3));
+            driver.pipeInput(recordFactory.create(topic, "D", 4));
+            driver.pipeInput(recordFactory.create(topic, "A", null));
+            driver.pipeInput(recordFactory.create(topic, "B", null));
+        }
 
         final List<MockProcessor<String, Integer>> processors = supplier.capturedProcessors(2);
 
@@ -136,63 +127,62 @@ public class KTableFilterTest {
                                    final KTableImpl<String, Integer, Integer> table2,
                                    final KTableImpl<String, Integer, Integer> table3,
                                    final String topic1) {
+
         KTableValueGetterSupplier<String, Integer> getterSupplier2 = table2.valueGetterSupplier();
         KTableValueGetterSupplier<String, Integer> getterSupplier3 = table3.valueGetterSupplier();
 
-        driver.setUp(builder, stateDir, Serdes.String(), Serdes.Integer());
+        try (final TopologyTestDriverWrapper driver = new TopologyTestDriverWrapper(builder.build(), props)) {
 
-        KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
-        KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
+            KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
+            KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
 
-        getter2.init(driver.context());
-        getter3.init(driver.context());
+            getter2.init(driver.getProcessorContext(topic1));
+            getter3.init(driver.getProcessorContext(topic1));
 
-        driver.process(topic1, "A", 1);
-        driver.process(topic1, "B", 1);
-        driver.process(topic1, "C", 1);
+            driver.pipeInput(recordFactory.create(topic1, "A", 1));
+            driver.pipeInput(recordFactory.create(topic1, "B", 1));
+            driver.pipeInput(recordFactory.create(topic1, "C", 1));
 
-        assertNull(getter2.get("A"));
-        assertNull(getter2.get("B"));
-        assertNull(getter2.get("C"));
+            assertNull(getter2.get("A"));
+            assertNull(getter2.get("B"));
+            assertNull(getter2.get("C"));
 
-        assertEquals(1, (int) getter3.get("A"));
-        assertEquals(1, (int) getter3.get("B"));
-        assertEquals(1, (int) getter3.get("C"));
+            assertEquals(1, (int) getter3.get("A"));
+            assertEquals(1, (int) getter3.get("B"));
+            assertEquals(1, (int) getter3.get("C"));
 
-        driver.process(topic1, "A", 2);
-        driver.process(topic1, "B", 2);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", 2));
+            driver.pipeInput(recordFactory.create(topic1, "B", 2));
 
-        assertEquals(2, (int) getter2.get("A"));
-        assertEquals(2, (int) getter2.get("B"));
-        assertNull(getter2.get("C"));
+            assertEquals(2, (int) getter2.get("A"));
+            assertEquals(2, (int) getter2.get("B"));
+            assertNull(getter2.get("C"));
 
-        assertNull(getter3.get("A"));
-        assertNull(getter3.get("B"));
-        assertEquals(1, (int) getter3.get("C"));
+            assertNull(getter3.get("A"));
+            assertNull(getter3.get("B"));
+            assertEquals(1, (int) getter3.get("C"));
 
-        driver.process(topic1, "A", 3);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", 3));
 
-        assertNull(getter2.get("A"));
-        assertEquals(2, (int) getter2.get("B"));
-        assertNull(getter2.get("C"));
+            assertNull(getter2.get("A"));
+            assertEquals(2, (int) getter2.get("B"));
+            assertNull(getter2.get("C"));
 
-        assertEquals(3, (int) getter3.get("A"));
-        assertNull(getter3.get("B"));
-        assertEquals(1, (int) getter3.get("C"));
+            assertEquals(3, (int) getter3.get("A"));
+            assertNull(getter3.get("B"));
+            assertEquals(1, (int) getter3.get("C"));
 
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "B", null));
 
-        assertNull(getter2.get("A"));
-        assertNull(getter2.get("B"));
-        assertNull(getter2.get("C"));
+            assertNull(getter2.get("A"));
+            assertNull(getter2.get("B"));
+            assertNull(getter2.get("C"));
 
-        assertNull(getter3.get("A"));
-        assertNull(getter3.get("B"));
-        assertEquals(1, (int) getter3.get("C"));
+            assertNull(getter3.get("A"));
+            assertNull(getter3.get("B"));
+            assertEquals(1, (int) getter3.get("C"));
+        }
     }
 
     @Test
@@ -259,34 +249,34 @@ public class KTableFilterTest {
         builder.build().addProcessor("proc1", supplier, table1.name);
         builder.build().addProcessor("proc2", supplier, table2.name);
 
-        driver.setUp(builder, stateDir, Serdes.String(), Serdes.Integer());
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
 
-        driver.process(topic1, "A", 1);
-        driver.process(topic1, "B", 1);
-        driver.process(topic1, "C", 1);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", 1));
+            driver.pipeInput(recordFactory.create(topic1, "B", 1));
+            driver.pipeInput(recordFactory.create(topic1, "C", 1));
 
-        final List<MockProcessor<String, Integer>> processors = supplier.capturedProcessors(2);
+            final List<MockProcessor<String, Integer>> processors = supplier.capturedProcessors(2);
 
-        processors.get(0).checkAndClearProcessResult("A:(1<-null)", "B:(1<-null)", "C:(1<-null)");
-        processors.get(1).checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)", "C:(null<-null)");
+            processors.get(0).checkAndClearProcessResult("A:(1<-null)", "B:(1<-null)", "C:(1<-null)");
+            processors.get(1).checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)", "C:(null<-null)");
 
-        driver.process(topic1, "A", 2);
-        driver.process(topic1, "B", 2);
-        driver.flushState();
-        processors.get(0).checkAndClearProcessResult("A:(2<-null)", "B:(2<-null)");
-        processors.get(1).checkAndClearProcessResult("A:(2<-null)", "B:(2<-null)");
+            driver.pipeInput(recordFactory.create(topic1, "A", 2));
+            driver.pipeInput(recordFactory.create(topic1, "B", 2));
 
-        driver.process(topic1, "A", 3);
-        driver.flushState();
-        processors.get(0).checkAndClearProcessResult("A:(3<-null)");
-        processors.get(1).checkAndClearProcessResult("A:(null<-null)");
+            processors.get(0).checkAndClearProcessResult("A:(2<-null)", "B:(2<-null)");
+            processors.get(1).checkAndClearProcessResult("A:(2<-null)", "B:(2<-null)");
 
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
-        driver.flushState();
-        processors.get(0).checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
-        processors.get(1).checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
+            driver.pipeInput(recordFactory.create(topic1, "A", 3));
+
+            processors.get(0).checkAndClearProcessResult("A:(3<-null)");
+            processors.get(1).checkAndClearProcessResult("A:(null<-null)");
+
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "B", null));
+
+            processors.get(0).checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
+            processors.get(1).checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
+        }
     }
 
 
@@ -340,34 +330,34 @@ public class KTableFilterTest {
         topology.addProcessor("proc1", supplier, table1.name);
         topology.addProcessor("proc2", supplier, table2.name);
 
-        driver.setUp(builder, stateDir, Serdes.String(), Serdes.Integer());
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
 
-        driver.process(topic1, "A", 1);
-        driver.process(topic1, "B", 1);
-        driver.process(topic1, "C", 1);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", 1));
+            driver.pipeInput(recordFactory.create(topic1, "B", 1));
+            driver.pipeInput(recordFactory.create(topic1, "C", 1));
 
-        final List<MockProcessor<String, Integer>> processors = supplier.capturedProcessors(2);
+            final List<MockProcessor<String, Integer>> processors = supplier.capturedProcessors(2);
 
-        processors.get(0).checkAndClearProcessResult("A:(1<-null)", "B:(1<-null)", "C:(1<-null)");
-        processors.get(1).checkEmptyAndClearProcessResult();
+            processors.get(0).checkAndClearProcessResult("A:(1<-null)", "B:(1<-null)", "C:(1<-null)");
+            processors.get(1).checkEmptyAndClearProcessResult();
 
-        driver.process(topic1, "A", 2);
-        driver.process(topic1, "B", 2);
-        driver.flushState();
-        processors.get(0).checkAndClearProcessResult("A:(2<-1)", "B:(2<-1)");
-        processors.get(1).checkAndClearProcessResult("A:(2<-null)", "B:(2<-null)");
+            driver.pipeInput(recordFactory.create(topic1, "A", 2));
+            driver.pipeInput(recordFactory.create(topic1, "B", 2));
 
-        driver.process(topic1, "A", 3);
-        driver.flushState();
-        processors.get(0).checkAndClearProcessResult("A:(3<-2)");
-        processors.get(1).checkAndClearProcessResult("A:(null<-2)");
+            processors.get(0).checkAndClearProcessResult("A:(2<-1)", "B:(2<-1)");
+            processors.get(1).checkAndClearProcessResult("A:(2<-null)", "B:(2<-null)");
 
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
-        driver.flushState();
-        processors.get(0).checkAndClearProcessResult("A:(null<-3)", "B:(null<-2)");
-        processors.get(1).checkAndClearProcessResult("B:(null<-2)");
+            driver.pipeInput(recordFactory.create(topic1, "A", 3));
+
+            processors.get(0).checkAndClearProcessResult("A:(3<-2)");
+            processors.get(1).checkAndClearProcessResult("A:(null<-2)");
+
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "B", null));
+
+            processors.get(0).checkAndClearProcessResult("A:(null<-3)", "B:(null<-2)");
+            processors.get(1).checkAndClearProcessResult("B:(null<-2)");
+        }
     }
 
     @Test
@@ -418,12 +408,13 @@ public class KTableFilterTest {
         topology.addProcessor("proc1", supplier, table1.name);
         topology.addProcessor("proc2", supplier, table2.name);
 
-        driver.setUp(builder, stateDir, stringSerde, stringSerde);
+        final ConsumerRecordFactory<String, String> stringRecordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
 
-        driver.process(topic1, "A", "reject");
-        driver.process(topic1, "B", "reject");
-        driver.process(topic1, "C", "reject");
-        driver.flushState();
+            driver.pipeInput(stringRecordFactory.create(topic1, "A", "reject"));
+            driver.pipeInput(stringRecordFactory.create(topic1, "B", "reject"));
+            driver.pipeInput(stringRecordFactory.create(topic1, "C", "reject"));
+        }
 
         final List<MockProcessor<String, String>> processors = supplier.capturedProcessors(2);
         processors.get(0).checkAndClearProcessResult("A:(reject<-null)", "B:(reject<-null)", "C:(reject<-null)");
@@ -437,7 +428,7 @@ public class KTableFilterTest {
 
         String topic1 = "topic1";
 
-        final Consumed<String, String> consumed = Consumed.with(stringSerde, stringSerde);
+        final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
         KTableImpl<String, String, String> table1 =
             (KTableImpl<String, String, String>) builder.table(topic1, consumed);
         KTableImpl<String, String, String> table2 = (KTableImpl<String, String, String>) table1.filter(
@@ -459,7 +450,7 @@ public class KTableFilterTest {
 
         String topic1 = "topic1";
 
-        final Consumed<String, String> consumed = Consumed.with(stringSerde, stringSerde);
+        final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
         KTableImpl<String, String, String> table1 =
             (KTableImpl<String, String, String>) builder.table(topic1, consumed);
         KTableImpl<String, String, String> table2 = (KTableImpl<String, String, String>) table1.filter(

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -161,13 +161,13 @@ public class KTableImplTest {
             assertEquals(2, driver.getAllStateStores().size());
 
             final KTableValueGetter<String, String> getter1 = getterSupplier1.get();
-            getter1.init(driver.getProcessorContext(topic1));
+            getter1.init(driver.getProcessorContext("KTABLE-SOURCE-0000000002"));
             final KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
-            getter2.init(driver.getProcessorContext(topic1));
+            getter2.init(driver.getProcessorContext("KTABLE-SOURCE-0000000002"));
             final KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
-            getter3.init(driver.getProcessorContext(topic1));
+            getter3.init(driver.getProcessorContext("KTABLE-SOURCE-0000000002"));
             final KTableValueGetter<String, String> getter4 = getterSupplier4.get();
-            getter4.init(driver.getProcessorContext(topic1));
+            getter4.init(driver.getProcessorContext("KTABLE-SOURCE-0000000009"));
 
             driver.pipeInput(recordFactory.create(topic1, "A", "01"));
             driver.pipeInput(recordFactory.create(topic1, "B", "01"));
@@ -226,7 +226,7 @@ public class KTableImplTest {
             assertEquals("02", getter4.get("B"));
             assertEquals("01", getter4.get("C"));
 
-            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "A", (String) null));
 
             assertNull(getter1.get("A"));
             assertEquals("02", getter1.get("B"));

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.TopologyTestDriverWrapper;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Predicate;
@@ -33,7 +37,7 @@ import org.apache.kafka.streams.kstream.ValueTransformerWithKeySupplier;
 import org.apache.kafka.streams.processor.internals.SinkNode;
 import org.apache.kafka.streams.processor.internals.SourceNode;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.test.KStreamTestDriver;
+import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.MockMapper;
@@ -41,36 +45,31 @@ import org.apache.kafka.test.MockProcessor;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockReducer;
 import org.apache.kafka.test.MockValueJoiner;
-import org.apache.kafka.test.TestUtils;
+import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Properties;
 
 import static org.easymock.EasyMock.mock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class KTableImplTest {
 
-    private final Serde<String> stringSerde = Serdes.String();
-    private final Consumed<String, String> consumed = Consumed.with(stringSerde, stringSerde);
-    private final Produced<String, String> produced = Produced.with(stringSerde, stringSerde);
+    private final Consumed<String, String> consumed = Consumed.with(Serdes.String(), Serdes.String());
+    private final Produced<String, String> produced = Produced.with(Serdes.String(), Serdes.String());
+    private final Properties props = StreamsTestUtils.topologyTestConfig(Serdes.String(), Serdes.String());
+    private final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
 
-    @Rule
-    public final KStreamTestDriver driver = new KStreamTestDriver();
-    private File stateDir = null;
     private StreamsBuilder builder;
     private KTable<String, String> table;
 
     @Before
     public void setUp() {
-        stateDir = TestUtils.tempDirectory("kafka-test");
         builder = new StreamsBuilder();
         table = builder.table("test");
     }
@@ -110,17 +109,12 @@ public class KTableImplTest {
 
         table4.toStream().process(supplier);
 
-        driver.setUp(builder, stateDir);
-
-        driver.process(topic1, "A", "01");
-        driver.flushState();
-        driver.process(topic1, "B", "02");
-        driver.flushState();
-        driver.process(topic1, "C", "03");
-        driver.flushState();
-        driver.process(topic1, "D", "04");
-        driver.flushState();
-        driver.flushState();
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            driver.pipeInput(recordFactory.create(topic1, "A", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "02"));
+            driver.pipeInput(recordFactory.create(topic1, "C", "03"));
+            driver.pipeInput(recordFactory.create(topic1, "D", "04"));
+        }
 
         final List<MockProcessor<String, Object>> processors = supplier.capturedProcessors(4);
         assertEquals(Utils.mkList("A:01", "B:02", "C:03", "D:04"), processors.get(0).processed);
@@ -161,99 +155,96 @@ public class KTableImplTest {
         final KTableValueGetterSupplier<String, Integer> getterSupplier3 = table3.valueGetterSupplier();
         final KTableValueGetterSupplier<String, String> getterSupplier4 = table4.valueGetterSupplier();
 
-        driver.setUp(builder, stateDir, null, null);
+        try (final TopologyTestDriverWrapper driver = new TopologyTestDriverWrapper(builder.build(), props)) {
 
-        // two state store should be created
-        assertEquals(2, driver.allStateStores().size());
+            // two state stores should be created
+            assertEquals(2, driver.getAllStateStores().size());
 
-        final KTableValueGetter<String, String> getter1 = getterSupplier1.get();
-        getter1.init(driver.context());
-        final KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
-        getter2.init(driver.context());
-        final KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
-        getter3.init(driver.context());
-        final KTableValueGetter<String, String> getter4 = getterSupplier4.get();
-        getter4.init(driver.context());
+            final KTableValueGetter<String, String> getter1 = getterSupplier1.get();
+            getter1.init(driver.getProcessorContext(topic1));
+            final KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
+            getter2.init(driver.getProcessorContext(topic1));
+            final KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
+            getter3.init(driver.getProcessorContext(topic1));
+            final KTableValueGetter<String, String> getter4 = getterSupplier4.get();
+            getter4.init(driver.getProcessorContext(topic1));
 
-        driver.process(topic1, "A", "01");
-        driver.process(topic1, "B", "01");
-        driver.process(topic1, "C", "01");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "C", "01"));
 
-        assertEquals("01", getter1.get("A"));
-        assertEquals("01", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertEquals("01", getter1.get("A"));
+            assertEquals("01", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
-        assertEquals(new Integer(1), getter2.get("A"));
-        assertEquals(new Integer(1), getter2.get("B"));
-        assertEquals(new Integer(1), getter2.get("C"));
+            assertEquals(new Integer(1), getter2.get("A"));
+            assertEquals(new Integer(1), getter2.get("B"));
+            assertEquals(new Integer(1), getter2.get("C"));
 
-        assertNull(getter3.get("A"));
-        assertNull(getter3.get("B"));
-        assertNull(getter3.get("C"));
+            assertNull(getter3.get("A"));
+            assertNull(getter3.get("B"));
+            assertNull(getter3.get("C"));
 
-        assertEquals("01", getter4.get("A"));
-        assertEquals("01", getter4.get("B"));
-        assertEquals("01", getter4.get("C"));
+            assertEquals("01", getter4.get("A"));
+            assertEquals("01", getter4.get("B"));
+            assertEquals("01", getter4.get("C"));
 
-        driver.process(topic1, "A", "02");
-        driver.process(topic1, "B", "02");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "02"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "02"));
 
-        assertEquals("02", getter1.get("A"));
-        assertEquals("02", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertEquals("02", getter1.get("A"));
+            assertEquals("02", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
-        assertEquals(new Integer(2), getter2.get("A"));
-        assertEquals(new Integer(2), getter2.get("B"));
-        assertEquals(new Integer(1), getter2.get("C"));
+            assertEquals(new Integer(2), getter2.get("A"));
+            assertEquals(new Integer(2), getter2.get("B"));
+            assertEquals(new Integer(1), getter2.get("C"));
 
-        assertEquals(new Integer(2), getter3.get("A"));
-        assertEquals(new Integer(2), getter3.get("B"));
-        assertNull(getter3.get("C"));
+            assertEquals(new Integer(2), getter3.get("A"));
+            assertEquals(new Integer(2), getter3.get("B"));
+            assertNull(getter3.get("C"));
 
-        assertEquals("02", getter4.get("A"));
-        assertEquals("02", getter4.get("B"));
-        assertEquals("01", getter4.get("C"));
+            assertEquals("02", getter4.get("A"));
+            assertEquals("02", getter4.get("B"));
+            assertEquals("01", getter4.get("C"));
 
-        driver.process(topic1, "A", "03");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "03"));
 
-        assertEquals("03", getter1.get("A"));
-        assertEquals("02", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertEquals("03", getter1.get("A"));
+            assertEquals("02", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
-        assertEquals(new Integer(3), getter2.get("A"));
-        assertEquals(new Integer(2), getter2.get("B"));
-        assertEquals(new Integer(1), getter2.get("C"));
+            assertEquals(new Integer(3), getter2.get("A"));
+            assertEquals(new Integer(2), getter2.get("B"));
+            assertEquals(new Integer(1), getter2.get("C"));
 
-        assertNull(getter3.get("A"));
-        assertEquals(new Integer(2), getter3.get("B"));
-        assertNull(getter3.get("C"));
+            assertNull(getter3.get("A"));
+            assertEquals(new Integer(2), getter3.get("B"));
+            assertNull(getter3.get("C"));
 
-        assertEquals("03", getter4.get("A"));
-        assertEquals("02", getter4.get("B"));
-        assertEquals("01", getter4.get("C"));
+            assertEquals("03", getter4.get("A"));
+            assertEquals("02", getter4.get("B"));
+            assertEquals("01", getter4.get("C"));
 
-        driver.process(topic1, "A", null);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
 
-        assertNull(getter1.get("A"));
-        assertEquals("02", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertNull(getter1.get("A"));
+            assertEquals("02", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
 
-        assertNull(getter2.get("A"));
-        assertEquals(new Integer(2), getter2.get("B"));
-        assertEquals(new Integer(1), getter2.get("C"));
+            assertNull(getter2.get("A"));
+            assertEquals(new Integer(2), getter2.get("B"));
+            assertEquals(new Integer(1), getter2.get("C"));
 
-        assertNull(getter3.get("A"));
-        assertEquals(new Integer(2), getter3.get("B"));
-        assertNull(getter3.get("C"));
+            assertNull(getter3.get("A"));
+            assertEquals(new Integer(2), getter3.get("B"));
+            assertNull(getter3.get("C"));
 
-        assertNull(getter4.get("A"));
-        assertEquals("02", getter4.get("B"));
-        assertEquals("01", getter4.get("C"));
+            assertNull(getter4.get("A"));
+            assertEquals("02", getter4.get("B"));
+            assertEquals("01", getter4.get("C"));
+        }
     }
 
     @Test
@@ -282,11 +273,10 @@ public class KTableImplTest {
                     }
                 });
 
-        driver.setUp(builder, stateDir, null, null);
-        driver.setTime(0L);
-
-        // two state stores should be created
-        assertEquals(2, driver.allStateStores().size());
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            // two state stores should be created
+            assertEquals(2, driver.getAllStateStores().size());
+        }
     }
 
     @Test
@@ -323,11 +313,25 @@ public class KTableImplTest {
                     }
                 });
 
-        driver.setUp(builder, stateDir, null, null);
-        driver.setTime(0L);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            // two state stores should be created
+            assertEquals(2, driver.getAllStateStores().size());
+        }
+    }
 
-        // two state store should be created
-        assertEquals(2, driver.allStateStores().size());
+    private TopologyDescription.Node getProcessor(final Topology topology, final String processorName) {
+        for (final TopologyDescription.Subtopology subtopology: topology.describe().subtopologies()) {
+            for (final TopologyDescription.Node node: subtopology.nodes()) {
+                if (node.name().equals(processorName)) {
+                    return node;
+                }
+            }
+        }
+        return null;
+    }
+
+    private void assertTopologyContainsProcessor(final Topology topology, final String processorName) {
+        assertNotNull(getProcessor(topology, processorName));
     }
 
     @Test
@@ -341,8 +345,8 @@ public class KTableImplTest {
                 (KTableImpl<String, String, String>) builder.table(topic1,
                                                                    consumed,
                                                                    Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as(storeName1)
-                                                                           .withKeySerde(stringSerde)
-                                                                           .withValueSerde(stringSerde)
+                                                                           .withKeySerde(Serdes.String())
+                                                                           .withValueSerde(Serdes.String())
                 );
 
         table1.groupBy(MockMapper.<String, String>noOpKeyValueMapper())
@@ -352,27 +356,28 @@ public class KTableImplTest {
         table1.groupBy(MockMapper.<String, String>noOpKeyValueMapper())
             .reduce(MockReducer.STRING_ADDER, MockReducer.STRING_REMOVER, Materialized.<String, String, KeyValueStore<Bytes, byte[]>>as("mock-result2"));
 
-        driver.setUp(builder, stateDir, stringSerde, stringSerde);
-        driver.setTime(0L);
+        final Topology topology = builder.build();
+        try (final TopologyTestDriverWrapper driver = new TopologyTestDriverWrapper(topology, props)) {
 
-        // three state store should be created, one for source, one for aggregate and one for reduce
-        assertEquals(3, driver.allStateStores().size());
+            // three state stores should be created, one for source, one for aggregate and one for reduce
+            assertEquals(3, driver.getAllStateStores().size());
 
-        // contains the corresponding repartition source / sink nodes
-        assertTrue(driver.allProcessorNames().contains("KSTREAM-SINK-0000000003"));
-        assertTrue(driver.allProcessorNames().contains("KSTREAM-SOURCE-0000000004"));
-        assertTrue(driver.allProcessorNames().contains("KSTREAM-SINK-0000000007"));
-        assertTrue(driver.allProcessorNames().contains("KSTREAM-SOURCE-0000000008"));
+            // contains the corresponding repartition source / sink nodes
+            assertTopologyContainsProcessor(topology, "KSTREAM-SINK-0000000003");
+            assertTopologyContainsProcessor(topology, "KSTREAM-SOURCE-0000000004");
+            assertTopologyContainsProcessor(topology, "KSTREAM-SINK-0000000007");
+            assertTopologyContainsProcessor(topology, "KSTREAM-SOURCE-0000000008");
 
-        Field valSerializerField  = ((SinkNode) driver.processor("KSTREAM-SINK-0000000003")).getClass().getDeclaredField("valSerializer");
-        Field valDeserializerField  = ((SourceNode) driver.processor("KSTREAM-SOURCE-0000000004")).getClass().getDeclaredField("valDeserializer");
-        valSerializerField.setAccessible(true);
-        valDeserializerField.setAccessible(true);
+            Field valSerializerField = ((SinkNode) driver.getProcessor("KSTREAM-SINK-0000000003")).getClass().getDeclaredField("valSerializer");
+            Field valDeserializerField = ((SourceNode) driver.getProcessor("KSTREAM-SOURCE-0000000004")).getClass().getDeclaredField("valDeserializer");
+            valSerializerField.setAccessible(true);
+            valDeserializerField.setAccessible(true);
 
-        assertNotNull(((ChangedSerializer) valSerializerField.get(driver.processor("KSTREAM-SINK-0000000003"))).inner());
-        assertNotNull(((ChangedDeserializer) valDeserializerField.get(driver.processor("KSTREAM-SOURCE-0000000004"))).inner());
-        assertNotNull(((ChangedSerializer) valSerializerField.get(driver.processor("KSTREAM-SINK-0000000007"))).inner());
-        assertNotNull(((ChangedDeserializer) valDeserializerField.get(driver.processor("KSTREAM-SOURCE-0000000008"))).inner());
+            assertNotNull(((ChangedSerializer) valSerializerField.get(driver.getProcessor("KSTREAM-SINK-0000000003"))).inner());
+            assertNotNull(((ChangedDeserializer) valDeserializerField.get(driver.getProcessor("KSTREAM-SOURCE-0000000004"))).inner());
+            assertNotNull(((ChangedSerializer) valSerializerField.get(driver.getProcessor("KSTREAM-SINK-0000000007"))).inner());
+            assertNotNull(((ChangedDeserializer) valDeserializerField.get(driver.getProcessor("KSTREAM-SOURCE-0000000008"))).inner());
+        }
     }
 
     @Test(expected = NullPointerException.class)

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableMapValuesTest.java
@@ -24,12 +24,14 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyTestDriverWrapper;
+import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.test.MockProcessor;
@@ -106,25 +108,31 @@ public class KTableMapValuesTest {
                                    final KTableImpl<String, String, String> table1,
                                    final KTableImpl<String, String, Integer> table2,
                                    final KTableImpl<String, Integer, Integer> table3,
-                                   final KTableImpl<String, String, String> table4,
-                                   final String procName1,
-                                   final String procName2,
-                                   final String procName3,
-                                   final String procName4) {
+                                   final KTableImpl<String, String, String> table4) {
+
+        final Topology topology = builder.build();
+
         final KTableValueGetterSupplier<String, String> getterSupplier1 = table1.valueGetterSupplier();
         final KTableValueGetterSupplier<String, Integer> getterSupplier2 = table2.valueGetterSupplier();
         final KTableValueGetterSupplier<String, Integer> getterSupplier3 = table3.valueGetterSupplier();
         final KTableValueGetterSupplier<String, String> getterSupplier4 = table4.valueGetterSupplier();
 
+        final InternalTopologyBuilder topologyBuilder = TopologyWrapper.getInternalTopologyBuilder(topology);
+        topologyBuilder.connectProcessorAndStateStores(table1.name, getterSupplier1.storeNames());
+        topologyBuilder.connectProcessorAndStateStores(table2.name, getterSupplier2.storeNames());
+        topologyBuilder.connectProcessorAndStateStores(table3.name, getterSupplier3.storeNames());
+        topologyBuilder.connectProcessorAndStateStores(table4.name, getterSupplier4.storeNames());
+
         try (final TopologyTestDriverWrapper driver = new TopologyTestDriverWrapper(builder.build(), props)) {
             KTableValueGetter<String, String> getter1 = getterSupplier1.get();
-            getter1.init(driver.getProcessorContext(procName1));
             KTableValueGetter<String, Integer> getter2 = getterSupplier2.get();
-            getter2.init(driver.getProcessorContext(procName2));
             KTableValueGetter<String, Integer> getter3 = getterSupplier3.get();
-            getter3.init(driver.getProcessorContext(procName3));
             KTableValueGetter<String, String> getter4 = getterSupplier4.get();
-            getter4.init(driver.getProcessorContext(procName4));
+
+            getter1.init(driver.setCurrentNodeForProcessorContext(table1.name));
+            getter2.init(driver.setCurrentNodeForProcessorContext(table2.name));
+            getter3.init(driver.setCurrentNodeForProcessorContext(table3.name));
+            getter4.init(driver.setCurrentNodeForProcessorContext(table4.name));
 
             driver.pipeInput(recordFactory.create(topic1, "A", "01"));
             driver.pipeInput(recordFactory.create(topic1, "B", "01"));
@@ -229,11 +237,7 @@ public class KTableMapValuesTest {
         table1.toStream().to(topic2, produced);
         final KTableImpl<String, String, String> table4 = (KTableImpl<String, String, String>) builder.table(topic2, consumed);
 
-        doTestValueGetter(builder, topic1, table1, table2, table3, table4,
-                "KTABLE-SOURCE-0000000002",
-                "KTABLE-SOURCE-0000000002",
-                "KTABLE-SOURCE-0000000002",
-                "KTABLE-SOURCE-0000000009");
+        doTestValueGetter(builder, topic1, table1, table2, table3, table4);
     }
 
     @Test
@@ -264,11 +268,7 @@ public class KTableMapValuesTest {
         table1.toStream().to(topic2, produced);
         final KTableImpl<String, String, String> table4 = (KTableImpl<String, String, String>) builder.table(topic2, consumed);
 
-        doTestValueGetter(builder, topic1, table1, table2, table3, table4,
-                "KTABLE-SOURCE-0000000002",
-                "KTABLE-MAPVALUES-0000000003",
-                "KTABLE-FILTER-0000000004",
-                "KTABLE-SOURCE-0000000009");
+        doTestValueGetter(builder, topic1, table1, table2, table3, table4);
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
@@ -20,11 +20,11 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.TopologyTestDriverWrapper;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
@@ -100,7 +100,7 @@ public class KTableSourceTest {
 
         try (final TopologyTestDriverWrapper driver = new TopologyTestDriverWrapper(builder.build(), props)) {
             final KTableValueGetter<String, String> getter1 = getterSupplier1.get();
-            getter1.init(driver.getProcessorContext(topic1));
+            getter1.init(driver.getProcessorContext("KTABLE-SOURCE-0000000002"));
 
             driver.pipeInput(recordFactory.create(topic1, "A", "01"));
             driver.pipeInput(recordFactory.create(topic1, "B", "01"));
@@ -123,8 +123,8 @@ public class KTableSourceTest {
             assertEquals("02", getter1.get("B"));
             assertEquals("01", getter1.get("C"));
 
-            driver.pipeInput(recordFactory.create(topic1, "A", null));
-            driver.pipeInput(recordFactory.create(topic1, "B", null));
+            driver.pipeInput(recordFactory.create(topic1, "A", (String) null));
+            driver.pipeInput(recordFactory.create(topic1, "B", (String) null));
 
             assertNull(getter1.get("A"));
             assertNull(getter1.get("B"));
@@ -164,8 +164,8 @@ public class KTableSourceTest {
 
             proc1.checkAndClearProcessResult("A:(03<-null)");
 
-            driver.pipeInput(recordFactory.create(topic1, "A", null));
-            driver.pipeInput(recordFactory.create(topic1, "B", null));
+            driver.pipeInput(recordFactory.create(topic1, "A", (String) null));
+            driver.pipeInput(recordFactory.create(topic1, "B", (String) null));
 
             proc1.checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
         }
@@ -206,8 +206,8 @@ public class KTableSourceTest {
 
             proc1.checkAndClearProcessResult("A:(03<-02)");
 
-            driver.pipeInput(recordFactory.create(topic1, "A", null));
-            driver.pipeInput(recordFactory.create(topic1, "B", null));
+            driver.pipeInput(recordFactory.create(topic1, "A", (String) null));
+            driver.pipeInput(recordFactory.create(topic1, "B", (String) null));
 
             proc1.checkAndClearProcessResult("A:(null<-03)", "B:(null<-02)");
         }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableSourceTest.java
@@ -16,22 +16,24 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
-import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.TopologyTestDriverWrapper;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
-import org.apache.kafka.test.KStreamTestDriver;
+import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.apache.kafka.test.MockProcessor;
 import org.apache.kafka.test.MockProcessorSupplier;
-import org.apache.kafka.test.TestUtils;
-import org.junit.Before;
-import org.junit.Rule;
+import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
-import java.io.File;
+import java.util.Properties;
 
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -42,17 +44,9 @@ import static org.junit.Assert.assertTrue;
 
 public class KTableSourceTest {
 
-    final private Serde<String> stringSerde = Serdes.String();
-    private final Consumed<String, String> stringConsumed = Consumed.with(stringSerde, stringSerde);
-    final private Serde<Integer> intSerde = Serdes.Integer();
-    @Rule
-    public final KStreamTestDriver driver = new KStreamTestDriver();
-    private File stateDir = null;
-
-    @Before
-    public void setUp() {
-        stateDir = TestUtils.tempDirectory("kafka-test");
-    }
+    private final Consumed<String, String> stringConsumed = Consumed.with(Serdes.String(), Serdes.String());
+    private final ConsumerRecordFactory<String, String> recordFactory = new ConsumerRecordFactory<>(new StringSerializer(), new StringSerializer());
+    private final Properties props = StreamsTestUtils.topologyTestConfig(Serdes.String(), Serdes.String());
 
     @Test
     public void testKTable() {
@@ -60,38 +54,38 @@ public class KTableSourceTest {
 
         final String topic1 = "topic1";
 
-        final KTable<String, Integer> table1 = builder.table(topic1, Consumed.with(stringSerde, intSerde));
+        final KTable<String, Integer> table1 = builder.table(topic1, Consumed.with(Serdes.String(), Serdes.Integer()));
 
         final MockProcessorSupplier<String, Integer> supplier = new MockProcessorSupplier<>();
         table1.toStream().process(supplier);
 
-        driver.setUp(builder, stateDir);
-        driver.process(topic1, "A", 1);
-        driver.process(topic1, "B", 2);
-        driver.process(topic1, "C", 3);
-        driver.process(topic1, "D", 4);
-        driver.flushState();
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
-        driver.flushState();
+        final ConsumerRecordFactory<String, Integer> integerFactory = new ConsumerRecordFactory<>(new StringSerializer(), new IntegerSerializer());
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            driver.pipeInput(integerFactory.create(topic1, "A", 1));
+            driver.pipeInput(integerFactory.create(topic1, "B", 2));
+            driver.pipeInput(integerFactory.create(topic1, "C", 3));
+            driver.pipeInput(integerFactory.create(topic1, "D", 4));
+            driver.pipeInput(integerFactory.create(topic1, "A", null));
+            driver.pipeInput(integerFactory.create(topic1, "B", null));
+        }
 
         assertEquals(Utils.mkList("A:1", "B:2", "C:3", "D:4", "A:null", "B:null"), supplier.theCapturedProcessor().processed);
     }
 
     @Test
     public void kTableShouldLogAndMeterOnSkippedRecords() {
-        final StreamsBuilder streamsBuilder = new StreamsBuilder();
+        final StreamsBuilder builder = new StreamsBuilder();
         final String topic = "topic";
-        streamsBuilder.table(topic, Consumed.with(stringSerde, intSerde));
+        builder.table(topic, stringConsumed);
 
         final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
-        driver.setUp(streamsBuilder, stateDir);
-        driver.process(topic, null, "value");
-        driver.flushState();
-        LogCaptureAppender.unregister(appender);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            driver.pipeInput(recordFactory.create(topic, null, "value"));
+            LogCaptureAppender.unregister(appender);
 
-        assertEquals(1.0, getMetricByName(driver.context().metrics().metrics(), "skipped-records-total", "stream-metrics").metricValue());
-        assertThat(appender.getMessages(), hasItem("Skipping record due to null key. topic=[topic] partition=[-1] offset=[-1]"));
+            assertEquals(1.0, getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue());
+            assertThat(appender.getMessages(), hasItem("Skipping record due to null key. topic=[topic] partition=[0] offset=[0]"));
+        }
     }
 
     @Test
@@ -104,37 +98,38 @@ public class KTableSourceTest {
 
         final KTableValueGetterSupplier<String, String> getterSupplier1 = table1.valueGetterSupplier();
 
-        driver.setUp(builder, stateDir);
-        final KTableValueGetter<String, String> getter1 = getterSupplier1.get();
-        getter1.init(driver.context());
+        try (final TopologyTestDriverWrapper driver = new TopologyTestDriverWrapper(builder.build(), props)) {
+            final KTableValueGetter<String, String> getter1 = getterSupplier1.get();
+            getter1.init(driver.getProcessorContext(topic1));
 
-        driver.process(topic1, "A", "01");
-        driver.process(topic1, "B", "01");
-        driver.process(topic1, "C", "01");
+            driver.pipeInput(recordFactory.create(topic1, "A", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "C", "01"));
 
-        assertEquals("01", getter1.get("A"));
-        assertEquals("01", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertEquals("01", getter1.get("A"));
+            assertEquals("01", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
-        driver.process(topic1, "A", "02");
-        driver.process(topic1, "B", "02");
+            driver.pipeInput(recordFactory.create(topic1, "A", "02"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "02"));
 
-        assertEquals("02", getter1.get("A"));
-        assertEquals("02", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertEquals("02", getter1.get("A"));
+            assertEquals("02", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
-        driver.process(topic1, "A", "03");
+            driver.pipeInput(recordFactory.create(topic1, "A", "03"));
 
-        assertEquals("03", getter1.get("A"));
-        assertEquals("02", getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertEquals("03", getter1.get("A"));
+            assertEquals("02", getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
 
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "B", null));
 
-        assertNull(getter1.get("A"));
-        assertNull(getter1.get("B"));
-        assertEquals("01", getter1.get("C"));
+            assertNull(getter1.get("A"));
+            assertNull(getter1.get("B"));
+            assertEquals("01", getter1.get("C"));
+        }
 
     }
 
@@ -148,35 +143,32 @@ public class KTableSourceTest {
 
         final MockProcessorSupplier<String, Integer> supplier = new MockProcessorSupplier<>();
 
-        builder.build().addProcessor("proc1", supplier, table1.name);
+        final Topology topology = builder.build().addProcessor("proc1", supplier, table1.name);
 
-        driver.setUp(builder, stateDir);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
 
-        final MockProcessor<String, Integer> proc1 = supplier.theCapturedProcessor();
+            final MockProcessor<String, Integer> proc1 = supplier.theCapturedProcessor();
 
-        driver.process(topic1, "A", "01");
-        driver.process(topic1, "B", "01");
-        driver.process(topic1, "C", "01");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "C", "01"));
 
-        proc1.checkAndClearProcessResult("A:(01<-null)", "B:(01<-null)", "C:(01<-null)");
+            proc1.checkAndClearProcessResult("A:(01<-null)", "B:(01<-null)", "C:(01<-null)");
 
-        driver.process(topic1, "A", "02");
-        driver.process(topic1, "B", "02");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "02"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "02"));
 
-        proc1.checkAndClearProcessResult("A:(02<-null)", "B:(02<-null)");
+            proc1.checkAndClearProcessResult("A:(02<-null)", "B:(02<-null)");
 
-        driver.process(topic1, "A", "03");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "03"));
 
-        proc1.checkAndClearProcessResult("A:(03<-null)");
+            proc1.checkAndClearProcessResult("A:(03<-null)");
 
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "B", null));
 
-        proc1.checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
+            proc1.checkAndClearProcessResult("A:(null<-null)", "B:(null<-null)");
+        }
     }
 
     @Test
@@ -193,34 +185,31 @@ public class KTableSourceTest {
 
         final MockProcessorSupplier<String, Integer> supplier = new MockProcessorSupplier<>();
 
-        builder.build().addProcessor("proc1", supplier, table1.name);
+        final Topology topology = builder.build().addProcessor("proc1", supplier, table1.name);
 
-        driver.setUp(builder, stateDir);
+        try (final TopologyTestDriver driver = new TopologyTestDriver(topology, props)) {
 
-        final MockProcessor<String, Integer> proc1 = supplier.theCapturedProcessor();
+            final MockProcessor<String, Integer> proc1 = supplier.theCapturedProcessor();
 
-        driver.process(topic1, "A", "01");
-        driver.process(topic1, "B", "01");
-        driver.process(topic1, "C", "01");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "01"));
+            driver.pipeInput(recordFactory.create(topic1, "C", "01"));
 
-        proc1.checkAndClearProcessResult("A:(01<-null)", "B:(01<-null)", "C:(01<-null)");
+            proc1.checkAndClearProcessResult("A:(01<-null)", "B:(01<-null)", "C:(01<-null)");
 
-        driver.process(topic1, "A", "02");
-        driver.process(topic1, "B", "02");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "02"));
+            driver.pipeInput(recordFactory.create(topic1, "B", "02"));
 
-        proc1.checkAndClearProcessResult("A:(02<-01)", "B:(02<-01)");
+            proc1.checkAndClearProcessResult("A:(02<-01)", "B:(02<-01)");
 
-        driver.process(topic1, "A", "03");
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", "03"));
 
-        proc1.checkAndClearProcessResult("A:(03<-02)");
+            proc1.checkAndClearProcessResult("A:(03<-02)");
 
-        driver.process(topic1, "A", null);
-        driver.process(topic1, "B", null);
-        driver.flushState();
+            driver.pipeInput(recordFactory.create(topic1, "A", null));
+            driver.pipeInput(recordFactory.create(topic1, "B", null));
 
-        proc1.checkAndClearProcessResult("A:(null<-03)", "B:(null<-02)");
+            proc1.checkAndClearProcessResult("A:(null<-03)", "B:(null<-02)");
+        }
     }
 }

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -175,13 +175,14 @@ public class TopologyTestDriver implements Closeable {
 
     private final static int PARTITION_ID = 0;
     private final static TaskId TASK_ID = new TaskId(0, PARTITION_ID);
-    private final StreamTask task;
+    final StreamTask task;
     private final GlobalStateUpdateTask globalStateTask;
     private final GlobalStateManager globalStateManager;
 
     private final StateDirectory stateDirectory;
     private final Metrics metrics;
-    private final ProcessorTopology processorTopology;
+    final ProcessorTopology processorTopology;
+    final ProcessorTopology globalTopology;
 
     private final MockProducer<byte[], byte[]> producer;
 
@@ -225,18 +226,6 @@ public class TopologyTestDriver implements Closeable {
      *
      * @param builder builder for the topology to be tested
      * @param config the configuration for the topology
-     */
-    TopologyTestDriver(final InternalTopologyBuilder builder,
-                       final Properties config) {
-        this(builder, config,  System.currentTimeMillis());
-
-    }
-
-    /**
-     * Create a new test diver instance.
-     *
-     * @param builder builder for the topology to be tested
-     * @param config the configuration for the topology
      * @param initialWallClockTimeMs the initial value of internally mocked wall-clock time
      */
     private TopologyTestDriver(final InternalTopologyBuilder builder,
@@ -249,7 +238,7 @@ public class TopologyTestDriver implements Closeable {
         internalTopologyBuilder.setApplicationId(streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG));
 
         processorTopology = internalTopologyBuilder.build(null);
-        final ProcessorTopology globalTopology = internalTopologyBuilder.buildGlobalStateTopology();
+        globalTopology = internalTopologyBuilder.buildGlobalStateTopology();
 
         final Serializer<byte[]> bytesSerializer = new ByteArraySerializer();
         producer = new MockProducer<byte[], byte[]>(true, bytesSerializer, bytesSerializer) {


### PR DESCRIPTION
This PR is a further step towards the complete replacement of `KStreamTestDriver` with `TopologyTestDriver`.

* Add task, processorTopology, and globalTopology access to TopologyTestDriverAccessor
* Add condition to prevent NPE in ProcessorContextImpl
* Refactor:
  - KTableFilterTest
  - KTableSourceTest
  - KTableMapValuesTest
  - KTableImplTest.


edit: To simplify the review process some straightforward changes were moved to another [PR](https://github.com/apache/kafka/pull/5052).