### PR TITLE
KAFKA-7144: Fix task assignment to be even

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -91,7 +91,6 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
                 // have seen the task.
             } else if (previousStandbyTaskAssignment.containsKey(taskId) &&
                        maybeAssignPreviousStandbyTask(tasksPerThread, assigned, taskId)) {
-
                 taskIdIterator.remove();
                 // assign any remaining unassigned tasks
             } else {
@@ -284,7 +283,7 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
                 if (!active && !pairs.contains(pair(task1, taskId))) {
                     return true;
                 }
-                if (!pairs.contains(pair(task1, taskId)) && task1.topicGroupId != taskId.topicGroupId) {
+                if (!pairs.contains(pair(task1, taskId))) {
                     return true;
                 }
             }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -79,23 +78,24 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
         final List<TaskId> allTasksSorted = new ArrayList<>(taskIds);
         Collections.sort(allTasksSorted);
 
-        for (final Iterator<TaskId> taskIdIterator = allTasksSorted.iterator(); taskIdIterator.hasNext(); ) {
-            final TaskId taskId = taskIdIterator.next();
+        for (final TaskId taskId : allTasksSorted) {
             // first try and re-assign existing active tasks to clients that previously had
             // the same active task
+
             if (previousActiveTaskAssignment.containsKey(taskId) &&
                 maybeAssignPreviousActiveTask(tasksPerThread, assigned, taskId)) {
-                taskIdIterator.remove();
-
-                // try and assign any remaining unassigned tasks to clients that previously
-                // have seen the task.
-            } else if (previousStandbyTaskAssignment.containsKey(taskId) &&
-                       maybeAssignPreviousStandbyTask(tasksPerThread, assigned, taskId)) {
-                taskIdIterator.remove();
-                // assign any remaining unassigned tasks
-            } else {
-                allocateTaskWithClientCandidates(taskId, clients.keySet(), true);
+                continue;
             }
+
+            // try and assign any remaining unassigned tasks to clients that previously
+            // have seen the task.
+            if (previousStandbyTaskAssignment.containsKey(taskId) &&
+                maybeAssignPreviousStandbyTask(tasksPerThread, assigned, taskId)) {
+                continue;
+            }
+
+            // assign any remaining unassigned tasks
+            allocateTaskWithClientCandidates(taskId, clients.keySet(), true);
 
         }
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignor.java
@@ -76,44 +76,58 @@ public class StickyTaskAssignor<ID> implements TaskAssignor<ID, TaskId> {
         final int tasksPerThread = taskIds.size() / totalCapacity;
         final Set<TaskId> assigned = new HashSet<>();
 
-        // first try and re-assign existing active tasks to clients that previously had
-        // the same active task
-        for (final Map.Entry<TaskId, ID> entry : previousActiveTaskAssignment.entrySet()) {
-            final TaskId taskId = entry.getKey();
-            if (taskIds.contains(taskId)) {
-                final ClientState client = clients.get(entry.getValue());
-                if (client.hasUnfulfilledQuota(tasksPerThread)) {
-                    assignTaskToClient(assigned, taskId, client);
-                }
+        final List<TaskId> allTasksSorted = new ArrayList<>(taskIds);
+        Collections.sort(allTasksSorted);
+
+        for (final Iterator<TaskId> taskIdIterator = allTasksSorted.iterator(); taskIdIterator.hasNext(); ) {
+            final TaskId taskId = taskIdIterator.next();
+            // first try and re-assign existing active tasks to clients that previously had
+            // the same active task
+            if (previousActiveTaskAssignment.containsKey(taskId) &&
+                maybeAssignPreviousActiveTask(tasksPerThread, assigned, taskId)) {
+                taskIdIterator.remove();
+
+                // try and assign any remaining unassigned tasks to clients that previously
+                // have seen the task.
+            } else if (previousStandbyTaskAssignment.containsKey(taskId) &&
+                       maybeAssignPreviousStandbyTask(tasksPerThread, assigned, taskId)) {
+
+                taskIdIterator.remove();
+                // assign any remaining unassigned tasks
+            } else {
+                allocateTaskWithClientCandidates(taskId, clients.keySet(), true);
+            }
+
+        }
+    }
+
+    private boolean maybeAssignPreviousActiveTask(final int tasksPerThread,
+                                                  final Set<TaskId> assigned,
+                                                  final TaskId taskId) {
+        boolean isAssigned = false;
+        final ID clientId = previousActiveTaskAssignment.get(taskId);
+        final ClientState client = clients.get(clientId);
+        if (client.hasUnfulfilledQuota(tasksPerThread)) {
+            assignTaskToClient(assigned, taskId, client);
+            isAssigned = true;
+        }
+        return isAssigned;
+    }
+
+    private boolean maybeAssignPreviousStandbyTask(final int tasksPerThread,
+                                                   final Set<TaskId> assigned,
+                                                   final TaskId taskId) {
+        boolean isAssigned = false;
+        final Set<ID> clientIds = previousStandbyTaskAssignment.get(taskId);
+        for (final ID clientId : clientIds) {
+            final ClientState client = clients.get(clientId);
+            if (client.hasUnfulfilledQuota(tasksPerThread)) {
+                assignTaskToClient(assigned, taskId, client);
+                isAssigned = true;
+                break;
             }
         }
-
-        final Set<TaskId> unassigned = new HashSet<>(taskIds);
-        unassigned.removeAll(assigned);
-
-        // try and assign any remaining unassigned tasks to clients that previously
-        // have seen the task.
-        for (final Iterator<TaskId> iterator = unassigned.iterator(); iterator.hasNext(); ) {
-            final TaskId taskId = iterator.next();
-            final Set<ID> clientIds = previousStandbyTaskAssignment.get(taskId);
-            if (clientIds != null) {
-                for (final ID clientId : clientIds) {
-                    final ClientState client = clients.get(clientId);
-                    if (client.hasUnfulfilledQuota(tasksPerThread)) {
-                        assignTaskToClient(assigned, taskId, client);
-                        iterator.remove();
-                        break;
-                    }
-                }
-            }
-        }
-
-        // assign any remaining unassigned tasks
-        List<TaskId> sortedTasks = new ArrayList<>(unassigned);
-        Collections.sort(sortedTasks);
-        for (final TaskId taskId : sortedTasks) {
-            allocateTaskWithClientCandidates(taskId, clients.keySet(), true);
-        }
+        return isAssigned;
     }
 
     private void allocateTaskWithClientCandidates(final TaskId taskId, final Set<ID> clientsWithin, final boolean active) {

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -153,31 +153,16 @@ public class StickyTaskAssignorTest {
 
     @Test
     public void shouldAssignTasksEvenlyWithUnequalTopicGroupSizes() {
-        final TaskId task10 = new TaskId(1, 0);
-        final TaskId task11 = new TaskId(1, 1);
-        final TaskId task12 = new TaskId(1, 2);
-        final TaskId task13 = new TaskId(1, 3);
-        final TaskId task14 = new TaskId(1, 4);
-        final TaskId task15 = new TaskId(1, 5);
-        final TaskId task16 = new TaskId(1, 6);
-        final TaskId task17 = new TaskId(1, 7);
-        final TaskId task18 = new TaskId(1, 8);
-        final TaskId task19 = new TaskId(1, 9);
-        final TaskId task110 = new TaskId(1, 10);
-        final TaskId task111 = new TaskId(1, 11);
 
-        createClientWithPreviousActiveTasks(p1, 1, task00, task10, task11, task12, task13, task14,
-                                                            task15, task16, task17, task18, task19,
-                                                            task110, task111);
+        createClientWithPreviousActiveTasks(p1, 1, task00, task01, task02, task03,
+                                                            task04, task05, task10);
 
         createClient(p2, 1);
 
-        final StickyTaskAssignor taskAssignor = createTaskAssignor(task110, task111, task12, task13, task14,
-                                                                   task15, task16, task17, task18, task19,
-                                                                   task10, task11, task00);
+        final StickyTaskAssignor taskAssignor = createTaskAssignor(task10, task00, task01, task02, task03, task04, task05);
 
-        final Set<TaskId> expectedClientITasks = new HashSet<>(Arrays.asList(task00, task10, task11, task12, task13, task14, task111));
-        final Set<TaskId> expectedClientIITasks = new HashSet<>(Arrays.asList(task15, task16, task17, task18, task19, task110));
+        final Set<TaskId> expectedClientITasks = new HashSet<>(Arrays.asList(task00, task01, task10, task05));
+        final Set<TaskId> expectedClientIITasks = new HashSet<>(Arrays.asList(task02, task03, task04));
 
         taskAssignor.assign(0);
 
@@ -279,6 +264,7 @@ public class StickyTaskAssignorTest {
         assertTrue(nonEmptyStandbyTaskCount >= 3);
         assertThat(allStandbyTasks(), equalTo(Arrays.asList(task00, task01, task02, task03)));
     }
+
 
 
     @Test
@@ -600,9 +586,7 @@ public class StickyTaskAssignorTest {
         final ClientState newClient = createClient(p4, 1);
         newClient.addPreviousStandbyTasks(Utils.mkSet(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23));
 
-        final StickyTaskAssignor<Integer>
-            taskAssignor =
-            createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
+        final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
         taskAssignor.assign(0);
 
         assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task13)));
@@ -633,9 +617,7 @@ public class StickyTaskAssignorTest {
         final ClientState bounce2 = createClient(p4, 1);
         bounce2.addPreviousStandbyTasks(Utils.mkSet(task02, task03, task10));
 
-        final StickyTaskAssignor<Integer>
-            taskAssignor =
-            createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
+        final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
         taskAssignor.assign(0);
 
         assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task13)));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -167,13 +167,13 @@ public class StickyTaskAssignorTest {
         final TaskId task111 = new TaskId(1, 11);
 
         createClientWithPreviousActiveTasks(p1, 1, task00, task10, task11, task12, task13, task14,
-                                                            task15, task15, task16, task17, task18, task19,
+                                                            task15, task16, task17, task18, task19,
                                                             task110, task111);
 
         createClient(p2, 1);
 
         final StickyTaskAssignor taskAssignor = createTaskAssignor(task110, task111, task12, task13, task14,
-                                                                   task15, task15, task16, task17, task18, task19,
+                                                                   task15, task16, task17, task18, task19,
                                                                    task10, task11, task00);
 
         final Set<TaskId> expectedClientITasks = new HashSet<>(Arrays.asList(task00, task10, task11, task12, task13, task14, task111));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -152,6 +152,40 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
+    public void shouldAssignTasksEvenlyWithUnequalTopicGroupSizes() {
+        final TaskId task10 = new TaskId(1, 0);
+        final TaskId task11 = new TaskId(1, 1);
+        final TaskId task12 = new TaskId(1, 2);
+        final TaskId task13 = new TaskId(1, 3);
+        final TaskId task14 = new TaskId(1, 4);
+        final TaskId task15 = new TaskId(1, 5);
+        final TaskId task16 = new TaskId(1, 6);
+        final TaskId task17 = new TaskId(1, 7);
+        final TaskId task18 = new TaskId(1, 8);
+        final TaskId task19 = new TaskId(1, 9);
+        final TaskId task110 = new TaskId(1, 10);
+        final TaskId task111 = new TaskId(1, 11);
+
+        createClientWithPreviousActiveTasks(p1, 1, task00, task10, task11, task12, task13, task14,
+                                                            task15, task15, task16, task17, task18, task19,
+                                                            task110, task111);
+
+        createClient(p2, 1);
+
+        final StickyTaskAssignor taskAssignor = createTaskAssignor(task110, task111, task12, task13, task14,
+                                                                   task15, task15, task16, task17, task18, task19,
+                                                                   task10, task11, task00);
+
+        final Set<TaskId> expectedClientITasks = new HashSet<>(Arrays.asList(task00, task10, task11, task12, task13, task14, task111));
+        final Set<TaskId> expectedClientIITasks = new HashSet<>(Arrays.asList(task15, task16, task17, task18, task19, task110));
+
+        taskAssignor.assign(0);
+
+        assertThat(clients.get(p1).activeTasks(), equalTo(expectedClientITasks));
+        assertThat(clients.get(p2).activeTasks(), equalTo(expectedClientIITasks));
+    }
+
+    @Test
     public void shouldKeepActiveTaskStickynessWhenMoreClientThanActiveTasks() {
         final int p5 = 5;
         createClientWithPreviousActiveTasks(p1, 1, task00);
@@ -245,7 +279,6 @@ public class StickyTaskAssignorTest {
         assertTrue(nonEmptyStandbyTaskCount >= 3);
         assertThat(allStandbyTasks(), equalTo(Arrays.asList(task00, task01, task02, task03)));
     }
-
 
 
     @Test
@@ -567,7 +600,9 @@ public class StickyTaskAssignorTest {
         final ClientState newClient = createClient(p4, 1);
         newClient.addPreviousStandbyTasks(Utils.mkSet(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23));
 
-        final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
+        final StickyTaskAssignor<Integer>
+            taskAssignor =
+            createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
         taskAssignor.assign(0);
 
         assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task13)));
@@ -598,7 +633,9 @@ public class StickyTaskAssignorTest {
         final ClientState bounce2 = createClient(p4, 1);
         bounce2.addPreviousStandbyTasks(Utils.mkSet(task02, task03, task10));
 
-        final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
+        final StickyTaskAssignor<Integer>
+            taskAssignor =
+            createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
         taskAssignor.assign(0);
 
         assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task13)));

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/assignment/StickyTaskAssignorTest.java
@@ -99,7 +99,7 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
-    public void shouldMigrateActiveTaskToOtherProcessOverStickiness() {
+    public void shouldNotMigrateActiveTaskToOtherProcess() {
         createClientWithPreviousActiveTasks(p1, 1, task00);
         createClientWithPreviousActiveTasks(p2, 1, task01);
 
@@ -119,7 +119,7 @@ public class StickyTaskAssignorTest {
         final StickyTaskAssignor secondAssignor = createTaskAssignor(task00, task01, task02);
         secondAssignor.assign(0);
 
-        assertThat(clients.get(p1).activeTasks(), hasItems(task00));
+        assertThat(clients.get(p1).activeTasks(), hasItems(task01));
         assertThat(clients.get(p2).activeTasks(), hasItems(task02));
         assertThat(allActiveTasks(), equalTo(Arrays.asList(task00, task01, task02)));
     }
@@ -547,7 +547,7 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
-    public void shouldLoadBalanceWhenAssigningTasksNotPreviouslyActiveToNewClient() {
+    public void shouldAssignTasksNotPreviouslyActiveToNewClient() {
         final TaskId task10 = new TaskId(0, 10);
         final TaskId task11 = new TaskId(0, 11);
         final TaskId task12 = new TaskId(1, 2);
@@ -570,14 +570,14 @@ public class StickyTaskAssignorTest {
         final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
         taskAssignor.assign(0);
 
-        assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task11)));
-        assertThat(c2.activeTasks(), equalTo(Utils.mkSet(task00, task02, task03)));
+        assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task13)));
+        assertThat(c2.activeTasks(), equalTo(Utils.mkSet(task00, task11, task22)));
         assertThat(c3.activeTasks(), equalTo(Utils.mkSet(task20, task21, task23)));
-        assertThat(newClient.activeTasks(), equalTo(Utils.mkSet(task13, task22, task10)));
+        assertThat(newClient.activeTasks(), equalTo(Utils.mkSet(task02, task03, task10)));
     }
 
     @Test
-    public void shouldFavorLoadBalancingTasksNotPreviouslyActiveToMultipleNewClients() {
+    public void shouldAssignTasksNotPreviouslyActiveToMultipleNewClients() {
         final TaskId task10 = new TaskId(0, 10);
         final TaskId task11 = new TaskId(0, 11);
         final TaskId task12 = new TaskId(1, 2);
@@ -601,10 +601,10 @@ public class StickyTaskAssignorTest {
         final StickyTaskAssignor<Integer> taskAssignor = createTaskAssignor(task00, task10, task01, task02, task11, task20, task03, task12, task21, task13, task22, task23);
         taskAssignor.assign(0);
 
-        assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task11)));
-        assertThat(c2.activeTasks(), equalTo(Utils.mkSet(task00, task02, task03)));
-        assertThat(bounce1.activeTasks(), equalTo(Utils.mkSet(task20, task21, task13)));
-        assertThat(bounce2.activeTasks(), equalTo(Utils.mkSet(task22, task23, task10)));
+        assertThat(c1.activeTasks(), equalTo(Utils.mkSet(task01, task12, task13)));
+        assertThat(c2.activeTasks(), equalTo(Utils.mkSet(task00, task11, task22)));
+        assertThat(bounce1.activeTasks(), equalTo(Utils.mkSet(task20, task21, task23)));
+        assertThat(bounce2.activeTasks(), equalTo(Utils.mkSet(task02, task03, task10)));
     }
 
     @Test
@@ -616,7 +616,7 @@ public class StickyTaskAssignorTest {
     }
 
     @Test
-    public void shouldAssignTasksToNewClientConsideringLoadBalancingFirstBetweenExistingClients() {
+    public void shouldAssignTasksToNewClientWithoutFlippingAssignmentBetweenExistingClients() {
         final ClientState c1 = createClientWithPreviousActiveTasks(p1, 1, task00, task01, task02);
         final ClientState c2 = createClientWithPreviousActiveTasks(p2, 1, task03, task04, task05);
         final ClientState newClient = createClient(p3, 1);
@@ -629,13 +629,13 @@ public class StickyTaskAssignorTest {
         assertThat(c1.activeTaskCount(), equalTo(2));
         assertThat(c2.activeTasks(), not(hasItems(task00)));
         assertThat(c2.activeTasks(), not(hasItems(task01)));
-        assertThat(c2.activeTasks(), hasItems(task02));
+        assertThat(c2.activeTasks(), not(hasItems(task02)));
         assertThat(c2.activeTaskCount(), equalTo(2));
         assertThat(newClient.activeTaskCount(), equalTo(2));
     }
 
     @Test
-    public void shouldAssignTasksToNewClientsConsideringLoadBalancingFirstBetweenExistingAndBouncedClients() {
+    public void shouldAssignTasksToNewClientWithoutFlippingAssignmentBetweenExistingAndBouncedClients() {
         final TaskId task06 = new TaskId(0, 6);
         final ClientState c1 = createClientWithPreviousActiveTasks(p1, 1, task00, task01, task02, task06);
         final ClientState c2 = createClient(p2, 1);
@@ -650,7 +650,7 @@ public class StickyTaskAssignorTest {
         assertThat(c1.activeTaskCount(), equalTo(3));
         assertThat(c2.activeTasks(), not(hasItems(task00)));
         assertThat(c2.activeTasks(), not(hasItems(task01)));
-        assertThat(c2.activeTasks(), hasItems(task02));
+        assertThat(c2.activeTasks(), not(hasItems(task02)));
         assertThat(c2.activeTaskCount(), equalTo(2));
         assertThat(newClient.activeTaskCount(), equalTo(2));
     }


### PR DESCRIPTION
This PR now justs removes the check in `TaskPairs.hasNewPair` that was causing the task assignment issue.

This was done as we need to further refine task assignment strategy and this approach needs to include the statefulness of tasks and is best done in one pass vs taking a "patchy" approach.

Updated current tests and ran locally

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
