### PR TITLE
HOTFIX: Use alternative state store changelog topic

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractTask.java
@@ -91,6 +91,7 @@ public abstract class AbstractTask implements Task {
                 changelogReader,
                 eosEnabled,
                 logContext);
+            stateMgr.setApplicationId(applicationId);
         } catch (final IOException e) {
             throw new ProcessorStateException(String.format("%sError while creating the state manager", logPrefix), e);
         }


### PR DESCRIPTION
I've tried multiple ways to add a upgrade path patch for users from StreamsBuilder users in 1.0 / 1.1 to 2.0 with source KTable topics reusing. The following approach has the smallest changes on code and hopefully have the least changes.

Note that I do not intentionally write a checkpoint file after the restoration is done, since it will cause the logic to become too complex with / without EOS. If we do not have this checkpoint file containing the offset of the source topic, then if there is a crash between starting the restoration and writing the first checkpoint file in task.commit during normal processing, upon resuming we will restore from the old changelog again and may have duplicates if EOS is not turned on. But both are existed today so we are not introducing any regressions.

Another note is that the changelog topic map now have three different code paths (it is not introduced by this PR, but just want to bring this up to attention):

1. From `InternalTopologyBuilder.topicGroups`, used by the partition assignor to create those changelog topics; for this case if a state store is not logging enabled it should not be in this map.

2. From `InternalTopologBuilder.build` that generates the `ProcessorTopology` and then later used in `ProcessorStateManager`. Here even if a store is not logging enabled, if it still need to be restored either in a standby task or as part of the restoration of an active task, it should still be in the storesToChangelogs map, but note that the changelog topic names may not always be `stateStore-changelog`.

3. In `StoreBuilder`, decide whether we should really wrap it with the logging layer, and if yes, which topic to write to. Here if logging is disabled we should never wrap the logging layer, otherwise we wrap logging with the normal `stateStore-changelog` topic name.

Right now these logic modules are handled by completely different code paths; it is a bit complex for future optimizations on the topology.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
