### PR TITLE
Minor: add exception to debug log for Sender#maybeSendTransactionalRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -364,7 +364,7 @@ public class Sender implements Runnable {
                 }
             } catch (IOException e) {
                 log.debug("Disconnect from {} while trying to send request {}. Going " +
-                        "to back off and retry. Encountered {}", targetNode, requestBuilder, e);
+                        "to back off and retry.", targetNode, requestBuilder, e);
                 if (nextRequestHandler.needsCoordinator()) {
                     // We break here so that we pick up the FindCoordinator request immediately.
                     transactionManager.lookupCoordinator(nextRequestHandler);
@@ -449,7 +449,7 @@ public class Sender implements Runnable {
                 transactionManager.transitionToFatalError(e);
                 break;
             } catch (IOException e) {
-                log.debug("Broker {} disconnected while awaiting InitProducerId response: {}", node, e);
+                log.debug("Broker {} disconnected while awaiting InitProducerId response", node, e);
             }
             log.trace("Retry InitProducerIdRequest in {}ms.", retryBackoffMs);
             time.sleep(retryBackoffMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -423,8 +423,9 @@ public class Sender implements Runnable {
 
     private void maybeWaitForProducerId() {
         while (!transactionManager.hasProducerId() && !transactionManager.hasError()) {
+            Node node = null;
             try {
-                Node node = awaitLeastLoadedNodeReady(requestTimeoutMs);
+                node = awaitLeastLoadedNodeReady(requestTimeoutMs);
                 if (node != null) {
                     ClientResponse response = sendAndAwaitInitProducerIdRequest(node);
                     InitProducerIdResponse initProducerIdResponse = (InitProducerIdResponse) response.responseBody();
@@ -448,7 +449,7 @@ public class Sender implements Runnable {
                 transactionManager.transitionToFatalError(e);
                 break;
             } catch (IOException e) {
-                log.debug("Broker disconnected while awaiting InitProducerId response: {}", e);
+                log.debug("Broker {} disconnected while awaiting InitProducerId response: {}", node, e);
             }
             log.trace("Retry InitProducerIdRequest in {}ms.", retryBackoffMs);
             time.sleep(retryBackoffMs);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -364,7 +364,7 @@ public class Sender implements Runnable {
                 }
             } catch (IOException e) {
                 log.debug("Disconnect from {} while trying to send request {}. Going " +
-                        "to back off and retry", targetNode, requestBuilder);
+                        "to back off and retry. Encountered {}", targetNode, requestBuilder, e);
                 if (nextRequestHandler.needsCoordinator()) {
                     // We break here so that we pick up the FindCoordinator request immediately.
                     transactionManager.lookupCoordinator(nextRequestHandler);

--- a/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java
@@ -448,7 +448,7 @@ public class Sender implements Runnable {
                 transactionManager.transitionToFatalError(e);
                 break;
             } catch (IOException e) {
-                log.debug("Broker {} disconnected while awaiting InitProducerId response", e);
+                log.debug("Broker disconnected while awaiting InitProducerId response: {}", e);
             }
             log.trace("Retry InitProducerIdRequest in {}ms.", retryBackoffMs);
             time.sleep(retryBackoffMs);


### PR DESCRIPTION
When looking at code related to RequestHandler (for KAFKA-7088), I found that the exception was not included in DEBUG log for Sender#maybeSendTransactionalRequest

This PR includes the exception in DEBUG log.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
