### PR TITLE
KAFKA-6725: Addition of isClosing to SinkTaskContext

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
@@ -85,4 +85,14 @@ public interface SinkTaskContext {
      */
     void requestCommit();
 
+    /**
+     * Determine if the Sink is about to be closed during preCommit.
+     *
+     * During the preCommit callback of a Sink, this method can be invokved to determine if the
+     * callback is being invoked because the task is about to close, so as to allow the Sink to
+     * determine if it wishes to behave differently. For example, a Sink might decide to commit
+     * progress earlier than it would during a normal preCommit invocation in order to avoid
+     * duplicating the work of processing messages that have already been processed.
+     */
+    boolean isClosing();
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -356,6 +356,7 @@ class WorkerSinkTask extends WorkerTask {
         final Map<TopicPartition, OffsetAndMetadata> taskProvidedOffsets;
         try {
             log.trace("{} Calling task.preCommit with current offsets: {}", this, currentOffsets);
+            context.setClosingInProgress(closing);
             taskProvidedOffsets = task.preCommit(new HashMap<>(currentOffsets));
         } catch (Throwable t) {
             if (closing) {
@@ -375,6 +376,7 @@ class WorkerSinkTask extends WorkerTask {
             if (closing) {
                 log.trace("{} Closing the task before committing the offsets: {}", this, currentOffsets);
                 task.close(currentOffsets.keySet());
+                context.setClosingInProgress(false);
             }
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTaskContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTaskContext.java
@@ -39,6 +39,7 @@ public class WorkerSinkTaskContext implements SinkTaskContext {
     private final WorkerSinkTask sinkTask;
     private final Set<TopicPartition> pausedPartitions;
     private boolean commitRequested;
+    private boolean closingInProgress;
 
     public WorkerSinkTaskContext(KafkaConsumer<byte[], byte[]> consumer, WorkerSinkTask sinkTask) {
         this.offsets = new HashMap<>();
@@ -146,6 +147,15 @@ public class WorkerSinkTaskContext implements SinkTaskContext {
 
     public void clearCommitRequest() {
         commitRequested = false;
+    }
+
+    @Override
+    public boolean isClosing() {
+        return closingInProgress;
+    }
+
+    public void setClosingInProgress(boolean newValue) {
+        closingInProgress = newValue;
     }
 
     @Override

--- a/docs/connect.html
+++ b/docs/connect.html
@@ -419,6 +419,9 @@
     <p>The <code>flush()</code> method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The <code>offsets</code> parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once
     delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the <code>flush()</code> operation atomically commits the data and offsets to a final location in HDFS.</p>
 
+    <p>Tasks may also implement a custom <code>preCommit()</code> method to determine what commits are sent back to Kafka during the regualar commit cycle. The default implementation will assume that all commits read so far are safe to commit, but you may wish to provide a custom implementation. This method may also wish to change its behavior if it is being invoked because the task is about to close. Tasks are closed for various reasons: rebalance, connect gets shut down, the connector
+    configuration is removed. If your <code>preCommit()</code> method wishes to know if its being invoked for this reason, it should invoke <code>context.isClosing()</code> from the <code>SinkTaskContext</code> that is passed in from your task's constructor. <code>isClosing()</code> will return true if the task is about to be closed.</p>
+
 
     <h5><a id="connect_resuming" href="#connect_resuming">Resuming from Previous Offsets</a></h5>
 


### PR DESCRIPTION
This PR implements KAFKA-6725 and KIP-275 to provide for the addition of an `isClosing` method on the `SinkTaskContext`. This permits `SinkTask`s to know if their `preCommit` hook is being invoked because the task is about to be shut down. This allows tasks to optionally apply different heuristics in a "I am about to close" situation.

For example, a sink configured to archive data to S3 might choose to checkpoint and upload sooner than it would have otherwise.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
