### PR TITLE
KAFKA-5638: Improve the Required ACL of ListGroups API (KIP-231)

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1245,12 +1245,8 @@ class KafkaApis(val requestChannel: RequestChannel,
         new ListGroupsResponse(requestThrottleMs, error, groups.map { group => new ListGroupsResponse.Group(group.groupId, group.protocolType) }.asJava))
     else {
       val filteredGroups = groups.filter(group => authorize(request.session, Describe, new Resource(Group, group.groupId, LITERAL)))
-      if (filteredGroups.isEmpty)
-        sendResponseMaybeThrottle(request, requestThrottleMs => new ListGroupsResponse(requestThrottleMs, Errors.NONE, List().asJava))
-      else {
-        sendResponseMaybeThrottle(request, requestThrottleMs =>
-          new ListGroupsResponse(requestThrottleMs, error, filteredGroups.map { group => new ListGroupsResponse.Group(group.groupId, group.protocolType) }.asJava))
-      }
+      sendResponseMaybeThrottle(request, requestThrottleMs =>
+        new ListGroupsResponse(requestThrottleMs, error, filteredGroups.map { group => new ListGroupsResponse.Group(group.groupId, group.protocolType) }.asJava))
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -1058,13 +1058,14 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     // it should list only one group now
     val groupList = adminClient.listConsumerGroups().all().get().asScala.toList
-    assertTrue(groupList.length == 1 && groupList.head.groupId == group)
+    assertEquals(1, groupList.length)
+    assertEquals(group, groupList.head.groupId)
 
     // now remove all acls and verify describe group access is required to list any group
     removeAllAcls()
     val listGroupResult = adminClient.listConsumerGroups()
-    assertTrue(listGroupResult.errors().get().isEmpty)
-    assertTrue(listGroupResult.all().get().isEmpty)
+    assertEquals(List(), listGroupResult.errors().get().asScala.toList)
+    assertEquals(List(), listGroupResult.all().get().asScala.toList)
     otherConsumer.close()
   }
 

--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -33,12 +33,12 @@
     <li>The default value for the producer's <code>retries</code> config was changed to <code>Integer.MAX_VALUE</code>, as we introduced <code>delivery.timeout.ms</code>
         in <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-91+Provide+Intuitive+User+Timeouts+in+The+Producer">KIP-91</a>,
         which sets an upper bound on the total time between sending a record and receiving acknowledgement from the broker. By default,
-        the delivery timeout is set to 2 minutes.
-    </li>
+        the delivery timeout is set to 2 minutes.</li>
     <li>By default, MirrorMaker now overrides <code>delivery.timeout.ms</code> to <code>Integer.MAX_VALUE</code> when
         configuring the producer. If you have overridden the value of <code>retries</code> in order to fail faster,
-        you will instead need to override <code>delivery.timeout.ms</code>.
-    </li>
+        you will instead need to override <code>delivery.timeout.ms</code>.</li>
+    <li>The <code>ListGroup</code> API now expects, as a recommended alternative, <code>Describe Group</code> access to the groups a user should be able to list.
+        Even though the old <code>Describe Cluster</code> access is still supported for backward compatibility, using it for this API is not advised.</li>
 </ol>
 
 


### PR DESCRIPTION
[KIP-231](https://cwiki.apache.org/confluence/display/KAFKA/KIP-231%3A+Improve+the+Required+ACL+of+ListGroups+API)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)