### PR TITLE
KAFKA-7028: Properly authorize custom principal objects

### DIFF
--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -110,7 +110,12 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
       throw new IllegalArgumentException("Only literal resources are supported. Got: " + resource.patternType)
     }
 
-    val principal = session.principal
+    // ensure we compare identical classes
+    val principal = if (classOf[KafkaPrincipal] != session.principal.getClass)
+      new KafkaPrincipal(session.principal.getPrincipalType, session.principal.getName)
+    else
+      session.principal
+
     val host = session.clientAddress.getHostAddress
 
     def isEmptyAclAndAuthorized(acls: Set[Acl]): Boolean = {

--- a/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
+++ b/core/src/main/scala/kafka/security/auth/SimpleAclAuthorizer.scala
@@ -111,10 +111,11 @@ class SimpleAclAuthorizer extends Authorizer with Logging {
     }
 
     // ensure we compare identical classes
-    val principal = if (classOf[KafkaPrincipal] != session.principal.getClass)
-      new KafkaPrincipal(session.principal.getPrincipalType, session.principal.getName)
+    val sessionPrincipal = session.principal
+    val principal = if (classOf[KafkaPrincipal] != sessionPrincipal.getClass)
+      new KafkaPrincipal(sessionPrincipal.getPrincipalType, sessionPrincipal.getName)
     else
-      session.principal
+      sessionPrincipal
 
     val host = session.clientAddress.getHostAddress
 


### PR DESCRIPTION
Previously, it would compare two different classes `KafkaPrincipal` and the custom class, which would always return false because of the implementation of `KafkaPrincipal#equals`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
