### PR TITLE
KAFKA-7043: Modified plugin isolation whitelist with recently added converters (KIP-305)

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -133,7 +133,6 @@ public class PluginUtils {
             + "|storage\\.LongConverter"
             + "|storage\\.ShortConverter"
             + "|storage\\.StringConverter"
-            + "|storage\\.SimpleHeaderConverter"
             + "|rest\\.basic\\.auth\\.extension\\.BasicAuthSecurityRestExtension"
             + "))$";
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -127,13 +127,13 @@ public class PluginUtils {
             + "|json\\..*"
             + "|file\\..*"
             + "|converters\\..*"
-            + "|storage\\.StringConverter"
-            + "|storage\\.SimpleHeaderConverter"
             + "|storage\\.DoubleConverter"
             + "|storage\\.FloatConverter"
             + "|storage\\.IntegerConverter"
             + "|storage\\.LongConverter"
             + "|storage\\.ShortConverter"
+            + "|storage\\.StringConverter"
+            + "|storage\\.SimpleHeaderConverter"
             + "|rest\\.basic\\.auth\\.extension\\.BasicAuthSecurityRestExtension"
             + "))$";
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/PluginUtils.java
@@ -128,6 +128,12 @@ public class PluginUtils {
             + "|file\\..*"
             + "|converters\\..*"
             + "|storage\\.StringConverter"
+            + "|storage\\.SimpleHeaderConverter"
+            + "|storage\\.DoubleConverter"
+            + "|storage\\.FloatConverter"
+            + "|storage\\.IntegerConverter"
+            + "|storage\\.LongConverter"
+            + "|storage\\.ShortConverter"
             + "|rest\\.basic\\.auth\\.extension\\.BasicAuthSecurityRestExtension"
             + "))$";
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -147,6 +147,24 @@ public class PluginUtilsTest {
                 "org.apache.kafka.connect.storage.StringConverter")
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.DoubleConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.FloatConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.IntegerConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.LongConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.ShortConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.SimpleHeaderConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
             "org.apache.kafka.connect.rest.basic.auth.extension.BasicAuthSecurityRestExtension"
         ));
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -162,9 +162,6 @@ public class PluginUtilsTest {
                 "org.apache.kafka.connect.storage.StringConverter")
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
-                "org.apache.kafka.connect.storage.SimpleHeaderConverter")
-        );
-        assertTrue(PluginUtils.shouldLoadInIsolation(
             "org.apache.kafka.connect.rest.basic.auth.extension.BasicAuthSecurityRestExtension"
         ));
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -144,9 +144,6 @@ public class PluginUtilsTest {
                 "org.apache.kafka.connect.converters.ByteArrayConverter")
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
-                "org.apache.kafka.connect.storage.StringConverter")
-        );
-        assertTrue(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.connect.storage.DoubleConverter")
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
@@ -160,6 +157,9 @@ public class PluginUtilsTest {
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.connect.storage.ShortConverter")
+        );
+        assertTrue(PluginUtils.shouldLoadInIsolation(
+                "org.apache.kafka.connect.storage.StringConverter")
         );
         assertTrue(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.connect.storage.SimpleHeaderConverter")


### PR DESCRIPTION
Several recently-added converters are included in the plugin isolation whitelist, similarly to the `StringConverter`. This is a change in the implementation, and does not affect the approved KIP. Several unit tests were added to verify they are being loaded in isolation, again similarly to `StringConverter`.

These changes should be applied only to `trunk` and `2.0`, since these converters were added as part of KIP-305 for AK 2.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
