### PR TITLE
KAFKA-6722: SensorAccess.getOrCreate should be more efficient

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -186,7 +186,7 @@ public class FileRecords extends AbstractRecords implements Closeable {
      */
     public boolean deleteIfExists() throws IOException {
         Utils.closeQuietly(channel, "FileChannel");
-        return Files.deleteIfExists(file.toPath());
+        return file.exists() ? file.delete() : false;
     }
 
     /**


### PR DESCRIPTION
*There's JIRA created for this Pull Request: https://issues.apache.org/jira/browse/KAFKA-6722 
Basically the read lock is completely unnecessary. If a temp variable is used, we can get rid of the read lock
 *

*Unit test built in Kafka source is run when running gradle to build the code. *

