### PR TITLE
KAFKA-6960: Remove the methods from the internal Scala AdminClient th…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/LegacyAdminClientTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LegacyAdminClientTest.scala
@@ -84,17 +84,6 @@ class LegacyAdminClientTest extends IntegrationTestHarness with Logging {
   }
 
   @Test
-  def testListGroups() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
-
-    val groups = client.listAllGroupsFlattened
-    assertFalse(groups.isEmpty)
-    val group = groups.head
-    assertEquals(groupId, group.groupId)
-    assertEquals("consumer", group.protocolType)
-  }
-
-  @Test
   def testListAllBrokerVersionInfo() {
     subscribeAndWaitForAssignment(topic, consumers.head)
 
@@ -107,36 +96,6 @@ class LegacyAdminClientTest extends IntegrationTestHarness with Logging {
       val brokerVersionInfo = tryBrokerVersionInfo.get
       assertEquals(2, brokerVersionInfo.latestUsableVersion(ApiKeys.API_VERSIONS))
     }
-  }
-
-  @Test
-  def testGetConsumerGroupSummary() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
-
-    val group = client.describeConsumerGroup(groupId)
-    assertEquals("range", group.assignmentStrategy)
-    assertEquals("Stable", group.state)
-    assertFalse(group.consumers.isEmpty)
-
-    val member = group.consumers.get.head
-    assertEquals(clientId, member.clientId)
-    assertFalse(member.host.isEmpty)
-    assertFalse(member.consumerId.isEmpty)
-  }
-
-  @Test
-  def testDescribeConsumerGroup() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
-
-    val consumerGroupSummary = client.describeConsumerGroup(groupId)
-    assertEquals(1, consumerGroupSummary.consumers.get.size)
-    assertEquals(List(tp, tp2), consumerGroupSummary.consumers.get.flatMap(_.assignment))
-  }
-
-  @Test
-  def testDescribeConsumerGroupForNonExistentGroup() {
-    val nonExistentGroup = "non" + groupId
-    assertTrue("Expected empty ConsumerSummary list", client.describeConsumerGroup(nonExistentGroup).consumers.get.isEmpty)
   }
 
   private def subscribeAndWaitForAssignment(topic: String, consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {


### PR DESCRIPTION
…at are provided by the new AdminClient

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

This is a follow-up task of KAFKA-6884. 

Remove all the methods from the internal Scala ``AdminClient`` that are provided by the new AdminClient. 
- deleted: ``deleteConsumerGroups, describeConsumerGroup, listGroups, listAllGroups,  listAllGroupsFlattened``, 
- updated ``LegacyAdminClientTest``. 

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

Deleted tests in ``LegacyAdminClientTest`` that validated the behaviour of the deleted methods in ``AdminClient.scala``.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
