### PR TITLE
MINOR: fix Vagrant VM setup

### DIFF
--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -89,6 +89,7 @@ get_kafka() {
 # Install Kibosh
 apt-get update -y && apt-get install -y git cmake pkg-config libfuse-dev
 pushd /opt
+rm -rf /opt/kibosh
 git clone -q  https://github.com/confluentinc/kibosh.git
 pushd "/opt/kibosh"
 git reset --hard $KIBOSH_VERSION


### PR DESCRIPTION
Starting up the VMs with `vagrant/vagrant-up.sh` fails with:
```
==> worker1: + git clone -q https://github.com/confluentinc/kibosh.git
==> worker1: fatal: destination path 'kibosh' already exists and is not an empty directory.
```