### PR TITLE
KAFKA-6562: (follow-up) Publish "jackson-databind" lib as provided scope dependency in clients maven artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -785,11 +785,19 @@ project(':examples') {
 project(':clients') {
   archivesBaseName = "kafka-clients"
 
+  configurations {
+    jacksonDatabindConfig
+  }
+
+  conf2ScopeMappings.addMapping(1000, configurations.jacksonDatabindConfig, "provided")
+
   dependencies {
     compile libs.lz4
     compile libs.snappy
     compile libs.slf4jApi
-    compile libs.jacksonDatabind // for SASL/OAUTHBEARER bearer token parsing
+    compileOnly libs.jacksonDatabind // for SASL/OAUTHBEARER bearer token parsing
+
+    jacksonDatabindConfig libs.jacksonDatabind // to publish as provided scope dependency.
 
     testCompile libs.bcpkix
     testCompile libs.junit
@@ -798,6 +806,7 @@ project(':clients') {
     testCompile libs.powermockEasymock
 
     testRuntime libs.slf4jlog4j
+    testRuntime libs.jacksonDatabind
   }
 
   task determineCommitId {

--- a/build.gradle
+++ b/build.gradle
@@ -789,6 +789,7 @@ project(':clients') {
     jacksonDatabindConfig
   }
 
+  // add jacksonDatabindConfig as provided scope config with high priority (1000)
   conf2ScopeMappings.addMapping(1000, configurations.jacksonDatabindConfig, "provided")
 
   dependencies {

--- a/docs/security.html
+++ b/docs/security.html
@@ -715,6 +715,9 @@
                 <pre>
     security.protocol=SASL_SSL (or SASL_PLAINTEXT if non-production)
     sasl.mechanism=OAUTHBEARER</pre></li>
+             <li>The default implementation of SASL/OAUTHBEARER depends on com.fasterxml.jackson.core:jackson-databind library.
+                This is added as provided scope dependency in Kafka clients maven artifact. Users must provide jackson-databind library
+                 to Kafka client runtime.</li>
             </ol>
         </li>
         <li><h5><a id="security_sasl_oauthbearer_unsecured_retrieval" href="#security_sasl_oauthbearer_unsecured_retrieval">Unsecured Token Creation Options for SASL/OAUTHBEARER</a></h5>

--- a/docs/security.html
+++ b/docs/security.html
@@ -715,9 +715,8 @@
                 <pre>
     security.protocol=SASL_SSL (or SASL_PLAINTEXT if non-production)
     sasl.mechanism=OAUTHBEARER</pre></li>
-             <li>The default implementation of SASL/OAUTHBEARER depends on com.fasterxml.jackson.core:jackson-databind library.
-                This is added as provided scope dependency in Kafka clients maven artifact. Users must provide jackson-databind library
-                 to Kafka client runtime.</li>
+             <li>The default implementation of SASL/OAUTHBEARER depends on the jackson-databind library.
+                 Since it's an optional dependency, users have to configure it as a dependency via their build tool.</li>
             </ol>
         </li>
         <li><h5><a id="security_sasl_oauthbearer_unsecured_retrieval" href="#security_sasl_oauthbearer_unsecured_retrieval">Unsecured Token Creation Options for SASL/OAUTHBEARER</a></h5>


### PR DESCRIPTION
1. jackson-databind library is mapped as a provided library by using maven plugin configuration-to-scope mapping feature.
https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/maven/Conf2ScopeMappingContainer.html
2. Clients using default implementation of SASL/OAUTHBEARER mechanism must provide jackson-databind library to Kafka client runtime.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
