### PR TITLE
MINOR: AdminClient consumer group domain objects should have public constructors

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ConsumerGroupDescription.java
@@ -37,12 +37,12 @@ public class ConsumerGroupDescription {
     private final ConsumerGroupState state;
     private final Node coordinator;
 
-    ConsumerGroupDescription(String groupId,
-            boolean isSimpleConsumerGroup,
-            Collection<MemberDescription> members,
-            String partitionAssignor,
-            ConsumerGroupState state,
-            Node coordinator) {
+    public ConsumerGroupDescription(String groupId,
+                                    boolean isSimpleConsumerGroup,
+                                    Collection<MemberDescription> members,
+                                    String partitionAssignor,
+                                    ConsumerGroupState state,
+                                    Node coordinator) {
         this.groupId = groupId == null ? "" : groupId;
         this.isSimpleConsumerGroup = isSimpleConsumerGroup;
         this.members = members == null ? Collections.<MemberDescription>emptyList() :

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberAssignment.java
@@ -34,7 +34,7 @@ public class MemberAssignment {
      *
      * @param topicPartitions List of topic partitions
      */
-    MemberAssignment(Set<TopicPartition> topicPartitions) {
+    public MemberAssignment(Set<TopicPartition> topicPartitions) {
         this.topicPartitions = topicPartitions == null ? Collections.<TopicPartition>emptySet() :
             Collections.unmodifiableSet(new HashSet<>(topicPartitions));
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/MemberDescription.java
@@ -31,7 +31,7 @@ public class MemberDescription {
     private final String host;
     private final MemberAssignment assignment;
 
-    MemberDescription(String memberId, String clientId, String host, MemberAssignment assignment) {
+    public MemberDescription(String memberId, String clientId, String host, MemberAssignment assignment) {
         this.memberId = memberId == null ? "" : memberId;
         this.clientId = clientId == null ? "" : clientId;
         this.host = host == null ? "" : host;


### PR DESCRIPTION
These constructors should be public to allow users to write test cases using them. We follow a similar pattern for the other domain objects that we expose in `AdminClient` (e.g. `TopicDescription`).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
