### PR TITLE
MINOR: resolve warnings in GroupedStreamAggregateBuilder

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/GroupedStreamAggregateBuilder.java
@@ -24,7 +24,7 @@ import org.apache.kafka.streams.kstream.internals.graph.OptimizableRepartitionNo
 import org.apache.kafka.streams.kstream.internals.graph.ProcessorParameters;
 import org.apache.kafka.streams.kstream.internals.graph.StatefulProcessorNode;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
-import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Collections;
@@ -62,10 +62,10 @@ class GroupedStreamAggregateBuilder<K, V> {
         this.streamsGraphNode = streamsGraphNode;
     }
 
-    <T> KTable<K, T> build(final KStreamAggProcessorSupplier<K, ?, V, T> aggregateSupplier,
-                           final String functionName,
-                           final StoreBuilder<KeyValueStore<K, T>> storeBuilder,
-                           final boolean isQueryable) {
+    <KR, T> KTable<KR, T> build(final KStreamAggProcessorSupplier<K, KR, V, T> aggregateSupplier,
+                                final String functionName,
+                                final StoreBuilder<? extends StateStore> storeBuilder,
+                                final boolean isQueryable) {
         final String aggFunctionName = builder.newProcessorName(functionName);
 
         final OptimizableRepartitionNode.OptimizableRepartitionNodeBuilder<K, V> repartitionNodeBuilder =

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KGroupedStreamImpl.java
@@ -32,7 +32,6 @@ import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windows;
 import org.apache.kafka.streams.kstream.internals.graph.StreamsGraphNode;
 import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Objects;
 import java.util.Set;
@@ -55,13 +54,15 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
                        final boolean repartitionRequired,
                        final StreamsGraphNode streamsGraphNode) {
         super(builder, name, sourceNodes, streamsGraphNode);
-        this.aggregateBuilder = new GroupedStreamAggregateBuilder<>(builder,
-                                                                    keySerde,
-                                                                    valSerde,
-                                                                    repartitionRequired,
-                                                                    sourceNodes,
-                                                                    name,
-                                                                    streamsGraphNode);
+        this.aggregateBuilder = new GroupedStreamAggregateBuilder<>(
+            builder,
+            keySerde,
+            valSerde,
+            repartitionRequired,
+            sourceNodes,
+            name,
+            streamsGraphNode
+        );
         this.keySerde = keySerde;
         this.valSerde = valSerde;
         this.repartitionRequired = repartitionRequired;
@@ -69,7 +70,7 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
 
     @Override
     public KTable<K, V> reduce(final Reducer<V> reducer) {
-        return reduce(reducer, Materialized.<K, V, KeyValueStore<Bytes, byte[]>>with(keySerde, valSerde));
+        return reduce(reducer, Materialized.with(keySerde, valSerde));
     }
 
     @Override
@@ -89,9 +90,10 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
         }
 
         return doAggregate(
-                new KStreamReduce<K, V>(materializedInternal.storeName(), reducer),
-                REDUCE_NAME,
-                materializedInternal);
+            new KStreamReduce<>(materializedInternal.storeName(), reducer),
+            REDUCE_NAME,
+            materializedInternal
+        );
     }
 
     @Override
@@ -110,15 +112,16 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
         }
 
         return doAggregate(
-                new KStreamAggregate<>(materializedInternal.storeName(), initializer, aggregator),
-                AGGREGATE_NAME,
-                materializedInternal);
+            new KStreamAggregate<>(materializedInternal.storeName(), initializer, aggregator),
+            AGGREGATE_NAME,
+            materializedInternal
+        );
     }
 
     @Override
     public <VR> KTable<K, VR> aggregate(final Initializer<VR> initializer,
                                         final Aggregator<? super K, ? super V, VR> aggregator) {
-        return aggregate(initializer, aggregator, Materialized.<K, VR, KeyValueStore<Bytes, byte[]>>with(keySerde, null));
+        return aggregate(initializer, aggregator, Materialized.with(keySerde, null));
     }
 
     @Override
@@ -158,35 +161,40 @@ class KGroupedStreamImpl<K, V> extends AbstractStream<K> implements KGroupedStre
 
     @Override
     public <W extends Window> TimeWindowedKStream<K, V> windowedBy(final Windows<W> windows) {
-        return new TimeWindowedKStreamImpl<>(windows,
-                                             builder,
-                                             sourceNodes,
-                                             name,
-                                             keySerde,
-                                             valSerde,
-                                             repartitionRequired,
-                                             parentGraphNode);
+        return new TimeWindowedKStreamImpl<>(
+            windows,
+            builder,
+            sourceNodes,
+            name,
+            keySerde,
+            valSerde,
+            repartitionRequired,
+            parentGraphNode
+        );
     }
 
     @Override
     public SessionWindowedKStream<K, V> windowedBy(final SessionWindows windows) {
-        return new SessionWindowedKStreamImpl<>(windows,
-                                                builder,
-                                                sourceNodes,
-                                                name,
-                                                keySerde,
-                                                valSerde,
-                                                aggregateBuilder,
-                                                parentGraphNode);
+        return new SessionWindowedKStreamImpl<>(
+            windows,
+            builder,
+            sourceNodes,
+            name,
+            keySerde,
+            valSerde,
+            aggregateBuilder,
+            parentGraphNode
+        );
     }
 
-    private <T> KTable<K, T> doAggregate(final KStreamAggProcessorSupplier<K, ?, V, T> aggregateSupplier,
-                                         final String functionName,
-                                         final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materializedInternal) {
-
-        final StoreBuilder<KeyValueStore<K, T>> storeBuilder = new KeyValueStoreMaterializer<>(materializedInternal)
-                .materialize();
-        return aggregateBuilder.build(aggregateSupplier, functionName, storeBuilder, materializedInternal.isQueryable());
-
+    private <KR, T> KTable<KR, T> doAggregate(final KStreamAggProcessorSupplier<K, KR, V, T> aggregateSupplier,
+                                              final String functionName,
+                                              final MaterializedInternal<K, T, KeyValueStore<Bytes, byte[]>> materializedInternal) {
+        return aggregateBuilder.build(
+            aggregateSupplier,
+            functionName,
+            new KeyValueStoreMaterializer<>(materializedInternal).materialize(),
+            materializedInternal.isQueryable()
+        );
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/SessionWindowedKStreamImpl.java
@@ -45,12 +45,7 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K> implemen
     private final Serde<K> keySerde;
     private final Serde<V> valSerde;
     private final GroupedStreamAggregateBuilder<K, V> aggregateBuilder;
-    private final Merger<K, Long> countMerger = new Merger<K, Long>() {
-        @Override
-        public Long apply(final K aggKey, final Long aggOne, final Long aggTwo) {
-            return aggOne + aggTwo;
-        }
-    };
+    private final Merger<K, Long> countMerger = (aggKey, aggOne, aggTwo) -> aggOne + aggTwo;
 
     SessionWindowedKStreamImpl(final SessionWindows windows,
                                final InternalStreamsBuilder builder,
@@ -86,7 +81,6 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K> implemen
         return doCount(materialized);
     }
 
-    @SuppressWarnings("unchecked")
     private KTable<Windowed<K>, Long> doCount(final Materialized<K, Long, SessionStore<Bytes, byte[]>> materialized) {
         final MaterializedInternal<K, Long, SessionStore<Bytes, byte[]>> materializedInternal = new MaterializedInternal<>(materialized);
         materializedInternal.generateStoreNameIfNeeded(builder, AGGREGATE_NAME);
@@ -97,19 +91,24 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K> implemen
             materializedInternal.withValueSerde(Serdes.Long());
         }
 
-        return (KTable<Windowed<K>, Long>) aggregateBuilder.build(
-            new KStreamSessionWindowAggregate<>(windows, materializedInternal.storeName(), aggregateBuilder.countInitializer, aggregateBuilder.countAggregator, countMerger),
+        return aggregateBuilder.build(
+            new KStreamSessionWindowAggregate<>(
+                windows, materializedInternal.storeName(),
+                aggregateBuilder.countInitializer,
+                aggregateBuilder.countAggregator,
+                countMerger
+            ),
             AGGREGATE_NAME,
             materialize(materializedInternal),
-            materializedInternal.isQueryable());
+            materializedInternal.isQueryable()
+        );
     }
 
     @Override
     public KTable<Windowed<K>, V> reduce(final Reducer<V> reducer) {
-        return reduce(reducer, Materialized.<K, V, SessionStore<Bytes, byte[]>>with(keySerde, valSerde));
+        return reduce(reducer, Materialized.with(keySerde, valSerde));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public KTable<Windowed<K>, V> reduce(final Reducer<V> reducer,
                                          final Materialized<K, V, SessionStore<Bytes, byte[]>> materialized) {
@@ -125,21 +124,27 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K> implemen
             materializedInternal.withValueSerde(valSerde);
         }
 
-        return (KTable<Windowed<K>, V>) aggregateBuilder.build(
-                new KStreamSessionWindowAggregate<>(windows, materializedInternal.storeName(), aggregateBuilder.reduceInitializer, reduceAggregator, mergerForAggregator(reduceAggregator)),
-                REDUCE_NAME,
-                materialize(materializedInternal),
-                materializedInternal.isQueryable());
+        return aggregateBuilder.build(
+            new KStreamSessionWindowAggregate<>(
+                windows,
+                materializedInternal.storeName(),
+                aggregateBuilder.reduceInitializer,
+                reduceAggregator,
+                mergerForAggregator(reduceAggregator)
+            ),
+            REDUCE_NAME,
+            materialize(materializedInternal),
+            materializedInternal.isQueryable()
+        );
     }
 
     @Override
     public <T> KTable<Windowed<K>, T> aggregate(final Initializer<T> initializer,
                                                 final Aggregator<? super K, ? super V, T> aggregator,
                                                 final Merger<? super K, T> sessionMerger) {
-        return aggregate(initializer, aggregator, sessionMerger, Materialized.<K, T, SessionStore<Bytes, byte[]>>with(keySerde, null));
+        return aggregate(initializer, aggregator, sessionMerger, Materialized.with(keySerde, null));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <VR> KTable<Windowed<K>, VR> aggregate(final Initializer<VR> initializer,
                                                   final Aggregator<? super K, ? super V, VR> aggregator,
@@ -155,22 +160,33 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K> implemen
         if (materializedInternal.keySerde() == null) {
             materializedInternal.withKeySerde(keySerde);
         }
-        return (KTable<Windowed<K>, VR>) aggregateBuilder.build(
-                new KStreamSessionWindowAggregate<>(windows, materializedInternal.storeName(), initializer, aggregator, sessionMerger),
-                AGGREGATE_NAME,
-                materialize(materializedInternal),
-                materializedInternal.isQueryable());
+        return aggregateBuilder.build(
+            new KStreamSessionWindowAggregate<>(
+                windows,
+                materializedInternal.storeName(),
+                initializer,
+                aggregator,
+                sessionMerger
+            ),
+            AGGREGATE_NAME,
+            materialize(materializedInternal),
+            materializedInternal.isQueryable()
+        );
     }
 
     private <VR> StoreBuilder<SessionStore<K, VR>> materialize(final MaterializedInternal<K, VR, SessionStore<Bytes, byte[]>> materialized) {
         SessionBytesStoreSupplier supplier = (SessionBytesStoreSupplier) materialized.storeSupplier();
         if (supplier == null) {
-            supplier = Stores.persistentSessionStore(materialized.storeName(),
-                                                     windows.maintainMs());
+            supplier = Stores.persistentSessionStore(
+                materialized.storeName(),
+                windows.maintainMs()
+            );
         }
-        final StoreBuilder<SessionStore<K, VR>> builder = Stores.sessionStoreBuilder(supplier,
-                                                                                     materialized.keySerde(),
-                                                                                     materialized.valueSerde());
+        final StoreBuilder<SessionStore<K, VR>> builder = Stores.sessionStoreBuilder(
+            supplier,
+            materialized.keySerde(),
+            materialized.valueSerde()
+        );
 
         if (materialized.loggingEnabled()) {
             builder.withLoggingEnabled(materialized.logConfig());
@@ -185,23 +201,10 @@ public class SessionWindowedKStreamImpl<K, V> extends AbstractStream<K> implemen
     }
 
     private Merger<K, V> mergerForAggregator(final Aggregator<K, V, V> aggregator) {
-        return new Merger<K, V>() {
-            @Override
-            public V apply(final K aggKey, final V aggOne, final V aggTwo) {
-                return aggregator.apply(aggKey, aggTwo, aggOne);
-            }
-        };
+        return (aggKey, aggOne, aggTwo) -> aggregator.apply(aggKey, aggTwo, aggOne);
     }
 
     private Aggregator<K, V, V> aggregatorForReducer(final Reducer<V> reducer) {
-        return new Aggregator<K, V, V>() {
-            @Override
-            public V apply(final K aggKey, final V value, final V aggregate) {
-                if (aggregate == null) {
-                    return value;
-                }
-                return reducer.apply(aggregate, value);
-            }
-        };
+        return (aggKey, value, aggregate) -> aggregate == null ? value : reducer.apply(aggregate, value);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -17,8 +17,8 @@
 
 package org.apache.kafka.streams.kstream.internals.graph;
 
+import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 import java.util.Arrays;
@@ -26,7 +26,7 @@ import java.util.Arrays;
 public class StatefulProcessorNode<K, V> extends StatelessProcessorNode<K, V> {
 
     private final String[] storeNames;
-    private final StoreBuilder<KeyValueStore<K, V>> storeBuilder;
+    private final StoreBuilder<? extends StateStore> storeBuilder;
     private final String maybeRepartitionedSourceName;
 
 
@@ -34,11 +34,13 @@ public class StatefulProcessorNode<K, V> extends StatelessProcessorNode<K, V> {
                                  final ProcessorParameters processorParameters,
                                  final String[] storeNames,
                                  final String maybeRepartitionedSourceName,
-                                 final StoreBuilder<KeyValueStore<K, V>> materializedKTableStoreBuilder,
+                                 final StoreBuilder<? extends StateStore> materializedKTableStoreBuilder,
                                  final boolean repartitionRequired) {
-        super(nodeName,
-              processorParameters,
-              repartitionRequired);
+        super(
+            nodeName,
+            processorParameters,
+            repartitionRequired
+        );
 
         this.storeNames = storeNames;
         this.storeBuilder = materializedKTableStoreBuilder;
@@ -67,7 +69,7 @@ public class StatefulProcessorNode<K, V> extends StatelessProcessorNode<K, V> {
         private boolean repartitionRequired;
         private String maybeRepartitionedSourceName;
         private String[] storeNames;
-        private StoreBuilder<KeyValueStore<K, V>> storeBuilder;
+        private StoreBuilder<? extends StateStore> storeBuilder;
 
         private StatefulProcessorNodeBuilder() {
         }
@@ -92,24 +94,24 @@ public class StatefulProcessorNode<K, V> extends StatelessProcessorNode<K, V> {
             return this;
         }
 
-        public StatefulProcessorNodeBuilder<K, V> withStoreBuilder(final StoreBuilder<KeyValueStore<K, V>> storeBuilder) {
+        public StatefulProcessorNodeBuilder<K, V> withStoreBuilder(final StoreBuilder<? extends StateStore> storeBuilder) {
             this.storeBuilder = storeBuilder;
             return this;
         }
 
-        public StatefulProcessorNodeBuilder<K, V> withMaybeRepartitionedSourceName(String maybeRepartitionedSourceName) {
+        public StatefulProcessorNodeBuilder<K, V> withMaybeRepartitionedSourceName(final String maybeRepartitionedSourceName) {
             this.maybeRepartitionedSourceName = maybeRepartitionedSourceName;
             return this;
         }
 
         public StatefulProcessorNode<K, V> build() {
             return new StatefulProcessorNode<>(nodeName,
-                                               processorSupplier,
-                                               storeNames,
-                                               maybeRepartitionedSourceName,
-                                               storeBuilder,
-                                               repartitionRequired);
-
+                processorSupplier,
+                storeNames,
+                maybeRepartitionedSourceName,
+                storeBuilder,
+                repartitionRequired
+            );
         }
     }
 }


### PR DESCRIPTION
We shouldn't be ignoring compiler warnings, since they tell us when our code is likely incorrect.

Sadly, our build produces hundreds of warnings in Streams alone. I plan to just go down the list and resolve them every now and then.

This is the second installment: GroupedStreamAggregateBuilder.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
