### PR TITLE
MINOR: Avoid conflicting versions of org.apache.mina for MiniKdc deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -564,9 +564,8 @@ project(':core') {
     testCompile libs.easymock
     testCompile(libs.apacheda) {
       exclude group: 'xml-apis', module: 'xml-apis'
-      // `apacheds` used by MiniKdc depends on ``mina-core-2.0.16`, but `apacheda` includes
-      // `mina-core-2.0.18` that contains a public API change. It is safer to use the
-      //  dependency from `apacheds` for MiniKdc.
+      // `mina-core` is a transitive dependency for `apacheds` and `apacheda`.
+      // It is safer to use from `apacheds` since that is the implementation.
       exclude module: 'mina-core'
     }
     testCompile libs.apachedsCoreApi

--- a/build.gradle
+++ b/build.gradle
@@ -564,6 +564,9 @@ project(':core') {
     testCompile libs.easymock
     testCompile(libs.apacheda) {
       exclude group: 'xml-apis', module: 'xml-apis'
+      // `apacheds` used by MiniKdc depends on ``mina-core-2.0.16`, but `apacheda` includes
+      // `mina-core-2.0.18` that contains a public API change. It is safer to use the
+      //  dependency from `apacheds` for MiniKdc.
       exclude module: 'mina-core'
     }
     testCompile libs.apachedsCoreApi

--- a/build.gradle
+++ b/build.gradle
@@ -564,6 +564,7 @@ project(':core') {
     testCompile libs.easymock
     testCompile(libs.apacheda) {
       exclude group: 'xml-apis', module: 'xml-apis'
+      exclude module: 'mina-core'
     }
     testCompile libs.apachedsCoreApi
     testCompile libs.apachedsInterceptorKerberos


### PR DESCRIPTION
We have updated `apacheda` to a newer version that uses `mina-core-2.0.18` while `apacheds` uses `mina-core-2.0.16`. Since these are used only for testing using `MiniKdc`, it would be better to use the versions from `apacheds`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
