### PR TITLE
KAFKA-7189 : Add a Merge Transformer for Kafka Connect

### DIFF
--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MergeField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MergeField.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.util.SchemaUtil;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+public abstract class MergeField<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    public static final String OVERVIEW_DOC =
+        "Merge a list of field under one root field, composing a nested field, with the possibility " +
+                "to keep the field or remove it. "
+                + "<p/>Use the concrete transformation type designed for the record key (<code>" + Key.class.getName() + "</code>) "
+                + "or value (<code>" + Value.class.getName() + "</code>).";
+    public static final String FIELD_ROOT_CONFIG = "field.root";
+    public static final String FIELD_LIST_CONFIG = "field.list";
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(FIELD_ROOT_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,  ConfigDef.Importance.MEDIUM,
+                    "The root fields")
+            .define(FIELD_LIST_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.MEDIUM,
+                    "The root fields");
+
+    private static final String PURPOSE = "merging";
+
+    private String fieldRoot;
+    private List<MergeSpec> fieldList;
+
+    private Cache<Object, Schema> schemaUpdateCache;
+
+
+    public static final class MergeSpec {
+        final String name;
+        final boolean optional;
+        final boolean keepIt;
+
+        public MergeSpec(String name, boolean keepIt, boolean optional) {
+            this.name = name;
+            this.optional = optional;
+            this.keepIt = keepIt;
+        }
+
+        public static MergeSpec parse(String spec) {
+
+            if (spec == null) return null;
+
+            else if (spec.startsWith("*") && spec.endsWith("?"))
+                return new MergeSpec(removeSpecs(spec), true, true);
+
+            else if (spec.startsWith("*") && !spec.endsWith("?"))
+                return new MergeSpec(removeSpecs(spec), true, false);
+
+            else if (!spec.startsWith("*") && spec.endsWith("?"))
+                return new MergeSpec(removeSpecs(spec), false, true);
+
+            else
+                return new MergeSpec(removeSpecs(spec), false, false);
+        }
+
+        private static String removeSpecs(String spec) {
+            return spec.replace("?", "").replace("*", "");
+        }
+
+    }
+
+
+    @Override
+    public R apply(R record) {
+
+        Schema newSchema = makeUpdatedSchema(operatingSchema(record), fieldRoot, fieldList);
+        Schema structSchema = buildNewStructSchema(operatingSchema(record), fieldList);
+        Struct newValue = buildNewValue(record, newSchema, structSchema);
+
+        return newRecord(record, newSchema, newValue);
+    }
+
+
+    public Struct buildNewValue(R record, Schema newSchema, Schema rootSchema) {
+
+        final Struct value = requireStruct(operatingValue(record), PURPOSE);
+        final Struct updatedValue = new Struct(newSchema);
+        final Struct nestedValue = new Struct(rootSchema);
+
+        rootSchema.fields().stream().forEach(field -> nestedValue.put(field.name(), value.get(field.name())));
+
+        newSchema.fields().stream().filter(field -> !field.name().equals(fieldRoot)).forEach(field -> updatedValue.put(field, value.get(field)));
+
+        updatedValue.put(fieldRoot, nestedValue);
+
+        return updatedValue;
+    }
+
+    public Schema buildNewStructSchema(Schema schema, List<MergeSpec> fieldList) {
+
+        return Optional.ofNullable(schemaUpdateCache.get(fieldRoot)).orElseGet(() -> {
+            SchemaBuilder builder = new SchemaBuilder(Schema.Type.STRUCT);
+
+            fieldList.stream().forEach(fieldSpec -> builder.field(
+                    schema.field(fieldSpec.name).name(),
+                    convertFieldSchema(schema.field(fieldSpec.name).schema(), fieldSpec.optional)
+            ));
+
+            Schema newStructSchema = builder.build();
+            schemaUpdateCache.put(fieldRoot, newStructSchema);
+            return newStructSchema;
+
+        });
+    }
+
+    private Schema convertFieldSchema(Schema orig, boolean optional) {
+        // Note that we don't use the schema translation cache here. It might save us a bit of effort, but we really
+        // only care about caching top-level schema translations.
+
+        final SchemaBuilder builder = SchemaUtil.copySchemaBasics(orig);
+        if (optional)
+            builder.optional();
+        return builder.build();
+    }
+
+    public Schema makeUpdatedSchema(Schema schema, String fieldRoot, List<MergeSpec> fieldList) {
+
+        return Optional.ofNullable(schemaUpdateCache.get(schema)).orElseGet( () -> {
+
+            final SchemaBuilder builder = SchemaUtil.copySchemaBasics(schema);
+
+            schema.fields().stream().forEach(field -> {
+                Optional<Boolean> shouldKeepIt = fieldList.stream()
+                        .filter(fieldSpec -> fieldSpec.name.equals(field.name()))
+                        .findFirst().map(fieldSpec -> fieldSpec.keepIt);
+
+                if (shouldKeepIt.orElse(true)) {
+                    builder.field(field.name(), field.schema());
+                }
+
+            });
+
+            Schema fieldListSchema = buildNewStructSchema(schema, fieldList);
+
+            builder.field(fieldRoot, fieldListSchema);
+
+            Schema newSchema = builder.build();
+
+            schemaUpdateCache.put(schema, newSchema);
+
+            return newSchema;
+
+        });
+    }
+
+    public static class Key<R extends ConnectRecord<R>> extends MergeField<R> {
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.keySchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.key();
+        }
+
+        @Override
+        protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
+            return record.newRecord(record.topic(), record.kafkaPartition(), updatedSchema, updatedValue, record.valueSchema(), record.value(), record.timestamp());
+        }
+    }
+
+    public static class Value<R extends ConnectRecord<R>> extends MergeField<R> {
+        @Override
+        protected Schema operatingSchema(R record) {
+            return record.valueSchema();
+        }
+
+        @Override
+        protected Object operatingValue(R record) {
+            return record.value();
+        }
+
+        @Override
+        protected R newRecord(R record, Schema updatedSchema, Object updatedValue) {
+            return record.newRecord(record.topic(), record.kafkaPartition(), record.keySchema(), record.key(), updatedSchema, updatedValue, record.timestamp());
+        }
+    }
+
+
+    protected abstract Schema operatingSchema(R record);
+
+    protected abstract Object operatingValue(R record);
+
+    protected abstract R newRecord(R record, Schema updatedSchema, Object updatedValue);
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        fieldRoot = config.getString(FIELD_ROOT_CONFIG);
+        fieldList = new ArrayList<MergeSpec>();
+
+        config.getList(FIELD_LIST_CONFIG).stream().forEach(field -> fieldList.add(MergeSpec.parse(field)));
+
+        schemaUpdateCache = new SynchronizedCache<>(new LRUCache<Object, Schema>(16));
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MergeField.java
+++ b/connect/transforms/src/main/java/org/apache/kafka/connect/transforms/MergeField.java
@@ -49,9 +49,9 @@ public abstract class MergeField<R extends ConnectRecord<R>> implements Transfor
 
     public static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(FIELD_ROOT_CONFIG, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE,  ConfigDef.Importance.MEDIUM,
-                    "The root fields")
+                    "The root field")
             .define(FIELD_LIST_CONFIG, ConfigDef.Type.LIST, ConfigDef.NO_DEFAULT_VALUE, ConfigDef.Importance.MEDIUM,
-                    "The root fields");
+                    "The list of fields to merge");
 
     private static final String PURPOSE = "merging";
 
@@ -59,7 +59,6 @@ public abstract class MergeField<R extends ConnectRecord<R>> implements Transfor
     private List<MergeSpec> fieldList;
 
     private Cache<Object, Schema> schemaUpdateCache;
-
 
     public static final class MergeSpec {
         final String name;

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MergeFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MergeFieldTest.java
@@ -24,12 +24,10 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.HashMap;
 import java.util.Map;
-
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -221,8 +219,6 @@ public class MergeFieldTest {
         expectedStruct2.put(rootField, nestedExpectedStruct2);
 
         assertEquals(expectedStruct2, transformed2.value());
-
-
     }
 
     @Test
@@ -252,6 +248,26 @@ public class MergeFieldTest {
 
         assertNull(transformed.keySchema());
         assertEquals(transformed.key(), expectedRecord);
+    }
+
+
+    void testMergeSpecHelper(MergeField.MergeSpec result, MergeField.MergeSpec expected) {
+        assertEquals(result.name,   expected.name);
+        assertEquals(result.keepIt,  expected.keepIt);
+        assertEquals(result.optional, expected.optional);
+    }
+
+    @Test
+    public void mergeSpecTest() {
+        String optionalMergeAndKeep = "*abcd?";
+        String optionalMergeAndRemove = "abcd?";
+        String mergeAndKeep = "*abcd";
+        String mergeAndRemove = "abcd";
+
+        testMergeSpecHelper(MergeField.MergeSpec.parse(optionalMergeAndKeep), new MergeField.MergeSpec("abcd", true, true));
+        testMergeSpecHelper(MergeField.MergeSpec.parse(optionalMergeAndRemove), new MergeField.MergeSpec("abcd", false, true));
+        testMergeSpecHelper(MergeField.MergeSpec.parse(mergeAndKeep), new MergeField.MergeSpec("abcd", true, false));
+        testMergeSpecHelper(MergeField.MergeSpec.parse(mergeAndRemove), new MergeField.MergeSpec("abcd", false, false));
     }
 
 }

--- a/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MergeFieldTest.java
+++ b/connect/transforms/src/test/java/org/apache/kafka/connect/transforms/MergeFieldTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.connect.transforms;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+
+public class MergeFieldTest {
+    private final MergeField<SourceRecord> xformKey = new MergeField.Key<>();
+    private final MergeField<SourceRecord> xformValue = new MergeField.Value<>();
+
+    @After
+    public void teardown() {
+        xformKey.close();
+        xformValue.close();
+    }
+
+    @Test(expected = DataException.class)
+    public void topLevelStructRequired() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(MergeField.FIELD_ROOT_CONFIG, "root");
+        props.put(MergeField.FIELD_LIST_CONFIG, "field");
+
+        xformValue.configure(props);
+
+        xformValue.apply(new SourceRecord(null, null, "topic", 0, Schema.INT32_SCHEMA, 42));
+    }
+
+    @Test
+    public void testMakeUpdatedSchema() {
+
+        String rootField = "root";
+
+        final Map<String, String> props = new HashMap<>();
+        props.put(MergeField.FIELD_ROOT_CONFIG, rootField);
+        props.put(MergeField.FIELD_LIST_CONFIG, "*field1?, *field2, field3?, field4");
+
+        xformValue.configure(props);
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("field", Schema.INT32_SCHEMA);
+        builder.field("field1", Schema.INT32_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        builder.field("field3", Schema.INT32_SCHEMA);
+        builder.field("field4", Schema.INT32_SCHEMA);
+        Schema schema = builder.build();
+
+
+        builder = SchemaBuilder.struct();
+        builder.field("field1", Schema.OPTIONAL_INT32_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        builder.field("field3", Schema.OPTIONAL_INT32_SCHEMA);
+        builder.field("field4", Schema.INT32_SCHEMA);
+        Schema nestedSchema = builder.build();
+
+
+        builder = SchemaBuilder.struct();
+        builder.field("field", Schema.INT32_SCHEMA);
+        builder.field("field1", Schema.INT32_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        builder.field(rootField, nestedSchema);
+
+        Schema expectedSchem = builder.build();
+
+        List<MergeField.MergeSpec> list = new ArrayList<MergeField.MergeSpec>();
+        list.add(new MergeField.MergeSpec("field1", true, true));
+        list.add(new MergeField.MergeSpec("field2", true, false));
+        list.add(new MergeField.MergeSpec("field3", false, true));
+        list.add(new MergeField.MergeSpec("field4", false, false));
+
+
+        assertEquals(xformValue.makeUpdatedSchema(schema, rootField,  list), expectedSchem);
+
+    }
+
+    @Test
+    public void testNestedStruct() {
+        String rootField = "root";
+
+        final Map<String, String> props = new HashMap<>();
+        props.put(MergeField.FIELD_ROOT_CONFIG, rootField);
+        props.put(MergeField.FIELD_LIST_CONFIG, "*field1?, *field2, field3?, field4, field5?");
+
+        xformValue.configure(props);
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("field", Schema.INT32_SCHEMA);
+        builder.field("field1", Schema.INT32_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        builder.field("field3", Schema.INT32_SCHEMA);
+        builder.field("field4", Schema.INT32_SCHEMA);
+        builder.field("field5", Schema.OPTIONAL_INT32_SCHEMA);
+        Schema schema = builder.build();
+
+
+
+
+        Struct struct = new Struct(schema);
+        struct.put("field", 0);
+        struct.put("field1", 1);
+        struct.put("field2", 2);
+        struct.put("field3", 3);
+        struct.put("field4", 4);
+        struct.put("field5", 5);
+
+
+        SourceRecord transformed = xformValue.apply(new SourceRecord(null, null,
+                "topic", 0, schema, struct));
+
+
+
+        builder = SchemaBuilder.struct();
+        builder.field("field1", Schema.OPTIONAL_INT32_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        builder.field("field3", Schema.OPTIONAL_INT32_SCHEMA);
+        builder.field("field4", Schema.INT32_SCHEMA);
+        builder.field("field5", Schema.OPTIONAL_INT32_SCHEMA);
+        Schema nestedSchema = builder.build();
+
+
+        builder = SchemaBuilder.struct();
+        builder.field("field", Schema.INT32_SCHEMA);
+        builder.field("field1", Schema.INT32_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        builder.field(rootField, nestedSchema);
+
+        Schema expectedSchema = builder.build();
+
+
+
+        Struct expectedStruct = new Struct(expectedSchema);
+
+        expectedStruct.put("field", 0);
+        expectedStruct.put("field1", 1);
+        expectedStruct.put("field2", 2);
+
+
+        List<MergeField.MergeSpec> list = new ArrayList<MergeField.MergeSpec>();
+        list.add(new MergeField.MergeSpec("field1", true, true));
+        list.add(new MergeField.MergeSpec("field2", true, false));
+        list.add(new MergeField.MergeSpec("field3", false, true));
+        list.add(new MergeField.MergeSpec("field4", false, false));
+        list.add(new MergeField.MergeSpec("field5", false, true));
+
+
+        Struct nestedExpectedStruct = new Struct(xformValue.buildNewStructSchema(schema, list));
+        nestedExpectedStruct.put("field1", 1);
+        nestedExpectedStruct.put("field2", 2);
+        nestedExpectedStruct.put("field3", 3);
+        nestedExpectedStruct.put("field4", 4);
+        nestedExpectedStruct.put("field5", 5);
+
+        expectedStruct.put(rootField, nestedExpectedStruct);
+
+        assertEquals(expectedStruct, transformed.value());
+
+
+
+        Struct struct2 = new Struct(schema);
+        struct2.put("field", 0);
+        struct2.put("field1", 1);
+        struct2.put("field2", 2);
+        struct2.put("field3", 3);
+        struct2.put("field4", 4);
+
+
+        SourceRecord transformed2 = xformValue.apply(new SourceRecord(null, null,
+                "topic", 0, schema, struct2));
+
+
+        Struct nestedExpectedStruct2 = new Struct(xformValue.buildNewStructSchema(schema, list));
+        nestedExpectedStruct2.put("field1", 1);
+        nestedExpectedStruct2.put("field2", 2);
+        nestedExpectedStruct2.put("field3", 3);
+        nestedExpectedStruct2.put("field4", 4);
+
+        Struct expectedStruct2 = new Struct(expectedSchema);
+
+        expectedStruct2.put("field", 0);
+        expectedStruct2.put("field1", 1);
+        expectedStruct2.put("field2", 2);
+        expectedStruct2.put(rootField, nestedExpectedStruct2);
+
+        assertEquals(expectedStruct2, transformed2.value());
+
+
+    }
+
+    @Test
+    public void testKey() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(MergeField.FIELD_ROOT_CONFIG, "root");
+        props.put(MergeField.FIELD_LIST_CONFIG, "*field1, field2");
+
+        xformKey.configure(props);
+
+        SchemaBuilder builder = SchemaBuilder.struct();
+        builder.field("field", Schema.INT8_SCHEMA);
+        builder.field("field1", Schema.INT16_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        Schema keySchema = builder.build();
+
+        Struct record = new Struct(keySchema);
+        record.put("field", (byte) 8);
+        record.put("field1", (short) 16);
+        record.put("field2", 32);
+
+        SourceRecord transformed =  xformKey.apply(new SourceRecord(null, null, "topic", keySchema, record, null, null));
+
+
+        builder = SchemaBuilder.struct();
+        builder.field("field1", Schema.INT16_SCHEMA);
+        builder.field("field2", Schema.INT32_SCHEMA);
+        Schema expectedNestedSchema = builder.build();
+
+        builder = SchemaBuilder.struct();
+        builder.field("field", Schema.INT8_SCHEMA);
+        builder.field("field1", Schema.INT16_SCHEMA);
+        builder.field("root", expectedNestedSchema);
+        Schema expectedSchema = builder.build();
+
+
+        Struct expectedNestedRecord = new Struct(expectedNestedSchema);
+        expectedNestedRecord.put("field1", (short) 16);
+        expectedNestedRecord.put("field2", 32);
+
+
+        Struct expectedRecord = new Struct(expectedSchema);
+        expectedRecord.put("field", (byte) 8);
+        expectedRecord.put("field1", (short) 16);
+        expectedRecord.put("root", expectedNestedRecord);
+
+
+        assertEquals(transformed.key(), expectedRecord);
+    }
+
+}


### PR DESCRIPTION
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

Like the flatten, there is the need too for a merge transformer.

Example transformation :
We want to add the offset and the partition for each record, and after that merge them into one field _metadata:
```"transforms":"AddOffset, AddPartition, MergeFields", 

"transforms.AddOffset.type":"org.apache.kafka.connect.transforms.InsertField$Value",
"transforms.AddOffset.offset.field":"offset!",

"transforms.AddPartition.type":"org.apache.kafka.connect.transforms.InsertField$Value",
"transforms.AddPartition.partition.field":"partition!",

"transforms.MergeFields.type":"org.apache.kafka.connect.transforms.Merge$Value",
"transforms.MergeFields.field.list":"offset,partition",
"transforms.MergeFields.field.root":"_metadata"
```

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

1. Test topLevelStrcuteRequired for records with Schema
2. Test topLevelMapRequired for schemaless records
3. Test Merge fields for a record value with schema for the 4 cases.
4. Test Merge fields for a schemaless record key. 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
