### PR TITLE
MINOR: Remove duplicate code which is invoked twice

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/NamedCache.java
@@ -257,7 +257,6 @@ class NamedCache {
         }
 
         remove(node);
-        cache.remove(key);
         dirtyKeys.remove(key);
         currentSizeBytes -= node.size();
         return node.entry();


### PR DESCRIPTION
*More detailed description of your change*
I have removed the logic that unnecessarily calls cache.remove twice.

*Summary of testing strategy*
I have confirmed that there is no problem by executing Unit Test of NamedCache.
`./gradlew -Dtest.single=NamedCacheTest streams:test`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
