### PR TITLE
MINOR: A few small cleanups from KAFKA-6299

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.kafka.clients.admin.internal;
+package org.apache.kafka.clients.admin.internals;
 
 import org.apache.kafka.clients.MetadataUpdater;
 import org.apache.kafka.common.Cluster;


### PR DESCRIPTION
Use local fields in `AdminClientRunnable` to avoid the need to pass the collections as method parameters and fix warnings about invalid javadoc tags. Also use the `internals` package name for `AdminMetadataManager` for consistency with `consumer.internals` and `producer.internals`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
