### PR TITLE
[KAFKA-7033] Modify AbstractOptions's timeoutMs as Long type

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AbstractOptions.java
@@ -23,14 +23,14 @@ package org.apache.kafka.clients.admin;
  */
 public abstract class AbstractOptions<T extends AbstractOptions> {
 
-    protected Integer timeoutMs = null;
+    protected Long timeoutMs = null;
 
     /**
      * Set the request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      */
     @SuppressWarnings("unchecked")
-    public T timeoutMs(Integer timeoutMs) {
+    public T timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return (T) this;
     }
@@ -39,7 +39,7 @@ public abstract class AbstractOptions<T extends AbstractOptions> {
      * The request timeout in milliseconds for this operation or {@code null} if the default request timeout for the
      * AdminClient should be used.
      */
-    public Integer timeoutMs() {
+    public Long timeoutMs() {
         return timeoutMs;
     }
 

--- a/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AlterConfigsOptions.java
@@ -37,7 +37,7 @@ public class AlterConfigsOptions extends AbstractOptions<AlterConfigsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public AlterConfigsOptions timeoutMs(Integer timeoutMs) {
+    public AlterConfigsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateAclsOptions.java
@@ -35,7 +35,7 @@ public class CreateAclsOptions extends AbstractOptions<CreateAclsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public CreateAclsOptions timeoutMs(Integer timeoutMs) {
+    public CreateAclsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/CreateTopicsOptions.java
@@ -37,7 +37,7 @@ public class CreateTopicsOptions extends AbstractOptions<CreateTopicsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public CreateTopicsOptions timeoutMs(Integer timeoutMs) {
+    public CreateTopicsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteAclsOptions.java
@@ -35,7 +35,7 @@ public class DeleteAclsOptions extends AbstractOptions<DeleteAclsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public DeleteAclsOptions timeoutMs(Integer timeoutMs) {
+    public DeleteAclsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DeleteTopicsOptions.java
@@ -35,7 +35,7 @@ public class DeleteTopicsOptions extends AbstractOptions<DeleteTopicsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public DeleteTopicsOptions timeoutMs(Integer timeoutMs) {
+    public DeleteTopicsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeAclsOptions.java
@@ -34,7 +34,7 @@ public class DescribeAclsOptions extends AbstractOptions<DescribeAclsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public DescribeAclsOptions timeoutMs(Integer timeoutMs) {
+    public DescribeAclsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeClusterOptions.java
@@ -33,7 +33,7 @@ public class DescribeClusterOptions extends AbstractOptions<DescribeClusterOptio
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public DescribeClusterOptions timeoutMs(Integer timeoutMs) {
+    public DescribeClusterOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeConfigsOptions.java
@@ -37,7 +37,7 @@ public class DescribeConfigsOptions extends AbstractOptions<DescribeConfigsOptio
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public DescribeConfigsOptions timeoutMs(Integer timeoutMs) {
+    public DescribeConfigsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/DescribeTopicsOptions.java
@@ -35,7 +35,7 @@ public class DescribeTopicsOptions extends AbstractOptions<DescribeTopicsOptions
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public DescribeTopicsOptions timeoutMs(Integer timeoutMs) {
+    public DescribeTopicsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -171,7 +171,7 @@ public class KafkaAdminClient extends AdminClient {
     /**
      * The default timeout to use for an operation.
      */
-    private final int defaultTimeoutMs;
+    private final long defaultTimeoutMs;
 
     /**
      * The name of this AdminClient instance.
@@ -292,7 +292,7 @@ public class KafkaAdminClient extends AdminClient {
      *
      * @return                  The deadline in milliseconds.
      */
-    private long calcDeadlineMs(long now, Integer optionTimeoutMs) {
+    private long calcDeadlineMs(long now, Long optionTimeoutMs) {
         if (optionTimeoutMs != null)
             return now + Math.max(0, optionTimeoutMs);
         return now + defaultTimeoutMs;

--- a/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/ListTopicsOptions.java
@@ -35,7 +35,7 @@ public class ListTopicsOptions extends AbstractOptions<ListTopicsOptions> {
      *
      */
     // This method is retained to keep binary compatibility with 0.11
-    public ListTopicsOptions timeoutMs(Integer timeoutMs) {
+    public ListTopicsOptions timeoutMs(Long timeoutMs) {
         this.timeoutMs = timeoutMs;
         return this;
     }

--- a/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/admin/KafkaAdminClientTest.java
@@ -228,7 +228,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(1000)).all();
+                    new CreateTopicsOptions().timeoutMs(1000L)).all();
             assertFutureError(future, TimeoutException.class);
         }
     }
@@ -254,7 +254,7 @@ public class KafkaAdminClientTest {
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all();
+                    new CreateTopicsOptions().timeoutMs(10000L)).all();
 
             future.get();
         }
@@ -281,7 +281,7 @@ public class KafkaAdminClientTest {
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all();
+                    new CreateTopicsOptions().timeoutMs(10000L)).all();
 
             future.get();
         }
@@ -306,7 +306,7 @@ public class KafkaAdminClientTest {
             env.kafkaClient().prepareResponse(new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
             KafkaFuture<Void> future = env.adminClient().createTopics(
                 Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                new CreateTopicsOptions().timeoutMs(1000)).all();
+                new CreateTopicsOptions().timeoutMs(1000L)).all();
             assertFutureError(future, SaslAuthenticationException.class);
         }
     }
@@ -320,7 +320,7 @@ public class KafkaAdminClientTest {
                     new CreateTopicsResponse(Collections.singletonMap("myTopic", new ApiError(Errors.NONE, ""))));
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all();
+                    new CreateTopicsOptions().timeoutMs(10000L)).all();
             future.get();
         }
     }
@@ -356,7 +356,7 @@ public class KafkaAdminClientTest {
 
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all();
+                    new CreateTopicsOptions().timeoutMs(10000L)).all();
 
             // Wait until the first attempt has failed, then advance the time
             TestUtils.waitForCondition(() -> mockClient.numAwaitingResponses() == 1,
@@ -388,7 +388,7 @@ public class KafkaAdminClientTest {
                 env.cluster().nodeById(1));
             KafkaFuture<Void> future = env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all();
+                    new CreateTopicsOptions().timeoutMs(10000L)).all();
             future.get();
         }
     }
@@ -486,7 +486,7 @@ public class KafkaAdminClientTest {
         try {
             env.adminClient().createTopics(
                     Collections.singleton(new NewTopic("myTopic", Collections.singletonMap(0, asList(0, 1, 2)))),
-                    new CreateTopicsOptions().timeoutMs(10000)).all().get();
+                    new CreateTopicsOptions().timeoutMs(10000L)).all().get();
             fail("Expected an authentication error.");
         } catch (ExecutionException e) {
             assertTrue("Expected an authentication error, but got " + Utils.stackTrace(e),
@@ -660,7 +660,7 @@ public class KafkaAdminClientTest {
             // Make a request with an extremely short timeout.
             // Then wait for it to fail by not supplying any response.
             log.info("Starting AdminClient#listTopics...");
-            final ListTopicsResult result = env.adminClient().listTopics(new ListTopicsOptions().timeoutMs(1000));
+            final ListTopicsResult result = env.adminClient().listTopics(new ListTopicsOptions().timeoutMs(1000L));
             TestUtils.waitForCondition(new TestCondition() {
                 @Override
                 public boolean conditionMet() {

--- a/core/src/main/scala/kafka/admin/ConfigCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConfigCommand.scala
@@ -252,7 +252,7 @@ object ConfigCommand extends Config {
       throw new InvalidConfigException(s"All sensitive broker config entries must be specified for --alter, missing entries: ${sensitiveEntries.keySet}")
     val newConfig = new JConfig(newEntries.asJava.values)
 
-    val alterOptions = new AlterConfigsOptions().timeoutMs(30000).validateOnly(false)
+    val alterOptions = new AlterConfigsOptions().timeoutMs(30000L).validateOnly(false)
     adminClient.alterConfigs(Map(configResource -> newConfig).asJava, alterOptions).all().get(60, TimeUnit.SECONDS)
 
     if (entityName.nonEmpty)

--- a/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
+++ b/core/src/main/scala/kafka/admin/ReassignPartitionsCommand.scala
@@ -602,7 +602,7 @@ class ReassignPartitionsCommand(zkClient: KafkaZkClient,
   private def alterReplicaLogDirsIgnoreReplicaNotAvailable(replicaAssignment: Map[TopicPartitionReplica, String],
                                                            adminClient: JAdminClient,
                                                            timeoutMs: Long): Set[TopicPartitionReplica] = {
-    val alterReplicaLogDirsResult = adminClient.alterReplicaLogDirs(replicaAssignment.asJava, new AlterReplicaLogDirsOptions().timeoutMs(timeoutMs.toInt))
+    val alterReplicaLogDirsResult = adminClient.alterReplicaLogDirs(replicaAssignment.asJava, new AlterReplicaLogDirsOptions().timeoutMs(timeoutMs.toLong))
     val replicasAssignedToFutureDir = alterReplicaLogDirsResult.values().asScala.flatMap { case (replica, future) => {
       try {
         future.get()

--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -156,7 +156,7 @@ public class StreamsResetter {
     private void validateNoActiveConsumers(final String groupId,
                                            final AdminClient adminClient) throws ExecutionException, InterruptedException {
         final DescribeConsumerGroupsResult describeResult = adminClient.describeConsumerGroups(Arrays.asList(groupId),
-                (new DescribeConsumerGroupsOptions()).timeoutMs(10 * 1000));
+                (new DescribeConsumerGroupsOptions()).timeoutMs(10 * 1000L));
         final List<MemberDescription> members =
             new ArrayList<MemberDescription>(describeResult.describedGroups().get(groupId).get().members());
         if (!members.isEmpty()) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/common/WorkerUtils.java
@@ -97,8 +97,8 @@ public final class WorkerUtils {
         }
     }
 
-    private static final int ADMIN_REQUEST_TIMEOUT = 25000;
-    private static final int CREATE_TOPICS_CALL_TIMEOUT = 180000;
+    private static final long ADMIN_REQUEST_TIMEOUT = 25000;
+    private static final long CREATE_TOPICS_CALL_TIMEOUT = 180000;
     private static final int MAX_CREATE_TOPICS_BATCH_SIZE = 10;
 
             //Map<String, Map<Integer, List<Integer>>> topics) throws Throwable {


### PR DESCRIPTION
[KAFKA-7033 | Modify AbstractOptions's timeoutMs as Long type](https://issues.apache.org/jira/browse/KAFKA-7033)

Currently AbstractOptions's timeoutMs is Integer and using Long to represent timeout Millisecond maybe better .

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
