### PR TITLE
MINOR: Fix broken Javadoc of [AbstractIndex|OffsetIndex]

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -17,7 +17,7 @@
 
 package kafka.log
 
-import java.io.{Closeable, File, RandomAccessFile}
+import java.io.{Closeable, File, IOException, RandomAccessFile}
 import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.{ByteBuffer, MappedByteBuffer}

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -20,6 +20,7 @@ package kafka.log
 import java.io.File
 import java.nio.ByteBuffer
 
+import kafka.common.IndexOffsetOverflowException
 import kafka.utils.CoreUtils.inLock
 import org.apache.kafka.common.errors.InvalidOffsetException
 


### PR DESCRIPTION
In the javadoc of `AbstractIndex` and `OffsetIndex`, thrown `Exception`s are not imported.
