### PR TITLE
KAFKA-7146: Grouping consumer requests per consumer coordinator in admin client in describeConsumerGroups

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2414,7 +2414,7 @@ public class KafkaAdminClient extends AdminClient {
                     coordinators.put(nodeId, groupIdsForNode);
                     returnedGroupId.add(groupId);
 
-                    // If all the groupIds are processed, send the group request
+                    // If all the groupIds are processed, send the group request.
                     if (returnedGroupId.size() == groupIds.size()) {
                         sendGroupRequests();
                     }
@@ -2427,7 +2427,7 @@ public class KafkaAdminClient extends AdminClient {
 
                     returnedGroupId.add(groupId);
 
-                    // If all the groupIds are processed, send the group request
+                    // If all the groupIds are processed, send the group request.
                     if (returnedGroupId.size() == groupIds.size()) {
                         sendGroupRequests();
                     }

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -2382,7 +2382,7 @@ public class KafkaAdminClient extends AdminClient {
         // TODO: KAFKA-6788, we should consider grouping the request per coordinator and send one request with a list of
         // all consumer groups this coordinator host
 
-        final Map<Integer, Queue<String>> coodinators = new ConcurrentHashMap<>();
+        final Map<Integer, Queue<String>> coordinators = new ConcurrentHashMap<>();
         final Map<Integer, FindCoordinatorResponse> fcResponses = new HashMap<>();
         final Queue<String> returnedGroupId = new ConcurrentLinkedQueue<>();
 
@@ -2414,9 +2414,9 @@ public class KafkaAdminClient extends AdminClient {
 
                     fcResponses.putIfAbsent(nodeId, fcResponse);
 
-                    Queue<String> groupIdsForNode = coodinators.getOrDefault(nodeId, new ConcurrentLinkedQueue<>());
+                    Queue<String> groupIdsForNode = coordinators.getOrDefault(nodeId, new ConcurrentLinkedQueue<>());
                     groupIdsForNode.add(groupId);
-                    coodinators.put(nodeId, groupIdsForNode);
+                    coordinators.put(nodeId, groupIdsForNode);
 
                     returnedGroupId.add(groupId);
 
@@ -2441,7 +2441,7 @@ public class KafkaAdminClient extends AdminClient {
                     final long nowDescribeConsumerGroups = time.milliseconds();
                     final long deadline = calcDeadlineMs(nowDescribeConsumerGroups, options.timeoutMs());
 
-                    for (final Map.Entry<Integer, Queue<String>> entry: coodinators.entrySet()) {
+                    for (final Map.Entry<Integer, Queue<String>> entry: coordinators.entrySet()) {
                         final int nodeId = entry.getKey();
                         runnable.call(new Call("describeConsumerGroups", deadline, new ConstantNodeIdProvider(nodeId)) {
                             @Override

--- a/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java
@@ -134,7 +134,10 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -2369,7 +2372,7 @@ public class KafkaAdminClient extends AdminClient {
             if (groupIdIsUnrepresentable(groupId)) {
                 KafkaFutureImpl<ConsumerGroupDescription> future = new KafkaFutureImpl<>();
                 future.completeExceptionally(new InvalidGroupIdException("The given group id '" +
-                        groupId + "' cannot be represented in a request."));
+                                                                         groupId + "' cannot be represented in a request."));
                 futures.put(groupId, future);
             } else if (!futures.containsKey(groupId)) {
                 futures.put(groupId, new KafkaFutureImpl<ConsumerGroupDescription>());
@@ -2378,6 +2381,11 @@ public class KafkaAdminClient extends AdminClient {
 
         // TODO: KAFKA-6788, we should consider grouping the request per coordinator and send one request with a list of
         // all consumer groups this coordinator host
+
+        final Map<Integer, Queue<String>> coodinators = new ConcurrentHashMap<>();
+        final Map<Integer, FindCoordinatorResponse> fcResponses = new HashMap<>();
+        final Queue<String> returnedGroupId = new ConcurrentLinkedQueue<>();
+
         for (final Map.Entry<String, KafkaFutureImpl<ConsumerGroupDescription>> entry : futures.entrySet()) {
             // skip sending request for those futures that already failed.
             if (entry.getValue().isCompletedExceptionally())
@@ -2387,6 +2395,7 @@ public class KafkaAdminClient extends AdminClient {
 
             final long startFindCoordinatorMs = time.milliseconds();
             final long deadline = calcDeadlineMs(startFindCoordinatorMs, options.timeoutMs());
+
 
             runnable.call(new Call("findCoordinator", deadline, new LeastLoadedNodeProvider()) {
                 @Override
@@ -2401,69 +2410,99 @@ public class KafkaAdminClient extends AdminClient {
                     if (handleFindCoordinatorError(fcResponse, futures.get(groupId)))
                         return;
 
-                    final long nowDescribeConsumerGroups = time.milliseconds();
                     final int nodeId = fcResponse.node().id();
-                    runnable.call(new Call("describeConsumerGroups", deadline, new ConstantNodeIdProvider(nodeId)) {
-                        @Override
-                        AbstractRequest.Builder createRequest(int timeoutMs) {
-                            return new DescribeGroupsRequest.Builder(Collections.singletonList(groupId));
-                        }
 
-                        @Override
-                        void handleResponse(AbstractResponse abstractResponse) {
-                            final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
+                    fcResponses.putIfAbsent(nodeId, fcResponse);
 
-                            KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
-                            final DescribeGroupsResponse.GroupMetadata groupMetadata = response.groups().get(groupId);
+                    Queue<String> groupIdsForNode = coodinators.getOrDefault(nodeId, new ConcurrentLinkedQueue<>());
+                    groupIdsForNode.add(groupId);
+                    coodinators.put(nodeId, groupIdsForNode);
 
-                            final Errors groupError = groupMetadata.error();
-                            if (groupError != Errors.NONE) {
-                                // TODO: KAFKA-6789, we can retry based on the error code
-                                future.completeExceptionally(groupError.exception());
-                            } else {
-                                final String protocolType = groupMetadata.protocolType();
-                                if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
-                                    final List<DescribeGroupsResponse.GroupMember> members = groupMetadata.members();
-                                    final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
+                    returnedGroupId.add(groupId);
 
-                                    for (DescribeGroupsResponse.GroupMember groupMember : members) {
-                                        Set<TopicPartition> partitions = Collections.emptySet();
-                                        if (groupMember.memberAssignment().remaining() > 0) {
-                                            final PartitionAssignor.Assignment assignment = ConsumerProtocol.
-                                                deserializeAssignment(groupMember.memberAssignment().duplicate());
-                                            partitions = new HashSet<>(assignment.partitions());
-                                        }
-                                        final MemberDescription memberDescription =
-                                            new MemberDescription(groupMember.memberId(),
-                                                groupMember.clientId(),
-                                                groupMember.clientHost(),
-                                                new MemberAssignment(partitions));
-                                        memberDescriptions.add(memberDescription);
-                                    }
-                                    final ConsumerGroupDescription consumerGroupDescription =
-                                            new ConsumerGroupDescription(groupId,
-                                                protocolType.isEmpty(),
-                                                memberDescriptions,
-                                                groupMetadata.protocol(),
-                                                ConsumerGroupState.parse(groupMetadata.state()),
-                                                fcResponse.node());
-                                    future.complete(consumerGroupDescription);
-                                }
-                            }
-                        }
-
-                        @Override
-                        void handleFailure(Throwable throwable) {
-                            KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
-                            future.completeExceptionally(throwable);
-                        }
-                    }, nowDescribeConsumerGroups);
+                    if (returnedGroupId.size() == groupIds.size()) {
+                        sendGroupRequest();
+                    }
                 }
 
                 @Override
                 void handleFailure(Throwable throwable) {
                     KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
                     future.completeExceptionally(throwable);
+
+                    returnedGroupId.add(groupId);
+
+                    if (returnedGroupId.size() == groupIds.size()) {
+                        sendGroupRequest();
+                    }
+                }
+
+                void sendGroupRequest() {
+                    final long nowDescribeConsumerGroups = time.milliseconds();
+                    final long deadline = calcDeadlineMs(nowDescribeConsumerGroups, options.timeoutMs());
+
+                    for (final Map.Entry<Integer, Queue<String>> entry: coodinators.entrySet()) {
+                        final int nodeId = entry.getKey();
+                        runnable.call(new Call("describeConsumerGroups", deadline, new ConstantNodeIdProvider(nodeId)) {
+                            @Override
+                            AbstractRequest.Builder createRequest(int timeoutMs) {
+                                return new DescribeGroupsRequest.Builder(Collections.unmodifiableList(new ArrayList<>(entry.getValue())));
+                            }
+
+                            @Override
+                            void handleResponse(AbstractResponse abstractResponse) {
+                                final DescribeGroupsResponse response = (DescribeGroupsResponse) abstractResponse;
+
+                                for (String groupId: entry.getValue()) {
+                                    KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
+                                    final DescribeGroupsResponse.GroupMetadata groupMetadata = response.groups().get(groupId);
+
+                                    final Errors groupError = groupMetadata.error();
+                                    if (groupError != Errors.NONE) {
+                                        // TODO: KAFKA-6789, we can retry based on the error code
+                                        future.completeExceptionally(groupError.exception());
+                                    } else {
+                                        final String protocolType = groupMetadata.protocolType();
+                                        if (protocolType.equals(ConsumerProtocol.PROTOCOL_TYPE) || protocolType.isEmpty()) {
+                                            final List<DescribeGroupsResponse.GroupMember> members = groupMetadata.members();
+                                            final List<MemberDescription> memberDescriptions = new ArrayList<>(members.size());
+
+                                            for (DescribeGroupsResponse.GroupMember groupMember : members) {
+                                                Set<TopicPartition> partitions = Collections.emptySet();
+                                                if (groupMember.memberAssignment().remaining() > 0) {
+                                                    final PartitionAssignor.Assignment assignment = ConsumerProtocol.
+                                                            deserializeAssignment(groupMember.memberAssignment().duplicate());
+                                                    partitions = new HashSet<>(assignment.partitions());
+                                                }
+                                                final MemberDescription memberDescription =
+                                                        new MemberDescription(groupMember.memberId(),
+                                                                              groupMember.clientId(),
+                                                                              groupMember.clientHost(),
+                                                                              new MemberAssignment(partitions));
+                                                memberDescriptions.add(memberDescription);
+                                            }
+                                            final ConsumerGroupDescription consumerGroupDescription =
+                                                    new ConsumerGroupDescription(groupId,
+                                                                                 protocolType.isEmpty(),
+                                                                                 memberDescriptions,
+                                                                                 groupMetadata.protocol(),
+                                                                                 ConsumerGroupState.parse(groupMetadata.state()),
+                                                                                 fcResponses.get(nodeId).node());
+                                            future.complete(consumerGroupDescription);
+                                        }
+                                    }
+                                }
+                            }
+
+                            @Override
+                            void handleFailure(Throwable throwable) {
+                                for (String groupId: entry.getValue()) {
+                                    KafkaFutureImpl<ConsumerGroupDescription> future = futures.get(groupId);
+                                    future.completeExceptionally(throwable);
+                                }
+                            }
+                        }, nowDescribeConsumerGroups);
+                    }
                 }
             }, startFindCoordinatorMs);
         }


### PR DESCRIPTION
This is a subtask from KAFKA-6788 (https://issues.apache.org/jira/browse/KAFKA-6788)

Basically the idea is to use thread-safe collections like ConcurrentLinkedQueue and ConcurrentHashMap to save to result of each "findCoordinator" response. In the map, we will have the coordinator node Id as the key, and the value will be the collection of all the belonging groupIds. 

When all the groupId processed (either successful or completed exceptionally), then we will iterate through the map and group the requests by coordinators.

This PR is mainly for discussion, there are a couple concerns:

1. Code logic: Is there any thing wrong with the logic of this solution?
2. Concurrency issues: can these collections guarantee the thread-safety?
3. Memory issue: using too many collections to store information, should cut down the memory usage.
4. Efficiency: is this more efficient than the implementation before (i.e. latency)?
5. Naming issues.
6. More unit tests.

I am open to all kind of suggestions and feedbacks, and will make several other commits after I receive opinion. 

P.S. Is a KIP needed?

@guozhangwang @cmccabe Thank you!