### PR TITLE
KAFKA-7104: Handle leader's log start offset beyond last fetched offset

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -100,8 +100,9 @@ class ReplicaAlterLogDirsThread(name: String,
 
     partition.appendRecordsToFollowerOrFutureReplica(records, isFuture = true)
     val futureReplicaHighWatermark = futureReplica.logEndOffset.messageOffset.min(partitionData.highWatermark)
+    val newLogStartOffset = futureReplica.logEndOffset.messageOffset.min(partitionData.logStartOffset)
     futureReplica.highWatermark = new LogOffsetMetadata(futureReplicaHighWatermark)
-    futureReplica.maybeIncrementLogStartOffset(partitionData.logStartOffset)
+    futureReplica.maybeIncrementLogStartOffset(newLogStartOffset)
 
     if (partition.maybeReplaceCurrentWithFutureReplica())
       removePartitions(Set(topicPartition))


### PR DESCRIPTION
Leader replica may return log start offset in the fetch response that is higher then last fetched offset. This may happen if the log start offset on the leader moves while the fetch response is being build (eg., due to rolling and deleting old segments, or deleting records). This PR limits setting log start offset on the follower to its LEO. 


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
