### PR TITLE
 KAFKA-6926: Simplified some logic to eliminate some suppressions of NPath complexity checks

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -114,7 +114,7 @@
               files="Values.java"/>
 
     <suppress checks="NPathComplexity"
-              files="(DistributedHerder|JsonConverter|KafkaConfigBackingStore).java"/>
+              files="(DistributedHerder|JsonConverter|KafkaConfigBackingStore|FileStreamSourceTask).java"/>
 
     <suppress checks="MethodLength"
               files="Values.java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -114,7 +114,7 @@
               files="Values.java"/>
 
     <suppress checks="NPathComplexity"
-              files="(AbstractStatus|ConnectHeaders|ConnectRecord|ConnectSchema|DistributedHerder|FileStreamSourceTask|JsonConverter|KafkaConfigBackingStore).java"/>
+              files="(DistributedHerder|JsonConverter|KafkaConfigBackingStore).java"/>
 
     <suppress checks="MethodLength"
               files="Values.java"/>

--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectRecord.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/ConnectRecord.java
@@ -155,24 +155,14 @@ public abstract class ConnectRecord<R extends ConnectRecord<R>> {
 
         ConnectRecord that = (ConnectRecord) o;
 
-        if (kafkaPartition != null ? !kafkaPartition.equals(that.kafkaPartition) : that.kafkaPartition != null)
-            return false;
-        if (topic != null ? !topic.equals(that.topic) : that.topic != null)
-            return false;
-        if (keySchema != null ? !keySchema.equals(that.keySchema) : that.keySchema != null)
-            return false;
-        if (key != null ? !key.equals(that.key) : that.key != null)
-            return false;
-        if (valueSchema != null ? !valueSchema.equals(that.valueSchema) : that.valueSchema != null)
-            return false;
-        if (value != null ? !value.equals(that.value) : that.value != null)
-            return false;
-        if (timestamp != null ? !timestamp.equals(that.timestamp) : that.timestamp != null)
-            return false;
-        if (!Objects.equals(headers, that.headers))
-            return false;
-
-        return true;
+        return Objects.equals(kafkaPartition, that.kafkaPartition)
+               && Objects.equals(topic, that.topic)
+               && Objects.equals(keySchema, that.keySchema)
+               && Objects.equals(key, that.key)
+               && Objects.equals(valueSchema, that.valueSchema)
+               && Objects.equals(value, that.value)
+               && Objects.equals(timestamp, that.timestamp)
+               && Objects.equals(headers, that.headers);
     }
 
     @Override

--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -218,14 +218,10 @@ public class ConnectSchema implements Schema {
             if (!schema.isOptional())
                 throw new DataException("Invalid value: null used for required field: \"" + name
                         + "\", schema type: " + schema.type());
-            else
-                return;
+            return;
         }
 
-        List<Class> expectedClasses = LOGICAL_TYPE_CLASSES.get(schema.name());
-
-        if (expectedClasses == null)
-                expectedClasses = SCHEMA_TYPE_CLASSES.get(schema.type());
+        List<Class> expectedClasses = expectedClassesFor(schema);
 
         if (expectedClasses == null)
             throw new DataException("Invalid Java object for schema type " + schema.type()
@@ -264,6 +260,13 @@ public class ConnectSchema implements Schema {
                 }
                 break;
         }
+    }
+
+    private static List<Class> expectedClassesFor(Schema schema) {
+        List<Class> expectedClasses = LOGICAL_TYPE_CLASSES.get(schema.name());
+        if (expectedClasses == null)
+            expectedClasses = SCHEMA_TYPE_CLASSES.get(schema.type());
+        return expectedClasses;
     }
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractStatus.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/AbstractStatus.java
@@ -16,6 +16,8 @@
  */
 package org.apache.kafka.connect.runtime;
 
+import java.util.Objects;
+
 public abstract class AbstractStatus<T> {
 
     public enum State {
@@ -81,12 +83,11 @@ public abstract class AbstractStatus<T> {
 
         AbstractStatus<?> that = (AbstractStatus<?>) o;
 
-        if (generation != that.generation) return false;
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (state != that.state) return false;
-        if (trace != null ? !trace.equals(that.trace) : that.trace != null) return false;
-        return workerId != null ? workerId.equals(that.workerId) : that.workerId == null;
-
+        return generation == that.generation
+                && Objects.equals(id, that.id)
+                && state == that.state
+                && Objects.equals(trace, that.trace)
+                && Objects.equals(workerId, that.workerId);
     }
 
     @Override


### PR DESCRIPTION
Modified several classes' `equals` methods and simplified a complex method to reduce the NPath complexity so they could be removed from the checkstyle suppressions that were required with the [recent move to Java 8 and upgrade of Checkstyle](https://github.com/apache/kafka/pull/5046).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
