### PR TITLE
MINOR: Upgrade Jackson to 2.9.6

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -53,7 +53,7 @@ versions += [
   argparse4j: "0.7.0",
   bcpkix: "1.59",
   easymock: "3.6",
-  jackson: "2.9.5",
+  jackson: "2.9.6",
   jetty: "9.4.10.v20180503",
   jersey: "2.27",
   jmh: "1.21",


### PR DESCRIPTION
Upgrade strongly recommended due to security fixes for
`jackson-databind` (same as ones in 2.7.9.4 and 2.8.11.2).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
