### PR TITLE
KAFKA-7060: Add override arguments to ConnectDistributed command line

### DIFF
--- a/bin/connect-distributed.sh
+++ b/bin/connect-distributed.sh
@@ -16,7 +16,7 @@
 
 if [ $# -lt 1 ];
 then
-        echo "USAGE: $0 [-daemon] connect-distributed.properties"
+        echo "USAGE: $0 [-daemon] connect-distributed.properties [--override property=value]*"
         exit 1
 fi
 

--- a/checkstyle/import-control.xml
+++ b/checkstyle/import-control.xml
@@ -345,6 +345,7 @@
       <allow pkg="org.apache.kafka.connect.storage" />
       <allow pkg="org.apache.kafka.connect.util" />
       <allow pkg="org.apache.kafka.common" />
+      <allow pkg="net.sourceforge.argparse4j" />
     </subpackage>
 
     <subpackage name="storage">

--- a/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/Utils.java
@@ -28,6 +28,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -516,6 +517,16 @@ public final class Utils {
             System.out.println("Did not load any properties since the property file is not specified");
         }
 
+        return props;
+    }
+
+    /**
+     * Convert a list of key=value strings into a Properties object.
+     */
+    public static Properties loadPropOverrides(List<String> overrides) throws IOException {
+        Properties props = new Properties();
+        String overridesStr = join(overrides, System.lineSeparator());
+        props.load(new StringReader(overridesStr));
         return props;
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/utils/UtilsTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Properties;
 import java.util.Random;
 
 import static org.apache.kafka.common.utils.Utils.formatAddress;
@@ -94,6 +95,16 @@ public class UtilsTest {
         assertEquals("", Utils.join(Collections.emptyList(), ","));
         assertEquals("1", Utils.join(Arrays.asList("1"), ","));
         assertEquals("1,2,3", Utils.join(Arrays.asList(1, 2, 3), ","));
+    }
+
+    @Test
+    public void testLoadPropOverrides() throws IOException {
+        assertEquals(Collections.emptyMap(), Utils.loadPropOverrides(Collections.<String>emptyList()));
+
+        Properties props = new Properties();
+        props.setProperty("key1", "val12");
+        props.setProperty("key2", "val21");
+        assertEquals(props, Utils.loadPropOverrides(Arrays.asList(new String[] {"key1=val11", "key2=val21", "key1=val12"})));
     }
     
     @Test


### PR DESCRIPTION
Allow ConnectDistributed to accept an unlimited number of --override key=value command-line arguments.

This is an implementation of KIP-316.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
