### PR TITLE
KAFKA-7003: Set error context in message headers (KIP-298)

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -44,8 +44,6 @@ import java.util.Set;
  */
 public class ConnectHeaders implements Headers {
 
-    public static final String HEADER_PREFIX = "__connect";
-
     private static final int EMPTY_HASH = Objects.hash(new LinkedList<>());
 
     /**

--- a/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/header/ConnectHeaders.java
@@ -44,6 +44,8 @@ import java.util.Set;
  */
 public class ConnectHeaders implements Headers {
 
+    public static final String HEADER_PREFIX = "__connect";
+
     private static final int EMPTY_HASH = Objects.hash(new LinkedList<>());
 
     /**

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
@@ -60,7 +60,8 @@ public class SinkConnectorConfig extends ConnectorConfig {
     public static final String DLQ_CONTEXT_HEADERS_ENABLE_CONFIG = DLQ_PREFIX + "context.headers.enable";
     public static final boolean DLQ_CONTEXT_HEADERS_ENABLE_DEFAULT = false;
     public static final String DLQ_CONTEXT_HEADERS_ENABLE_DOC = "If true, add headers containing error context to the messages " +
-            "written to the dead letter queue. All error context headers will be prefixed with \"__connect.errors\".";
+            "written to the dead letter queue. To avoid clashing with headers from the original record, all error context header " +
+            "keys, all error context header keys will start with <code>__connect.errors.</code>";
     private static final String DLQ_CONTEXT_HEADERS_ENABLE_DISPLAY = "Enable Error Context Headers";
 
     static ConfigDef config = ConnectorConfig.configDef()

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
@@ -60,7 +60,8 @@ public class SinkConnectorConfig extends ConnectorConfig {
 
     public static final String DLQ_CONTEXT_HEADERS_ENABLE_CONFIG = DLQ_PREFIX + "context.headers.enable";
     public static final boolean DLQ_CONTEXT_HEADERS_ENABLE_DEFAULT = false;
-    public static final String DLQ_CONTEXT_HEADERS_ENABLE_DOC = "If true, add headers containing error context to the messages written to the dead letter queue.";
+    public static final String DLQ_CONTEXT_HEADERS_ENABLE_DOC = "If true, add headers containing error context to the messages " +
+            "written to the dead letter queue. All error context headers will be prefixed with \"__connect.errors\".";
     private static final String DLQ_CONTEXT_HEADERS_ENABLE_DISPLAY = "Enable Error Context Headers";
 
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
@@ -52,16 +52,24 @@ public class SinkConnectorConfig extends ConnectorConfig {
     public static final String DLQ_TOPIC_DEFAULT = "";
     private static final String DLQ_TOPIC_DISPLAY = "Dead Letter Queue Topic Name";
 
+
     public static final String DLQ_TOPIC_REPLICATION_FACTOR_CONFIG = DLQ_PREFIX + "topic.replication.factor";
     private static final String DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DOC = "Replication factor used to create the dead letter queue topic when it doesn't already exist.";
     public static final short DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DEFAULT = 3;
     private static final String DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DISPLAY = "Dead Letter Queue Topic Replication Factor";
 
+    public static final String DLQ_CONTEXT_HEADERS_ENABLE_CONFIG = DLQ_PREFIX + "context.headers.enable";
+    public static final boolean DLQ_CONTEXT_HEADERS_ENABLE_DEFAULT = false;
+    public static final String DLQ_CONTEXT_HEADERS_ENABLE_DOC = "If true, add headers containing error context to the messages written to the dead letter queue.";
+    private static final String DLQ_CONTEXT_HEADERS_ENABLE_DISPLAY = "Enable Error Context Headers";
+
+
     static ConfigDef config = ConnectorConfig.configDef()
         .define(TOPICS_CONFIG, ConfigDef.Type.LIST, TOPICS_DEFAULT, ConfigDef.Importance.HIGH, TOPICS_DOC, COMMON_GROUP, 4, ConfigDef.Width.LONG, TOPICS_DISPLAY)
         .define(TOPICS_REGEX_CONFIG, ConfigDef.Type.STRING, TOPICS_REGEX_DEFAULT, new RegexValidator(), ConfigDef.Importance.HIGH, TOPICS_REGEX_DOC, COMMON_GROUP, 4, ConfigDef.Width.LONG, TOPICS_REGEX_DISPLAY)
         .define(DLQ_TOPIC_NAME_CONFIG, ConfigDef.Type.STRING, DLQ_TOPIC_DEFAULT, Importance.MEDIUM, DLQ_TOPIC_NAME_DOC, ERROR_GROUP, 6, ConfigDef.Width.MEDIUM, DLQ_TOPIC_DISPLAY)
-        .define(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, ConfigDef.Type.SHORT, DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DEFAULT, Importance.MEDIUM, DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DOC, ERROR_GROUP, 7, ConfigDef.Width.MEDIUM, DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DISPLAY);
+        .define(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, ConfigDef.Type.SHORT, DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DEFAULT, Importance.MEDIUM, DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DOC, ERROR_GROUP, 7, ConfigDef.Width.MEDIUM, DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DISPLAY)
+        .define(DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, ConfigDef.Type.BOOLEAN, DLQ_CONTEXT_HEADERS_ENABLE_DEFAULT, Importance.MEDIUM, DLQ_CONTEXT_HEADERS_ENABLE_DOC, ERROR_GROUP, 8, ConfigDef.Width.MEDIUM, DLQ_CONTEXT_HEADERS_ENABLE_DISPLAY);
 
     public static ConfigDef configDef() {
         return config;
@@ -106,5 +114,9 @@ public class SinkConnectorConfig extends ConnectorConfig {
 
     public short dlqTopicReplicationFactor() {
         return getShort(DLQ_TOPIC_REPLICATION_FACTOR_CONFIG);
+    }
+
+    public boolean isDlqContextHeadersEnabled() {
+        return getBoolean(DLQ_CONTEXT_HEADERS_ENABLE_CONFIG);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SinkConnectorConfig.java
@@ -52,7 +52,6 @@ public class SinkConnectorConfig extends ConnectorConfig {
     public static final String DLQ_TOPIC_DEFAULT = "";
     private static final String DLQ_TOPIC_DISPLAY = "Dead Letter Queue Topic Name";
 
-
     public static final String DLQ_TOPIC_REPLICATION_FACTOR_CONFIG = DLQ_PREFIX + "topic.replication.factor";
     private static final String DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DOC = "Replication factor used to create the dead letter queue topic when it doesn't already exist.";
     public static final short DLQ_TOPIC_REPLICATION_FACTOR_CONFIG_DEFAULT = 3;
@@ -63,7 +62,6 @@ public class SinkConnectorConfig extends ConnectorConfig {
     public static final String DLQ_CONTEXT_HEADERS_ENABLE_DOC = "If true, add headers containing error context to the messages " +
             "written to the dead letter queue. All error context headers will be prefixed with \"__connect.errors\".";
     private static final String DLQ_CONTEXT_HEADERS_ENABLE_DISPLAY = "Enable Error Context Headers";
-
 
     static ConfigDef config = ConnectorConfig.configDef()
         .define(TOPICS_CONFIG, ConfigDef.Type.LIST, TOPICS_DEFAULT, ConfigDef.Importance.HIGH, TOPICS_DOC, COMMON_GROUP, 4, ConfigDef.Width.LONG, TOPICS_DISPLAY)

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -530,7 +530,7 @@ public class Worker {
         // check if topic for dead letter queue exists
         String topic = connConfig.dlqTopicName();
         if (topic != null && !topic.isEmpty()) {
-            DeadLetterQueueReporter reporter = DeadLetterQueueReporter.createAndSetup(config, connConfig, producerProps);
+            DeadLetterQueueReporter reporter = DeadLetterQueueReporter.createAndSetup(config, id, connConfig, producerProps);
             reporters.add(reporter);
         }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -22,17 +22,24 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.WorkerConfig;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static java.util.Collections.singleton;
+import static org.apache.kafka.connect.header.ConnectHeaders.HEADER_PREFIX;
 
 /**
  * Write the original consumed record into a dead letter queue. The dead letter queue is a Kafka topic located
@@ -46,12 +53,26 @@ public class DeadLetterQueueReporter implements ErrorReporter {
 
     private static final int DLQ_NUM_DESIRED_PARTITIONS = 1;
 
+    public static final String ERROR_HEADER_PREFIX = HEADER_PREFIX + ".errors";
+    public static final String ERROR_HEADER_ORIG_TOPIC = "topic";
+    public static final String ERROR_HEADER_ORIG_PARTITION = "partition";
+    public static final String ERROR_HEADER_ORIG_OFFSET = "offset";
+    public static final String ERROR_HEADER_CONNECTOR_NAME = "connector.name";
+    public static final String ERROR_HEADER_TASK_ID = "task.id";
+    public static final String ERROR_HEADER_STAGE = "stage";
+    public static final String ERROR_HEADER_EXECUTING_CLASS = "class.name";
+    public static final String ERROR_HEADER_EXECPTION = "exception.class.name";
+    public static final String ERROR_HEADER_EXECPTION_MESSAGE = "exception.message";
+    public static final String ERROR_HEADER_EXECPTION_STACK_TRACE = "exception.stacktrace";
+
     private final SinkConnectorConfig connConfig;
+    private final ConnectorTaskId connectorTaskId;
 
     private KafkaProducer<byte[], byte[]> kafkaProducer;
     private ErrorHandlingMetrics errorHandlingMetrics;
 
     public static DeadLetterQueueReporter createAndSetup(WorkerConfig workerConfig,
+                                                         ConnectorTaskId id,
                                                          SinkConnectorConfig sinkConfig, Map<String, Object> producerProps) {
         String topic = sinkConfig.dlqTopicName();
 
@@ -70,7 +91,7 @@ public class DeadLetterQueueReporter implements ErrorReporter {
         }
 
         KafkaProducer<byte[], byte[]> dlqProducer = new KafkaProducer<>(producerProps);
-        return new DeadLetterQueueReporter(dlqProducer, sinkConfig);
+        return new DeadLetterQueueReporter(dlqProducer, sinkConfig, id);
     }
 
     /**
@@ -79,9 +100,10 @@ public class DeadLetterQueueReporter implements ErrorReporter {
      * @param kafkaProducer a Kafka Producer to produce the original consumed records.
      */
     // Visible for testing
-    DeadLetterQueueReporter(KafkaProducer<byte[], byte[]> kafkaProducer, SinkConnectorConfig connConfig) {
+    DeadLetterQueueReporter(KafkaProducer<byte[], byte[]> kafkaProducer, SinkConnectorConfig connConfig, ConnectorTaskId id) {
         this.kafkaProducer = kafkaProducer;
         this.connConfig = connConfig;
+        this.connectorTaskId = id;
     }
 
     @Override
@@ -117,6 +139,10 @@ public class DeadLetterQueueReporter implements ErrorReporter {
                     originalMessage.key(), originalMessage.value(), originalMessage.headers());
         }
 
+        if (connConfig.isDlqContextHeadersEnabled()) {
+            populateContextHeaders(producerRecord, context);
+        }
+
         this.kafkaProducer.send(producerRecord, (metadata, exception) -> {
             if (exception != null) {
                 log.error("Could not produce message to dead letter queue. topic=" + dlqTopicName, exception);
@@ -124,4 +150,62 @@ public class DeadLetterQueueReporter implements ErrorReporter {
             }
         });
     }
+
+    // Visible for testing
+    void populateContextHeaders(ProducerRecord<byte[], byte[]> producerRecord, ProcessingContext context) {
+        String topic = "";
+        int partition = -1;
+        long offset = -1;
+        if (context.consumerRecord() != null) {
+            topic = context.consumerRecord().topic();
+            partition = context.consumerRecord().partition();
+            offset = context.consumerRecord().offset();
+        }
+
+        add(producerRecord.headers(), prefix(ERROR_HEADER_ORIG_TOPIC), topic);
+        add(producerRecord.headers(), prefix(ERROR_HEADER_ORIG_PARTITION), String.valueOf(partition));
+        add(producerRecord.headers(), prefix(ERROR_HEADER_ORIG_OFFSET), String.valueOf(offset));
+        add(producerRecord.headers(), prefix(ERROR_HEADER_CONNECTOR_NAME), connectorTaskId.connector());
+        add(producerRecord.headers(), prefix(ERROR_HEADER_TASK_ID), String.valueOf(connectorTaskId.task()));
+        add(producerRecord.headers(), prefix(ERROR_HEADER_STAGE), context.stage().name());
+        add(producerRecord.headers(), prefix(ERROR_HEADER_EXECUTING_CLASS), context.executingClass().getName());
+        if (context.error() != null) {
+            add(producerRecord.headers(), prefix(ERROR_HEADER_EXECPTION), context.error().getClass().getName());
+            add(producerRecord.headers(), prefix(ERROR_HEADER_EXECPTION_MESSAGE), context.error().getMessage());
+            byte[] trace;
+            if ((trace = stacktrace(context.error())) != null) {
+                add(producerRecord.headers(), prefix(ERROR_HEADER_EXECPTION_STACK_TRACE), trace);
+            }
+        }
+    }
+
+    private byte[] stacktrace(Throwable error) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try {
+            PrintStream stream = new PrintStream(bos, true, "UTF-8");
+            error.printStackTrace(stream);
+            bos.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            log.error("Could not serialize stacktrace.", e);
+        }
+        return null;
+    }
+
+    private void add(Headers headers, String key, String value) {
+        add(headers, key, value.getBytes(Charset.forName("UTF-8")));
+    }
+
+    private void add(Headers headers, String key, byte[] value) {
+        if (headers.lastHeader(key) == null) {
+            headers.add(key, value);
+        } else {
+            log.error("Header already contains the '" + key + "' key.");
+        }
+    }
+
+    private String prefix(String errorHeaderName) {
+        return ERROR_HEADER_PREFIX + "." + errorHeaderName;
+    }
+
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -60,9 +60,9 @@ public class DeadLetterQueueReporter implements ErrorReporter {
     public static final String ERROR_HEADER_TASK_ID = HEADER_PREFIX + "task.id";
     public static final String ERROR_HEADER_STAGE = HEADER_PREFIX + "stage";
     public static final String ERROR_HEADER_EXECUTING_CLASS = HEADER_PREFIX + "class.name";
-    public static final String ERROR_HEADER_EXECPTION = HEADER_PREFIX + "exception.class.name";
-    public static final String ERROR_HEADER_EXECPTION_MESSAGE = HEADER_PREFIX + "exception.message";
-    public static final String ERROR_HEADER_EXECPTION_STACK_TRACE = HEADER_PREFIX + "exception.stacktrace";
+    public static final String ERROR_HEADER_EXCEPTION = HEADER_PREFIX + "exception.class.name";
+    public static final String ERROR_HEADER_EXCEPTION_MESSAGE = HEADER_PREFIX + "exception.message";
+    public static final String ERROR_HEADER_EXCEPTION_STACK_TRACE = HEADER_PREFIX + "exception.stacktrace";
 
     private final SinkConnectorConfig connConfig;
     private final ConnectorTaskId connectorTaskId;
@@ -164,11 +164,11 @@ public class DeadLetterQueueReporter implements ErrorReporter {
         headers.add(ERROR_HEADER_STAGE, toBytes(context.stage().name()));
         headers.add(ERROR_HEADER_EXECUTING_CLASS, toBytes(context.executingClass().getName()));
         if (context.error() != null) {
-            headers.add(ERROR_HEADER_EXECPTION, toBytes(context.error().getClass().getName()));
-            headers.add(ERROR_HEADER_EXECPTION_MESSAGE, toBytes(context.error().getMessage()));
+            headers.add(ERROR_HEADER_EXCEPTION, toBytes(context.error().getClass().getName()));
+            headers.add(ERROR_HEADER_EXCEPTION_MESSAGE, toBytes(context.error().getMessage()));
             byte[] trace;
             if ((trace = stacktrace(context.error())) != null) {
-                headers.add(ERROR_HEADER_EXECPTION_STACK_TRACE, trace);
+                headers.add(ERROR_HEADER_EXCEPTION_STACK_TRACE, trace);
             }
         }
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -34,12 +34,11 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static java.util.Collections.singleton;
-import static org.apache.kafka.connect.header.ConnectHeaders.HEADER_PREFIX;
 
 /**
  * Write the original consumed record into a dead letter queue. The dead letter queue is a Kafka topic located
@@ -53,17 +52,17 @@ public class DeadLetterQueueReporter implements ErrorReporter {
 
     private static final int DLQ_NUM_DESIRED_PARTITIONS = 1;
 
-    public static final String ERROR_HEADER_PREFIX = HEADER_PREFIX + ".errors";
-    public static final String ERROR_HEADER_ORIG_TOPIC = ERROR_HEADER_PREFIX + ".topic";
-    public static final String ERROR_HEADER_ORIG_PARTITION = ERROR_HEADER_PREFIX + ".partition";
-    public static final String ERROR_HEADER_ORIG_OFFSET = ERROR_HEADER_PREFIX + ".offset";
-    public static final String ERROR_HEADER_CONNECTOR_NAME = ERROR_HEADER_PREFIX + ".connector.name";
-    public static final String ERROR_HEADER_TASK_ID = ERROR_HEADER_PREFIX + ".task.id";
-    public static final String ERROR_HEADER_STAGE = ERROR_HEADER_PREFIX + ".stage";
-    public static final String ERROR_HEADER_EXECUTING_CLASS = ERROR_HEADER_PREFIX + ".class.name";
-    public static final String ERROR_HEADER_EXECPTION = ERROR_HEADER_PREFIX + ".exception.class.name";
-    public static final String ERROR_HEADER_EXECPTION_MESSAGE = ERROR_HEADER_PREFIX + ".exception.message";
-    public static final String ERROR_HEADER_EXECPTION_STACK_TRACE = ERROR_HEADER_PREFIX + ".exception.stacktrace";
+    public static final String HEADER_PREFIX = "__connect.errors.";
+    public static final String ERROR_HEADER_ORIG_TOPIC = HEADER_PREFIX + "topic";
+    public static final String ERROR_HEADER_ORIG_PARTITION = HEADER_PREFIX + "partition";
+    public static final String ERROR_HEADER_ORIG_OFFSET = HEADER_PREFIX + "offset";
+    public static final String ERROR_HEADER_CONNECTOR_NAME = HEADER_PREFIX + "connector.name";
+    public static final String ERROR_HEADER_TASK_ID = HEADER_PREFIX + "task.id";
+    public static final String ERROR_HEADER_STAGE = HEADER_PREFIX + "stage";
+    public static final String ERROR_HEADER_EXECUTING_CLASS = HEADER_PREFIX + "class.name";
+    public static final String ERROR_HEADER_EXECPTION = HEADER_PREFIX + "exception.class.name";
+    public static final String ERROR_HEADER_EXECPTION_MESSAGE = HEADER_PREFIX + "exception.message";
+    public static final String ERROR_HEADER_EXECPTION_STACK_TRACE = HEADER_PREFIX + "exception.stacktrace";
 
     private final SinkConnectorConfig connConfig;
     private final ConnectorTaskId connectorTaskId;
@@ -196,6 +195,6 @@ public class DeadLetterQueueReporter implements ErrorReporter {
     }
 
     private byte[] toBytes(String value) {
-        return value.getBytes(Charset.forName("UTF-8"));
+        return value.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -54,16 +54,16 @@ public class DeadLetterQueueReporter implements ErrorReporter {
     private static final int DLQ_NUM_DESIRED_PARTITIONS = 1;
 
     public static final String ERROR_HEADER_PREFIX = HEADER_PREFIX + ".errors";
-    public static final String ERROR_HEADER_ORIG_TOPIC = ERROR_HEADER_PREFIX + "." + "topic";
-    public static final String ERROR_HEADER_ORIG_PARTITION = ERROR_HEADER_PREFIX + "." + "partition";
-    public static final String ERROR_HEADER_ORIG_OFFSET = ERROR_HEADER_PREFIX + "." + "offset";
-    public static final String ERROR_HEADER_CONNECTOR_NAME = ERROR_HEADER_PREFIX + "." + "connector.name";
-    public static final String ERROR_HEADER_TASK_ID = ERROR_HEADER_PREFIX + "." + "task.id";
-    public static final String ERROR_HEADER_STAGE = ERROR_HEADER_PREFIX + "." + "stage";
-    public static final String ERROR_HEADER_EXECUTING_CLASS = ERROR_HEADER_PREFIX + "." + "class.name";
-    public static final String ERROR_HEADER_EXECPTION = ERROR_HEADER_PREFIX + "." + "exception.class.name";
-    public static final String ERROR_HEADER_EXECPTION_MESSAGE = ERROR_HEADER_PREFIX + "." + "exception.message";
-    public static final String ERROR_HEADER_EXECPTION_STACK_TRACE = ERROR_HEADER_PREFIX + "." + "exception.stacktrace";
+    public static final String ERROR_HEADER_ORIG_TOPIC = ERROR_HEADER_PREFIX + ".topic";
+    public static final String ERROR_HEADER_ORIG_PARTITION = ERROR_HEADER_PREFIX + ".partition";
+    public static final String ERROR_HEADER_ORIG_OFFSET = ERROR_HEADER_PREFIX + ".offset";
+    public static final String ERROR_HEADER_CONNECTOR_NAME = ERROR_HEADER_PREFIX + ".connector.name";
+    public static final String ERROR_HEADER_TASK_ID = ERROR_HEADER_PREFIX + ".task.id";
+    public static final String ERROR_HEADER_STAGE = ERROR_HEADER_PREFIX + ".stage";
+    public static final String ERROR_HEADER_EXECUTING_CLASS = ERROR_HEADER_PREFIX + ".class.name";
+    public static final String ERROR_HEADER_EXECPTION = ERROR_HEADER_PREFIX + ".exception.class.name";
+    public static final String ERROR_HEADER_EXECPTION_MESSAGE = ERROR_HEADER_PREFIX + ".exception.message";
+    public static final String ERROR_HEADER_EXECPTION_STACK_TRACE = ERROR_HEADER_PREFIX + ".exception.stacktrace";
 
     private final SinkConnectorConfig connConfig;
     private final ConnectorTaskId connectorTaskId;

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
@@ -18,7 +18,9 @@ package org.apache.kafka.connect.runtime.errors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.ConnectMetrics;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
@@ -26,6 +28,7 @@ import org.apache.kafka.connect.runtime.MockConnectMetrics;
 import org.apache.kafka.connect.runtime.SinkConnectorConfig;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.easymock.EasyMock;
 import org.easymock.Mock;
@@ -43,8 +46,20 @@ import java.util.concurrent.Future;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_CONNECTOR_NAME;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECPTION;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECPTION_MESSAGE;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECPTION_STACK_TRACE;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECUTING_CLASS;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_ORIG_OFFSET;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_ORIG_PARTITION;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_ORIG_TOPIC;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_PREFIX;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_STAGE;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_TASK_ID;
 import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
@@ -81,7 +96,7 @@ public class ErrorReporterTest {
 
     @Test
     public void testDLQConfigWithEmptyTopicName() {
-        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(emptyMap()));
+        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(emptyMap()), TASK_ID);
         deadLetterQueueReporter.metrics(errorHandlingMetrics);
 
         ProcessingContext context = processingContext();
@@ -96,7 +111,7 @@ public class ErrorReporterTest {
 
     @Test
     public void testDLQConfigWithValidTopicName() {
-        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC)));
+        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC)), TASK_ID);
         deadLetterQueueReporter.metrics(errorHandlingMetrics);
 
         ProcessingContext context = processingContext();
@@ -111,7 +126,7 @@ public class ErrorReporterTest {
 
     @Test
     public void testReportDLQTwice() {
-        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC)));
+        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC)), TASK_ID);
         deadLetterQueueReporter.metrics(errorHandlingMetrics);
 
         ProcessingContext context = processingContext();
@@ -187,6 +202,56 @@ public class ErrorReporterTest {
 
         configuration = config(singletonMap(SinkConnectorConfig.DLQ_TOPIC_REPLICATION_FACTOR_CONFIG, "7"));
         assertEquals(configuration.dlqTopicReplicationFactor(), 7);
+    }
+
+    public void testDlqHeaderConsumerRecord() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC);
+        props.put(SinkConnectorConfig.DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, "true");
+        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(props), TASK_ID);
+
+        ProcessingContext context = new ProcessingContext();
+        context.consumerRecord(new ConsumerRecord<>("source-topic", 7, 10, "source-key".getBytes(), "source-value".getBytes()));
+        context.currentContext(Stage.TRANSFORMATION, Transformation.class);
+        context.error(new ConnectException("Test Exception"));
+
+        ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(DLQ_TOPIC, "source-key".getBytes(), "source-value".getBytes());
+
+        deadLetterQueueReporter.populateContextHeaders(producerRecord, context);
+        assertEquals("source-topic", headerValue(producerRecord, ERROR_HEADER_ORIG_TOPIC));
+        assertEquals("7", headerValue(producerRecord, ERROR_HEADER_ORIG_PARTITION));
+        assertEquals("10", headerValue(producerRecord, ERROR_HEADER_ORIG_OFFSET));
+        assertEquals(TASK_ID.connector(), headerValue(producerRecord, ERROR_HEADER_CONNECTOR_NAME));
+        assertEquals(String.valueOf(TASK_ID.task()), headerValue(producerRecord, ERROR_HEADER_TASK_ID));
+        assertEquals(Stage.TRANSFORMATION.name(), headerValue(producerRecord, ERROR_HEADER_STAGE));
+        assertEquals(Transformation.class.getName(), headerValue(producerRecord, ERROR_HEADER_EXECUTING_CLASS));
+        assertEquals(ConnectException.class.getName(), headerValue(producerRecord, ERROR_HEADER_EXECPTION));
+        assertEquals("Test Exception", headerValue(producerRecord, ERROR_HEADER_EXECPTION_MESSAGE));
+        assertTrue(headerValue(producerRecord, ERROR_HEADER_EXECPTION_STACK_TRACE).length() > 0);
+        assertTrue(headerValue(producerRecord, ERROR_HEADER_EXECPTION_STACK_TRACE).startsWith("org.apache.kafka.connect.errors.ConnectException: Test Exception"));
+    }
+
+    @Test
+    public void testDlqHeaderIsNotOverWritten() {
+        Map<String, String> props = new HashMap<>();
+        props.put(SinkConnectorConfig.DLQ_TOPIC_NAME_CONFIG, DLQ_TOPIC);
+        props.put(SinkConnectorConfig.DLQ_CONTEXT_HEADERS_ENABLE_CONFIG, "true");
+        DeadLetterQueueReporter deadLetterQueueReporter = new DeadLetterQueueReporter(producer, config(props), TASK_ID);
+
+        ProcessingContext context = new ProcessingContext();
+        context.consumerRecord(new ConsumerRecord<>("source-topic", 7, 10, "source-key".getBytes(), "source-value".getBytes()));
+        context.currentContext(Stage.TRANSFORMATION, Transformation.class);
+        context.error(new ConnectException("Test Exception"));
+
+        ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(DLQ_TOPIC, "source-key".getBytes(), "source-value".getBytes());
+        producerRecord.headers().add(ERROR_HEADER_PREFIX + "." + ERROR_HEADER_ORIG_TOPIC, "dummy".getBytes());
+
+        deadLetterQueueReporter.populateContextHeaders(producerRecord, context);
+        assertEquals("dummy", headerValue(producerRecord, ERROR_HEADER_ORIG_TOPIC));
+    }
+
+    private String headerValue(ProducerRecord<byte[], byte[]> producerRecord, String headerSuffix) {
+        return new String(producerRecord.headers().lastHeader(ERROR_HEADER_PREFIX + "." + headerSuffix).value());
     }
 
     private ProcessingContext processingContext() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/errors/ErrorReporterTest.java
@@ -48,9 +48,9 @@ import java.util.concurrent.Future;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_CONNECTOR_NAME;
-import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECPTION;
-import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECPTION_MESSAGE;
-import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECPTION_STACK_TRACE;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXCEPTION;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXCEPTION_MESSAGE;
+import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXCEPTION_STACK_TRACE;
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_EXECUTING_CLASS;
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_ORIG_OFFSET;
 import static org.apache.kafka.connect.runtime.errors.DeadLetterQueueReporter.ERROR_HEADER_ORIG_PARTITION;
@@ -225,10 +225,10 @@ public class ErrorReporterTest {
         assertEquals(String.valueOf(TASK_ID.task()), headerValue(producerRecord, ERROR_HEADER_TASK_ID));
         assertEquals(Stage.TRANSFORMATION.name(), headerValue(producerRecord, ERROR_HEADER_STAGE));
         assertEquals(Transformation.class.getName(), headerValue(producerRecord, ERROR_HEADER_EXECUTING_CLASS));
-        assertEquals(ConnectException.class.getName(), headerValue(producerRecord, ERROR_HEADER_EXECPTION));
-        assertEquals("Test Exception", headerValue(producerRecord, ERROR_HEADER_EXECPTION_MESSAGE));
-        assertTrue(headerValue(producerRecord, ERROR_HEADER_EXECPTION_STACK_TRACE).length() > 0);
-        assertTrue(headerValue(producerRecord, ERROR_HEADER_EXECPTION_STACK_TRACE).startsWith("org.apache.kafka.connect.errors.ConnectException: Test Exception"));
+        assertEquals(ConnectException.class.getName(), headerValue(producerRecord, ERROR_HEADER_EXCEPTION));
+        assertEquals("Test Exception", headerValue(producerRecord, ERROR_HEADER_EXCEPTION_MESSAGE));
+        assertTrue(headerValue(producerRecord, ERROR_HEADER_EXCEPTION_STACK_TRACE).length() > 0);
+        assertTrue(headerValue(producerRecord, ERROR_HEADER_EXCEPTION_STACK_TRACE).startsWith("org.apache.kafka.connect.errors.ConnectException: Test Exception"));
     }
 
     @Test


### PR DESCRIPTION
If the property `errors.deadletterqueue.context.headers.enable` is set to true, add a set of headers to the message describing the context under which the error took place.

A unit test is added to check the correctness of header creation.

Signed-off-by: Arjun Satish <arjun@confluent.io>

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
