### PR TITLE
 KIP-228 Negative record timestamp support

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -67,9 +67,9 @@ public class ProducerRecord<K, V> {
     public ProducerRecord(String topic, Integer partition, Long timestamp, K key, V value, Iterable<Header> headers) {
         if (topic == null)
             throw new IllegalArgumentException("Topic cannot be null.");
-        if (timestamp != null && timestamp < 0)
+        if (timestamp == -1)
             throw new IllegalArgumentException(
-                    String.format("Invalid timestamp: %d. Timestamp should always be non-negative or null.", timestamp));
+                    String.format("Invalid timestamp: %d. Timestamp cannot be equal to -1 or null.", timestamp));
         if (partition != null && partition < 0)
             throw new IllegalArgumentException(
                     String.format("Invalid partition: %d. Partition number should always be non-negative or null.", partition));

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -67,7 +67,7 @@ public class ProducerRecord<K, V> {
     public ProducerRecord(String topic, Integer partition, Long timestamp, K key, V value, Iterable<Header> headers) {
         if (topic == null)
             throw new IllegalArgumentException("Topic cannot be null.");
-        if (timestamp == -1)
+        if (timestamp != null && timestamp == -1)
             throw new IllegalArgumentException(
                     String.format("Invalid timestamp: %d. Timestamp cannot be equal to -1 or null.", timestamp));
         if (partition != null && partition < 0)

--- a/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LegacyRecord.java
@@ -452,8 +452,6 @@ public final class LegacyRecord {
                               ByteBuffer value) throws IOException {
         if (magic != RecordBatch.MAGIC_VALUE_V0 && magic != RecordBatch.MAGIC_VALUE_V1)
             throw new IllegalArgumentException("Invalid magic value " + magic);
-        if (timestamp < 0 && timestamp != RecordBatch.NO_TIMESTAMP)
-            throw new IllegalArgumentException("Invalid message timestamp " + timestamp);
 
         // write crc
         out.writeInt((int) (crc & 0xffffffffL));

--- a/core/src/main/scala/kafka/message/Message.scala
+++ b/core/src/main/scala/kafka/message/Message.scala
@@ -354,8 +354,6 @@ class Message(val buffer: ByteBuffer,
   private def validateTimestampAndMagicValue(timestamp: Long, magic: Byte) {
     if (magic != MagicValue_V0 && magic != MagicValue_V1)
       throw new IllegalArgumentException(s"Invalid magic value $magic")
-    if (timestamp < 0 && timestamp != NoTimestamp)
-      throw new IllegalArgumentException(s"Invalid message timestamp $timestamp")
     if (magic == MagicValue_V0 && timestamp != NoTimestamp)
       throw new IllegalArgumentException(s"Invalid timestamp $timestamp. Timestamp must be $NoTimestamp when magic = $MagicValue_V0")
   }

--- a/core/src/test/scala/unit/kafka/message/MessageTest.scala
+++ b/core/src/test/scala/unit/kafka/message/MessageTest.scala
@@ -112,11 +112,6 @@ class MessageTest extends JUnitSuite {
   }
 
   @Test(expected = classOf[IllegalArgumentException])
-  def testInvalidTimestamp() {
-    new Message("hello".getBytes, -3L, Message.MagicValue_V1)
-  }
-
-  @Test(expected = classOf[IllegalArgumentException])
   def testInvalidMagicByte() {
     new Message("hello".getBytes, 0L, 2.toByte)
   }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/ExtractRecordMetadataTimestamp.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/ExtractRecordMetadataTimestamp.java
@@ -57,7 +57,7 @@ abstract class ExtractRecordMetadataTimestamp implements TimestampExtractor {
     public long extract(final ConsumerRecord<Object, Object> record, final long previousTimestamp) {
         final long timestamp = record.timestamp();
 
-        if (timestamp < 0) {
+        if (timestamp == -1) {
             return onInvalidTimestamp(record, timestamp, previousTimestamp);
         }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordQueue.java
@@ -112,8 +112,8 @@ public class RecordQueue {
             }
             log.trace("Source node {} extracted timestamp {} for record {}", source.name(), timestamp, record);
 
-            // drop message if TS is invalid, i.e., negative
-            if (timestamp < 0) {
+            // drop message if TS is invalid
+            if (timestamp == -1) {
                 log.warn(
                     "Skipping record due to negative extracted timestamp. topic=[{}] partition=[{}] offset=[{}] extractedTimestamp=[{}] extractor=[{}]",
                     record.topic(), record.partition(), record.offset(), timestamp, timestampExtractor.getClass().getCanonicalName()

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java
@@ -79,8 +79,8 @@ public class SinkNode<K, V> extends ProcessorNode<K, V> {
         final RecordCollector collector = ((RecordCollector.Supplier) context).recordCollector();
 
         final long timestamp = context.timestamp();
-        if (timestamp < 0) {
-            throw new StreamsException("Invalid (negative) timestamp of " + timestamp + " for output record <" + key + ":" + value + ">.");
+        if (timestamp == -1) {
+            throw new StreamsException("Invalid timestamp of " + timestamp + " for output record <" + key + ":" + value + ">.");
         }
 
         try {


### PR DESCRIPTION
Kafka does not support negative record timestamps, and this prevents the storage of historical data in Kafka. In general, negative timestamps are supported by UNIX system timestamps.

In general, there should be is no reason to fail on broker/client side working with negative timestamps.

### Committer Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)