### PR TITLE
KAFKA-6906: Fixed to commit transactions if data is produced via wall clock punctuation

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtensionContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtensionContext.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.rest;
 
 import org.apache.kafka.connect.health.ConnectClusterState;
 
-//import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Configurable;
 
 /**
  * The interface provides the ability for {@link ConnectRestExtension} implementations to access the JAX-RS
@@ -33,7 +33,7 @@ public interface ConnectRestExtensionContext {
      *
      * @return @return the JAX-RS {@link javax.ws.rs.core.Configurable}; never {@code null}
      */
-   // Configurable<? extends Configurable> configurable();
+    Configurable<? extends Configurable> configurable();
 
     /**
      * Provides the cluster state and health information about the connectors and tasks.

--- a/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtensionContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/rest/ConnectRestExtensionContext.java
@@ -19,7 +19,7 @@ package org.apache.kafka.connect.rest;
 
 import org.apache.kafka.connect.health.ConnectClusterState;
 
-import javax.ws.rs.core.Configurable;
+//import javax.ws.rs.core.Configurable;
 
 /**
  * The interface provides the ability for {@link ConnectRestExtension} implementations to access the JAX-RS
@@ -33,7 +33,7 @@ public interface ConnectRestExtensionContext {
      *
      * @return @return the JAX-RS {@link javax.ws.rs.core.Configurable}; never {@code null}
      */
-    Configurable<? extends Configurable> configurable();
+   // Configurable<? extends Configurable> configurable();
 
     /**
      * Provides the cluster state and health information about the connectors and tasks.

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -418,7 +418,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
                 stateMgr.putOffsetLimit(partition, offset);
             }
-            if (eosEnabled && transactionInFlight) {
+            if (eosEnabled) {
                 producer.sendOffsetsToTransaction(consumedOffsetsAndMetadata, applicationId);
                 producer.commitTransaction();
                 transactionInFlight = false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -421,6 +421,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                     consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
                     stateMgr.putOffsetLimit(partition, offset);
                 }
+
                 if (eosEnabled) {
                     producer.sendOffsetsToTransaction(consumedOffsetsAndMetadata, applicationId);
                 } else {
@@ -428,6 +429,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 }
                 commitOffsetNeeded = false;
             }
+
             if (eosEnabled) {
                 producer.commitTransaction();
                 transactionInFlight = false;
@@ -436,6 +438,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                     transactionInFlight = true;
                 }
             }
+
             if (eosEnabled && !startNewTransaction && transactionInFlight) { // need to make sure to commit txn for suspend case
                 producer.commitTransaction();
                 transactionInFlight = false;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -418,7 +418,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                 consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
                 stateMgr.putOffsetLimit(partition, offset);
             }
-
             if (eosEnabled && transactionInFlight) {
                 producer.sendOffsetsToTransaction(consumedOffsetsAndMetadata, applicationId);
                 producer.commitTransaction();

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -70,6 +70,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
     private final int maxBufferedSize;
 
     private boolean commitRequested = false;
+    private boolean commitOffsetNeeded = false;
     private boolean transactionInFlight = false;
     private final Time time;
     private final TaskMetrics taskMetrics;
@@ -290,6 +291,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
 
             // update the consumed offset map after processing is done
             consumedOffsets.put(partition, record.offset());
+            commitOffsetNeeded = true;
 
             // after processing this record, if its partition queue's buffered size has been
             // decreased to the threshold, we can then resume the consumption on this partition
@@ -410,24 +412,29 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
      */
     private void commitOffsets(final boolean startNewTransaction) {
         try {
-            log.trace("Committing offsets");
-            final Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
-            for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
-                final TopicPartition partition = entry.getKey();
-                final long offset = entry.getValue() + 1;
-                consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
-                stateMgr.putOffsetLimit(partition, offset);
+            if (commitOffsetNeeded) {
+                log.trace("Committing offsets");
+                final Map<TopicPartition, OffsetAndMetadata> consumedOffsetsAndMetadata = new HashMap<>(consumedOffsets.size());
+                for (final Map.Entry<TopicPartition, Long> entry : consumedOffsets.entrySet()) {
+                    final TopicPartition partition = entry.getKey();
+                    final long offset = entry.getValue() + 1;
+                    consumedOffsetsAndMetadata.put(partition, new OffsetAndMetadata(offset));
+                    stateMgr.putOffsetLimit(partition, offset);
+                }
+                if (eosEnabled) {
+                    producer.sendOffsetsToTransaction(consumedOffsetsAndMetadata, applicationId);
+                } else {
+                    consumer.commitSync(consumedOffsetsAndMetadata);
+                }
+                commitOffsetNeeded = false;
             }
             if (eosEnabled) {
-                producer.sendOffsetsToTransaction(consumedOffsetsAndMetadata, applicationId);
                 producer.commitTransaction();
                 transactionInFlight = false;
                 if (startNewTransaction) {
                     producer.beginTransaction();
                     transactionInFlight = true;
                 }
-            } else {
-                consumer.commitSync(consumedOffsetsAndMetadata);
             }
             if (eosEnabled && !startNewTransaction && transactionInFlight) { // need to make sure to commit txn for suspend case
                 producer.commitTransaction();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -913,6 +913,7 @@ public class StreamTaskTest {
     @Test
     public void shouldCloseProducerOnCloseWhenEosEnabled() {
         task = createStatelessTask(createConfig(true));
+        task.initializeTopology();
         task.close(true, false);
         task = null;
 
@@ -1145,4 +1146,12 @@ public class StreamTaskTest {
         );
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowOnCleanCloseTaskWhenEosEnabledIfTransactionInFlight() {
+        task = createStatelessTask(createConfig(true));
+        task.close(true, false);
+        task = null;
+
+        assertTrue(producer.closed());
+    }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -660,7 +660,7 @@ public class StreamThreadTest {
             new TestCondition() {
                 @Override
                 public boolean conditionMet() {
-                    return producer.commitCount() == 1;
+                    return producer.commitCount() == 2;
                 }
             },
             "StreamsThread did not commit transaction.");
@@ -681,7 +681,7 @@ public class StreamThreadTest {
             },
             "StreamsThread did not remove fenced zombie task.");
 
-        assertThat(producer.commitCount(), equalTo(1L));
+        assertThat(producer.commitCount(), equalTo(2L));
     }
 
     @Test

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -660,7 +660,7 @@ public class StreamThreadTest {
             new TestCondition() {
                 @Override
                 public boolean conditionMet() {
-                    return producer.commitCount() == 2;
+                    return producer.commitCount() == 1;
                 }
             },
             "StreamsThread did not commit transaction.");
@@ -681,7 +681,7 @@ public class StreamThreadTest {
             },
             "StreamsThread did not remove fenced zombie task.");
 
-        assertThat(producer.commitCount(), equalTo(2L));
+        assertThat(producer.commitCount(), equalTo(1L));
     }
 
     @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-6906

Fixed `StreamTask` to commit transactions if the data is produced via wall-clock punctuation too.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
