### PR TITLE
MINOR: some fix in Javadocs of StateStore.WindowStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/WindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/WindowStore.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.processor.StateStore;
 public interface WindowStore<K, V> extends StateStore, ReadOnlyWindowStore<K, V> {
 
     /**
-     * Put a key-value pair with the current wall-clock time as the timestamp
+     * Put a key-value pair with the current {@link org.apache.kafka.streams.processor.ProcessorContext#timestamp() timestamp}
      * into the corresponding window
      * @param key The key to associate the value to
      * @param value The value to update, it can be null;


### PR DESCRIPTION
`WindowStore` docs tell us that `put(K key, V value)` uses wall-clock time as the timestamp but it is not true. All window stores (`CachingWindowStore`, `ChangeLoggingWindowBytesStore`, `MeteredWindowStore` and `RocksDBWindowStore`) use `context.timestamp()` as if we use `put(K key, V value, long timestamp)`.
```java
put(key, value, context.timestamp());
```
So I think there is mistake here, correct me if I be wrong.