### PR TITLE
KAFKA-6975: Fix fetching from non-batch-aligned log start offset

### DIFF
--- a/core/src/main/scala/kafka/common/OffsetsOutOfOrderException.scala
+++ b/core/src/main/scala/kafka/common/OffsetsOutOfOrderException.scala
@@ -21,6 +21,5 @@ package kafka.common
  * Indicates the follower received records with non-monotonically increasing offsets
  */
 class OffsetsOutOfOrderException(message: String) extends RuntimeException(message) {
-  def this() = this(null)
 }
 

--- a/core/src/main/scala/kafka/common/OffsetsOutOfOrderException.scala
+++ b/core/src/main/scala/kafka/common/OffsetsOutOfOrderException.scala
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.common
+
+/**
+ * Indicates the follower received records with non-monotonically increasing offsets
+ */
+class OffsetsOutOfOrderException(message: String) extends RuntimeException(message) {
+  def this() = this(null)
+}
+

--- a/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
+++ b/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
@@ -19,8 +19,11 @@ package kafka.common
 
 /**
  * Indicates the follower or the future replica received records from the leader (or current
- * replica) with first or last offset less than expected next offset
+ * replica) with first offset less than expected next offset. 
  * @param firstOffset The first offset of the records to append
+ * @param lastOffset  The last offset of the records to append
  */
-class UnexpectedAppendOffsetException(val message: String, val firstOffset: Long) extends RuntimeException(message) {
+class UnexpectedAppendOffsetException(val message: String,
+                                      val firstOffset: Long,
+                                      val lastOffset: Long) extends RuntimeException(message) {
 }

--- a/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
+++ b/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
@@ -18,8 +18,8 @@
 package kafka.common
 
 /**
- * Indicates unexpected offset received from the leader that the follower may still be
- * able to append (after some recovery)
+ * Indicates the follower or the future replica received an unexpected offset from the leader (or
+ * current replica)
  */
-class UnexpectedAppendOffsetException(val message: String, val firstOffset: Long) extends RuntimeException(message) {
+class UnexpectedAppendOffsetException(val message: String, val firstOffset: Option[Long]) extends RuntimeException(message) {
 }

--- a/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
+++ b/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
@@ -18,8 +18,8 @@
 package kafka.common
 
 /**
- * Indicates the follower or the future replica received an unexpected offset from the leader (or
- * current replica)
+ * Indicates the follower or the future replica received records from the leader (or current
+ * replica) with first or last offset less than expected next offset
  * @param firstOffset The first offset of the records to append
  */
 class UnexpectedAppendOffsetException(val message: String, val firstOffset: Long) extends RuntimeException(message) {

--- a/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
+++ b/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
@@ -22,5 +22,4 @@ package kafka.common
  * able to append (after some recovery)
  */
 class UnexpectedAppendOffsetException(val message: String, val firstOffset: Long) extends RuntimeException(message) {
-    def this(firstOffset: Long) = this(null, firstOffset)
 }

--- a/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
+++ b/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
@@ -20,6 +20,7 @@ package kafka.common
 /**
  * Indicates the follower or the future replica received an unexpected offset from the leader (or
  * current replica)
+ * @param firstOffset The first offset of the records to append
  */
-class UnexpectedAppendOffsetException(val message: String, val firstOffset: Option[Long]) extends RuntimeException(message) {
+class UnexpectedAppendOffsetException(val message: String, val firstOffset: Long) extends RuntimeException(message) {
 }

--- a/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
+++ b/core/src/main/scala/kafka/common/UnexpectedAppendOffsetException.scala
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.common
+
+/**
+ * Indicates unexpected offset received from the leader that the follower may still be
+ * able to append (after some recovery)
+ */
+class UnexpectedAppendOffsetException(val message: String, val firstOffset: Long) extends RuntimeException(message) {
+    def this(firstOffset: Long) = this(null, firstOffset)
+}

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -29,7 +29,7 @@ import java.util.regex.Pattern
 
 import com.yammer.metrics.core.Gauge
 import kafka.api.KAFKA_0_10_0_IV0
-import kafka.common.{InvalidOffsetException, KafkaException, LogSegmentOffsetOverflowException, LongRef, UnexpectedAppendOffsetException}
+import kafka.common.{InvalidOffsetException, KafkaException, LogSegmentOffsetOverflowException, LongRef, UnexpectedAppendOffsetException, OffsetsOutOfOrderException}
 import kafka.message.{BrokerCompressionCodec, CompressionCodec, NoCompressionCodec}
 import kafka.metrics.KafkaMetricsGroup
 import kafka.server.checkpoints.{LeaderEpochCheckpointFile, LeaderEpochFile}
@@ -799,8 +799,8 @@ class Log(@volatile var dir: File,
         } else {
           // we are taking the offsets we are given
           if (!appendInfo.offsetsMonotonic)
-            throw new IllegalArgumentException(s"Out of order offsets found in append to $topicPartition: " +
-                                               records.records.asScala.map(_.offset))
+            throw new OffsetsOutOfOrderException(s"Out of order offsets found in append to $topicPartition: " +
+                                                 records.records.asScala.map(_.offset))
 
           if (appendInfo.firstOrLastOffset < nextOffsetMetadata.messageOffset) {
             // we may still be able to recover in some situations

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -72,6 +72,7 @@ object LogAppendInfo {
  * @param shallowCount The number of shallow messages
  * @param validBytes The number of valid bytes
  * @param offsetsMonotonic Are the offsets in this message set monotonically increasing
+ * @param lastOffsetOfFirstBatch The last offset of the first batch
  */
 case class LogAppendInfo(var firstOffset: Option[Long],
                          var lastOffset: Long,

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -736,6 +736,8 @@ class Log(@volatile var dir: File,
    * @param assignOffsets Should the log assign offsets to this message set or blindly apply what it is given
    * @param leaderEpoch The partition's leader epoch which will be applied to messages when offsets are assigned on the leader
    * @throws KafkaStorageException If the append fails due to an I/O error.
+   * @throws OffsetsOutOfOrderException If out of order offsets found in 'records'
+   * @throws UnexpectedAppendOffsetException If the first or last offset in append is less than next offset
    * @return Information about the appended messages including the first and last offset.
    */
   private def append(records: MemoryRecords, isFromClient: Boolean, assignOffsets: Boolean, leaderEpoch: Int): LogAppendInfo = {
@@ -816,7 +818,7 @@ class Log(@volatile var dir: File,
               s"Unexpected offset in append to $topicPartition. $firstOrLast " +
               s"offset ${appendInfo.firstOrLastOffset} is less than the next offset ${nextOffsetMetadata.messageOffset}. " +
               s"First 10 offsets in append: ${records.records.asScala.take(10).map(_.offset)}, last offset in" +
-              s" append: ${appendInfo.lastOffset}", firstOffset)
+              s" append: ${appendInfo.lastOffset}. Log start offset = $logStartOffset", firstOffset)
           }
         }
 

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -103,14 +103,14 @@ class ReplicaAlterLogDirsThread(name: String,
       partition.appendRecordsToFutureReplica(records)
     } catch {
       case e: UnexpectedAppendOffsetException =>
-        if (e.firstOffset.isDefined && futureReplica.logEndOffset.messageOffset == futureReplica.logStartOffset) {
+        if (futureReplica.logEndOffset.messageOffset == futureReplica.logStartOffset) {
           // This may happen if the log start offset on the current replica falls in the middle of the
           // batch due to delete records request and the future replica tries to fetch its first offset
           // from the current replica. We will truncate fully again, so that the log segment starts from
           // the base offset that is the base offset of the batch, and try to append records again.
-          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset.get} is less than log start offset ${futureReplica.logStartOffset}." +
-               s" Since this is the first record to be appended to the future replica's log, will start the log from offset ${e.firstOffset.get}.")
-          partition.truncateFullyAndStartAt(e.firstOffset.get, isFuture = true)
+          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${futureReplica.logStartOffset}." +
+               s" Since this is the first record to be appended to the future replica's log, will start the log from offset ${e.firstOffset}.")
+          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = true)
           partition.appendRecordsToFutureReplica(records)
         } else
           throw e

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -98,7 +98,7 @@ class ReplicaAlterLogDirsThread(name: String,
       throw new IllegalStateException("Offset mismatch for the future replica %s: fetched offset = %d, log end offset = %d.".format(
         topicPartition, fetchOffset, futureReplica.logEndOffset.messageOffset))
 
-    partition.appendRecordsToFollower(records, isFuture = true)
+    partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = true)
     val futureReplicaHighWatermark = futureReplica.logEndOffset.messageOffset.min(partitionData.highWatermark)
     futureReplica.highWatermark = new LogOffsetMetadata(futureReplicaHighWatermark)
     futureReplica.maybeIncrementLogStartOffset(partitionData.logStartOffset)

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -103,13 +103,14 @@ class ReplicaAlterLogDirsThread(name: String,
       partition.appendRecordsToFutureReplica(records)
     } catch {
       case e: UnexpectedAppendOffsetException =>
-        if (futureReplica.logEndOffset.messageOffset == futureReplica.logStartOffset) {
+        if (e.firstOffset.isDefined && futureReplica.logEndOffset.messageOffset == futureReplica.logStartOffset) {
           // This may happen if the log start offset on the current replica falls in the middle of the
           // batch due to delete records request and the future replica tries to fetch its first offset
           // from the current replica. We will truncate fully again, so that the log segment starts from
           // the base offset that is the base offset of the batch, and try to append records again.
-          info(s"${e.message}. Since this is the first record to be appended to the future replica's log, will start the log from offset ${e.firstOffset}.")
-          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = true)
+          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset.get} is less than log start offset ${futureReplica.logStartOffset}." +
+               s" Since this is the first record to be appended to the future replica's log, will start the log from offset ${e.firstOffset.get}.")
+          partition.truncateFullyAndStartAt(e.firstOffset.get, isFuture = true)
           partition.appendRecordsToFutureReplica(records)
         } else
           throw e

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -22,7 +22,6 @@ import java.util
 
 import kafka.api.Request
 import kafka.cluster.BrokerEndPoint
-import kafka.common.UnexpectedAppendOffsetException
 import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import kafka.server.QuotaFactory.UnboundedQuota
 import kafka.server.ReplicaAlterLogDirsThread.{FetchRequest, PartitionData}
@@ -99,23 +98,7 @@ class ReplicaAlterLogDirsThread(name: String,
       throw new IllegalStateException("Offset mismatch for the future replica %s: fetched offset = %d, log end offset = %d.".format(
         topicPartition, fetchOffset, futureReplica.logEndOffset.messageOffset))
 
-    try {
-      partition.appendRecordsToFutureReplica(records)
-    } catch {
-      case e: UnexpectedAppendOffsetException =>
-        if (futureReplica.logEndOffset.messageOffset == futureReplica.logStartOffset) {
-          // This may happen if the log start offset on the current replica falls in the middle of the
-          // batch due to delete records request and the future replica tries to fetch its first offset
-          // from the current replica. We will truncate fully again, so that the log segment starts from
-          // the base offset that is the base offset of the batch, and try to append records again.
-          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${futureReplica.logStartOffset}." +
-               s" Since this is the first record to be appended to the future replica's log, will start the log from offset ${e.firstOffset}.")
-          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = true)
-          partition.appendRecordsToFutureReplica(records)
-        } else
-          throw e
-    }
-
+    partition.appendRecordsToFollower(records, isFuture = true)
     val futureReplicaHighWatermark = futureReplica.logEndOffset.messageOffset.min(partitionData.highWatermark)
     futureReplica.highWatermark = new LogOffsetMetadata(futureReplicaHighWatermark)
     futureReplica.maybeIncrementLogStartOffset(partitionData.logStartOffset)

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -22,6 +22,7 @@ import java.util
 
 import kafka.api.Request
 import kafka.cluster.BrokerEndPoint
+import kafka.common.UnexpectedAppendOffsetException
 import kafka.server.AbstractFetcherThread.ResultWithPartitions
 import kafka.server.QuotaFactory.UnboundedQuota
 import kafka.server.ReplicaAlterLogDirsThread.{FetchRequest, PartitionData}
@@ -98,8 +99,22 @@ class ReplicaAlterLogDirsThread(name: String,
       throw new IllegalStateException("Offset mismatch for the future replica %s: fetched offset = %d, log end offset = %d.".format(
         topicPartition, fetchOffset, futureReplica.logEndOffset.messageOffset))
 
-    // Append the leader's messages to the log
-    partition.appendRecordsToFutureReplica(records)
+    try {
+      partition.appendRecordsToFutureReplica(records)
+    } catch {
+      case e: UnexpectedAppendOffsetException =>
+        if (futureReplica.logEndOffset.messageOffset == futureReplica.logStartOffset) {
+          // This may happen if the log start offset on the current replica falls in the middle of the
+          // batch due to delete records request and the future replica tries to fetch its first offset
+          // from the current replica. We will truncate fully again, so that the log segment starts from
+          // the base offset that is the base offset of the batch, and try to append records again.
+          info(s"${e.message}. Since this is the first record to be appended to the future replica's log, will start the log from offset ${e.firstOffset}.")
+          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = true)
+          partition.appendRecordsToFutureReplica(records)
+        } else
+          throw e
+    }
+
     val futureReplicaHighWatermark = futureReplica.logEndOffset.messageOffset.min(partitionData.highWatermark)
     futureReplica.highWatermark = new LogOffsetMetadata(futureReplicaHighWatermark)
     futureReplica.maybeIncrementLogStartOffset(partitionData.logStartOffset)

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -26,7 +26,6 @@ import kafka.log.LogConfig
 import kafka.server.ReplicaFetcherThread._
 import kafka.server.epoch.LeaderEpochCache
 import kafka.zk.AdminZkClient
-import kafka.common.UnexpectedAppendOffsetException
 import org.apache.kafka.clients.FetchSessionHandler
 import org.apache.kafka.common.requests.EpochEndOffset._
 import org.apache.kafka.common.TopicPartition
@@ -113,22 +112,7 @@ class ReplicaFetcherThread(name: String,
         .format(replica.logEndOffset.messageOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
     // Append the leader's messages to the log
-    try {
-      partition.appendRecordsToFollower(records)
-    } catch {
-      case e: UnexpectedAppendOffsetException =>
-        if (replica.logEndOffset.messageOffset == replica.logStartOffset) {
-          // This may happen if the log start offset on the leader falls in the middle of the
-          // batch due to delete records request and the follower tries to fetch its first offset
-          // from the leader. We will truncate fully again, so that the log segment starts from
-          // the base offset that is the base offset of the batch, and try to append records again.
-          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${replica.logStartOffset}." +
-               s" Since this is the first record to be appended to the log, will start the log from offset ${e.firstOffset}.")
-          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = false)
-          partition.appendRecordsToFollower(records)
-        } else
-          throw e
-    }
+    partition.appendRecordsToFollower(records, isFuture = false)
 
     if (isTraceEnabled)
       trace("Follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -117,14 +117,14 @@ class ReplicaFetcherThread(name: String,
       partition.appendRecordsToFollower(records)
     } catch {
       case e: UnexpectedAppendOffsetException =>
-        if (e.firstOffset.isDefined && replica.logEndOffset.messageOffset == replica.logStartOffset) {
+        if (replica.logEndOffset.messageOffset == replica.logStartOffset) {
           // This may happen if the log start offset on the leader falls in the middle of the
           // batch due to delete records request and the follower tries to fetch its first offset
           // from the leader. We will truncate fully again, so that the log segment starts from
           // the base offset that is the base offset of the batch, and try to append records again.
-          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset.get} is less than log start offset ${replica.logStartOffset}." +
-               s" Since this is the first record to be appended to the log, will start the log from offset ${e.firstOffset.get}.")
-          partition.truncateFullyAndStartAt(e.firstOffset.get, isFuture = false)
+          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset} is less than log start offset ${replica.logStartOffset}." +
+               s" Since this is the first record to be appended to the log, will start the log from offset ${e.firstOffset}.")
+          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = false)
           partition.appendRecordsToFollower(records)
         } else
           throw e

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -112,7 +112,7 @@ class ReplicaFetcherThread(name: String,
         .format(replica.logEndOffset.messageOffset, topicPartition, records.sizeInBytes, partitionData.highWatermark))
 
     // Append the leader's messages to the log
-    partition.appendRecordsToFollower(records, isFuture = false)
+    partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false)
 
     if (isTraceEnabled)
       trace("Follower has replica log end offset %d after appending %d bytes of messages for partition %s"

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -117,13 +117,14 @@ class ReplicaFetcherThread(name: String,
       partition.appendRecordsToFollower(records)
     } catch {
       case e: UnexpectedAppendOffsetException =>
-        if (replica.logEndOffset.messageOffset == replica.logStartOffset) {
+        if (e.firstOffset.isDefined && replica.logEndOffset.messageOffset == replica.logStartOffset) {
           // This may happen if the log start offset on the leader falls in the middle of the
           // batch due to delete records request and the follower tries to fetch its first offset
           // from the leader. We will truncate fully again, so that the log segment starts from
           // the base offset that is the base offset of the batch, and try to append records again.
-          info(s"${e.message}. Since this is the first record to be appended to the log, will start the log from offset ${e.firstOffset}.")
-          partition.truncateFullyAndStartAt(e.firstOffset, isFuture = false)
+          info(s"Unexpected offset in append to $topicPartition. First offset ${e.firstOffset.get} is less than log start offset ${replica.logStartOffset}." +
+               s" Since this is the first record to be appended to the log, will start the log from offset ${e.firstOffset.get}.")
+          partition.truncateFullyAndStartAt(e.firstOffset.get, isFuture = false)
           partition.appendRecordsToFollower(records)
         } else
           throw e

--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -23,7 +23,6 @@ import java.util.concurrent.{ExecutionException, TimeUnit}
 import java.io.File
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
-import kafka.api.Request
 import org.apache.kafka.clients.admin.KafkaAdminClientTest
 import org.apache.kafka.common.utils.{Time, Utils}
 import kafka.log.LogConfig

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -104,23 +104,23 @@ class PartitionTest {
                                      new SimpleRecord("k2".getBytes, "v2".getBytes),
                                      new SimpleRecord("k3".getBytes, "v3".getBytes)),
                                 baseOffset = newLogStartOffset)
-    partition.appendRecordsToFollower(records, isFuture = false)
+    partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = false)
     assertEquals(s"Log end offset after append of 3 records with base offset $newLogStartOffset:", 7L, replica.logEndOffset.messageOffset)
-    assertEquals(s"Log end offset after append of 3 records with base offset $newLogStartOffset:", newLogStartOffset, replica.logStartOffset)
+    assertEquals(s"Log start offset after append of 3 records with base offset $newLogStartOffset:", newLogStartOffset, replica.logStartOffset)
 
     // and we can append more records after that
-    partition.appendRecordsToFollower(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 7L), isFuture = false)
+    partition.appendRecordsToFollowerOrFutureReplica(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 7L), isFuture = false)
     assertEquals(s"Log end offset after append of 1 record at offset 7:", 8L, replica.logEndOffset.messageOffset)
     assertEquals(s"Log start offset not expected to change:", newLogStartOffset, replica.logStartOffset)
 
     // but we cannot append to offset < log start if the log is not empty
     assertThrows[UnexpectedAppendOffsetException] {
-      partition.appendRecordsToFollower(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 3L), isFuture = false)
+      partition.appendRecordsToFollowerOrFutureReplica(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 3L), isFuture = false)
     }
     assertEquals(s"Log end offset should not change after failure to append", 8L, replica.logEndOffset.messageOffset)
 
     // we still can append to next offset
-    partition.appendRecordsToFollower(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 8L), isFuture = false)
+    partition.appendRecordsToFollowerOrFutureReplica(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 8L), isFuture = false)
     assertEquals(s"Log end offset after append of 1 record at offset 8:", 9L, replica.logEndOffset.messageOffset)
     assertEquals(s"Log start offset not expected to change:", newLogStartOffset, replica.logStartOffset)
   }

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.cluster
+
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
+
+import kafka.common.UnexpectedAppendOffsetException
+import kafka.log.{Log, LogConfig, LogManager, CleanerConfig}
+import kafka.server._
+import kafka.utils.{MockTime, TestUtils, MockScheduler}
+import kafka.utils.timer.MockTimer
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.utils.Utils
+import org.apache.kafka.common.record._
+import org.junit.{After, Before, Test}
+import org.junit.Assert._
+import org.scalatest.Assertions.assertThrows
+import scala.collection.JavaConverters._
+
+class PartitionTest {
+
+  val brokerId = 101
+  val topicPartition = new TopicPartition("test-topic", 0)
+  val time = new MockTime()
+  val brokerTopicStats = new BrokerTopicStats
+  val metrics = new Metrics
+
+  var tmpDir: File = _
+  var logDir: File = _
+  var replicaManager: ReplicaManager = _
+  var logManager: LogManager = _
+  var logConfig: LogConfig = _
+
+  @Before
+  def setup(): Unit = {
+    val logProps = new Properties()
+    logProps.put(LogConfig.SegmentBytesProp, 512: java.lang.Integer)
+    logProps.put(LogConfig.SegmentIndexBytesProp, 1000: java.lang.Integer)
+    logProps.put(LogConfig.RetentionMsProp, 999: java.lang.Integer)
+    logConfig = LogConfig(logProps)
+
+    tmpDir = TestUtils.tempDir()
+    logDir = TestUtils.randomPartitionLogDir(tmpDir)
+    logManager = TestUtils.createLogManager(
+      logDirs = Seq(logDir), defaultConfig = logConfig, CleanerConfig(enableCleaner = false), time)
+    logManager.startup()
+
+    val brokerProps = TestUtils.createBrokerConfig(brokerId, TestUtils.MockZkConnect)
+    brokerProps.put("log.dir", logDir.getAbsolutePath)
+    val brokerConfig = KafkaConfig.fromProps(brokerProps)
+    replicaManager = new ReplicaManager(
+      config = brokerConfig, metrics, time, zkClient = null, new MockScheduler(time),
+      logManager, new AtomicBoolean(false), QuotaFactory.instantiate(brokerConfig, metrics, time, ""),
+      brokerTopicStats, new MetadataCache(brokerId), new LogDirFailureChannel(brokerConfig.logDirs.size))
+  }
+
+  @After
+  def tearDown(): Unit = {
+    brokerTopicStats.close()
+    metrics.close()
+
+    logManager.shutdown()
+    Utils.delete(tmpDir)
+    logManager.liveLogDirs.foreach(Utils.delete)
+    replicaManager.shutdown(checkpointHW = false)
+  }
+
+  @Test
+  def testAppendRecordsAsFollowerBelowLogStartOffset(): Unit = {
+    val log = logManager.getOrCreateLog(topicPartition, logConfig)
+    val replica = new Replica(brokerId, topicPartition, time, log = Some(log))
+    val partition = new Partition(topicPartition.topic, topicPartition.partition, time, replicaManager)
+    partition.addReplicaIfNotExists(replica)
+    assertEquals(Some(replica), partition.getReplica(replica.brokerId))
+
+    val initialLogStartOffset = 5L
+    partition.truncateFullyAndStartAt(initialLogStartOffset, isFuture = false)
+    assertEquals(s"Log end offset after truncate fully and start at $initialLogStartOffset:",
+                 initialLogStartOffset, replica.logEndOffset.messageOffset)
+    assertEquals(s"Log start offset after truncate fully and start at $initialLogStartOffset:",
+                 initialLogStartOffset, replica.logStartOffset)
+
+    // verify that we can append records with first offset < log start offset if the log is empty
+    val newLogStartOffset = 4L
+    val records = createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes),
+                                     new SimpleRecord("k2".getBytes, "v2".getBytes),
+                                     new SimpleRecord("k3".getBytes, "v3".getBytes)),
+                                baseOffset = newLogStartOffset)
+    partition.appendRecordsToFollower(records, isFuture = false)
+    assertEquals(s"Log end offset after append of 3 records with base offset $newLogStartOffset:", 7L, replica.logEndOffset.messageOffset)
+    assertEquals(s"Log end offset after append of 3 records with base offset $newLogStartOffset:", newLogStartOffset, replica.logStartOffset)
+
+    // and we can append more records after that
+    partition.appendRecordsToFollower(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 7L), isFuture = false)
+    assertEquals(s"Log end offset after append of 1 record at offset 7:", 8L, replica.logEndOffset.messageOffset)
+    assertEquals(s"Log start offset not expected to change:", newLogStartOffset, replica.logStartOffset)
+
+    // but we cannot append to offset < log start if the log is not empty
+    assertThrows[UnexpectedAppendOffsetException] {
+      partition.appendRecordsToFollower(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 3L), isFuture = false)
+    }
+    assertEquals(s"Log end offset should not change after failure to append", 8L, replica.logEndOffset.messageOffset)
+
+    // we still can append to next offset
+    partition.appendRecordsToFollower(createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes)), baseOffset = 8L), isFuture = false)
+    assertEquals(s"Log end offset after append of 1 record at offset 8:", 9L, replica.logEndOffset.messageOffset)
+    assertEquals(s"Log start offset not expected to change:", newLogStartOffset, replica.logStartOffset)
+  }
+
+  def createRecords(records: Iterable[SimpleRecord], baseOffset: Long, partitionLeaderEpoch: Int = 0): MemoryRecords = {
+    val buf = ByteBuffer.allocate(DefaultRecordBatch.sizeInBytes(records.asJava))
+    val builder = MemoryRecords.builder(
+      buf, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.LOG_APPEND_TIME,
+      baseOffset, time.milliseconds, partitionLeaderEpoch)
+    records.foreach(builder.append)
+    builder.build()
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -143,7 +143,7 @@ class PartitionTest {
   }
 
   @Test
-  def testAppendRecordsToFollowerWithNoReplicaThrowsExpection(): Unit = {
+  def testAppendRecordsToFollowerWithNoReplicaThrowsException(): Unit = {
     val partition = new Partition(topicPartition.topic, topicPartition.partition, time, replicaManager)
     assertThrows[ReplicaNotAvailableException] {
       partition.appendRecordsToFollowerOrFutureReplica(

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -1929,10 +1929,13 @@ class LogTest {
     for (magic <- magicVals) {
       val batch = singletonRecordsWithLeaderEpoch(value = "random".getBytes, leaderEpoch = 1,
                                                   offset = firstOffset, codec = CompressionType.LZ4, magicValue = magic)
-      val actualFirstOffset = intercept[UnexpectedAppendOffsetException] {
+      val exception = intercept[UnexpectedAppendOffsetException] {
         log.appendAsFollower(records = batch)
-      }.firstOffset
+      }
+      val actualFirstOffset = exception.firstOffset
+      val actualLastOffset = exception.lastOffset
       assertEquals(s"Magic $magic. UnexpectedAppendOffsetException#firstOffset", firstOffset, actualFirstOffset)
+      assertEquals(s"Magic $magic. UnexpectedAppendOffsetException#lastOffset", firstOffset, actualLastOffset)
     }
   }
 


### PR DESCRIPTION
It is possible that log start offset may fall in the middle of the batch after AdminClient#deleteRecords(). This will cause a follower starting from log start offset to fail fetching (all records). Use-cases when a follower will start fetching from log start offset includes: 1) new replica due to partition re-assignment; 2) new local replica created as a result of AdminClient#AlterReplicaLogDirs(); 3) broker that was down for some time while AdminClient#deleteRecords() move log start offset beyond its HW. 

Added two integration tests:
1) Produce and then AdminClient#deleteRecords() while one of the followers is down, and then restart of the follower requires fetching from log start offset;
2)  AdminClient#AlterReplicaLogDirs() after AdminClient#deleteRecords()

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
