### PR TITLE
KAFKA-7019; Make reading metadata lock-free by maintaining an atomically-updated read snapshot

### DIFF
--- a/core/src/main/scala/kafka/server/MetadataCache.scala
+++ b/core/src/main/scala/kafka/server/MetadataCache.scala
@@ -209,14 +209,14 @@ class MetadataCache(brokerId: Int) extends Logging {
   }
 
   // This method returns the deleted TopicPartitions received from UpdateMetadataRequest
-  def updateMetadataSnapshot(correlationId: Int, updateMetadataRequest: UpdateMetadataRequest): Seq[TopicPartition] = {
+  def updateMetadata(correlationId: Int, updateMetadataRequest: UpdateMetadataRequest): Seq[TopicPartition] = {
     inWriteLock(partitionMetadataLock) {
 
       //since kafka may do partial metadata updates, we start by copying the previous state
       val partitionStates = new mutable.AnyRefMap[String, mutable.LongMap[UpdateMetadataRequest.PartitionState]](metadataSnapshot.partitionStates.size)
-      metadataSnapshot.partitionStates.foreach { case (topic, md) =>
-        val copy = new mutable.LongMap[UpdateMetadataRequest.PartitionState](md.size)
-        copy ++= md
+      metadataSnapshot.partitionStates.foreach { case (topic, oldPartitionStates) =>
+        val copy = new mutable.LongMap[UpdateMetadataRequest.PartitionState](oldPartitionStates.size)
+        copy ++= oldPartitionStates
         partitionStates += (topic -> copy)
       }
       val aliveBrokers = new mutable.LongMap[Broker](metadataSnapshot.aliveBrokers.size)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1006,7 +1006,7 @@ class ReplicaManager(val config: KafkaConfig,
         stateChangeLogger.warn(stateControllerEpochErrorMessage)
         throw new ControllerMovedException(stateChangeLogger.messageWithPrefix(stateControllerEpochErrorMessage))
       } else {
-        val deletedPartitions = metadataCache.updateMetadataSnapshot(correlationId, updateMetadataRequest)
+        val deletedPartitions = metadataCache.updateMetadata(correlationId, updateMetadataRequest)
         controllerEpoch = updateMetadataRequest.controllerEpoch
         deletedPartitions
       }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1006,7 +1006,7 @@ class ReplicaManager(val config: KafkaConfig,
         stateChangeLogger.warn(stateControllerEpochErrorMessage)
         throw new ControllerMovedException(stateChangeLogger.messageWithPrefix(stateControllerEpochErrorMessage))
       } else {
-        val deletedPartitions = metadataCache.updateCache(correlationId, updateMetadataRequest)
+        val deletedPartitions = metadataCache.updateMetadataSnapshot(correlationId, updateMetadataRequest)
         controllerEpoch = updateMetadataRequest.controllerEpoch
         deletedPartitions
       }

--- a/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
@@ -130,7 +130,7 @@ class AddPartitionsTest extends BaseRequestTest {
     assertEquals(0, partitionMetadata(0).partition)
     assertEquals(1, partitionMetadata(1).partition)
     assertEquals(2, partitionMetadata(2).partition)
-    val replicas = topicMetadata.partitionMetadata.get(1).replicas
+    val replicas = partitionMetadata(1).replicas
     assertEquals(2, replicas.size)
     assertTrue(replicas.asScala.head.id == 0 || replicas.asScala.head.id == 1)
     assertTrue(replicas.asScala(1).id == 0 || replicas.asScala(1).id == 1)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -478,7 +478,7 @@ class KafkaApisTest {
     )
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
       0, Map.empty[TopicPartition, UpdateMetadataRequest.PartitionState].asJava, brokers.asJava).build()
-    metadataCache.updateCache(correlationId = 0, updateMetadataRequest)
+    metadataCache.updateMetadataSnapshot(correlationId = 0, updateMetadataRequest)
     (plaintextListener, anotherListener)
   }
 
@@ -575,6 +575,6 @@ class KafkaApisTest {
     val partitions = (0 until numPartitions).map(new TopicPartition(topic, _) -> partitionState).toMap
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
       0, partitions.asJava, Set(broker).asJava).build()
-    metadataCache.updateCache(correlationId = 0, updateMetadataRequest)
+    metadataCache.updateMetadataSnapshot(correlationId = 0, updateMetadataRequest)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -478,7 +478,7 @@ class KafkaApisTest {
     )
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
       0, Map.empty[TopicPartition, UpdateMetadataRequest.PartitionState].asJava, brokers.asJava).build()
-    metadataCache.updateMetadataSnapshot(correlationId = 0, updateMetadataRequest)
+    metadataCache.updateMetadata(correlationId = 0, updateMetadataRequest)
     (plaintextListener, anotherListener)
   }
 
@@ -575,6 +575,6 @@ class KafkaApisTest {
     val partitions = (0 until numPartitions).map(new TopicPartition(topic, _) -> partitionState).toMap
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(ApiKeys.UPDATE_METADATA.latestVersion, 0,
       0, partitions.asJava, Set(broker).asJava).build()
-    metadataCache.updateMetadataSnapshot(correlationId = 0, updateMetadataRequest)
+    metadataCache.updateMetadata(correlationId = 0, updateMetadataRequest)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -72,7 +72,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateCache(15, updateMetadataRequest)
+    cache.updateMetadataSnapshot(15, updateMetadataRequest)
 
     for (securityProtocol <- Seq(SecurityProtocol.PLAINTEXT, SecurityProtocol.SSL)) {
       val listenerName = ListenerName.forSecurityProtocol(securityProtocol)
@@ -166,7 +166,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateCache(15, updateMetadataRequest)
+    cache.updateMetadataSnapshot(15, updateMetadataRequest)
 
     val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableListeners = errorUnavailableListeners)
     assertEquals(1, topicMetadatas.size)
@@ -210,7 +210,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateCache(15, updateMetadataRequest)
+    cache.updateMetadataSnapshot(15, updateMetadataRequest)
 
     // Validate errorUnavailableEndpoints = false
     val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = false)
@@ -270,7 +270,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateCache(15, updateMetadataRequest)
+    cache.updateMetadataSnapshot(15, updateMetadataRequest)
 
     // Validate errorUnavailableEndpoints = false
     val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = false)
@@ -322,7 +322,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, partitionStates.asJava,
       brokers.asJava).build()
-    cache.updateCache(15, updateMetadataRequest)
+    cache.updateMetadataSnapshot(15, updateMetadataRequest)
 
     val topicMetadata = cache.getTopicMetadata(Set(topic), ListenerName.forSecurityProtocol(SecurityProtocol.SSL))
     assertEquals(1, topicMetadata.size)
@@ -351,7 +351,7 @@ class MetadataCacheTest {
       val version = ApiKeys.UPDATE_METADATA.latestVersion
       val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, partitionStates.asJava,
         brokers.asJava).build()
-      cache.updateCache(15, updateMetadataRequest)
+      cache.updateMetadataSnapshot(15, updateMetadataRequest)
     }
 
     val initialBrokerIds = (0 to 2).toSet

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -72,7 +72,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateMetadataSnapshot(15, updateMetadataRequest)
+    cache.updateMetadata(15, updateMetadataRequest)
 
     for (securityProtocol <- Seq(SecurityProtocol.PLAINTEXT, SecurityProtocol.SSL)) {
       val listenerName = ListenerName.forSecurityProtocol(securityProtocol)
@@ -166,7 +166,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateMetadataSnapshot(15, updateMetadataRequest)
+    cache.updateMetadata(15, updateMetadataRequest)
 
     val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableListeners = errorUnavailableListeners)
     assertEquals(1, topicMetadatas.size)
@@ -210,7 +210,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateMetadataSnapshot(15, updateMetadataRequest)
+    cache.updateMetadata(15, updateMetadataRequest)
 
     // Validate errorUnavailableEndpoints = false
     val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = false)
@@ -270,7 +270,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, controllerId, controllerEpoch,
       partitionStates.asJava, brokers.asJava).build()
-    cache.updateMetadataSnapshot(15, updateMetadataRequest)
+    cache.updateMetadata(15, updateMetadataRequest)
 
     // Validate errorUnavailableEndpoints = false
     val topicMetadatas = cache.getTopicMetadata(Set(topic), listenerName, errorUnavailableEndpoints = false)
@@ -322,7 +322,7 @@ class MetadataCacheTest {
     val version = ApiKeys.UPDATE_METADATA.latestVersion
     val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, partitionStates.asJava,
       brokers.asJava).build()
-    cache.updateMetadataSnapshot(15, updateMetadataRequest)
+    cache.updateMetadata(15, updateMetadataRequest)
 
     val topicMetadata = cache.getTopicMetadata(Set(topic), ListenerName.forSecurityProtocol(SecurityProtocol.SSL))
     assertEquals(1, topicMetadata.size)
@@ -351,7 +351,7 @@ class MetadataCacheTest {
       val version = ApiKeys.UPDATE_METADATA.latestVersion
       val updateMetadataRequest = new UpdateMetadataRequest.Builder(version, 2, controllerEpoch, partitionStates.asJava,
         brokers.asJava).build()
-      cache.updateMetadataSnapshot(15, updateMetadataRequest)
+      cache.updateMetadata(15, updateMetadataRequest)
     }
 
     val initialBrokerIds = (0 to 2).toSet


### PR DESCRIPTION
we've seen cases where under a constant metadata update load (automated partition rebalance) request handling threads can block for a significant amount of time on the metadata lock.

the reason is that for large enough clusters (~200,000 topic partitions) a read operation can actually take a long while to compose a response. under a constant stream of reads + writes we see situations where a reader is currently in, a writer is pending (blocked) and then a big pile-up of more readers that are blocked behind the pending writer.

this patch makes the read path lock-free. the metadata is now stored in a logically-immutable snapshot. all read operations grab a snapshot and serve data out of it. write paths create an entirely new snapshot and atomically assign it. writers are still under a lock, for mutual exclusion.

here's the benchmark code i used to measure the effects of this patch:
```java
public class MetadataCacheBenchmark {
    private volatile boolean running = true;

    int numBrokers = 150;
    int numTopics = 3500;
    int maxPartitionsPerTopic = 100;
    int replicationFactor = 2;
    int numUpdaters = 1;
    double updateRateLimit = 10.0; //qps
    int numReaders = 5;
    boolean partialUpdate = true;

    private final ListenerName listener = new ListenerName("listener");

    private final AtomicLong updateCounter = new AtomicLong();
    private final AtomicLong readCounter = new AtomicLong();

    @Test
    public void benchmarkAllTheThings() throws Exception {
        //long seed = System.currentTimeMillis();
        long seed = 666;
        System.err.println("seed is " + seed);
        Random r = new Random(seed);

        MetadataCache cache = new MetadataCache(666);
        UpdateMetadataRequest fullRequest = buildRequest(r, -1);
        UpdateMetadataRequest partialRequest = buildRequest(r, 1);

        cache.updateCache(0, fullRequest); //initial data (useful in case there are no writers)

        Set<String> allTopics = new HashSet<>();
        for (int i = 0; i < numTopics; i++) {
            allTopics.add("topic-" + i);
        }
        scala.collection.mutable.Set<String> topicsScalaSet = JavaConverters.asScalaSetConverter(allTopics).asScala();

        Thread.UncaughtExceptionHandler exceptionHandler = new Thread.UncaughtExceptionHandler() {
            @Override
            public void uncaughtException(Thread t, Throwable e) {
                running = false;
                System.err.println("thread " + t + " died");
                e.printStackTrace(System.err);
                System.exit(1);
            }
        };
        List<Thread> threads = new ArrayList<>();

        for (int i = 0; i < numUpdaters; i++) {
            UpdateMetadataRequest req = partialUpdate ? partialRequest : fullRequest;

            Runnable updaterRunnable;
            if (updateRateLimit > 0) {
                updaterRunnable = new RateLimitedUpdateRunnable(updateRateLimit, cache, req);
            } else {
                updaterRunnable = new UpdateRunnable(cache, req);
            }
            Thread updaterThread = new Thread(updaterRunnable, "updater-" + i);
            updaterThread.setDaemon(true);
            updaterThread.setUncaughtExceptionHandler(exceptionHandler);
            threads.add(updaterThread);
        }

        for (int i = 0; i < numReaders; i++) {
            ReadRunnable readRunnable = new ReadRunnable(cache, topicsScalaSet);
            Thread readerThread = new Thread(readRunnable, "reader-" + i);
            readerThread.setDaemon(true);
            readerThread.setUncaughtExceptionHandler(exceptionHandler);
            threads.add(readerThread);
        }

        for (Thread t : threads) {
            t.start();
        }

        long prevTime = System.currentTimeMillis();
        long prevUpdates = 0;
        long prevReads = 0;

        long now;
        long updates;
        long reads;

        long timeDiff;
        long updateDiff;
        long readDiff;

        double updateQps;
        double readQps;

        while (running) {
            Thread.sleep(TimeUnit.SECONDS.toMillis(30));
            now = System.currentTimeMillis();
            updates = updateCounter.longValue();
            reads = readCounter.longValue();

            timeDiff = now - prevTime;
            updateDiff = updates - prevUpdates;
            readDiff = reads - prevReads;

            updateQps = ((double) updateDiff * 1000) / timeDiff;
            readQps = ((double) readDiff * 1000) / timeDiff;

            prevTime = now;
            prevUpdates = updates;
            prevReads = reads;

            System.err.println("updates: " + updateQps + " / sec");
            System.err.println("reads: " + readQps + " / sec");
        }
    }

    private UpdateMetadataRequest buildRequest(Random random, int numTopicsOverride) {
        int controllerEpoch = 0;
        int totalPartitions = 0;
        Set<UpdateMetadataRequest.Broker> liveBrokers = new HashSet<>();

        for (int i = 0; i < numBrokers; i++) {
            UpdateMetadataRequest.EndPoint endPoint =
                new UpdateMetadataRequest.EndPoint("host-" + i, 6666, SecurityProtocol.PLAINTEXT, listener);
            UpdateMetadataRequest.Broker broker =
                new UpdateMetadataRequest.Broker(i, Collections.singletonList(endPoint), "rack-" + i);
            liveBrokers.add(broker);
        }

        Map<TopicPartition, UpdateMetadataRequest.PartitionState> partitions = new HashMap<>();

        int topicCount = numTopicsOverride > 0 ? numTopicsOverride : numTopics;

        for (int i = 0; i < topicCount; i++) {
            String topicName = "topic-" + i;
            int numPartitions = 1 + random.nextInt(maxPartitionsPerTopic);
            for (int j = 0; j < numPartitions; j++) {
                TopicPartition tp = new TopicPartition(topicName, j);
                List<Integer> replicas = pick(replicationFactor, numBrokers, random);
                UpdateMetadataRequest.PartitionState state =
                    new UpdateMetadataRequest.PartitionState(controllerEpoch, replicas.get(0), 0, replicas, 0, replicas,
                        Collections.<Integer>emptyList());
                partitions.put(tp, state);
            }
            totalPartitions += numPartitions;
        }

        UpdateMetadataRequest.Builder builder =
            new UpdateMetadataRequest.Builder((short) 4, 0, controllerEpoch, partitions, liveBrokers);

        UpdateMetadataRequest request = builder.build((short) 4);
        System.err.println("request has " + totalPartitions + " TPs total");
        return request;
    }

    private List<Integer> pick(int howMany, int from, Random random) {
        List<Integer> result = new ArrayList<>(howMany);
        while (result.size() < howMany) {
            int chosen = random.nextInt(from); //exclusive
            if (!result.contains(chosen)) {
                result.add(chosen);
            }
        }
        return result;
    }

    private class UpdateRunnable implements Runnable {
        private final MetadataCache cache;
        private final UpdateMetadataRequest request;
        private int counter = 0;

        public UpdateRunnable(MetadataCache cache, UpdateMetadataRequest request) {
            this.cache = cache;
            this.request = request;
        }

        @Override
        public void run() {
            while (running) {
                cache.updateCache(counter++, request);
                updateCounter.incrementAndGet();
            }
        }
    }

    private class RateLimitedUpdateRunnable implements Runnable {
        private final MetadataCache cache;
        private final UpdateMetadataRequest request;
        private int counter = 0;

        private final double targetQps;
        private final int intervalMillis;

        public RateLimitedUpdateRunnable(double targetQps, MetadataCache cache, UpdateMetadataRequest request) {
            this.cache = cache;
            this.request = request;
            this.targetQps = targetQps;
            this.intervalMillis = (int) (1000.0 / targetQps);
        }

        @Override
        public void run() {
            while (running) {
                long start = System.currentTimeMillis();
                cache.updateCache(counter++, request);
                long end = System.currentTimeMillis();
                updateCounter.incrementAndGet();
                long took = end - start;
                long remaining = intervalMillis - took;
                if (remaining > 0) {
                    try {
                        Thread.sleep(remaining);
                    } catch (Exception e) {
                        e.printStackTrace(System.err);
                    }
                }
            }
        }
    }

    private class ReadRunnable implements Runnable {
        private final MetadataCache cache;
        private final scala.collection.mutable.Set<String> topics;

        public ReadRunnable(MetadataCache cache, scala.collection.mutable.Set<String> topics) {
            this.cache = cache;
            this.topics = topics;
        }

        @Override
        public void run() {
            while (running) {
                cache.getTopicMetadata(topics, listener, false);
                readCounter.incrementAndGet();
            }
        }
    }
}
```

the interesting/problematic scenario is a combination of writers and readers,