### PR TITLE
MINOR: Fixing JavaDoc for METRICS_RECORDING_LEVEL_CONFIG on ProducerClient

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -152,7 +152,7 @@ public class ProducerConfig extends AbstractConfig {
     public static final String METRICS_NUM_SAMPLES_CONFIG = CommonClientConfigs.METRICS_NUM_SAMPLES_CONFIG;
 
     /**
-     * <code>metrics.log.level</code>
+     * <code>metrics.recording.level</code>
      */
     public static final String METRICS_RECORDING_LEVEL_CONFIG = CommonClientConfigs.METRICS_RECORDING_LEVEL_CONFIG;
 


### PR DESCRIPTION
A minor fix, the JavaDoc for the `METRICS_RECORDING_LEVEL_CONFIG` was pointing to an outdated/incorrect value.

