### PR TITLE
MINOR: Upgrade RocksDB to 5.13.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ versions += [
   // PowerMock 1.x doesn't support Java 9, so use PowerMock 2.0.0 beta
   powermock: "2.0.0-beta.5",
   reflections: "0.9.11",
-  rocksDB: "5.7.3",
+  rocksDB: "5.12.5",
   scalatest: "3.0.5",
   scoverage: "1.3.1",
   slf4j: "1.7.25",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -76,7 +76,7 @@ versions += [
   // PowerMock 1.x doesn't support Java 9, so use PowerMock 2.0.0 beta
   powermock: "2.0.0-beta.5",
   reflections: "0.9.11",
-  rocksDB: "5.12.5",
+  rocksDB: "5.13.4",
   scalatest: "3.0.5",
   scoverage: "1.3.1",
   slf4j: "1.7.25",

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -248,11 +248,6 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
                 } catch (final RocksDBException e) {
                     throw new ProcessorStateException("Error while range compacting during restoring  store " + this.name, e);
                 }
-
-                // we need to re-open with the old num.levels again, this is a workaround
-                // until https://github.com/facebook/rocksdb/pull/2740 is merged in rocksdb
-                close();
-                openDB(internalProcessorContext);
             }
         }
 


### PR DESCRIPTION
There are a few JNI improvements added recently in RocksDB, plus some bug fixes that may cause `assertion error` that we have seen transiently in Streams unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
