### PR TITLE
KAFKA-6966: Extend TopologyDescription.Sink to return TopicNameExtractor

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -90,6 +90,14 @@
         We have also removed some public APIs that are deprecated prior to 1.0.x in 2.0.0.
         See below for a detailed list of removed APIs.
     </p>
+    <h3><a id="streams_api_changes_210" href="#streams_api_changes_210">Streams API changes in 2.1.0</a></h3>
+    <p>
+        We updated <code>TopologyDescription</code> API to allow for better runtime checking.
+        Users are encouraged to use <code>#topicSet()</code> and <code>#topicPattern()</code> accordingly on <code>TopologyDescription.Source</code> nodes,
+        instead of using <code>#topics()</code>, which has since been deprecated. Similarly, use <code>#topic()</code> and <code>#topicNameExtractor()</code>
+        to get descriptions of <code>TopologyDescription.Sink</code> nodes. For more details, see
+        <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-321%3A+Update+TopologyDescription+to+better+represent+Source+and+Sink+Nodes">KIP-321</a>.
+    </p>
 
     <h3><a id="streams_api_changes_200" href="#streams_api_changes_200">Streams API changes in 2.0.0</a></h3>
     <p>

--- a/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TopologyDescription.java
@@ -16,9 +16,11 @@
  */
 package org.apache.kafka.streams;
 
+import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.internals.StreamTask;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * A meta representation of a {@link Topology topology}.
@@ -113,8 +115,22 @@ public interface TopologyDescription {
         /**
          * The topic names this source node is reading from.
          * @return comma separated list of topic names or pattern (as String)
+         * @deprecated use {@link #topicSet()} or {@link #topicPattern()} instead
          */
+        @Deprecated
         String topics();
+
+        /**
+         * The topic names this source node is reading from.
+         * @return a set of topic names
+         */
+        Set<String> topicSet();
+
+        /**
+         * The pattern used to match topic names that is reading from.
+         * @return the pattern used to match topic names
+         */
+        Pattern topicPattern();
     }
 
     /**
@@ -134,10 +150,17 @@ public interface TopologyDescription {
     interface Sink extends Node {
         /**
          * The topic name this sink node is writing to.
-         * Could be null if the topic name can only be dynamically determined based on {@code TopicNameExtractor}
+         * Could be {@code null} if the topic name can only be dynamically determined based on {@link TopicNameExtractor}
          * @return a topic name
          */
         String topic();
+
+        /**
+         * The {@link TopicNameExtractor} class that this sink node uses to dynamically extract the topic name to write to.
+         * Could be {@code null} if the topic name is not dynamically determined.
+         * @return the {@link TopicNameExtractor} class used get the topic name
+         */
+        TopicNameExtractor topicNameExtractor();
     }
 
     /**

--- a/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/TopologyTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.RecordContext;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -371,6 +372,23 @@ public class TopologyTest {
     }
 
     @Test
+    public void sinkShouldReturnNullTopicWithDynamicRouting() {
+        final TopologyDescription.Sink expectedSinkNode
+                = new InternalTopologyBuilder.Sink("sink", (key, value, record) -> record.topic() + "-" + key);
+
+        assertThat(expectedSinkNode.topic(), equalTo(null));
+    }
+
+    @Test
+    public void sinkShouldReturnTopicNameExtractorWithDynamicRouting() {
+        final TopicNameExtractor topicNameExtractor = (key, value, record) -> record.topic() + "-" + key;
+        final TopologyDescription.Sink expectedSinkNode
+                = new InternalTopologyBuilder.Sink("sink", topicNameExtractor);
+
+        assertThat(expectedSinkNode.topicNameExtractor(), equalTo(topicNameExtractor));
+    }
+
+    @Test
     public void singleSourceShouldHaveSingleSubtopology() {
         final TopologyDescription.Source expectedSourceNode = addSource("source", "topic");
 
@@ -627,6 +645,34 @@ public class TopologyTest {
         addGlobalStoreToTopologyAndExpectedDescription("globalStore1", "source1", "globalTopic1", "processor1", 0);
         addGlobalStoreToTopologyAndExpectedDescription("globalStore2", "source2", "globalTopic2", "processor2", 1);
         assertThat(topology.describe(), equalTo(expectedDescription));
+    }
+
+    @Test
+    public void topologyWithDynamicRoutingShouldDescribeExtractorClass() {
+        final StreamsBuilder builder  = new StreamsBuilder();
+
+        final TopicNameExtractor topicNameExtractor = new TopicNameExtractor() {
+            @Override
+            public String extract(final Object key, final Object value, final RecordContext recordContext) {
+                return recordContext.topic() + "-" + key;
+            }
+
+            @Override
+            public String toString() {
+                return "anonymous topic name extractor. topic is [recordContext.topic()]-[key]";
+            }
+        };
+        builder.stream("input-topic").to(topicNameExtractor);
+        final TopologyDescription describe = builder.build().describe();
+
+        assertEquals(
+                "Topologies:\n" +
+                "   Sub-topology: 0\n" +
+                "    Source: KSTREAM-SOURCE-0000000000 (topics: [input-topic])\n" +
+                "      --> KSTREAM-SINK-0000000001\n" +
+                "    Sink: KSTREAM-SINK-0000000001 (extractor class: anonymous topic name extractor. topic is [recordContext.topic()]-[key])\n" +
+                "      <-- KSTREAM-SOURCE-0000000000\n\n",
+                describe.toString());
     }
 
     @Test
@@ -1048,13 +1094,13 @@ public class TopologyTest {
         for (int i = 1; i < sourceTopic.length; ++i) {
             allSourceTopics.append(", ").append(sourceTopic[i]);
         }
-        return new InternalTopologyBuilder.Source(sourceName, allSourceTopics.toString());
+        return new InternalTopologyBuilder.Source(sourceName, new HashSet<>(Arrays.asList(sourceTopic)), null);
     }
 
     private TopologyDescription.Source addSource(final String sourceName,
                                                  final Pattern sourcePattern) {
         topology.addSource(null, sourceName, null, null, null, sourcePattern);
-        return new InternalTopologyBuilder.Source(sourceName, sourcePattern.toString());
+        return new InternalTopologyBuilder.Source(sourceName, null, sourcePattern);
     }
 
     private TopologyDescription.Processor addProcessor(final String processorName,


### PR DESCRIPTION
This is an update `TopologyDescription.Sink` and `TopologyDescription.Source`.

The original intent for `TopologyDescription` was to provide users with an interface to perform runtime checking of Topologies. However, `TopologyDescription` has relied too heavily on returning strings as representations of various inner components of Topologies such as topics, topic pattern, etc. This PR instead changes the return types to that of the underlying object and relies on the `toString()` method of these objects to maintain their human readable representations.

More details are outlined in this PR's corresponding [KIP](https://cwiki.apache.org/confluence/display/KAFKA/KIP-321%3A+Update+TopologyDescription+to+better+represent+Source+and+Sink+Nodes).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
