### PR TITLE
KAFKA-7032 The TimeUnit is neglected by KakfaConsumer#close(long, Tim…

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -2081,7 +2081,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
     @Deprecated
     @Override
     public void close(long timeout, TimeUnit timeUnit) {
-        close(Duration.ofMillis(TimeUnit.MILLISECONDS.toMillis(timeout)));
+        close(Duration.ofMillis(timeUnit.toMillis(timeout)));
     }
 
     /**


### PR DESCRIPTION
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
