### PR TITLE
KAFKA-6896: Add producer metrics exporting in KafkaStreams.java

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -70,6 +69,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
     private boolean producerFenced;
     private boolean sentOffsets;
     private long commitCount = 0L;
+    private Map<MetricName, Metric> mockMetrics;
 
     /**
      * Create a mock producer
@@ -99,6 +99,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         this.consumerGroupOffsets = new ArrayList<>();
         this.uncommittedConsumerGroupOffsets = new HashMap<>();
         this.completions = new ArrayDeque<>();
+        this.mockMetrics = new HashMap<>();
     }
 
     /**
@@ -293,7 +294,14 @@ public class MockProducer<K, V> implements Producer<K, V> {
     }
 
     public Map<MetricName, Metric> metrics() {
-        return Collections.emptyMap();
+        return mockMetrics;
+    }
+
+    /**
+     * Set a mock metric for testing purpose
+     */
+    public void setMockMetrics(MetricName name, Metric metric) {
+        mockMetrics.put(name, metric);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -383,10 +383,11 @@ public class KafkaStreams {
      *
      * @return Map of all metrics.
      */
-    // TODO: we can add metrics for producer and admin client as well
+    // TODO: we can add metrics for admin client as well
     public Map<MetricName, ? extends Metric> metrics() {
         final Map<MetricName, Metric> result = new LinkedHashMap<>();
         for (final StreamThread thread : threads) {
+            result.putAll(thread.producerMetrics());
             result.putAll(thread.consumerMetrics());
         }
         if (globalStreamThread != null) result.putAll(globalStreamThread.consumerMetrics());

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -742,4 +742,8 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     RecordCollector recordCollector() {
         return recordCollector;
     }
+
+    Producer<byte[], byte[]> getProducer() {
+        return producer;
+    }
 }


### PR DESCRIPTION
We would like to also export the producer metrics from `StreamThread` just like consumer metrics, so that we could gain more visibility of stream application. The approach is to pass in the `threadProducer` into the StreamThread so that we could export its metrics in dynamic. 

Note that this is a pure internal change that doesn't require a KIP, and in the future we also want to export admin client metrics. A followup KIP for admin client will be created once this is merged.