### PR TITLE
Update kafka-run-class.sh to work with paths containing spaces

### DIFF
--- a/bin/kafka-run-class.sh
+++ b/bin/kafka-run-class.sh
@@ -225,7 +225,7 @@ fi
 if [ -z "$JAVA_HOME" ]; then
   JAVA="java"
 else
-  JAVA="$JAVA_HOME/bin/java"
+  JAVA="\"$JAVA_HOME/bin/java\""
 fi
 
 # Memory options


### PR DESCRIPTION
we need to escape the JAVA binary variable to avoid issues with paths containing specials characters (eg: SPACE)

#### the contribution is my original work and I license the work to the project under the project's open source license

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)

