### PR TITLE
KAFKA-6809: Count inbound connections in the connection-creation metric

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -265,6 +265,7 @@ public class Selector implements Selectable, AutoCloseable {
     public void register(String id, SocketChannel socketChannel) throws IOException {
         ensureNotRegistered(id);
         registerChannel(id, socketChannel, SelectionKey.OP_READ);
+        this.sensors.connectionCreated.record();
     }
 
     private void ensureNotRegistered(String id) {

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -586,22 +586,22 @@ public class SelectorTest {
     @Test
     public void testOutboundConnectionsCountInConnectionCreationMetric() throws Exception {
         // create connections
-        int conns = 5;
+        int expectedConnections = 5;
         InetSocketAddress addr = new InetSocketAddress("localhost", server.port);
-        for (int i = 0; i < conns; i++)
+        for (int i = 0; i < expectedConnections; i++)
             connect(Integer.toString(i), addr);
 
         // Poll continuously, as we cannot guarantee that the first call will see all connections
+        int seenConnections = 0;
         for (int i = 0; i < 10; i++) {
-            selector.poll(0L);
-            if (selector.connected().size() == conns)
+            selector.poll(100L);
+            seenConnections += selector.connected().size();
+            if (seenConnections == expectedConnections)
                 break;
-
-            Thread.sleep(100);
         }
 
-        assertEquals((double) conns, getMetric("connection-creation-total").metricValue());
-        assertEquals((double) conns, getMetric("connection-count").metricValue());
+        assertEquals((double) expectedConnections, getMetric("connection-creation-total").metricValue());
+        assertEquals((double) expectedConnections, getMetric("connection-count").metricValue());
     }
 
     @Test


### PR DESCRIPTION
Previously, the connection-creation metric only accounted for opened connections **from** the broker. This change extends it to account for received connections.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
