### PR TITLE
KAFKA-7103: Use bulkloading for RocksDBSegmentedBytesStore during init

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -201,7 +201,11 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
                 // will only close the database and open it again with bulk loading enabled.
                 if (!bulkLoadSegments.contains(segment)) {
                     segment.toggleDbForBulkLoading(true);
-                    bulkLoadSegments.add(segment);
+                    // If the store does not exist yet, the getOrCreateSegmentIfLive will call openDB that
+                    // makes the open flag for the newly created store.
+                    // if the store does exist already, then toggleDbForBulkLoading will make sure that
+                    // the store is already open here.
+                    bulkLoadSegments = new HashSet<>(segments.allSegments());
                 }
                 final WriteBatch batch = writeBatchMap.computeIfAbsent(segment, s -> new WriteBatch());
                 if (record.value == null) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -174,7 +174,7 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
     void restoreAllInternal(final Collection<KeyValue<byte[], byte[]>> records) {
         try {
             final Map<Segment, WriteBatch> writeBatchMap = getWriteBatches(records);
-            for (Map.Entry<Segment, WriteBatch> entry: writeBatchMap.entrySet()) {
+            for (final Map.Entry<Segment, WriteBatch> entry : writeBatchMap.entrySet()) {
                 final Segment segment = entry.getKey();
                 final WriteBatch batch = entry.getValue();
                 segment.write(batch);

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -191,10 +191,7 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
             final long segmentId = segments.segmentId(keySchema.segmentTimestamp(Bytes.wrap(record.key)));
             final Segment segment = segments.getOrCreateSegmentIfLive(segmentId, context);
             if (segment != null) {
-                if (!writeBatchMap.containsKey(segment)) {
-                    writeBatchMap.put(segment, new WriteBatch());
-                }
-                final WriteBatch batch = writeBatchMap.get(segment);
+                final WriteBatch batch = writeBatchMap.computeIfAbsent(segment, s -> new WriteBatch());
                 if (record.value == null) {
                     batch.remove(record.key);
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -173,10 +173,10 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
     // Visible for testing
     void restoreAllInternal(final Collection<KeyValue<byte[], byte[]>> records) {
         try {
-            Map<Segment, WriteBatch> writeBatchMap = getWriteBatches(records);
+            final Map<Segment, WriteBatch> writeBatchMap = getWriteBatches(records);
             for (Map.Entry<Segment, WriteBatch> entry: writeBatchMap.entrySet()) {
-                Segment segment = entry.getKey();
-                WriteBatch batch = entry.getValue();
+                final Segment segment = entry.getKey();
+                final WriteBatch batch = entry.getValue();
                 segment.write(batch);
             }
         } catch (final RocksDBException e) {
@@ -186,15 +186,12 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
 
     // Visible for testing
     Map<Segment, WriteBatch> getWriteBatches(final Collection<KeyValue<byte[], byte[]>> records) {
-        Map<Segment, WriteBatch> writeBatchMap = new HashMap<>();
+        final Map<Segment, WriteBatch> writeBatchMap = new HashMap<>();
         for (final KeyValue<byte[], byte[]> record : records) {
             final long segmentId = segments.segmentId(keySchema.segmentTimestamp(Bytes.wrap(record.key)));
             final Segment segment = segments.getOrCreateSegmentIfLive(segmentId, context);
             if (segment != null) {
-                if (!writeBatchMap.containsKey(segment)) {
-                    writeBatchMap.put(segment, new WriteBatch());
-                }
-                WriteBatch batch = writeBatchMap.get(segment);
+                final WriteBatch batch = writeBatchMap.getOrDefault(segment, new WriteBatch());
                 if (record.value == null) {
                     batch.remove(record.key);
                 } else {
@@ -206,12 +203,12 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
     }
 
     private void toggleForBulkLoading(final boolean prepareForBulkload) {
-        for (Segment segment: segments.allSegments()) {
+        for (final Segment segment: segments.allSegments()) {
             segment.toggleDbForBulkLoading(prepareForBulkload);
         }
     }
 
-    class RocksDBSegmentsBatchingRestoreCallback extends AbstractNotifyingBatchingRestoreCallback {
+    private class RocksDBSegmentsBatchingRestoreCallback extends AbstractNotifyingBatchingRestoreCallback {
 
         @Override
         public void restoreAll(final Collection<KeyValue<byte[], byte[]>> records) {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -205,7 +205,7 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
         return writeBatchMap;
     }
 
-    private void toggleForBulkLoaidng(final boolean prepareForBulkload) {
+    private void toggleForBulkLoading(final boolean prepareForBulkload) {
         for (Segment segment: segments.allSegments()) {
             segment.toggleDbForBulkLoading(prepareForBulkload);
         }
@@ -223,14 +223,14 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
                                    final String storeName,
                                    final long startingOffset,
                                    final long endingOffset) {
-            toggleForBulkLoaidng(true);
+            toggleForBulkLoading(true);
         }
 
         @Override
         public void onRestoreEnd(final TopicPartition topicPartition,
                                  final String storeName,
                                  final long totalRestored) {
-            toggleForBulkLoaidng(false);
+            toggleForBulkLoading(false);
         }
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -207,11 +207,15 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
                     // the store is already open here.
                     bulkLoadSegments = new HashSet<>(segments.allSegments());
                 }
-                final WriteBatch batch = writeBatchMap.computeIfAbsent(segment, s -> new WriteBatch());
-                if (record.value == null) {
-                    batch.remove(record.key);
-                } else {
-                    batch.put(record.key, record.value);
+                try {
+                    final WriteBatch batch = writeBatchMap.computeIfAbsent(segment, s -> new WriteBatch());
+                    if (record.value == null) {
+                        batch.remove(record.key);
+                    } else {
+                        batch.put(record.key, record.value);
+                    }
+                } catch (final RocksDBException e) {
+                    throw new ProcessorStateException("Error restoring batch to store " + this.name, e);
                 }
             }
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -191,7 +191,10 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
             final long segmentId = segments.segmentId(keySchema.segmentTimestamp(Bytes.wrap(record.key)));
             final Segment segment = segments.getOrCreateSegmentIfLive(segmentId, context);
             if (segment != null) {
-                final WriteBatch batch = writeBatchMap.getOrDefault(segment, new WriteBatch());
+                if (!writeBatchMap.containsKey(segment)) {
+                    writeBatchMap.put(segment, new WriteBatch());
+                }
+                final WriteBatch batch = writeBatchMap.get(segment);
                 if (record.value == null) {
                     batch.remove(record.key);
                 } else {

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -90,7 +90,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
     private FlushOptions fOptions;
 
     private volatile boolean prepareForBulkload = false;
-    private ProcessorContext internalProcessorContext;
+    protected ProcessorContext internalProcessorContext;
     // visible for testing
     volatile BatchingStateRestoreCallback batchingStateRestoreCallback = null;
 
@@ -230,7 +230,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         }
     }
 
-    private void toggleDbForBulkLoading(final boolean prepareForBulkload) {
+    protected void toggleDbForBulkLoading(final boolean prepareForBulkload) {
 
         if (prepareForBulkload) {
             // if the store is not empty, we need to compact to get around the num.levels check
@@ -276,7 +276,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         return originalValue;
     }
 
-    private void restoreAllInternal(final Collection<KeyValue<byte[], byte[]>> records) {
+    void restoreAllInternal(final Collection<KeyValue<byte[], byte[]>> records) {
         try (final WriteBatch batch = new WriteBatch()) {
             for (final KeyValue<byte[], byte[]> record : records) {
                 if (record.value == null) {
@@ -285,7 +285,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
                     batch.put(record.key, record.value);
                 }
             }
-            db.write(wOptions, batch);
+            write(batch);
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error restoring batch to store " + this.name, e);
         }
@@ -310,6 +310,10 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         }
     }
 
+    protected void write(final WriteBatch batch) throws RocksDBException {
+        db.write(wOptions, batch);
+    }
+
     @Override
     public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
         try (final WriteBatch batch = new WriteBatch()) {
@@ -321,7 +325,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
                     batch.put(entry.key.get(), entry.value);
                 }
             }
-            db.write(wOptions, batch);
+            write(batch);
         } catch (final RocksDBException e) {
             throw new ProcessorStateException("Error while batch writing to store " + this.name, e);
         }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -90,7 +90,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
     private FlushOptions fOptions;
 
     private volatile boolean prepareForBulkload = false;
-    protected ProcessorContext internalProcessorContext;
+    ProcessorContext internalProcessorContext;
     // visible for testing
     volatile BatchingStateRestoreCallback batchingStateRestoreCallback = null;
 
@@ -230,7 +230,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         }
     }
 
-    protected void toggleDbForBulkLoading(final boolean prepareForBulkload) {
+    void toggleDbForBulkLoading(final boolean prepareForBulkload) {
 
         if (prepareForBulkload) {
             // if the store is not empty, we need to compact to get around the num.levels check
@@ -310,7 +310,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         }
     }
 
-    protected void write(final WriteBatch batch) throws RocksDBException {
+    void write(final WriteBatch batch) throws RocksDBException {
         db.write(wOptions, batch);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -39,10 +39,12 @@ class Segment extends RocksDBStore implements Comparable<Segment> {
         return Long.compare(id, segment.id);
     }
 
+
     @Override
     public void openDB(final ProcessorContext context) {
         super.openDB(context);
         // skip the registering step
+        this.internalProcessorContext = context;
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/Segment.java
@@ -44,7 +44,7 @@ class Segment extends RocksDBStore implements Comparable<Segment> {
     public void openDB(final ProcessorContext context) {
         super.openDB(context);
         // skip the registering step
-        this.internalProcessorContext = context;
+        internalProcessorContext = context;
     }
 
     @Override

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.internals.MockStreamsMetrics;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.StateSerdes;
@@ -32,12 +33,14 @@ import org.apache.kafka.test.InternalMockProcessorContext;
 import org.apache.kafka.test.NoOpRecordCollector;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.Parameter;
+import org.rocksdb.WriteBatch;
 
 import static org.apache.kafka.streams.state.internals.WindowKeySchema.timeWindowForSize;
 
@@ -46,10 +49,12 @@ import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.SimpleTimeZone;
 
@@ -289,6 +294,56 @@ public class RocksDBSegmentedBytesStoreTest {
         bytesStore.close();
         bytesStore.init(context, bytesStore);
         bytesStore.put(serializeKey(new Windowed<>(key, windows[1])), serializeValue(100));
+    }
+
+    @Test
+    public void shouldCreateWriteBatches() {
+        final String key = "a";
+        final Collection<KeyValue<byte[], byte[]>> records = new ArrayList<>();
+        records.add(new KeyValue<>(serializeKey(new Windowed<>(key, windows[0])).get(), serializeValue(50L)));
+        records.add(new KeyValue<>(serializeKey(new Windowed<>(key, windows[3])).get(), serializeValue(100L)));
+        Map<Segment, WriteBatch> writeBatchMap = bytesStore.getWriteBatches(records);
+        assertEquals(2, writeBatchMap.size());
+        for (WriteBatch batch: writeBatchMap.values()) {
+            assertEquals(1, batch.count());
+        }
+    }
+
+    @Test
+    public void shouldRestoreToByteStore() {
+        final String key = "a";
+        final Collection<KeyValue<byte[], byte[]>> records = new ArrayList<>();
+        records.add(new KeyValue<>(serializeKey(new Windowed<>(key, windows[0])).get(), serializeValue(50L)));
+        records.add(new KeyValue<>(serializeKey(new Windowed<>(key, windows[3])).get(), serializeValue(100L)));
+        bytesStore.restoreAllInternal(records);
+
+        final List<KeyValue<Windowed<String>, Long>> expected = new ArrayList<>();
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[0]), 50L));
+        expected.add(new KeyValue<>(new Windowed<>(key, windows[3]), 100L));
+
+        final List<KeyValue<Windowed<String>, Long>> results = toList(bytesStore.all());
+        assertEquals(expected, results);
+    }
+
+    @Test
+    public void shouldRespectBulkloadOptionsDuringInit() {
+        bytesStore.init(context, bytesStore);
+        final String key = "a";
+        bytesStore.put(serializeKey(new Windowed<>(key, windows[0])), serializeValue(50));
+        assertEquals(1, bytesStore.getSegments().size());
+
+        StateRestoreListener restoreListener = context.getRestoreListener(bytesStore.name());
+
+        restoreListener.onRestoreStart(null, bytesStore.name(), 0L, 0L);
+
+        for (Segment segment: bytesStore.getSegments()) {
+            Assert.assertThat(segment.getOptions().level0FileNumCompactionTrigger(), equalTo(1 << 30));
+        }
+
+        restoreListener.onRestoreEnd(null, bytesStore.name(), 0L);
+        for (Segment segment: bytesStore.getSegments()) {
+            Assert.assertThat(segment.getOptions().level0FileNumCompactionTrigger(), equalTo(4));
+        }
     }
 
     private Set<String> segmentDirs() {

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
@@ -302,9 +302,9 @@ public class RocksDBSegmentedBytesStoreTest {
         final Collection<KeyValue<byte[], byte[]>> records = new ArrayList<>();
         records.add(new KeyValue<>(serializeKey(new Windowed<>(key, windows[0])).get(), serializeValue(50L)));
         records.add(new KeyValue<>(serializeKey(new Windowed<>(key, windows[3])).get(), serializeValue(100L)));
-        Map<Segment, WriteBatch> writeBatchMap = bytesStore.getWriteBatches(records);
+        final Map<Segment, WriteBatch> writeBatchMap = bytesStore.getWriteBatches(records);
         assertEquals(2, writeBatchMap.size());
-        for (WriteBatch batch: writeBatchMap.values()) {
+        for (final WriteBatch batch: writeBatchMap.values()) {
             assertEquals(1, batch.count());
         }
     }

--- a/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStoreTest.java
@@ -329,19 +329,20 @@ public class RocksDBSegmentedBytesStoreTest {
     public void shouldRespectBulkloadOptionsDuringInit() {
         bytesStore.init(context, bytesStore);
         final String key = "a";
-        bytesStore.put(serializeKey(new Windowed<>(key, windows[0])), serializeValue(50));
-        assertEquals(1, bytesStore.getSegments().size());
+        bytesStore.put(serializeKey(new Windowed<>(key, windows[0])), serializeValue(50L));
+        bytesStore.put(serializeKey(new Windowed<>(key, windows[3])), serializeValue(100L));
+        assertEquals(2, bytesStore.getSegments().size());
 
-        StateRestoreListener restoreListener = context.getRestoreListener(bytesStore.name());
+        final StateRestoreListener restoreListener = context.getRestoreListener(bytesStore.name());
 
         restoreListener.onRestoreStart(null, bytesStore.name(), 0L, 0L);
 
-        for (Segment segment: bytesStore.getSegments()) {
+        for (final Segment segment: bytesStore.getSegments()) {
             Assert.assertThat(segment.getOptions().level0FileNumCompactionTrigger(), equalTo(1 << 30));
         }
 
         restoreListener.onRestoreEnd(null, bytesStore.name(), 0L);
-        for (Segment segment: bytesStore.getSegments()) {
+        for (final Segment segment: bytesStore.getSegments()) {
             Assert.assertThat(segment.getOptions().level0FileNumCompactionTrigger(), equalTo(4));
         }
     }


### PR DESCRIPTION
This PR uses bulk loading for recovering RocksDBWindowStore, same as RocksDBStore. Will perform unit test and integration test. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
