### PR TITLE
MINOR: Remove findbugs exclusion matching removed old producer

### DIFF
--- a/gradle/findbugs-exclude.xml
+++ b/gradle/findbugs-exclude.xml
@@ -89,12 +89,6 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     </Match>
 
     <Match>
-        <!-- Add a suppression for having the thread start in the constructor of the old, deprecated consumer. -->
-        <Class name="kafka.producer.Producer"/>
-        <Bug pattern="SC_START_IN_CTOR"/>
-    </Match>
-
-    <Match>
         <!-- Add a suppression for the equals() method of NetworkClientBlockingOps. -->
         <Class name="kafka.utils.NetworkClientBlockingOps"/>
         <Bug pattern="EQ_UNUSUAL"/>


### PR DESCRIPTION
KAFKA-6921 removed deprecated scala producer.
This pull request aims to remove now unnecessary findbugs exclusion that matched one of the affected classes.

Tested by running `gradle :core:findbugsMain`. No problems reported.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
