### PR TITLE
KAFKA-7066 added better logging in case of Serialisation issue

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -169,7 +169,7 @@ public final class StateSerdes<K, V> {
         try {
             return keySerde.serializer().serialize(topic, key);
         } catch (final ClassCastException e) {
-            final String keyClass = key.getClass().getName();
+            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
             throw new StreamsException(
                     String.format("A serializer (key: %s) is not compatible to the actual key type " +
                                     "(key type: %s). Change the default Serdes in StreamConfig or " +
@@ -190,7 +190,7 @@ public final class StateSerdes<K, V> {
         try {
             return valueSerde.serializer().serialize(topic, value);
         } catch (final ClassCastException e) {
-            final String valueClass = value.getClass().getName();
+            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
             throw new StreamsException(
                     String.format("A serializer (value: %s) is not compatible to the actual value type " +
                                     "(value type: %s). Change the default Serdes in StreamConfig or " +

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -168,8 +168,7 @@ public final class StateSerdes<K, V> {
     public byte[] rawKey(K key) {
         try {
             return keySerde.serializer().serialize(topic, key);
-        }
-        catch (final ClassCastException e) {
+        } catch (final ClassCastException e) {
             final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
             throw new StreamsException(
                     String.format("A serializer (key: %s) is not compatible to the actual key type " +

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -169,7 +169,7 @@ public final class StateSerdes<K, V> {
         try {
             return keySerde.serializer().serialize(topic, key);
         } catch (final ClassCastException e) {
-            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
+            final String keyClass = key.getClass().getName();
             throw new StreamsException(
                     String.format("A serializer (key: %s) is not compatible to the actual key type " +
                                     "(key type: %s). Change the default Serdes in StreamConfig or " +
@@ -190,7 +190,7 @@ public final class StateSerdes<K, V> {
         try {
             return valueSerde.serializer().serialize(topic, value);
         } catch (final ClassCastException e) {
-            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            final String valueClass = value.getClass().getName();
             throw new StreamsException(
                     String.format("A serializer (value: %s) is not compatible to the actual value type " +
                                     "(value type: %s). Change the default Serdes in StreamConfig or " +

--- a/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/StateSerdes.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.errors.StreamsException;
 
 import java.util.Objects;
 
@@ -165,7 +166,19 @@ public final class StateSerdes<K, V> {
      * @return     the serialized key
      */
     public byte[] rawKey(K key) {
-        return keySerde.serializer().serialize(topic, key);
+        try {
+            return keySerde.serializer().serialize(topic, key);
+        }
+        catch (final ClassCastException e) {
+            final String keyClass = key == null ? "unknown because key is null" : key.getClass().getName();
+            throw new StreamsException(
+                    String.format("A serializer (key: %s) is not compatible to the actual key type " +
+                                    "(key type: %s). Change the default Serdes in StreamConfig or " +
+                                    "provide correct Serdes via method parameters.",
+                            keySerializer().getClass().getName(),
+                            keyClass),
+                    e);
+        }
     }
 
     /**
@@ -175,6 +188,17 @@ public final class StateSerdes<K, V> {
      * @return       the serialized value
      */
     public byte[] rawValue(V value) {
-        return valueSerde.serializer().serialize(topic, value);
+        try {
+            return valueSerde.serializer().serialize(topic, value);
+        } catch (final ClassCastException e) {
+            final String valueClass = value == null ? "unknown because value is null" : value.getClass().getName();
+            throw new StreamsException(
+                    String.format("A serializer (value: %s) is not compatible to the actual value type " +
+                                    "(value type: %s). Change the default Serdes in StreamConfig or " +
+                                    "provide correct Serdes via method parameters.",
+                            valueSerializer().getClass().getName(),
+                            valueClass),
+                    e);
+        }
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StateSerdesTest.java
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.errors.StreamsException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -84,6 +85,22 @@ public class StateSerdesTest {
     @Test(expected = NullPointerException.class)
     public void shouldThrowIfValueClassIsNull() {
         new StateSerdes<>("anyName", Serdes.ByteArray(), null);
+    }
+
+    @Test(expected = StreamsException.class)
+    public void shouldThrowIfIncompatibleSerdeForValue() throws ClassNotFoundException {
+        Class myClass = Class.forName("java.lang.String");
+        StateSerdes<Object, Object> stateSerdes = new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
+        Integer myInt = 123;
+        stateSerdes.rawValue(myInt);
+    }
+
+    @Test(expected = StreamsException.class)
+    public void shouldThrowIfIncompatibleSerdeForKey() throws ClassNotFoundException {
+        Class myClass = Class.forName("java.lang.String");
+        StateSerdes<Object, Object> stateSerdes = new StateSerdes<Object, Object>("anyName", Serdes.serdeFrom(myClass), Serdes.serdeFrom(myClass));
+        Integer myInt = 123;
+        stateSerdes.rawKey(myInt);
     }
 
 }


### PR DESCRIPTION
Following the error message of: https://github.com/apache/kafka/blob/trunk/streams/src/main/java/org/apache/kafka/streams/processor/internals/SinkNode.java#L93

Would be good if included in 2.0