### PR TITLE
KAFKA-6999: Document read-write lock usage of caching enabled stores

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/ReadOnlyKeyValueStore.java
@@ -23,6 +23,12 @@ import org.apache.kafka.streams.errors.InvalidStateStoreException;
  * Implementations should be thread-safe as concurrent reads and writes
  * are expected.
  *
+ * Please note that this contract defines the thread-safe read functionality only; it does not
+ * guarantee anything about whether the actual instance is writable by another thread, or
+ * whether it uses some locking mechanism under the hood. For this reason, making dependencies
+ * between the read and write operations on different StateStore instances can cause concurrency
+ * problems like deadlock.
+ *
  * @param <K> the key type
  * @param <V> the value type
  */


### PR DESCRIPTION
Add description for the deadlock vulnerability of `ReadOnlyKeyValueStore`.