### PR TITLE
KAFKA-7009: Suppress the Reflections log warning messages in system tests

### DIFF
--- a/tests/kafkatest/services/templates/connect_log4j.properties
+++ b/tests/kafkatest/services/templates/connect_log4j.properties
@@ -27,3 +27,4 @@ log4j.appender.FILE.layout.conversionPattern=[%d] %p %m (%c)%n
 
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.I0Itec.zkclient=ERROR
+log4j.logger.org.reflections=ERROR


### PR DESCRIPTION
This could be backported to older branches to reduce the extra log warning messages there, too.

Running Connect system tests in this branch builder job: https://jenkins.confluent.io/job/system-test-kafka-branch-builder/1773/

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
