### PR TITLE
MINOR: Fix recently added method in SinkTaskContext to be backward compatible

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
@@ -32,8 +32,14 @@ public interface SinkTaskContext {
      * For example, this method can be used to obtain the latest configuration if an external secret has changed,
      * and the configuration is using variable references such as those compatible with
      * {@link org.apache.kafka.common.config.ConfigTransformer}.
+     *
+     * @since 2.0
      */
-    public Map<String, String> configs();
+    default Map<String, String> configs() {
+        // This method added in 2.0, but this default implementation used to prevent compilation failures
+        // on non-Connect implementations. Always implement this method properly.
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Reset the consumer offsets for the given topic partitions. SinkTasks should use this if they manage offsets


### PR DESCRIPTION
Although Connect should always implement this interface and all its methods, other projects might implement this for tests or other environments, so we should make it backward compatible.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
