### PR TITLE
KAFKA-7068 : KIP-297 : Handle null config values during transform

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/ConfigTransformer.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/ConfigTransformer.java
@@ -77,11 +77,13 @@ public class ConfigTransformer {
 
         // Collect the variables from the given configs that need transformation
         for (Map.Entry<String, String> config : configs.entrySet()) {
-            List<ConfigVariable> vars = getVars(config.getKey(), config.getValue(), DEFAULT_PATTERN);
-            for (ConfigVariable var : vars) {
-                Map<String, Set<String>> keysByPath = keysByProvider.computeIfAbsent(var.providerName, k -> new HashMap<>());
-                Set<String> keys = keysByPath.computeIfAbsent(var.path, k -> new HashSet<>());
-                keys.add(var.variable);
+            if (config.getValue() != null) {
+                List<ConfigVariable> vars = getVars(config.getKey(), config.getValue(), DEFAULT_PATTERN);
+                for (ConfigVariable var : vars) {
+                    Map<String, Set<String>> keysByPath = keysByProvider.computeIfAbsent(var.providerName, k -> new HashMap<>());
+                    Set<String> keys = keysByPath.computeIfAbsent(var.path, k -> new HashSet<>());
+                    keys.add(var.variable);
+                }
             }
         }
 
@@ -128,6 +130,9 @@ public class ConfigTransformer {
     private static String replace(Map<String, Map<String, Map<String, String>>> lookupsByProvider,
                                   String value,
                                   Pattern pattern) {
+        if (value == null) {
+            return null;
+        }
         Matcher matcher = pattern.matcher(value);
         StringBuilder builder = new StringBuilder();
         int i = 0;

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
@@ -24,8 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ConfigTransformerTest {

--- a/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/config/ConfigTransformerTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -36,6 +37,7 @@ public class ConfigTransformerTest {
     public static final String TEST_PATH = "testPath";
     public static final String TEST_RESULT = "testResult";
     public static final String TEST_RESULT_WITH_TTL = "testResultWithTTL";
+    public static final String TEST_RESULT_NO_PATH = "testResultNoPath";
 
     private ConfigTransformer configTransformer;
 
@@ -83,6 +85,24 @@ public class ConfigTransformerTest {
         assertEquals("${test:testPath:testResult}", data.get(MY_KEY));
     }
 
+    @Test
+    public void testReplaceVariableNoPath() throws Exception {
+        ConfigTransformerResult result = configTransformer.transform(Collections.singletonMap(MY_KEY, "${test:testKey}"));
+        Map<String, String> data = result.data();
+        Map<String, Long> ttls = result.ttls();
+        assertEquals(TEST_RESULT_NO_PATH, data.get(MY_KEY));
+        assertTrue(ttls.isEmpty());
+    }
+
+    @Test
+    public void testNullConfigValue() throws Exception {
+        ConfigTransformerResult result = configTransformer.transform(Collections.singletonMap(MY_KEY, null));
+        Map<String, String> data = result.data();
+        Map<String, Long> ttls = result.ttls();
+        assertNull(data.get(MY_KEY));
+        assertTrue(ttls.isEmpty());
+    }
+
     public static class TestConfigProvider implements ConfigProvider {
 
         public void configure(Map<String, ?> configs) {
@@ -95,7 +115,7 @@ public class ConfigTransformerTest {
         public ConfigData get(String path, Set<String> keys) {
             Map<String, String> data = new HashMap<>();
             Long ttl = null;
-            if (path.equals(TEST_PATH)) {
+            if (TEST_PATH.equals(path)) {
                 if (keys.contains(TEST_KEY)) {
                     data.put(TEST_KEY, TEST_RESULT);
                 }
@@ -105,6 +125,10 @@ public class ConfigTransformerTest {
                 }
                 if (keys.contains(TEST_INDIRECTION)) {
                     data.put(TEST_INDIRECTION, "${test:testPath:testResult}");
+                }
+            } else {
+                if (keys.contains(TEST_KEY)) {
+                    data.put(TEST_KEY, TEST_RESULT_NO_PATH);
                 }
             }
             return new ConfigData(data, ttl);


### PR DESCRIPTION
Fix NPE when processing null config values during transform.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
