### PR TITLE
MINOR: Print exception stack traces in ConsumerGroupCommand.

### DIFF
--- a/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
+++ b/core/src/main/scala/kafka/admin/ConsumerGroupCommand.scala
@@ -80,7 +80,7 @@ object ConsumerGroupCommand extends Logging {
 
   def printError(msg: String, e: Option[Throwable] = None): Unit = {
     println(s"Error: $msg")
-    e.foreach(debug("Exception in consumer group command", _))
+    e.foreach(_.printStackTrace())
   }
 
   def convertTimestamp(timeString: String): java.lang.Long = {


### PR DESCRIPTION
When an exception is caught in ConsumerGroupCommand command line utility it does not print the stack trace, this could lead to crucial information regarding the error to not be displayed to the user.

More specifically, when misconfiguring consumer configuration the user will only see the message:
```
Error: Executing consumer group command failed due to Failed to construct kafka consumer
```
This happens since [the code which instantiates this exception](https://github.com/apache/kafka/blob/2.0.0-rc0/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L795) does not add all relevant information in the message but rather in the "cause" member.

In order to find out the issue I had to compile Kafka and debug this code to find out that the error was due to a misconfiguration of the consumer:
```
Caused by: org.apache.kafka.common.config.ConfigException: request.timeout.ms should be greater than session.timeout.ms and fetch.max.wait.ms
```

Suggested change is to simply print the stack traces since this is a command line utility (same as the error is printed in the line preceding this one). This will provide the user with the most information for cases like these when the exception message is not sufficient.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
