### PR TITLE
KAFKA-7097 VerifiableProducer does not work properly with --message-create-time argument

### DIFF
--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -165,7 +165,7 @@ public class VerifiableProducer {
                 .action(store())
                 .required(false)
                 .setDefault(-1)
-                .type(Integer.class)
+                .type(Long.class)
                 .metavar("CREATETIME")
                 .dest("createTime")
                 .help("Send messages with creation time starting at the arguments value, in milliseconds since epoch");

--- a/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
+++ b/tools/src/main/java/org/apache/kafka/tools/VerifiableProducer.java
@@ -215,7 +215,7 @@ public class VerifiableProducer {
         int throughput = res.getInt("throughput");
         String configFile = res.getString("producer.config");
         Integer valuePrefix = res.getInt("valuePrefix");
-        Long createTime = (long) res.getInt("createTime");
+        Long createTime = res.getLong("createTime");
         Integer repeatingKeys = res.getInt("repeatingKeys");
 
         if (createTime == -1L)


### PR DESCRIPTION
Currently create time is interpreted as integer.

This PR makes the tool accept long values.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
