### PR TITLE
MINOR: Fix bug in AdminClient node reassignment following connection failure

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClientResponse.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.clients;
 
+import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.RequestHeader;
@@ -33,6 +34,7 @@ public class ClientResponse {
     private final long latencyMs;
     private final boolean disconnected;
     private final UnsupportedVersionException versionMismatch;
+    private final AuthenticationException authenticationException;
     private final AbstractResponse responseBody;
 
     /**
@@ -53,6 +55,7 @@ public class ClientResponse {
                           long receivedTimeMs,
                           boolean disconnected,
                           UnsupportedVersionException versionMismatch,
+                          AuthenticationException authenticationException,
                           AbstractResponse responseBody) {
         this.requestHeader = requestHeader;
         this.callback = callback;
@@ -61,6 +64,7 @@ public class ClientResponse {
         this.latencyMs = receivedTimeMs - createdTimeMs;
         this.disconnected = disconnected;
         this.versionMismatch = versionMismatch;
+        this.authenticationException = authenticationException;
         this.responseBody = responseBody;
     }
 
@@ -74,6 +78,10 @@ public class ClientResponse {
 
     public UnsupportedVersionException versionMismatch() {
         return versionMismatch;
+    }
+
+    public AuthenticationException authenticationException() {
+        return authenticationException;
     }
 
     public RequestHeader requestHeader() {

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -831,7 +831,6 @@ public class KafkaAdminClient extends AdminClient {
             Iterator<Call> pendingIter = pendingCalls.iterator();
             while (pendingIter.hasNext()) {
                 Call call = pendingIter.next();
-                log.trace("Attempting to choose node for call " + call.callName);
 
                 // If the call is being retried, await the proper backoff before finding the node
                 if (now < call.nextAllowedTryMs) {
@@ -1106,7 +1105,7 @@ public class KafkaAdminClient extends AdminClient {
 
                 // Ensure that we use a small poll timeout if there is nothing in flight and we have
                 // pending calls which need to be sent
-                if (client.inFlightRequestCount() == 0 && !pendingCalls.isEmpty())
+                if (client.hasInFlightRequests() && !pendingCalls.isEmpty())
                     pollTimeout = Math.min(pollTimeout, retryBackoffMs);
 
                 // Wait for network responses.

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -138,6 +138,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
 
 import static org.apache.kafka.common.utils.Utils.closeQuietly;
 
@@ -820,39 +821,51 @@ public class KafkaAdminClient extends AdminClient {
          * Choose nodes for the calls in the pendingCalls list.
          *
          * @param now           The current time in milliseconds.
-         * @param pendingIter   An iterator yielding pending calls.
+         * @return              The minimum time until a call is ready to be retried if any of the pending
+         *                      calls are backing off after a failure
          */
-        private long chooseNodesForPendingCalls(long now, Iterator<Call> pendingIter) {
+        private long checkPendingCalls(long now) {
             long pollTimeout = Long.MAX_VALUE;
-            log.trace("Trying to choose nodes for {} at {}", pendingIter, now);
+            log.trace("Trying to choose nodes for {} at {}", pendingCalls, now);
+
+            Iterator<Call> pendingIter = pendingCalls.iterator();
             while (pendingIter.hasNext()) {
                 Call call = pendingIter.next();
+                log.trace("Attempting to choose node for call " + call.callName);
 
                 // If the call is being retried, await the proper backoff before finding the node
                 if (now < call.nextAllowedTryMs) {
                     pollTimeout = Math.min(pollTimeout, call.nextAllowedTryMs - now);
-                    continue;
-                }
-
-                Node node = null;
-                try {
-                    node = call.nodeProvider.provide();
-                } catch (Throwable t) {
-                    // Handle authentication errors while choosing nodes.
-                    log.debug("Unable to choose node for {}", call, t);
+                } else if (checkPendingCall(call, now)) {
                     pendingIter.remove();
-                    call.fail(now, t);
-                }
-                if (node != null) {
-                    log.trace("Assigned {} to node {}", call, node);
-                    pendingIter.remove();
-                    call.curNode = node;
-                    getOrCreateListValue(callsToSend, node).add(call);
-                } else {
-                    log.trace("Unable to assign {} to a node.", call);
                 }
             }
             return pollTimeout;
+        }
+
+        /**
+         * Check whether a pending call can be assigned a node. Return true if the pending call was either
+         * transferred to the callsToSend collection or if the call was failed. Return false if it
+         * should remain pending.
+         */
+        private boolean checkPendingCall(Call call, long now) {
+            try {
+                Node node = call.nodeProvider.provide();
+                if (node != null) {
+                    log.trace("Assigned {} to node {}", call, node);
+                    call.curNode = node;
+                    getOrCreateListValue(callsToSend, node).add(call);
+                    return true;
+                } else {
+                    log.trace("Unable to assign {} to a node.", call);
+                    return false;
+                }
+            } catch (Throwable t) {
+                // Handle authentication errors while choosing nodes.
+                log.debug("Unable to choose node for {}", call, t);
+                call.fail(now, t);
+                return true;
+            }
         }
 
         /**
@@ -996,22 +1009,20 @@ public class KafkaAdminClient extends AdminClient {
          * all unsent calls are reassigned to handle controller change and node changes.
          * When a node is disconnected, all calls assigned to the node are reassigned.
          *
-         * @param now The current time in milliseconds
-         * @param disconnectedOnly Reassign only calls to nodes that were disconnected
-         *                         in the last poll
+         * @param shouldReassign Condition for reassignment. If the predicate is true, then the calls will
+         *                       be put back in the pendingCalls collection and they will be reassigned
          */
-        private void reassignUnsentCalls(long now, boolean disconnectedOnly) {
-            ArrayList<Call> pendingCallsToSend = new ArrayList<>();
+        private void reassignUnsentCalls(Predicate<Node> shouldReassign) {
             for (Iterator<Map.Entry<Node, List<Call>>> iter = callsToSend.entrySet().iterator(); iter.hasNext(); ) {
                 Map.Entry<Node, List<Call>> entry = iter.next();
-                if (!disconnectedOnly || client.connectionFailed(entry.getKey())) {
-                    for (Call call : entry.getValue()) {
-                        pendingCallsToSend.add(call);
-                    }
+                Node node = entry.getKey();
+                List<Call> awaitingCalls = entry.getValue();
+
+                if (shouldReassign.test(node)) {
+                    pendingCalls.addAll(awaitingCalls);
                     iter.remove();
                 }
             }
-            chooseNodesForPendingCalls(now, pendingCallsToSend.iterator());
         }
 
         private boolean hasActiveExternalCalls(Collection<Call> calls) {
@@ -1076,20 +1087,27 @@ public class KafkaAdminClient extends AdminClient {
                 }
 
                 // Choose nodes for our pending calls.
-                pollTimeout = Math.min(pollTimeout, chooseNodesForPendingCalls(now, pendingCalls.iterator()));
+                pollTimeout = Math.min(pollTimeout, checkPendingCalls(now));
                 long metadataFetchDelayMs = metadataManager.metadataFetchDelayMs(now);
                 if (metadataFetchDelayMs == 0) {
                     metadataManager.transitionToUpdatePending(now);
                     Call metadataCall = makeMetadataCall(now);
                     // Create a new metadata fetch call and add it to the end of pendingCalls.
                     // Assign a node for just the new call (we handled the other pending nodes above).
-                    pendingCalls.add(metadataCall);
-                    chooseNodesForPendingCalls(now, pendingCalls.listIterator(pendingCalls.size() - 1));
+
+                    if (!checkPendingCall(metadataCall, now))
+                        pendingCalls.add(metadataCall);
                 }
                 pollTimeout = Math.min(pollTimeout, sendEligibleCalls(now));
+
                 if (metadataFetchDelayMs > 0) {
                     pollTimeout = Math.min(pollTimeout, metadataFetchDelayMs);
                 }
+
+                // Ensure that we use a small poll timeout if there is nothing in flight and we have
+                // pending calls which need to be sent
+                if (client.inFlightRequestCount() == 0 && !pendingCalls.isEmpty())
+                    pollTimeout = Math.min(pollTimeout, retryBackoffMs);
 
                 // Wait for network responses.
                 log.trace("Entering KafkaClient#poll(timeout={})", pollTimeout);
@@ -1098,7 +1116,7 @@ public class KafkaAdminClient extends AdminClient {
 
                 // Update the current time and handle the latest responses.
                 now = time.milliseconds();
-                reassignUnsentCalls(now, true); // reassign calls to disconnected nodes
+                reassignUnsentCalls(client::connectionFailed); // reassign calls to disconnected nodes
                 handleResponses(now, responses);
             }
             int numTimedOut = 0;
@@ -1184,7 +1202,9 @@ public class KafkaAdminClient extends AdminClient {
                     MetadataResponse response = (MetadataResponse) abstractResponse;
                     long now = time.milliseconds();
                     metadataManager.update(response.cluster(), now);
-                    reassignUnsentCalls(now, false);
+
+                    // Reassign all requests after a metadata refresh
+                    reassignUnsentCalls(node -> true);
                 }
 
                 @Override

--- a/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/AdminClientUnitTestEnv.java
@@ -54,12 +54,16 @@ public class AdminClientUnitTestEnv implements AutoCloseable {
         this(newMockClient(time, cluster), time, cluster, config);
     }
 
+    public AdminClientUnitTestEnv(MockClient mockClient, Time time, Cluster cluster) {
+        this(mockClient, time, cluster, newStrMap());
+    }
+
     private static MockClient newMockClient(Time time, Cluster cluster) {
         MockClient mockClient = new MockClient(time);
         mockClient.prepareResponse(new MetadataResponse(cluster.nodes(),
             cluster.clusterResource().clusterId(),
-            cluster.controller().id(),
-            Collections.<MetadataResponse.TopicMetadata>emptyList()));
+            cluster.controller() == null ? MetadataResponse.NO_CONTROLLER_ID : cluster.controller().id(),
+            Collections.emptyList()));
         return mockClient;
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -114,7 +114,7 @@ public class KafkaAdminClientTest {
     private static final Logger log = LoggerFactory.getLogger(KafkaAdminClientTest.class);
 
     @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000);
+    final public Timeout globalTimeout = Timeout.millis(120000000);
 
     @Test
     public void testGetOrCreateListValue() {
@@ -183,8 +183,8 @@ public class KafkaAdminClientTest {
         nodes.put(1, new Node(1, "localhost", 8122));
         nodes.put(2, new Node(2, "localhost", 8123));
         return new Cluster("mockClusterId", nodes.values(),
-                Collections.<PartitionInfo>emptySet(), Collections.<String>emptySet(),
-                Collections.<String>emptySet(), nodes.get(controllerIndex));
+                Collections.emptySet(), Collections.emptySet(),
+                Collections.emptySet(), nodes.get(controllerIndex));
     }
 
     private static AdminClientUnitTestEnv mockClientEnv(String... configVals) {
@@ -229,6 +229,60 @@ public class KafkaAdminClientTest {
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
                     new CreateTopicsOptions().timeoutMs(1000)).all();
             assertFutureError(future, TimeoutException.class);
+        }
+    }
+
+    @Test
+    public void testConnectionFailureOnMetadataUpdate() throws Exception {
+        // This tests the scenario in which we successfully connect to the bootstrap server, but
+        // the server disconnects before sending a response
+
+        Cluster cluster = Cluster.bootstrap(Collections.singletonList(new InetSocketAddress("localhost", 8121)));
+        MockClient mockClient = new MockClient(Time.SYSTEM);
+        mockClient.setNodeApiVersions(NodeApiVersions.create());
+        mockClient.setNode(cluster.nodes().get(0));
+
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockClient, Time.SYSTEM, cluster)) {
+            Cluster discoveredCluster = mockCluster(0);
+            env.kafkaClient().prepareResponse(request -> request instanceof MetadataRequest, null, true);
+            env.kafkaClient().prepareResponse(body -> body instanceof MetadataRequest,
+                    new  MetadataResponse(discoveredCluster.nodes(), discoveredCluster.clusterResource().clusterId(),
+                            1, Collections.emptyList()));
+            env.kafkaClient().prepareResponse(body -> body instanceof CreateTopicsRequest,
+                    new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
+
+            KafkaFuture<Void> future = env.adminClient().createTopics(
+                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                    new CreateTopicsOptions().timeoutMs(10000)).all();
+
+            future.get();
+        }
+    }
+
+    @Test
+    public void testUnreachableBootstrapServer() throws Exception {
+        // This tests the scenario in which the bootstrap server is unreachable for a short while,
+        // which prevents NetworkClient from being able to accept the initial metadata request
+
+        Cluster cluster = Cluster.bootstrap(Collections.singletonList(new InetSocketAddress("localhost", 8121)));
+        MockClient mockClient = new MockClient(Time.SYSTEM);
+        mockClient.setNodeApiVersions(NodeApiVersions.create());
+        mockClient.setNode(cluster.nodes().get(0));
+        mockClient.setUnreachable(cluster.nodes().get(0), 50);
+
+        try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockClient, Time.SYSTEM, cluster)) {
+            Cluster discoveredCluster = mockCluster(0);
+            env.kafkaClient().prepareResponse(body -> body instanceof MetadataRequest,
+                    new  MetadataResponse(discoveredCluster.nodes(), discoveredCluster.clusterResource().clusterId(),
+                            1, Collections.emptyList()));
+            env.kafkaClient().prepareResponse(body -> body instanceof CreateTopicsRequest,
+                    new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
+
+            KafkaFuture<Void> future = env.adminClient().createTopics(
+                    Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
+                    new CreateTopicsOptions().timeoutMs(10000)).all();
+
+            future.get();
         }
     }
 

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -192,7 +192,7 @@ public class KafkaAdminClientTest {
     }
 
     @Test
-    public void testCloseAdminClient() throws Exception {
+    public void testCloseAdminClient() {
         try (AdminClientUnitTestEnv env = mockClientEnv()) {
         }
     }
@@ -235,7 +235,7 @@ public class KafkaAdminClientTest {
     @Test
     public void testConnectionFailureOnMetadataUpdate() throws Exception {
         // This tests the scenario in which we successfully connect to the bootstrap server, but
-        // the server disconnects before sending a response
+        // the server disconnects before sending the full response
 
         Cluster cluster = Cluster.bootstrap(Collections.singletonList(new InetSocketAddress("localhost", 8121)));
         MockClient mockClient = new MockClient(Time.SYSTEM);
@@ -262,13 +262,13 @@ public class KafkaAdminClientTest {
     @Test
     public void testUnreachableBootstrapServer() throws Exception {
         // This tests the scenario in which the bootstrap server is unreachable for a short while,
-        // which prevents NetworkClient from being able to accept the initial metadata request
+        // which prevents AdminClient from being able to send the initial metadata request
 
         Cluster cluster = Cluster.bootstrap(Collections.singletonList(new InetSocketAddress("localhost", 8121)));
         MockClient mockClient = new MockClient(Time.SYSTEM);
         mockClient.setNodeApiVersions(NodeApiVersions.create());
         mockClient.setNode(cluster.nodes().get(0));
-        mockClient.setUnreachable(cluster.nodes().get(0), 50);
+        mockClient.blackout(cluster.nodes().get(0), 200);
 
         try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockClient, Time.SYSTEM, cluster)) {
             Cluster discoveredCluster = mockCluster(0);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -268,7 +268,7 @@ public class KafkaAdminClientTest {
         MockClient mockClient = new MockClient(Time.SYSTEM);
         mockClient.setNodeApiVersions(NodeApiVersions.create());
         mockClient.setNode(cluster.nodes().get(0));
-        mockClient.blackout(cluster.nodes().get(0), 200);
+        mockClient.setUnreachable(cluster.nodes().get(0), 200);
 
         try (final AdminClientUnitTestEnv env = new AdminClientUnitTestEnv(mockClient, Time.SYSTEM, cluster)) {
             Cluster discoveredCluster = mockCluster(0);

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -114,7 +114,7 @@ public class KafkaAdminClientTest {
     private static final Logger log = LoggerFactory.getLogger(KafkaAdminClientTest.class);
 
     @Rule
-    final public Timeout globalTimeout = Timeout.millis(120000000);
+    final public Timeout globalTimeout = Timeout.millis(120000);
 
     @Test
     public void testGetOrCreateListValue() {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -333,7 +333,6 @@ public class KafkaConsumerTest {
         return new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer());
     }
 
-
     @Test
     public void verifyHeartbeatSent() throws Exception {
         Time time = new MockTime();
@@ -1215,7 +1214,7 @@ public class KafkaConsumerTest {
         Set<TopicPartition> partitions = Utils.mkSet(tp0, tp1);
         consumer.assign(partitions);
         // verify consumer's assignment
-        assertTrue(consumer.assignment().equals(partitions));
+        assertEquals(partitions, consumer.assignment());
 
         consumer.pause(partitions);
         consumer.seekToEnd(partitions);
@@ -1491,8 +1490,52 @@ public class KafkaConsumerTest {
         }
     }
 
-    @Test
-    public void testConsumerWithinBlackoutPeriodAfterAuthenticationFailure() {
+    @Test(expected = AuthenticationException.class)
+    public void testPartitionsForAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        consumer.partitionsFor("some other topic");
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testBeginningOffsetsAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        consumer.beginningOffsets(Collections.singleton(tp0));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testEndOffsetsAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        consumer.endOffsets(Collections.singleton(tp0));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testPollAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        consumer.subscribe(singleton(topic));
+        consumer.poll(Duration.ZERO);
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testOffsetsForTimesAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        consumer.offsetsForTimes(singletonMap(tp0, 0L));
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testCommitSyncAuthenticationFailure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        offsets.put(tp0, new OffsetAndMetadata(10L));
+        consumer.commitSync(offsets);
+    }
+
+    @Test(expected = AuthenticationException.class)
+    public void testCommittedAuthenticationFaiure() {
+        final KafkaConsumer<String, String> consumer = consumerWithPendingAuthentication();
+        consumer.committed(tp0);
+    }
+
+    private KafkaConsumer<String, String> consumerWithPendingAuthentication() {
         Time time = new MockTime();
         Map<String, Integer> tpCounts = new HashMap<>();
         tpCounts.put(topic, 1);
@@ -1500,70 +1543,14 @@ public class KafkaConsumerTest {
         Node node = cluster.nodes().get(0);
 
         Metadata metadata = createMetadata();
-        metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
+        metadata.update(cluster, Collections.emptySet(), time.milliseconds());
 
         MockClient client = new MockClient(time, metadata);
         client.setNode(node);
-        client.authenticationFailed(node, 300);
         PartitionAssignor assignor = new RangeAssignor();
 
-        final KafkaConsumer<String, String> consumer = newConsumer(time, client, metadata, assignor, true);
-        consumer.subscribe(Collections.singleton(topic));
-        callConsumerApisAndExpectAnAuthenticationError(consumer, tp0);
-
-        time.sleep(30); // wait less than the blackout period
-        assertTrue(client.connectionFailed(node));
-        callConsumerApisAndExpectAnAuthenticationError(consumer, tp0);
-
-        client.requests().clear();
-        consumer.close(0, TimeUnit.MILLISECONDS);
-    }
-
-    private void callConsumerApisAndExpectAnAuthenticationError(KafkaConsumer<?, ?> consumer, TopicPartition partition) {
-        try {
-            consumer.partitionsFor("some other topic");
-            fail("Expected an authentication error!");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        try {
-            consumer.beginningOffsets(Collections.singleton(partition));
-            fail("Expected an authentication error!");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        try {
-            consumer.endOffsets(Collections.singleton(partition));
-            fail("Expected an authentication error!");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        try {
-            consumer.poll(Duration.ZERO);
-            fail("Expected an authentication error!");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        Map<TopicPartition, OffsetAndMetadata> offset = new HashMap<>();
-        offset.put(partition, new OffsetAndMetadata(10L));
-
-        try {
-            consumer.commitSync(offset);
-            fail("Expected an authentication error!");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        try {
-            consumer.committed(partition);
-            fail("Expected an authentication error!");
-        } catch (AuthenticationException e) {
-            // OK
-        }
+        client.createPendingAuthenticationError(node, 0);
+        return newConsumer(time, client, metadata, assignor, false);
     }
 
     private ConsumerRebalanceListener getConsumerRebalanceListener(final KafkaConsumer<String, String> consumer) {
@@ -1724,12 +1711,11 @@ public class KafkaConsumerTest {
                     builder.append(0L, ("key-" + i).getBytes(), ("value-" + i).getBytes());
                 records = builder.build();
             }
-            tpResponses.put(partition,
-                            new FetchResponse.PartitionData(
-                                    Errors.NONE, 0, FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                                    0L, null, records));
+            tpResponses.put(partition, new FetchResponse.PartitionData<>(
+                    Errors.NONE, 0, FetchResponse.INVALID_LAST_STABLE_OFFSET,
+                    0L, null, records));
         }
-        return new FetchResponse(Errors.NONE, tpResponses, 0, INVALID_SESSION_ID);
+        return new FetchResponse<>(Errors.NONE, tpResponses, 0, INVALID_SESSION_ID);
     }
 
     private FetchResponse fetchResponse(TopicPartition partition, long fetchOffset, int count) {

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinatorTest.java
@@ -521,20 +521,10 @@ public class AbstractCoordinatorTest {
     }
 
     @Test
-    public void testEnsureCoordinatorReadyWithinBlackoutPeriodAfterAuthenticationFailure() {
+    public void testAuthenticationErrorInEnsureCoordinatorReady() {
         setupCoordinator(RETRY_BACKOFF_MS);
 
-        mockClient.authenticationFailed(node, 300);
-
-        try {
-            coordinator.ensureCoordinatorReady(Long.MAX_VALUE);
-            fail("Expected an authentication error.");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        mockTime.sleep(30); // wait less than the blackout period
-        assertTrue(mockClient.connectionFailed(node));
+        mockClient.createPendingAuthenticationError(node, 300);
 
         try {
             coordinator.ensureCoordinatorReady(Long.MAX_VALUE);

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1572,18 +1572,8 @@ public class ConsumerCoordinatorTest {
     }
 
     @Test
-    public void testEnsureActiveGroupWithinBlackoutPeriodAfterAuthenticationFailure() {
-        client.authenticationFailed(node, 300);
-
-        try {
-            coordinator.ensureActiveGroup();
-            fail("Expected an authentication error.");
-        } catch (AuthenticationException e) {
-            // OK
-        }
-
-        time.sleep(30); // wait less than the blackout period
-        assertTrue(client.connectionFailed(node));
+    public void testAuthenticationFailureInEnsureActiveGroup() {
+        client.createPendingAuthenticationError(node, 300);
 
         try {
             coordinator.ensureActiveGroup();

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -181,7 +181,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
         val request = requestAndHandler.request.asInstanceOf[WriteTxnMarkersRequest.Builder].build()
         val response = createResponse(request)
         requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-          null, null, 0, 0, false, null, response))
+          null, null, 0, 0, false, null, null, response))
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerChannelManagerTest.scala
@@ -302,7 +302,7 @@ class TransactionMarkerChannelManagerTest {
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
       requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-        null, null, 0, 0, false, null, response))
+        null, null, 0, 0, false, null, null, response))
     }
 
     EasyMock.verify(txnStateManager)
@@ -351,7 +351,7 @@ class TransactionMarkerChannelManagerTest {
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
       requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-        null, null, 0, 0, false, null, response))
+        null, null, 0, 0, false, null, null, response))
     }
 
     EasyMock.verify(txnStateManager)
@@ -406,7 +406,7 @@ class TransactionMarkerChannelManagerTest {
     val response = new WriteTxnMarkersResponse(createPidErrorMap(Errors.NONE))
     for (requestAndHandler <- requestAndHandlers) {
       requestAndHandler.handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-        null, null, 0, 0, false, null, response))
+        null, null, 0, 0, false, null, null, response))
     }
 
     // call this again so that append log will be retried

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandlerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionMarkerRequestCompletionHandlerTest.scala
@@ -72,7 +72,7 @@ class TransactionMarkerRequestCompletionHandlerTest {
     EasyMock.replay(markerChannelManager)
 
     handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-      null, null, 0, 0, true, null, null))
+      null, null, 0, 0, true, null, null, null))
 
     EasyMock.verify(markerChannelManager)
   }
@@ -86,7 +86,7 @@ class TransactionMarkerRequestCompletionHandlerTest {
 
     try {
       handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-        null, null, 0, 0, false, null, response))
+        null, null, 0, 0, false, null, null, response))
       fail("should have thrown illegal argument exception")
     } catch {
       case _: IllegalStateException => // ok
@@ -204,7 +204,7 @@ class TransactionMarkerRequestCompletionHandlerTest {
 
     val response = new WriteTxnMarkersResponse(createProducerIdErrorMap(error))
     handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-      null, null, 0, 0, false, null, response))
+      null, null, 0, 0, false, null, null, response))
 
     assertEquals(txnMetadata.topicPartitions, mutable.Set[TopicPartition](topicPartition))
     EasyMock.verify(markerChannelManager)
@@ -216,7 +216,7 @@ class TransactionMarkerRequestCompletionHandlerTest {
     val response = new WriteTxnMarkersResponse(createProducerIdErrorMap(error))
     try {
       handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-        null, null, 0, 0, false, null, response))
+        null, null, 0, 0, false, null, null, response))
       fail("should have thrown illegal state exception")
     } catch {
       case _: IllegalStateException => // ok
@@ -237,7 +237,7 @@ class TransactionMarkerRequestCompletionHandlerTest {
 
     val response = new WriteTxnMarkersResponse(createProducerIdErrorMap(error))
     handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-      null, null, 0, 0, false, null, response))
+      null, null, 0, 0, false, null, null, response))
 
     assertTrue(txnMetadata.topicPartitions.isEmpty)
     assertTrue(completed)
@@ -257,7 +257,7 @@ class TransactionMarkerRequestCompletionHandlerTest {
 
     val response = new WriteTxnMarkersResponse(createProducerIdErrorMap(error))
     handler.onComplete(new ClientResponse(new RequestHeader(ApiKeys.PRODUCE, 0, "client", 1),
-      null, null, 0, 0, false, null, response))
+      null, null, 0, 0, false, null, null, response))
 
     assertTrue(removed)
   }


### PR DESCRIPTION
We added logic to reassign nodes in `callToSend` after a connection failure, but we do not handle the case when there is no node currently available to reassign the request to. This can happen when using `MetadataUpdateNodeIdProvider` if all of the known nodes are blacked out awaiting the retry backoff. To fix this, we need to ensure that the call is added to `pendingCalls` if a new node cannot be found.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
