### PR TITLE
MINOR: KIP-297 related - Fix regex to exclude ConfigProvider interface from class loading isolation

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -122,14 +122,16 @@ public class PluginUtils {
             + "|org\\.slf4j"
             + ")\\..*$";
 
-    private static final String WHITELIST = "^org\\.apache\\.kafka\\.(?:common.config..*ConfigProvider|connect\\.(?:"
+    private static final String WHITELIST = "^org\\.apache\\.kafka\\.(?:connect\\.(?:"
             + "transforms\\.(?!Transformation$).*"
             + "|json\\..*"
             + "|file\\..*"
             + "|converters\\..*"
             + "|storage\\.StringConverter"
             + "|rest\\.basic\\.auth\\.extension\\.BasicAuthSecurityRestExtension"
-            + "))$";
+            + ")"
+            + "|common\\.config\\.(?!ConfigProvider$).*ConfigProvider"
+            + ")$";
 
     private static final DirectoryStream.Filter<Path> PLUGIN_PATH_FILTER = new DirectoryStream
             .Filter<Path>() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -114,6 +114,9 @@ public class PluginUtilsTest {
         assertFalse(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.clients.admin.KafkaAdminClient")
         );
+        assertFalse(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.rest.ConnectRestExtension"
+        ));
     }
 
     @Test
@@ -153,6 +156,11 @@ public class PluginUtilsTest {
 
     @Test
     public void testClientConfigProvider() throws Exception {
+        // Should not attempt to load the interface in isolation because it will break
+        // initialization of class loading isolation during scanning.
+        assertFalse(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.common.config.ConfigProvider")
+        );
         assertTrue(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.common.config.FileConfigProvider")
         );


### PR DESCRIPTION
This PR is fixing a bug in the regex that was recently added by https://github.com/apache/kafka/pull/5141 when implementations of the `ConfigProvider` interface were added to the set of Connect plugins benefit from class loading isolation.

To prevent breaking initialization of class loading isolation during class scanning and allow for future extension of plugin interfaces, such interfaces should not be loaded in isolation. They are considered part of the framework. A previous example is Transformation interface in Connect.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
