### PR TITLE
KAFKA-6993: Fix defective documentations for KStream/KTable methods

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -417,8 +417,8 @@ public interface KStream<K, V> {
     KStream<K, V> merge(final KStream<K, V> stream);
 
     /**
-     * Materialize this stream to a topic and creates a new {@code KStream} from the topic using default serializers and
-     * deserializers and producer's {@link DefaultPartitioner}.
+     * Materialize this stream to a topic and creates a new {@code KStream} from the topic using default serializers,
+     * deserializers, and producer's {@link DefaultPartitioner}.
      * The specified topic should be manually created before it is used (i.e., before the Kafka Streams application is
      * started).
      * <p>

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KStream.java
@@ -947,8 +947,9 @@ public interface KStream<K, V> {
                                  final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join with default
-     * serializers and deserializers.
+     * Join records of this stream with another {@code KStream}'s records using windowed inner equi join using the
+     * {@link Joined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value serde},
+     * and {@link Serde the other stream's value serde}.
      * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
      * Furthermore, two records are only joined if their timestamps are close to each other as defined by the given
      * {@link JoinWindows}, i.e., the window defines an additional join predicate on the record timestamps.
@@ -1106,8 +1107,9 @@ public interface KStream<K, V> {
                                      final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed left equi join with default
-     * serializers and deserializers.
+     * Join records of this stream with another {@code KStream}'s records using windowed left equi join using the
+     * {@link Joined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value serde},
+     * and {@link Serde the other stream's value serde}.
      * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join}, all records from this stream will
      * produce at least one output record (cf. below).
      * The join is computed on the records' key with join attribute {@code thisKStream.key == otherKStream.key}.
@@ -1270,8 +1272,9 @@ public interface KStream<K, V> {
                                       final JoinWindows windows);
 
     /**
-     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join with default
-     * serializers and deserializers.
+     * Join records of this stream with another {@code KStream}'s records using windowed outer equi join using the
+     * {@link Joined} instance for configuration of the {@link Serde key serde}, {@link Serde this stream's value serde},
+     * and {@link Serde the other stream's value serde}.
      * In contrast to {@link #join(KStream, ValueJoiner, JoinWindows) inner-join} or
      * {@link #leftJoin(KStream, ValueJoiner, JoinWindows) left-join}, all records from both streams will produce at
      * least one output record (cf. below).

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -192,7 +192,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and state store.
+     * (with possibly a new type) in the new {@code KTable}, with default serializers, deserializers, and state store.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -226,7 +226,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and state store.
+     * (with possibly a new type) in the new {@code KTable}, with default serializers, deserializers, and state store.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -261,7 +261,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with the {@link Serde key serde}, {@link Serde value serde},
+     * (with possibly a new type) in the new {@code KTable}, with the {@link Serde key serde}, {@link Serde value serde},
      * and the underlying {@link KeyValueStore materialized state storage} configured in the {@link Materialized}
      * instance.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
@@ -307,7 +307,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with the {@link Serde key serde}, {@link Serde value serde},
+     * (with possibly a new type) in the new {@code KTable}, with the {@link Serde key serde}, {@link Serde value serde},
      * and the underlying {@link KeyValueStore materialized state storage} configured in the {@link Materialized}
      * instance.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
@@ -391,7 +391,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type), with default serializers, deserializers, and state store.
+     * (with possibly a new type), with default serializers, deserializers, and state store.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -464,7 +464,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type), with the {@link Serde key serde}, {@link Serde value serde}, and the underlying
+     * (with possibly a new type), with the {@link Serde key serde}, {@link Serde value serde}, and the underlying
      * {@link KeyValueStore materialized state storage} configured in the {@link Materialized} instance.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -70,7 +70,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
-     * predicate.
+     * predicate, with default serializers, deserializers and internal state storage.
      * All records that do not satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -92,7 +92,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
-     * predicate.
+     * predicate, using the {@link Materialized} instance for configuration of the {@link Serde key serde},
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * All records that do not satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -130,7 +131,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
-     * given predicate.
+     * given predicate, with default serializers, deserializers and internal state storage.
      * All records that <em>do</em> satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -152,7 +153,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
-     * given predicate.
+     * given predicate, using the {@link Materialized} instance for configuration of the {@link Serde key serde},
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * All records that <em>do</em> satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -190,7 +192,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possible new type) in the new {@code KTable}.
+     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers and internal state
+     * storage.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -224,7 +227,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possible new type) in the new {@code KTable}.
+     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers and internal state
+     * storage.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -259,7 +263,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possible new type) in the new {@code KTable}.
+     * (with possibly new type) in the new {@code KTable}, using the {@link Materialized} instance for configuration of
+     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -303,7 +308,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possible new type) in the new {@code KTable}.
+     * (with possibly new type) in the new {@code KTable}, using the {@link Materialized} instance for configuration of
+     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -384,8 +390,8 @@ public interface KTable<K, V> {
     <KR> KStream<KR, V> toStream(final KeyValueMapper<? super K, ? super V, ? extends KR> mapper);
 
     /**
-     * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value,
-     * (with possibly new type).
+     * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
+     * (with possibly new type), with default serializers, deserializers and internal state storage.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -457,8 +463,9 @@ public interface KTable<K, V> {
                                        final String... stateStoreNames);
 
     /**
-     * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value,
-     * (with possibly new type).
+     * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
+     * (with possibly new type), using the {@link Materialized} instance for configuration of the {@link Serde key serde},
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * This is similar to {@link #mapValues(ValueMapperWithKey)}, but more flexible, allowing stateful, rather than stateless,
@@ -598,7 +605,8 @@ public interface KTable<K, V> {
                                            final Serialized<KR, VR> serialized);
 
     /**
-     * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join.
+     * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join,
+     * with default serializers, deserializers and internal state storage.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * The result is an ever updating {@code KTable} that represents the <em>current</em> (i.e., processing time) result
      * of the join.
@@ -672,7 +680,9 @@ public interface KTable<K, V> {
                                 final ValueJoiner<? super V, ? super VO, ? extends VR> joiner);
 
     /**
-     * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join.
+     * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join,
+     * with the {@link Materialized} instance for configuration of the {@link Serde key serde},
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * The result is an ever updating {@code KTable} that represents the <em>current</em> (i.e., processing time) result
      * of the join.
@@ -751,7 +761,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed left equi join.
+     * non-windowed left equi join, with default serializers, deserializers and internal state storage.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from left {@code KTable} will produce
      * an output record (cf. below).
@@ -833,7 +843,8 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed left equi join.
+     * non-windowed left equi join, with the {@link Materialized} instance for configuration of the {@link Serde key serde},
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from left {@code KTable} will produce
      * an output record (cf. below).
@@ -919,7 +930,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed outer equi join.
+     * non-windowed outer equi join, with default serializers, deserializers and internal state storage.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join} or {@link #leftJoin(KTable, ValueJoiner) left-join},
      * all records from both input {@code KTable}s will produce an output record (cf. below).
@@ -1000,7 +1011,8 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed outer equi join.
+     * non-windowed outer equi join, with the {@link Materialized} instance for configuration of the {@link Serde key serde},
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join} or {@link #leftJoin(KTable, ValueJoiner) left-join},
      * all records from both input {@code KTable}s will produce an output record (cf. below).

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -92,8 +92,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
-     * predicate, using the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
+     * predicate, with the {@link Serde key serde}, {@link Serde value serde}, and the underlying
+     * {@link KeyValueStore materialized state storage} configured in the {@link Materialized} instance.
      * All records that do not satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -153,8 +153,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
-     * given predicate, using the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
+     * given predicate, with the {@link Serde key serde}, {@link Serde value serde}, and the underlying
+     * {@link KeyValueStore materialized state storage} configured in the {@link Materialized} instance.
      * All records that <em>do</em> satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -261,8 +261,9 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, using the {@link Materialized} instance for configuration of
-     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
+     * (with possibly new type) in the new {@code KTable}, with the {@link Serde key serde}, {@link Serde value serde},
+     * and the underlying {@link KeyValueStore materialized state storage} configured in the {@link Materialized}
+     * instance.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -306,8 +307,9 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, using the {@link Materialized} instance for configuration of
-     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
+     * (with possibly new type) in the new {@code KTable}, with the {@link Serde key serde}, {@link Serde value serde},
+     * and the underlying {@link KeyValueStore materialized state storage} configured in the {@link Materialized}
+     * instance.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -462,8 +464,8 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type), using the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
+     * (with possibly new type), with the {@link Serde key serde}, {@link Serde value serde}, and the underlying
+     * {@link KeyValueStore materialized state storage} configured in the {@link Materialized} instance.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * This is similar to {@link #mapValues(ValueMapperWithKey)}, but more flexible, allowing stateful, rather than stateless,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -70,7 +70,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
-     * predicate, with default serializers, deserializers and internal state storage.
+     * predicate, with default serializers, deserializers, and internal state storage.
      * All records that do not satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -131,7 +131,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
-     * given predicate, with default serializers, deserializers and internal state storage.
+     * given predicate, with default serializers, deserializers, and internal state storage.
      * All records that <em>do</em> satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -192,7 +192,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers and internal state
+     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and internal state
      * storage.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
@@ -227,7 +227,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers and internal state
+     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and internal state
      * storage.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
@@ -391,7 +391,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type), with default serializers, deserializers and internal state storage.
+     * (with possibly new type), with default serializers, deserializers, and internal state storage.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -606,7 +606,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join,
-     * with default serializers, deserializers and internal state storage.
+     * with default serializers, deserializers, and internal state storage.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * The result is an ever updating {@code KTable} that represents the <em>current</em> (i.e., processing time) result
      * of the join.
@@ -761,7 +761,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed left equi join, with default serializers, deserializers and internal state storage.
+     * non-windowed left equi join, with default serializers, deserializers, and internal state storage.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from left {@code KTable} will produce
      * an output record (cf. below).
@@ -930,7 +930,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed outer equi join, with default serializers, deserializers and internal state storage.
+     * non-windowed outer equi join, with default serializers, deserializers, and internal state storage.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join} or {@link #leftJoin(KTable, ValueJoiner) left-join},
      * all records from both input {@code KTable}s will produce an output record (cf. below).

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -70,7 +70,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
-     * predicate, with default serializers, deserializers, and internal state storage.
+     * predicate, with default serializers, deserializers, and state store.
      * All records that do not satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -93,7 +93,7 @@ public interface KTable<K, V> {
     /**
      * Create a new {@code KTable} that consists of all records of this {@code KTable} which satisfy the given
      * predicate, using the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * All records that do not satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -131,7 +131,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
-     * given predicate, with default serializers, deserializers, and internal state storage.
+     * given predicate, with default serializers, deserializers, and state store.
      * All records that <em>do</em> satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -154,7 +154,7 @@ public interface KTable<K, V> {
     /**
      * Create a new {@code KTable} that consists all records of this {@code KTable} which do <em>not</em> satisfy the
      * given predicate, using the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * All records that <em>do</em> satisfy the predicate are dropped.
      * For each {@code KTable} update, the filter is evaluated based on the current update
      * record and then an update record is produced for the result {@code KTable}.
@@ -192,8 +192,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and internal state
-     * storage.
+     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and state store.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -227,8 +226,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and internal state
-     * storage.
+     * (with possibly new type) in the new {@code KTable}, with default serializers, deserializers, and state store.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -264,7 +262,7 @@ public interface KTable<K, V> {
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
      * (with possibly new type) in the new {@code KTable}, using the {@link Materialized} instance for configuration of
-     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * For each {@code KTable} update the provided {@link ValueMapper} is applied to the value of the updated record and
      * computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -309,7 +307,7 @@ public interface KTable<K, V> {
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
      * (with possibly new type) in the new {@code KTable}, using the {@link Materialized} instance for configuration of
-     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * the {@link Serde key serde}, {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * For each {@code KTable} update the provided {@link ValueMapperWithKey} is applied to the value of the update
      * record and computes a new value for it, resulting in an updated record for the result {@code KTable}.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -391,7 +389,7 @@ public interface KTable<K, V> {
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
-     * (with possibly new type), with default serializers, deserializers, and internal state storage.
+     * (with possibly new type), with default serializers, deserializers, and state store.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * Thus, an input record {@code <K,V>} can be transformed into an output record {@code <K:V'>}.
@@ -465,7 +463,7 @@ public interface KTable<K, V> {
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value
      * (with possibly new type), using the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * A {@link ValueTransformerWithKey} (provided by the given {@link ValueTransformerWithKeySupplier}) is applied to each input
      * record value and computes a new value for it.
      * This is similar to {@link #mapValues(ValueMapperWithKey)}, but more flexible, allowing stateful, rather than stateless,
@@ -606,7 +604,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join,
-     * with default serializers, deserializers, and internal state storage.
+     * with default serializers, deserializers, and state store.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * The result is an ever updating {@code KTable} that represents the <em>current</em> (i.e., processing time) result
      * of the join.
@@ -682,7 +680,7 @@ public interface KTable<K, V> {
     /**
      * Join records of this {@code KTable} with another {@code KTable}'s records using non-windowed inner equi join,
      * with the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * The result is an ever updating {@code KTable} that represents the <em>current</em> (i.e., processing time) result
      * of the join.
@@ -761,7 +759,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed left equi join, with default serializers, deserializers, and internal state storage.
+     * non-windowed left equi join, with default serializers, deserializers, and state store.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from left {@code KTable} will produce
      * an output record (cf. below).
@@ -844,7 +842,7 @@ public interface KTable<K, V> {
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
      * non-windowed left equi join, with the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join}, all records from left {@code KTable} will produce
      * an output record (cf. below).
@@ -930,7 +928,7 @@ public interface KTable<K, V> {
 
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
-     * non-windowed outer equi join, with default serializers, deserializers, and internal state storage.
+     * non-windowed outer equi join, with default serializers, deserializers, and state store.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join} or {@link #leftJoin(KTable, ValueJoiner) left-join},
      * all records from both input {@code KTable}s will produce an output record (cf. below).
@@ -1012,7 +1010,7 @@ public interface KTable<K, V> {
     /**
      * Join records of this {@code KTable} (left input) with another {@code KTable}'s (right input) records using
      * non-windowed outer equi join, with the {@link Materialized} instance for configuration of the {@link Serde key serde},
-     * {@link Serde the result table's value serde}, and {@link KeyValueStore internal state storage}.
+     * {@link Serde the result table's value serde}, and {@link KeyValueStore state store}.
      * The join is a primary key join with join attribute {@code thisKTable.key == otherKTable.key}.
      * In contrast to {@link #join(KTable, ValueJoiner) inner-join} or {@link #leftJoin(KTable, ValueJoiner) left-join},
      * all records from both input {@code KTable}s will produce an output record (cf. below).


### PR DESCRIPTION
1. Fix the documentation of following methods, e.g., making more detailed description for the overloaded methods:

	- KStream#join
	- KStream#leftJoin
	- KStream#outerJoin
	- KTable#filter
	- KTable#filterNot
	- KTable#mapValues
	- KTable#transformValues
	- KTable#join
	- KTable#leftJoin
	- KTable#outerJoin

2. (trivial) with possible new type -> with possibly new type.