### PR TITLE
KAFKA-7193: Use ZooKeeper IP address in streams tests to avoid timeouts

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -147,6 +147,9 @@
        error to the client.</p></li>
     <li>Dynamic broker configuration options can be stored in ZooKeeper using kafka-configs.sh before brokers are started.
         This option can be used to avoid storing clear passwords in server.properties as all password configs may be stored encrypted in ZooKeeper.</li>
+    <li>ZooKeeper hosts are now re-resolved if connection attempt fails. But if your ZooKeeper host names resolve
+    to multiple addresses and some of them are not reachable, then you may need to increase the connection timeout
+    <code>zookeeper.connection.timeout.ms</code>.</li>
 </ul>
 
 <h5><a id="upgrade_200_new_protocols" href="#upgrade_200_new_protocols">New Protocol Versions</a></h5>

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/EmbeddedKafkaCluster.java
@@ -128,7 +128,7 @@ public class EmbeddedKafkaCluster extends ExternalResource {
      * You can use this to e.g. tell Kafka brokers how to connect to this instance.
      */
     public String zKConnectString() {
-        return "localhost:" + zookeeper.port();
+        return "127.0.0.1:" + zookeeper.port();
     }
 
     /**


### PR DESCRIPTION
ZooKeeper client from version 3.4.13 doesn't handle connections to `localhost` very well. If ZooKeeper is started on 127.0.0.1 on a machine that has both ipv4 and ipv6 and a client is created using `localhost` rather than the IP address in the connection string, ZooKeeper client attempts to connect to ipv4 or ipv6 randomly with a fixed one second backoff if connection fails. Use `127.0.0.1` instead of `localhost` in streams tests to avoid intermittent test failures due to ZK client connection timeouts if ipv6 is chosen in consecutive address selections. Also add note to upgrade docs for 2.0.0.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
