### PR TITLE
MINOR: code cleanup follow up for KAFKA-6906

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -438,11 +438,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
                     transactionInFlight = true;
                 }
             }
-
-            if (eosEnabled && !startNewTransaction && transactionInFlight) { // need to make sure to commit txn for suspend case
-                producer.commitTransaction();
-                transactionInFlight = false;
-            }
         } catch (final CommitFailedException | ProducerFencedException fatal) {
             throw new TaskMigratedException(this, fatal);
         }


### PR DESCRIPTION
Intellij warned that the condition of the `if` will always be `false` -- thinking about this, it makes sense. After refactoring the code in KAFKA-6906 and moving the EOS-part out of the `commitOffsetNeeded` block L433-440 cover this case already and we can remove redundant code.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
