### PR TITLE
MINOR: Upgrade Gradle to 4.8 and bug fix updates for other deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     classpath 'org.scoverage:gradle-scoverage:2.3.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
-    classpath 'org.owasp:dependency-check-gradle:3.1.2'
+    classpath 'org.owasp:dependency-check-gradle:3.2.1'
   }
 }
 
@@ -76,7 +76,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.7"
+  gradleVersion = "4.8"
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -48,7 +48,7 @@ versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("
 
 versions += [
   activation: "1.1.1",
-  apacheda: "1.0.1",
+  apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
   bcpkix: "1.59",
@@ -79,7 +79,7 @@ versions += [
   scalatest: "3.0.5",
   scoverage: "1.3.1",
   slf4j: "1.7.25",
-  snappy: "1.1.7.1",
+  snappy: "1.1.7.2",
   zkclient: "0.10",
   zookeeper: "3.4.12"
 ]


### PR DESCRIPTION
In addition to Gradle, updated snappy, owasp-dependency-check,
apache directory service api.

Gradle 4.8 fixes a fatal issue when building with Java 11, but
full support is coming in 4.9 or later.

Manually tested that `jarAll` and importing into IntelliJ works,
relying on PR build for the rest.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
