### PR TITLE
MINOR: Implicit conversion from Long to SessionWindows

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/ImplicitConversions.scala
@@ -81,4 +81,6 @@ object ImplicitConversions {
                                                       valueSerde: Serde[V],
                                                       otherValueSerde: Serde[VO]): Joined[K, V, VO] =
     Joined.`with`(keySerde, valueSerde, otherValueSerde)
+
+  implicit def longToSessionWindows(x: Long): SessionWindows = SessionWindows.`with`(x)
 }


### PR DESCRIPTION
Some syntactic sugar on the Scala Streams API with an implicit conversion from Long to Session Windows to use the ```windowedBy(SessionWindows)``` function this way:
```scala
stream
  .groupBy((_, _) => something)
  .windowedBy(5l)
```