### PR TITLE
KAFKA-6895: (WIP) Schema Inferencing for JsonConverter

### DIFF
--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverter.java
@@ -785,7 +785,7 @@ public class JsonConverter implements Converter, HeaderConverter {
                     return Schema.FLOAT64_SCHEMA;
                 }
             case ARRAY:
-                SchemaBuilder arrayBuilder = SchemaBuilder.array(inferSchema(jsonValue.elements().next()));
+                SchemaBuilder arrayBuilder = SchemaBuilder.array(jsonValue.elements().hasNext() ? inferSchema(jsonValue.elements().next()) : Schema.OPTIONAL_STRING_SCHEMA);
                 return arrayBuilder.build();
             case OBJECT:
                 SchemaBuilder structBuilder = SchemaBuilder.struct();
@@ -797,6 +797,10 @@ public class JsonConverter implements Converter, HeaderConverter {
                 return structBuilder.build();
             case STRING:
                 return Schema.STRING_SCHEMA;
+
+            case BINARY:
+            case MISSING:
+            case POJO:
             default:
                 return null;
         }

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -39,6 +39,11 @@ public class JsonConverterConfig extends ConverterConfig {
     private static final String SCHEMAS_CACHE_SIZE_DOC = "The maximum number of schemas that can be cached in this converter instance.";
     private static final String SCHEMAS_CACHE_SIZE_DISPLAY = "Schema Cache Size";
 
+    public static final String SCHEMAS_INFER_ENABLE_CONFIG = "schemas.infer.enable";
+    public static final boolean SCHEMAS_INFER_ENABLE_DEFAULT = false;
+    private static final String SCHEMAS_INFER_ENABLE_DOC = "Infer the schemas when they are missing within each of the serialized values and keys.";
+    private static final String SCHEMAS_INFER_ENABLE_DISPLAY = "Enable Infer Schemas";
+
     private final static ConfigDef CONFIG;
 
     static {
@@ -49,6 +54,8 @@ public class JsonConverterConfig extends ConverterConfig {
                       orderInGroup++, Width.MEDIUM, SCHEMAS_ENABLE_DISPLAY);
         CONFIG.define(SCHEMAS_CACHE_SIZE_CONFIG, Type.INT, SCHEMAS_CACHE_SIZE_DEFAULT, Importance.HIGH, SCHEMAS_CACHE_SIZE_DOC, group,
                       orderInGroup++, Width.MEDIUM, SCHEMAS_CACHE_SIZE_DISPLAY);
+        CONFIG.define(SCHEMAS_INFER_ENABLE_CONFIG, Type.BOOLEAN, SCHEMAS_INFER_ENABLE_DEFAULT, Importance.HIGH, SCHEMAS_INFER_ENABLE_DOC, group,
+                orderInGroup++, Width.MEDIUM, SCHEMAS_INFER_ENABLE_DISPLAY);
     }
 
     public static ConfigDef configDef() {
@@ -75,5 +82,14 @@ public class JsonConverterConfig extends ConverterConfig {
      */
     public int schemaCacheSize() {
         return getInt(SCHEMAS_CACHE_SIZE_CONFIG);
+    }
+
+    /**
+     * Return whether schema inferencing is enabled.
+     *
+     * @return true if enabled, or false otherwise
+     */
+    public boolean schemasInferEnabled() {
+        return getBoolean(SCHEMAS_INFER_ENABLE_CONFIG);
     }
 }

--- a/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
+++ b/connect/json/src/main/java/org/apache/kafka/connect/json/JsonConverterConfig.java
@@ -41,7 +41,7 @@ public class JsonConverterConfig extends ConverterConfig {
 
     public static final String SCHEMAS_INFER_ENABLE_CONFIG = "schemas.infer.enable";
     public static final boolean SCHEMAS_INFER_ENABLE_DEFAULT = false;
-    private static final String SCHEMAS_INFER_ENABLE_DOC = "Infer the schemas when they are missing within each of the serialized values and keys.";
+    private static final String SCHEMAS_INFER_ENABLE_DOC = "Infer the schemas when they are missing within each of the serialized values and keys. Only applied when " + SCHEMAS_ENABLE_CONFIG + " is false.";
     private static final String SCHEMAS_INFER_ENABLE_DISPLAY = "Enable Infer Schemas";
 
     private final static ConfigDef CONFIG;

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -182,6 +182,8 @@ public class JsonConverterTest {
         prepareSchemalessJsonConverter();
         byte[] arrayJson = "[1, 2, 3]".getBytes();
         assertEquals(new SchemaAndValue(SchemaBuilder.array(Schema.INT64_SCHEMA).build(), Arrays.asList(1L, 2L, 3L)), converter.toConnectData(TOPIC, arrayJson));
+        arrayJson = "[]".getBytes();
+        assertEquals(new SchemaAndValue(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build(), Arrays.asList()), converter.toConnectData(TOPIC, arrayJson));
     }
 
     @Test


### PR DESCRIPTION
**Work in Progress: Do not merge until KIP and this PR are both approved.**

KIP: https://cwiki.apache.org/confluence/display/KAFKA/KIP-301%3A+Schema+Inferencing+for+JsonConverter

This introduces a new configuration for the JsonConverter class called "schemas.infer.enable". When "schemas.enable" is false and the "schemas.infer.enable" flag is set to true, the converter will infer the schema from the contents of the JSON record and return that as part of the SchemaAndValue object for Sink Connectors.

Author: Allen Tang <natengall@gmail.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
