### PR TITLE
MINOR: Reduce required disconnect message frequency

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -91,9 +91,9 @@ class StreamsBrokerDownResilience(BaseStreamsTest):
         broker_unavailable_message = "Broker may not be available"
 
         # verify streams instances unable to connect to broker, kept trying
-        self.wait_for_verification(processor, broker_unavailable_message, processor.LOG_FILE, 100)
-        self.wait_for_verification(processor_2, broker_unavailable_message, processor_2.LOG_FILE, 100)
-        self.wait_for_verification(processor_3, broker_unavailable_message, processor_3.LOG_FILE, 100)
+        self.wait_for_verification(processor, broker_unavailable_message, processor.LOG_FILE, 10)
+        self.wait_for_verification(processor_2, broker_unavailable_message, processor_2.LOG_FILE, 10)
+        self.wait_for_verification(processor_3, broker_unavailable_message, processor_3.LOG_FILE, 10)
 
         # now start broker
         self.kafka.start_node(node)


### PR DESCRIPTION
Due to https://github.com/apache/kafka/pull/4644 the consumer connector logs will be much more clean with fewer "broker may not be available" entries. We need to reduce the required frequency from 100 to a smaller number.

I've thought about reducing to just 1, but it may still be transient (i.e. even if broker is starting up you may see a few entries) so I reduced it to 10.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
