### PR TITLE
improve kafka client sensor registration performance by lazily calculating JMX attributes

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java
@@ -214,20 +214,23 @@ public class JmxReporter implements MetricsReporter {
 
         @Override
         public MBeanInfo getMBeanInfo() {
-            MBeanAttributeInfo[] attrs = new MBeanAttributeInfo[metrics.size()];
-            int i = 0;
-            for (Map.Entry<String, KafkaMetric> entry : this.metrics.entrySet()) {
-                String attribute = entry.getKey();
-                KafkaMetric metric = entry.getValue();
-                attrs[i] = new MBeanAttributeInfo(attribute,
-                                                  double.class.getName(),
-                                                  metric.metricName().description(),
-                                                  true,
-                                                  false,
-                                                  false);
-                i += 1;
-            }
-            return new MBeanInfo(this.getClass().getName(), "", attrs, null, null, null);
+            return new LazyMBeanInfo(this.getClass().getName(), "", null, null, null,
+                () -> {
+                    MBeanAttributeInfo[] attrs = new MBeanAttributeInfo[metrics.size()];
+                    int i = 0;
+                    for (Map.Entry<String, KafkaMetric> entry : metrics.entrySet()) {
+                        String attribute = entry.getKey();
+                        KafkaMetric metric = entry.getValue();
+                        attrs[i] = new MBeanAttributeInfo(attribute,
+                                double.class.getName(),
+                                metric.metricName().description(),
+                                true,
+                                false,
+                                false);
+                        i += 1;
+                    }
+                    return attrs;
+                });
         }
 
         @Override

--- a/clients/src/main/java/org/apache/kafka/common/metrics/LazyMBeanInfo.java
+++ b/clients/src/main/java/org/apache/kafka/common/metrics/LazyMBeanInfo.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.metrics;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanConstructorInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanNotificationInfo;
+import javax.management.MBeanOperationInfo;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+
+/**
+ * an MBeanInfo subclass that lazily calculates attributes
+ */
+public class LazyMBeanInfo extends MBeanInfo implements Serializable  {
+    private final Supplier<MBeanAttributeInfo[]> supplier;
+    private volatile MBeanAttributeInfo[] lazyAttrs = null;
+
+    public LazyMBeanInfo(
+        String className,
+        String description,
+        MBeanConstructorInfo[] constructors,
+        MBeanOperationInfo[] operations,
+        MBeanNotificationInfo[] notifications,
+        Supplier<MBeanAttributeInfo[]> supplier
+    ) throws IllegalArgumentException {
+        super(className, description, null, constructors, operations, notifications);
+        this.supplier = supplier;
+    }
+
+    @Override
+    public MBeanAttributeInfo[] getAttributes() {
+        MBeanAttributeInfo[] val = lazyAttrs;
+        if (val != null) {
+            return val.clone(); //match upstream behaviour
+        }
+        val = supplier.get();
+        if (val == null) {
+            val = new MBeanAttributeInfo[0];
+        }
+        lazyAttrs = val;
+        return val.clone();
+    }
+
+    /**
+     * JMX uses RMI, which relies on serializing MBeans over to the remote (jconsole) JVM.
+     * This means we cant ship any custom classes over, as they would not be found for
+     * de-serializations.
+     * @return a vanilla {@link MBeanInfo} instance in our stead
+     * @throws ObjectStreamException
+     */
+    protected Object writeReplace() throws ObjectStreamException {
+        return new MBeanInfo(
+                getClassName(), 
+                getDescription(), 
+                getAttributes(), //materializes the attributes 
+                getConstructors(), 
+                getOperations(),
+                getNotifications(),
+                getDescriptor()
+        );
+    }
+}


### PR DESCRIPTION
kafka re-registers its sensor MBean on any sensor change (addition/removal of sensors).
kafka also has per-topic-partition sensors, and the mbean attribute array size is a multiple of those.
on large assignment sets (~35K topic partitions assigned to a single consumer), we've seen sensor registration code take 5 entire consecutive minutes (!!) of CPU time.

the offending code path is in (re)registering the MBean, which triggers this code (called by `DefaultMBeanServerInterceptor.registerMBean()`)
```java
    private static String getNewMBeanClassName(Object mbeanToRegister)
            throws NotCompliantMBeanException {
        if (mbeanToRegister instanceof DynamicMBean) {
            DynamicMBean mbean = (DynamicMBean) mbeanToRegister;
            final String name;
            try {
                name = mbean.getMBeanInfo().getClassName(); <----- THIS
            } catch (Exception e) {
                // Includes case where getMBeanInfo() returns null
                NotCompliantMBeanException ncmbe =
                    new NotCompliantMBeanException("Bad getMBeanInfo()");
                ncmbe.initCause(e);
                throw ncmbe;
            }
            if (name == null) {
                final String msg = "MBeanInfo has null class name";
                throw new NotCompliantMBeanException(msg);
            }
            return name;
        } else
            return mbeanToRegister.getClass().getName();
    }
```
this triggers the creation of the (big) attribute array, while the caller really only wants the mbean name.

this patch delays the array creation to the time when the mbean attributes are actually queried - which may be never (in case no one is even looking at the jmx sensors).

in local testing this removes a ~5 minute delay in rebalancing/assigning large groups of topic partitions.
