### PR TITLE
KAFKA-7015: Fixed RecordCollectorImpl exception messages with more human readable context info.

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WrappedStateStore.java
@@ -16,7 +16,11 @@
  */
 package org.apache.kafka.streams.state.internals;
 
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 
@@ -93,6 +97,16 @@ public interface WrappedStateStore extends StateStore {
         @Override
         public StateStore wrappedStore() {
             return innerState;
+        }
+
+        void throwException(final KafkaException exception, final String message) {
+            if (exception instanceof ProducerFencedException) {
+                throw new ProducerFencedException(message);
+            } else if (exception instanceof ProcessorStateException) {
+                throw new ProcessorStateException(message, exception);
+            } else {
+                throw new StreamsException(message, exception);
+            }
         }
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7015
Fixed `RecordCollectorImpl` class to enhance exceptions messages  to human readable format for Key/Value pair.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
