### PR TITLE
KAFKA-7001: Rename errors.allowed.max property in Connect to errors.tolerance (KIP-298)

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/ConnectorConfig.java
@@ -120,7 +120,7 @@ public class ConnectorConfig extends AbstractConfig {
     public static final String ERRORS_RETRY_MAX_DELAY_DOC = "The maximum duration in milliseconds between consecutive retry attempts. " +
             "Jitter will be added to the delay once this limit is reached to prevent thundering herd issues.";
 
-    public static final String ERRORS_TOLERANCE_CONFIG = "errors.allowed.max";
+    public static final String ERRORS_TOLERANCE_CONFIG = "errors.tolerance";
     public static final String ERRORS_TOLERANCE_DISPLAY = "Error Tolerance";
     public static final ToleranceType ERRORS_TOLERANCE_DEFAULT = ToleranceType.NONE;
     public static final String ERRORS_TOLERANCE_DOC = "Behavior for tolerating errors during connector operation. 'none' is the default value " +


### PR DESCRIPTION
Signed-off-by: Arjun Satish <arjun@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
