### PR TITLE
KAFKA-7098: Improve accuracy of throttling by avoiding under-estimating actual rate in Throttler

### DIFF
--- a/core/src/main/scala/kafka/utils/Throttler.scala
+++ b/core/src/main/scala/kafka/utils/Throttler.scala
@@ -73,7 +73,7 @@ class Throttler(desiredRatePerSec: Double,
             time.sleep(sleepTime)
           }
         }
-        periodStartNs = now
+        periodStartNs = time.nanoseconds()
         observedSoFar = 0
       }
     }

--- a/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
+++ b/core/src/test/scala/unit/kafka/utils/ThrottlerTest.scala
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.kafka.utils
+
+import kafka.utils.Throttler
+import org.apache.kafka.common.utils.MockTime
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+
+class ThrottlerTest {
+  @Test
+  def testThrottleDesiredRate() {
+    val throttleCheckIntervalMs = 100
+    val desiredCountPerMs = 1.0
+    val desiredRatePerSec = desiredCountPerMs * 1000
+    val desiredCountPerInterval = desiredCountPerMs * throttleCheckIntervalMs
+
+    val mockTime = new MockTime()
+    val throttler = new Throttler(desiredRatePerSec = desiredRatePerSec,
+                                  checkIntervalMs = throttleCheckIntervalMs,
+                                  time = mockTime)
+
+    val startTime = mockTime.milliseconds()
+
+    // Observe desiredCountPerInterval at t0 = startTime
+    throttler.maybeThrottle(desiredCountPerInterval)
+    mockTime.sleep(throttleCheckIntervalMs + 1)
+
+    // Observe desiredCountPerInterval at t1 = t0 + throttleCheckIntervalMs + 1,
+    // in total observe 2*desiredCountPerInterval, should block until t2 = t0 + 2*throttleCheckIntervalMs
+    throttler.maybeThrottle(desiredCountPerInterval)
+
+    // Observe (2*desiredCountPerInterval-desiredCountPerMs) after throttling at t2,
+    throttler.maybeThrottle(2 * desiredCountPerInterval - desiredCountPerMs)
+    mockTime.sleep(throttleCheckIntervalMs + 1)
+
+    // Observer desiredCountPerMs at t3 = t2 + throttleCheckIntervalMs + 1,
+    // in total observe 2*desiredCountPerInterval, should block until t4 = t2 + 2*throttleCheckIntervalMs
+    throttler.maybeThrottle(desiredCountPerMs)
+
+    // Expect 4*desiredCountPerInterval observation and 4*throttleCheckIntervalMs elapsedTimeMs
+    val elapsedTimeMs = mockTime.milliseconds() - startTime
+    val actualRatePerSec = 4 * desiredCountPerInterval * 1000 / elapsedTimeMs
+    assertTrue(actualRatePerSec <= desiredRatePerSec)
+  }
+}


### PR DESCRIPTION
This PR modifies Throttler.scala by setting the `periodStartNs` to the current time instead of the time before the potential `sleep` call when throttling is needed. The reason behind is that if we reset `periodStartNs` to the time before `sleep`, we will increase the time window in the next actual rate calculation, which will underestimate the actual rate and may miss the throttling opportunity or sleep for less time. A unit test is also added to test the fix.

For example, if we use Throttler to throttle the pre sec rate to 10 with checkInterval 1s, in the original implementation:
1. 15 events happen during [t0, t0+1s]
2. Throttler will sleep the thread until t0+1.5s, then reset period start time to t0+1s
3. 10 events happen during [t0+1.5s, t0+2s], Throttler will not throttle this time because the estimated rate is `10 / [(t0+2s) - (t0+1s)] = 10`

But the actual rate during [t0, t0+2s] is `(10+15) / 2 = 12.5 > 10`

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
