### PR TITLE
MINOR: Upgrade to Gradle 4.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "3.2.1"
+  gradleVersion = "4.8.1"
   buildVersionFileName = "kafka-version.properties"
 
   maxPermSizeArgs = []


### PR DESCRIPTION
Maven Central dropped support for all versions but
TLS 1.2, so dependency resolution fails if Gradle
builds run with JDK 7. 2.0 and trunk require JDK 8,
but every other version is affected. Gradle 4.8.1
fixes the issue by enabling TLS 1.2 by default even
when JDK 7 is used.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
