### PR TITLE
MINOR: increase dev version from 1.1.1-SNAPSHOT to 1.1.2-SNAPSHOT

### DIFF
--- a/tests/kafkatest/version.py
+++ b/tests/kafkatest/version.py
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 
-from kafkatest.utils import kafkatest_version
-
 from distutils.version import LooseVersion
+from kafkatest.utils import kafkatest_version
 
 
 class KafkaVersion(LooseVersion):
@@ -61,7 +60,7 @@ def get_version(node=None):
         return DEV_BRANCH
 
 DEV_BRANCH = KafkaVersion("dev")
-DEV_VERSION = KafkaVersion("1.1.1-SNAPSHOT")
+DEV_VERSION = KafkaVersion("1.1.2-SNAPSHOT")
 
 # 0.8.2.X versions
 V_0_8_2_1 = KafkaVersion("0.8.2.1")


### PR DESCRIPTION
With the release of `1.1.1` the `StreamsUpgradeTest.test_metadata_upgrade` and `StreamsUpgradeTest.test_metadata_downgrade` system tests were failing unable to find Kafka Streams version `1.1.1-SNAPSHOT`.  This PR updates `DEV_VERSION` in `version.py` to `1.1.2-SNAPSHOT`

Testing was completed by running the streams system tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
