### PR TITLE
MINOR: resolve warnings in topology graph

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -171,17 +171,19 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
         String name = builder.newProcessorName(KEY_SELECT_NAME);
 
 
-        KStreamMap kStreamMap = new KStreamMap<>(
+        KStreamMap<K, V, K1, V> kStreamMap = new KStreamMap<>(
             (KeyValueMapper<K, V, KeyValue<K1, V>>) (key, value) -> new KeyValue<>(mapper.apply(key, value), value));
 
 
-        ProcessorParameters<K1, V> processorParameters = new ProcessorParameters<>(kStreamMap, name);
+        ProcessorParameters<K, V> processorParameters = new ProcessorParameters<K, V>(kStreamMap, name);
 
         builder.internalTopologyBuilder.addProcessor(name, kStreamMap, this.name);
 
-        return  new StatelessProcessorNode<>(name,
-                                             processorParameters,
-                                             repartitionRequired);
+        return new StatelessProcessorNode<>(
+            name,
+            processorParameters,
+            repartitionRequired
+        );
 
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GroupedTableOperationRepartitionNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GroupedTableOperationRepartitionNode.java
@@ -25,61 +25,76 @@ import org.apache.kafka.streams.kstream.internals.ChangedSerializer;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
-public class GroupedTableOperationRepartitionNode<K, V> extends BaseRepartitionNode {
+public class GroupedTableOperationRepartitionNode<K, V> extends BaseRepartitionNode<K, V> {
 
 
-    GroupedTableOperationRepartitionNode(final String nodeName,
-                                         final Serde<K> keySerde,
-                                         final Serde<V> valueSerde,
-                                         final String sinkName,
-                                         final String sourceName,
-                                         final String repartitionTopic,
-                                         final ProcessorParameters processorParameters) {
+    private GroupedTableOperationRepartitionNode(final String nodeName,
+                                                 final Serde<K> keySerde,
+                                                 final Serde<V> valueSerde,
+                                                 final String sinkName,
+                                                 final String sourceName,
+                                                 final String repartitionTopic,
+                                                 final ProcessorParameters processorParameters) {
 
-        super(nodeName,
-              sourceName,
-              processorParameters,
-              keySerde,
-              valueSerde,
-              sinkName,
-              repartitionTopic
+        super(
+            nodeName,
+            sourceName,
+            processorParameters,
+            keySerde,
+            valueSerde,
+            sinkName,
+            repartitionTopic
         );
     }
 
     @Override
-    Serializer getValueSerializer() {
-        final Serializer<? extends V> valueSerializer = valueSerde == null ? null : valueSerde.serializer();
-        return new ChangedSerializer<>(valueSerializer);
+    Serializer<V> getValueSerializer() {
+        final Serializer<V> valueSerializer = valueSerde == null ? null : valueSerde.serializer();
+        return unsafeCastChangedToValueSerializer(valueSerializer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Serializer<V> unsafeCastChangedToValueSerializer(final Serializer<V> valueSerializer) {
+        return (Serializer<V>) new ChangedSerializer<>(valueSerializer);
     }
 
     @Override
-    Deserializer getValueDeserializer() {
+    Deserializer<V> getValueDeserializer() {
         final Deserializer<? extends V> valueDeserializer = valueSerde == null ? null : valueSerde.deserializer();
-        return new ChangedDeserializer<>(valueDeserializer);
+        return unsafeCastChangedToValueDeserializer(valueDeserializer);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Deserializer<V> unsafeCastChangedToValueDeserializer(final Deserializer<? extends V> valueDeserializer) {
+        return (Deserializer<V>) new ChangedDeserializer<>(valueDeserializer);
     }
 
 
     @Override
-    public void writeToTopology(InternalTopologyBuilder topologyBuilder) {
+    public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
         final Serializer<K> keySerializer = keySerde != null ? keySerde.serializer() : null;
         final Deserializer<K> keyDeserializer = keySerde != null ? keySerde.deserializer() : null;
 
 
         topologyBuilder.addInternalTopic(repartitionTopic);
 
-        topologyBuilder.addSink(sinkName,
-                                repartitionTopic,
-                                keySerializer,
-                                getValueSerializer(),
-                                null,
-                                parentNode().nodeName());
+        topologyBuilder.addSink(
+            sinkName,
+            repartitionTopic,
+            keySerializer,
+            getValueSerializer(),
+            null,
+            parentNode().nodeName()
+        );
 
-        topologyBuilder.addSource(null,
-                                  sourceName,
-                                  new FailOnInvalidTimestamp(),
-                                  keyDeserializer,
-                                  getValueDeserializer(),
-                                  repartitionTopic);
+        topologyBuilder.addSource(
+            null,
+            sourceName,
+            new FailOnInvalidTimestamp(),
+            keyDeserializer,
+            getValueDeserializer(),
+            repartitionTopic
+        );
 
     }
 
@@ -101,49 +116,50 @@ public class GroupedTableOperationRepartitionNode<K, V> extends BaseRepartitionN
         private GroupedTableOperationRepartitionNodeBuilder() {
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withKeySerde(Serde<K> keySerde) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withKeySerde(final Serde<K> keySerde) {
             this.keySerde = keySerde;
             return this;
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withValueSerde(Serde<V> valueSerde) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withValueSerde(final Serde<V> valueSerde) {
             this.valueSerde = valueSerde;
             return this;
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withSinkName(String sinkName) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withSinkName(final String sinkName) {
             this.sinkName = sinkName;
             return this;
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withNodeName(String nodeName) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withNodeName(final String nodeName) {
             this.nodeName = nodeName;
             return this;
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withSourceName(String sourceName) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withSourceName(final String sourceName) {
             this.sourceName = sourceName;
             return this;
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withRepartitionTopic(String repartitionTopic) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withRepartitionTopic(final String repartitionTopic) {
             this.repartitionTopic = repartitionTopic;
             return this;
         }
 
-        public GroupedTableOperationRepartitionNodeBuilder<K, V> withProcessorParameters(ProcessorParameters processorParameters) {
+        public GroupedTableOperationRepartitionNodeBuilder<K, V> withProcessorParameters(final ProcessorParameters processorParameters) {
             this.processorParameters = processorParameters;
             return this;
         }
 
         public GroupedTableOperationRepartitionNode<K, V> build() {
-            return new GroupedTableOperationRepartitionNode(nodeName,
-                                                            keySerde,
-                                                            valueSerde,
-                                                            sinkName,
-                                                            sourceName,
-                                                            repartitionTopic,
-                                                            processorParameters
+            return new GroupedTableOperationRepartitionNode<>(
+                nodeName,
+                keySerde,
+                valueSerde,
+                sinkName,
+                sourceName,
+                repartitionTopic,
+                processorParameters
             );
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/OptimizableRepartitionNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/OptimizableRepartitionNode.java
@@ -23,23 +23,25 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
 
-public class OptimizableRepartitionNode<K, V> extends BaseRepartitionNode {
+public class OptimizableRepartitionNode<K, V> extends BaseRepartitionNode<K, V> {
 
-    OptimizableRepartitionNode(final String nodeName,
-                               final String sourceName,
-                               final ProcessorParameters processorParameters,
-                               final Serde<K> keySerde,
-                               final Serde<V> valueSerde,
-                               final String sinkName,
-                               final String repartitionTopic) {
+    private OptimizableRepartitionNode(final String nodeName,
+                                       final String sourceName,
+                                       final ProcessorParameters processorParameters,
+                                       final Serde<K> keySerde,
+                                       final Serde<V> valueSerde,
+                                       final String sinkName,
+                                       final String repartitionTopic) {
 
-        super(nodeName,
-              sourceName,
-              processorParameters,
-              keySerde,
-              valueSerde,
-              sinkName,
-              repartitionTopic);
+        super(
+            nodeName,
+            sourceName,
+            processorParameters,
+            keySerde,
+            valueSerde,
+            sinkName,
+            repartitionTopic
+        );
 
     }
 
@@ -50,36 +52,41 @@ public class OptimizableRepartitionNode<K, V> extends BaseRepartitionNode {
 
     @Override
     Deserializer<V> getValueDeserializer() {
-        return  valueSerde != null ? valueSerde.deserializer() : null;
+        return valueSerde != null ? valueSerde.deserializer() : null;
     }
 
 
     @Override
-    public void writeToTopology(InternalTopologyBuilder topologyBuilder) {
+    public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
         final Serializer<K> keySerializer = keySerde != null ? keySerde.serializer() : null;
         final Deserializer<K> keyDeserializer = keySerde != null ? keySerde.deserializer() : null;
 
 
-
         topologyBuilder.addInternalTopic(repartitionTopic);
 
-        topologyBuilder.addProcessor(processorParameters.processorName(),
-                                     processorParameters.processorSupplier(),
-                                     parentNode().nodeName());
+        topologyBuilder.addProcessor(
+            processorParameters.processorName(),
+            processorParameters.processorSupplier(),
+            parentNode().nodeName()
+        );
 
-        topologyBuilder.addSink(sinkName,
-                                repartitionTopic,
-                                keySerializer,
-                                getValueSerializer(),
-                                null,
-                                processorParameters.processorName());
+        topologyBuilder.addSink(
+            sinkName,
+            repartitionTopic,
+            keySerializer,
+            getValueSerializer(),
+            null,
+            processorParameters.processorName()
+        );
 
-        topologyBuilder.addSource(null,
-                                  sourceName,
-                                  new FailOnInvalidTimestamp(),
-                                  keyDeserializer,
-                                  getValueDeserializer(),
-                                  repartitionTopic);
+        topologyBuilder.addSource(
+            null,
+            sourceName,
+            new FailOnInvalidTimestamp(),
+            keyDeserializer,
+            getValueDeserializer(),
+            repartitionTopic
+        );
 
     }
 
@@ -139,13 +146,14 @@ public class OptimizableRepartitionNode<K, V> extends BaseRepartitionNode {
 
         public OptimizableRepartitionNode<K, V> build() {
 
-            return new OptimizableRepartitionNode<>(nodeName,
-                                                    sourceName,
-                                                    processorParameters,
-                                                    keySerde,
-                                                    valueSerde,
-                                                    sinkName,
-                                                    repartitionTopic
+            return new OptimizableRepartitionNode<>(
+                nodeName,
+                sourceName,
+                processorParameters,
+                keySerde,
+                valueSerde,
+                sinkName,
+                repartitionTopic
             );
 
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatelessProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatelessProcessorNode.java
@@ -41,19 +41,18 @@ public class StatelessProcessorNode<K, V> extends StreamsGraphNode {
 
 
     public StatelessProcessorNode(final String nodeName,
-                           final ProcessorParameters processorParameters,
-                           final boolean repartitionRequired) {
+                                  final ProcessorParameters<K, V> processorParameters,
+                                  final boolean repartitionRequired) {
 
-        super(nodeName,
-              repartitionRequired);
+        super(nodeName, repartitionRequired);
 
         this.processorParameters = processorParameters;
     }
 
     public StatelessProcessorNode(final String nodeName,
-                           final ProcessorParameters processorParameters,
-                           final boolean repartitionRequired,
-                           final List<String> multipleParentNames) {
+                                  final ProcessorParameters<K, V> processorParameters,
+                                  final boolean repartitionRequired,
+                                  final List<String> multipleParentNames) {
 
         this(nodeName, processorParameters, repartitionRequired);
 


### PR DESCRIPTION
We shouldn't be ignoring compiler warnings, since they tell us when our code is likely incorrect.

Sadly, our build produces hundreds of warnings in Streams alone. I plan to just go down the list and resolve them every now and then.

This is the fourth installment: OptimizableRepartitionNode, StatelessProcessorNode, and GroupedTableOperationRepartitionNode.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
