### PR TITLE
KAFKA-6978: make window retention time strict

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalProcessorContextImpl.java
@@ -97,7 +97,7 @@ public class GlobalProcessorContextImpl extends AbstractProcessorContext {
     }
 
     @Override
-    public Long streamTime() {
+    public long streamTime() {
         throw new RuntimeException("Stream time is not implemented for the global processor context.");
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -64,5 +64,5 @@ public interface InternalProcessorContext extends ProcessorContext {
      */
     void uninitialize();
 
-    Long streamTime();
+    long streamTime();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilder.java
@@ -123,83 +123,51 @@ public class InternalTopologyBuilder {
     private Map<Integer, Set<String>> nodeGroups = null;
 
     // TODO: this is only temporary for 2.0 and should be removed
-    public final Map<StoreBuilder, String> storeToSourceChangelogTopic = new HashMap<>();
+    private final Map<StoreBuilder, String> storeToSourceChangelogTopic = new HashMap<>();
 
-    public interface StateStoreFactory {
-        Set<String> users();
-        boolean loggingEnabled();
-        StateStore build();
-        String name();
-        boolean isWindowStore();
-        Map<String, String> logConfig();
-        long retentionPeriod();
-    }
-
-    private static abstract class AbstractStateStoreFactory implements StateStoreFactory {
-        private final Set<String> users = new HashSet<>();
-        private final String name;
-        private final boolean loggingEnabled;
-        private final boolean windowStore;
-        private final Map<String, String> logConfig;
-
-        AbstractStateStoreFactory(final String name,
-                                  final boolean loggingEnabled,
-                                  final boolean windowStore,
-                                  final Map<String, String> logConfig) {
-            this.name = name;
-            this.loggingEnabled = loggingEnabled;
-            this.windowStore = windowStore;
-            this.logConfig = logConfig;
-        }
-
-        @Override
-        public Set<String> users() {
-            return users;
-        }
-
-        @Override
-        public boolean loggingEnabled() {
-            return loggingEnabled;
-        }
-
-        @Override
-        public String name() {
-            return name;
-        }
-
-        @Override
-        public boolean isWindowStore() {
-            return windowStore;
-        }
-
-        @Override
-        public Map<String, String> logConfig() {
-            return logConfig;
-        }
-    }
-
-    private static class StoreBuilderFactory extends AbstractStateStoreFactory {
+    public static class StateStoreFactory {
         private final StoreBuilder builder;
+        private final Set<String> users = new HashSet<>();
 
-        StoreBuilderFactory(final StoreBuilder<?> builder) {
-            super(builder.name(),
-                  builder.loggingEnabled(),
-                  builder instanceof WindowStoreBuilder,
-                  builder.logConfig());
+        private StateStoreFactory(final StoreBuilder<?> builder) {
             this.builder = builder;
         }
 
-        @Override
         public StateStore build() {
             return builder.build();
         }
 
-        @Override
-        public long retentionPeriod() {
-            if (!isWindowStore()) {
+        long retentionPeriod() {
+            if (isWindowStore()) {
+                return ((WindowStoreBuilder) builder).retentionPeriod();
+            } else {
                 throw new IllegalStateException("retentionPeriod is not supported when not a window store");
             }
-            return ((WindowStoreBuilder) builder).retentionPeriod();
+        }
+
+        private Set<String> users() {
+            return users;
+        }
+
+        /** Visible for testing */
+        public boolean loggingEnabled() {
+            return builder.loggingEnabled();
+        }
+
+        private String name() {
+            return builder.name();
+        }
+
+        private boolean isWindowStore() {
+            return builder instanceof WindowStoreBuilder;
+        }
+
+        // Apparently Java strips the generics from this method because we're using the raw type for builder,
+        // even though this method doesn't use builder's (missing) type parameter. Our usage seems obviously
+        // correct, though, hence the suppression.
+        @SuppressWarnings("unchecked")
+        private Map<String, String> logConfig() {
+            return builder.logConfig();
         }
     }
 
@@ -526,7 +494,7 @@ public class InternalTopologyBuilder {
             throw new TopologyException("StateStore " + storeBuilder.name() + " is already added.");
         }
 
-        stateFactories.put(storeBuilder.name(), new StoreBuilderFactory(storeBuilder));
+        stateFactories.put(storeBuilder.name(), new StateStoreFactory(storeBuilder));
 
         if (processorNames != null) {
             for (final String processorName : processorNames) {
@@ -1124,12 +1092,12 @@ public class InternalTopologyBuilder {
 
     private InternalTopicConfig createChangelogTopicConfig(final StateStoreFactory factory,
                                                            final String name) {
-        if (!factory.isWindowStore()) {
-            return new UnwindowedChangelogTopicConfig(name, factory.logConfig());
-        } else {
+        if (factory.isWindowStore()) {
             final WindowedChangelogTopicConfig config = new WindowedChangelogTopicConfig(name, factory.logConfig());
             config.setRetentionMs(factory.retentionPeriod());
             return config;
+        } else {
+            return new UnwindowedChangelogTopicConfig(name, factory.logConfig());
         }
     }
 
@@ -1744,18 +1712,18 @@ public class InternalTopologyBuilder {
         public String toString() {
             final StringBuilder sb = new StringBuilder();
             sb.append("Topologies:\n ");
-            final TopologyDescription.Subtopology[] sortedSubtopologies = 
+            final TopologyDescription.Subtopology[] sortedSubtopologies =
                 subtopologies.descendingSet().toArray(new TopologyDescription.Subtopology[subtopologies.size()]);
-            final TopologyDescription.GlobalStore[] sortedGlobalStores = 
+            final TopologyDescription.GlobalStore[] sortedGlobalStores =
                 globalStores.descendingSet().toArray(new TopologyDescription.GlobalStore[globalStores.size()]);
             int expectedId = 0;
             int subtopologiesIndex = sortedSubtopologies.length - 1;
             int globalStoresIndex = sortedGlobalStores.length - 1;
             while (subtopologiesIndex != -1 && globalStoresIndex != -1) {
                 sb.append("  ");
-                final TopologyDescription.Subtopology subtopology = 
+                final TopologyDescription.Subtopology subtopology =
                     sortedSubtopologies[subtopologiesIndex];
-                final TopologyDescription.GlobalStore globalStore = 
+                final TopologyDescription.GlobalStore globalStore =
                     sortedGlobalStores[globalStoresIndex];
                 if (subtopology.id() == expectedId) {
                     sb.append(subtopology);
@@ -1767,14 +1735,14 @@ public class InternalTopologyBuilder {
                 expectedId++;
             }
             while (subtopologiesIndex != -1) {
-                final TopologyDescription.Subtopology subtopology = 
+                final TopologyDescription.Subtopology subtopology =
                     sortedSubtopologies[subtopologiesIndex];
                 sb.append("  ");
                 sb.append(subtopology);
                 subtopologiesIndex--;
             }
             while (globalStoresIndex != -1) {
-                final TopologyDescription.GlobalStore globalStore = 
+                final TopologyDescription.GlobalStore globalStore =
                     sortedGlobalStores[globalStoresIndex];
                 sb.append("  ");
                 sb.append(globalStore);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ProcessorContextImpl.java
@@ -28,13 +28,12 @@ import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 public class ProcessorContextImpl extends AbstractProcessorContext implements RecordCollector.Supplier {
 
     private final StreamTask task;
     private final RecordCollector collector;
-    private Supplier<Long> streamTimeSupplier;
+    private TimestampSupplier streamTimeSupplier;
     private final ToInternal toInternal = new ToInternal();
     private final static To SEND_TO_ALL = To.all();
 
@@ -56,7 +55,7 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
 
     @Override
     public RecordCollector recordCollector() {
-        return this.collector;
+        return collector;
     }
 
     /**
@@ -155,13 +154,13 @@ public class ProcessorContextImpl extends AbstractProcessorContext implements Re
         return task.schedule(interval, type, callback);
     }
 
-    void setStreamTimeSupplier(final Supplier<Long> streamTimeSupplier) {
+    void setStreamTimeSupplier(final TimestampSupplier streamTimeSupplier) {
         this.streamTimeSupplier = streamTimeSupplier;
     }
 
     @Override
-    public Long streamTime() {
-        return this.streamTimeSupplier.get();
+    public long streamTime() {
+        return streamTimeSupplier.get();
     }
 
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyContextImpl.java
@@ -217,7 +217,7 @@ class StandbyContextImpl extends AbstractProcessorContext implements RecordColle
     }
 
     @Override
-    public Long streamTime() {
+    public long streamTime() {
         throw new RuntimeException("Stream time is not implemented for the standby context.");
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -635,7 +635,6 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
      * @param partition the partition
      * @param records   the records
      */
-    @SuppressWarnings("unchecked")
     public void addRecords(final TopicPartition partition, final Iterable<ConsumerRecord<byte[], byte[]>> records) {
         final int newQueueSize = partitionGroup.addRawRecords(partition, records);
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TimestampSupplier.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TimestampSupplier.java
@@ -14,21 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.kstream.internals;
+package org.apache.kafka.streams.processor.internals;
 
-import org.apache.kafka.streams.kstream.Reducer;
-import org.apache.kafka.streams.kstream.Window;
-import org.apache.kafka.streams.kstream.Windows;
-
-class KStreamWindowReduce<K, V, W extends Window> extends KStreamWindowAggregate<K, V, V, W> {
-    KStreamWindowReduce(final Windows<W> windows,
-                        final String storeName,
-                        final Reducer<V> reducer) {
-        super(
-            windows,
-            storeName,
-            () -> null,
-            (key, newValue, oldValue) -> oldValue == null ? newValue : reducer.apply(oldValue, newValue)
-        );
-    }
+public interface TimestampSupplier {
+    long get();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/WindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/WindowStore.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.processor.StateStore;
 public interface WindowStore<K, V> extends StateStore, ReadOnlyWindowStore<K, V> {
 
     /**
-     * Put a key-value pair with the current wall-clock time as the timestamp
+     * Put a key-value pair with the current record time as the timestamp
      * into the corresponding window
      * @param key The key to associate the value to
      * @param value The value to update, it can be null;

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBWindowStore.java
@@ -102,7 +102,7 @@ public class RocksDBWindowStore<K, V> extends WrappedStateStore.AbstractStateSto
         final KeyValueIterator<Bytes, byte[]> bytesIterator = bytesStore.all();
         return new WindowStoreIteratorWrapper<>(bytesIterator, serdes, windowSize).keyValueIterator();
     }
-    
+
     @Override
     public KeyValueIterator<Windowed<K>, V> fetchAll(final long timeFrom, final long timeTo) {
         final KeyValueIterator<Bytes, byte[]> bytesIterator = bytesStore.fetchAll(timeFrom, timeTo);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowAggregateTest.java
@@ -16,23 +16,26 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.TimeWindows;
-import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
+import org.apache.kafka.streams.test.OutputVerifier;
 import org.apache.kafka.test.MockAggregator;
 import org.apache.kafka.test.MockInitializer;
 import org.apache.kafka.test.MockProcessor;
@@ -44,7 +47,10 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
@@ -134,12 +140,7 @@ public class KStreamWindowAggregateTest {
         table2.toStream().process(supplier);
 
 
-        table1.join(table2, new ValueJoiner<String, String, String>() {
-            @Override
-            public String apply(final String p1, final String p2) {
-                return p1 + "%" + p2;
-            }
-        }).toStream().process(supplier);
+        table1.join(table2, (p1, p2) -> p1 + "%" + p2).toStream().process(supplier);
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
             driver.pipeInput(recordFactory.create(topic1, "A", "1", 0L));
@@ -151,11 +152,11 @@ public class KStreamWindowAggregateTest {
             final List<MockProcessor<Windowed<String>, String>> processors = supplier.capturedProcessors(3);
 
             processors.get(0).checkAndClearProcessResult(
-                    "[A@0/10]:0+1",
-                    "[B@0/10]:0+2",
-                    "[C@0/10]:0+3",
-                    "[D@0/10]:0+4",
-                    "[A@0/10]:0+1+1"
+                "[A@0/10]:0+1",
+                "[B@0/10]:0+2",
+                "[C@0/10]:0+3",
+                "[D@0/10]:0+4",
+                "[A@0/10]:0+1+1"
             );
             processors.get(1).checkAndClearProcessResult();
             processors.get(2).checkAndClearProcessResult();
@@ -167,11 +168,11 @@ public class KStreamWindowAggregateTest {
             driver.pipeInput(recordFactory.create(topic1, "C", "3", 9L));
 
             processors.get(0).checkAndClearProcessResult(
-                    "[A@0/10]:0+1+1+1", "[A@5/15]:0+1",
-                    "[B@0/10]:0+2+2", "[B@5/15]:0+2",
-                    "[D@0/10]:0+4+4", "[D@5/15]:0+4",
-                    "[B@0/10]:0+2+2+2", "[B@5/15]:0+2+2",
-                    "[C@0/10]:0+3+3", "[C@5/15]:0+3"
+                "[A@0/10]:0+1+1+1", "[A@5/15]:0+1",
+                "[B@0/10]:0+2+2", "[B@5/15]:0+2",
+                "[D@0/10]:0+4+4", "[D@5/15]:0+4",
+                "[B@0/10]:0+2+2+2", "[B@5/15]:0+2+2",
+                "[C@0/10]:0+3+3", "[C@5/15]:0+3"
             );
             processors.get(1).checkAndClearProcessResult();
             processors.get(2).checkAndClearProcessResult();
@@ -184,18 +185,18 @@ public class KStreamWindowAggregateTest {
 
             processors.get(0).checkAndClearProcessResult();
             processors.get(1).checkAndClearProcessResult(
-                    "[A@0/10]:0+a",
-                    "[B@0/10]:0+b",
-                    "[C@0/10]:0+c",
-                    "[D@0/10]:0+d",
-                    "[A@0/10]:0+a+a"
+                "[A@0/10]:0+a",
+                "[B@0/10]:0+b",
+                "[C@0/10]:0+c",
+                "[D@0/10]:0+d",
+                "[A@0/10]:0+a+a"
             );
             processors.get(2).checkAndClearProcessResult(
-                    "[A@0/10]:0+1+1+1%0+a",
-                    "[B@0/10]:0+2+2+2%0+b",
-                    "[C@0/10]:0+3+3%0+c",
-                    "[D@0/10]:0+4+4%0+d",
-                    "[A@0/10]:0+1+1+1%0+a+a");
+                "[A@0/10]:0+1+1+1%0+a",
+                "[B@0/10]:0+2+2+2%0+b",
+                "[C@0/10]:0+3+3%0+c",
+                "[D@0/10]:0+4+4%0+d",
+                "[A@0/10]:0+1+1+1%0+a+a");
 
             driver.pipeInput(recordFactory.create(topic2, "A", "a", 5L));
             driver.pipeInput(recordFactory.create(topic2, "B", "b", 6L));
@@ -205,18 +206,18 @@ public class KStreamWindowAggregateTest {
 
             processors.get(0).checkAndClearProcessResult();
             processors.get(1).checkAndClearProcessResult(
-                    "[A@0/10]:0+a+a+a", "[A@5/15]:0+a",
-                    "[B@0/10]:0+b+b", "[B@5/15]:0+b",
-                    "[D@0/10]:0+d+d", "[D@5/15]:0+d",
-                    "[B@0/10]:0+b+b+b", "[B@5/15]:0+b+b",
-                    "[C@0/10]:0+c+c", "[C@5/15]:0+c"
+                "[A@0/10]:0+a+a+a", "[A@5/15]:0+a",
+                "[B@0/10]:0+b+b", "[B@5/15]:0+b",
+                "[D@0/10]:0+d+d", "[D@5/15]:0+d",
+                "[B@0/10]:0+b+b+b", "[B@5/15]:0+b+b",
+                "[C@0/10]:0+c+c", "[C@5/15]:0+c"
             );
             processors.get(2).checkAndClearProcessResult(
-                    "[A@0/10]:0+1+1+1%0+a+a+a", "[A@5/15]:0+1%0+a",
-                    "[B@0/10]:0+2+2+2%0+b+b", "[B@5/15]:0+2+2%0+b",
-                    "[D@0/10]:0+4+4%0+d+d", "[D@5/15]:0+4%0+d",
-                    "[B@0/10]:0+2+2+2%0+b+b+b", "[B@5/15]:0+2+2%0+b+b",
-                    "[C@0/10]:0+3+3%0+c+c", "[C@5/15]:0+3%0+c"
+                "[A@0/10]:0+1+1+1%0+a+a+a", "[A@5/15]:0+1%0+a",
+                "[B@0/10]:0+2+2+2%0+b+b", "[B@5/15]:0+2+2%0+b",
+                "[D@0/10]:0+4+4%0+d+d", "[D@5/15]:0+4%0+d",
+                "[B@0/10]:0+2+2+2%0+b+b+b", "[B@5/15]:0+2+2%0+b+b",
+                "[C@0/10]:0+3+3%0+c+c", "[C@5/15]:0+3%0+c"
             );
         }
     }
@@ -231,7 +232,7 @@ public class KStreamWindowAggregateTest {
             .windowedBy(TimeWindows.of(10).advanceBy(5))
             .aggregate(
                 MockInitializer.STRING_INIT,
-                MockAggregator.<String, String>toStringInstance("+"),
+                MockAggregator.toStringInstance("+"),
                 Materialized.<String, String, WindowStore<Bytes, byte[]>>as("topic1-Canonicalized").withValueSerde(Serdes.String())
             );
 
@@ -243,5 +244,57 @@ public class KStreamWindowAggregateTest {
             assertEquals(1.0, getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue());
             assertThat(appender.getMessages(), hasItem("Skipping record due to null key. value=[1] topic=[topic] partition=[0] offset=[0]"));
         }
+    }
+
+    @Test
+    public void shouldLogAndMeterWhenSkippingExpiredWindow() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final String topic = "topic";
+
+        final KStream<String, String> stream1 = builder.stream(topic, Consumed.with(Serdes.String(), Serdes.String()));
+        stream1.groupByKey(Serialized.with(Serdes.String(), Serdes.String()))
+            .windowedBy(TimeWindows.of(10).advanceBy(5).until(100))
+            .aggregate(
+                () -> "",
+                MockAggregator.toStringInstance("+"),
+                Materialized.<String, String, WindowStore<Bytes, byte[]>>as("topic1-Canonicalized").withValueSerde(Serdes.String()).withCachingDisabled().withLoggingDisabled()
+            )
+            .toStream()
+            .map((key, value) -> new KeyValue<>(key.toString(), value))
+            .to("output");
+
+        final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props, 0L)) {
+            driver.pipeInput(recordFactory.create(topic, "k", "100", 100L));
+            driver.pipeInput(recordFactory.create(topic, "k", "0", 0L));
+            driver.pipeInput(recordFactory.create(topic, "k", "1", 1L));
+            driver.pipeInput(recordFactory.create(topic, "k", "2", 2L));
+            driver.pipeInput(recordFactory.create(topic, "k", "3", 3L));
+            driver.pipeInput(recordFactory.create(topic, "k", "4", 4L));
+            driver.pipeInput(recordFactory.create(topic, "k", "5", 5L));
+            driver.pipeInput(recordFactory.create(topic, "k", "6", 6L));
+            LogCaptureAppender.unregister(appender);
+
+            assertThat(getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue(), equalTo(7.0));
+            assertThat(appender.getMessages(), hasItems(
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[1] timestamp=[0] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[2] timestamp=[1] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[3] timestamp=[2] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[4] timestamp=[3] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[5] timestamp=[4] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[6] timestamp=[5] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[topic] partition=[0] offset=[7] timestamp=[6] window=[0] expiration=[0]"
+            ));
+
+            OutputVerifier.compareKeyValueTimestamp(getOutput(driver), "[k@95/105]", "+100", 100);
+            OutputVerifier.compareKeyValueTimestamp(getOutput(driver), "[k@100/110]", "+100", 100);
+            OutputVerifier.compareKeyValueTimestamp(getOutput(driver), "[k@5/15]", "+5", 5);
+            OutputVerifier.compareKeyValueTimestamp(getOutput(driver), "[k@5/15]", "+5+6", 6);
+            assertThat(driver.readOutput("output"), nullValue());
+        }
+    }
+
+    private ProducerRecord<String, String> getOutput(final TopologyTestDriver driver) {
+        return driver.readOutput("output", new StringDeserializer(), new StringDeserializer());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowReduceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/KStreamWindowReduceTest.java
@@ -16,23 +16,29 @@
  */
 package org.apache.kafka.streams.kstream.internals;
 
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.Reducer;
 import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.processor.internals.testutil.LogCaptureAppender;
 import org.apache.kafka.streams.test.ConsumerRecordFactory;
+import org.apache.kafka.streams.test.OutputVerifier;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
 import java.util.Properties;
 
 import static org.apache.kafka.test.StreamsTestUtils.getMetricByName;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
@@ -49,12 +55,7 @@ public class KStreamWindowReduceTest {
             .stream("TOPIC", Consumed.with(Serdes.String(), Serdes.String()))
             .groupByKey(Serialized.with(Serdes.String(), Serdes.String()))
             .windowedBy(TimeWindows.of(500L))
-            .reduce(new Reducer<String>() {
-                @Override
-                public String apply(final String value1, final String value2) {
-                    return value1 + "+" + value2;
-                }
-            });
+            .reduce((value1, value2) -> value1 + "+" + value2);
 
 
         try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
@@ -65,5 +66,49 @@ public class KStreamWindowReduceTest {
             assertEquals(1.0, getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue());
             assertThat(appender.getMessages(), hasItem("Skipping record due to null key. value=[asdf] topic=[TOPIC] partition=[0] offset=[0]"));
         }
+    }
+
+    @Test
+    public void shouldLogAndMeterOnExpiredEvent() {
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .stream("TOPIC", Consumed.with(Serdes.String(), Serdes.String()))
+            .groupByKey(Serialized.with(Serdes.String(), Serdes.String()))
+            .windowedBy(TimeWindows.of(5L).until(100))
+            .reduce((value1, value2) -> value1 + "+" + value2)
+            .toStream()
+            .map((key, value) -> new KeyValue<>(key.toString(), value))
+            .to("output");
+
+
+        try (final TopologyTestDriver driver = new TopologyTestDriver(builder.build(), props)) {
+            final LogCaptureAppender appender = LogCaptureAppender.createAndRegister();
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "100", 100L));
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "0", 0L));
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "1", 1L));
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "2", 2L));
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "3", 3L));
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "4", 4L));
+            driver.pipeInput(recordFactory.create("TOPIC", "k", "5", 5L));
+            LogCaptureAppender.unregister(appender);
+
+            assertThat(getMetricByName(driver.metrics(), "skipped-records-total", "stream-metrics").metricValue(), equalTo(5.0));
+            assertThat(appender.getMessages(), hasItems(
+                "Skipping record for expired window. key=[k] topic=[TOPIC] partition=[0] offset=[1] timestamp=[0] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[TOPIC] partition=[0] offset=[2] timestamp=[1] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[TOPIC] partition=[0] offset=[3] timestamp=[2] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[TOPIC] partition=[0] offset=[4] timestamp=[3] window=[0] expiration=[0]",
+                "Skipping record for expired window. key=[k] topic=[TOPIC] partition=[0] offset=[5] timestamp=[4] window=[0] expiration=[0]"
+            ));
+
+            OutputVerifier.compareKeyValueTimestamp(getOutput(driver), "[k@100/105]", "100", 100);
+            OutputVerifier.compareKeyValueTimestamp(getOutput(driver), "[k@5/10]", "5", 5);
+            assertThat(driver.readOutput("output"), nullValue());
+        }
+    }
+
+    private ProducerRecord<String, String> getOutput(final TopologyTestDriver driver) {
+        return driver.readOutput("output", new StringDeserializer(), new StringDeserializer());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -218,7 +218,7 @@ public class AbstractProcessorContextTest {
         public void commit() {}
 
         @Override
-        public Long streamTime() {
+        public long streamTime() {
             throw new RuntimeException("not implemented");
         }
     }

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -61,7 +61,7 @@ public class InternalMockProcessorContext extends AbstractProcessorContext imple
     private Serde<?> keySerde;
     private Serde<?> valSerde;
     private long timestamp = -1L;
-    private long streamTime = -1;
+    private long streamTime = -1L;
 
     public InternalMockProcessorContext() {
         this(null,
@@ -119,12 +119,7 @@ public class InternalMockProcessorContext extends AbstractProcessorContext imple
             valSerde,
             new StreamsMetricsImpl(new Metrics(), "mock"),
             new StreamsConfig(StreamsTestUtils.minimalStreamsConfig()),
-            new RecordCollector.Supplier() {
-                @Override
-                public RecordCollector recordCollector() {
-                    return collector;
-                }
-            },
+            () -> collector,
             cache
         );
     }
@@ -180,12 +175,12 @@ public class InternalMockProcessorContext extends AbstractProcessorContext imple
     @Override
     public void initialized() {}
 
-    public void setStreamTime(final long time) {
-        streamTime = time;
+    public void setStreamTime(final long currentTime) {
+        streamTime = currentTime;
     }
 
     @Override
-    public Long streamTime() {
+    public long streamTime() {
         return streamTime;
     }
 
@@ -346,5 +341,4 @@ public class InternalMockProcessorContext extends AbstractProcessorContext imple
 
         return new WrappedBatchingStateRestoreCallback(restoreCallback);
     }
-
 }

--- a/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
@@ -86,8 +86,8 @@ public class NoOpProcessorContext extends AbstractProcessorContext {
     }
 
     @Override
-    public Long streamTime() {
-        throw new RuntimeException("not implemented");
+    public long streamTime() {
+        throw new RuntimeException("streamTime is not implemented for NoOpProcessorContext");
     }
 
     @Override

--- a/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
+++ b/streams/test-utils/src/test/java/org/apache/kafka/streams/TopologyTestDriverTest.java
@@ -54,6 +54,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -63,9 +64,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Arrays;
 import java.util.regex.Pattern;
 
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkProperties;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -97,13 +100,11 @@ public class TopologyTestDriverTest {
     private final ConsumerRecord<byte[], byte[]> consumerRecord2 = consumerRecordFactory.create(SOURCE_TOPIC_2, key2, value2, timestamp2);
 
     private TopologyTestDriver testDriver;
-    private final Properties config = new Properties() {
-        {
-            put(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver");
-            put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234");
-            put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath());
-        }
-    };
+    private final Properties config = mkProperties(mkMap(
+        mkEntry(StreamsConfig.APPLICATION_ID_CONFIG, "test-TopologyTestDriver"),
+        mkEntry(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234"),
+        mkEntry(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getAbsolutePath())
+    ));
     private KeyValueStore<String, Long> store;
 
     private final StringDeserializer stringDeserializer = new StringDeserializer();

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -50,6 +50,17 @@ class StreamsSimpleBenchmarkTest(Test):
 
         self.replication = 1
 
+
+    @cluster(num_nodes=12)
+    @matrix(test=["streamcount", "streamcountwindowed"], scale=[1])
+    def test_count_benchmark(self, test, scale):
+        """
+        Run count Kafka Streams benchmarks
+        """
+
+        return self.test_simple_benchmark(test, scale)
+
+
     @cluster(num_nodes=12)
     @matrix(test=["consume", "consumeproduce", "streams-simple", "streams-count", "streams-join"], scale=[1])
     def test_simple_benchmark(self, test, scale):

--- a/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
+++ b/tests/kafkatest/benchmarks/streams/streams_simple_benchmark_test.py
@@ -50,17 +50,6 @@ class StreamsSimpleBenchmarkTest(Test):
 
         self.replication = 1
 
-
-    @cluster(num_nodes=12)
-    @matrix(test=["streamcount", "streamcountwindowed"], scale=[1])
-    def test_count_benchmark(self, test, scale):
-        """
-        Run count Kafka Streams benchmarks
-        """
-
-        return self.test_simple_benchmark(test, scale)
-
-
     @cluster(num_nodes=12)
     @matrix(test=["consume", "consumeproduce", "streams-simple", "streams-count", "streams-join"], scale=[1])
     def test_simple_benchmark(self, test, scale):


### PR DESCRIPTION
Enforce window retention times strictly:
* records for windows that are expired get dropped
* queries for timestamps old enough to be expired immediately answered with `null`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
