### PR TITLE
KAFKA-6905: Document that Transformers may be re-used by Streams

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Transformer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Transformer.java
@@ -51,6 +51,8 @@ public interface Transformer<K, V, R> {
     /**
      * Initialize this transformer.
      * This is called once per instance when the topology gets initialized.
+     * When the framework is done with the transformer, {@link #close()} will be called on it; the
+     * framework may later re-use the transformer by calling {@link #init()} again.
      * <p>
      * The provided {@link ProcessorContext context} can be used to access topology and record meta data, to
      * {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule} a method to be
@@ -81,7 +83,8 @@ public interface Transformer<K, V, R> {
     R transform(final K key, final V value);
 
     /**
-     * Close this processor and clean up any resources.
+     * Close this transformer and clean up any resources. The framework may
+     * later re-use this transformer by calling {@link #init()} on it again.
      * <p>
      * To generate new {@link KeyValue} pairs {@link ProcessorContext#forward(Object, Object)} and
      * {@link ProcessorContext#forward(Object, Object, To)} can be used.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformer.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/ValueTransformer.java
@@ -50,6 +50,8 @@ public interface ValueTransformer<V, VR> {
     /**
      * Initialize this transformer.
      * This is called once per instance when the topology gets initialized.
+     * When the framework is done with the transformer, {@link #close()} will be called on it; the
+     * framework may later re-use the transformer by calling {@link #init()} again.
      * <p>
      * The provided {@link ProcessorContext context} can be used to access topology and record meta data, to
      * {@link ProcessorContext#schedule(long, PunctuationType, Punctuator) schedule} a method to be
@@ -84,7 +86,8 @@ public interface ValueTransformer<V, VR> {
     VR transform(final V value);
 
     /**
-     * Close this processor and clean up any resources.
+     * Close this transformer and clean up any resources. The framework may
+     * later re-use this transformer by calling {@link #init()} on it again.
      * <p>
      * It is not possible to return any new output records within {@code close()}.
      * Using {@link ProcessorContext#forward(Object, Object)} or {@link ProcessorContext#forward(Object, Object, To)}


### PR DESCRIPTION
This is a follow-up to #5022 which added documentation to the Processor
interface. This commit adds similar documentation to Transformer and
ValueTransformer.

Also, s/processor/transformer/ in the close() docs.
