### PR TITLE
KAFKA-7027: Add overloaded build method to StreamsBuilder

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.state.StoreBuilder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.regex.Pattern;
 
 /**
@@ -513,10 +514,23 @@ public class StreamsBuilder {
 
     /**
      * Returns the {@link Topology} that represents the specified processing logic.
+     * Note that using this method means no optimizations are performed.
      *
      * @return the {@link Topology} that represents the specified processing logic
      */
     public synchronized Topology build() {
+        return build(null);
+    }
+
+    /**
+     * Returns the {@link Topology} that represents the specified processing logic and accepts
+     * a {@link Properties} instance used to indicate whether to optimize topology or not.
+     *
+     * @param props the {@link Properties} used for building possibly optimized topology
+     * @return the {@link Topology} that represents the specified processing logic
+     */
+    public synchronized Topology build(final Properties props) {
+        // the props instance will be used once optimization framework merged
         return topology;
     }
 }


### PR DESCRIPTION
Implementation of [KIP-312](https://cwiki.apache.org/confluence/display/KAFKA/KIP-312%3A+Add+Overloaded+StreamsBuilder+Build+Method+to+Accept+java.util.Properties) required for enabling the use of the optimization framework.  

This PR is required to allow for a 4th PR following on from https://github.com/apache/kafka/pull/5201 to enable optimizations.

The existing streams tests were used for testing.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
