### PR TITLE
KAFKA-6566: Improve Connect Resource Cleanup

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -88,7 +88,6 @@ class WorkerSinkTask extends WorkerTask {
     private int commitFailures;
     private boolean pausedForRedelivery;
     private boolean committing;
-    private boolean stopped;
 
     public WorkerSinkTask(ConnectorTaskId id,
                           SinkTask task,
@@ -122,7 +121,6 @@ class WorkerSinkTask extends WorkerTask {
         this.commitSeqno = 0;
         this.commitStarted = -1;
         this.commitFailures = 0;
-        this.stopped = false;
         this.sinkTaskMetricsGroup = new SinkTaskMetricsGroup(id, connectMetrics);
         this.sinkTaskMetricsGroup.recordOffsetSequenceNumber(commitSeqno);
     }
@@ -143,26 +141,18 @@ class WorkerSinkTask extends WorkerTask {
     public void stop() {
         // Offset commit is handled upon exit in work thread
         super.stop();
-        tryStop();
         consumer.wakeup();
-    }
-
-    private void tryStop() {
-        if (!stopped) {
-            try {
-                task.stop();
-                stopped = true;
-            } catch (Throwable t) {
-                log.warn("Could not stop task", t);
-            }
-        }
     }
 
     @Override
     protected void close() {
         // FIXME Kafka needs to add a timeout parameter here for us to properly obey the timeout
         // passed in
-        tryStop();
+        try {
+            task.stop();
+        } catch (Throwable t) {
+            log.warn("Could not stop task", t);
+        }
         if (consumer != null) {
             try {
                 consumer.close();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -157,13 +157,13 @@ class WorkerSinkTask extends WorkerTask {
             try {
                 consumer.close();
             } catch (Throwable t) {
-                log.warn("Could not stop consumer", t);
+                log.warn("Could not close consumer", t);
             }
         }
         try {
             transformationChain.close();
         } catch (Throwable t) {
-            log.warn("Could not stop transformation chain", t);
+            log.warn("Could not close transformation chain", t);
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -138,20 +138,18 @@ class WorkerSourceTask extends WorkerTask {
 
     @Override
     protected void close() {
-        synchronized (this) {
-            tryStop();
-        }
+        tryStop();
         if (producer != null) {
             try {
                 producer.close(30, TimeUnit.SECONDS);
             } catch (Throwable t) {
-                log.warn("Could not stop producer", t);
+                log.warn("Could not close producer", t);
             }
         }
         try {
             transformationChain.close();
         } catch (Throwable t) {
-            log.warn("Could not stop transformation chain", t);
+            log.warn("Could not close transformation chain", t);
         }
     }
 
@@ -172,7 +170,7 @@ class WorkerSourceTask extends WorkerTask {
         }
     }
 
-    private void tryStop() {
+    private synchronized void tryStop() {
         if (!stopped) {
             try {
                 task.stop();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSourceTask.java
@@ -138,7 +138,9 @@ class WorkerSourceTask extends WorkerTask {
 
     @Override
     protected void close() {
-        tryStop();
+        if (!shouldPause()) {
+            tryStop();
+        }
         if (producer != null) {
             try {
                 producer.close(30, TimeUnit.SECONDS);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -164,9 +164,6 @@ public class WorkerSourceTaskTest extends ThreadedTest {
             }
         });
 
-        sourceTask.stop();
-        EasyMock.expectLastCall();
-
         producer.close(EasyMock.anyLong(), EasyMock.anyObject(TimeUnit.class));
         EasyMock.expectLastCall();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSourceTaskTest.java
@@ -164,6 +164,9 @@ public class WorkerSourceTaskTest extends ThreadedTest {
             }
         });
 
+        sourceTask.stop();
+        EasyMock.expectLastCall();
+
         producer.close(EasyMock.anyLong(), EasyMock.anyObject(TimeUnit.class));
         EasyMock.expectLastCall();
 


### PR DESCRIPTION
This is a change to improve resource cleanup for sink tasks and source tasks.  Now `Task.stop()` is called from both `WorkerSinkTask.close()` and `WorkerSourceTask.close()`.

It is called from `WorkerXXXTask.close()` since this method is called in the `finally` block of `WorkerTask.run()`, and Connect developers use `stop()` to clean up resources.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)