### PR TITLE
KAFKA-6916: Refresh metadata in admin client if broker connection fails

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -1011,6 +1011,7 @@ public class KafkaAdminClient extends AdminClient {
         @Override
         public void run() {
             long now = time.milliseconds();
+            long lastIterationTimeMs = Long.MAX_VALUE;
             log.trace("Thread starting");
             while (true) {
                 // Copy newCalls into pendingCalls.
@@ -1030,6 +1031,18 @@ public class KafkaAdminClient extends AdminClient {
                 long pollTimeout = Math.min(1200000, timeoutProcessor.nextTimeoutMs());
                 if (curHardShutdownTimeMs != INVALID_SHUTDOWN_TIME) {
                     pollTimeout = Math.min(pollTimeout, curHardShutdownTimeMs - now);
+                }
+
+                // For calls which have not yet been sent, update the node to send to if
+                // metadata has been refreshed. This is to handle controller change and
+                // node disconnections.
+                if (metadataManager.updater().lastMetadataUpdateMs() > lastIterationTimeMs) {
+                    ArrayList<Call> pendingCallsToSend = new ArrayList<>();
+                    for (List<Call> pending : callsToSend.values()) {
+                        pendingCallsToSend.addAll(pending);
+                    }
+                    callsToSend.clear();
+                    chooseNodesForPendingCalls(now, pendingCallsToSend.iterator());
                 }
 
                 // Choose nodes for our pending calls.
@@ -1054,6 +1067,7 @@ public class KafkaAdminClient extends AdminClient {
                 log.trace("KafkaClient#poll retrieved {} response(s)", responses.size());
 
                 // Update the current time and handle the latest responses.
+                lastIterationTimeMs = now;
                 now = time.milliseconds();
                 handleResponses(now, responses);
             }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -116,7 +116,11 @@ public class AdminMetadataManager {
 
         @Override
         public void requestUpdate() {
-            // Do nothing
+            AdminMetadataManager.this.requestUpdate();
+        }
+
+        public long lastMetadataUpdateMs() {
+            return lastMetadataUpdateMs;
         }
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/internals/AdminMetadataManager.java
@@ -118,10 +118,6 @@ public class AdminMetadataManager {
         public void requestUpdate() {
             AdminMetadataManager.this.requestUpdate();
         }
-
-        public long lastMetadataUpdateMs() {
-            return lastMetadataUpdateMs;
-        }
     }
 
     /**


### PR DESCRIPTION
Refresh metadata if broker connection fails so that new calls are sent only to nodes that are alive and requests to controller are sent to the new controller if controller changes due to broker failure. Also reassign calls that could not be sent.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
