### PR TITLE
 MINOR: Handle segment splitting edge cases and fix recovery bug 

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/BufferSupplier.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/BufferSupplier.java
@@ -93,4 +93,36 @@ public abstract class BufferSupplier implements AutoCloseable {
             bufferMap.clear();
         }
     }
+
+    /**
+     * Simple buffer supplier for single-threaded usage. It caches a single buffer, which grows
+     * monotonically as needed to fulfill the allocation request.
+     */
+    public static class GrowableBufferSupplier extends BufferSupplier {
+        private ByteBuffer cachedBuffer;
+
+        @Override
+        public ByteBuffer get(int minCapacity) {
+            if (cachedBuffer != null && cachedBuffer.capacity() >= minCapacity) {
+                ByteBuffer res = cachedBuffer;
+                cachedBuffer = null;
+                return res;
+            } else {
+                cachedBuffer = null;
+                return ByteBuffer.allocate(minCapacity);
+            }
+        }
+
+        @Override
+        public void release(ByteBuffer buffer) {
+            buffer.clear();
+            cachedBuffer = buffer;
+        }
+
+        @Override
+        public void close() {
+            cachedBuffer = null;
+        }
+    }
+
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -109,7 +109,6 @@ public class FileRecords extends AbstractRecords implements Closeable {
      *
      * @param buffer The buffer to write the batches to
      * @param position Position in the buffer to read from
-     * @return The same buffer
      * @throws IOException If an I/O error occurs, see {@link FileChannel#read(ByteBuffer, long)} for details on the
      * possible exceptions
      */

--- a/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/FileRecords.java
@@ -113,10 +113,9 @@ public class FileRecords extends AbstractRecords implements Closeable {
      * @throws IOException If an I/O error occurs, see {@link FileChannel#read(ByteBuffer, long)} for details on the
      * possible exceptions
      */
-    public ByteBuffer readInto(ByteBuffer buffer, int position) throws IOException {
+    public void readInto(ByteBuffer buffer, int position) throws IOException {
         Utils.readFully(channel, buffer, position + this.start);
         buffer.flip();
-        return buffer;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/record/BufferSupplierTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/BufferSupplierTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.record;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class BufferSupplierTest {
+
+    @Test
+    public void testGrowableBuffer() {
+        BufferSupplier.GrowableBufferSupplier supplier = new BufferSupplier.GrowableBufferSupplier();
+        ByteBuffer buffer = supplier.get(1024);
+        assertEquals(0, buffer.position());
+        assertEquals(1024, buffer.capacity());
+        supplier.release(buffer);
+
+        ByteBuffer cached = supplier.get(512);
+        assertEquals(0, cached.position());
+        assertSame(buffer, cached);
+
+        ByteBuffer increased = supplier.get(2048);
+        assertEquals(2048, increased.capacity());
+        assertEquals(0, increased.position());
+    }
+
+}

--- a/core/src/main/scala/kafka/common/LogSegmentOffsetOverflowException.scala
+++ b/core/src/main/scala/kafka/common/LogSegmentOffsetOverflowException.scala
@@ -25,7 +25,6 @@ import kafka.log.LogSegment
  * KAFKA-5413. With KAFKA-6264, we have the ability to split such log segments into multiple log segments such that we
  * do not have any segments with offset overflow.
  */
-class LogSegmentOffsetOverflowException(message: String, cause: Throwable, val logSegment: LogSegment) extends KafkaException(message, cause) {
-  def this(cause: Throwable, logSegment: LogSegment) = this(null, cause, logSegment)
-  def this(message: String, logSegment: LogSegment) = this(message, null, logSegment)
+class LogSegmentOffsetOverflowException(val segment: LogSegment, val offset: Long)
+  extends KafkaException(s"Detected offset overflow at offset $offset in segment $segment") {
 }

--- a/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
+++ b/core/src/main/scala/kafka/coordinator/group/GroupMetadataManager.scala
@@ -532,8 +532,8 @@ class GroupMetadataManager(brokerId: Int,
             case records: MemoryRecords => records
             case fileRecords: FileRecords =>
               buffer.clear()
-              val bufferRead = fileRecords.readInto(buffer, 0)
-              MemoryRecords.readableRecords(bufferRead)
+              fileRecords.readInto(buffer, 0)
+              MemoryRecords.readableRecords(buffer)
           }
 
           memRecords.batches.asScala.foreach { batch =>

--- a/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
+++ b/core/src/main/scala/kafka/coordinator/transaction/TransactionStateManager.scala
@@ -313,8 +313,8 @@ class TransactionStateManager(brokerId: Int,
               case records: MemoryRecords => records
               case fileRecords: FileRecords =>
                 buffer.clear()
-                val bufferRead = fileRecords.readInto(buffer, 0)
-                MemoryRecords.readableRecords(bufferRead)
+                fileRecords.readInto(buffer, 0)
+                MemoryRecords.readableRecords(buffer)
             }
 
             memRecords.batches.asScala.foreach { batch =>

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1888,11 +1888,6 @@ class Log(@volatile var dir: File,
       if (!newSegments.exists(_.baseOffset - segment.baseOffset > Int.MaxValue))
         throw new IllegalStateException(s"Could not find the expected overflow offset in $segment")
 
-      // It is possible to have only one segment after splitting if all the messages in the segment to split
-      // have offsets that overflow
-      if (newSegments.size == 1 && newSegments.headOption.forall(_.baseOffset == segment.baseOffset))
-        throw new IllegalStateException(s"Failed to split segment $segment. ")
-
       // prepare new segments
       var totalSizeOfNewSegments = 0
       info(s"Split messages from $segment into ${newSegments.length} new segments")

--- a/core/src/main/scala/kafka/log/LogCleaner.scala
+++ b/core/src/main/scala/kafka/log/LogCleaner.scala
@@ -513,7 +513,7 @@ private[log] class Cleaner(val id: Int,
           case e: LogSegmentOffsetOverflowException =>
             // Split the current segment. It's also safest to abort the current cleaning process, so that we retry from
             // scratch once the split is complete.
-            info(s"Caught LogSegmentOverflowException during log cleaning $e")
+            info(s"Caught segment overflow error during cleaning: ${e.getMessage}")
             log.splitOverflowedSegment(currentSegment)
             throw new LogCleaningAbortedException()
         }
@@ -529,8 +529,7 @@ private[log] class Cleaner(val id: Int,
       cleaned.lastModified = modified
 
       // swap in new segment
-      info(s"Swapping in cleaned segment ${cleaned.baseOffset} for segment(s) ${segments.map(_.baseOffset).mkString(",")} " +
-        s"in log ${log.name}")
+      info(s"Swapping in cleaned segment $cleaned for segment(s) $segments in log $log")
       log.replaceSegments(List(cleaned), segments)
     } catch {
       case e: LogCleaningAbortedException =>

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -154,8 +154,7 @@ class LogSegment private[log] (val log: FileRecords,
 
   private def ensureOffsetInRange(offset: Long): Unit = {
     if (!canConvertToRelativeOffset(offset))
-      throw new LogSegmentOffsetOverflowException(s"Detected offset overflow at offset $offset " +
-        s"in segment $this", this)
+      throw new LogSegmentOffsetOverflowException(this, offset)
   }
 
   private def appendChunkFromFile(records: FileRecords, position: Int, bufferSupplier: BufferSupplier): Int = {
@@ -198,6 +197,9 @@ class LogSegment private[log] (val log: FileRecords,
   /**
    * Append records from a file beginning at the given position until either the end of the file
    * is reached or an offset is found which is too large to convert to a relative offset for the indexes.
+   *
+   * @return the number of bytes appended to the log (may be less than the size of the input if an
+   *         offset is encountered which would overflow this segment)
    */
   def appendFromFile(records: FileRecords, start: Int): Int = {
     var position = start

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -183,7 +183,7 @@ class LogSegment private[log] (val log: FileRecords,
     if (bytesToAppend == 0) {
       0
     } else {
-      // Grow buffer if needed
+      // Grow buffer if needed to ensure we copy at least one batch
       if (readBuffer.capacity < bytesToAppend)
         readBuffer = bufferSupplier.get(bytesToAppend)
 

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -21,7 +21,7 @@ import java.nio.file.{Files, NoSuchFileException}
 import java.nio.file.attribute.FileTime
 import java.util.concurrent.TimeUnit
 
-import kafka.common.{IndexOffsetOverflowException, LogSegmentOffsetOverflowException}
+import kafka.common.LogSegmentOffsetOverflowException
 import kafka.metrics.{KafkaMetricsGroup, KafkaTimer}
 import kafka.server.epoch.LeaderEpochCache
 import kafka.server.{FetchDataInfo, LogOffsetMetadata}
@@ -132,14 +132,11 @@ class LogSegment private[log] (val log: FileRecords,
       if (physicalPosition == 0)
         rollingBasedTimestamp = Some(largestTimestamp)
 
-      if (!canConvertToRelativeOffset(largestOffset))
-        throw new LogSegmentOffsetOverflowException(
-          s"largest offset $largestOffset cannot be safely converted to relative offset for segment with baseOffset $baseOffset",
-          this)
+      ensureOffsetInRange(largestOffset)
 
       // append the messages
       val appendedBytes = log.append(records)
-      trace(s"Appended $appendedBytes to ${log.file()} at end offset $largestOffset")
+      trace(s"Appended $appendedBytes to ${log.file} at end offset $largestOffset")
       // Update the in memory max timestamp and corresponding offset.
       if (largestTimestamp > maxTimestampSoFar) {
         maxTimestampSoFar = largestTimestamp
@@ -147,12 +144,71 @@ class LogSegment private[log] (val log: FileRecords,
       }
       // append an entry to the index (if needed)
       if (bytesSinceLastIndexEntry > indexIntervalBytes) {
-        appendToOffsetIndex(largestOffset, physicalPosition)
-        maybeAppendToTimeIndex(maxTimestampSoFar, offsetOfMaxTimestamp)
+        offsetIndex.append(largestOffset, physicalPosition)
+        timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestamp)
         bytesSinceLastIndexEntry = 0
       }
       bytesSinceLastIndexEntry += records.sizeInBytes
     }
+  }
+
+  private def ensureOffsetInRange(offset: Long): Unit = {
+    if (!canConvertToRelativeOffset(offset))
+      throw new LogSegmentOffsetOverflowException(s"Detected offset overflow at offset $offset " +
+        s"in segment $this", this)
+  }
+
+  private def appendChunkFromFile(records: FileRecords, position: Int, bufferSupplier: BufferSupplier): Int = {
+    var bytesToAppend = 0
+    var maxTimestamp = Long.MinValue
+    var offsetOfMaxTimestamp = Long.MinValue
+    var maxOffset = Long.MinValue
+    var readBuffer = bufferSupplier.get(1024 * 1024)
+
+    def bufferHasRoomFor(batch: RecordBatch) =
+      bytesToAppend == 0 || bytesToAppend + batch.sizeInBytes() < readBuffer.capacity()
+
+    // find all batches that are valid to be appended to the current log segment and
+    // determine the maximum offset and timestamp
+    for (batch <- records.batchesFrom(position).asScala
+         if canConvertToRelativeOffset(batch.lastOffset) && bufferHasRoomFor(batch)) {
+      if (batch.maxTimestamp > maxTimestamp) {
+        maxTimestamp = batch.maxTimestamp
+        offsetOfMaxTimestamp = batch.lastOffset
+      }
+      maxOffset = batch.lastOffset
+      bytesToAppend += batch.sizeInBytes
+    }
+
+    if (bytesToAppend == 0) {
+      0
+    } else {
+      // Grow buffer if needed
+      if (readBuffer.capacity < bytesToAppend)
+        readBuffer = bufferSupplier.get(bytesToAppend)
+
+      readBuffer.limit(bytesToAppend)
+      records.readInto(readBuffer, position)
+
+      append(maxOffset, maxTimestamp, offsetOfMaxTimestamp, MemoryRecords.readableRecords(readBuffer))
+      bytesToAppend
+    }
+  }
+
+  /**
+   * Append records from a file beginning at the given position until either the end of the file
+   * is reached or an offset is found which is too large to convert to a relative offset for the indexes.
+   */
+  def appendFromFile(records: FileRecords, start: Int): Int = {
+    var position = start
+    val bufferSupplier: BufferSupplier = new BufferSupplier.GrowableBufferSupplier
+    while (position < start + records.sizeInBytes) {
+      val bytesAppended = appendChunkFromFile(records, position, bufferSupplier)
+      if (bytesAppended == 0)
+        return position - start
+      position += bytesAppended
+    }
+    position - start
   }
 
   @nonthreadsafe
@@ -281,6 +337,7 @@ class LogSegment private[log] (val log: FileRecords,
     try {
       for (batch <- log.batches.asScala) {
         batch.ensureValid()
+        ensureOffsetInRange(batch.lastOffset)
 
         // The max timestamp is exposed at the batch level, so no need to iterate the records
         if (batch.maxTimestamp > maxTimestampSoFar) {
@@ -290,8 +347,8 @@ class LogSegment private[log] (val log: FileRecords,
 
         // Build offset index
         if (validBytes - lastIndexEntry > indexIntervalBytes) {
-          appendToOffsetIndex(batch.lastOffset, validBytes)
-          maybeAppendToTimeIndex(maxTimestampSoFar, offsetOfMaxTimestamp)
+          offsetIndex.append(batch.lastOffset, validBytes)
+          timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestamp)
           lastIndexEntry = validBytes
         }
         validBytes += batch.sizeInBytes()
@@ -316,7 +373,7 @@ class LogSegment private[log] (val log: FileRecords,
     log.truncateTo(validBytes)
     offsetIndex.trimToValidSize()
     // A normally closed segment always appends the biggest timestamp ever seen into log segment, we do this as well.
-    maybeAppendToTimeIndex(maxTimestampSoFar, offsetOfMaxTimestamp, skipFullCheck = true)
+    timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestamp, skipFullCheck = true)
     timeIndex.trimToValidSize()
     truncated
   }
@@ -429,7 +486,7 @@ class LogSegment private[log] (val log: FileRecords,
    * The time index entry appended will be used to decide when to delete the segment.
    */
   def onBecomeInactiveSegment() {
-    maybeAppendToTimeIndex(maxTimestampSoFar, offsetOfMaxTimestamp, skipFullCheck = true)
+    timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestamp, skipFullCheck = true)
     offsetIndex.trimToValidSize()
     timeIndex.trimToValidSize()
     log.trim()
@@ -493,7 +550,7 @@ class LogSegment private[log] (val log: FileRecords,
    * Close this log segment
    */
   def close() {
-    CoreUtils.swallow(maybeAppendToTimeIndex(maxTimestampSoFar, offsetOfMaxTimestamp, skipFullCheck = true), this)
+    CoreUtils.swallow(timeIndex.maybeAppend(maxTimestampSoFar, offsetOfMaxTimestamp, skipFullCheck = true), this)
     CoreUtils.swallow(offsetIndex.close(), this)
     CoreUtils.swallow(timeIndex.close(), this)
     CoreUtils.swallow(log.close(), this)
@@ -554,24 +611,6 @@ class LogSegment private[log] (val log: FileRecords,
     Files.setLastModifiedTime(timeIndex.file.toPath, fileTime)
   }
 
-  private def maybeAppendToTimeIndex(timestamp: Long, offset: Long, skipFullCheck: Boolean = false): Unit = {
-    maybeHandleOffsetOverflowException {
-      timeIndex.maybeAppend(timestamp, offset, skipFullCheck)
-    }
-  }
-
-  private def appendToOffsetIndex(offset: Long, position: Int): Unit = {
-    maybeHandleOffsetOverflowException {
-      offsetIndex.append(offset, position)
-    }
-  }
-
-  private def maybeHandleOffsetOverflowException[T](fun: => T): T = {
-    try fun
-    catch {
-      case e: IndexOffsetOverflowException => throw new LogSegmentOffsetOverflowException(e, this)
-    }
-  }
 }
 
 object LogSegment {

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -170,7 +170,8 @@ class LogSegment private[log] (val log: FileRecords,
 
     // find all batches that are valid to be appended to the current log segment and
     // determine the maximum offset and timestamp
-    for (batch <- records.batchesFrom(position).asScala if canAppend(batch)) {
+    val nextBatches = records.batchesFrom(position).asScala.iterator
+    for (batch <- nextBatches.takeWhile(canAppend)) {
       if (batch.maxTimestamp > maxTimestamp) {
         maxTimestamp = batch.maxTimestamp
         offsetOfMaxTimestamp = batch.lastOffset

--- a/core/src/main/scala/kafka/log/LogSegment.scala
+++ b/core/src/main/scala/kafka/log/LogSegment.scala
@@ -395,6 +395,14 @@ class LogSegment private[log] (val log: FileRecords,
     }
   }
 
+  /**
+   * Check whether the last offset of the last batch in this segment overflows the indexes.
+   */
+  def hasOverflow: Boolean = {
+    val nextOffset = readNextOffset
+    nextOffset > baseOffset && !canConvertToRelativeOffset(nextOffset - 1)
+  }
+
   def collectAbortedTxns(fetchOffset: Long, upperBoundOffset: Long): TxnIndexSearchResult =
     txnIndex.collectAbortedTxns(fetchOffset, upperBoundOffset)
 

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -1495,7 +1495,6 @@ class GroupMetadataManagerTest {
       EasyMock.eq(true), EasyMock.eq(IsolationLevel.READ_UNCOMMITTED)))
       .andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
     EasyMock.expect(fileRecordsMock.readInto(EasyMock.anyObject(classOf[ByteBuffer]), EasyMock.anyInt()))
-      .andReturn(records.buffer)
     EasyMock.replay(fileRecordsMock)
 
     endOffset

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -1500,7 +1500,7 @@ class GroupMetadataManagerTest {
     EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
       override def answer: Unit = {
         val buffer = bufferCapture.getValue
-        buffer.put(records.buffer.duplicate())
+        buffer.put(records.buffer.duplicate)
         buffer.flip()
       }
     })

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -1494,7 +1494,17 @@ class GroupMetadataManagerTest {
     EasyMock.expect(logMock.read(EasyMock.eq(startOffset), EasyMock.anyInt(), EasyMock.eq(None),
       EasyMock.eq(true), EasyMock.eq(IsolationLevel.READ_UNCOMMITTED)))
       .andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
-    EasyMock.expect(fileRecordsMock.readInto(EasyMock.anyObject(classOf[ByteBuffer]), EasyMock.anyInt()))
+
+    val bufferCapture = EasyMock.newCapture[ByteBuffer]
+    fileRecordsMock.readInto(EasyMock.capture(bufferCapture), EasyMock.anyInt())
+    EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
+      override def answer: Unit = {
+        val buffer = bufferCapture.getValue
+        buffer.put(records.buffer.duplicate())
+        buffer.flip()
+      }
+    })
+
     EasyMock.replay(fileRecordsMock)
 
     endOffset

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -261,7 +261,6 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
       EasyMock.eq(true), EasyMock.eq(IsolationLevel.READ_UNCOMMITTED)))
       .andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
     EasyMock.expect(fileRecordsMock.readInto(EasyMock.anyObject(classOf[ByteBuffer]), EasyMock.anyInt()))
-      .andReturn(records.buffer)
 
     EasyMock.replay(logMock, fileRecordsMock)
     synchronized {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -22,21 +22,19 @@ import kafka.coordinator.AbstractCoordinatorConcurrencyTest
 import kafka.coordinator.AbstractCoordinatorConcurrencyTest._
 import kafka.coordinator.transaction.TransactionCoordinatorConcurrencyTest._
 import kafka.log.Log
-import kafka.server.{ DelayedOperationPurgatory, FetchDataInfo, KafkaConfig, LogOffsetMetadata, MetadataCache }
+import kafka.server.{DelayedOperationPurgatory, FetchDataInfo, KafkaConfig, LogOffsetMetadata, MetadataCache}
 import kafka.utils.timer.MockTimer
-import kafka.utils.{ Pool, TestUtils}
-
-import org.apache.kafka.clients.{ ClientResponse, NetworkClient }
-import org.apache.kafka.common.{ Node, TopicPartition }
+import kafka.utils.{Pool, TestUtils}
+import org.apache.kafka.clients.{ClientResponse, NetworkClient}
+import org.apache.kafka.common.{Node, TopicPartition}
 import org.apache.kafka.common.internals.Topic.TRANSACTION_STATE_TOPIC_NAME
-import org.apache.kafka.common.protocol.{ ApiKeys, Errors }
-import org.apache.kafka.common.record.{ CompressionType, FileRecords, MemoryRecords, SimpleRecord }
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.record.{CompressionType, FileRecords, MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.requests._
-import org.apache.kafka.common.utils.{ LogContext, MockTime }
-
-import org.easymock.EasyMock
+import org.apache.kafka.common.utils.{LogContext, MockTime}
+import org.easymock.{EasyMock, IAnswer}
 import org.junit.Assert._
-import org.junit.{ After, Before, Test }
+import org.junit.{After, Before, Test}
 
 import scala.collection.Map
 import scala.collection.mutable
@@ -260,7 +258,16 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     EasyMock.expect(logMock.read(EasyMock.eq(startOffset), EasyMock.anyInt(), EasyMock.eq(None),
       EasyMock.eq(true), EasyMock.eq(IsolationLevel.READ_UNCOMMITTED)))
       .andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
-    EasyMock.expect(fileRecordsMock.readInto(EasyMock.anyObject(classOf[ByteBuffer]), EasyMock.anyInt()))
+
+    val bufferCapture = EasyMock.newCapture[ByteBuffer]
+    fileRecordsMock.readInto(EasyMock.capture(bufferCapture), EasyMock.anyInt())
+    EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
+      override def answer: Unit = {
+        val buffer = bufferCapture.getValue
+        buffer.put(records.buffer.duplicate())
+        buffer.flip()
+      }
+    })
 
     EasyMock.replay(logMock, fileRecordsMock)
     synchronized {

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionCoordinatorConcurrencyTest.scala
@@ -264,7 +264,7 @@ class TransactionCoordinatorConcurrencyTest extends AbstractCoordinatorConcurren
     EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
       override def answer: Unit = {
         val buffer = bufferCapture.getValue
-        buffer.put(records.buffer.duplicate())
+        buffer.put(records.buffer.duplicate)
         buffer.flip()
       }
     })

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -585,8 +585,16 @@ class TransactionStateManagerTest {
     EasyMock.expect(logMock.read(EasyMock.eq(startOffset), EasyMock.anyInt(), EasyMock.eq(None),
       EasyMock.eq(true), EasyMock.eq(IsolationLevel.READ_UNCOMMITTED)))
       .andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
-    EasyMock.expect(fileRecordsMock.readInto(EasyMock.anyObject(classOf[ByteBuffer]), EasyMock.anyInt()))
 
+    val bufferCapture = EasyMock.newCapture[ByteBuffer]
+    fileRecordsMock.readInto(EasyMock.capture(bufferCapture), EasyMock.anyInt())
+    EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
+      override def answer: Unit = {
+        val buffer = bufferCapture.getValue
+        buffer.put(records.buffer.duplicate())
+        buffer.flip()
+      }
+    })
     EasyMock.replay(logMock, fileRecordsMock, replicaManager)
   }
 

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -586,7 +586,6 @@ class TransactionStateManagerTest {
       EasyMock.eq(true), EasyMock.eq(IsolationLevel.READ_UNCOMMITTED)))
       .andReturn(FetchDataInfo(LogOffsetMetadata(startOffset), fileRecordsMock))
     EasyMock.expect(fileRecordsMock.readInto(EasyMock.anyObject(classOf[ByteBuffer]), EasyMock.anyInt()))
-      .andReturn(records.buffer)
 
     EasyMock.replay(logMock, fileRecordsMock, replicaManager)
   }

--- a/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/transaction/TransactionStateManagerTest.scala
@@ -591,7 +591,7 @@ class TransactionStateManagerTest {
     EasyMock.expectLastCall().andAnswer(new IAnswer[Unit] {
       override def answer: Unit = {
         val buffer = bufferCapture.getValue
-        buffer.put(records.buffer.duplicate())
+        buffer.put(records.buffer.duplicate)
         buffer.flip()
       }
     })

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -39,6 +39,7 @@ import org.apache.kafka.common.utils.{Time, Utils}
 import org.easymock.EasyMock
 import org.junit.Assert._
 import org.junit.{After, Before, Test}
+import org.scalatest.Assertions
 
 import scala.collection.Iterable
 import scala.collection.JavaConverters._
@@ -2118,38 +2119,72 @@ class LogTest {
   def testSplitOnOffsetOverflow(): Unit = {
     // create a log such that one log segment has offsets that overflow, and call the split API on that segment
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    val (log, segmentWithOverflow, inputRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, segmentWithOverflow) = createLogWithOffsetOverflow(logConfig)
     assertTrue("At least one segment must have offset overflow", LogTest.hasOffsetOverflow(log))
+
+    val allRecordsBeforeSplit = LogTest.allRecords(log)
 
     // split the segment with overflow
     log.splitOverflowedSegment(segmentWithOverflow)
 
     // assert we were successfully able to split the segment
-    assertEquals(log.numberOfSegments, 4)
-    assertTrue(LogTest.verifyRecordsInLog(log, inputRecords))
+    assertEquals(4, log.numberOfSegments)
+    LogTest.verifyRecordsInLog(log, allRecordsBeforeSplit)
 
     // verify we do not have offset overflow anymore
     assertFalse(LogTest.hasOffsetOverflow(log))
   }
 
   @Test
+  def testDegenerateSegmentSplit(): Unit = {
+    // This tests a scenario where all of the batches appended to a segment have overflowed.
+    // When we split the overflowed segment, only one new segment will be created.
+
+    val segment = LogTest.rawSegment(logDir, 0L)
+    val overflowOffset = Int.MaxValue + 1L
+    segment.append(MemoryRecords.withRecords(overflowOffset, CompressionType.NONE, 0,
+      new SimpleRecord("a".getBytes)))
+    segment.append(MemoryRecords.withRecords(overflowOffset + 1, CompressionType.NONE, 0,
+      new SimpleRecord("b".getBytes)))
+    segment.close()
+
+    // Create clean shutdown file so that we do not split during the load
+    createCleanShutdownFile()
+
+    val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
+    val log = createLog(logDir, logConfig, recoveryPoint = Long.MaxValue)
+    val segmentWithOverflow = LogTest.firstOverflowSegment(log).getOrElse {
+      Assertions.fail("Failed to create log with a segment which has overflowed offsets")
+    }
+
+    val allRecordsBeforeSplit = LogTest.allRecords(log)
+    log.splitOverflowedSegment(segmentWithOverflow)
+
+    assertEquals(1, log.numberOfSegments)
+    assertEquals(overflowOffset, log.activeSegment.baseOffset)
+    LogTest.verifyRecordsInLog(log, allRecordsBeforeSplit)
+
+    assertFalse(LogTest.hasOffsetOverflow(log))
+  }
+
+  @Test
   def testRecoveryOfSegmentWithOffsetOverflow(): Unit = {
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    var (log, segmentWithOverflow, initialRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, _) = createLogWithOffsetOverflow(logConfig)
     val expectedKeys = LogTest.keysInLog(log)
 
     // Run recovery on the log. This should split the segment underneath. Ignore .deleted files as we could have still
     // have them lying around after the split.
-    log = LogTest.recoverAndCheck(logDir, logConfig, expectedKeys, brokerTopicStats, expectDeletedFiles = true)
-    assertEquals(expectedKeys, LogTest.keysInLog(log))
+    val recoveredLog = recoverAndCheck(logConfig, expectedKeys)
+    assertEquals(expectedKeys, LogTest.keysInLog(recoveredLog))
 
     // Running split again would throw an error
-    for (segment <- log.logSegments) {
+    for (segment <- recoveredLog.logSegments) {
       try {
         log.splitOverflowedSegment(segment)
         fail()
       } catch {
-        case _: IllegalArgumentException =>
+        case _: IllegalStateException =>
       }
     }
   }
@@ -2157,7 +2192,7 @@ class LogTest {
   @Test
   def testRecoveryAfterCrashDuringSplitPhase1(): Unit = {
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    var (log, segmentWithOverflow, initialRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, segmentWithOverflow) = createLogWithOffsetOverflow(logConfig)
     val expectedKeys = LogTest.keysInLog(log)
     val numSegmentsInitial = log.logSegments.size
 
@@ -2172,16 +2207,17 @@ class LogTest {
     })
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
       Utils.atomicMoveWithFallback(file.toPath, Paths.get(CoreUtils.replaceSuffix(file.getPath, Log.DeletedFileSuffix, "")))
-    log = LogTest.recoverAndCheck(logDir, logConfig, expectedKeys, brokerTopicStats, expectDeletedFiles = true)
-    assertEquals(expectedKeys, LogTest.keysInLog(log))
-    assertEquals(numSegmentsInitial + 1, log.logSegments.size)
-    log.close()
+
+    val recoveredLog = recoverAndCheck(logConfig, expectedKeys)
+    assertEquals(expectedKeys, LogTest.keysInLog(recoveredLog))
+    assertEquals(numSegmentsInitial + 1, recoveredLog.logSegments.size)
+    recoveredLog.close()
   }
 
   @Test
   def testRecoveryAfterCrashDuringSplitPhase2(): Unit = {
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    var (log, segmentWithOverflow, initialRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, segmentWithOverflow) = createLogWithOffsetOverflow(logConfig)
     val expectedKeys = LogTest.keysInLog(log)
     val numSegmentsInitial = log.logSegments.size
 
@@ -2190,25 +2226,26 @@ class LogTest {
 
     // Simulate recovery just after one of the new segments has been renamed to .swap. On recovery, existing split
     // operation is aborted but the recovery process itself kicks off split which should complete.
-    newSegments.reverse.foreach(segment => {
-      if (segment != newSegments.tail)
+    newSegments.reverse.foreach { segment =>
+      if (segment != newSegments.last)
         segment.changeFileSuffixes("", Log.CleanedFileSuffix)
       else
         segment.changeFileSuffixes("", Log.SwapFileSuffix)
       segment.truncateTo(0)
-    })
+    }
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
       Utils.atomicMoveWithFallback(file.toPath, Paths.get(CoreUtils.replaceSuffix(file.getPath, Log.DeletedFileSuffix, "")))
-    log = LogTest.recoverAndCheck(logDir, logConfig, expectedKeys, brokerTopicStats, expectDeletedFiles = true)
-    assertEquals(expectedKeys, LogTest.keysInLog(log))
-    assertEquals(numSegmentsInitial + 1, log.logSegments.size)
-    log.close()
+
+    val recoveredLog = recoverAndCheck(logConfig, expectedKeys)
+    assertEquals(expectedKeys, LogTest.keysInLog(recoveredLog))
+    assertEquals(numSegmentsInitial + 1, recoveredLog.logSegments.size)
+    recoveredLog.close()
   }
 
   @Test
   def testRecoveryAfterCrashDuringSplitPhase3(): Unit = {
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    var (log, segmentWithOverflow, initialRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, segmentWithOverflow) = createLogWithOffsetOverflow(logConfig)
     val expectedKeys = LogTest.keysInLog(log)
     val numSegmentsInitial = log.logSegments.size
 
@@ -2226,16 +2263,16 @@ class LogTest {
     // Truncate the old segment
     segmentWithOverflow.truncateTo(0)
 
-    log = LogTest.recoverAndCheck(logDir, logConfig, expectedKeys, brokerTopicStats, expectDeletedFiles = true)
-    assertEquals(expectedKeys, LogTest.keysInLog(log))
-    assertEquals(numSegmentsInitial + 1, log.logSegments.size)
+    val recoveredLog = recoverAndCheck(logConfig, expectedKeys)
+    assertEquals(expectedKeys, LogTest.keysInLog(recoveredLog))
+    assertEquals(numSegmentsInitial + 1, recoveredLog.logSegments.size)
     log.close()
   }
 
   @Test
   def testRecoveryAfterCrashDuringSplitPhase4(): Unit = {
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    var (log, segmentWithOverflow, initialRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, segmentWithOverflow) = createLogWithOffsetOverflow(logConfig)
     val expectedKeys = LogTest.keysInLog(log)
     val numSegmentsInitial = log.logSegments.size
 
@@ -2244,25 +2281,24 @@ class LogTest {
 
     // Simulate recovery right after all new segments have been renamed to .swap and old segment has been deleted. On
     // recovery, existing split operation is completed.
-    newSegments.reverse.foreach(segment => {
-      segment.changeFileSuffixes("", Log.SwapFileSuffix)
-    })
+    newSegments.reverse.foreach(_.changeFileSuffixes("", Log.SwapFileSuffix))
+
     for (file <- logDir.listFiles if file.getName.endsWith(Log.DeletedFileSuffix))
       Utils.delete(file)
 
     // Truncate the old segment
     segmentWithOverflow.truncateTo(0)
 
-    log = LogTest.recoverAndCheck(logDir, logConfig, expectedKeys, brokerTopicStats, expectDeletedFiles = true)
-    assertEquals(expectedKeys, LogTest.keysInLog(log))
-    assertEquals(numSegmentsInitial + 1, log.logSegments.size)
-    log.close()
+    val recoveredLog = recoverAndCheck(logConfig, expectedKeys)
+    assertEquals(expectedKeys, LogTest.keysInLog(recoveredLog))
+    assertEquals(numSegmentsInitial + 1, recoveredLog.logSegments.size)
+    recoveredLog.close()
   }
 
   @Test
   def testRecoveryAfterCrashDuringSplitPhase5(): Unit = {
     val logConfig = LogTest.createLogConfig(indexIntervalBytes = 1, fileDeleteDelayMs = 1000)
-    var (log, segmentWithOverflow, initialRecords) = createLogWithOffsetOverflow(Some(logConfig))
+    val (log, segmentWithOverflow) = createLogWithOffsetOverflow(logConfig)
     val expectedKeys = LogTest.keysInLog(log)
     val numSegmentsInitial = log.logSegments.size
 
@@ -2276,10 +2312,10 @@ class LogTest {
     // Truncate the old segment
     segmentWithOverflow.truncateTo(0)
 
-    log = LogTest.recoverAndCheck(logDir, logConfig, expectedKeys, brokerTopicStats, expectDeletedFiles = true)
-    assertEquals(expectedKeys, LogTest.keysInLog(log))
-    assertEquals(numSegmentsInitial + 1, log.logSegments.size)
-    log.close()
+    val recoveredLog = recoverAndCheck(logConfig, expectedKeys)
+    assertEquals(expectedKeys, LogTest.keysInLog(recoveredLog))
+    assertEquals(numSegmentsInitial + 1, recoveredLog.logSegments.size)
+    recoveredLog.close()
   }
 
   @Test
@@ -3390,13 +3426,28 @@ class LogTest {
                         time: Time = mockTime,
                         maxProducerIdExpirationMs: Int = 60 * 60 * 1000,
                         producerIdExpirationCheckIntervalMs: Int = LogManager.ProducerIdExpirationCheckIntervalMs): Log = {
-    return LogTest.createLog(dir, config, brokerTopicStats, scheduler, time, logStartOffset, recoveryPoint,
+    LogTest.createLog(dir, config, brokerTopicStats, scheduler, time, logStartOffset, recoveryPoint,
       maxProducerIdExpirationMs, producerIdExpirationCheckIntervalMs)
   }
 
-  private def createLogWithOffsetOverflow(logConfig: Option[LogConfig]): (Log, LogSegment, List[Record]) = {
-    return LogTest.createLogWithOffsetOverflow(logDir, brokerTopicStats, logConfig, mockTime.scheduler, mockTime)
+  private def createLogWithOffsetOverflow(logConfig: LogConfig): (Log, LogSegment) = {
+    LogTest.initializeLogDirWithOverflowedSegment(logDir)
+
+    val log = createLog(logDir, logConfig, recoveryPoint = Long.MaxValue)
+    val segmentWithOverflow = LogTest.firstOverflowSegment(log).getOrElse {
+      Assertions.fail("Failed to create log with a segment which has overflowed offsets")
+    }
+
+    (log, segmentWithOverflow)
   }
+
+  private def recoverAndCheck(config: LogConfig,
+                              expectedKeys: Iterable[Long],
+                              expectDeletedFiles: Boolean = true): Log = {
+    LogTest.recoverAndCheck(logDir, config, expectedKeys, brokerTopicStats, mockTime, mockTime.scheduler,
+      expectDeletedFiles)
+  }
+
 }
 
 object LogTest {
@@ -3453,133 +3504,77 @@ object LogTest {
    * @param log Log to check
    * @return true if log contains at least one segment with offset overflow; false otherwise
    */
-  def hasOffsetOverflow(log: Log): Boolean = {
-    for (logSegment <- log.logSegments) {
-      val baseOffset = logSegment.baseOffset
-      for (batch <- logSegment.log.batches.asScala) {
-        val it = batch.iterator()
-        while (it.hasNext()) {
-          val record = it.next()
-          if (record.offset > baseOffset + Int.MaxValue || record.offset < baseOffset)
-            return true
-        }
-      }
+  def hasOffsetOverflow(log: Log): Boolean = firstOverflowSegment(log).isDefined
+
+  def firstOverflowSegment(log: Log): Option[LogSegment] = {
+    def hasOverflow(baseOffset: Long, batch: RecordBatch): Boolean =
+      batch.lastOffset > baseOffset + Int.MaxValue || batch.baseOffset < baseOffset
+
+    for (segment <- log.logSegments) {
+      val overflowBatch = segment.log.batches.asScala.find(batch => hasOverflow(segment.baseOffset, batch))
+      if (overflowBatch.isDefined)
+        return Some(segment)
     }
-    false
+    None
   }
+
+  private def rawSegment(logDir: File, baseOffset: Long): FileRecords =
+    FileRecords.open(Log.logFile(logDir, baseOffset))
 
   /**
-   * Create a log such that one of the log segments has messages with offsets that cause index offset overflow.
-   * @param logDir Directory in which log should be created
-   * @param brokerTopicStats Container for Broker Topic Yammer Metrics
-   * @param logConfigOpt Optional log configuration to use
-   * @param scheduler The thread pool scheduler used for background actions
-   * @param time The time instance to use
-   * @return (1) Created log containing segment with offset overflow, (2) Log segment within log containing messages with
-   *         offset overflow, and (3) List of messages in the log
+   * Initialize the given log directory with a set of segments, one of which will have an
+   * offset which overflows the segment
    */
-  def createLogWithOffsetOverflow(logDir: File, brokerTopicStats: BrokerTopicStats, logConfigOpt: Option[LogConfig] = None,
-                                  scheduler: Scheduler, time: Time): (Log, LogSegment, List[Record]) = {
-    val logConfig =
-      if (logConfigOpt.isDefined)
-        logConfigOpt.get
-      else
-        createLogConfig(indexIntervalBytes = 1)
-
-    var log = createLog(logDir, logConfig, brokerTopicStats, scheduler, time)
-    val inputRecords = ListBuffer[Record]()
-
-    // References to files we want to "merge" to emulate offset overflow
-    val toMerge = ListBuffer[File]()
-
-    def getRecords(baseOffset: Long): List[MemoryRecords] = {
-      def toBytes(value: Long): Array[Byte] = value.toString.getBytes
-
-      val set1 = MemoryRecords.withRecords(baseOffset, CompressionType.NONE, 0,
-        new SimpleRecord(toBytes(baseOffset), toBytes(baseOffset)))
-      val set2 = MemoryRecords.withRecords(baseOffset + 1, CompressionType.NONE, 0,
-        new SimpleRecord(toBytes(baseOffset + 1), toBytes(baseOffset + 1)),
-        new SimpleRecord(toBytes(baseOffset + 2), toBytes(baseOffset + 2)));
-      val set3 = MemoryRecords.withRecords(baseOffset + Int.MaxValue - 1, CompressionType.NONE, 0,
-        new SimpleRecord(toBytes(baseOffset + Int.MaxValue - 1), toBytes(baseOffset + Int.MaxValue - 1)));
-      List(set1, set2, set3)
-    }
-
-    // Append some messages to the log. This will create four log segments.
-    var firstOffset = 0L
-    for (i <- 0 until 4) {
-      val recordsToAppend = getRecords(firstOffset)
-      for (records <- recordsToAppend)
-        log.appendAsFollower(records)
-
-      if (i == 1 || i == 2)
-        toMerge += log.activeSegment.log.file
-
-      firstOffset += Int.MaxValue + 1L
-    }
-
-    // assert that we have the correct number of segments
-    assertEquals(log.numberOfSegments, 4)
-
-    // assert number of batches
-    for (logSegment <- log.logSegments) {
-      var numBatches = 0
-      for (_ <- logSegment.log.batches.asScala)
-        numBatches += 1
-      assertEquals(numBatches, 3)
-    }
-
-    // create a list of appended records
-    for (logSegment <- log.logSegments) {
-      for (batch <- logSegment.log.batches.asScala) {
-        val it = batch.iterator()
-        while (it.hasNext())
-          inputRecords += it.next()
+  def initializeLogDirWithOverflowedSegment(logDir: File): Unit = {
+    def writeSampleBatches(baseOffset: Long, segment: FileRecords): Long = {
+      def record(offset: Long) = {
+        val data = offset.toString.getBytes
+        new SimpleRecord(data, data)
       }
+
+      segment.append(MemoryRecords.withRecords(baseOffset, CompressionType.NONE, 0,
+        record(baseOffset)))
+      segment.append(MemoryRecords.withRecords(baseOffset + 1, CompressionType.NONE, 0,
+        record(baseOffset + 1),
+        record(baseOffset + 2)))
+      segment.append(MemoryRecords.withRecords(baseOffset + Int.MaxValue - 1, CompressionType.NONE, 0,
+        record(baseOffset + Int.MaxValue - 1)))
+      baseOffset + Int.MaxValue
     }
 
-    log.flush()
-    log.close()
-
-    // We want to "merge" log segments 1 and 2. This is where the offset overflow will be.
-    // Current: segment #1 | segment #2 | segment #3 | segment# 4
-    // Final: segment #1 | segment #2' | segment #4
-    // where 2' corresponds to segment #2 and segment #3 combined together.
-    // Append segment #3 at the end of segment #2 to create 2'
-    var dest: FileOutputStream = null
-    var source: FileInputStream = null
-    try {
-      dest = new FileOutputStream(toMerge(0), true)
-      source = new FileInputStream(toMerge(1))
-      val sourceBytes = new Array[Byte](toMerge(1).length.toInt)
-      source.read(sourceBytes)
-      dest.write(sourceBytes)
-    } finally {
-      dest.close()
-      source.close()
+    def writeNormalSegment(baseOffset: Long): Long = {
+      val segment = rawSegment(logDir, baseOffset)
+      try writeSampleBatches(baseOffset, segment)
+      finally segment.close()
     }
 
-    // Delete segment #3 including any index, etc.
-    toMerge(1).delete()
-    log = createLog(logDir, logConfig, brokerTopicStats, scheduler, time, recoveryPoint = Long.MaxValue)
+    def writeOverflowSegment(baseOffset: Long): Long = {
+      val segment = rawSegment(logDir, baseOffset)
+      try {
+        val nextOffset = writeSampleBatches(baseOffset, segment)
+        writeSampleBatches(nextOffset, segment)
+      } finally segment.close()
+    }
 
-    // assert that there is now one less segment than before, and that the records in the log are same as before
-    assertEquals(log.numberOfSegments, 3)
-    assertTrue(verifyRecordsInLog(log, inputRecords.toList))
-
-    (log, log.logSegments.toList(1), inputRecords.toList)
+    // We create three segments, the second of which contains offsets which overflow
+    var nextOffset = 0L
+    nextOffset = writeNormalSegment(nextOffset)
+    nextOffset = writeOverflowSegment(nextOffset)
+    writeNormalSegment(nextOffset)
   }
 
-  def verifyRecordsInLog(log: Log, expectedRecords: List[Record]): Boolean = {
+  def allRecords(log: Log): List[Record] = {
     val recordsFound = ListBuffer[Record]()
     for (logSegment <- log.logSegments) {
       for (batch <- logSegment.log.batches.asScala) {
-        val it = batch.iterator()
-        while (it.hasNext())
-          recordsFound += it.next()
+        recordsFound ++= batch.iterator().asScala
       }
     }
-    return recordsFound.equals(expectedRecords)
+    recordsFound.toList
+  }
+
+  def verifyRecordsInLog(log: Log, expectedRecords: List[Record]): Unit = {
+    assertEquals(expectedRecords, allRecords(log))
   }
 
   /* extract all the keys from a log */
@@ -3590,12 +3585,16 @@ object LogTest {
       yield TestUtils.readString(record.key).toLong
   }
 
-  def recoverAndCheck(logDir: File, config: LogConfig, expectedKeys: Iterable[Long],
-                      brokerTopicStats: BrokerTopicStats, expectDeletedFiles: Boolean = false): Log = {
-    val time = new MockTime()
+  def recoverAndCheck(logDir: File,
+                      config: LogConfig,
+                      expectedKeys: Iterable[Long],
+                      brokerTopicStats: BrokerTopicStats,
+                      time: Time,
+                      scheduler: Scheduler,
+                      expectDeletedFiles: Boolean = false): Log = {
     // Recover log file and check that after recovery, keys are as expected
     // and all temporary files have been deleted
-    val recoveredLog = createLog(logDir, config, brokerTopicStats, time.scheduler, time)
+    val recoveredLog = createLog(logDir, config, brokerTopicStats, scheduler, time)
     time.sleep(config.fileDeleteDelayMs + 1)
     for (file <- logDir.listFiles) {
       if (!expectDeletedFiles)

--- a/core/src/test/scala/unit/kafka/log/LogTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogTest.scala
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}
 import java.util.Properties
 
-import org.apache.kafka.common.errors._
 import kafka.common.{OffsetsOutOfOrderException, UnexpectedAppendOffsetException, KafkaException}
 import kafka.log.Log.DeleteDirSuffix
 import kafka.server.epoch.{EpochEntry, LeaderEpochCache, LeaderEpochFileCache}


### PR DESCRIPTION
This patch fixes the following issues in the log splitting logic added to address KAFKA-6264:

1. We were not handling the case when all messages in the segment overflowed the index. In this case, there is only one resulting segment following the split.
2. There was an off-by-one error in the recovery logic when completing a swap operation which caused an unintended segment deletion.

Additionally, this patch factors out of `splitOverflowedSegment` a method to write to a segment using from with an instance of `FileRecords`. This allows for future reuse and isolated testing.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
