### PR TITLE
KAFKA-6973: TopicCommand should verify topic-level config

### DIFF
--- a/core/src/main/scala/kafka/log/LogConfig.scala
+++ b/core/src/main/scala/kafka/log/LogConfig.scala
@@ -254,7 +254,7 @@ object LogConfig {
         KafkaConfig.LogPreAllocateProp)
       .define(MessageFormatVersionProp, STRING, Defaults.MessageFormatVersion, MEDIUM, MessageFormatVersionDoc,
         KafkaConfig.LogMessageFormatVersionProp)
-      .define(MessageTimestampTypeProp, STRING, Defaults.MessageTimestampType, MEDIUM, MessageTimestampTypeDoc,
+      .define(MessageTimestampTypeProp, STRING, Defaults.MessageTimestampType, in("CreateTime", "LogAppendTime"), MEDIUM, MessageTimestampTypeDoc,
         KafkaConfig.LogMessageTimestampTypeProp)
       .define(MessageTimestampDifferenceMaxMsProp, LONG, Defaults.MessageTimestampDifferenceMaxMs,
         atLeast(0), MEDIUM, MessageTimestampDifferenceMaxMsDoc, KafkaConfig.LogMessageTimestampDifferenceMaxMsProp)

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -225,4 +225,24 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     assertTrue(output.contains(topic) && output.contains(markedForDeletionList))
   }
 
+  @Test
+  def testInvalidTopicLevelConfig(): Unit = {
+    val brokers = List(0)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic = "test"
+    val numPartitions = 1
+
+    // create the topic
+    try {
+      val createOpts = new TopicCommandOptions(
+        Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic,
+          "--config", "message.timestamp.type=boom"))
+      TopicCommand.createTopic(zkClient, createOpts)
+      fail("Expected exception on invalid topic-level config.")
+    } catch {
+      case e: Exception => // topic create should fail due to the invalid config
+    }
+  }
+
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -230,18 +230,15 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     val brokers = List(0)
     TestUtils.createBrokersInZk(zkClient, brokers)
 
-    val topic = "test"
-    val numPartitions = 1
-
     // create the topic
     try {
       val createOpts = new TopicCommandOptions(
-        Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic,
+        Array("--partitions", "1", "--replication-factor", "1", "--topic", "test",
           "--config", "message.timestamp.type=boom"))
       TopicCommand.createTopic(zkClient, createOpts)
       fail("Expected exception on invalid topic-level config.")
     } catch {
-      case e: Exception => // topic create should fail due to the invalid config
+      case _: Exception => // topic creation should fail due to the invalid config
     }
   }
 


### PR DESCRIPTION
KAFKA-6973: https://issues.apache.org/jira/browse/KAFKA-6973

Specifying an invalid config other than `CreateTime` or `LogAppendTime` will cause broker restarting to fail.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
