### PR TITLE
KAFKA-6738: (WIP) Error Handling in Connect

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -80,7 +80,7 @@
               files="(KafkaConfigBackingStore|RequestResponseTest|WorkerSinkTaskTest).java"/>
 
     <suppress checks="ParameterNumber"
-              files="WorkerSourceTask.java"/>
+              files="(WorkerSourceTask|WorkerSinkTask).java"/>
     <suppress checks="ParameterNumber"
               files="WorkerCoordinator.java"/>
     <suppress checks="ParameterNumber"

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -24,6 +24,8 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.errors.Stage;
+import org.apache.kafka.connect.runtime.errors.StageType;
 import org.apache.kafka.connect.runtime.isolation.PluginDesc;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.transforms.Transformation;
@@ -164,6 +166,21 @@ public class ConnectorConfig extends AbstractConfig {
         }
 
         return transformations;
+    }
+
+    public List<Stage> transformationAsStages() {
+        final List<String> transformAliases = getList(TRANSFORMS_CONFIG);
+        List<Stage> stages = new ArrayList<>();
+        for (String alias : transformAliases) {
+            final String prefix = TRANSFORMS_CONFIG + "." + alias + ".";
+            stages.add(Stage.newBuilder(StageType.TRANSFORMATION)
+                    .setExecutingClass(getClass(prefix + "type"))
+                    .setConfig(originalsWithPrefix(prefix))
+                    .build()
+            );
+        }
+
+        return stages;
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -93,6 +93,8 @@ public class ConnectorConfig extends AbstractConfig {
     private static final String TRANSFORMS_DOC = "Aliases for the transformations to be applied to records.";
     private static final String TRANSFORMS_DISPLAY = "Transforms";
 
+    public static final String ERROR_HANDLING_CONFIG = "errors";
+
     private final EnrichedConnectorConfig enrichedConfig;
     private static class EnrichedConnectorConfig extends AbstractConfig {
         EnrichedConnectorConfig(ConfigDef configDef, Map<String, String> props) {
@@ -139,6 +141,10 @@ public class ConnectorConfig extends AbstractConfig {
                 enrich(plugins, configDef, props, true),
                 props
         );
+    }
+
+    public Map<String, ?> errorHandlerConfig() {
+        return originalsWithPrefix(ERROR_HANDLING_CONFIG + ".");
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -143,6 +143,9 @@ public class ConnectorConfig extends AbstractConfig {
         );
     }
 
+    /**
+     * @return properties to configure error handlers and reporters.
+     */
     public Map<String, ?> errorHandlerConfig() {
         return originalsWithPrefix(ERROR_HANDLING_CONFIG + ".");
     }
@@ -174,6 +177,10 @@ public class ConnectorConfig extends AbstractConfig {
         return transformations;
     }
 
+    /**
+     * @return an ordered list of stages describing the transformations in this connector. The order is specified by
+     * {@link #TRANSFORMS_CONFIG}.
+     */
     public List<Stage> transformationAsStages() {
         final List<String> transformAliases = getList(TRANSFORMS_CONFIG);
         List<Stage> stages = new ArrayList<>();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -43,6 +43,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
 
         for (final Transformation<R> transformation : transformations) {
             final R current = record;
+            processingContext.setRecord(current);
             record = operationExecutor.execute(new OperationExecutor.Operation<R>() {
                 @Override
                 public R apply() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -44,13 +44,18 @@ public class TransformationChain<R extends ConnectRecord<R>> {
         for (final Transformation<R> transformation : transformations) {
             final R current = record;
 
+            // set the current record
             processingContext.setRecord(current);
+
+            // execute the operation
             record = operationExecutor.execute(new OperationExecutor.Operation<R>() {
                 @Override
                 public R apply() {
                     return transformation.apply(current);
                 }
             }, null, processingContext);
+
+            // move to the next stage
             processingContext.next();
 
             if (record == null) break;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -35,7 +35,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
     }
 
     public R apply(R record) {
-        return apply(record, new NoopExecutor(), null);
+        return apply(record, NoopExecutor.INSTANCE, null);
     }
 
     public R apply(R record, OperationExecutor operationExecutor, ProcessingContext processingContext) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -17,6 +17,9 @@
 package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.impl.NoopExecutor;
 import org.apache.kafka.connect.transforms.Transformation;
 
 import java.util.Collections;
@@ -32,10 +35,21 @@ public class TransformationChain<R extends ConnectRecord<R>> {
     }
 
     public R apply(R record) {
+        return apply(record, new NoopExecutor(), null);
+    }
+
+    public R apply(R record, OperationExecutor operationExecutor, ProcessingContext processingContext) {
         if (transformations.isEmpty()) return record;
 
-        for (Transformation<R> transformation : transformations) {
-            record = transformation.apply(record);
+        for (final Transformation<R> transformation : transformations) {
+            final R current = record;
+            record = operationExecutor.execute(new OperationExecutor.Operation<R>() {
+                @Override
+                public R apply() {
+                    return transformation.apply(current);
+                }
+            }, null, processingContext);
+
             if (record == null) break;
         }
 
@@ -62,7 +76,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
     }
 
     public static <R extends ConnectRecord<R>> TransformationChain<R> noOp() {
-        return new TransformationChain<R>(Collections.<Transformation<R>>emptyList());
+        return new TransformationChain<>(Collections.<Transformation<R>>emptyList());
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/TransformationChain.java
@@ -43,6 +43,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
 
         for (final Transformation<R> transformation : transformations) {
             final R current = record;
+
             processingContext.setRecord(current);
             record = operationExecutor.execute(new OperationExecutor.Operation<R>() {
                 @Override
@@ -50,6 +51,7 @@ public class TransformationChain<R extends ConnectRecord<R>> {
                     return transformation.apply(current);
                 }
             }, null, processingContext);
+            processingContext.next();
 
             if (record == null) break;
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -530,13 +530,14 @@ public class Worker {
         }
     }
 
+    /**
+     * Setup properties for dead letter queue using the producer properties from worker config before overriding them
+     * from the connector config.
+     * @param connConfig connector config
+     * @return reporters to log error context
+     */
     private List<ErrorReporter> errorReportersConfig(ConnectorConfig connConfig) {
-        Map<String, Object> reporterProps = new HashMap<>();
-        for (Map.Entry<String, Object> e: producerProps.entrySet()) {
-            reporterProps.put(DLQReporter.DLQ_PRODUCER_PROPERTIES + "." + e.getKey(), e.getValue());
-        }
-        reporterProps.putAll(connConfig.errorHandlerConfig());
-        return new ReporterFactory().forConfig(reporterProps);
+        return new ReporterFactory().forConfig(producerProps, connConfig);
     }
 
     private void stopTask(ConnectorTaskId taskId) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -30,6 +30,9 @@ import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectMetrics.LiteralSupplier;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.Stage;
+import org.apache.kafka.connect.runtime.errors.StageType;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.isolation.Plugins.ClassLoaderUsage;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -364,6 +367,8 @@ public class Worker {
         if (tasks.containsKey(id))
             throw new ConnectException("Task already exists in this worker: " + id);
 
+        ProcessingContext.Builder prContextBuilder = ProcessingContext.newBuilder(id, config.originals());
+
         final WorkerTask workerTask;
         ClassLoader savedLoader = plugins.currentThreadLoader();
         try {
@@ -395,26 +400,46 @@ public class Worker {
                     WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG,
                     ClassLoaderUsage.CURRENT_CLASSLOADER
             );
+
+            Stage.Builder keyConverterStage = Stage.newBuilder(StageType.KEY_CONVERTER);
+            Stage.Builder valueConverterStage = Stage.newBuilder(StageType.VALUE_CONVERTER);
+            Stage.Builder headerConverterStage = Stage.newBuilder(StageType.HEADER_CONVERTER);
+
             if (keyConverter == null) {
                 keyConverter = plugins.newConverter(config, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
+                keyConverterStage.setConfig(config.originalsWithPrefix(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG + "."));
                 log.info("Set up the key converter {} for task {} using the worker config", keyConverter.getClass(), id);
             } else {
+                keyConverterStage.setConfig(connConfig.originalsWithPrefix(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG + "."));
                 log.info("Set up the key converter {} for task {} using the connector config", keyConverter.getClass(), id);
             }
+            keyConverterStage.setExecutingClass(keyConverter.getClass());
+
             if (valueConverter == null) {
                 valueConverter = plugins.newConverter(config, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
+                valueConverterStage.setConfig(config.originalsWithPrefix(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG + "."));
                 log.info("Set up the value converter {} for task {} using the worker config", valueConverter.getClass(), id);
             } else {
+                valueConverterStage.setConfig(connConfig.originalsWithPrefix(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG + "."));
                 log.info("Set up the value converter {} for task {} using the connector config", valueConverter.getClass(), id);
             }
+            valueConverterStage.setExecutingClass(valueConverter.getClass());
+
             if (headerConverter == null) {
                 headerConverter = plugins.newHeaderConverter(config, WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
+                headerConverterStage.setConfig(config.originalsWithPrefix(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG + "."));
                 log.info("Set up the header converter {} for task {} using the worker config", headerConverter.getClass(), id);
             } else {
+                headerConverterStage.setConfig(connConfig.originalsWithPrefix(WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG + "."));
                 log.info("Set up the header converter {} for task {} using the connector config", headerConverter.getClass(), id);
             }
+            headerConverterStage.setExecutingClass(headerConverter.getClass());
 
-            workerTask = buildWorkerTask(connConfig, id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, connectorLoader);
+            prContextBuilder.appendStage(keyConverterStage.build());
+            prContextBuilder.appendStage(valueConverterStage.build());
+            prContextBuilder.appendStage(headerConverterStage.build());
+
+            workerTask = buildWorkerTask(connConfig, id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, connectorLoader, prContextBuilder);
             workerTask.initialize(taskConfig);
             Plugins.compareAndSwapLoaders(savedLoader);
         } catch (Throwable t) {
@@ -447,7 +472,8 @@ public class Worker {
                                        Converter keyConverter,
                                        Converter valueConverter,
                                        HeaderConverter headerConverter,
-                                       ClassLoader loader) {
+                                       ClassLoader loader,
+                                       ProcessingContext.Builder prContextBuilder) {
         // Decide which type of worker task we need based on the type of task.
         if (task instanceof SourceTask) {
             TransformationChain<SourceRecord> transformationChain = new TransformationChain<>(connConfig.<SourceRecord>transformations());
@@ -456,12 +482,39 @@ public class Worker {
             OffsetStorageWriter offsetWriter = new OffsetStorageWriter(offsetBackingStore, id.connector(),
                     internalKeyConverter, internalValueConverter);
             KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(producerProps);
+
+            for (Stage stage: connConfig.transformationAsStages()) {
+                prContextBuilder.prependStage(stage);
+            }
+
+            prContextBuilder.prependStage(Stage.newBuilder(StageType.TASK_POLL)
+                    .setConfig(connConfig.originals())
+                    .setExecutingClass(task.getClass())
+                    .build()
+            );
+
+            prContextBuilder.appendStage(Stage.newBuilder(StageType.KAFKA_PRODUCE).build());
+
             return new WorkerSourceTask(id, (SourceTask) task, statusListener, initialState, keyConverter, valueConverter,
-                    headerConverter, transformationChain, producer, offsetReader, offsetWriter, config, metrics, loader, time);
+                    headerConverter, transformationChain, producer, offsetReader, offsetWriter, config, metrics, loader, time, prContextBuilder.build());
         } else if (task instanceof SinkTask) {
             TransformationChain<SinkRecord> transformationChain = new TransformationChain<>(connConfig.<SinkRecord>transformations());
+
+            for (Stage stage: connConfig.transformationAsStages()) {
+                prContextBuilder.appendStage(stage);
+            }
+
+            prContextBuilder.appendStage(Stage.newBuilder(StageType.TASK_POLL)
+                    .setConfig(connConfig.originals())
+                    .setExecutingClass(task.getClass())
+                    .build()
+            );
+
+            prContextBuilder.prependStage(Stage.newBuilder(StageType.KAFKA_CONSUME).build());
+
             return new WorkerSinkTask(id, (SinkTask) task, statusListener, initialState, config, metrics, keyConverter,
-                    valueConverter, headerConverter, transformationChain, loader, time);
+                    valueConverter, headerConverter, transformationChain, loader, time, prContextBuilder.build());
+
         } else {
             log.error("Tasks must be a subclass of either SourceTask or SinkTask", task);
             throw new ConnectException("Tasks must be a subclass of either SourceTask or SinkTask");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -40,6 +40,9 @@ import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.StageType;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.storage.Converter;
@@ -100,8 +103,9 @@ class WorkerSinkTask extends WorkerTask {
                           HeaderConverter headerConverter,
                           TransformationChain<SinkRecord> transformationChain,
                           ClassLoader loader,
-                          Time time) {
-        super(id, statusListener, initialState, loader, connectMetrics);
+                          Time time,
+                          ProcessingContext processingContext) {
+        super(id, statusListener, initialState, loader, connectMetrics, processingContext);
 
         this.workerConfig = workerConfig;
         this.task = task;
@@ -294,9 +298,16 @@ class WorkerSinkTask extends WorkerTask {
         }
 
         log.trace("{} Polling consumer with timeout {} ms", this, timeoutMs);
-        ConsumerRecords<byte[], byte[]> msgs = pollConsumer(timeoutMs);
+        final long minTimeout = timeoutMs;
+        processingContext().position(StageType.KAFKA_CONSUME);
+        ConsumerRecords<byte[], byte[]> msgs = operationExecutor().execute(new OperationExecutor.Operation<ConsumerRecords<byte[], byte[]>>() {
+            @Override
+            public ConsumerRecords<byte[], byte[]> apply() {
+                return pollConsumer(minTimeout);
+            }
+        }, ConsumerRecords.<byte[], byte[]>empty(), processingContext());
         assert messageBatch.isEmpty() || msgs.isEmpty();
-        log.trace("{} Polling returned {} messages", this, msgs.count());
+        log.info("{} Polling returned {} messages", this, msgs.count());
 
         convertMessages(msgs);
         deliverMessages();
@@ -461,12 +472,39 @@ class WorkerSinkTask extends WorkerTask {
 
     private void convertMessages(ConsumerRecords<byte[], byte[]> msgs) {
         origOffsets.clear();
-        for (ConsumerRecord<byte[], byte[]> msg : msgs) {
+        for (final ConsumerRecord<byte[], byte[]> msg : msgs) {
             log.trace("{} Consuming and converting message in topic '{}' partition {} at offset {} and timestamp {}",
                     this, msg.topic(), msg.partition(), msg.offset(), msg.timestamp());
-            SchemaAndValue keyAndSchema = keyConverter.toConnectData(msg.topic(), msg.key());
-            SchemaAndValue valueAndSchema = valueConverter.toConnectData(msg.topic(), msg.value());
-            Headers headers = convertHeadersFor(msg);
+
+            processingContext().position(StageType.KEY_CONVERTER);
+            SchemaAndValue keyAndSchema = operationExecutor().execute(new OperationExecutor.Operation<SchemaAndValue>() {
+                @Override
+                public SchemaAndValue apply() {
+                    return keyConverter.toConnectData(msg.topic(), msg.key());
+                }
+            }, DEFAULT_SCHEMA_AND_VALUE, processingContext());
+
+            processingContext().position(StageType.VALUE_CONVERTER);
+            SchemaAndValue valueAndSchema = operationExecutor().execute(new OperationExecutor.Operation<SchemaAndValue>() {
+                @Override
+                public SchemaAndValue apply() {
+                    return valueConverter.toConnectData(msg.topic(), msg.value());
+                }
+            }, DEFAULT_SCHEMA_AND_VALUE, processingContext());
+
+            processingContext().position(StageType.HEADER_CONVERTER);
+            Headers headers = operationExecutor().execute(new OperationExecutor.Operation<Headers>() {
+                @Override
+                public Headers apply() {
+                    return convertHeadersFor(msg);
+                }
+            }, DEFAULT_HEADERS, processingContext());
+
+            if (keyAndSchema == DEFAULT_SCHEMA_AND_VALUE || valueAndSchema == DEFAULT_SCHEMA_AND_VALUE
+                    || headers == DEFAULT_HEADERS) {
+                continue;
+            }
+
             Long timestamp = ConnectUtils.checkAndConvertTimestamp(msg.timestamp());
             SinkRecord origRecord = new SinkRecord(msg.topic(), msg.partition(),
                     keyAndSchema.schema(), keyAndSchema.value(),
@@ -475,9 +513,12 @@ class WorkerSinkTask extends WorkerTask {
                     timestamp,
                     msg.timestampType(),
                     headers);
+
             log.trace("{} Applying transformations to record in topic '{}' partition {} at offset {} and timestamp {} with key {} and value {}",
                     this, msg.topic(), msg.partition(), msg.offset(), timestamp, keyAndSchema.value(), valueAndSchema.value());
-            SinkRecord transRecord = transformationChain.apply(origRecord);
+            processingContext().position(StageType.TRANSFORMATION);
+            SinkRecord transRecord = transformationChain.apply(origRecord, operationExecutor(), processingContext());
+
             origOffsets.put(
                     new TopicPartition(origRecord.topic(), origRecord.kafkaPartition()),
                     new OffsetAndMetadata(origRecord.kafkaOffset() + 1)
@@ -521,7 +562,15 @@ class WorkerSinkTask extends WorkerTask {
             // Since we reuse the messageBatch buffer, ensure we give the task its own copy
             log.trace("{} Delivering batch of {} messages to task", this, messageBatch.size());
             long start = time.milliseconds();
-            task.put(new ArrayList<>(messageBatch));
+            processingContext().position(StageType.TASK_PUT);
+            operationExecutor().execute(new OperationExecutor.Operation<Object>() {
+                @Override
+                public Object apply() {
+                    task.put(new ArrayList<>(messageBatch));
+                    return null;
+                }
+            }, processingContext());
+
             recordBatch(messageBatch.size());
             sinkTaskMetricsGroup.recordPut(time.milliseconds() - start);
             currentOffsets.putAll(origOffsets);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -43,6 +43,7 @@ import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.errors.OperationExecutor;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.errors.StageType;
+import org.apache.kafka.connect.runtime.errors.impl.NoopExecutor;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.storage.Converter;
@@ -105,7 +106,24 @@ class WorkerSinkTask extends WorkerTask {
                           ClassLoader loader,
                           Time time,
                           ProcessingContext processingContext) {
-        super(id, statusListener, initialState, loader, connectMetrics, processingContext);
+        this(id, task, statusListener, initialState, workerConfig, connectMetrics, keyConverter, valueConverter, headerConverter, transformationChain, loader, time, processingContext, NoopExecutor.INSTANCE);
+    }
+
+    public WorkerSinkTask(ConnectorTaskId id,
+                          SinkTask task,
+                          TaskStatus.Listener statusListener,
+                          TargetState initialState,
+                          WorkerConfig workerConfig,
+                          ConnectMetrics connectMetrics,
+                          Converter keyConverter,
+                          Converter valueConverter,
+                          HeaderConverter headerConverter,
+                          TransformationChain<SinkRecord> transformationChain,
+                          ClassLoader loader,
+                          Time time,
+                          ProcessingContext processingContext,
+                          OperationExecutor operationExecutor) {
+        super(id, statusListener, initialState, loader, connectMetrics, processingContext, operationExecutor);
 
         this.workerConfig = workerConfig;
         this.task = task;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -37,6 +37,7 @@ import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.errors.OperationExecutor;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.errors.StageType;
+import org.apache.kafka.connect.runtime.errors.impl.NoopExecutor;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.storage.Converter;
@@ -107,7 +108,28 @@ class WorkerSourceTask extends WorkerTask {
                             ClassLoader loader,
                             Time time,
                             ProcessingContext processingContext) {
-        super(id, statusListener, initialState, loader, connectMetrics, processingContext);
+        this(id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, transformationChain,
+                producer, offsetReader, offsetWriter, workerConfig, connectMetrics, loader, time, processingContext, NoopExecutor.INSTANCE);
+    }
+
+    public WorkerSourceTask(ConnectorTaskId id,
+                SourceTask task,
+                TaskStatus.Listener statusListener,
+                TargetState initialState,
+                Converter keyConverter,
+                Converter valueConverter,
+                HeaderConverter headerConverter,
+                TransformationChain<SourceRecord> transformationChain,
+                KafkaProducer<byte[], byte[]> producer,
+                OffsetStorageReader offsetReader,
+                OffsetStorageWriter offsetWriter,
+                WorkerConfig workerConfig,
+                ConnectMetrics connectMetrics,
+                ClassLoader loader,
+                Time time,
+                ProcessingContext processingContext,
+                OperationExecutor operationExecutor) {
+        super(id, statusListener, initialState, loader, connectMetrics, processingContext, operationExecutor);
 
         this.workerConfig = workerConfig;
         this.task = task;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -34,6 +34,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.storage.Converter;
@@ -102,8 +103,9 @@ class WorkerSourceTask extends WorkerTask {
                             WorkerConfig workerConfig,
                             ConnectMetrics connectMetrics,
                             ClassLoader loader,
-                            Time time) {
-        super(id, statusListener, initialState, loader, connectMetrics);
+                            Time time,
+                            ProcessingContext processingContext) {
+        super(id, statusListener, initialState, loader, connectMetrics, processingContext);
 
         this.workerConfig = workerConfig;
         this.task = task;

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -34,7 +34,9 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.StageType;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.storage.Converter;
@@ -186,7 +188,13 @@ class WorkerSourceTask extends WorkerTask {
                 if (toSend == null) {
                     log.trace("{} Nothing to send to Kafka. Polling source for additional records", this);
                     long start = time.milliseconds();
-                    toSend = task.poll();
+                    processingContext().position(StageType.TASK_POLL);
+                    toSend = operationExecutor().execute(new OperationExecutor.Operation<List<SourceRecord>>() {
+                        @Override
+                        public List<SourceRecord> apply() throws InterruptedException {
+                            return task.poll();
+                        }
+                    }, processingContext());
                     if (toSend != null) {
                         recordPollReturned(toSend.size(), time.milliseconds() - start);
                     }
@@ -218,7 +226,8 @@ class WorkerSourceTask extends WorkerTask {
         recordBatch(toSend.size());
         final SourceRecordWriteCounter counter = new SourceRecordWriteCounter(toSend.size(), sourceTaskMetricsGroup);
         for (final SourceRecord preTransformRecord : toSend) {
-            final SourceRecord record = transformationChain.apply(preTransformRecord);
+            processingContext().position(StageType.TRANSFORMATION);
+            final SourceRecord record = transformationChain.apply(preTransformRecord, operationExecutor(), processingContext());
 
             if (record == null) {
                 counter.skipRecord();
@@ -226,9 +235,32 @@ class WorkerSourceTask extends WorkerTask {
                 continue;
             }
 
-            RecordHeaders headers = convertHeaderFor(record);
-            byte[] key = keyConverter.fromConnectData(record.topic(), record.keySchema(), record.key());
-            byte[] value = valueConverter.fromConnectData(record.topic(), record.valueSchema(), record.value());
+            processingContext().setRecord(record);
+
+            processingContext().position(StageType.HEADER_CONVERTER);
+            RecordHeaders headers = operationExecutor().execute(new OperationExecutor.Operation<RecordHeaders>() {
+                @Override
+                public RecordHeaders apply() {
+                    return convertHeaderFor(record);
+                }
+            }, DEFAULT_RECORD_HEADERS, processingContext());
+
+            processingContext().position(StageType.KEY_CONVERTER);
+            byte[] key = operationExecutor().execute(new OperationExecutor.Operation<byte[]>() {
+                @Override
+                public byte[] apply() {
+                    return keyConverter.fromConnectData(record.topic(), record.keySchema(), record.key());
+                }
+            }, processingContext());
+
+            processingContext().position(StageType.VALUE_CONVERTER);
+            byte[] value = operationExecutor().execute(new OperationExecutor.Operation<byte[]>() {
+                @Override
+                public byte[] apply() {
+                    return valueConverter.fromConnectData(record.topic(), record.valueSchema(), record.value());
+                }
+            }, processingContext());
+
             final ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(record.topic(), record.kafkaPartition(),
                     ConnectUtils.checkAndConvertTimestamp(record.timestamp()), key, value, headers);
             log.trace("{} Appending record with key {}, value {}", this, record.key(), record.value());
@@ -249,30 +281,37 @@ class WorkerSourceTask extends WorkerTask {
             }
             try {
                 final String topic = producerRecord.topic();
-                producer.send(
-                        producerRecord,
-                        new Callback() {
-                            @Override
-                            public void onCompletion(RecordMetadata recordMetadata, Exception e) {
-                                if (e != null) {
-                                    // Given the default settings for zero data loss, this should basically never happen --
-                                    // between "infinite" retries, indefinite blocking on full buffers, and "infinite" request
-                                    // timeouts, callbacks with exceptions should never be invoked in practice. If the
-                                    // user overrode these settings, the best we can do is notify them of the failure via
-                                    // logging.
-                                    log.error("{} failed to send record to {}: {}", this, topic, e);
-                                    log.debug("{} Failed record: {}", this, preTransformRecord);
-                                } else {
-                                    log.trace("{} Wrote record successfully: topic {} partition {} offset {}",
-                                            this,
-                                            recordMetadata.topic(), recordMetadata.partition(),
-                                            recordMetadata.offset());
-                                    commitTaskRecord(preTransformRecord);
-                                }
-                                recordSent(producerRecord);
-                                counter.completeRecord();
-                            }
-                        });
+                processingContext().position(StageType.KAFKA_PRODUCE);
+                processingContext().setRecord(record);
+                operationExecutor().execute(new OperationExecutor.Operation<Future<RecordMetadata>>() {
+                    @Override
+                    public Future<RecordMetadata> apply() {
+                        return producer.send(
+                                producerRecord,
+                                new Callback() {
+                                    @Override
+                                    public void onCompletion(RecordMetadata recordMetadata, Exception e) {
+                                        if (e != null) {
+                                            // Given the default settings for zero data loss, this should basically never happen --
+                                            // between "infinite" retries, indefinite blocking on full buffers, and "infinite" request
+                                            // timeouts, callbacks with exceptions should never be invoked in practice. If the
+                                            // user overrode these settings, the best we can do is notify them of the failure via
+                                            // logging.
+                                            log.error("{} failed to send record to {}: {}", this, topic, e);
+                                            log.debug("{} Failed record: {}", this, preTransformRecord);
+                                        } else {
+                                            log.trace("{} Wrote record successfully: topic {} partition {} offset {}",
+                                                    this,
+                                                    recordMetadata.topic(), recordMetadata.partition(),
+                                                    recordMetadata.offset());
+                                            commitTaskRecord(preTransformRecord);
+                                        }
+                                        recordSent(producerRecord);
+                                        counter.completeRecord();
+                                    }
+                                });
+                    }
+                }, processingContext());
                 lastSendFailed = false;
             } catch (RetriableException e) {
                 log.warn("{} Failed to send {}, backing off before retrying:", this, producerRecord, e);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.metrics.Measurable;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Sensor;
@@ -72,6 +73,7 @@ abstract class WorkerTask implements Runnable {
 
     protected static final SchemaAndValue DEFAULT_SCHEMA_AND_VALUE = new SchemaAndValue(Schema.BOOLEAN_SCHEMA, false);
     protected static final Headers DEFAULT_HEADERS = new ConnectHeaders();
+    protected static final RecordHeaders DEFAULT_RECORD_HEADERS = new RecordHeaders();
 
     public WorkerTask(ConnectorTaskId id,
                       TaskStatus.Listener statusListener,

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorReporter.java
@@ -16,10 +16,14 @@
  */
 package org.apache.kafka.connect.runtime.errors;
 
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.connect.data.Struct;
 
-public interface ErrorReporter {
+public abstract class ErrorReporter implements Configurable {
 
-    void report(Struct report);
+    public void initialize() {
+    }
+
+    public abstract void report(ProcessingContext report);
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorReporter.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+import org.apache.kafka.connect.data.Struct;
+
+public interface ErrorReporter {
+
+    void report(Struct report);
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ErrorReporter.java
@@ -17,7 +17,6 @@
 package org.apache.kafka.connect.runtime.errors;
 
 import org.apache.kafka.common.Configurable;
-import org.apache.kafka.connect.data.Struct;
 
 public abstract class ErrorReporter implements Configurable {
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/OperationExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/OperationExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+/**
+ * Execute a connect worker operation with configurable retries and tolerances. An operation here means applying tranformations
+ * on a ConnectRecord, converting it to a format used by the Connect framework, writing it to a sink or reading from a source.
+ *
+ * <p/>The following failures will be retried:
+ *
+ * <ol>
+ *     <li> Connector tasks fail with RetriableException when reading/writing records from/to external system.
+ *     <li> Transformations fail and throw exceptions while processing records.
+ *     <li> Converters fail to correctly serialize/deserialize records.
+ *     <li> Exceptions while producing/consuming to/from Kafka topics in the Connect framework.
+ * </ol>
+ *
+ * The executor will report errors on failure (after reattempting). It will throw a {@link ToleranceExceededException} if
+ * any of the tolerance limits are crossed.
+ */
+public abstract class OperationExecutor {
+
+    public <V> V execute(Operation<V> operation, ProcessingContext context) {
+        return execute(operation, null, context);
+    }
+
+    public abstract <V> V execute(Operation<V> operation, V value, ProcessingContext context);
+
+    public interface Operation<V> {
+        V apply();
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/OperationExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/OperationExecutor.java
@@ -41,7 +41,7 @@ public abstract class OperationExecutor {
     public abstract <V> V execute(Operation<V> operation, V value, ProcessingContext context);
 
     public interface Operation<V> {
-        V apply();
+        V apply() throws Exception;
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/OperationExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/OperationExecutor.java
@@ -16,6 +16,10 @@
  */
 package org.apache.kafka.connect.runtime.errors;
 
+import org.apache.kafka.common.Configurable;
+
+import java.util.Map;
+
 /**
  * Execute a connect worker operation with configurable retries and tolerances. An operation here means applying tranformations
  * on a ConnectRecord, converting it to a format used by the Connect framework, writing it to a sink or reading from a source.
@@ -32,10 +36,17 @@ package org.apache.kafka.connect.runtime.errors;
  * The executor will report errors on failure (after reattempting). It will throw a {@link ToleranceExceededException} if
  * any of the tolerance limits are crossed.
  */
-public abstract class OperationExecutor {
+public abstract class OperationExecutor implements Configurable {
 
     public <V> V execute(Operation<V> operation, ProcessingContext context) {
         return execute(operation, null, context);
+    }
+
+    /**
+     * Configure this class with the given key-value pairs
+     */
+    @Override
+    public void configure(Map<String, ?> configs) {
     }
 
     public abstract <V> V execute(Operation<V> operation, V value, ProcessingContext context);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ProcessingContext.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This object will contain all the runtime context for an error which occurs in the Connect framework while
+ * processing a record.
+ */
+public class ProcessingContext implements Structable {
+
+    private final String taskId;
+    private final Map<String, Object> workerConfig;
+    private final List<Stage> stages;
+    private final List<ErrorReporter> reporters;
+
+    private Exception exception;
+    private int current = 0;
+    private int attempt;
+    private ConnectRecord record;
+    private long timetstamp;
+
+    public static Builder newBuilder(ConnectorTaskId taskId, Map<String, Object> workerConfig) {
+        Objects.requireNonNull(taskId);
+        Objects.requireNonNull(workerConfig);
+
+        return new Builder(taskId.toString(), workerConfig);
+    }
+
+    // VisibleForTesting
+    public static ProcessingContext noop(String taskId) {
+        return new ProcessingContext(taskId, Collections.<String, Object>emptyMap(), Collections.<Stage>emptyList(), Collections.<ErrorReporter>emptyList());
+    }
+
+    private ProcessingContext(String taskId, Map<String, Object> workerConfig, List<Stage> stages, List<ErrorReporter> reporters) {
+        Objects.requireNonNull(taskId);
+        Objects.requireNonNull(workerConfig);
+        Objects.requireNonNull(stages);
+        Objects.requireNonNull(reporters);
+
+        this.taskId = taskId;
+        this.workerConfig = workerConfig;
+        this.stages = stages;
+        this.reporters = reporters;
+    }
+
+    /**
+     * @return the configuration of the Connect worker
+     */
+    public Map<String, Object> workerConfig() {
+        return workerConfig;
+    }
+
+    /**
+     * @return which task reported this error
+     */
+    public String taskId() {
+        return taskId;
+    }
+
+    /**
+     * @return an ordered list of stages. Connect will start with executing stage 0 and then move up the list.
+     */
+    public List<Stage> stages() {
+        return stages;
+    }
+
+    /**
+     * @return at what stage did this operation fail (0 indicates first stage)
+     */
+    public int index() {
+        return current;
+    }
+
+    /**
+     * @return which attempt was this (first error will be 0)
+     */
+    public int attempt() {
+        return attempt;
+    }
+
+    /**
+     * @return the (epoch) time of failure
+     */
+    public long timeOfError() {
+        return timetstamp;
+    }
+
+    /**
+     * The exception accompanying this failure (if any)
+     */
+    public Exception exception() {
+        return exception;
+    }
+
+    /**
+     * @return the record which when input the current stage caused the failure.
+     */
+    public ConnectRecord record() {
+        return record;
+    }
+
+    public void setRecord(ConnectRecord record) {
+        this.record = record;
+    }
+
+    public void setException(Exception ex) {
+        this.exception = ex;
+    }
+
+    public void report() {
+        Struct report = this.toStruct();
+        for (ErrorReporter reporter : reporters) {
+            reporter.report(report);
+        }
+    }
+
+    @Override
+    public Struct toStruct() {
+        return null;
+    }
+
+    public void reset() {
+        current = 0;
+        attempt = 0;
+    }
+
+    /**
+     * Position index to the first stage of the given type
+     *
+     * @param type the given type
+     */
+    public void position(StageType type) {
+        reset();
+        for (int i = 0; i < stages.size(); i++) {
+            if (type == stages.get(i).type()) {
+                current = i;
+                break;
+            }
+        }
+    }
+
+    public void incrementAttempt() {
+        attempt++;
+    }
+
+    public static class Builder {
+        private final Map<String, Object> workerConfig;
+        private final String taskId;
+
+        private List<ErrorReporter> reporters = new ArrayList<>();
+        private LinkedList<Stage> stages = new LinkedList<>();
+
+        private Builder(String taskId, Map<String, Object> workerConfig) {
+            this.taskId = taskId;
+            this.workerConfig = workerConfig;
+        }
+
+        public void prependStage(Stage stage) {
+            stages.addFirst(stage);
+        }
+
+        public void appendStage(Stage stage) {
+            stages.addLast(stage);
+        }
+
+        public ProcessingContext build() {
+            return new ProcessingContext(taskId, workerConfig, stages, reporters);
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Stage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Stage.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+public class Stage implements Structable {
+
+    private final StageType type;
+    private final Map<String, Object> config;
+    private final Class<?> klass;
+
+    public static Builder newBuilder(StageType type) {
+        return new Builder(type);
+    }
+
+    private Stage(StageType type, Map<String, Object> config, Class<?> klass) {
+        this.type = type;
+        this.config = config;
+        this.klass = klass;
+    }
+
+    /**
+     * @return at what stage in processing did the error happen
+     */
+    public StageType type() {
+        return type;
+    }
+
+    /**
+     * @return name of the class executing this stage.
+     */
+    public Class<?> executingClass() {
+        return klass;
+    }
+
+    /**
+     * @return properties used to configure this stage
+     */
+    public Map<String, Object> config() {
+        return config;
+    }
+
+    @Override
+    public Struct toStruct() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "Stage{" + toStruct() + "}";
+    }
+
+    public static class Builder {
+        private StageType type;
+        private Map<String, Object> config;
+        private Class<?> klass;
+
+        private Builder(StageType type) {
+            this.type = type;
+        }
+
+        public Builder setExecutingClass(Class<?> klass) {
+            this.klass = klass;
+            return this;
+        }
+
+        public Builder setConfig(Map<String, Object> config) {
+            this.config = config;
+            return this;
+        }
+
+        public Stage build() {
+            Objects.requireNonNull(type);
+            return new Stage(type, config == null ? Collections.<String, Object>emptyMap() : config, klass);
+        }
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Stage.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Stage.java
@@ -41,6 +41,7 @@ public class Stage implements Structable {
     /**
      * @return at what stage in processing did the error happen
      */
+    @Field("type")
     public StageType type() {
         return type;
     }
@@ -48,6 +49,7 @@ public class Stage implements Structable {
     /**
      * @return name of the class executing this stage.
      */
+    @Field("class")
     public Class<?> executingClass() {
         return klass;
     }
@@ -55,6 +57,7 @@ public class Stage implements Structable {
     /**
      * @return properties used to configure this stage
      */
+    @Field("config")
     public Map<String, Object> config() {
         return config;
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/StageType.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/StageType.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+/**
+ * A logical stage in a Connect pipeline
+ */
+public enum StageType {
+
+    /**
+     * When the task starts up
+     */
+    TASK_START,
+
+    /**
+     * when running any transform operation on a record
+     */
+    TRANSFORMATION,
+
+    /**
+     * when calling the poll() method on a SourceConnector
+     */
+    TASK_POLL,
+
+    /**
+     * when calling the put() method on a SinkConnector
+     */
+    TASK_PUT,
+
+    /**
+     * when using the key converter to serialize/deserialize keys in ConnectRecords
+     */
+    KEY_CONVERTER,
+
+    /**
+     * when using the value converter to serialize/deserialize values in ConnectRecords
+     */
+    VALUE_CONVERTER,
+
+    /**
+     * when using the header converter to serialize/deserialize headers in ConnectRecords
+     */
+    HEADER_CONVERTER,
+
+    /**
+     * when the worker is committing offsets for the task
+     */
+    COMMIT_OFFSETS,
+
+    /**
+     * When the task is shutting down
+     */
+    TASK_CLOSE,
+
+    /**
+     * Producing to Kafka topic
+     */
+    KAFKA_PRODUCE,
+
+    /**
+     * Consuming from a Kafka topic
+     */
+    KAFKA_CONSUME
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Structable.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/Structable.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+import org.apache.kafka.connect.data.Struct;
+
+public interface Structable {
+
+    /**
+     * @return a {@link Struct} representation of this object
+     */
+    Struct toStruct();
+
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ToleranceExceededException.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/ToleranceExceededException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+public class ToleranceExceededException extends ConnectException {
+
+    public ToleranceExceededException(String msg, Throwable throwable) {
+        super(msg, throwable);
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/DLQReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/DLQReporter.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.errors.ErrorReporter;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
@@ -78,8 +77,7 @@ public class DLQReporter extends ErrorReporter {
                 .define(DLQ_TOPIC_REPLICATION_FACTOR, ConfigDef.Type.SHORT, DLQ_TOPIC_REPLICATION_FACTOR_DEFAULT, atLeast(1), ConfigDef.Importance.HIGH, DLQ_TOPIC_REPLICATION_FACTOR_DOC)
                 .define(DLQ_INCLUDE_CONFIGS, ConfigDef.Type.BOOLEAN, DLQ_INCLUDE_CONFIGS_DEFAULT, ConfigDef.Importance.HIGH, DLQ_INCLUDE_CONFIGS_DOC)
                 .define(DLQ_INCLUDE_MESSAGES, ConfigDef.Type.BOOLEAN, DLQ_INCLUDE_MESSAGES_DEFAULT, ConfigDef.Importance.HIGH, DLQ_INCLUDE_MESSAGES_DOC)
-                .define(DLQ_CONVERTER, ConfigDef.Type.CLASS, DLQ_CONVERTER_DEFAULT, ConfigDef.Importance.HIGH, DLQ_CONVERTER_DOC)
-                ;
+                .define(DLQ_CONVERTER, ConfigDef.Type.CLASS, DLQ_CONVERTER_DEFAULT, ConfigDef.Importance.HIGH, DLQ_CONVERTER_DOC);
     }
 
     @Override

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/DLQReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/DLQReporter.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.errors.ErrorReporter;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.apache.kafka.connect.util.TopicAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+
+public class DLQReporter extends ErrorReporter {
+
+    private static final Logger log = LoggerFactory.getLogger(DLQReporter.class);
+
+    public static final String DLQ_TOPIC_NAME = "errors.dlq.topic.name";
+    public static final String DLQ_TOPIC_NAME_DOC = "The name of the topic where these messages are written to.";
+
+    public static final String DLQ_TOPIC_PARTITIONS = "errors.dlq.topic.partitions";
+    public static final String DLQ_TOPIC_PARTITIONS_DOC = "Number of partitions for the DLQ topic.";
+    public static final int DLQ_TOPIC_PARTITIONS_DEFAULT = 25;
+
+    public static final String DLQ_TOPIC_REPLICATION_FACTOR = "errors.dlq.topic.replication.factor";
+    public static final String DLQ_TOPIC_REPLICATION_FACTOR_DOC = "The replication factor for the DLQ topic.";
+    public static final short DLQ_TOPIC_REPLICATION_FACTOR_DEFAULT = 3;
+
+    public static final String DLQ_INCLUDE_CONFIGS = "dlq.include.configs";
+    public static final String DLQ_INCLUDE_CONFIGS_DOC = "Include the (worker, connector) configs in the log.";
+    public static final boolean DLQ_INCLUDE_CONFIGS_DEFAULT = false;
+
+    public static final String DLQ_INCLUDE_MESSAGES = "dlq.include.messages";
+    public static final String DLQ_INCLUDE_MESSAGES_DOC = "Include the Connect Record which failed to process in the log.";
+    public static final boolean DLQ_INCLUDE_MESSAGES_DEFAULT = false;
+
+    public static final String DLQ_CONVERTER = "dlq.converter";
+    public static final String DLQ_CONVERTER_DOC = "Include the Connect Record which failed to process in the log.";
+    public static final Class<? extends Converter> DLQ_CONVERTER_DEFAULT = StringConverter.class;
+
+    public static final String DLQ_PRODUCER_PROPERTIES = "dlq.producer";
+
+    private DlqReporterConfig config;
+    private KafkaProducer<byte[], byte[]> producer;
+    private Converter converter;
+
+    static ConfigDef getConfigDef() {
+        return new ConfigDef()
+                .define(DLQ_TOPIC_NAME, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, DLQ_TOPIC_NAME_DOC)
+                .define(DLQ_TOPIC_PARTITIONS, ConfigDef.Type.INT, DLQ_TOPIC_PARTITIONS_DEFAULT, atLeast(1), ConfigDef.Importance.HIGH, DLQ_TOPIC_PARTITIONS_DOC)
+                .define(DLQ_TOPIC_REPLICATION_FACTOR, ConfigDef.Type.SHORT, DLQ_TOPIC_REPLICATION_FACTOR_DEFAULT, atLeast(1), ConfigDef.Importance.HIGH, DLQ_TOPIC_REPLICATION_FACTOR_DOC)
+                .define(DLQ_INCLUDE_CONFIGS, ConfigDef.Type.BOOLEAN, DLQ_INCLUDE_CONFIGS_DEFAULT, ConfigDef.Importance.HIGH, DLQ_INCLUDE_CONFIGS_DOC)
+                .define(DLQ_INCLUDE_MESSAGES, ConfigDef.Type.BOOLEAN, DLQ_INCLUDE_MESSAGES_DEFAULT, ConfigDef.Importance.HIGH, DLQ_INCLUDE_MESSAGES_DOC)
+                .define(DLQ_CONVERTER, ConfigDef.Type.CLASS, DLQ_CONVERTER_DEFAULT, ConfigDef.Importance.HIGH, DLQ_CONVERTER_DOC)
+                ;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        config = new DlqReporterConfig(configs);
+    }
+
+    @Override
+    public void initialize() {
+        // check if topic exists
+        NewTopic topicDescription = TopicAdmin.defineTopic(config.topic())
+                .partitions(config.topicPartitions())
+                .replicationFactor(config.topicReplicationFactor())
+                .build();
+
+        Map<String, Object> adminProps = config.getProducerProps();
+        try (TopicAdmin admin = new TopicAdmin(adminProps)) {
+            admin.createTopics(topicDescription);
+        }
+
+        Map<String, Object> producerProps = config.getProducerProps();
+        producer = new KafkaProducer<>(producerProps);
+
+        try {
+            if (config.converter().isAssignableFrom(Converter.class)) {
+                converter = config.converter().newInstance();
+            }
+        } catch (InstantiationException e) {
+            throw new ConnectException("Could not instantiate converter");
+        } catch (IllegalAccessException e) {
+            throw new ConnectException("Could not access class");
+        }
+    }
+
+    @Override
+    public void report(final ProcessingContext report) {
+        byte[] val;
+        try {
+            val = converter.fromConnectData(config.topic(), SchemaBuilder.struct().schema(), report);
+        } catch (Exception e) {
+            log.error("Could not convert report for producing", e);
+            return;
+        }
+
+
+
+        producer.send(new ProducerRecord<byte[], byte[]>(config.topic(), val), new Callback() {
+            @Override
+            public void onCompletion(RecordMetadata metadata, Exception exception) {
+                if (exception != null) {
+                    log.error("Could not write record to DLQ", report);
+                }
+            }
+        });
+    }
+
+    private static class DlqReporterConfig extends AbstractConfig {
+        public DlqReporterConfig(Map<?, ?> originals) {
+            super(getConfigDef(), originals);
+        }
+
+        public String topic() {
+            return getString(DLQ_TOPIC_NAME);
+        }
+
+        public int topicPartitions() {
+            return getInt(DLQ_TOPIC_NAME);
+        }
+
+        public short topicReplicationFactor() {
+            return getShort(DLQ_TOPIC_REPLICATION_FACTOR);
+        }
+
+        public boolean includeConfigs() {
+            return getBoolean(DLQ_INCLUDE_CONFIGS);
+        }
+
+        public boolean includeMessages() {
+            return getBoolean(DLQ_INCLUDE_MESSAGES);
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<? extends Converter> converter() {
+            return (Class<? extends Converter>) getClass(DLQ_CONVERTER);
+        }
+
+        public Map<String, Object> getProducerProps() {
+            return originalsWithPrefix(DLQ_PRODUCER_PROPERTIES + ".");
+        }
+
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ErrorMetricsReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ErrorMetricsReporter.java
@@ -14,27 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.connect.runtime.errors;
+package org.apache.kafka.connect.runtime.errors.impl;
 
-import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.runtime.errors.ErrorReporter;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.util.Map;
 
-import static java.lang.annotation.ElementType.METHOD;
+public class ErrorMetricsReporter extends ErrorReporter {
 
-public interface Structable {
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
 
-    /**
-     * @return a {@link Struct} representation of this object
-     */
-    Struct toStruct();
+    @Override
+    public void report(ProcessingContext report) {
 
-    @Target({METHOD})
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface Field {
-        String value();
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/LogReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/LogReporter.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.runtime.errors.ErrorReporter;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class LogReporter extends ErrorReporter {
+
+    private static final Logger log = LoggerFactory.getLogger(LogReporter.class);
+
+    public static final String LOG_INCLUDE_CONFIGS = "log.include.configs";
+    public static final String LOG_INCLUDE_CONFIGS_DOC = "Include the (worker, connector) configs in the log.";
+    public static final boolean LOG_INCLUDE_CONFIGS_DEFAULT = false;
+
+    public static final String LOG_INCLUDE_MESSAGES = "log.include.messages";
+    public static final String LOG_INCLUDE_MESSAGES_DOC = "Include the Connect Record which failed to process in the log.";
+    public static final boolean LOG_INCLUDE_MESSAGES_DEFAULT = false;
+
+    private LogReporterConfig config;
+
+    static ConfigDef getConfigDef() {
+        return new ConfigDef()
+                .define(LOG_INCLUDE_CONFIGS, ConfigDef.Type.BOOLEAN, LOG_INCLUDE_CONFIGS_DEFAULT, ConfigDef.Importance.HIGH, LOG_INCLUDE_CONFIGS_DOC)
+                .define(LOG_INCLUDE_MESSAGES, ConfigDef.Type.BOOLEAN, LOG_INCLUDE_MESSAGES_DEFAULT, ConfigDef.Importance.HIGH, LOG_INCLUDE_MESSAGES_DOC);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        config = new LogReporterConfig(configs);
+    }
+
+    @Override
+    public void report(ProcessingContext context) {
+        log.info("Error processing record. Context={}", createLogString(context));
+    }
+
+    public String createLogString(ProcessingContext context) {
+        return String.valueOf(context.toStruct());
+    }
+
+    static class LogReporterConfig extends AbstractConfig {
+        public LogReporterConfig(Map<?, ?> originals) {
+            super(getConfigDef(), originals);
+        }
+
+        public boolean includeConfigs() {
+            return getBoolean(LOG_INCLUDE_CONFIGS);
+        }
+
+        public boolean includeMessages() {
+            return getBoolean(LOG_INCLUDE_MESSAGES);
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
@@ -23,7 +23,13 @@ public class NoopExecutor extends OperationExecutor {
 
     @Override
     public <V> V execute(OperationExecutor.Operation<V> operation, V value, ProcessingContext context) {
-        return operation.apply();
+        try {
+            return operation.apply();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception ignored) {
+        }
+        return value;
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+
+public class NoopExecutor extends OperationExecutor {
+
+    @Override
+    public <V> V execute(OperationExecutor.Operation<V> operation, V value, ProcessingContext context) {
+        return operation.apply();
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
@@ -21,15 +21,17 @@ import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 
 public class NoopExecutor extends OperationExecutor {
 
+
+
     @Override
     public <V> V execute(OperationExecutor.Operation<V> operation, V value, ProcessingContext context) {
         try {
             return operation.apply();
         } catch (RuntimeException e) {
             throw e;
-        } catch (Exception ignored) {
+        } catch (Exception e) {
+            context.setException(e);
+            throw new RuntimeException(e);
         }
-        return value;
     }
-
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/NoopExecutor.java
@@ -21,7 +21,10 @@ import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 
 public class NoopExecutor extends OperationExecutor {
 
+    public static final OperationExecutor INSTANCE = new NoopExecutor();
 
+    private NoopExecutor() {
+    }
 
     @Override
     public <V> V execute(OperationExecutor.Operation<V> operation, V value, ProcessingContext context) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ReporterFactory.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ReporterFactory.java
@@ -19,12 +19,16 @@ package org.apache.kafka.connect.runtime.errors.impl;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.runtime.errors.ErrorReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class ReporterFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(ReporterFactory.class);
 
     public static final String DLQ_ENABLE = "dlq.enable";
     public static final String DLQ_ENABLE_DOC = "Log the error context along with the other application logs.";
@@ -43,14 +47,17 @@ public class ReporterFactory {
     public List<ErrorReporter> forConfig(Map<String, ?> configs) {
         ReporterFactoryConfig config = new ReporterFactoryConfig(getConfigDef(), configs);
         List<ErrorReporter> reporters = new ArrayList<>(3);
+        log.info("Adding metrics reporter for reporting errors");
         reporters.add(new ErrorMetricsReporter());
         if (config.isDlqReporterEnabled()) {
+            log.info("Adding DLQ reporter for reporting errors");
             DLQReporter reporter = new DLQReporter();
             reporter.configure(configs);
             reporter.initialize();
             reporters.add(reporter);
         }
         if (config.isLogReporterEnabled()) {
+            log.info("Adding Log reporter for reporting errors");
             LogReporter reporter = new LogReporter();
             reporter.configure(configs);
             reporter.initialize();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ReporterFactory.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ReporterFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.runtime.errors.ErrorReporter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ReporterFactory {
+
+    public static final String DLQ_ENABLE = "dlq.enable";
+    public static final String DLQ_ENABLE_DOC = "Log the error context along with the other application logs.";
+    public static final boolean DLQ_ENABLE_DEFAULT = false;
+
+    public static final String LOG_ENABLE = "log.enable";
+    public static final String LOG_ENABLE_DOC = "Log the error context along with the other application logs.";
+    public static final boolean LOG_ENABLE_DEFAULT = false;
+
+    static ConfigDef getConfigDef() {
+        return new ConfigDef()
+                .define(DLQ_ENABLE, ConfigDef.Type.BOOLEAN, DLQ_ENABLE_DEFAULT, ConfigDef.Importance.HIGH, DLQ_ENABLE_DOC)
+                .define(LOG_ENABLE, ConfigDef.Type.BOOLEAN, LOG_ENABLE_DEFAULT, ConfigDef.Importance.HIGH, LOG_ENABLE_DOC);
+    }
+
+    public List<ErrorReporter> forConfig(Map<String, ?> configs) {
+        ReporterFactoryConfig config = new ReporterFactoryConfig(getConfigDef(), configs);
+        List<ErrorReporter> reporters = new ArrayList<>(3);
+        reporters.add(new ErrorMetricsReporter());
+        if (config.isDlqReporterEnabled()) {
+            DLQReporter reporter = new DLQReporter();
+            reporter.configure(configs);
+            reporter.initialize();
+            reporters.add(reporter);
+        }
+        if (config.isLogReporterEnabled()) {
+            LogReporter reporter = new LogReporter();
+            reporter.configure(configs);
+            reporter.initialize();
+            reporters.add(reporter);
+        }
+        return reporters;
+    }
+
+    static class ReporterFactoryConfig extends AbstractConfig {
+
+        public ReporterFactoryConfig(ConfigDef definition, Map<?, ?> originals) {
+            super(definition, originals, false);
+        }
+
+        public boolean isLogReporterEnabled() {
+            return getBoolean(LOG_ENABLE);
+        }
+
+        public boolean isDlqReporterEnabled() {
+            return getBoolean(DLQ_ENABLE);
+        }
+    }
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ReporterFactory.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/ReporterFactory.java
@@ -18,11 +18,13 @@ package org.apache.kafka.connect.runtime.errors.impl;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.errors.ErrorReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -44,7 +46,13 @@ public class ReporterFactory {
                 .define(LOG_ENABLE, ConfigDef.Type.BOOLEAN, LOG_ENABLE_DEFAULT, ConfigDef.Importance.HIGH, LOG_ENABLE_DOC);
     }
 
-    public List<ErrorReporter> forConfig(Map<String, ?> configs) {
+    public List<ErrorReporter> forConfig(Map<String, Object> workerProducerProps, ConnectorConfig connConfig) {
+        Map<String, Object> configs = new HashMap<>();
+        for (Map.Entry<String, Object> e: workerProducerProps.entrySet()) {
+            configs.put(DLQReporter.DLQ_PRODUCER_PROPERTIES + "." + e.getKey(), e.getValue());
+        }
+        configs.putAll(connConfig.errorHandlerConfig());
+
         ReporterFactoryConfig config = new ReporterFactoryConfig(getConfigDef(), configs);
         List<ErrorReporter> reporters = new ArrayList<>(3);
         log.info("Adding metrics reporter for reporting errors");

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+
+public class RetryWithToleranceExecutor extends OperationExecutor {
+
+    @Override
+    public <V> V execute(Operation<V> operation, V value, ProcessingContext context) {
+        return operation.apply();
+    }
+
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
@@ -16,20 +16,217 @@
  */
 package org.apache.kafka.connect.runtime.errors.impl;
 
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.errors.OperationExecutor;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.common.config.ConfigDef.Range.atLeast;
+import static org.apache.kafka.common.config.ConfigDef.ValidString.in;
 
 public class RetryWithToleranceExecutor extends OperationExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(RetryWithToleranceExecutor.class);
+
+    public static final String RETRIES_LIMIT = "retries.limit";
+    public static final String RETRIES_LIMIT_DOC = "The maximum number of retries before failing an operation";
+    public static final long RETRIES_LIMIT_DEFAULT = 0;
+
+    public static final String RETRIES_DELAY_MAX_MS = "retries.delay.max.ms";
+    public static final String RETRIES_DELAY_MAX_MS_DOC = "The maximum duration between two consecutive retries (in milliseconds).";
+    public static final long RETRIES_DELAY_MAX_MS_DEFAULT = 60000;
+
+    public static final long RETRIES_DELAY_MIN_MS = 1000;
+
+    public static final String TOLERANCE_LIMIT = "tolerance.limit";
+    public static final String TOLERANCE_LIMIT_DOC = "Fail the task if we exceed specified number of errors overall.";
+    public static final long TOLERANCE_LIMIT_DEFAULT = 0;
+
+    public static final String TOLERANCE_RATE_LIMIT = "tolerance.rate.limit";
+    public static final String TOLERANCE_RATE_LIMIT_DOC = "Fail the task if we exceed specified number of errors in the observed duration.";
+    public static final long TOLERANCE_RATE_LIMIT_DEFAULT = 0;
+
+    public static final String TOLERANCE_RATE_DURATION = "tolerance.rate.duration";
+    public static final String TOLERANCE_RATE_DURATION_DOC = "The duration of the window for which we will monitor errors.";
+    public static final String TOLERANCE_RATE_DURATION_DEFAULT = "minute";
+
+    private final Time time;
+    private RetryWithToleranceExecutorConfig config;
+
+    private long totalFailures = 0;
+    private long totalFailuresInDuration = 0;
+    private long durationWindow = 0;
+    private long durationStart = 0;
+
+    public RetryWithToleranceExecutor() {
+        this(new SystemTime());
+    }
+
+    public RetryWithToleranceExecutor(Time time) {
+        this.time = time;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        config = new RetryWithToleranceExecutorConfig(configs);
+        durationWindow = TimeUnit.MILLISECONDS.convert(1, config.toleranceRateDuration());
+        durationStart = time.milliseconds() % durationWindow;
+    }
+
+    static ConfigDef getConfigDef() {
+        return new ConfigDef()
+                .define(RETRIES_LIMIT, ConfigDef.Type.INT, RETRIES_LIMIT_DEFAULT, ConfigDef.Importance.HIGH, RETRIES_LIMIT_DOC)
+                .define(RETRIES_DELAY_MAX_MS, ConfigDef.Type.INT, RETRIES_DELAY_MAX_MS_DEFAULT, atLeast(1), ConfigDef.Importance.MEDIUM, RETRIES_DELAY_MAX_MS_DOC)
+                .define(TOLERANCE_LIMIT, ConfigDef.Type.INT, TOLERANCE_LIMIT_DEFAULT, ConfigDef.Importance.HIGH, TOLERANCE_LIMIT_DOC)
+                .define(TOLERANCE_RATE_LIMIT, ConfigDef.Type.INT, TOLERANCE_RATE_LIMIT_DEFAULT, ConfigDef.Importance.MEDIUM, TOLERANCE_RATE_LIMIT_DOC)
+                .define(TOLERANCE_RATE_DURATION, ConfigDef.Type.STRING, TOLERANCE_RATE_DURATION_DEFAULT, in("minute", "hour", "day"), ConfigDef.Importance.MEDIUM, TOLERANCE_RATE_DURATION_DOC);
+    }
 
     @Override
     public <V> V execute(Operation<V> operation, V value, ProcessingContext context) {
         try {
-            return operation.apply();
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception ignored) {
+            switch (context.current().type()) {
+                case TRANSFORMATION:
+                case HEADER_CONVERTER:
+                case KEY_CONVERTER:
+                case VALUE_CONVERTER:
+                    return handleExceptions(operation, value, context, Exception.class);
+                case KAFKA_PRODUCE:
+                case KAFKA_CONSUME:
+                    return handleExceptions(operation, value, context, org.apache.kafka.common.errors.RetriableException.class);
+                default:
+                    return handleExceptions(operation, value, context, org.apache.kafka.connect.errors.RetriableException.class);
+            }
+        } finally {
+            if (context.exception() != null) {
+                context.report();
+            }
         }
+    }
+
+    private <V> V handleExceptions(Operation<V> operation, V value, ProcessingContext context, Class<? extends Exception> handled) {
+        Response<V> response = new Response<>();
+        boolean retry;
+        do {
+            apply(response, operation, handled);
+            context.incrementAttempt();
+            switch (response.status) {
+                case SUCCESS:
+                    return response.result;
+                case RETRY:
+                    context.setException(response.ex);
+                    retry = config.retriesLimit() > 0 && (context.attempt() - 1) < config.retriesLimit();
+                    break;
+                case UNHANDLED_EXCEPTION:
+                    context.setException(response.ex);
+                    throw new ConnectException(response.ex);
+                default:
+                    throw new ConnectException("Undefined state: " + response.status);
+            }
+            if (retry) {
+                backoff(context);
+                if (Thread.currentThread().isInterrupted()) {
+                    // thread was interrupted during sleep. kill the task.
+                    throw new ConnectException("Thread was interrupted");
+                }
+            }
+        } while (retry);
+
+        // mark this record as failed.
+        totalFailures++;
+
+        long newDurationStart = context.timeOfError() - context.timeOfError() % durationWindow;
+        if (newDurationStart > durationStart) {
+            durationStart = newDurationStart;
+            totalFailuresInDuration = 0;
+        }
+        totalFailuresInDuration++;
+
+        if (totalFailures > config.toleranceLimit()) {
+            throw new ConnectException("Tolerance Limit Exceeded", response.ex);
+        }
+
         return value;
     }
 
+    private void backoff(ProcessingContext context) {
+        int numRetry = context.attempt() - 1;
+        long delay = RETRIES_DELAY_MIN_MS << numRetry;
+        if (delay > config.retriesDelayMax()) {
+            delay = ThreadLocalRandom.current().nextLong(config.retriesDelayMax());
+        }
+
+        log.debug("Sleeping for {} millis", delay);
+        time.sleep(delay);
+    }
+
+    private <V> void apply(Response<V> response, Operation<V> operation, Class<? extends Exception> handled) {
+        try {
+            response.result = operation.apply();
+            response.ex = null;
+            response.status = ResponseStatus.SUCCESS;
+        } catch (Exception e) {
+            response.ex = e;
+            response.result = null;
+            if (handled.isAssignableFrom(e.getClass())) {
+                response.status = ResponseStatus.RETRY;
+            } else {
+                response.status = ResponseStatus.UNHANDLED_EXCEPTION;
+            }
+        }
+    }
+
+    static class Response<V> {
+        ResponseStatus status;
+        Exception ex;
+        V result;
+    }
+
+    enum ResponseStatus {
+        SUCCESS,
+        RETRY,
+        UNHANDLED_EXCEPTION
+    }
+
+    static class RetryWithToleranceExecutorConfig extends AbstractConfig {
+
+        public RetryWithToleranceExecutorConfig(Map<?, ?> originals) {
+            super(getConfigDef(), originals);
+        }
+
+        public long retriesLimit() {
+            return getLong(RETRIES_LIMIT);
+        }
+
+        public long retriesDelayMax() {
+            return getLong(RETRIES_DELAY_MAX_MS);
+        }
+
+        public long toleranceLimit() {
+            return getLong(TOLERANCE_LIMIT);
+        }
+
+        public long toleranceRateLimit() {
+            return getLong(TOLERANCE_LIMIT);
+        }
+
+        public TimeUnit toleranceRateDuration() {
+            switch (getString(TOLERANCE_LIMIT).toLowerCase()) {
+                case "minute": return TimeUnit.MINUTES;
+                case "hour": return TimeUnit.HOURS;
+                case "day": return TimeUnit.DAYS;
+                default: throw new ConfigException("Could not recognize value " + getString(TOLERANCE_LIMIT) + " for config " + TOLERANCE_RATE_DURATION);
+            }
+        }
+    }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
@@ -23,7 +23,13 @@ public class RetryWithToleranceExecutor extends OperationExecutor {
 
     @Override
     public <V> V execute(Operation<V> operation, V value, ProcessingContext context) {
-        return operation.apply();
+        try {
+            return operation.apply();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception ignored) {
+        }
+        return value;
     }
 
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutor.java
@@ -127,6 +127,7 @@ public class RetryWithToleranceExecutor extends OperationExecutor {
                 case RETRY:
                     context.setException(response.ex);
                     retry = checkRetry(context);
+                    log.trace("Operation failed. For attempt={}, limit={}, retry={}", context.attempt(), config.retriesLimit(), retry);
                     break;
                 case UNHANDLED_EXCEPTION:
                     context.setException(response.ex);
@@ -159,7 +160,7 @@ public class RetryWithToleranceExecutor extends OperationExecutor {
             throw new ConnectException("Tolerance Limit Exceeded", response.ex);
         }
 
-        log.info("Returning default value={}", value);
+        log.trace("Operation failed but within tolerance limits. Returning default value={}", value);
         return value;
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/StructUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/StructUtil.java
@@ -71,7 +71,7 @@ public class StructUtil {
                     } else if (object.getClass().isEnum()) {
                         object = String.valueOf(object);
                     } else if (Class.class.isAssignableFrom(object.getClass())) {
-                        object = String.valueOf(object);
+                        object = ((Class<?>) object).getName();
                     } else if (object instanceof Map) {
                         Map<String, String> m = new HashMap<>();
                         Map<Object, Object> mm = (Map<Object, Object>) object;
@@ -108,21 +108,21 @@ public class StructUtil {
 
             Class<?> type = method.getReturnType();
             if (method.getReturnType().equals(int.class)) {
-                schemaBuilder.field(field.value(), Schema.INT32_SCHEMA);
+                schemaBuilder.field(field.value(), Schema.OPTIONAL_INT32_SCHEMA);
             } else if (method.getReturnType().equals(String.class)) {
-                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+                schemaBuilder.field(field.value(), Schema.OPTIONAL_STRING_SCHEMA);
             } else if (method.getReturnType().equals(long.class)) {
-                schemaBuilder.field(field.value(), Schema.INT64_SCHEMA);
+                schemaBuilder.field(field.value(), Schema.OPTIONAL_INT64_SCHEMA);
             } else if (method.getReturnType().equals(Exception.class)) {
-                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+                schemaBuilder.field(field.value(), Schema.OPTIONAL_STRING_SCHEMA);
             } else if (method.getReturnType().equals(Structable.class)) {
                 schemaBuilder.field(field.value(), getSchemaFor((Class<? extends Structable>) method.getReturnType()));
             } else if (method.getReturnType().isEnum()) {
-                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+                schemaBuilder.field(field.value(), Schema.OPTIONAL_STRING_SCHEMA);
             } else if (Class.class.isAssignableFrom(method.getReturnType())) {
-                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+                schemaBuilder.field(field.value(), Schema.OPTIONAL_STRING_SCHEMA);
             } else if (Map.class.isAssignableFrom(method.getReturnType())) {
-                schemaBuilder.field(field.value(), SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA));
+                schemaBuilder.field(field.value(), SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).build());
             } else {
                 throw new DataException("Could not translate type: " + type + " for method " + method);
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/StructUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/StructUtil.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.runtime.errors.impl;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -30,6 +29,8 @@ import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class StructUtil {
                 if (object != null) {
                     if (object instanceof Exception) {
                         Exception ex = (Exception) object;
-                        object = ExceptionUtils.getMessage(ex) + "\n" + ExceptionUtils.getStackTrace(ex);
+                        object = getMessage(ex) + "\n" + getStackTrace(ex);
                     } else if (object.getClass().isEnum()) {
                         object = String.valueOf(object);
                     } else if (Class.class.isAssignableFrom(object.getClass())) {
@@ -127,6 +128,22 @@ public class StructUtil {
             }
         }
         return schemaBuilder.build();
+    }
+
+    public static String getMessage(final Throwable th) {
+        if (th == null) {
+            return "";
+        }
+        final String clsName = th.getClass().getName();
+        final String msg = th.getMessage();
+        return clsName + ": " + msg;
+    }
+
+    public static String getStackTrace(final Throwable throwable) {
+        final StringWriter sw = new StringWriter();
+        final PrintWriter pw = new PrintWriter(sw, true);
+        throwable.printStackTrace(pw);
+        return sw.getBuffer().toString();
     }
 
     public static void main(String[] args) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/StructUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/impl/StructUtil.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.Stage;
+import org.apache.kafka.connect.runtime.errors.StageType;
+import org.apache.kafka.connect.runtime.errors.Structable;
+import org.apache.kafka.connect.sink.SinkTask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class StructUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(StructUtil.class);
+
+    public static Struct toStruct(Structable structable) {
+        Objects.requireNonNull(structable);
+
+        Schema objectSchema = getSchemaFor(structable.getClass());
+        return getStructFor(structable, objectSchema);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Struct getStructFor(Structable structable, Schema schema) {
+        Objects.requireNonNull(structable);
+
+        Struct struct = new Struct(schema);
+        Method[] methods = structable.getClass().getMethods();
+        for (Method method: methods) {
+            Structable.Field field = method.getAnnotation(Structable.Field.class);
+            if (field == null) {
+                continue;
+            }
+            if (method.getParameterTypes().length > 0) {
+                log.debug("Cannot invoke method with non-zero parameters.");
+                continue;
+            }
+            try {
+                Object object = method.invoke(structable);
+                if (object != null) {
+                    if (object instanceof Exception) {
+                        Exception ex = (Exception) object;
+                        object = ExceptionUtils.getMessage(ex) + "\n" + ExceptionUtils.getStackTrace(ex);
+                    } else if (object.getClass().isEnum()) {
+                        object = String.valueOf(object);
+                    } else if (Class.class.isAssignableFrom(object.getClass())) {
+                        object = String.valueOf(object);
+                    } else if (object instanceof Map) {
+                        Map<String, String> m = new HashMap<>();
+                        Map<Object, Object> mm = (Map<Object, Object>) object;
+                        for (Map.Entry<Object, Object> e: mm.entrySet()) {
+                            String key = e.getKey() instanceof String ? (String) e.getKey() : String.valueOf(e.getKey());
+                            String val = e.getValue() instanceof String ? (String) e.getValue() : String.valueOf(e.getValue());
+                            m.put(key, val);
+                        }
+                        object = m;
+                    }
+                    struct.put(field.value(), object);
+                }
+
+            } catch (Exception e) {
+                log.error("Could nto invoke method " + method, e);
+            }
+        }
+        return struct;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Schema getSchemaFor(Class<? extends Structable> structable) {
+        SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+        Method[] methods = structable.getMethods();
+        for (Method method: methods) {
+            Structable.Field field = method.getAnnotation(Structable.Field.class);
+            if (field == null) {
+                continue;
+            }
+            if (method.getParameterTypes().length > 0) {
+                log.debug("Cannot invoke method with non-zero parameters.");
+                continue;
+            }
+
+            Class<?> type = method.getReturnType();
+            if (method.getReturnType().equals(int.class)) {
+                schemaBuilder.field(field.value(), Schema.INT32_SCHEMA);
+            } else if (method.getReturnType().equals(String.class)) {
+                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+            } else if (method.getReturnType().equals(long.class)) {
+                schemaBuilder.field(field.value(), Schema.INT64_SCHEMA);
+            } else if (method.getReturnType().equals(Exception.class)) {
+                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+            } else if (method.getReturnType().equals(Structable.class)) {
+                schemaBuilder.field(field.value(), getSchemaFor((Class<? extends Structable>) method.getReturnType()));
+            } else if (method.getReturnType().isEnum()) {
+                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+            } else if (Class.class.isAssignableFrom(method.getReturnType())) {
+                schemaBuilder.field(field.value(), Schema.STRING_SCHEMA);
+            } else if (Map.class.isAssignableFrom(method.getReturnType())) {
+                schemaBuilder.field(field.value(), SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA));
+            } else {
+                throw new DataException("Could not translate type: " + type + " for method " + method);
+            }
+        }
+        return schemaBuilder.build();
+    }
+
+    public static void main(String[] args) {
+        new StructUtil().test();
+    }
+
+    private Exception foo() {
+        return new ConnectException("connect");
+    }
+
+    private void test() {
+        System.out.println(RuntimeException.class.isAssignableFrom(Exception.class));
+        System.out.println(Exception.class.isAssignableFrom(RuntimeException.class));
+        System.out.println(RuntimeException.class.isAssignableFrom(RuntimeException.class));
+
+        ProcessingContext context = ProcessingContext.noop("my-task");
+        context.setException(new RuntimeException("hello", foo()));
+        Struct contextStruct = toStruct(context);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("k1", "v1");
+        config.put("k2", 10);
+        Stage stage = Stage.newBuilder(StageType.TASK_START).setExecutingClass(SinkTask.class).setConfig(config).build();
+        Struct stageStruct = toStruct(stage);
+
+        Schema combinedSchema = SchemaBuilder.struct()
+                .field("context", contextStruct.schema())
+                .field("stage", stageStruct.schema())
+                .build();
+        Struct struct = new Struct(combinedSchema);
+        struct.put("context", contextStruct);
+        struct.put("stage", stageStruct);
+
+        System.out.println(struct.toString().replaceAll("\n", "\\\\n"));
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -31,6 +31,8 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.runtime.WorkerSinkTask.SinkTaskMetricsGroup;
@@ -161,7 +163,8 @@ public class WorkerSinkTaskTest {
     private void createTask(TargetState initialState) {
         workerTask = PowerMock.createPartialMock(
                 WorkerSinkTask.class, new String[]{"createConsumer"},
-                taskId, sinkTask, statusListener, initialState, workerConfig, metrics, keyConverter, valueConverter, headerConverter, transformationChain, pluginLoader, time);
+                taskId, sinkTask, statusListener, initialState, workerConfig, metrics, keyConverter, valueConverter, headerConverter, transformationChain, pluginLoader, time,
+                ProcessingContext.noop(taskId.toString()));
     }
 
     @After
@@ -1361,7 +1364,7 @@ public class WorkerSinkTaskTest {
         EasyMock.expect(valueConverter.toConnectData(TOPIC, RAW_VALUE)).andReturn(new SchemaAndValue(VALUE_SCHEMA, VALUE)).times(numMessages);
 
         final Capture<SinkRecord> recordCapture = EasyMock.newCapture();
-        EasyMock.expect(transformationChain.apply(EasyMock.capture(recordCapture)))
+        EasyMock.expect(transformationChain.apply(EasyMock.capture(recordCapture), EasyMock.<OperationExecutor>anyObject(), EasyMock.<ProcessingContext>anyObject()))
                 .andAnswer(new IAnswer<SinkRecord>() {
                     @Override
                     public SinkRecord answer() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskThreadedTest.java
@@ -28,6 +28,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.sink.SinkConnector;
@@ -137,7 +139,8 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         workerTask = PowerMock.createPartialMock(
                 WorkerSinkTask.class, new String[]{"createConsumer"},
                 taskId, sinkTask, statusListener, initialState, workerConfig, metrics, keyConverter,
-                valueConverter, headerConverter, TransformationChain.noOp(), pluginLoader, time);
+                valueConverter, headerConverter, TransformationChain.<SinkRecord>noOp(), pluginLoader, time,
+                ProcessingContext.noop(taskId.toString()));
 
         recordsReturned = 0;
     }
@@ -573,7 +576,7 @@ public class WorkerSinkTaskThreadedTest extends ThreadedTest {
         EasyMock.expect(valueConverter.toConnectData(TOPIC, RAW_VALUE)).andReturn(new SchemaAndValue(VALUE_SCHEMA, VALUE)).anyTimes();
 
         final Capture<SinkRecord> recordCapture = EasyMock.newCapture();
-        EasyMock.expect(transformationChain.apply(EasyMock.capture(recordCapture))).andAnswer(new IAnswer<SinkRecord>() {
+        EasyMock.expect(transformationChain.apply(EasyMock.capture(recordCapture), EasyMock.<OperationExecutor>anyObject(), EasyMock.<ProcessingContext>anyObject())).andAnswer(new IAnswer<SinkRecord>() {
             @Override
             public SinkRecord answer() {
                 return recordCapture.getValue();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.WorkerSourceTask.SourceTaskMetricsGroup;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
@@ -774,7 +775,7 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
     private void expectApplyTransformationChain(boolean anyTimes) {
         final Capture<SourceRecord> recordCapture = EasyMock.newCapture();
-        IExpectationSetters<SourceRecord> convertKeyExpect = EasyMock.expect(transformationChain.apply(EasyMock.capture(recordCapture)));
+        IExpectationSetters<SourceRecord> convertKeyExpect = EasyMock.expect(transformationChain.apply(EasyMock.capture(recordCapture), EasyMock.<OperationExecutor>anyObject(), EasyMock.<ProcessingContext>anyObject()));
         if (anyTimes)
             convertKeyExpect.andStubAnswer(new IAnswer<SourceRecord>() {
                 @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.WorkerSourceTask.SourceTaskMetricsGroup;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -146,7 +147,8 @@ public class WorkerSourceTaskTest extends ThreadedTest {
 
     private void createWorkerTask(TargetState initialState) {
         workerTask = new WorkerSourceTask(taskId, sourceTask, statusListener, initialState, keyConverter, valueConverter, headerConverter,
-                transformationChain, producer, offsetReader, offsetWriter, config, metrics, plugins.delegatingLoader(), Time.SYSTEM);
+                transformationChain, producer, offsetReader, offsetWriter, config, metrics, plugins.delegatingLoader(), Time.SYSTEM,
+                ProcessingContext.noop(taskId.toString()));
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTaskTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.WorkerTask.TaskMetricsGroup;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.common.utils.MockTime;
@@ -77,9 +78,10 @@ public class WorkerTaskTest {
                         TaskStatus.Listener.class,
                         TargetState.class,
                         ClassLoader.class,
-                        ConnectMetrics.class
+                        ConnectMetrics.class,
+                        ProcessingContext.class
                 )
-                .withArgs(taskId, statusListener, TargetState.STARTED, loader, metrics)
+                .withArgs(taskId, statusListener, TargetState.STARTED, loader, metrics, ProcessingContext.noop("test"))
                 .addMockedMethod("initialize")
                 .addMockedMethod("execute")
                 .addMockedMethod("close")
@@ -123,9 +125,10 @@ public class WorkerTaskTest {
                         TaskStatus.Listener.class,
                         TargetState.class,
                         ClassLoader.class,
-                        ConnectMetrics.class
+                        ConnectMetrics.class,
+                        ProcessingContext.class
                 )
-                .withArgs(taskId, statusListener, TargetState.STARTED, loader, metrics)
+                .withArgs(taskId, statusListener, TargetState.STARTED, loader, metrics, ProcessingContext.noop("test"))
                 .addMockedMethod("initialize")
                 .addMockedMethod("execute")
                 .addMockedMethod("close")
@@ -162,9 +165,10 @@ public class WorkerTaskTest {
                         TaskStatus.Listener.class,
                         TargetState.class,
                         ClassLoader.class,
-                        ConnectMetrics.class
+                        ConnectMetrics.class,
+                        ProcessingContext.class
                 )
-                .withArgs(taskId, statusListener, TargetState.STARTED, loader, metrics)
+                .withArgs(taskId, statusListener, TargetState.STARTED, loader, metrics, ProcessingContext.noop("test"))
                 .addMockedMethod("initialize")
                 .addMockedMethod("execute")
                 .addMockedMethod("close")

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.MockConnectMetrics.MockMetricsReporter;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
@@ -492,7 +493,8 @@ public class WorkerTest extends ThreadedTest {
                 EasyMock.eq(config),
                 anyObject(ConnectMetrics.class),
                 anyObject(ClassLoader.class),
-                anyObject(Time.class))
+                anyObject(Time.class),
+                anyObject(ProcessingContext.class))
                 .andReturn(workerTask);
         Map<String, String> origProps = new HashMap<>();
         origProps.put(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
@@ -629,7 +631,8 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(WorkerConfig.class),
                 anyObject(ConnectMetrics.class),
                 EasyMock.eq(pluginLoader),
-                anyObject(Time.class))
+                anyObject(Time.class),
+                anyObject(ProcessingContext.class))
                 .andReturn(workerTask);
         Map<String, String> origProps = new HashMap<>();
         origProps.put(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
@@ -720,7 +723,8 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(WorkerConfig.class),
                 anyObject(ConnectMetrics.class),
                 EasyMock.eq(pluginLoader),
-                anyObject(Time.class))
+                anyObject(Time.class),
+                anyObject(ProcessingContext.class))
                 .andReturn(workerTask);
         Map<String, String> origProps = new HashMap<>();
         origProps.put(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -33,6 +33,7 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.MockConnectMetrics.MockMetricsReporter;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
 import org.apache.kafka.connect.runtime.errors.impl.NoopExecutor;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
@@ -479,7 +480,6 @@ public class WorkerTest extends ThreadedTest {
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
         EasyMock.expect(workerTask.processingContext()).andStubReturn(ProcessingContext.noop(TASK_ID.toString()));
         EasyMock.expect(workerTask.operationExecutor()).andStubReturn(NoopExecutor.INSTANCE);
-        EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
         PowerMock.expectNew(
@@ -498,7 +498,8 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(ConnectMetrics.class),
                 anyObject(ClassLoader.class),
                 anyObject(Time.class),
-                anyObject(ProcessingContext.class))
+                anyObject(ProcessingContext.class),
+                anyObject(OperationExecutor.class))
                 .andReturn(workerTask);
         Map<String, String> origProps = new HashMap<>();
         origProps.put(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
@@ -638,7 +639,8 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(ConnectMetrics.class),
                 EasyMock.eq(pluginLoader),
                 anyObject(Time.class),
-                anyObject(ProcessingContext.class))
+                anyObject(ProcessingContext.class),
+                anyObject(OperationExecutor.class))
                 .andReturn(workerTask);
         Map<String, String> origProps = new HashMap<>();
         origProps.put(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());
@@ -732,7 +734,8 @@ public class WorkerTest extends ThreadedTest {
                 anyObject(ConnectMetrics.class),
                 EasyMock.eq(pluginLoader),
                 anyObject(Time.class),
-                anyObject(ProcessingContext.class))
+                anyObject(ProcessingContext.class),
+                anyObject(OperationExecutor.class))
                 .andReturn(workerTask);
         Map<String, String> origProps = new HashMap<>();
         origProps.put(TaskConfig.TASK_CLASS_CONFIG, TestSourceTask.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.connect.json.JsonConverterConfig;
 import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.MockConnectMetrics.MockMetricsReporter;
 import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.impl.NoopExecutor;
 import org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader;
 import org.apache.kafka.connect.runtime.isolation.PluginClassLoader;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
@@ -476,6 +477,9 @@ public class WorkerTest extends ThreadedTest {
         expectStartStorage();
 
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
+        EasyMock.expect(workerTask.processingContext()).andStubReturn(ProcessingContext.noop(TASK_ID.toString()));
+        EasyMock.expect(workerTask.operationExecutor()).andStubReturn(NoopExecutor.INSTANCE);
+        EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
 
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
         PowerMock.expectNew(
@@ -614,6 +618,8 @@ public class WorkerTest extends ThreadedTest {
         expectStartStorage();
 
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
+        EasyMock.expect(workerTask.processingContext()).andStubReturn(ProcessingContext.noop(TASK_ID.toString()));
+        EasyMock.expect(workerTask.operationExecutor()).andStubReturn(NoopExecutor.INSTANCE);
 
         EasyMock.expect(plugins.currentThreadLoader()).andReturn(delegatingLoader).times(2);
         PowerMock.expectNew(
@@ -702,6 +708,8 @@ public class WorkerTest extends ThreadedTest {
         expectStartStorage();
 
         EasyMock.expect(workerTask.id()).andStubReturn(TASK_ID);
+        EasyMock.expect(workerTask.processingContext()).andStubReturn(ProcessingContext.noop(TASK_ID.toString()));
+        EasyMock.expect(workerTask.operationExecutor()).andStubReturn(NoopExecutor.INSTANCE);
 
         Capture<TestConverter> keyConverter = EasyMock.newCapture();
         Capture<TestConfigurableConverter> valueConverter = EasyMock.newCapture();

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutorTest.java
@@ -97,7 +97,6 @@ public class RetryWithToleranceExecutorTest {
         testHandleExceptionInStage(StageType.TASK_POLL, new Exception());
     }
 
-
     @Test(expected = Exception.class)
     public void testThrowExceptionInKafkaConsume() {
         testHandleExceptionInStage(StageType.KAFKA_CONSUME, new Exception());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutorTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/impl/RetryWithToleranceExecutorTest.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.runtime.errors.impl;
+
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.connect.runtime.errors.OperationExecutor;
+import org.apache.kafka.connect.runtime.errors.ProcessingContext;
+import org.apache.kafka.connect.runtime.errors.Stage;
+import org.apache.kafka.connect.runtime.errors.StageType;
+import org.easymock.EasyMock;
+import org.easymock.Mock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ProcessingContext.class})
+public class RetryWithToleranceExecutorTest {
+
+    @Mock
+    private ProcessingContext processingContext;
+
+    Object ref = new Object();
+
+    @Test
+    public void testHandleExceptionInTransformations() {
+        testHandleExceptionInStage(StageType.TRANSFORMATION, new Exception());
+    }
+
+    @Test
+    public void testHandleExceptionInHeaderConverter() {
+        testHandleExceptionInStage(StageType.HEADER_CONVERTER, new Exception());
+    }
+
+    @Test
+    public void testHandleExceptionInValueConverter() {
+        testHandleExceptionInStage(StageType.VALUE_CONVERTER, new Exception());
+    }
+
+    @Test
+    public void testHandleExceptionInKeyConverter() {
+        testHandleExceptionInStage(StageType.KEY_CONVERTER, new Exception());
+    }
+
+    @Test
+    public void testHandleExceptionInKafkaConsume() {
+        testHandleExceptionInStage(StageType.KAFKA_CONSUME, new org.apache.kafka.common.errors.RetriableException() {});
+    }
+
+    @Test
+    public void testHandleExceptionInKafkaProduce() {
+        testHandleExceptionInStage(StageType.KAFKA_PRODUCE, new org.apache.kafka.common.errors.RetriableException() {});
+    }
+
+    @Test
+    public void testHandleExceptionInTaskPut() {
+        testHandleExceptionInStage(StageType.TASK_PUT, new org.apache.kafka.connect.errors.RetriableException("Test"));
+    }
+
+    @Test
+    public void testHandleExceptionInTaskPoll() {
+        testHandleExceptionInStage(StageType.TASK_POLL, new org.apache.kafka.connect.errors.RetriableException("Test"));
+    }
+
+    @Test(expected = Exception.class)
+    public void testThrowExceptionInTaskPut() {
+        testHandleExceptionInStage(StageType.TASK_PUT, new Exception());
+    }
+
+    @Test(expected = Exception.class)
+    public void testThrowExceptionInTaskPoll() {
+        testHandleExceptionInStage(StageType.TASK_POLL, new Exception());
+    }
+
+
+    @Test(expected = Exception.class)
+    public void testThrowExceptionInKafkaConsume() {
+        testHandleExceptionInStage(StageType.KAFKA_CONSUME, new Exception());
+    }
+
+    @Test(expected = Exception.class)
+    public void testThrowExceptionInKafkaProduce() {
+        testHandleExceptionInStage(StageType.KAFKA_PRODUCE, new Exception());
+    }
+
+    private void testHandleExceptionInStage(StageType type, Exception ex) {
+        RetryWithToleranceExecutor executor = setupExecutor();
+        setupProcessingContext(type, ex);
+        replay(processingContext);
+        assertEquals(ref, executor.execute(new ExceptionThrower(ex), ref, processingContext));
+        PowerMock.verifyAll();
+    }
+
+    private RetryWithToleranceExecutor setupExecutor() {
+        RetryWithToleranceExecutor executor = new RetryWithToleranceExecutor();
+        Map<String, Object> props = config(RetryWithToleranceExecutor.RETRIES_LIMIT, "0");
+        props.put(RetryWithToleranceExecutor.TOLERANCE_LIMIT, "10");
+        props.put(RetryWithToleranceExecutor.TOLERANCE_RATE_LIMIT, "10");
+        executor.configure(props);
+        return executor;
+    }
+
+    private void setupProcessingContext(StageType type, Exception ex) {
+        EasyMock.expect(processingContext.current()).andReturn(Stage.newBuilder(type).build());
+        EasyMock.expect(processingContext.exception()).andReturn(ex);
+        EasyMock.expect(processingContext.attempt()).andReturn(1);
+        EasyMock.expect(processingContext.timeOfError()).andReturn(System.currentTimeMillis());
+        processingContext.setTimeOfError(EasyMock.anyLong());
+
+        processingContext.incrementAttempt();
+        EasyMock.expectLastCall();
+
+        processingContext.report();
+        EasyMock.expectLastCall();
+
+        processingContext.setException(ex);
+        EasyMock.expectLastCall();
+    }
+
+    @Test
+    public void testCheckRetryLimit() {
+        RetryWithToleranceExecutor executor = new RetryWithToleranceExecutor();
+        Map<String, Object> props = config(RetryWithToleranceExecutor.RETRIES_LIMIT, "5");
+        props.put(RetryWithToleranceExecutor.RETRIES_DELAY_MAX_MS, "120000");
+        executor.configure(props);
+
+        EasyMock.expect(processingContext.attempt()).andReturn(1);
+        EasyMock.expect(processingContext.attempt()).andReturn(2);
+        EasyMock.expect(processingContext.attempt()).andReturn(3);
+        EasyMock.expect(processingContext.attempt()).andReturn(4);
+        EasyMock.expect(processingContext.attempt()).andReturn(5);
+        EasyMock.expect(processingContext.attempt()).andReturn(6);
+
+        replay(processingContext);
+
+        assertTrue(executor.checkRetry(processingContext));
+        assertTrue(executor.checkRetry(processingContext));
+        assertTrue(executor.checkRetry(processingContext));
+        assertTrue(executor.checkRetry(processingContext));
+        assertTrue(executor.checkRetry(processingContext));
+        assertFalse(executor.checkRetry(processingContext));
+    }
+
+    @Test
+    public void testBackoffLimit() {
+        MockTime time = new MockTime(0, 0, 0);
+        RetryWithToleranceExecutor executor = new RetryWithToleranceExecutor(time);
+
+        Map<String, Object> props = config(RetryWithToleranceExecutor.RETRIES_LIMIT, "5");
+        props.put(RetryWithToleranceExecutor.RETRIES_DELAY_MAX_MS, "10000");
+        executor.configure(props);
+
+        EasyMock.expect(processingContext.attempt()).andReturn(1);
+        EasyMock.expect(processingContext.attempt()).andReturn(2);
+        EasyMock.expect(processingContext.attempt()).andReturn(3);
+        EasyMock.expect(processingContext.attempt()).andReturn(4);
+        EasyMock.expect(processingContext.attempt()).andReturn(5);
+
+        replay(processingContext);
+
+        long prevTs = time.hiResClockMs();
+        executor.backoff(processingContext);
+        assertEquals(time.hiResClockMs() - prevTs, 1000);
+
+        prevTs = time.hiResClockMs();
+        executor.backoff(processingContext);
+        assertEquals(time.hiResClockMs() - prevTs, 2000);
+
+        prevTs = time.hiResClockMs();
+        executor.backoff(processingContext);
+        assertEquals(time.hiResClockMs() - prevTs, 4000);
+
+        prevTs = time.hiResClockMs();
+        executor.backoff(processingContext);
+        assertEquals(time.hiResClockMs() - prevTs, 8000);
+
+        prevTs = time.hiResClockMs();
+        executor.backoff(processingContext);
+        assertTrue(time.hiResClockMs() - prevTs < 10000);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testToleranceLimitWithinDuration() {
+        RetryWithToleranceExecutor executor = new RetryWithToleranceExecutor(new MockTime(0, 0, 0));
+        Map<String, Object> props = config(RetryWithToleranceExecutor.TOLERANCE_RATE_LIMIT, "1");
+        props.put(RetryWithToleranceExecutor.TOLERANCE_RATE_DURATION, "minute");
+        executor.configure(props);
+
+        long errorTimeMs = 1;
+        EasyMock.expect(processingContext.timeOfError()).andReturn(errorTimeMs);
+        EasyMock.expect(processingContext.timeOfError()).andReturn(errorTimeMs + 1);
+
+        replay(processingContext);
+
+        assertTrue(executor.withinToleranceLimits(processingContext));
+        assertFalse(executor.withinToleranceLimits(processingContext));
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testToleranceLimitAcrossDuration() {
+        MockTime time = new MockTime(0, 0, 0);
+        RetryWithToleranceExecutor executor = new RetryWithToleranceExecutor(time);
+        Map<String, Object> props = config(RetryWithToleranceExecutor.TOLERANCE_RATE_LIMIT, "1");
+        props.put(RetryWithToleranceExecutor.TOLERANCE_RATE_DURATION, "minute");
+        executor.configure(props);
+
+        // first error occurs at 59 seconds
+        long errorTimeMs = 59000;
+        EasyMock.expect(processingContext.timeOfError()).andReturn(errorTimeMs);
+        // second error occurs at 61 seconds
+        errorTimeMs = 61000;
+        EasyMock.expect(processingContext.timeOfError()).andReturn(errorTimeMs);
+
+        replay(processingContext);
+
+        assertTrue(executor.withinToleranceLimits(processingContext));
+
+        time.setCurrentTimeMs(60000);
+
+        assertTrue(executor.withinToleranceLimits(processingContext));
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testDefaultConfigs() {
+        RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig configuration;
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(new HashMap<>());
+        assertEquals(configuration.retriesLimit(), 0);
+        assertEquals(configuration.retriesDelayMax(), 60000);
+        assertEquals(configuration.toleranceLimit(), 0);
+        assertEquals(configuration.toleranceRateLimit(), 0);
+        assertEquals(configuration.toleranceRateDuration(), TimeUnit.MINUTES);
+
+        PowerMock.verifyAll();
+    }
+
+    @Test
+    public void testConfigs() {
+        RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig configuration;
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("retries.limit", "100"));
+        assertEquals(configuration.retriesLimit(), 100);
+
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("retries.delay.max.ms", "100"));
+        assertEquals(configuration.retriesDelayMax(), 100);
+
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("tolerance.limit", "1024"));
+        assertEquals(configuration.toleranceLimit(), 1024);
+
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("tolerance.rate.limit", "125"));
+        assertEquals(configuration.toleranceRateLimit(), 125);
+
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("tolerance.rate.duration", "minute"));
+        assertEquals(configuration.toleranceRateDuration(), TimeUnit.MINUTES);
+
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("tolerance.rate.duration", "day"));
+        assertEquals(configuration.toleranceRateDuration(), TimeUnit.DAYS);
+
+        configuration = new RetryWithToleranceExecutor.RetryWithToleranceExecutorConfig(config("tolerance.rate.duration", "hour"));
+        assertEquals(configuration.toleranceRateDuration(), TimeUnit.HOURS);
+
+        PowerMock.verifyAll();
+    }
+
+    Map<String, Object> config(String key, Object val) {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(key, val);
+        return configs;
+    }
+
+    private static class ExceptionThrower implements OperationExecutor.Operation {
+        private Exception e;
+
+        public ExceptionThrower(Exception e) {
+            this.e = e;
+        }
+
+        @Override
+        public Object apply() throws Exception {
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
**_This PR is a WIP. It has been created to serve as a high-level reference for discussions on the proposal at https://cwiki.apache.org/confluence/display/KAFKA/KIP-298%3A+Error+Handling+in+Connect._**

This feature aims to change the Connect framework to allow it to automatically deal with errors while processing records in a Connector. The following behavior changes are introduced here: 
1. **Retry on Failure**: Retry the failed operation a configurable number of times, with backoff between each retry.
2. **Task Tolerance Limits**: Tolerate up to a configurable number of failures in a task.

We also add the following ways to report errors, along with sufficient context to simplify the  debugging process: 
1. **Log Error Context**: The error information along with processing context is logged along with the standard application logs.
2. **Dead Letter Queue**: Produce the error information and processing context into a Kafka topic.

The logged information consists of the following bits:
1. Descriptions of the different stages (source/sink tasks, transformations and converters) in the connector, and their configs.
2. The record which caused the exception.
3. The exception and stack trace, if available.
4. Number of attempts (if applicable) made to execute the failed operation.
5. The time of error.

New metrics which will monitor the number of failures, and the behavior of the response handler are added.

The changes proposed here are **backward compatible**. The current behavior in Connect is to kill the task on the first error in any stage. This will remain the default behavior if the connector does not override any of the new configurations which are provided as part of this feature.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
