### PR TITLE
KAFKA-7168: Treat connection close during SSL handshake as retriable

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SslTransportLayer.java
@@ -841,9 +841,8 @@ public class SslTransportLayer implements TransportLayer {
     // when we are not sure, we will treat only the first exception string as a handshake exception.
     private void maybeProcessHandshakeFailure(SSLException sslException, boolean flush, IOException ioException) throws IOException {
         if (sslException instanceof SSLHandshakeException || sslException instanceof SSLProtocolException ||
-                sslException instanceof SSLPeerUnverifiedException || sslException instanceof SSLKeyException) {
-            handshakeFailure(sslException, flush);
-        } else if (sslException.getMessage().contains("Unrecognized SSL message"))
+                sslException instanceof SSLPeerUnverifiedException || sslException instanceof SSLKeyException ||
+                sslException.getMessage().contains("Unrecognized SSL message"))
             handshakeFailure(sslException, flush);
         else if (ioException == null)
             throw sslException;


### PR DESCRIPTION
SSL `close_notify` from broker connection close is processed as an `SSLException` while unwrapping the final message when the I/O exception due to remote close is processed. This should be handled as a retriable `IOException` rather than a non-retriable `SslAuthenticationException`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
