### PR TITLE
KAFKA-6987 Reimplement KafkaFuture with CompletableFuture

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
+++ b/clients/src/main/java/org/apache/kafka/common/KafkaFuture.java
@@ -19,14 +19,19 @@ package org.apache.kafka.common;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.internals.KafkaFutureImpl;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A flexible future which supports call chaining and other asynchronous programming patterns. This will
- * eventually become a thin shim on top of Java 8's CompletableFuture.
+ * A flexible future which supports call chaining and other asynchronous programming patterns. This
+ * is a thin shim on top of Java 8's CompletableFuture.
+ *
+ * Please note that while this class offers methods similar to CompletableFuture's whenComplete and thenApply,
+ * functions passed to these methods will never be called with CompletionException. If you wish to use
+ * CompletableFuture semantics, use {@link #toCompletableFuture()}.
  *
  * The API for this class is still evolving and we may break compatibility in minor releases, if necessary.
  */
@@ -202,4 +207,13 @@ public abstract class KafkaFuture<T> implements Future<T> {
      */
     @Override
     public abstract boolean isDone();
+
+    /**
+     * Returns a ComletableFuture equivalent to this Future.
+     *
+     * Implemented in {@link KafkaFuture} throws UnsuportedOperationException.
+     */
+    public CompletableFuture<T> toCompletableFuture() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/gradle/findbugs-exclude.xml
+++ b/gradle/findbugs-exclude.xml
@@ -94,6 +94,12 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Bug pattern="EQ_UNUSUAL"/>
     </Match>
 
+   <Match>
+        <!-- Null is a valid parameter to CompletableFuture.complete(). Exclude false positive. -->
+        <Source name="KafkaAdminClient.java"/>
+        <Bug pattern="NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS"/>
+    </Match>
+
     <Match>
         <!-- Add a suppression for auto-generated calls to instanceof in kafka.utils.Json -->
         <Source name="Json.scala"/>


### PR DESCRIPTION
Use CompletableFuture in KafkaFutureImpl to implement KafkaFuture.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
