### PR TITLE
Fix typo in ConsumerRebalanceListener JavaDoc

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.java
@@ -102,7 +102,7 @@ public interface ConsumerRebalanceListener {
 
     /**
      * A callback method the user can implement to provide handling of customized offsets on completion of a successful
-     * partition re-assignment. This method will be called after an partition re-assignment completes and before the
+     * partition re-assignment. This method will be called after the partition re-assignment completes and before the
      * consumer starts fetching data, and only as the result of a {@link Consumer#poll(long) poll(long)} call.
      * <p>
      * It is guaranteed that all the processes in a consumer group will execute their

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerRebalanceListener.java
@@ -102,7 +102,7 @@ public interface ConsumerRebalanceListener {
 
     /**
      * A callback method the user can implement to provide handling of customized offsets on completion of a successful
-     * partition re-assignment. This method will be called after an offset re-assignment completes and before the
+     * partition re-assignment. This method will be called after an partition re-assignment completes and before the
      * consumer starts fetching data, and only as the result of a {@link Consumer#poll(long) poll(long)} call.
      * <p>
      * It is guaranteed that all the processes in a consumer group will execute their


### PR DESCRIPTION
This is just a minor typo in the javadoc. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
