### PR TITLE
MINOR: Make replica verification test deterministic

### DIFF
--- a/tests/kafkatest/tests/tools/replica_verification_test.py
+++ b/tests/kafkatest/tests/tools/replica_verification_test.py
@@ -82,6 +82,7 @@ class ReplicaVerificationToolTest(Test):
         # Verify that there is no lag in replicas and is correctly reported by ReplicaVerificationTool
         wait_until(lambda: self.replica_verifier.get_lag_for_partition(TOPIC, 0) == 0, timeout_sec=10,
                    err_msg="Timed out waiting to reach zero replica lags.")
+        self.producer.wait(timeout_sec=10)
         self.stop_producer()
 
         self.start_producer(max_messages=10000, acks=0, timeout=5)


### PR DESCRIPTION
It is possible for replica_verificaiton_test to fail with a `RemoteCommandError` when `self.stop_producer()` is called. This looks like a timing issue, as the implementation for `BackgroundThreadService#stop` is the following:

```
    def stop(self):
        alive_workers = [worker for worker in self.worker_threads.itervalues() if worker.is_alive()]
        if len(alive_workers) > 0:
            self.logger.debug(
                "Called stop with at least one worker thread is still running: " + str(alive_workers))

            self.logger.debug("%s" % str(self.worker_threads))

        super(BackgroundThreadService, self).stop()
```

It is possible that the worker exits after the point `alive_workers` is constructed.

`VerifiableProducer#stop` expects the process to exist, and sets `allow_fail` to `false`.

```
    def stop_node(self, node):
        self.kill_node(node, clean_shutdown=True, allow_fail=False)

        stopped = self.wait_node(node, timeout_sec=self.stop_timeout_sec)
        assert stopped, "Node %s: did not stop within the specified timeout of %s seconds" % \
                        (str(node.account), str(self.stop_timeout_sec))
```

This patch adds a wait to make sure the producer has finished before we try to stop it.