### PR TITLE
MINOR: Reduce time windows for flaky test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractJoinIntegrationTest {
     }
 
     void prepareEnvironment() throws InterruptedException {
-        CLUSTER.deleteAndRecreateTopics(INPUT_TOPIC_LEFT, INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
+        CLUSTER.createTopics(INPUT_TOPIC_LEFT, INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
 
         if (!cacheEnabled)
             STREAMS_CONFIG.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/AbstractJoinIntegrationTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractJoinIntegrationTest {
     }
 
     void prepareEnvironment() throws InterruptedException {
-        CLUSTER.createTopics(INPUT_TOPIC_LEFT, INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
+        CLUSTER.deleteAndRecreateTopics(INPUT_TOPIC_LEFT, INPUT_TOPIC_RIGHT, OUTPUT_TOPIC);
 
         if (!cacheEnabled)
             STREAMS_CONFIG.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StreamStreamJoinIntegrationTest.java
@@ -79,7 +79,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             Arrays.asList("D-a", "D-b", "D-c", "D-d")
         );
 
-        leftStream.join(rightStream, valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+        leftStream.join(rightStream, valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }
@@ -109,7 +109,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.map(MockMapper.<Long, String>noOpKeyValueMapper())
                 .join(rightStream.flatMap(MockMapper.<Long, String>noOpFlatKeyValueMapper())
                                  .selectKey(MockMapper.<Long, String>selectKeyKeyValueMapper()),
-                       valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+                       valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }
@@ -136,7 +136,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             Arrays.asList("D-a", "D-b", "D-c", "D-d")
         );
 
-        leftStream.leftJoin(rightStream, valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+        leftStream.leftJoin(rightStream, valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }
@@ -166,7 +166,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.map(MockMapper.<Long, String>noOpKeyValueMapper())
                 .leftJoin(rightStream.flatMap(MockMapper.<Long, String>noOpFlatKeyValueMapper())
                                      .selectKey(MockMapper.<Long, String>selectKeyKeyValueMapper()),
-                        valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+                        valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }
@@ -193,7 +193,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
             Arrays.asList("D-a", "D-b", "D-c", "D-d")
         );
 
-        leftStream.outerJoin(rightStream, valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+        leftStream.outerJoin(rightStream, valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }
@@ -223,7 +223,7 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
         leftStream.map(MockMapper.<Long, String>noOpKeyValueMapper())
                 .outerJoin(rightStream.flatMap(MockMapper.<Long, String>noOpFlatKeyValueMapper())
                                 .selectKey(MockMapper.<Long, String>selectKeyKeyValueMapper()),
-                        valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+                        valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }
@@ -254,8 +254,8 @@ public class StreamStreamJoinIntegrationTest extends AbstractJoinIntegrationTest
                         "D-c-b", "D-c-c", "D-c-d", "D-d-a", "D-d-b", "D-d-c", "D-d-d")
         );
 
-        leftStream.join(rightStream, valueJoiner, JoinWindows.of(10000))
-                .join(rightStream, valueJoiner, JoinWindows.of(10000)).to(OUTPUT_TOPIC);
+        leftStream.join(rightStream, valueJoiner, JoinWindows.of(1000))
+                .join(rightStream, valueJoiner, JoinWindows.of(1000)).to(OUTPUT_TOPIC);
 
         runTest(expectedResult);
     }


### PR DESCRIPTION
The `StreamStreamJoinIntegrationTest` is a bit flaky.  The failures seem to occur with caching turned off.  With join windows of 10 seconds, it's possible that if one stream experiences some latency there may be values present from the other stream for a join when not expected by the test.

Tested by running streams tests and running the `StreamStreamJoinIntegrationTest` test 25 times.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
