### PR TITLE
MINOR: Remove MaxPermSize from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ group=org.apache.kafka
 version=2.0.0-SNAPSHOT
 scalaVersion=2.11.12
 task=build
-org.gradle.jvmargs=-XX:MaxPermSize=512m -Xmx1024m -Xss2m
+org.gradle.jvmargs=-Xmx1024m -Xss2m


### PR DESCRIPTION
No longer needed since we dropped support for Java 7.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
