### PR TITLE
KAFKA-6971: Passing in help flag to kafka-console-producer should pri…

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -351,7 +351,7 @@ object ConsoleConsumer extends Logging {
       .describedAs("consumer group id")
       .ofType(classOf[String])
 
-    if (args.length == 0)
+    if (args.length == 0 || args(0).equals("--help"))
       CommandLineUtils.printUsageAndDie(parser, "The console consumer is a tool that reads data from Kafka and outputs it to standard output.")
 
     var groupIdPassed = true

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -204,7 +204,7 @@ object ConsoleProducer {
       .ofType(classOf[String])
 
     val options = parser.parse(args : _*)
-    if (args.length == 0)
+    if (args.length == 0 || args(0).equals("--help"))
       CommandLineUtils.printUsageAndDie(parser, "Read data from standard input and publish it to Kafka.")
     CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, brokerListOpt)
 


### PR DESCRIPTION
this small fix introduces to print all available option for Kafka console producer and consumer. I did few tests while producing and consuming messages after this one-liner change which looks positive and dont have any side effects.