### PR TITLE
KAFKA-6931 Make worker id configurable

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/CliUtil.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/CliUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.cli;
+
+import org.apache.kafka.connect.runtime.WorkerConfig;
+
+/**
+ * a collection of helper methods used to build the kafka connector.
+ */
+final class CliUtil {
+
+    /**
+     * @param config the configuration used to find the worker id
+     * @return worker id if the key(WorkerConfig.WORKER_ID_CONFIG) exists. null otherwise
+     */
+    static String workerId(WorkerConfig config) {
+        return config.getString(WorkerConfig.WORKER_ID_CONFIG);
+    }
+
+    /**
+     * disable the instantiation
+     */
+    private CliUtil(){}
+}

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java
@@ -79,7 +79,10 @@ public class ConnectDistributed {
 
             RestServer rest = new RestServer(config);
             URI advertisedUrl = rest.advertisedUrl();
-            String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+            String workerId = CliUtil.workerId(config);
+            if (workerId == null || workerId.isEmpty()) {
+                workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+            }
 
             KafkaOffsetBackingStore offsetBackingStore = new KafkaOffsetBackingStore();
             offsetBackingStore.configure(config);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectStandalone.java
@@ -83,7 +83,10 @@ public class ConnectStandalone {
 
             RestServer rest = new RestServer(config);
             URI advertisedUrl = rest.advertisedUrl();
-            String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+            String workerId = CliUtil.workerId(config);
+            if (workerId == null || workerId.isEmpty()) {
+                workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
+            }
 
             Worker worker = new Worker(workerId, time, plugins, config, new FileOffsetBackingStore());
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerConfig.java
@@ -176,6 +176,8 @@ public class WorkerConfig extends AbstractConfig {
     public static final String METRICS_NUM_SAMPLES_CONFIG = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
     public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
     public static final String METRIC_REPORTER_CLASSES_CONFIG = CommonClientConfigs.METRIC_REPORTER_CLASSES_CONFIG;
+    public static final String WORKER_ID_CONFIG = "worker.id";
+    protected static final String WORKER_ID_DOC = "The worker id for this server. If unset, server will use advertised host + advertised port instead";
 
     /**
      * Get a basic ConfigDef for a WorkerConfig. This includes all the common settings. Subclasses can use this to
@@ -236,7 +238,12 @@ public class WorkerConfig extends AbstractConfig {
                         ConfigDef.Type.STRING, "none", ConfigDef.Importance.LOW, BrokerSecurityConfigs.SSL_CLIENT_AUTH_DOC)
                 .define(HEADER_CONVERTER_CLASS_CONFIG, Type.CLASS,
                         HEADER_CONVERTER_CLASS_DEFAULT,
-                        Importance.LOW, HEADER_CONVERTER_CLASS_DOC);
+                        Importance.LOW, HEADER_CONVERTER_CLASS_DOC)
+                .define(WORKER_ID_CONFIG,
+                        Type.STRING,
+                        null,
+                        Importance.LOW,
+                        WORKER_ID_DOC);
     }
 
     @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/cli/CliUtilTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/cli/CliUtilTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.cli;
+import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+public class CliUtilTest {
+
+    private static Map<String, String> config(String workerId) {
+        Map<String, String> map = new HashMap<>();
+        map.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        map.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        map.put(WorkerConfig.INTERNAL_KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        map.put(WorkerConfig.INTERNAL_VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.json.JsonConverter");
+        map.put(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, "CliUtilTest.tempfile");
+        map.put(DistributedConfig.GROUP_ID_CONFIG, "CliUtilTest.id");
+        map.put(DistributedConfig.OFFSET_STORAGE_TOPIC_CONFIG, "CliUtilTest.offset.storage");
+        map.put(DistributedConfig.CONFIG_TOPIC_CONFIG, "CliUtilTest.config.storage");
+        map.put(DistributedConfig.STATUS_STORAGE_TOPIC_CONFIG, "CliUtilTest.status.storage");
+        if (workerId != null) map.put(WorkerConfig.WORKER_ID_CONFIG, workerId);
+        return map;
+    }
+
+    @Test
+    public void testWorkerID() {
+        List<WorkerConfig> configs = Arrays.asList(new StandaloneConfig(config(null)), new DistributedConfig(config(null)));
+        for (WorkerConfig config : configs) {
+            Assert.assertNull(CliUtil.workerId(config));
+        }
+
+        String workerId = "worker_id";
+        Map<String, String> map = config(workerId);
+        configs = Arrays.asList(new StandaloneConfig(map), new DistributedConfig(map));
+        for (WorkerConfig config : configs) {
+            Assert.assertEquals(workerId, CliUtil.workerId(config));
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6931
The broker id and consumer/producer id (client id) are configurable so why we don't make the worker id configurable? This pr enable user to configure the worker id by the property file. If unset, we use the advertised host and port instead. Also, the worker id is used in metrics hence a configurable id make the metrics more readable.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
