### PR TITLE
MINOR: Add thread dumps if broker node cannot be stopped

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -288,7 +288,16 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         for pid in pids:
             node.account.signal(pid, sig, allow_fail=False)
-        wait_until(lambda: len(self.pids(node)) == 0, timeout_sec=60, err_msg="Kafka node failed to stop")
+
+        try:
+            wait_until(lambda: len(self.pids(node)) == 0, timeout_sec=60, err_msg="Kafka node failed to stop")
+        except Exception:
+            self.thread_dump(node)
+            raise
+
+    def thread_dump(self, node):
+        for pid in self.pids(node):
+            node.account.signal(pid, signal.SIGQUIT, allow_fail=False)
 
     def clean_node(self, node):
         JmxMixin.clean_node(self, node)

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -297,7 +297,10 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
     def thread_dump(self, node):
         for pid in self.pids(node):
-            node.account.signal(pid, signal.SIGQUIT, allow_fail=False)
+            try:
+                node.account.signal(pid, signal.SIGQUIT, allow_fail=True)
+            except:
+                self.logger.warn("Could not dump threads on node")
 
     def clean_node(self, node):
         JmxMixin.clean_node(self, node)


### PR DESCRIPTION
In system tests, it is useful to have the thread dumps if a broker cannot be stopped using SIGTERM.

Signed-off-by: Arjun Satish <arjun@confluent.io>
