### PR TITLE
KAFKA-6913: Add Connect converters and header converters for short, integer, long, float, and double (WIP)

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/DoubleConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/DoubleConverter.java
@@ -32,9 +32,4 @@ public class DoubleConverter extends NumberConverter<Double> {
     public DoubleConverter() {
         super("double", Schema.OPTIONAL_FLOAT64_SCHEMA, new DoubleSerializer(), new DoubleDeserializer());
     }
-
-    @Override
-    protected Double cast(Object value) {
-        return (Double) value;
-    }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/DoubleConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/DoubleConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from double values.
+ * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return an
+ * optional FLOAT64 schema.
+ * <p>
+ * This implementation currently does nothing with the topic names or header names.
+ */
+public class DoubleConverter extends NumberConverter<Double> {
+
+    public DoubleConverter() {
+        super("double", Schema.OPTIONAL_FLOAT64_SCHEMA, new DoubleSerializer(), new DoubleDeserializer());
+    }
+
+    @Override
+    protected Double cast(Object value) {
+        return (Double) value;
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/FloatConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/FloatConverter.java
@@ -32,9 +32,4 @@ public class FloatConverter extends NumberConverter<Float> {
     public FloatConverter() {
         super("float", Schema.OPTIONAL_FLOAT32_SCHEMA, new FloatSerializer(), new FloatDeserializer());
     }
-
-    @Override
-    protected Float cast(Object value) {
-        return (Float) value;
-    }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/FloatConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/FloatConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from float values.
+ * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return an
+ * optional FLOAT32 schema.
+ * <p>
+ * This implementation currently does nothing with the topic names or header names.
+ */
+public class FloatConverter extends NumberConverter<Float> {
+
+    public FloatConverter() {
+        super("float", Schema.OPTIONAL_FLOAT32_SCHEMA, new FloatSerializer(), new FloatDeserializer());
+    }
+
+    @Override
+    protected Float cast(Object value) {
+        return (Float) value;
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/IntegerConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/IntegerConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from integer values.
+ * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return an
+ * optional INT32 schema.
+ * <p>
+ * This implementation currently does nothing with the topic names or header names.
+ */
+public class IntegerConverter extends NumberConverter<Integer> {
+
+    public IntegerConverter() {
+        super("integer", Schema.OPTIONAL_INT32_SCHEMA, new IntegerSerializer(), new IntegerDeserializer());
+    }
+
+    @Override
+    protected Integer cast(Object value) {
+        return (Integer) value;
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/IntegerConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/IntegerConverter.java
@@ -32,9 +32,4 @@ public class IntegerConverter extends NumberConverter<Integer> {
     public IntegerConverter() {
         super("integer", Schema.OPTIONAL_INT32_SCHEMA, new IntegerSerializer(), new IntegerDeserializer());
     }
-
-    @Override
-    protected Integer cast(Object value) {
-        return (Integer) value;
-    }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/LongConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/LongConverter.java
@@ -33,8 +33,4 @@ public class LongConverter extends NumberConverter<Long> {
         super("long", Schema.OPTIONAL_INT64_SCHEMA, new LongSerializer(), new LongDeserializer());
     }
 
-    @Override
-    protected Long cast(Object value) {
-        return (Long) value;
-    }
 }

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/LongConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/LongConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from long values.
+ * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return an
+ * optional INT64 schema.
+ * <p>
+ * This implementation currently does nothing with the topic names or header names.
+ */
+public class LongConverter extends NumberConverter<Long> {
+
+    public LongConverter() {
+        super("long", Schema.OPTIONAL_INT64_SCHEMA, new LongSerializer(), new LongDeserializer());
+    }
+
+    @Override
+    protected Long cast(Object value) {
+        return (Long) value;
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from number values.
+ * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return the specified
+ * optional schema.
+ * <p>
+ * This implementation currently does nothing with the topic names or header names.
+ */
+public abstract class NumberConverter<T extends Number> implements Converter, HeaderConverter {
+
+    private final Serializer<T> serializer;
+    private final Deserializer<T> deserializer;
+    private final String typeName;
+    private final Schema schema;
+
+    /**
+     * Create the converter.
+     *
+     * @param typeName the displayable name of the type; may not be null
+     * @param schema the optional schema to be used for all deserialized forms; may not be null
+     * @param serializer the serializer; may not be null
+     * @param deserializer the deserializer; may not be null
+     */
+    protected NumberConverter(String typeName, Schema schema, Serializer<T> serializer, Deserializer<T> deserializer) {
+        this.typeName = typeName;
+        this.schema = schema;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+        assert this.serializer != null;
+        assert this.deserializer != null;
+        assert this.typeName != null;
+        assert this.schema != null;
+        assert this.schema.isOptional();
+    }
+
+    @Override
+    public ConfigDef config() {
+        return null;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        NumberConverterConfig conf = new NumberConverterConfig(configs);
+        boolean isKey = conf.type() == ConverterType.KEY;
+        serializer.configure(configs, isKey);
+        deserializer.configure(configs, isKey);
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        Map<String, Object> conf = new HashMap<>(configs);
+        conf.put(StringConverterConfig.TYPE_CONFIG, isKey ? ConverterType.KEY.getName() : ConverterType.VALUE.getName());
+        configure(conf);
+    }
+
+    protected abstract T cast(Object value);
+
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        try {
+            return serializer.serialize(topic, value == null ? null : cast(value));
+        } catch (ClassCastException e) {
+            throw new DataException("Failed to serialize to " + typeName + " (was " + value.getClass() + "): ", e);
+        } catch (SerializationException e) {
+            throw new DataException("Failed to serialize to " + typeName + ": ", e);
+        }
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+        try {
+            return new SchemaAndValue(schema, deserializer.deserialize(topic, value));
+        } catch (SerializationException e) {
+            throw new DataException("Failed to deserialize " + typeName + ": ", e);
+        }
+    }
+
+    @Override
+    public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+        return fromConnectData(topic, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+        return toConnectData(topic, value);
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverter.java
@@ -64,7 +64,7 @@ public abstract class NumberConverter<T extends Number> implements Converter, He
 
     @Override
     public ConfigDef config() {
-        return null;
+        return NumberConverterConfig.configDef();
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverter.java
@@ -31,11 +31,11 @@ import java.util.Map;
 /**
  * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from number values.
  * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return the specified
- * optional schema.
+ * schema.
  * <p>
  * This implementation currently does nothing with the topic names or header names.
  */
-public abstract class NumberConverter<T extends Number> implements Converter, HeaderConverter {
+abstract class NumberConverter<T extends Number> implements Converter, HeaderConverter {
 
     private final Serializer<T> serializer;
     private final Deserializer<T> deserializer;
@@ -59,7 +59,6 @@ public abstract class NumberConverter<T extends Number> implements Converter, He
         assert this.deserializer != null;
         assert this.typeName != null;
         assert this.schema != null;
-        assert this.schema.isOptional();
     }
 
     @Override
@@ -83,7 +82,9 @@ public abstract class NumberConverter<T extends Number> implements Converter, He
         configure(conf);
     }
 
-    protected abstract T cast(Object value);
+    protected T cast(Object value) {
+        return (T) value;
+    }
 
     @Override
     public byte[] fromConnectData(String topic, Schema schema, Object value) {

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverterConfig.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverterConfig.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+/**
+ * Configuration options for {@link StringConverter} instances.
+ */
+public class NumberConverterConfig extends ConverterConfig {
+
+    private final static ConfigDef CONFIG;
+
+    static {
+        CONFIG = ConverterConfig.newConfigDef();
+    }
+
+    public static ConfigDef configDef() {
+        return CONFIG;
+    }
+
+    public NumberConverterConfig(Map<String, ?> props) {
+        super(CONFIG, props);
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverterConfig.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverterConfig.java
@@ -21,7 +21,8 @@ import org.apache.kafka.common.config.ConfigDef;
 import java.util.Map;
 
 /**
- * Configuration options for {@link StringConverter} instances.
+ * Configuration options for instances of {@link LongConverter}, {@link IntegerConverter}, {@link ShortConverter}, {@link DoubleConverter},
+ * and {@link FloatConverter} instances.
  */
 public class NumberConverterConfig extends ConverterConfig {
 

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverterConfig.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/NumberConverterConfig.java
@@ -25,11 +25,7 @@ import java.util.Map;
  */
 public class NumberConverterConfig extends ConverterConfig {
 
-    private final static ConfigDef CONFIG;
-
-    static {
-        CONFIG = ConverterConfig.newConfigDef();
-    }
+    private final static ConfigDef CONFIG = ConverterConfig.newConfigDef();
 
     public static ConfigDef configDef() {
         return CONFIG;

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/ShortConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/ShortConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.ShortDeserializer;
+import org.apache.kafka.common.serialization.ShortSerializer;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * {@link Converter} and {@link HeaderConverter} implementation that only supports serializing to and deserializing from short values.
+ * It does support handling nulls. When converting from bytes to Kafka Connect format, the converter will always return an
+ * optional INT16 schema.
+ * <p>
+ * This implementation currently does nothing with the topic names or header names.
+ */
+public class ShortConverter extends NumberConverter<Short> {
+
+    public ShortConverter() {
+        super("short", Schema.OPTIONAL_INT16_SCHEMA, new ShortSerializer(), new ShortDeserializer());
+    }
+
+    @Override
+    protected Short cast(Object value) {
+        return (Short) value;
+    }
+}

--- a/connect/api/src/main/java/org/apache/kafka/connect/storage/ShortConverter.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/storage/ShortConverter.java
@@ -32,9 +32,4 @@ public class ShortConverter extends NumberConverter<Short> {
     public ShortConverter() {
         super("short", Schema.OPTIONAL_INT16_SCHEMA, new ShortSerializer(), new ShortDeserializer());
     }
-
-    @Override
-    protected Short cast(Object value) {
-        return (Short) value;
-    }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/DoubleConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/DoubleConverterTest.java
@@ -17,56 +17,27 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
+public class DoubleConverterTest extends NumberConverterTest<Double> {
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-public class DoubleConverterTest {
-    private static final String TOPIC = "topic";
-    private static final Double SAMPLE_VALUE = 1234.31d;
-    private static final byte[] SAMPLE_VALUE_BYTES = new DoubleSerializer().serialize(TOPIC, SAMPLE_VALUE);
-    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_FLOAT64_SCHEMA;
-    private static final DoubleConverter CONVERTER = new DoubleConverter();
-
-    @Test
-    public void testNumberToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    public Double[] samples() {
+        return new Double[]{Double.MIN_VALUE, 1234.31, Double.MAX_VALUE};
     }
 
-    @Test
-    public void testNullToBytes() {
-        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    @Override
+    protected Schema schema() {
+        return Schema.OPTIONAL_FLOAT64_SCHEMA;
     }
 
-    @Test
-    public void testBytesToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(SAMPLE_VALUE, data.value());
+    @Override
+    protected NumberConverter<Double> createConverter() {
+        return new DoubleConverter();
     }
 
-    @Test
-    public void testBytesNullToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(null, data.value());
-    }
-
-    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
-    // The following simply verify that the delegation works.
-
-    @Test
-    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
-    }
-
-    @Test
-    public void testNullHeaderValueToBytes() {
-        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    @Override
+    protected Serializer<Double> createSerializer() {
+        return new DoubleSerializer();
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/DoubleConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/DoubleConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.DoubleSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class DoubleConverterTest {
+    private static final String TOPIC = "topic";
+    private static final Double SAMPLE_VALUE = 1234.31d;
+    private static final byte[] SAMPLE_VALUE_BYTES = new DoubleSerializer().serialize(TOPIC, SAMPLE_VALUE);
+    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_FLOAT64_SCHEMA;
+    private static final DoubleConverter CONVERTER = new DoubleConverter();
+
+    @Test
+    public void testNumberToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullToBytes() {
+        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    }
+
+    @Test
+    public void testBytesToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(SAMPLE_VALUE, data.value());
+    }
+
+    @Test
+    public void testBytesNullToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(null, data.value());
+    }
+
+    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
+    // The following simply verify that the delegation works.
+
+    @Test
+    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullHeaderValueToBytes() {
+        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/FloatConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/FloatConverterTest.java
@@ -17,56 +17,27 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
+public class FloatConverterTest extends NumberConverterTest<Float> {
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-public class FloatConverterTest {
-    private static final String TOPIC = "topic";
-    private static final Float SAMPLE_VALUE = 1234.1f;
-    private static final byte[] SAMPLE_VALUE_BYTES = new FloatSerializer().serialize(TOPIC, SAMPLE_VALUE);
-    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_FLOAT32_SCHEMA;
-    private static final FloatConverter CONVERTER = new FloatConverter();
-
-    @Test
-    public void testNumberToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    public Float[] samples() {
+        return new Float[]{Float.MIN_VALUE, 1234.31f, Float.MAX_VALUE};
     }
 
-    @Test
-    public void testNullToBytes() {
-        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    @Override
+    protected Schema schema() {
+        return Schema.OPTIONAL_FLOAT32_SCHEMA;
     }
 
-    @Test
-    public void testBytesToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(SAMPLE_VALUE, data.value());
+    @Override
+    protected NumberConverter<Float> createConverter() {
+        return new FloatConverter();
     }
 
-    @Test
-    public void testBytesNullToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(null, data.value());
-    }
-
-    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
-    // The following simply verify that the delegation works.
-
-    @Test
-    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
-    }
-
-    @Test
-    public void testNullHeaderValueToBytes() {
-        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    @Override
+    protected Serializer<Float> createSerializer() {
+        return new FloatSerializer();
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/FloatConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/FloatConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class FloatConverterTest {
+    private static final String TOPIC = "topic";
+    private static final Float SAMPLE_VALUE = 1234.1f;
+    private static final byte[] SAMPLE_VALUE_BYTES = new FloatSerializer().serialize(TOPIC, SAMPLE_VALUE);
+    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_FLOAT32_SCHEMA;
+    private static final FloatConverter CONVERTER = new FloatConverter();
+
+    @Test
+    public void testNumberToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullToBytes() {
+        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    }
+
+    @Test
+    public void testBytesToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(SAMPLE_VALUE, data.value());
+    }
+
+    @Test
+    public void testBytesNullToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(null, data.value());
+    }
+
+    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
+    // The following simply verify that the delegation works.
+
+    @Test
+    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullHeaderValueToBytes() {
+        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/IntegerConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/IntegerConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class IntegerConverterTest {
+    private static final String TOPIC = "topic";
+    private static final Integer SAMPLE_VALUE = 1234;
+    private static final byte[] SAMPLE_VALUE_BYTES = new IntegerSerializer().serialize(TOPIC, SAMPLE_VALUE);
+    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_INT32_SCHEMA;
+    private static final IntegerConverter CONVERTER = new IntegerConverter();
+
+    @Test
+    public void testNumberToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullToBytes() {
+        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    }
+
+    @Test
+    public void testBytesToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(SAMPLE_VALUE, data.value());
+    }
+
+    @Test
+    public void testBytesNullToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(null, data.value());
+    }
+
+    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
+    // The following simply verify that the delegation works.
+
+    @Test
+    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullHeaderValueToBytes() {
+        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/IntegerConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/IntegerConverterTest.java
@@ -17,56 +17,27 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
+public class IntegerConverterTest extends NumberConverterTest<Integer> {
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-public class IntegerConverterTest {
-    private static final String TOPIC = "topic";
-    private static final Integer SAMPLE_VALUE = 1234;
-    private static final byte[] SAMPLE_VALUE_BYTES = new IntegerSerializer().serialize(TOPIC, SAMPLE_VALUE);
-    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_INT32_SCHEMA;
-    private static final IntegerConverter CONVERTER = new IntegerConverter();
-
-    @Test
-    public void testNumberToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    public Integer[] samples() {
+        return new Integer[]{Integer.MIN_VALUE, 1234, Integer.MAX_VALUE};
     }
 
-    @Test
-    public void testNullToBytes() {
-        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    @Override
+    protected Schema schema() {
+        return Schema.OPTIONAL_INT32_SCHEMA;
     }
 
-    @Test
-    public void testBytesToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(SAMPLE_VALUE, data.value());
+    @Override
+    protected NumberConverter<Integer> createConverter() {
+        return new IntegerConverter();
     }
 
-    @Test
-    public void testBytesNullToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(null, data.value());
-    }
-
-    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
-    // The following simply verify that the delegation works.
-
-    @Test
-    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
-    }
-
-    @Test
-    public void testNullHeaderValueToBytes() {
-        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    @Override
+    protected Serializer<Integer> createSerializer() {
+        return new IntegerSerializer();
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/LongConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/LongConverterTest.java
@@ -17,56 +17,27 @@
 package org.apache.kafka.connect.storage;
 
 import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
+public class LongConverterTest extends NumberConverterTest<Long> {
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-public class LongConverterTest {
-    private static final String TOPIC = "topic";
-    private static final Long SAMPLE_VALUE = 1234L;
-    private static final byte[] SAMPLE_VALUE_BYTES = new LongSerializer().serialize(TOPIC, SAMPLE_VALUE);
-    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_INT64_SCHEMA;
-    private static final LongConverter CONVERTER = new LongConverter();
-
-    @Test
-    public void testNumberToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    public Long[] samples() {
+        return new Long[]{Long.MIN_VALUE, 1234L, Long.MAX_VALUE};
     }
 
-    @Test
-    public void testNullToBytes() {
-        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    @Override
+    protected Schema schema() {
+        return Schema.OPTIONAL_INT64_SCHEMA;
     }
 
-    @Test
-    public void testBytesToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(SAMPLE_VALUE, data.value());
+    @Override
+    protected NumberConverter<Long> createConverter() {
+        return new LongConverter();
     }
 
-    @Test
-    public void testBytesNullToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(null, data.value());
-    }
-
-    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
-    // The following simply verify that the delegation works.
-
-    @Test
-    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
-    }
-
-    @Test
-    public void testNullHeaderValueToBytes() {
-        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    @Override
+    protected Serializer<Long> createSerializer() {
+        return new LongSerializer();
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/LongConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/LongConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class LongConverterTest {
+    private static final String TOPIC = "topic";
+    private static final Long SAMPLE_VALUE = 1234L;
+    private static final byte[] SAMPLE_VALUE_BYTES = new LongSerializer().serialize(TOPIC, SAMPLE_VALUE);
+    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_INT64_SCHEMA;
+    private static final LongConverter CONVERTER = new LongConverter();
+
+    @Test
+    public void testNumberToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullToBytes() {
+        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    }
+
+    @Test
+    public void testBytesToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(SAMPLE_VALUE, data.value());
+    }
+
+    @Test
+    public void testBytesNullToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(null, data.value());
+    }
+
+    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
+    // The following simply verify that the delegation works.
+
+    @Test
+    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullHeaderValueToBytes() {
+        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/NumberConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/NumberConverterTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.connect.storage;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,6 +69,26 @@ public abstract class NumberConverterTest<T extends Number> {
             assertEquals(schema, data.schema());
             assertEquals(sample, data.value());
         }
+    }
+
+    @Test(expected = DataException.class)
+    public void testDeserializingDataWithTooManyBytes() {
+        converter.toConnectData(TOPIC, new byte[10]);
+    }
+
+    @Test(expected = DataException.class)
+    public void testDeserializingHeaderWithTooManyBytes() {
+        converter.toConnectHeader(TOPIC, HEADER_NAME, new byte[10]);
+    }
+
+    @Test(expected = DataException.class)
+    public void testSerializingIncorrectType() {
+        converter.fromConnectData(TOPIC, schema, "not a valid number");
+    }
+
+    @Test(expected = DataException.class)
+    public void testSerializingIncorrectHeader() {
+        converter.fromConnectHeader(TOPIC, HEADER_NAME, schema, "not a valid number");
     }
 
     @Test

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/NumberConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/NumberConverterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public abstract class NumberConverterTest<T extends Number> {
+    private static final String TOPIC = "topic";
+    private static final String HEADER_NAME = "header";
+
+    private T[] samples;
+    private Schema schema;
+    private NumberConverter<T> converter;
+    private Serializer<T> serializer;
+
+    protected abstract T[] samples();
+
+    protected abstract NumberConverter<T> createConverter();
+
+    protected abstract Serializer<T> createSerializer();
+
+    protected abstract Schema schema();
+
+    @Before
+    public void setup() {
+        converter = createConverter();
+        serializer = createSerializer();
+        schema = schema();
+        samples = samples();
+    }
+
+    @Test
+    public void testConvertingSamplesToAndFromBytes() throws UnsupportedOperationException {
+        for (T sample : samples) {
+            byte[] expected = serializer.serialize(TOPIC, sample);
+
+            // Data conversion
+            assertArrayEquals(expected, converter.fromConnectData(TOPIC, schema, sample));
+            SchemaAndValue data = converter.toConnectData(TOPIC, expected);
+            assertEquals(schema, data.schema());
+            assertEquals(sample, data.value());
+
+            // Header conversion
+            assertArrayEquals(expected, converter.fromConnectHeader(TOPIC, HEADER_NAME, schema, sample));
+            data = converter.toConnectHeader(TOPIC, HEADER_NAME, expected);
+            assertEquals(schema, data.schema());
+            assertEquals(sample, data.value());
+        }
+    }
+
+    @Test
+    public void testNullToBytes() {
+        assertEquals(null, converter.fromConnectData(TOPIC, schema, null));
+    }
+
+    @Test
+    public void testBytesNullToNumber() {
+        SchemaAndValue data = converter.toConnectData(TOPIC, null);
+        assertEquals(schema(), data.schema());
+        assertEquals(null, data.value());
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/NumberConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/NumberConverterTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public abstract class NumberConverterTest<T extends Number> {
     private static final String TOPIC = "topic";
@@ -78,6 +79,6 @@ public abstract class NumberConverterTest<T extends Number> {
     public void testBytesNullToNumber() {
         SchemaAndValue data = converter.toConnectData(TOPIC, null);
         assertEquals(schema(), data.schema());
-        assertEquals(null, data.value());
+        assertNull(data.value());
     }
 }

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/ShortConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/ShortConverterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.storage;
+
+import org.apache.kafka.common.serialization.ShortSerializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class ShortConverterTest {
+    private static final String TOPIC = "topic";
+    private static final Short SAMPLE_VALUE = 123;
+    private static final byte[] SAMPLE_VALUE_BYTES = new ShortSerializer().serialize(TOPIC, SAMPLE_VALUE);
+    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_INT16_SCHEMA;
+    private static final ShortConverter CONVERTER = new ShortConverter();
+
+    @Test
+    public void testNumberToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullToBytes() {
+        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    }
+
+    @Test
+    public void testBytesToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(SAMPLE_VALUE, data.value());
+    }
+
+    @Test
+    public void testBytesNullToNumber() {
+        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
+        assertEquals(SAMPLE_SCHEMA, data.schema());
+        assertEquals(null, data.value());
+    }
+
+    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
+    // The following simply verify that the delegation works.
+
+    @Test
+    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
+        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
+    }
+
+    @Test
+    public void testNullHeaderValueToBytes() {
+        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    }
+}

--- a/connect/api/src/test/java/org/apache/kafka/connect/storage/ShortConverterTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/storage/ShortConverterTest.java
@@ -16,57 +16,29 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.ShortSerializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
-import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
+public class ShortConverterTest extends NumberConverterTest<Short> {
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-public class ShortConverterTest {
-    private static final String TOPIC = "topic";
-    private static final Short SAMPLE_VALUE = 123;
-    private static final byte[] SAMPLE_VALUE_BYTES = new ShortSerializer().serialize(TOPIC, SAMPLE_VALUE);
-    private static final Schema SAMPLE_SCHEMA = Schema.OPTIONAL_INT16_SCHEMA;
-    private static final ShortConverter CONVERTER = new ShortConverter();
-
-    @Test
-    public void testNumberToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, SAMPLE_VALUE));
+    public Short[] samples() {
+        return new Short[]{Short.MIN_VALUE, 123, Short.MAX_VALUE};
     }
 
-    @Test
-    public void testNullToBytes() {
-        assertEquals(null, CONVERTER.fromConnectData(TOPIC, SAMPLE_SCHEMA, null));
+    @Override
+    protected Schema schema() {
+        return Schema.OPTIONAL_INT16_SCHEMA;
     }
 
-    @Test
-    public void testBytesToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, SAMPLE_VALUE_BYTES);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(SAMPLE_VALUE, data.value());
+    @Override
+    protected NumberConverter<Short> createConverter() {
+        return new ShortConverter();
     }
 
-    @Test
-    public void testBytesNullToNumber() {
-        SchemaAndValue data = CONVERTER.toConnectData(TOPIC, null);
-        assertEquals(SAMPLE_SCHEMA, data.schema());
-        assertEquals(null, data.value());
-    }
-
-    // Note: the header conversion methods delegates to the data conversion methods, which are tested above.
-    // The following simply verify that the delegation works.
-
-    @Test
-    public void testHeaderValueToBytes() throws UnsupportedEncodingException {
-        assertArrayEquals(SAMPLE_VALUE_BYTES, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, SAMPLE_VALUE));
-    }
-
-    @Test
-    public void testNullHeaderValueToBytes() {
-        assertEquals(null, CONVERTER.fromConnectHeader(TOPIC, "hdr", SAMPLE_SCHEMA, null));
+    @Override
+    protected Serializer<Short> createSerializer() {
+        return new ShortSerializer();
     }
 }
+


### PR DESCRIPTION
*[KIP-305](https://cwiki.apache.org/confluence/display/KAFKA/KIP-305%3A+Add+Connect+primitive+number+converters) has been approved.*

Added converters and header converters for the primitive number types for which Kafka already had serializers and deserializers. All extend a common base class, `NumberConverter`, that encapsulates most of the shared functionality. Unit tests were added to check the basic functionality.

These classes are not used by any other Connect code, and must be explicitly used in Connect workers and connectors.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
