### PR TITLE
KAFKA-7059 Offer new constructor on ProducerRecord

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerRecord.java
@@ -107,7 +107,19 @@ public class ProducerRecord<K, V> {
     public ProducerRecord(String topic, Integer partition, K key, V value, Iterable<Header> headers) {
         this(topic, partition, null, key, value, headers);
     }
-    
+
+    /**
+     * Creates a record to be sent to a specified topic and partition
+     *
+     * @param topic The topic the record will be appended to
+     * @param key The key that will be included in the record
+     * @param value The record contents
+     * @param headers The headers that will be included in the record
+     */
+    public ProducerRecord(String topic, K key, V value, Iterable<Header> headers) {
+        this(topic, null, null, key, value, headers);
+    }
+
     /**
      * Creates a record to be sent to a specified topic and partition
      *


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <matzew@apache.org>

Done for https://issues.apache.org/jira/browse/KAFKA-7059 

When developers are creating a ProducerRecord, with custom headers, it currently requires the usage of a constructor with a slightly longer arguments list.

This is OK, but it would be handy or more convenient if there was a ctor, like:

```java
public ProducerRecord(String topic, K key, V value, Iterable<Header> headers)
```

