### PR TITLE
KAFKA-6894: Improve err msg when explicitly connecting processor to global store

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -712,6 +712,10 @@ public class InternalTopologyBuilder {
 
     private void connectProcessorAndStateStore(final String processorName,
                                                final String stateStoreName) {
+        if (globalStateStores.containsKey(stateStoreName)) {
+            throw new TopologyException("Global StateStore " + stateStoreName +
+                    " can be used by a Processor without being specified; it should not be explicitly passed.");
+        }
         if (!stateFactories.containsKey(stateStoreName)) {
             throw new TopologyException("StateStore " + stateStoreName + " is not added yet.");
         }


### PR DESCRIPTION
I've improved the error message when explicitly trying to connect a processor to a global store as in this example:
```
      builder.globalTable("supersteps", Consumed.with(Serdes.Integer(), Serdes.Long()),
                        Materialized.<Integer, Long, KeyValueStore<Bytes, byte[]>>as("superstepStore")
                                .withKeySerde(Serdes.Integer()).withValueSerde(Serdes.Long()));

      stream.transform((TransformerSupplier<K, Tuple3<Integer, VV, Map<K, Message>>, KeyValue<Integer, Long>>)
                        InitialTransformer::new, "superstepStore");
```