### PR TITLE
KAKFA-7018: remember consumer member id during service restart

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -32,6 +32,8 @@
     <suppress checks="ParameterNumber"
               files="ConsumerCoordinator.java"/>
     <suppress checks="ParameterNumber"
+              files="AbstractCoordinator.java"/>
+    <suppress checks="ParameterNumber"
               files="Fetcher.java"/>
     <suppress checks="ParameterNumber"
               files="Sender.java"/>

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -246,6 +246,18 @@ public class ConsumerConfig extends AbstractConfig {
      */
     static final String LEAVE_GROUP_ON_CLOSE_CONFIG = "internal.leave.group.on.close";
 
+    /**
+     * <code>internal.generation.dir.name</code>
+     * The directory path for persisting consumer generation cross service restart.
+     */
+    static final String GENERATION_DIR_NAME = "internal.generation.dir.name";
+
+    /**
+     * <code>internal.record.generation</code>
+     * The internal config deciding whether we should save generation info for consumer cross service restart.
+     */
+    static final String RECORD_GENERATION = "internal.record.generation";
+
     /** <code>isolation.level</code> */
     public static final String ISOLATION_LEVEL_CONFIG = "isolation.level";
     public static final String ISOLATION_LEVEL_DOC = "<p>Controls how to read messages written transactionally. If set to <code>read_committed</code>, consumer.poll() will only return" +
@@ -446,6 +458,14 @@ public class ConsumerConfig extends AbstractConfig {
                                                 Type.BOOLEAN,
                                                 true,
                                                 Importance.LOW)
+                                .defineInternal(GENERATION_DIR_NAME,
+                                        Type.STRING,
+                                        "/tmp",
+                                        Importance.LOW)
+                                .defineInternal(RECORD_GENERATION,
+                                        Type.BOOLEAN,
+                                        false,
+                                        Importance.LOW)
                                 .define(ISOLATION_LEVEL_CONFIG,
                                         Type.STRING,
                                         DEFAULT_ISOLATION_LEVEL,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -766,7 +766,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
                     config.getInt(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG),
                     this.interceptors,
                     config.getBoolean(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG),
-                    config.getBoolean(ConsumerConfig.LEAVE_GROUP_ON_CLOSE_CONFIG));
+                    config.getBoolean(ConsumerConfig.LEAVE_GROUP_ON_CLOSE_CONFIG),
+                    clientId,
+                    config.getString(ConsumerConfig.GENERATION_DIR_NAME),
+                    config.getBoolean(ConsumerConfig.RECORD_GENERATION));
             this.fetcher = new Fetcher<>(
                     logContext,
                     this.client,

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -130,7 +130,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                                int autoCommitIntervalMs,
                                ConsumerInterceptors<?, ?> interceptors,
                                boolean excludeInternalTopics,
-                               final boolean leaveGroupOnClose) {
+                               final boolean leaveGroupOnClose,
+                               String clientId,
+                               String generationDir,
+                               boolean recordGeneration) {
         super(logContext,
               client,
               groupId,
@@ -141,7 +144,10 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
               metricGrpPrefix,
               time,
               retryBackoffMs,
-              leaveGroupOnClose);
+              leaveGroupOnClose,
+              clientId,
+              generationDir,
+              recordGeneration);
         this.log = logContext.logger(ConsumerCoordinator.class);
         this.metadata = metadata;
         this.metadataSnapshot = new MetadataSnapshot(subscriptions, metadata.fetch());

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/KafkaConsumerTest.java
@@ -1793,7 +1793,10 @@ public class KafkaConsumerTest {
                 autoCommitIntervalMs,
                 interceptors,
                 excludeInternalTopics,
-                true);
+                true,
+                "",
+                "",
+                false);
 
         Fetcher<String, String> fetcher = new Fetcher<>(
                 loggerFactory,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinatorTest.java
@@ -1875,7 +1875,10 @@ public class ConsumerCoordinatorTest {
                 autoCommitIntervalMs,
                 null,
                 excludeInternalTopics,
-                leaveGroup);
+                leaveGroup,
+                "",
+                "",
+                false);
     }
 
     private FindCoordinatorResponse groupCoordinatorResponse(Node node, Errors error) {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/distributed/WorkerCoordinator.java
@@ -83,7 +83,10 @@ public final class WorkerCoordinator extends AbstractCoordinator implements Clos
               metricGrpPrefix,
               time,
               retryBackoffMs,
-              true);
+              true,
+              "",
+              "",
+              false);
         this.log = logContext.logger(WorkerCoordinator.class);
         this.restUrl = restUrl;
         this.configStorage = configStorage;

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -114,6 +114,19 @@ public class StateDirectory {
         return dir;
     }
 
+    /**
+     * Get or create the directory for the consumer generation recovery.
+     * @return directory for consumer generation data
+     */
+    File consumerGenerationStateDir() {
+        final File dir = new File(stateDir, "consumer-generation");
+        if (!dir.exists() && !dir.mkdir()) {
+            log.error(String.format("consumer generation state directory [%s] doesn't exist and couldn't be created", dir.getPath()));
+            return null;
+        }
+        return dir;
+    }
+
     private String logPrefix() {
         return String.format("stream-thread [%s]", Thread.currentThread().getName());
     }


### PR DESCRIPTION
Hey there,
I have come up with an implementation for the consumer generation materialization. Jira here:
https://issues.apache.org/jira/browse/KAFKA-7018

The background is that to reduce number of rebalance during consumer restart and blocking rebalance based on session timeout (especially for stream applications), we are proposing to remember the consumer client-id to generation mapping, so that on the broker side when the same instance connects with existing generation data, it would be treated as an existing member so that no rebalance will be triggered.

This implementation doesn't have unit test yet. We hope to have an initial review to finalize details.
Looking forward to @guozhangwang @mjsax @hachikuji @Ishiihara to review!