### PR TITLE
KAFKA-7055: Update InternalTopologyBuilder to throw TopologyException…

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -442,6 +442,10 @@ public class InternalTopologyBuilder {
                                      final String... predecessorNames) {
         Objects.requireNonNull(name, "name must not be null");
         Objects.requireNonNull(topic, "topic must not be null");
+        if (predecessorNames.length == 0) {
+            throw new TopologyException("Sink " + name + " must have at least one parent");
+        }
+
         addSink(name, new StaticTopicNameExtractor<K, V>(topic), keySerializer, valSerializer, partitioner, predecessorNames);
         nodeToSinkTopic.put(name, topic);
     }
@@ -456,6 +460,9 @@ public class InternalTopologyBuilder {
         Objects.requireNonNull(topicExtractor, "topic extractor must not be null");
         if (nodeFactories.containsKey(name)) {
             throw new TopologyException("Processor " + name + " is already added.");
+        }
+        if (predecessorNames.length == 0) {
+            throw new TopologyException("Sink " + name + " must have at least one parent");
         }
 
         for (final String predecessor : predecessorNames) {
@@ -483,6 +490,9 @@ public class InternalTopologyBuilder {
         Objects.requireNonNull(supplier, "supplier must not be null");
         if (nodeFactories.containsKey(name)) {
             throw new TopologyException("Processor " + name + " is already added.");
+        }
+        if (predecessorNames.length == 0) {
+            throw new TopologyException("Processor " + name + " must have at least one parent");
         }
 
         for (final String predecessor : predecessorNames) {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -116,7 +116,8 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
             if (sendTo != null) {
                 final ProcessorNode child = currentNode().getChild(sendTo);
                 if (child == null) {
-                    throw new StreamsException("Unknown processor name: " + sendTo);
+                    throw new StreamsException("Unknown downstream node: " + sendTo + " either does not exist or is not" +
+                            " connected to this processor.");
                 }
                 forward(child, key, value);
             } else {

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -174,6 +174,15 @@ public class TopologyTest {
         } catch (final TopologyException expected) { }
     }
 
+    @Test
+    public void shouldNotAllowToAddProcessorWithoutAtLeastOneParent() {
+        topology.addSource("source", "topic-1");
+        try {
+            topology.addProcessor("processor", new MockProcessorSupplier());
+            fail("Should throw TopologyException for processor without at least one parent node");
+        } catch (final TopologyException expected) { }
+    }
+
     @Test(expected = TopologyException.class)
     public void shouldFailOnUnknownSource() {
         topology.addProcessor("processor", new MockProcessorSupplier(), "source");
@@ -191,6 +200,16 @@ public class TopologyTest {
         try {
             topology.addSink("sink", "topic-3", "source");
             fail("Should throw TopologyException for duplicate sink name");
+        } catch (final TopologyException expected) { }
+    }
+
+    @Test
+    public void shouldNotAllowToAddSinkWithoutAtLeastOneParent() {
+        topology.addSource("source", "topic-1");
+        topology.addProcessor("processor", new MockProcessorSupplier(), "source");
+        try {
+            topology.addSink("sink", "topic-2");
+            fail("Should throw TopologyException for sink without at least one parent node");
         } catch (final TopologyException expected) { }
     }
 
@@ -236,7 +255,8 @@ public class TopologyTest {
     public void shouldNotAllowToAddStateStoreToSink() {
         mockStoreBuilder();
         EasyMock.replay(storeBuilder);
-        topology.addSink("sink-1", "topic-1");
+        topology.addSource("source-1", "topic-1");
+        topology.addSink("sink-1", "topic-1", "source-1");
         try {
             topology.addStateStore(storeBuilder, "sink-1");
             fail("Should have thrown TopologyException for adding store to sink node");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -275,7 +275,8 @@ public class InternalTopologyBuilderTest {
 
     @Test
     public void testAddStateStoreWithSink() {
-        builder.addSink("sink-1", "topic-1", null, null, null);
+        builder.addSource(null, "source-1", null, null, null, "topic-1");
+        builder.addSink("sink-1", "topic-1", null, null, null, "source-1");
         try {
             builder.addStateStore(storeBuilder, "sink-1");
             fail("Should throw TopologyException with store cannot be added to sink");

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -597,7 +597,7 @@ public class StreamThreadTest {
     @Test
     public void shouldNotNullPointerWhenStandbyTasksAssignedAndNoStateStoresForTopology() {
         internalTopologyBuilder.addSource(null, "name", null, null, null, "topic");
-        internalTopologyBuilder.addSink("out", "output", null, null, null);
+        internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
         final StreamThread thread = createStreamThread(clientId, config, false);
 
@@ -690,7 +690,7 @@ public class StreamThreadTest {
     @Test
     public void shouldCloseTaskAsZombieAndRemoveFromActiveTasksIfProducerGotFencedAtBeginTransactionWhenTaskIsResumed() {
         internalTopologyBuilder.addSource(null, "name", null, null, null, topic1);
-        internalTopologyBuilder.addSink("out", "output", null, null, null);
+        internalTopologyBuilder.addSink("out", "output", null, null, null, "name");
 
         final StreamThread thread = createStreamThread(clientId, new StreamsConfig(configProps(true)), true);
 


### PR DESCRIPTION
… if a processor or sink is added with no upstream node attached

InternalTopologyBuilder throws an exception if a sink or a processor is added without at least one upstream node, as records cannot be forwarded downstream to an unconnected node. This does not prevent users from attempting to forward to unconnected nodes, but it does prevent them from attaching effectively useless downstream nodes, and the error message for forwarding to an unconnected node has been updated to be slightly more specific.