### PR TITLE
[KAFKA-6899] Fix potential NPE when retrieving JAAS configuration

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/kerberos/KerberosLogin.java
@@ -105,7 +105,7 @@ public class KerberosLogin extends AbstractLogin {
         isKrbTicket = !subject.getPrivateCredentials(KerberosTicket.class).isEmpty();
 
         AppConfigurationEntry[] entries = configuration().getAppConfigurationEntry(contextName());
-        if (entries.length == 0) {
+        if (entries == null || entries.length == 0) {
             isUsingTicketCache = false;
             principal = null;
         } else {


### PR DESCRIPTION
We have developed a static analysis tool [NPEDetector ](https://github.com/lujiefsi/NPEDetector) find some potential NPE. Our analysis shows that NPE reason can be simple:some callees may return null directly in corner case(e.g. node crash , IO exception), some of their callers have  !=null check but some do not have. 

### Bug:

callee JaasConfig#getAppConfigurationEntry  can return null, it has 13 callers, 11 of the callers have the null check while using the return value, one of them have no checker :

<pre>
//caller:KerberosLogin#login()
AppConfigurationEntry[] entries = configuration().getAppConfigurationEntry(contextName());
if (entries.length == 0)/may NPE
</pre>
I am not sure whether it is an bug or not, please correct me without any without any hesitation.