### PR TITLE
MINOR:Fix table outer join test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KTableImplTest.java
@@ -472,7 +472,7 @@ public class KTableImplTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldThrowNullPointerOnOuterJoinWhenMaterializedIsNull() {
-        table.leftJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null);
+        table.outerJoin(table, MockValueJoiner.TOSTRING_JOINER, (Materialized) null);
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
*In the class test KTableImplTest the method shouldThrowNullPointerOnOuterJoinWhenMaterializedIsNull is testing the wrong method*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
