### PR TITLE
[MINOR] Fix chunked down-conversion behavior when no valid batch exists after conversion

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
@@ -162,9 +162,13 @@ public class LazyDownConversionRecords implements BaseRecords {
                     sizeSoFar += currentBatch.sizeInBytes();
                     isFirstBatch = false;
                 }
-                ConvertedRecords records = RecordsUtil.downConvert(batches, toMagic, firstOffset, time);
-                if (records.records().sizeInBytes() > 0)
-                    return records;
+                ConvertedRecords convertedRecords = RecordsUtil.downConvert(batches, toMagic, firstOffset, time);
+                // During conversion, it is possible that we drop certain batches because they do not have an equivalent
+                // representation in the message format we want to convert to. For example, V0 and V1 message formats
+                // have no notion of transaction markers which were introduced in V2 so they get dropped during conversion.
+                // We return converted records only when we have at least one valid batch of messages after conversion.
+                if (convertedRecords.records().sizeInBytes() > 0)
+                    return convertedRecords;
             }
             return allDone();
         }

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.utils.AbstractIterator;
 import org.apache.kafka.common.utils.Time;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -57,13 +56,16 @@ public class LazyDownConversionRecords implements BaseRecords {
         // need to make sure that we are able to accommodate one full batch of down-converted messages. The way we achieve
         // this is by having sizeInBytes method factor in the size of the first down-converted batch and return at least
         // its size.
-        AbstractIterator<? extends RecordBatch> it = records.batchIterator();
+        java.util.Iterator<ConvertedRecords> it = iterator(0);
         if (it.hasNext()) {
-            firstConvertedBatch = RecordsUtil.downConvert(Collections.singletonList(it.peek()), toMagic, firstOffset, time);
+            firstConvertedBatch = it.next();
             sizeInBytes = Math.max(records.sizeInBytes(), firstConvertedBatch.records().sizeInBytes());
         } else {
+            // If there are no messages we got after down-conversion, make sure we are able to send at least an overflow
+            // message to the consumer. Typically, the consumer would need to increase the fetch size in such cases so
+            // that we are able to send at least one message batch.
             firstConvertedBatch = null;
-            sizeInBytes = 0;
+            sizeInBytes = LazyDownConversionRecordsSend.MIN_OVERFLOW_MESSAGE_LENGTH;
         }
     }
 
@@ -148,21 +150,24 @@ public class LazyDownConversionRecords implements BaseRecords {
                 return convertedBatch;
             }
 
-            if (!batchIterator.hasNext())
-                return allDone();
+            while (batchIterator.hasNext()) {
+                List<RecordBatch> batches = new ArrayList<>();
+                boolean isFirstBatch = true;
+                long sizeSoFar = 0;
 
-            // Figure out batches we should down-convert based on the size constraints
-            List<RecordBatch> batches = new ArrayList<>();
-            boolean isFirstBatch = true;
-            long sizeSoFar = 0;
-            while (batchIterator.hasNext() &&
-                    (isFirstBatch || (batchIterator.peek().sizeInBytes() + sizeSoFar) <= maximumReadSize)) {
-                RecordBatch currentBatch = batchIterator.next();
-                batches.add(currentBatch);
-                sizeSoFar += currentBatch.sizeInBytes();
-                isFirstBatch = false;
+                // Figure out batches we should down-convert based on the size constraints
+                while (batchIterator.hasNext() &&
+                        (isFirstBatch || (batchIterator.peek().sizeInBytes() + sizeSoFar) <= maximumReadSize)) {
+                    RecordBatch currentBatch = batchIterator.next();
+                    batches.add(currentBatch);
+                    sizeSoFar += currentBatch.sizeInBytes();
+                    isFirstBatch = false;
+                }
+                ConvertedRecords records = RecordsUtil.downConvert(batches, toMagic, firstOffset, time);
+                if (records.records().sizeInBytes() > 0)
+                    return records;
             }
-            return RecordsUtil.downConvert(batches, toMagic, firstOffset, time);
+            return allDone();
         }
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecords.java
@@ -62,8 +62,7 @@ public class LazyDownConversionRecords implements BaseRecords {
             sizeInBytes = Math.max(records.sizeInBytes(), firstConvertedBatch.records().sizeInBytes());
         } else {
             // If there are no messages we got after down-conversion, make sure we are able to send at least an overflow
-            // message to the consumer. Typically, the consumer would need to increase the fetch size in such cases so
-            // that we are able to send at least one message batch.
+            // message to the consumer. Typically, the consumer would need to increase the fetch size in such cases.
             firstConvertedBatch = null;
             sizeInBytes = LazyDownConversionRecordsSend.MIN_OVERFLOW_MESSAGE_LENGTH;
         }

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -55,7 +55,7 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
                 ConvertedRecords<MemoryRecords> recordsAndStats = convertedRecordsIterator.next();
                 convertedRecords = recordsAndStats.records();
                 recordConversionStats.add(recordsAndStats.recordConversionStats());
-                log.debug("Got converted records for partition {} with length={}", topicPartition(), convertedRecords.sizeInBytes());
+                log.debug("Down-converted records for partition {} with length={}", topicPartition(), convertedRecords.sizeInBytes());
             } else {
                 // We do not have any records left to down-convert. Construct an overflow message for the length remaining.
                 // This message will be ignored by the consumer because its length will be past the length of maximum

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -67,7 +67,7 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
                 ByteBuffer overflowMessageBatch = ByteBuffer.allocate(
                         Math.max(MIN_OVERFLOW_MESSAGE_LENGTH, Math.min(remaining + 1, MAX_READ_SIZE)));
                 overflowMessageBatch.putLong(-1L);
-                overflowMessageBatch.putInt(remaining + 1);
+                overflowMessageBatch.putInt(Math.max(remaining + 1, DefaultRecordBatch.RECORD_BATCH_OVERHEAD));
                 convertedRecords = MemoryRecords.readableRecords(overflowMessageBatch);
                 log.debug("Constructed overflow message batch for partition {} with length={}", topicPartition(), remaining);
             }

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
@@ -33,6 +32,7 @@ import java.util.Iterator;
 public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownConversionRecords> {
     private static final Logger log = LoggerFactory.getLogger(LazyDownConversionRecordsSend.class);
     private static final int MAX_READ_SIZE = 128 * 1024;
+    static final int MIN_OVERFLOW_MESSAGE_LENGTH = Records.LOG_OVERHEAD;
 
     private RecordConversionStats recordConversionStats;
     private RecordsSend convertedRecordsWriter;
@@ -49,39 +49,28 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
     public long writeTo(GatheringByteChannel channel, long previouslyWritten, int remaining) throws IOException {
         if (convertedRecordsWriter == null || convertedRecordsWriter.completed()) {
             MemoryRecords convertedRecords;
-
             // Check if we have more chunks left to down-convert
             if (convertedRecordsIterator.hasNext()) {
                 // Get next chunk of down-converted messages
                 ConvertedRecords<MemoryRecords> recordsAndStats = convertedRecordsIterator.next();
                 convertedRecords = recordsAndStats.records();
-
-                int sizeOfFirstConvertedBatch = convertedRecords.batchIterator().next().sizeInBytes();
-                if (previouslyWritten == 0 && sizeOfFirstConvertedBatch > size())
-                    throw new EOFException("Unable to send first batch completely." +
-                            " maximum_size: " + size() +
-                            " converted_records_size: " + sizeOfFirstConvertedBatch);
-
                 recordConversionStats.add(recordsAndStats.recordConversionStats());
-                log.debug("Got lazy converted records for partition {} with length={}", topicPartition(), convertedRecords.sizeInBytes());
+                log.debug("Got converted records for partition {} with length={}", topicPartition(), convertedRecords.sizeInBytes());
             } else {
-                if (previouslyWritten == 0)
-                    throw new EOFException("Unable to get the first batch of down-converted records");
-
-                // We do not have any records left to down-convert. Construct a "fake" message for the length remaining.
+                // We do not have any records left to down-convert. Construct an overflow message for the length remaining.
                 // This message will be ignored by the consumer because its length will be past the length of maximum
                 // possible response size.
                 // DefaultRecordBatch =>
                 //      BaseOffset => Int64
                 //      Length => Int32
                 //      ...
-                log.debug("Constructing fake message batch for partition {} for remaining length={}", topicPartition(), remaining);
-                ByteBuffer fakeMessageBatch = ByteBuffer.allocate(Math.max(Records.LOG_OVERHEAD, Math.min(remaining + 1, MAX_READ_SIZE)));
-                fakeMessageBatch.putLong(-1L);
-                fakeMessageBatch.putInt(remaining + 1);
-                convertedRecords = MemoryRecords.readableRecords(fakeMessageBatch);
+                ByteBuffer overflowMessageBatch = ByteBuffer.allocate(
+                        Math.max(MIN_OVERFLOW_MESSAGE_LENGTH, Math.min(remaining + 1, MAX_READ_SIZE)));
+                overflowMessageBatch.putLong(-1L);
+                overflowMessageBatch.putInt(remaining + 1);
+                convertedRecords = MemoryRecords.readableRecords(overflowMessageBatch);
+                log.debug("Constructed overflow message batch for partition {} with length={}", topicPartition(), remaining);
             }
-
             convertedRecordsWriter = new DefaultRecordsSend(destination(), convertedRecords, Math.min(convertedRecords.sizeInBytes(), remaining));
         }
         return convertedRecordsWriter.writeTo(channel);

--- a/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/LazyDownConversionRecordsSend.java
@@ -67,6 +67,9 @@ public final class LazyDownConversionRecordsSend extends RecordsSend<LazyDownCon
                 ByteBuffer overflowMessageBatch = ByteBuffer.allocate(
                         Math.max(MIN_OVERFLOW_MESSAGE_LENGTH, Math.min(remaining + 1, MAX_READ_SIZE)));
                 overflowMessageBatch.putLong(-1L);
+
+                // Fill in the length of the overflow batch. A valid batch must be at least as long as the minimum batch
+                // overhead.
                 overflowMessageBatch.putInt(Math.max(remaining + 1, DefaultRecordBatch.RECORD_BATCH_OVERHEAD));
                 convertedRecords = MemoryRecords.readableRecords(overflowMessageBatch);
                 log.debug("Constructed overflow message batch for partition {} with length={}", topicPartition(), remaining);

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -112,6 +112,17 @@ public final class Utils {
     }
 
     /**
+     * Read a UTF8 string from the current position till the end of a byte buffer. The position of the byte buffer is
+     * not affected by this method.
+     *
+     * @param buffer The buffer to read from
+     * @return The UTF8 string
+     */
+    public static String utf8(ByteBuffer buffer) {
+        return utf8(buffer, buffer.remaining());
+    }
+
+    /**
      * Read a UTF8 string from a byte buffer at a given offset. Note that the position of the byte buffer
      * is not affected by this method.
      *

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -431,7 +431,7 @@ public class FileRecordsTest {
     }
 
     private String utf8(ByteBuffer buffer) {
-        return Utils.utf8(buffer, buffer.remaining());
+        return Utils.utf8(buffer);
     }
 
     private void downConvertAndVerifyRecords(List<SimpleRecord> initialRecords,

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -38,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.utf8;
 import static org.apache.kafka.test.TestUtils.tempFile;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -486,8 +486,8 @@ public class FileRecordsTest {
                 for (Record record : batch) {
                     assertTrue("Inner record should have magic " + magicByte, record.hasMagic(batch.magic()));
                     assertEquals("Offset should not change", initialOffsets.get(i).longValue(), record.offset());
-                    assertEquals("Key should not change", Utils.utf8(initialRecords.get(i).key()), Utils.utf8(record.key()));
-                    assertEquals("Value should not change", Utils.utf8(initialRecords.get(i).value()), Utils.utf8(record.value()));
+                    assertEquals("Key should not change", utf8(initialRecords.get(i).key()), utf8(record.key()));
+                    assertEquals("Value should not change", utf8(initialRecords.get(i).value()), utf8(record.value()));
                     assertFalse(record.hasTimestampType(TimestampType.LOG_APPEND_TIME));
                     if (batch.magic() == RecordBatch.MAGIC_VALUE_V0) {
                         assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());

--- a/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/FileRecordsTest.java
@@ -430,10 +430,6 @@ public class FileRecordsTest {
         }
     }
 
-    private String utf8(ByteBuffer buffer) {
-        return Utils.utf8(buffer);
-    }
-
     private void downConvertAndVerifyRecords(List<SimpleRecord> initialRecords,
                                              List<Long> initialOffsets,
                                              FileRecords fileRecords,
@@ -490,8 +486,8 @@ public class FileRecordsTest {
                 for (Record record : batch) {
                     assertTrue("Inner record should have magic " + magicByte, record.hasMagic(batch.magic()));
                     assertEquals("Offset should not change", initialOffsets.get(i).longValue(), record.offset());
-                    assertEquals("Key should not change", utf8(initialRecords.get(i).key()), utf8(record.key()));
-                    assertEquals("Value should not change", utf8(initialRecords.get(i).value()), utf8(record.value()));
+                    assertEquals("Key should not change", Utils.utf8(initialRecords.get(i).key()), Utils.utf8(record.key()));
+                    assertEquals("Value should not change", Utils.utf8(initialRecords.get(i).value()), Utils.utf8(record.value()));
                     assertFalse(record.hasTimestampType(TimestampType.LOG_APPEND_TIME));
                     if (batch.magic() == RecordBatch.MAGIC_VALUE_V0) {
                         assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());

--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
@@ -41,80 +41,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(value = Parameterized.class)
 public class LazyDownConversionRecordsTest {
-    private final CompressionType compressionType;
-    private final byte toMagic;
-    private final DownConversionTest test;
 
-    public LazyDownConversionRecordsTest(CompressionType compressionType, byte toMagic, DownConversionTest test) {
-        this.compressionType = compressionType;
-        this.toMagic = toMagic;
-        this.test = test;
-    }
 
-    enum DownConversionTest {
-        DEFAULT,
-        OVERFLOW,
-    }
-
-    @Parameterized.Parameters(name = "compressionType={0}, toMagic={1}, test={2}")
-    public static Collection<Object[]> data() {
-        List<Object[]> values = new ArrayList<>();
-        for (byte toMagic = RecordBatch.MAGIC_VALUE_V0; toMagic <= RecordBatch.CURRENT_MAGIC_VALUE; toMagic++) {
-            for (DownConversionTest test : DownConversionTest.values()) {
-                values.add(new Object[]{CompressionType.NONE, toMagic, test});
-                values.add(new Object[]{CompressionType.GZIP, toMagic, test});
-            }
-        }
-        return values;
-    }
-
-    @Test
-    public void doTestConversion() throws IOException {
-        List<Long> offsets = asList(0L, 2L, 3L, 9L, 11L, 15L, 16L, 17L, 22L, 24L);
-
-        Header[] headers = {new RecordHeader("headerKey1", "headerValue1".getBytes()),
-                            new RecordHeader("headerKey2", "headerValue2".getBytes()),
-                            new RecordHeader("headerKey3", "headerValue3".getBytes())};
-
-        List<SimpleRecord> records = asList(
-                new SimpleRecord(1L, "k1".getBytes(), "hello".getBytes()),
-                new SimpleRecord(2L, "k2".getBytes(), "goodbye".getBytes()),
-                new SimpleRecord(3L, "k3".getBytes(), "hello again".getBytes()),
-                new SimpleRecord(4L, "k4".getBytes(), "goodbye for now".getBytes()),
-                new SimpleRecord(5L, "k5".getBytes(), "hello again".getBytes()),
-                new SimpleRecord(6L, "k6".getBytes(), "I sense indecision".getBytes()),
-                new SimpleRecord(7L, "k7".getBytes(), "what now".getBytes()),
-                new SimpleRecord(8L, "k8".getBytes(), "running out".getBytes(), headers),
-                new SimpleRecord(9L, "k9".getBytes(), "ok, almost done".getBytes()),
-                new SimpleRecord(10L, "k10".getBytes(), "finally".getBytes(), headers));
-        assertEquals("incorrect test setup", offsets.size(), records.size());
-
-        ByteBuffer buffer = ByteBuffer.allocate(1024);
-        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType,
-                TimestampType.CREATE_TIME, 0L);
-        for (int i = 0; i < 3; i++)
-            builder.appendWithOffset(offsets.get(i), records.get(i));
-        builder.close();
-
-        builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
-                0L);
-        for (int i = 3; i < 6; i++)
-            builder.appendWithOffset(offsets.get(i), records.get(i));
-        builder.close();
-
-        builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
-                0L);
-        for (int i = 6; i < 10; i++)
-            builder.appendWithOffset(offsets.get(i), records.get(i));
-        builder.close();
-
-        buffer.flip();
-
+    public static MemoryRecords convertRecords(MemoryRecords recordsToConvert, byte toMagic, int toWrite) throws IOException {
         try (FileRecords inputRecords = FileRecords.open(tempFile())) {
-            MemoryRecords memoryRecords = MemoryRecords.readableRecords(buffer);
-            inputRecords.append(memoryRecords);
+            inputRecords.append(recordsToConvert);
             inputRecords.flush();
 
             LazyDownConversionRecords lazyRecords = new LazyDownConversionRecords(new TopicPartition("test", 1),
@@ -123,50 +55,138 @@ public class LazyDownConversionRecordsTest {
             File outputFile = tempFile();
             FileChannel channel = new RandomAccessFile(outputFile, "rw").getChannel();
 
-            // Size of lazy records is at least as much as the size of underlying records
-            assertTrue(lazyRecords.sizeInBytes() >= inputRecords.sizeInBytes());
-
-            int toWrite;
             int written = 0;
-            List<SimpleRecord> recordsBeingConverted;
-            List<Long> offsetsOfRecords;
-            switch (test) {
-                case DEFAULT:
-                    toWrite = inputRecords.sizeInBytes();
-                    recordsBeingConverted = records;
-                    offsetsOfRecords = offsets;
-                    break;
-                case OVERFLOW:
-                    toWrite = inputRecords.sizeInBytes() * 2;
-                    recordsBeingConverted = records;
-                    offsetsOfRecords = offsets;
-                    break;
-                default:
-                    throw new IllegalArgumentException();
-            }
             while (written < toWrite)
                 written += lazySend.writeTo(channel, written, toWrite - written);
 
             FileRecords convertedRecords = FileRecords.open(outputFile, true, (int) channel.size(), false);
             ByteBuffer convertedRecordsBuffer = ByteBuffer.allocate(convertedRecords.sizeInBytes());
             convertedRecords.readInto(convertedRecordsBuffer, 0);
-            MemoryRecords convertedMemoryRecords = MemoryRecords.readableRecords(convertedRecordsBuffer);
-            verifyDownConvertedRecords(recordsBeingConverted, offsetsOfRecords, convertedMemoryRecords, compressionType, toMagic);
 
+            // cleanup
             convertedRecords.close();
             channel.close();
+
+            return MemoryRecords.readableRecords(convertedRecordsBuffer);
         }
     }
 
-    private String utf8(ByteBuffer buffer) {
+    @Test
+    public void testConversionOfCommitMarker() throws IOException {
+        MemoryRecords recordsToConvert = MemoryRecords.withEndTransactionMarker(0, Time.SYSTEM.milliseconds(), RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                1, (short) 1, new EndTransactionMarker(ControlRecordType.COMMIT, 0));
+        MemoryRecords convertedRecords = convertRecords(recordsToConvert, (byte) 1, recordsToConvert.sizeInBytes());
+        ByteBuffer buffer = convertedRecords.buffer();
+        buffer.getLong();
+        int sizeOfConvertedRecords = buffer.getInt();
+        assertTrue(sizeOfConvertedRecords > buffer.limit());
+        assertFalse(convertedRecords.batchIterator().hasNext());
+    }
+
+    @RunWith(value = Parameterized.class)
+    public static class ParameterizedConversionTest {
+        private final CompressionType compressionType;
+        private final byte toMagic;
+        private final DownConversionTest test;
+
+        public ParameterizedConversionTest(CompressionType compressionType, byte toMagic, DownConversionTest test) {
+            this.compressionType = compressionType;
+            this.toMagic = toMagic;
+            this.test = test;
+        }
+
+        enum DownConversionTest {
+            DEFAULT,
+            OVERFLOW,
+        }
+
+        @Parameterized.Parameters(name = "compressionType={0}, toMagic={1}, test={2}")
+        public static Collection<Object[]> data() {
+            List<Object[]> values = new ArrayList<>();
+            for (byte toMagic = RecordBatch.MAGIC_VALUE_V0; toMagic <= RecordBatch.CURRENT_MAGIC_VALUE; toMagic++) {
+                for (DownConversionTest test : DownConversionTest.values()) {
+                    values.add(new Object[]{CompressionType.NONE, toMagic, test});
+                    values.add(new Object[]{CompressionType.GZIP, toMagic, test});
+                }
+            }
+            return values;
+        }
+
+        @Test
+        public void doTestConversion() throws IOException {
+            List<Long> offsets = asList(0L, 2L, 3L, 9L, 11L, 15L, 16L, 17L, 22L, 24L);
+
+            Header[] headers = {new RecordHeader("headerKey1", "headerValue1".getBytes()),
+                                new RecordHeader("headerKey2", "headerValue2".getBytes()),
+                                new RecordHeader("headerKey3", "headerValue3".getBytes())};
+
+            List<SimpleRecord> records = asList(
+                    new SimpleRecord(1L, "k1".getBytes(), "hello".getBytes()),
+                    new SimpleRecord(2L, "k2".getBytes(), "goodbye".getBytes()),
+                    new SimpleRecord(3L, "k3".getBytes(), "hello again".getBytes()),
+                    new SimpleRecord(4L, "k4".getBytes(), "goodbye for now".getBytes()),
+                    new SimpleRecord(5L, "k5".getBytes(), "hello again".getBytes()),
+                    new SimpleRecord(6L, "k6".getBytes(), "I sense indecision".getBytes()),
+                    new SimpleRecord(7L, "k7".getBytes(), "what now".getBytes()),
+                    new SimpleRecord(8L, "k8".getBytes(), "running out".getBytes(), headers),
+                    new SimpleRecord(9L, "k9".getBytes(), "ok, almost done".getBytes()),
+                    new SimpleRecord(10L, "k10".getBytes(), "finally".getBytes(), headers));
+            assertEquals("incorrect test setup", offsets.size(), records.size());
+
+            ByteBuffer buffer = ByteBuffer.allocate(1024);
+            MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType,
+                    TimestampType.CREATE_TIME, 0L);
+            for (int i = 0; i < 3; i++)
+                builder.appendWithOffset(offsets.get(i), records.get(i));
+            builder.close();
+
+            builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
+                    0L);
+            for (int i = 3; i < 6; i++)
+                builder.appendWithOffset(offsets.get(i), records.get(i));
+            builder.close();
+
+            builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, TimestampType.CREATE_TIME,
+                    0L);
+            for (int i = 6; i < 10; i++)
+                builder.appendWithOffset(offsets.get(i), records.get(i));
+            builder.close();
+
+            buffer.flip();
+
+            MemoryRecords memoryRecords = MemoryRecords.readableRecords(buffer);
+            int toWrite;
+            List<SimpleRecord> recordsBeingConverted;
+            List<Long> offsetsOfRecords;
+            switch (test) {
+                case DEFAULT:
+                    toWrite = memoryRecords.sizeInBytes();
+                    recordsBeingConverted = records;
+                    offsetsOfRecords = offsets;
+                    break;
+                case OVERFLOW:
+                    toWrite = memoryRecords.sizeInBytes() * 2;
+                    recordsBeingConverted = records;
+                    offsetsOfRecords = offsets;
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+
+            MemoryRecords convertedRecords = convertRecords(memoryRecords, toMagic, toWrite);
+            verifyDownConvertedRecords(recordsBeingConverted, offsetsOfRecords, convertedRecords, compressionType, toMagic);
+        }
+    }
+
+    private static String utf8(ByteBuffer buffer) {
         return Utils.utf8(buffer, buffer.remaining());
     }
 
-    private void verifyDownConvertedRecords(List<SimpleRecord> initialRecords,
-                                            List<Long> initialOffsets,
-                                            MemoryRecords downConvertedRecords,
-                                            CompressionType compressionType,
-                                            byte toMagic) {
+    private static void verifyDownConvertedRecords(List<SimpleRecord> initialRecords,
+                                                   List<Long> initialOffsets,
+                                                   MemoryRecords downConvertedRecords,
+                                                   CompressionType compressionType,
+                                                   byte toMagic) {
         int i = 0;
         for (RecordBatch batch : downConvertedRecords.batches()) {
             assertTrue("Magic byte should be lower than or equal to " + toMagic, batch.magic() <= toMagic);

--- a/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/LazyDownConversionRecordsTest.java
@@ -20,7 +20,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -35,6 +34,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.apache.kafka.common.utils.Utils.utf8;
 import static org.apache.kafka.test.TestUtils.tempFile;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -194,8 +194,8 @@ public class LazyDownConversionRecordsTest {
             for (Record record : batch) {
                 assertTrue("Inner record should have magic " + toMagic, record.hasMagic(batch.magic()));
                 assertEquals("Offset should not change", initialOffsets.get(i).longValue(), record.offset());
-                assertEquals("Key should not change", Utils.utf8(initialRecords.get(i).key()), Utils.utf8(record.key()));
-                assertEquals("Value should not change", Utils.utf8(initialRecords.get(i).value()), Utils.utf8(record.value()));
+                assertEquals("Key should not change", utf8(initialRecords.get(i).key()), utf8(record.key()));
+                assertEquals("Value should not change", utf8(initialRecords.get(i).value()), utf8(record.value()));
                 assertFalse(record.hasTimestampType(TimestampType.LOG_APPEND_TIME));
                 if (batch.magic() == RecordBatch.MAGIC_VALUE_V0) {
                     assertEquals(RecordBatch.NO_TIMESTAMP, record.timestamp());

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -568,8 +568,8 @@ public class MemoryRecordsBuilderTest {
         }
     }
 
-    private String utf8(ByteBuffer buffer) {
-        return Utils.utf8(buffer, buffer.remaining());
+    private static String utf8(ByteBuffer buffer) {
+        return Utils.utf8(buffer);
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 
+import static org.apache.kafka.common.utils.Utils.utf8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -534,9 +535,9 @@ public class MemoryRecordsBuilderTest {
         }
 
         List<Record> logRecords = Utils.toList(records.records().iterator());
-        assertEquals("1", Utils.utf8(logRecords.get(0).key()));
-        assertEquals("2", Utils.utf8(logRecords.get(1).key()));
-        assertEquals("3", Utils.utf8(logRecords.get(2).key()));
+        assertEquals("1", utf8(logRecords.get(0).key()));
+        assertEquals("2", utf8(logRecords.get(1).key()));
+        assertEquals("3", utf8(logRecords.get(2).key()));
 
         convertedRecords = MemoryRecords.readableRecords(buffer).downConvert(RecordBatch.MAGIC_VALUE_V1, 2L, time);
         records = convertedRecords.records();
@@ -550,9 +551,9 @@ public class MemoryRecordsBuilderTest {
             assertEquals(0, batches.get(0).baseOffset());
             assertEquals(RecordBatch.MAGIC_VALUE_V1, batches.get(1).magic());
             assertEquals(1, batches.get(1).baseOffset());
-            assertEquals("1", Utils.utf8(logRecords.get(0).key()));
-            assertEquals("2", Utils.utf8(logRecords.get(1).key()));
-            assertEquals("3", Utils.utf8(logRecords.get(2).key()));
+            assertEquals("1", utf8(logRecords.get(0).key()));
+            assertEquals("2", utf8(logRecords.get(1).key()));
+            assertEquals("3", utf8(logRecords.get(2).key()));
             verifyRecordsProcessingStats(convertedRecords.recordConversionStats(), 3, 2,
                     records.sizeInBytes(), buffer.limit());
         } else {
@@ -561,8 +562,8 @@ public class MemoryRecordsBuilderTest {
             assertEquals(0, batches.get(0).baseOffset());
             assertEquals(RecordBatch.MAGIC_VALUE_V1, batches.get(1).magic());
             assertEquals(2, batches.get(1).baseOffset());
-            assertEquals("1", Utils.utf8(logRecords.get(0).key()));
-            assertEquals("3", Utils.utf8(logRecords.get(1).key()));
+            assertEquals("1", utf8(logRecords.get(0).key()));
+            assertEquals("3", utf8(logRecords.get(1).key()));
             verifyRecordsProcessingStats(convertedRecords.recordConversionStats(), 3, 1,
                     records.sizeInBytes(), buffer.limit());
         }

--- a/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/MemoryRecordsBuilderTest.java
@@ -534,9 +534,9 @@ public class MemoryRecordsBuilderTest {
         }
 
         List<Record> logRecords = Utils.toList(records.records().iterator());
-        assertEquals("1", utf8(logRecords.get(0).key()));
-        assertEquals("2", utf8(logRecords.get(1).key()));
-        assertEquals("3", utf8(logRecords.get(2).key()));
+        assertEquals("1", Utils.utf8(logRecords.get(0).key()));
+        assertEquals("2", Utils.utf8(logRecords.get(1).key()));
+        assertEquals("3", Utils.utf8(logRecords.get(2).key()));
 
         convertedRecords = MemoryRecords.readableRecords(buffer).downConvert(RecordBatch.MAGIC_VALUE_V1, 2L, time);
         records = convertedRecords.records();
@@ -550,9 +550,9 @@ public class MemoryRecordsBuilderTest {
             assertEquals(0, batches.get(0).baseOffset());
             assertEquals(RecordBatch.MAGIC_VALUE_V1, batches.get(1).magic());
             assertEquals(1, batches.get(1).baseOffset());
-            assertEquals("1", utf8(logRecords.get(0).key()));
-            assertEquals("2", utf8(logRecords.get(1).key()));
-            assertEquals("3", utf8(logRecords.get(2).key()));
+            assertEquals("1", Utils.utf8(logRecords.get(0).key()));
+            assertEquals("2", Utils.utf8(logRecords.get(1).key()));
+            assertEquals("3", Utils.utf8(logRecords.get(2).key()));
             verifyRecordsProcessingStats(convertedRecords.recordConversionStats(), 3, 2,
                     records.sizeInBytes(), buffer.limit());
         } else {
@@ -561,15 +561,11 @@ public class MemoryRecordsBuilderTest {
             assertEquals(0, batches.get(0).baseOffset());
             assertEquals(RecordBatch.MAGIC_VALUE_V1, batches.get(1).magic());
             assertEquals(2, batches.get(1).baseOffset());
-            assertEquals("1", utf8(logRecords.get(0).key()));
-            assertEquals("3", utf8(logRecords.get(1).key()));
+            assertEquals("1", Utils.utf8(logRecords.get(0).key()));
+            assertEquals("3", Utils.utf8(logRecords.get(1).key()));
             verifyRecordsProcessingStats(convertedRecords.recordConversionStats(), 3, 1,
                     records.sizeInBytes(), buffer.limit());
         }
-    }
-
-    private static String utf8(ByteBuffer buffer) {
-        return Utils.utf8(buffer);
     }
 
     @Test

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -120,12 +120,13 @@
     <li><a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-290%3A+Support+for+Prefixed+ACLs">KIP-290</a> adds the ability
         to define ACLs on prefixed resources, e.g. any topic starting with 'foo'.</li>
     <li><a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-283%3A+Efficient+Memory+Usage+for+Down-Conversion">KIP-283</a> improves message down-conversion
-        handling on Kafka broker, which has typically been a memory-intensive operation. The KIP adds new topic and broker configurations <code>message.downconversion.enable</code>
-        and <code>log.message.downconversion.enable</code> respectively to control whether down-conversion is enabled. When down-conversion is enabled, the KIP
-        also adds a mechanism by which the operation becomes less memory intensive by converting chunks of partition data at a time which helps put an upper
-        bound on memory consumption. With this improvement, there is a change in <code>FetchResponse</code> protocol behavior where the broker could send an
-        oversized message batch towards the end of the response with an invalid offset. Such oversized messages must be ignored by consumer clients, as is done
-        by <code>KafkaConsumer</code>.</li>
+        handling on Kafka broker, which has typically been a memory-intensive operation. The KIP adds a mechanism by which the operation becomes less memory intensive
+        by down-converting chunks of partition data at a time which helps put an upper bound on memory consumption. With this improvement, there is a change in
+        <code>FetchResponse</code> protocol behavior where the broker could send an oversized message batch towards the end of the response with an invalid offset.
+        Such oversized messages must be ignored by consumer clients, as is done by <code>KafkaConsumer</code>.
+    <p>KIP-283 also adds new topic and broker configurations <code>message.downconversion.enable</code> and <code>log.message.downconversion.enable</code> respectively
+       to control whether down-conversion is enabled. When disabled, broker does not perform any down-conversion and instead sends an <code>UNSUPPORTED_VERSION</code>
+       error to the client.</p></li>
 </ul>
 
 <h5><a id="upgrade_200_new_protocols" href="#upgrade_200_new_protocols">New Protocol Versions</a></h5>

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -119,6 +119,13 @@
     </li>
     <li><a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-290%3A+Support+for+Prefixed+ACLs">KIP-290</a> adds the ability
         to define ACLs on prefixed resources, e.g. any topic starting with 'foo'.</li>
+    <li><a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-283%3A+Efficient+Memory+Usage+for+Down-Conversion">KIP-283</a> improves message down-conversion
+        handling on Kafka broker, which has typically been a memory-intensive operation. The KIP adds new topic and broker configurations <code>message.downconversion.enable</code>
+        and <code>log.message.downconversion.enable</code> respectively to control whether down-conversion is enabled. When down-conversion is enabled, the KIP
+        also adds a mechanism by which the operation becomes less memory intensive by converting chunks of partition data at a time which helps put an upper
+        bound on memory consumption. With this improvement, there is a change in <code>FetchResponse</code> protocol behavior where the broker could send an
+        oversized message batch towards the end of the response with an invalid offset. Such oversized messages must be ignored by consumer clients, as is done
+        by <code>KafkaConsumer</code>.</li>
 </ul>
 
 <h5><a id="upgrade_200_new_protocols" href="#upgrade_200_new_protocols">New Protocol Versions</a></h5>


### PR DESCRIPTION
We might decide to drop certain message batches during down-conversion because older clients might not be able to interpret them. One such example is control batches which are typically removed by the broker if down-conversion to V0 or V1 is required. This patch makes sure the chunked down-conversion implementation is able to handle such cases.

Credit to @omkreddy for reporting this issue, providing logs and a reproducible test case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
