### PR TITLE
MINOR: follow-up test for create topic acl (KIP-277)

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -44,6 +44,8 @@ import org.apache.kafka.common.resource.ResourceNameType.LITERAL
 import org.apache.kafka.common.resource.{ResourcePattern, ResourcePatternFilter, ResourceType => AdminResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, SecurityProtocol}
 import org.apache.kafka.common.{KafkaException, Node, TopicPartition, requests}
+import org.apache.kafka.test.{TestUtils => JTestUtils}
+
 import org.junit.Assert._
 import org.junit.{After, Assert, Before, Test}
 
@@ -863,21 +865,28 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
 
   @Test
   def testCreatePermissionMetadataRequestAutoCreate() {
-    // existing topic
     val readAcls = topicReadAcl.get(topicResource).get
     addAndVerifyAcls(readAcls, topicResource)
+    assertTrue(zkClient.topicExists(topicResource.name))
 
-    // non-existing topic
-    val newTopicPartition = new TopicPartition(createTopic, 0)
-    val newTopicResource = new Resource(Topic, createTopic)
-    addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), newTopicResource)
+    addAndVerifyAcls(readAcls, createTopicResource)
+    assertFalse(zkClient.topicExists(createTopic))
 
-    val metadataRequest = new requests.MetadataRequest.Builder(List(topic, createTopic).asJava, true).build()
-    val response = connectAndSend(metadataRequest, ApiKeys.METADATA)
-    val metadataResponse = MetadataResponse.parse(response, ApiKeys.METADATA.latestVersion)
+    val metadataRequest = new MetadataRequest.Builder(List(topic, createTopic).asJava, true).build()
+    val metadataResponse = MetadataResponse.parse(connectAndSend(metadataRequest, ApiKeys.METADATA), ApiKeys.METADATA.latestVersion)
 
     assertEquals(Set(topic).asJava, metadataResponse.topicsByError(Errors.NONE));
-    assertEquals(Set(createTopic).asJava, metadataResponse.topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED));
+    assertEquals(Set(createTopic).asJava, metadataResponse.topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED))
+
+    val createAcls = topicCreateAcl.get(createTopicResource).get
+    addAndVerifyAcls(createAcls, createTopicResource)
+
+    // retry as topic being created can have MetadataResponse with Errors.LEADER_NOT_AVAILABLE
+    TestUtils.retry(JTestUtils.DEFAULT_MAX_WAIT_MS)( () => {
+      val metadataResponse = MetadataResponse.parse(connectAndSend(metadataRequest, ApiKeys.METADATA), ApiKeys.METADATA.latestVersion)
+      assertEquals(Set().asJava, metadataResponse.topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED))
+      assertEquals(Set(topic, createTopic).asJava, metadataResponse.topicsByError(Errors.NONE))
+    })
   }
 
   @Test(expected = classOf[AuthorizationException])

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -882,9 +882,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     addAndVerifyAcls(createAcls, createTopicResource)
 
     // retry as topic being created can have MetadataResponse with Errors.LEADER_NOT_AVAILABLE
-    TestUtils.retry(JTestUtils.DEFAULT_MAX_WAIT_MS)( () => {
+    TestUtils.retry(JTestUtils.DEFAULT_MAX_WAIT_MS)(() => {
       val metadataResponse = MetadataResponse.parse(connectAndSend(metadataRequest, ApiKeys.METADATA), ApiKeys.METADATA.latestVersion)
-      assertEquals(Set().asJava, metadataResponse.topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED))
       assertEquals(Set(topic, createTopic).asJava, metadataResponse.topicsByError(Errors.NONE))
     })
   }


### PR DESCRIPTION
Check handling of a Metadata Request with a mix of existing and
non-existing topics.

The particular codepath was not exercised by a test in the original PR.
@ijuma fixed the code path on merge
This small testcase covers that

Co-authored-by: Edoardo Comar <ecomar@uk.ibm.com>
Co-authored-by: Mickael Maison <mickael.maison@gmail.com>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
