### PR TITLE
MINOR: Avoid using a big lock in pool#getAndMaybePut

### DIFF
--- a/core/src/main/scala/kafka/utils/Pool.scala
+++ b/core/src/main/scala/kafka/utils/Pool.scala
@@ -27,7 +27,6 @@ import collection.JavaConverters._
 class Pool[K,V](valueFactory: Option[K => V] = None) extends Iterable[(K, V)] {
 
   private val pool: ConcurrentMap[K, V] = new ConcurrentHashMap[K, V]
-  private val createLock = new Object
   
   def put(k: K, v: V): V = pool.put(k, v)
   
@@ -57,21 +56,10 @@ class Pool[K,V](valueFactory: Option[K => V] = None) extends Iterable[(K, V)] {
     * @param createValue Factory function.
     * @return The final value associated with the key.
     */
-  def getAndMaybePut(key: K, createValue: => V): V = {
-    val current = pool.get(key)
-    if (current == null) {
-      createLock synchronized {
-        val current = pool.get(key)
-        if (current == null) {
-          val value = createValue
-          pool.put(key, value)
-          value
-        }
-        else current
-      }
-    }
-    else current
-  }
+  def getAndMaybePut(key: K, createValue: => V): V =
+    pool.computeIfAbsent(key, new java.util.function.Function[K,V] {
+        override def apply(k:K):V = createValue
+      })
 
   def contains(id: K): Boolean = pool.containsKey(id)
   

--- a/core/src/main/scala/kafka/utils/Pool.scala
+++ b/core/src/main/scala/kafka/utils/Pool.scala
@@ -57,9 +57,9 @@ class Pool[K,V](valueFactory: Option[K => V] = None) extends Iterable[(K, V)] {
     * @return The final value associated with the key.
     */
   def getAndMaybePut(key: K, createValue: => V): V =
-    pool.computeIfAbsent(key, new java.util.function.Function[K,V] {
-        override def apply(k:K): V = createValue
-      })
+    pool.computeIfAbsent(key, new java.util.function.Function[K, V] {
+      override def apply(k: K): V = createValue
+    })
 
   def contains(id: K): Boolean = pool.containsKey(id)
   

--- a/core/src/main/scala/kafka/utils/Pool.scala
+++ b/core/src/main/scala/kafka/utils/Pool.scala
@@ -58,7 +58,7 @@ class Pool[K,V](valueFactory: Option[K => V] = None) extends Iterable[(K, V)] {
     */
   def getAndMaybePut(key: K, createValue: => V): V =
     pool.computeIfAbsent(key, new java.util.function.Function[K,V] {
-        override def apply(k:K):V = createValue
+        override def apply(k:K): V = createValue
       })
 
   def contains(id: K): Boolean = pool.containsKey(id)


### PR DESCRIPTION
Avoid using a big createLock in pool#getAndMaybePut by using the
ConcurrentHashMap#computeIfAbsent function.