### PR TITLE
MINOR: Add exception.toString for error log formatting

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -110,7 +110,7 @@ public class RecordCollectorImpl implements RecordCollector {
                             if (sendException == null) {
                                 log.error("Error sending record (key {} value {} timestamp {}) to topic {} due to {}; " +
                                                 "No more records will be sent and no more offsets will be recorded for this task.",
-                                        key, value, timestamp, topic, exception);
+                                        key, value, timestamp, topic, exception.toString());
                                 if (exception instanceof ProducerFencedException) {
                                     sendException = new ProducerFencedException(String.format("%sAbort sending since producer got fenced with a previous record (key %s value %s timestamp %d) to topic %s, error message: %s",
                                             logPrefix, key, value, timestamp, topic, exception.getMessage()));


### PR DESCRIPTION
Update to use `exception.toString()` as a parameter for `log.error` as in log4j impl, if the passed in parameter is an Exception and it is the last parameter, it is not considered as the parameter of the forming string.  (thanks to @guozhangwang for that)

There will also be a corresponding PR coming for 1.1

Testing strategy - ran current tests.
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
