### PR TITLE
KAFKA-7058 [Connect] Comparing schema default values using Objects#deepEquals()

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/data/ConnectSchema.java
@@ -291,7 +291,7 @@ public class ConnectSchema implements Schema {
                 Objects.equals(name, schema.name) &&
                 Objects.equals(doc, schema.doc) &&
                 Objects.equals(type, schema.type) &&
-                Objects.equals(defaultValue, schema.defaultValue) &&
+                Objects.deepEquals(defaultValue, schema.defaultValue) &&
                 Objects.equals(fields, schema.fields) &&
                 Objects.equals(keySchema, schema.keySchema) &&
                 Objects.equals(valueSchema, schema.valueSchema) &&

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/ConnectSchemaTest.java
@@ -269,6 +269,16 @@ public class ConnectSchemaTest {
     }
 
     @Test
+    public void testArrayDefaultValueEquality() {
+        ConnectSchema s1 = new ConnectSchema(Schema.Type.ARRAY, false, new String[] {"a", "b"}, null, null, null, null, null, null, SchemaBuilder.int8().build());
+        ConnectSchema s2 = new ConnectSchema(Schema.Type.ARRAY, false, new String[] {"a", "b"}, null, null, null, null, null, null, SchemaBuilder.int8().build());
+        ConnectSchema differentValueSchema = new ConnectSchema(Schema.Type.ARRAY, false, new String[] {"b", "c"}, null, null, null, null, null, null, SchemaBuilder.int8().build());
+
+        assertEquals(s1, s2);
+        assertNotEquals(s1, differentValueSchema);
+    }
+
+    @Test
     public void testMapEquality() {
         // Same as testArrayEquality, but for both key and value schemas
         ConnectSchema s1 = new ConnectSchema(Schema.Type.MAP, false, null, null, null, null, null, null, SchemaBuilder.int8().build(), SchemaBuilder.int16().build());


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7058
* Summary of testing strategy: Added new unit test

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
