### PR TITLE
MINOR: Close ZooKeeperClient if waitUntilConnected fails during construction

### DIFF
--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -92,9 +92,8 @@ class ZooKeeperClient(connectString: String,
   metricNames += "SessionState"
 
   expiryScheduler.startup()
-  try {
-    waitUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)
-  } catch {
+  try waitUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)
+  catch {
     case e: Throwable =>
       close()
       throw e

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -96,7 +96,7 @@ class ZooKeeperClient(connectString: String,
     waitUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)
   } catch {
     case e: ZooKeeperClientTimeoutException =>
-      zooKeeper.close()
+      close()
       throw e
   }
 

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -95,7 +95,7 @@ class ZooKeeperClient(connectString: String,
   try {
     waitUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)
   } catch {
-    case e: ZooKeeperClientException =>
+    case e: Throwable =>
       close()
       throw e
   }

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -95,7 +95,7 @@ class ZooKeeperClient(connectString: String,
   try {
     waitUntilConnected(connectionTimeoutMs, TimeUnit.MILLISECONDS)
   } catch {
-    case e: ZooKeeperClientTimeoutException =>
+    case e: ZooKeeperClientException =>
       close()
       throw e
   }

--- a/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
+++ b/core/src/main/scala/kafka/zookeeper/ZooKeeperClient.scala
@@ -222,6 +222,7 @@ class ZooKeeperClient(connectString: String,
       var state = connectionState
       while (!state.isConnected && state.isAlive) {
         if (nanos <= 0) {
+          zooKeeper.close()
           throw new ZooKeeperClientTimeoutException(s"Timed out waiting for connection while in state: $state")
         }
         nanos = isConnectedOrExpiredCondition.awaitNanos(nanos)

--- a/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zookeeper/ZooKeeperClientTest.scala
@@ -64,14 +64,14 @@ class ZooKeeperClientTest extends ZooKeeperTestHarness {
         Int.MaxValue, time, "testMetricGroup", "testMetricType")
     } catch {
       case e: ZooKeeperClientTimeoutException =>
-        assertEquals("ZooKeeper client threads still running", Set.empty,  runningZkSendThreads())
+        assertEquals("ZooKeeper client threads still running", Set.empty,  runningZkSendThreads)
     }
   }
 
-  private def runningZkSendThreads(): collection.Set[String] = Thread.getAllStackTraces.keySet.asScala
+  private def runningZkSendThreads: collection.Set[String] = Thread.getAllStackTraces.keySet.asScala
     .filter(_.isAlive)
     .map(_.getName)
-    .filter(t => t.contains("SendThread()")) //Verify threadName pattern for unresolvable host zk send threads
+    .filter(t => t.contains("SendThread()"))
 
   @Test(expected = classOf[ZooKeeperClientTimeoutException])
   def testConnectionTimeout(): Unit = {


### PR DESCRIPTION
This has always been an issue, but the recent upgrade to ZooKeeper
3.4.13 means that it is also an issue when an unresolvable ZK
address is used, causing some tests to leak threads.

The change in behaviour in ZK 3.4.13 is that no exception is thrown
from the ZooKeeper constructor in case of an unresolvable address.
Instead, ZooKeeper tries to re-resolve the address hoping it becomes
resolvable again. We eventually throw a
`ZooKeeperClientTimeoutException`, which is similar to the case
where the the address is resolvable, but ZooKeeper is not
reachable.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)