### PR TITLE
MINOR: Use explicit construction of clients in IntegrationTestHarness

### DIFF
--- a/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AdminClientIntegrationTest.scala
@@ -724,10 +724,11 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
     client = AdminClient.create(createConfig)
 
-    val consumer = consumers.head
+    val consumer = createConsumer()
     subscribeAndWaitForAssignment(topic, consumer)
 
-    sendRecords(producers.head, 10, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 10, topicPartition)
     consumer.seekToBeginning(Collections.singleton(topicPartition))
     assertEquals(0L, consumer.position(topicPartition))
 
@@ -752,9 +753,11 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
     client = AdminClient.create(createConfig)
 
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
-    sendRecords(producers.head, 10, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 10, topicPartition)
     var result = client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(5L)).asJava)
     var lowWatermark: Option[Long] = Some(result.lowWatermarks.get(topicPartition).get.lowWatermark)
     assertEquals(Some(5), lowWatermark)
@@ -790,9 +793,12 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
     client = AdminClient.create(createConfig)
 
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
-    sendRecords(producers.head, 10, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 10, topicPartition)
+
     val result = client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(3L)).asJava)
     val lowWatermark = result.lowWatermarks.get(topicPartition).get.lowWatermark
     assertEquals(3L, lowWatermark)
@@ -824,7 +830,8 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     killBroker(followerIndex)
 
     client = AdminClient.create(createConfig)
-    sendRecords(producers.head, 100, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 100, topicPartition)
 
     val result = client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(3L)).asJava)
     result.all().get()
@@ -840,7 +847,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
     // kill the same follower again, produce more records, and delete records beyond follower's LOE
     killBroker(followerIndex)
-    sendRecords(producers.head, 100, topicPartition)
+    sendRecords(producer, 100, topicPartition)
     val result1 = client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(117L)).asJava)
     result1.all().get()
     restartDeadBrokers()
@@ -852,7 +859,8 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
     client = AdminClient.create(createConfig)
     createTopic(topic, numPartitions = 1, replicationFactor = serverCount)
     val expectedLEO = 100
-    sendRecords(producers.head, expectedLEO, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, expectedLEO, topicPartition)
 
     // delete records to move log start offset
     val result = client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(3L)).asJava)
@@ -884,10 +892,11 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
     client = AdminClient.create(createConfig)
 
-    val consumer = consumers.head
+    val consumer = createConsumer()
     subscribeAndWaitForAssignment(topic, consumer)
 
-    sendRecords(producers.head, 10, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 10, topicPartition)
     assertEquals(0L, consumer.offsetsForTimes(Map(topicPartition -> JLong.valueOf(0L)).asJava).get(topicPartition).offset())
 
     var result = client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(5L)).asJava)
@@ -901,12 +910,13 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
   @Test
   def testConsumeAfterDeleteRecords(): Unit = {
-    val consumer = consumers.head
+    val consumer = createConsumer()
     subscribeAndWaitForAssignment(topic, consumer)
 
     client = AdminClient.create(createConfig)
 
-    sendRecords(producers.head, 10, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 10, topicPartition)
     var messageCount = 0
     TestUtils.waitUntilTrue(() => {
       messageCount += consumer.poll(0).count
@@ -932,11 +942,13 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
 
   @Test
   def testDeleteRecordsWithException(): Unit = {
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
     client = AdminClient.create(createConfig)
 
-    sendRecords(producers.head, 10, topicPartition)
+    val producer = createProducer()
+    sendRecords(producer, 10, topicPartition)
 
     assertEquals(5L, client.deleteRecords(Map(topicPartition -> RecordsToDelete.beforeOffset(5L)).asJava)
       .lowWatermarks.get(topicPartition).get.lowWatermark)
@@ -1107,7 +1119,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
         new NewTopic(testTopicName, testNumPartitions, 1))).all().get()
       waitForTopics(client, List(testTopicName), List())
 
-      val producer = createProducer
+      val producer = createProducer()
       try {
         producer.send(new ProducerRecord(testTopicName, 0, null, null)).get()
       } finally {
@@ -1119,11 +1131,7 @@ class AdminClientIntegrationTest extends IntegrationTestHarness with Logging {
       val newConsumerConfig = new Properties(consumerConfig)
       newConsumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, testGroupId)
       newConsumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, testClientId)
-      val consumer = TestUtils.createConsumer(brokerList,
-        securityProtocol = this.securityProtocol,
-        trustStoreFile = this.trustStoreFile,
-        saslProperties = this.clientSaslProperties,
-        props = Some(newConsumerConfig))
+      val consumer = createConsumer(configOverrides = newConsumerConfig)
       try {
         // Start a consumer in a thread that will subscribe to a new group.
         val consumerThread = new Thread {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -95,16 +95,12 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   val transactionIdWriteAcl = Map(transactionalIdResource -> Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)))
   val transactionalIdDescribeAcl = Map(transactionalIdResource -> Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)))
 
-
-  val consumers = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
-  val producers = Buffer[KafkaProducer[Array[Byte], Array[Byte]]]()
-
-  val producerCount = 1
-  val consumerCount = 2
-  val producerConfig = new Properties
   val numRecords = 1
-
   val adminClients = Buffer[AdminClient]()
+
+  producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "1")
+  producerConfig.setProperty(ProducerConfig.MAX_BLOCK_MS_CONFIG, "3000")
+  consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, group)
 
   override def propertyOverrides(properties: Properties): Unit = {
     properties.put(KafkaConfig.AuthorizerClassNameProp, classOf[SimpleAclAuthorizer].getName)
@@ -230,25 +226,16 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     ApiKeys.ALTER_REPLICA_LOG_DIRS -> clusterAlterAcl,
     ApiKeys.DESCRIBE_LOG_DIRS -> clusterDescribeAcl,
     ApiKeys.CREATE_PARTITIONS -> topicAlterAcl
-
   )
 
   @Before
   override def setUp() {
-    super.setUp()
+    doSetup(createOffsetsTopic = false)
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, ClusterAction)), Resource.ClusterResource)
 
-    for (_ <- 0 until producerCount)
-      producers += TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-        maxBlockMs = 3000,
-        acks = 1)
+    TestUtils.createOffsetsTopic(zkClient, servers)
 
-    for (_ <- 0 until consumerCount)
-      consumers += TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT)
-
-    // create the consumer offset topic
-    createTopic(GROUP_METADATA_TOPIC_NAME, topicConfig = servers.head.groupCoordinator.offsetsTopicConfigs)
     // create the test topic with all the brokers as replicas
     createTopic(topic)
     createTopic(deleteTopic)
@@ -256,9 +243,6 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
 
   @After
   override def tearDown() = {
-    producers.foreach(_.close())
-    consumers.foreach(_.wakeup())
-    consumers.foreach(_.close())
     adminClients.foreach(_.close())
     removeAllAcls()
     super.tearDown()
@@ -531,7 +515,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testProduceWithNoTopicAccess() {
     try {
-      sendRecords(numRecords, tp)
+      val producer = createProducer()
+      sendRecords(producer, numRecords, tp)
       fail("should have thrown exception")
     } catch {
       case _: TopicAuthorizationException => //expected
@@ -542,7 +527,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def testProduceWithTopicDescribe() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), topicResource)
     try {
-      sendRecords(numRecords, tp)
+      val producer = createProducer()
+      sendRecords(producer, numRecords, tp)
       fail("should have thrown exception")
     } catch {
       case e: TopicAuthorizationException =>
@@ -554,7 +540,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def testProduceWithTopicRead() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     try {
-      sendRecords(numRecords, tp)
+      val producer = createProducer()
+      sendRecords(producer, numRecords, tp)
       fail("should have thrown exception")
     } catch {
       case e: TopicAuthorizationException =>
@@ -565,7 +552,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testProduceWithTopicWrite() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(numRecords, tp)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
   }
 
   @Test
@@ -582,8 +570,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val topicPartition = new TopicPartition(createTopic, 0)
     val newTopicResource = Resource(Topic, createTopic, LITERAL)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), newTopicResource)
+    val producer = createProducer()
     try {
-      sendRecords(numRecords, topicPartition)
+      sendRecords(producer, numRecords, topicPartition)
       Assert.fail("should have thrown exception")
     } catch {
       case e: TopicAuthorizationException =>
@@ -593,30 +582,35 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val resource = if (resType == Topic) newTopicResource else Resource.ClusterResource
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Create)), resource)
 
-    sendRecords(numRecords, topicPartition)
+    sendRecords(producer, numRecords, topicPartition)
   }
 
   @Test(expected = classOf[TopicAuthorizationException])
   def testConsumeUsingAssignWithNoAccess(): Unit = {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
-    this.consumers.head.assign(List(tp).asJava)
-    consumeRecords(this.consumers.head)
+    
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeRecords(consumer)
   }
 
   @Test
   def testSimpleConsumeWithOffsetLookupAndNoGroupAccess(): Unit = {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     try {
       // note this still depends on group access because we haven't set offsets explicitly, which means
       // they will first be fetched from the consumer coordinator (which requires group access)
-      this.consumers.head.assign(List(tp).asJava)
-      consumeRecords(this.consumers.head)
+      val consumer = createConsumer()
+      consumer.assign(List(tp).asJava)
+      consumeRecords(consumer)
       Assert.fail("should have thrown exception")
     } catch {
       case e: GroupAuthorizationException => assertEquals(group, e.groupId())
@@ -626,42 +620,48 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testSimpleConsumeWithExplicitSeekAndNoGroupAccess(): Unit = {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
 
     // in this case, we do an explicit seek, so there should be no need to query the coordinator at all
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.seekToBeginning(List(tp).asJava)
-    consumeRecords(this.consumers.head)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.seekToBeginning(List(tp).asJava)
+    consumeRecords(consumer)
   }
 
   @Test(expected = classOf[KafkaException])
   def testConsumeWithoutTopicDescribeAccess() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    this.consumers.head.assign(List(tp).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
 
     // the consumer should raise an exception if it receives UNKNOWN_TOPIC_OR_PARTITION
     // from the ListOffsets response when looking up the initial position.
-    consumeRecords(this.consumers.head)
+    consumeRecords(consumer)
   }
 
   @Test
   def testConsumeWithTopicDescribe() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     try {
-      this.consumers.head.assign(List(tp).asJava)
-      consumeRecords(this.consumers.head)
+      val consumer = createConsumer()
+      consumer.assign(List(tp).asJava)
+      consumeRecords(consumer)
       Assert.fail("should have thrown exception")
     } catch {
       case e: TopicAuthorizationException => assertEquals(Collections.singleton(topic), e.unauthorizedTopics())
@@ -671,14 +671,16 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testConsumeWithTopicWrite() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     try {
-      this.consumers.head.assign(List(tp).asJava)
-      consumeRecords(this.consumers.head)
+      val consumer = createConsumer()
+      consumer.assign(List(tp).asJava)
+      consumeRecords(consumer)
       Assert.fail("should have thrown exception")
     } catch {
       case e: TopicAuthorizationException =>
@@ -689,36 +691,43 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testConsumeWithTopicAndGroupRead() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    this.consumers.head.assign(List(tp).asJava)
-    consumeRecords(this.consumers.head)
+
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeRecords(consumer)
   }
 
   @Test
   def testPatternSubscriptionWithNoTopicAccess() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    this.consumers.head.subscribe(Pattern.compile(topicPattern), new NoOpConsumerRebalanceListener)
-    this.consumers.head.poll(50)
-    assertTrue(this.consumers.head.subscription.isEmpty)
+
+    val consumer = createConsumer()
+    consumer.subscribe(Pattern.compile(topicPattern), new NoOpConsumerRebalanceListener)
+    consumer.poll(50)
+    assertTrue(consumer.subscription.isEmpty)
   }
 
   @Test
   def testPatternSubscriptionWithTopicDescribeOnlyAndGroupRead() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    val consumer = consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(Pattern.compile(topicPattern))
     try {
       consumeRecords(consumer)
@@ -731,18 +740,19 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testPatternSubscriptionWithTopicAndGroupRead() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
 
     // create an unmatched topic
     val unmatchedTopic = "unmatched"
     createTopic(unmatchedTopic)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)),  Resource(Topic, unmatchedTopic, LITERAL))
-    sendRecords(1, new TopicPartition(unmatchedTopic, part))
+    sendRecords(producer, 1, new TopicPartition(unmatchedTopic, part))
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    val consumer = consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(Pattern.compile(topicPattern))
     consumeRecords(consumer)
 
@@ -759,35 +769,33 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   @Test
   def testPatternSubscriptionMatchingInternalTopic() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
 
-    val consumerConfig = new Properties
     consumerConfig.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false")
-    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group,
-      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(consumerConfig))
-    try {
-      // ensure that internal topics are not included if no permission
-      consumer.subscribe(Pattern.compile(".*"))
-      consumeRecords(consumer)
-      assertEquals(Set(topic).asJava, consumer.subscription)
+    val consumer = createConsumer()
+    // ensure that internal topics are not included if no permission
+    consumer.subscribe(Pattern.compile(".*"))
+    consumeRecords(consumer)
+    assertEquals(Set(topic).asJava, consumer.subscription)
 
-      // now authorize the user for the internal topic and verify that we can subscribe
-      addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), Resource(Topic,
-        GROUP_METADATA_TOPIC_NAME, LITERAL))
-      consumer.subscribe(Pattern.compile(GROUP_METADATA_TOPIC_NAME))
-      consumer.poll(0)
-      assertEquals(Set(GROUP_METADATA_TOPIC_NAME), consumer.subscription.asScala)
-    } finally consumer.close()
+    // now authorize the user for the internal topic and verify that we can subscribe
+    addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), Resource(Topic,
+      GROUP_METADATA_TOPIC_NAME, LITERAL))
+    consumer.subscribe(Pattern.compile(GROUP_METADATA_TOPIC_NAME))
+    consumer.poll(0)
+    assertEquals(Set(GROUP_METADATA_TOPIC_NAME), consumer.subscription.asScala)
   }
 
   @Test
   def testPatternSubscriptionMatchingInternalTopicWithDescribeOnlyPermission() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
@@ -795,10 +803,8 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val internalTopicResource = Resource(Topic, GROUP_METADATA_TOPIC_NAME, LITERAL)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), internalTopicResource)
 
-    val consumerConfig = new Properties
     consumerConfig.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false")
-    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group,
-      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(consumerConfig))
+    val consumer = createConsumer()
     try {
       consumer.subscribe(Pattern.compile(".*"))
       // It is possible that the first call returns records of "topic" and the second call throws TopicAuthorizationException
@@ -807,22 +813,21 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
       Assert.fail("Expected TopicAuthorizationException")
     } catch {
       case _: TopicAuthorizationException => //expected
-    } finally consumer.close()
+    }
   }
 
   @Test
   def testPatternSubscriptionNotMatchingInternalTopic() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, 1, tp)
     removeAllAcls()
 
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
 
-    val consumerConfig = new Properties
     consumerConfig.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false")
-    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group,
-      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(consumerConfig))
+    val consumer = createConsumer()
     try {
       consumer.subscribe(Pattern.compile(topicPattern))
       consumeRecords(consumer)
@@ -848,9 +853,10 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val newTopicResource = Resource(Topic, newTopic, LITERAL)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), newTopicResource)
     addAndVerifyAcls(groupReadAcl(groupResource), groupResource)
-    this.consumers.head.assign(List(topicPartition).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(topicPartition).asJava)
     val unauthorizedTopics = intercept[TopicAuthorizationException] {
-      (0 until 10).foreach(_ => consumers.head.poll(Duration.ofMillis(50L)))
+      (0 until 10).foreach(_ => consumer.poll(Duration.ofMillis(50L)))
     }.unauthorizedTopics
     assertEquals(Collections.singleton(newTopic), unauthorizedTopics)
 
@@ -858,7 +864,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     addAndVerifyAcls(acls, resource)
 
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(Duration.ofMillis(50L))
+      consumer.poll(Duration.ofMillis(50L))
       this.zkClient.topicExists(newTopic)
     }, "Expected topic was not created")
   }
@@ -875,7 +881,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val metadataRequest = new MetadataRequest.Builder(List(topic, createTopic).asJava, true).build()
     val metadataResponse = MetadataResponse.parse(connectAndSend(metadataRequest, ApiKeys.METADATA), ApiKeys.METADATA.latestVersion)
 
-    assertEquals(Set(topic).asJava, metadataResponse.topicsByError(Errors.NONE));
+    assertEquals(Set(topic).asJava, metadataResponse.topicsByError(Errors.NONE))
     assertEquals(Set(createTopic).asJava, metadataResponse.topicsByError(Errors.TOPIC_AUTHORIZATION_FAILED))
 
     val createAcls = topicCreateAcl.get(createTopicResource).get
@@ -890,60 +896,69 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
 
   @Test(expected = classOf[AuthorizationException])
   def testCommitWithNoAccess() {
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    val consumer = createConsumer()
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
   @Test(expected = classOf[KafkaException])
   def testCommitWithNoTopicAccess() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    val consumer = createConsumer()
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
   @Test(expected = classOf[TopicAuthorizationException])
   def testCommitWithTopicWrite() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    val consumer = createConsumer()
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
   @Test(expected = classOf[TopicAuthorizationException])
   def testCommitWithTopicDescribe() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), topicResource)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    val consumer = createConsumer()
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
   @Test(expected = classOf[GroupAuthorizationException])
   def testCommitWithNoGroupAccess() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    val consumer = createConsumer()
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
   @Test
   def testCommitWithTopicAndGroupRead() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
+    val consumer = createConsumer()
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5)).asJava)
   }
 
   @Test(expected = classOf[AuthorizationException])
   def testOffsetFetchWithNoAccess() {
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.position(tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.position(tp)
   }
 
   @Test(expected = classOf[GroupAuthorizationException])
   def testOffsetFetchWithNoGroupAccess() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.position(tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.position(tp)
   }
 
   @Test(expected = classOf[KafkaException])
   def testOffsetFetchWithNoTopicAccess() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.position(tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.position(tp)
   }
 
   @Test
@@ -951,8 +966,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val offset = 15L
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(offset)).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(offset)).asJava)
 
     removeAllAcls()
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
@@ -978,27 +994,31 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def testOffsetFetchTopicDescribe() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), topicResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.position(tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.position(tp)
   }
 
   @Test
   def testOffsetFetchWithTopicAndGroupRead() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.position(tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.position(tp)
   }
 
   @Test(expected = classOf[TopicAuthorizationException])
   def testListOffsetsWithNoTopicAccess() {
-    this.consumers.head.partitionsFor(topic)
+    val consumer = createConsumer()
+    consumer.partitionsFor(topic)
   }
 
   @Test
   def testListOffsetsWithTopicDescribe() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Describe)), topicResource)
-    this.consumers.head.partitionsFor(topic)
+    val consumer = createConsumer()
+    consumer.partitionsFor(topic)
   }
 
   @Test
@@ -1074,8 +1094,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Delete)), groupResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5, "")).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5, "")).asJava)
     createAdminClient().deleteConsumerGroups(Seq(group).asJava).deletedGroups().get(group).get()
   }
 
@@ -1083,8 +1104,9 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def testDeleteGroupApiWithNoDeleteGroupAcl() {
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.commitSync(Map(tp -> new OffsetAndMetadata(5, "")).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.commitSync(Map(tp -> new OffsetAndMetadata(5, "")).asJava)
     val result = createAdminClient().deleteConsumerGroups(Seq(group).asJava)
     TestUtils.assertFutureExceptionTypeEquals(result.deletedGroups().get(group), classOf[GroupAuthorizationException])
   }
@@ -1436,9 +1458,11 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     response
   }
 
-  private def sendRecords(numRecords: Int, tp: TopicPartition) {
+  private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
+                          numRecords: Int,
+                          tp: TopicPartition) {
     val futures = (0 until numRecords).map { i =>
-      this.producers.head.send(new ProducerRecord(tp.topic(), tp.partition(), i.toString.getBytes, i.toString.getBytes))
+      producer.send(new ProducerRecord(tp.topic(), tp.partition(), i.toString.getBytes, i.toString.getBytes))
     }
     try {
       futures.foreach(_.get)
@@ -1481,21 +1505,15 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   }
 
   private def buildTransactionalProducer(): KafkaProducer[Array[Byte], Array[Byte]] = {
-    val transactionalProperties = new Properties()
-    transactionalProperties.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
-    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-      overrides = Some(transactionalProperties))
-    producers += producer
-    producer
+    producerConfig.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
+    producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "all")
+    createProducer()
   }
 
   private def buildIdempotentProducer(): KafkaProducer[Array[Byte], Array[Byte]] = {
-    val idempotentProperties = new Properties()
-    idempotentProperties.setProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
-    val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-      overrides = Some(idempotentProperties))
-    producers += producer
-    producer
+    producerConfig.setProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
+    producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "all")
+    createProducer()
   }
 
   private def createAdminClient(): AdminClient = {

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -768,7 +768,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val consumerConfig = new Properties
     consumerConfig.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false")
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group,
-      securityProtocol = SecurityProtocol.PLAINTEXT, props = Some(consumerConfig))
+      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(consumerConfig))
     try {
       // ensure that internal topics are not included if no permission
       consumer.subscribe(Pattern.compile(".*"))
@@ -798,7 +798,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val consumerConfig = new Properties
     consumerConfig.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false")
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group,
-      securityProtocol = SecurityProtocol.PLAINTEXT, props = Some(consumerConfig))
+      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(consumerConfig))
     try {
       consumer.subscribe(Pattern.compile(".*"))
       // It is possible that the first call returns records of "topic" and the second call throws TopicAuthorizationException
@@ -822,7 +822,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val consumerConfig = new Properties
     consumerConfig.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, "false")
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group,
-      securityProtocol = SecurityProtocol.PLAINTEXT, props = Some(consumerConfig))
+      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(consumerConfig))
     try {
       consumer.subscribe(Pattern.compile(topicPattern))
       consumeRecords(consumer)
@@ -1484,7 +1484,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val transactionalProperties = new Properties()
     transactionalProperties.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
     val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-      props = Some(transactionalProperties))
+      overrides = Some(transactionalProperties))
     producers += producer
     producer
   }
@@ -1493,7 +1493,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
     val idempotentProperties = new Properties()
     idempotentProperties.setProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
     val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-      props = Some(idempotentProperties))
+      overrides = Some(idempotentProperties))
     producers += producer
     producer
   }

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -1051,15 +1051,17 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   def testListGroupApiWithAndWithoutListGroupAcls() {
     // write some record to the topic
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Write)), topicResource)
-    sendRecords(1, tp)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 1, tp)
 
     // use two consumers to write to two different groups
     val group2 = "other group"
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), groupResource)
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), Resource(Group, group2, LITERAL))
     addAndVerifyAcls(Set(new Acl(userPrincipal, Allow, Acl.WildCardHost, Read)), topicResource)
-    this.consumers.head.subscribe(Collections.singleton(topic))
-    consumeRecords(this.consumers.head)
+    val consumer = createConsumer()
+    consumer.subscribe(Collections.singleton(topic))
+    consumeRecords(consumer)
 
     val otherConsumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = group2, securityProtocol = SecurityProtocol.PLAINTEXT)
     otherConsumer.subscribe(Collections.singleton(topic))

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -17,7 +17,6 @@ import java.util
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.record.TimestampType
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 import kafka.utils.ShutdownableThread
 import kafka.server.KafkaConfig
@@ -295,9 +294,10 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
    */
   def isPartitionAssignmentValid(assignments: Buffer[Set[TopicPartition]],
                                  partitions: Set[TopicPartition]): Boolean = {
-    val allNonEmptyAssignments = assignments forall (assignment => assignment.nonEmpty)
+    val allNonEmptyAssignments = assignments.forall(assignment => assignment.nonEmpty)
     if (!allNonEmptyAssignments) {
       // at least one consumer got empty assignment
+      val uniqueAssignedPartitions = (Set[TopicPartition]() /: assignments) (_ ++ _)
       return false
     }
 

--- a/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseConsumerTest.scala
@@ -36,8 +36,6 @@ import org.apache.kafka.common.internals.Topic
 abstract class BaseConsumerTest extends IntegrationTestHarness {
 
   val epsilon = 0.1
-  val producerCount = 1
-  val consumerCount = 2
   val serverCount = 3
 
   val topic = "topic"
@@ -74,19 +72,21 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
   @Test
   def testSimpleConsumption() {
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
-    assertEquals(0, this.consumers.head.assignment.size)
-    this.consumers.head.assign(List(tp).asJava)
-    assertEquals(1, this.consumers.head.assignment.size)
+    val consumer = createConsumer()
+    assertEquals(0, consumer.assignment.size)
+    consumer.assign(List(tp).asJava)
+    assertEquals(1, consumer.assignment.size)
 
-    this.consumers.head.seek(tp, 0)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = numRecords, startingOffset = 0)
+    consumer.seek(tp, 0)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, startingOffset = 0)
 
     // check async commit callbacks
     val commitCallback = new CountConsumerCommitCallback()
-    this.consumers.head.commitAsync(commitCallback)
-    awaitCommitCallback(this.consumers.head, commitCallback)
+    consumer.commitAsync(commitCallback)
+    awaitCommitCallback(consumer, commitCallback)
   }
 
   @Test
@@ -94,20 +94,19 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
     val listener = new TestConsumerReassignmentListener()
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "5000")
     this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "2000")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
-    consumer0.subscribe(List(topic).asJava, listener)
+    consumer.subscribe(List(topic).asJava, listener)
 
     // the initial subscription should cause a callback execution
-    consumer0.poll(2000)
+    consumer.poll(2000)
 
     assertEquals(1, listener.callsToAssigned)
 
     // get metadata for the topic
     var parts: Seq[PartitionInfo] = null
     while (parts == null)
-      parts = consumer0.partitionsFor(Topic.GROUP_METADATA_TOPIC_NAME).asScala
+      parts = consumer.partitionsFor(Topic.GROUP_METADATA_TOPIC_NAME).asScala
     assertEquals(1, parts.size)
     assertNotNull(parts.head.leader())
 
@@ -115,7 +114,7 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
     val coordinator = parts.head.leader().id()
     this.servers(coordinator).shutdown()
 
-    consumer0.poll(5000)
+    consumer.poll(5000)
 
     // the failover should not cause a rebalance
     assertEquals(1, listener.callsToAssigned)
@@ -136,12 +135,6 @@ abstract class BaseConsumerTest extends IntegrationTestHarness {
       callsToRevoked += 1
     }
   }
-
-  protected def sendRecords(numRecords: Int): Seq[ProducerRecord[Array[Byte], Array[Byte]]] =
-    sendRecords(numRecords, tp)
-
-  protected def sendRecords(numRecords: Int, tp: TopicPartition): Seq[ProducerRecord[Array[Byte], Array[Byte]]] =
-    sendRecords(this.producers.head, numRecords, tp)
 
   protected def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]], numRecords: Int,
                             tp: TopicPartition): Seq[ProducerRecord[Array[Byte], Array[Byte]]] = {

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -72,7 +72,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
                                lingerMs: Int = 0,
                                props: Option[Properties] = None): KafkaProducer[Array[Byte],Array[Byte]] = {
     val producer = TestUtils.createProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
-      saslProperties = clientSaslProperties, lingerMs = lingerMs, props = props)
+      saslProperties = clientSaslProperties, lingerMs = lingerMs, overrides = props)
     registerProducer(producer)
   }
 

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -70,9 +70,14 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
 
   protected def createProducer(brokerList: String,
                                lingerMs: Int = 0,
-                               props: Option[Properties] = None): KafkaProducer[Array[Byte],Array[Byte]] = {
-    val producer = TestUtils.createProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
-      saslProperties = clientSaslProperties, lingerMs = lingerMs, overrides = props)
+                               batchSize: Int = 16384,
+                               compressionType: String = "none"): KafkaProducer[Array[Byte],Array[Byte]] = {
+    val producer = TestUtils.createProducer(brokerList,
+      compressionType = compressionType,
+      securityProtocol = securityProtocol,
+      trustStoreFile = trustStoreFile,
+      saslProperties = clientSaslProperties,
+      lingerMs = lingerMs)
     registerProducer(producer)
   }
 
@@ -170,9 +175,9 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
 
   @Test
   def testSendCompressedMessageWithCreateTime() {
-    val producerProps = new Properties()
-    producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")
-    val producer = createProducer(brokerList = brokerList, lingerMs = Int.MaxValue, props = Some(producerProps))
+    val producer = createProducer(brokerList = brokerList,
+      compressionType = "gzip",
+      lingerMs = Int.MaxValue)
     sendAndVerifyTimestamp(producer, TimestampType.CREATE_TIME)
   }
 

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -128,18 +128,17 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 
     // Since producer may have been throttled after producing a couple of records,
     // consume from beginning till throttled
-    consumers.head.seekToBeginning(Collections.singleton(new TopicPartition(topic1, 0)))
+    quotaTestClients.consumer.seekToBeginning(Collections.singleton(new TopicPartition(topic1, 0)))
     quotaTestClients.consumeUntilThrottled(numRecords + produced)
     quotaTestClients.verifyConsumeThrottle(expectThrottle = true)
   }
 
   @Test
   def testThrottledRequest() {
-
     quotaTestClients.overrideQuotas(Long.MaxValue, Long.MaxValue, 0.1)
     quotaTestClients.waitForQuotaUpdate(Long.MaxValue, Long.MaxValue, 0.1)
 
-    val consumer = consumers.head
+    val consumer = quotaTestClients.consumer
     consumer.subscribe(Collections.singleton(topic1))
     val endTimeMs = System.currentTimeMillis + 10000
     var throttled = false
@@ -167,8 +166,8 @@ abstract class QuotaTestClients(topic: String,
                                 leaderNode: KafkaServer,
                                 producerClientId: String,
                                 consumerClientId: String,
-                                producer: KafkaProducer[Array[Byte], Array[Byte]],
-                                consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {
+                                val producer: KafkaProducer[Array[Byte], Array[Byte]],
+                                val consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {
 
   def userPrincipal : KafkaPrincipal
   def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double)

--- a/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseQuotaTest.scala
@@ -33,8 +33,6 @@ import scala.collection.JavaConverters._
 abstract class BaseQuotaTest extends IntegrationTestHarness {
 
   override val serverCount = 2
-  val producerCount = 1
-  val consumerCount = 1
 
   protected def producerClientId = "QuotasTestProducer-1"
   protected def consumerClientId = "QuotasTestConsumer-1"
@@ -46,7 +44,7 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
   this.serverConfig.setProperty(KafkaConfig.GroupMinSessionTimeoutMsProp, "100")
   this.serverConfig.setProperty(KafkaConfig.GroupMaxSessionTimeoutMsProp, "30000")
   this.serverConfig.setProperty(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
-  this.producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "0")
+  this.producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "-1")
   this.producerConfig.setProperty(ProducerConfig.BUFFER_MEMORY_CONFIG, "300000")
   this.producerConfig.setProperty(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
   this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "QuotasTest")
@@ -79,7 +77,6 @@ abstract class BaseQuotaTest extends IntegrationTestHarness {
 
   @Test
   def testThrottledProducerConsumer() {
-
     val numRecords = 1000
     val produced = quotaTestClients.produceUntilThrottled(numRecords)
     quotaTestClients.verifyProduceThrottle(expectThrottle = true)
@@ -169,7 +166,7 @@ abstract class QuotaTestClients(topic: String,
                                 val producer: KafkaProducer[Array[Byte], Array[Byte]],
                                 val consumer: KafkaConsumer[Array[Byte], Array[Byte]]) {
 
-  def userPrincipal : KafkaPrincipal
+  def userPrincipal: KafkaPrincipal
   def overrideQuotas(producerQuota: Long, consumerQuota: Long, requestQuota: Double)
   def removeQuotaOverrides()
 
@@ -229,9 +226,9 @@ abstract class QuotaTestClients(topic: String,
   def verifyThrottleTimeMetric(quotaType: QuotaType, clientId: String, expectThrottle: Boolean): Unit = {
     val throttleMetricValue = metricValue(throttleMetric(quotaType, clientId))
     if (expectThrottle) {
-      assertTrue("Should have been throttled", throttleMetricValue > 0)
+      assertTrue(s"Client with id=$clientId should have been throttled", throttleMetricValue > 0)
     } else {
-      assertEquals("Should not have been throttled", 0.0, throttleMetricValue, 0.0)
+      assertEquals(s"Client with id=$clientId should not have been throttled", 0.0, throttleMetricValue, 0.0)
     }
   }
 

--- a/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ClientIdQuotaTest.scala
@@ -34,7 +34,10 @@ class ClientIdQuotaTest extends BaseQuotaTest {
   }
 
   override def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients = {
-    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producers.head, consumers.head) {
+    val producer = createProducer()
+    val consumer = createConsumer()
+
+    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
       override def userPrincipal: KafkaPrincipal = KafkaPrincipal.ANONYMOUS
       override def quotaMetricTags(clientId: String): Map[String, String] = {
         Map("user" -> "", "client-id" -> clientId)

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -19,31 +19,19 @@ import java.util.{Collection, Collections, Properties}
 import kafka.server.{BaseRequestTest, KafkaConfig}
 import kafka.utils.{CoreUtils, Logging, ShutdownableThread, TestUtils}
 import org.apache.kafka.clients.consumer._
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{FindCoordinatorRequest, FindCoordinatorResponse}
-import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert._
 import org.junit.{After, Before, Ignore, Test}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.Buffer
-
 
 /**
  * Integration tests for the consumer that cover basic usage as well as server failures
  */
 class ConsumerBounceTest extends BaseRequestTest with Logging {
-
-  override def numBrokers: Int = 3
-
-  val producerCount = 1
-  val consumerCount = 2
-
-  val consumers = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
-  val producers = Buffer[KafkaProducer[Array[Byte], Array[Byte]]]()
-
   val topic = "topic"
   val part = 0
   val tp = new TopicPartition(topic, part)
@@ -52,16 +40,7 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
   val gracefulCloseTimeMs = 1000
   val executor = Executors.newScheduledThreadPool(2)
 
-  val producerConfig = new Properties
-  val consumerConfig = new Properties
-  this.producerConfig.setProperty(ProducerConfig.ACKS_CONFIG, "all")
-  this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "my-test")
-  this.consumerConfig.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, 4096.toString)
-  this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000")
-  this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "3000")
-  this.consumerConfig.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-
-  def serverConfig(): Properties = {
+  override def generateConfigs = {
     val properties = new Properties
     properties.put(KafkaConfig.OffsetsTopicReplicationFactorProp, "3") // don't want to lose offset
     properties.put(KafkaConfig.OffsetsTopicPartitionsProp, "1")
@@ -69,38 +48,17 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     properties.put(KafkaConfig.GroupInitialRebalanceDelayMsProp, "0")
     properties.put(KafkaConfig.UncleanLeaderElectionEnableProp, "true")
     properties.put(KafkaConfig.AutoCreateTopicsEnableProp, "false")
-    properties
-  }
 
-  override def generateConfigs = {
     FixedPortTestUtils.createBrokerConfigs(numBrokers, zkConnect, enableControlledShutdown = false)
-      .map(KafkaConfig.fromProps(_, serverConfig))
+      .map(KafkaConfig.fromProps(_, properties))
   }
 
   @Before
   override def setUp() {
     super.setUp()
 
-    for (_ <- 0 until producerCount)
-      producers += createProducer
-
-    for (_ <- 0 until consumerCount)
-      consumers += createConsumer
-
     // create the test topic with all the brokers as replicas
     createTopic(topic, 1, numBrokers)
-  }
-
-  def createProducer: KafkaProducer[Array[Byte], Array[Byte]] = {
-    TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-        securityProtocol = SecurityProtocol.PLAINTEXT,
-        overrides = Some(producerConfig))
-  }
-
-  def createConsumer: KafkaConsumer[Array[Byte], Array[Byte]] = {
-    TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
-        securityProtocol = SecurityProtocol.PLAINTEXT,
-        overrides = Some(consumerConfig))
   }
 
   @After
@@ -109,8 +67,6 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
       executor.shutdownNow()
       // Wait for any active tasks to terminate to ensure consumer is not closed while being used from another thread
       assertTrue("Executor did not terminate", executor.awaitTermination(5000, TimeUnit.MILLISECONDS))
-      producers.foreach(_.close())
-      consumers.foreach(_.close())
     } finally {
       super.tearDown()
     }
@@ -126,11 +82,11 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
    */
   def consumeWithBrokerFailures(numIters: Int) {
     val numRecords = 1000
-    sendRecords(numRecords)
-    this.producers.foreach(_.close)
+    val producer = createProducer()
+    sendRecords(producer, numRecords)
 
     var consumed = 0L
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
 
     consumer.subscribe(Collections.singletonList(topic))
 
@@ -164,10 +120,10 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
 
   def seekAndCommitWithBrokerFailures(numIters: Int) {
     val numRecords = 1000
-    sendRecords(numRecords)
-    this.producers.foreach(_.close)
+    val producer = createProducer()
+    sendRecords(producer, numRecords)
 
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
     consumer.assign(Collections.singletonList(tp))
     consumer.seek(tp, 0)
 
@@ -203,19 +159,21 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     val numRecords = 1000
     val newtopic = "newtopic"
 
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(Collections.singleton(newtopic))
     executor.schedule(new Runnable {
         def run() = createTopic(newtopic, numPartitions = numBrokers, replicationFactor = numBrokers)
       }, 2, TimeUnit.SECONDS)
     consumer.poll(0)
 
+    val producer = createProducer()
+
     def sendRecords(numRecords: Int, topic: String) {
       var remainingRecords = numRecords
       val endTimeMs = System.currentTimeMillis + 20000
       while (remainingRecords > 0 && System.currentTimeMillis < endTimeMs) {
         val futures = (0 until remainingRecords).map { i =>
-          this.producers.head.send(new ProducerRecord(topic, part, i.toString.getBytes, i.toString.getBytes))
+          producer.send(new ProducerRecord(topic, part, i.toString.getBytes, i.toString.getBytes))
         }
         futures.map { future =>
           try {
@@ -243,11 +201,11 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     future.get
   }
 
-
   @Test
   def testClose() {
     val numRecords = 10
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords)
 
     checkCloseGoodPath(numRecords, "group1")
     checkCloseWithCoordinatorFailure(numRecords, "group2", "group3")
@@ -295,7 +253,6 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     val response = FindCoordinatorResponse.parse(resp, ApiKeys.FIND_COORDINATOR.latestVersion())
     response.node().id()
   }
-
 
   /**
    * Consumer is closed while all brokers are unavailable. Cannot rebalance or commit offsets since
@@ -357,7 +314,7 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     }
 
     def createConsumerToRebalance(): Future[Any] = {
-      val consumer = createConsumer(groupId)
+      val consumer = createConsumerWithGroupId(groupId)
       val rebalanceSemaphore = new Semaphore(0)
       val future = subscribeAndPoll(consumer, Some(rebalanceSemaphore))
       // Wait for consumer to poll and trigger rebalance
@@ -367,9 +324,9 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
       future
     }
 
-    val consumer1 = createConsumer(groupId)
+    val consumer1 = createConsumerWithGroupId(groupId)
     waitForRebalance(2000, subscribeAndPoll(consumer1))
-    val consumer2 = createConsumer(groupId)
+    val consumer2 = createConsumerWithGroupId(groupId)
     waitForRebalance(2000, subscribeAndPoll(consumer2), consumer1)
     val rebalanceFuture = createConsumerToRebalance()
 
@@ -392,15 +349,13 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     closeFuture2.get(2000, TimeUnit.MILLISECONDS)
   }
 
-  private def createConsumer(groupId: String) : KafkaConsumer[Array[Byte], Array[Byte]] = {
-    this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
-    val consumer = createConsumer
-    consumers += consumer
-    consumer
+  private def createConsumerWithGroupId(groupId: String): KafkaConsumer[Array[Byte], Array[Byte]] = {
+    consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
+    createConsumer()
   }
 
-  private def createConsumerAndReceive(groupId: String, manualAssign: Boolean, numRecords: Int) : KafkaConsumer[Array[Byte], Array[Byte]] = {
-    val consumer = createConsumer(groupId)
+  private def createConsumerAndReceive(groupId: String, manualAssign: Boolean, numRecords: Int): KafkaConsumer[Array[Byte], Array[Byte]] = {
+    val consumer = createConsumerWithGroupId(groupId)
     if (manualAssign)
       consumer.assign(Collections.singleton(tp))
     else
@@ -439,7 +394,7 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     // Check that close was graceful with offsets committed and leave group sent.
     // New instance of consumer should be assigned partitions immediately and should see committed offsets.
     val assignSemaphore = new Semaphore(0)
-    val consumer = createConsumer(groupId)
+    val consumer = createConsumerWithGroupId(groupId)
     consumer.subscribe(Collections.singletonList(topic),  new ConsumerRebalanceListener {
       def onPartitionsAssigned(partitions: Collection[TopicPartition]) {
         assignSemaphore.release()
@@ -447,7 +402,7 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
       def onPartitionsRevoked(partitions: Collection[TopicPartition]) {
       }})
     consumer.poll(3000)
-    assertTrue("Assigment did not complete on time", assignSemaphore.tryAcquire(1, TimeUnit.SECONDS))
+    assertTrue("Assignment did not complete on time", assignSemaphore.tryAcquire(1, TimeUnit.SECONDS))
     if (committedRecords > 0)
       assertEquals(committedRecords, consumer.committed(tp).offset)
     consumer.close()
@@ -470,12 +425,13 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
     }
   }
 
-  private def sendRecords(numRecords: Int, topic: String = this.topic) {
+  private def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
+                          numRecords: Int,
+                          topic: String = this.topic) {
     val futures = (0 until numRecords).map { i =>
-      this.producers.head.send(new ProducerRecord(topic, part, i.toString.getBytes, i.toString.getBytes))
+      producer.send(new ProducerRecord(topic, part, i.toString.getBytes, i.toString.getBytes))
     }
     futures.map(_.get)
   }
-
 
 }

--- a/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ConsumerBounceTest.scala
@@ -94,13 +94,13 @@ class ConsumerBounceTest extends BaseRequestTest with Logging {
   def createProducer: KafkaProducer[Array[Byte], Array[Byte]] = {
     TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
         securityProtocol = SecurityProtocol.PLAINTEXT,
-        props = Some(producerConfig))
+        overrides = Some(producerConfig))
   }
 
   def createConsumer: KafkaConsumer[Array[Byte], Array[Byte]] = {
     TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
         securityProtocol = SecurityProtocol.PLAINTEXT,
-        props = Some(consumerConfig))
+        overrides = Some(consumerConfig))
   }
 
   @After

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -16,7 +16,7 @@ package kafka.api
 
 import java.io.File
 import java.{lang, util}
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import java.util.{Collections, Properties}
 
@@ -202,7 +202,6 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
   }
 
   private def addUser(user: String, leader: Int): GroupedUser = {
-
     val password = s"$user:secret"
     createScramCredentials(zkConnect, user, password)
     servers.foreach { server =>
@@ -213,7 +212,7 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
     val userGroup = group(user)
     val topic = s"${userGroup}_topic"
     val producerClientId = s"$user:producer-client-id"
-    val consumerClientId = s"$user:producer-client-id"
+    val consumerClientId = s"$user:consumer-client-id"
 
     producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, ScramLoginModule(user, password).toString)

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -219,6 +219,7 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
     val producer = createProducer()
 
     consumerConfig.put(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientId)
+    consumerConfig.put(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, 4096.toString)
     consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, s"$user-group")
     consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, ScramLoginModule(user, password).toString)
     val consumer = createConsumer()

--- a/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
+++ b/core/src/test/scala/integration/kafka/api/CustomQuotaCallbackTest.scala
@@ -48,8 +48,6 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
   override protected def interBrokerListenerName: ListenerName = new ListenerName("BROKER")
 
   override protected lazy val trustStoreFile = Some(File.createTempFile("truststore", ".jks"))
-  override val consumerCount: Int = 0
-  override val producerCount: Int = 0
   override val serverCount: Int = 2
 
   private val kafkaServerSaslMechanisms = Seq("SCRAM-SHA-256")
@@ -77,18 +75,11 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
 
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG,
       ScramLoginModule(JaasTestUtils.KafkaScramAdmin, JaasTestUtils.KafkaScramAdminPassword).toString)
-    producerWithoutQuota = createProducer
-    producers += producerWithoutQuota
+    producerWithoutQuota = createProducer()
   }
 
   @After
   override def tearDown(): Unit = {
-    // Close producers and consumers without waiting for requests to complete
-    // to avoid waiting for throttled responses
-    producers.foreach(_.close(0, TimeUnit.MILLISECONDS))
-    producers.clear()
-    consumers.foreach(_.close(0, TimeUnit.MILLISECONDS))
-    consumers.clear()
     adminClients.foreach(_.close())
     super.tearDown()
   }
@@ -226,22 +217,20 @@ class CustomQuotaCallbackTest extends IntegrationTestHarness with SaslSetup {
 
     producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, producerClientId)
     producerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, ScramLoginModule(user, password).toString)
-    val producer = createProducer
-    producers += producer
+    val producer = createProducer()
 
     consumerConfig.put(ConsumerConfig.CLIENT_ID_CONFIG, consumerClientId)
     consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, s"$user-group")
     consumerConfig.put(SaslConfigs.SASL_JAAS_CONFIG, ScramLoginModule(user, password).toString)
-    val consumer = createConsumer
-    consumers += consumer
+    val consumer = createConsumer()
 
     GroupedUser(user, userGroup, topic, servers(leader), producerClientId, consumerClientId, producer, consumer)
   }
 
   case class GroupedUser(user: String, userGroup: String, topic: String, leaderNode: KafkaServer,
                          producerClientId: String, consumerClientId: String,
-                         producer: KafkaProducer[Array[Byte], Array[Byte]],
-                         consumer: KafkaConsumer[Array[Byte], Array[Byte]]) extends
+                         override val producer: KafkaProducer[Array[Byte], Array[Byte]],
+                         override val consumer: KafkaConsumer[Array[Byte], Array[Byte]]) extends
     QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
 
     override def userPrincipal: KafkaPrincipal = GroupedUserPrincipal(user, userGroup)

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -416,11 +416,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   }
 
   protected final def consumeRecords(consumer: Consumer[Array[Byte], Array[Byte]],
-                             numRecords: Int = 1,
-                             startingOffset: Int = 0,
-                             topic: String = topic,
-                             part: Int = part,
-                             timeout: Long = 10000) {
+                                     numRecords: Int = 1,
+                                     startingOffset: Int = 0,
+                                     topic: String = topic,
+                                     part: Int = part,
+                                     timeout: Long = 10000) {
     val records = new ArrayList[ConsumerRecord[Array[Byte], Array[Byte]]]()
 
     val deadlineMs = System.currentTimeMillis() + timeout

--- a/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/EndToEndAuthorizationTest.scala
@@ -55,8 +55,6 @@ import scala.collection.JavaConverters._
   * would end up with ZooKeeperTestHarness twice.
   */
 abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with SaslSetup {
-  override val producerCount = 1
-  override val consumerCount = 2
   override val serverCount = 3
 
   override def configureSecurityBeforeServersStart() {
@@ -187,21 +185,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     createTopic(topic, 1, 3)
   }
 
-  override def createProducer: KafkaProducer[Array[Byte], Array[Byte]] = {
-    TestUtils.createProducer(brokerList,
-      maxBlockMs = 3000L,
-      securityProtocol = this.securityProtocol,
-      trustStoreFile = this.trustStoreFile,
-      saslProperties = this.clientSaslProperties,
-      props = Some(producerConfig))
-  }
-
   /**
     * Closes MiniKDC last when tearing down.
     */
   @After
   override def tearDown() {
-    consumers.foreach(_.wakeup())
     super.tearDown()
     closeSasl()
   }
@@ -212,31 +200,37 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @Test
   def testProduceConsumeViaAssign(): Unit = {
     setAclsAndProduce(tp)
-    consumers.head.assign(List(tp).asJava)
-    consumeRecords(this.consumers.head, numRecords)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeRecords(consumer, numRecords)
   }
 
   @Test
   def testProduceConsumeViaSubscribe(): Unit = {
     setAclsAndProduce(tp)
-    consumers.head.subscribe(List(topic).asJava)
-    consumeRecords(this.consumers.head, numRecords)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
+    consumeRecords(consumer, numRecords)
   }
 
   @Test
   def testProduceConsumeWithWildcardAcls(): Unit = {
     setWildcardResourceAcls()
-    sendRecords(numRecords, tp)
-    consumers.head.subscribe(List(topic).asJava)
-    consumeRecords(this.consumers.head, numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
+    consumeRecords(consumer, numRecords)
   }
 
   @Test
   def testProduceConsumeWithPrefixedAcls(): Unit = {
     setPrefixedResourceAcls()
-    sendRecords(numRecords, tp)
-    consumers.head.subscribe(List(topic).asJava)
-    consumeRecords(this.consumers.head, numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
+    consumeRecords(consumer, numRecords)
   }
 
   @Test
@@ -244,8 +238,9 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     // topic2 is not created on setup()
     val tp2 = new TopicPartition("topic2", 0)
     setAclsAndProduce(tp2)
-    consumers.head.assign(List(tp2).asJava)
-    consumeRecords(this.consumers.head, numRecords, topic = tp2.topic)
+    val consumer = createConsumer()
+    consumer.assign(List(tp2).asJava)
+    consumeRecords(consumer, numRecords, topic = tp2.topic)
   }
 
   private def setWildcardResourceAcls() {
@@ -271,7 +266,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
       TestUtils.waitAndVerifyAcls(TopicReadAcl ++ TopicWriteAcl ++ TopicDescribeAcl ++ TopicCreateAcl, s.apis.authorizer.get, new Resource(Topic, tp.topic))
       TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
-    sendRecords(numRecords, tp)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
   }
 
   /**
@@ -280,7 +276,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     */
   @Test(expected = classOf[TopicAuthorizationException])
   def testNoProduceWithoutDescribeAcl(): Unit = {
-    sendRecords(numRecords, tp)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
   }
 
   @Test
@@ -290,7 +287,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
       TestUtils.waitAndVerifyAcls(TopicDescribeAcl, s.apis.authorizer.get, topicResource)
     }
     try{
-      sendRecords(numRecords, tp)
+      val producer = createProducer()
+      sendRecords(producer, numRecords, tp)
       fail("exception expected")
     } catch {
       case e: TopicAuthorizationException =>
@@ -305,17 +303,19 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @Test(expected = classOf[KafkaException])
   def testNoConsumeWithoutDescribeAclViaAssign(): Unit = {
     noConsumeWithoutDescribeAclSetup()
-    consumers.head.assign(List(tp).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
     // the exception is expected when the consumer attempts to lookup offsets
-    consumeRecords(this.consumers.head)
+    consumeRecords(consumer)
   }
   
   @Test(expected = classOf[TopicAuthorizationException])
   def testNoConsumeWithoutDescribeAclViaSubscribe(): Unit = {
     noConsumeWithoutDescribeAclSetup()
-    consumers.head.subscribe(List(topic).asJava)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
     // this should timeout since the consumer will not be able to fetch any metadata for the topic
-    consumeRecords(this.consumers.head, timeout = 3000)
+    consumeRecords(consumer, timeout = 3000)
   }
   
   private def noConsumeWithoutDescribeAclSetup(): Unit = {
@@ -326,7 +326,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
       TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
 
-    sendRecords(numRecords, tp)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
     AclCommand.main(deleteDescribeAclArgs)
     AclCommand.main(deleteWriteAclArgs)
@@ -338,10 +339,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @Test
   def testNoConsumeWithDescribeAclViaAssign(): Unit = {
     noConsumeWithDescribeAclSetup()
-    consumers.head.assign(List(tp).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
 
     try {
-      consumeRecords(this.consumers.head)
+      consumeRecords(consumer)
       fail("Topic authorization exception expected")
     } catch {
       case e: TopicAuthorizationException =>
@@ -352,10 +354,11 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
   @Test
   def testNoConsumeWithDescribeAclViaSubscribe(): Unit = {
     noConsumeWithDescribeAclSetup()
-    consumers.head.subscribe(List(topic).asJava)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
 
     try {
-      consumeRecords(this.consumers.head)
+      consumeRecords(consumer)
       fail("Topic authorization exception expected")
     } catch {
       case e: TopicAuthorizationException =>
@@ -370,7 +373,8 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
       TestUtils.waitAndVerifyAcls(TopicWriteAcl ++ TopicDescribeAcl ++ TopicCreateAcl, s.apis.authorizer.get, topicResource)
       TestUtils.waitAndVerifyAcls(GroupReadAcl, s.apis.authorizer.get, groupResource)
     }
-    sendRecords(numRecords, tp)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
   }
 
   /**
@@ -383,10 +387,13 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     servers.foreach { s =>
       TestUtils.waitAndVerifyAcls(TopicWriteAcl ++ TopicDescribeAcl ++ TopicCreateAcl, s.apis.authorizer.get, topicResource)
     }
-    sendRecords(numRecords, tp)
-    consumers.head.assign(List(tp).asJava)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
+
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
     try {
-      consumeRecords(this.consumers.head)
+      consumeRecords(consumer)
       fail("Topic authorization exception expected")
     } catch {
       case e: GroupAuthorizationException =>
@@ -394,11 +401,12 @@ abstract class EndToEndAuthorizationTest extends IntegrationTestHarness with Sas
     }
   }
 
-  protected final def sendRecords(numRecords: Int, tp: TopicPartition) {
+  protected final def sendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
+                                  numRecords: Int, tp: TopicPartition) {
     val futures = (0 until numRecords).map { i =>
       val record = new ProducerRecord(tp.topic(), tp.partition(), s"$i".getBytes, s"$i".getBytes)
       debug(s"Sending this record: $record")
-      this.producers.head.send(record)
+      producer.send(record)
     }
     try {
       futures.foreach(_.get)

--- a/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
@@ -26,7 +26,6 @@ import java.util.Properties
 
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.record.CompressionType
-import org.apache.kafka.common.security.auth.SecurityProtocol
 
 class GroupCoordinatorIntegrationTest extends KafkaServerTestHarness {
   val offsetsTopicCompressionCodec = CompressionType.GZIP

--- a/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/GroupCoordinatorIntegrationTest.scala
@@ -40,8 +40,7 @@ class GroupCoordinatorIntegrationTest extends KafkaServerTestHarness {
 
   @Test
   def testGroupCoordinatorPropagatesOfffsetsTopicCompressionCodec() {
-    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
-                                               securityProtocol = SecurityProtocol.PLAINTEXT)
+    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers))
     val offsetMap = Map(
       new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0) -> new OffsetAndMetadata(10, "")
     ).asJava

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -38,8 +38,9 @@ import scala.collection.mutable
  * A helper class for writing integration tests that involve producers, consumers, and servers
  */
 abstract class IntegrationTestHarness extends KafkaServerTestHarness {
-  val serverCount: Int
-  var logDirCount: Int = 1
+  protected def serverCount: Int
+  protected def logDirCount: Int = 1
+
   val producerConfig = new Properties
   val consumerConfig = new Properties
   val serverConfig = new Properties

--- a/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
+++ b/core/src/test/scala/integration/kafka/api/IntegrationTestHarness.scala
@@ -74,8 +74,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
 
   def doSetup(createOffsetsTopic: Boolean): Unit = {
     // Generate client security properties before starting the brokers in case certs are needed
-    producerConfig.putAll(clientSecurityProps("producer"))
-    consumerConfig.putAll(clientSecurityProps("consumer"))
+    producerConfig ++= clientSecurityProps("producer")
+    consumerConfig ++= clientSecurityProps("consumer")
 
     super.setUp()
 
@@ -103,8 +103,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                            valueSerializer: Serializer[V] = new ByteArraySerializer,
                            configOverrides: Properties = new Properties): KafkaProducer[K, V] = {
     val props = new Properties
-    props.putAll(producerConfig)
-    props.putAll(configOverrides)
+    props ++= producerConfig
+    props ++= configOverrides
     val producer = new KafkaProducer[K, V](props, keySerializer, valueSerializer)
     producers += producer
     producer
@@ -114,8 +114,8 @@ abstract class IntegrationTestHarness extends KafkaServerTestHarness {
                            valueDeserializer: Deserializer[V] = new ByteArrayDeserializer,
                            configOverrides: Properties = new Properties): KafkaConsumer[K, V] = {
     val props = new Properties
-    props.putAll(consumerConfig)
-    props.putAll(configOverrides)
+    props ++= consumerConfig
+    props ++= configOverrides
     val consumer = new KafkaConsumer[K, V](props, keyDeserializer, valueDeserializer)
     consumers += consumer
     consumer

--- a/core/src/test/scala/integration/kafka/api/LegacyAdminClientTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LegacyAdminClientTest.scala
@@ -79,13 +79,14 @@ class LegacyAdminClientTest extends IntegrationTestHarness with Logging {
 
   @Test
   def testOffsetsForTimesWhenOffsetNotFound() {
-    val consumer = consumers.head
+    val consumer = createConsumer()
     assertNull(consumer.offsetsForTimes(Map(tp -> JLong.valueOf(0L)).asJava).get(tp))
   }
 
   @Test
   def testListGroups() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
     val groups = client.listAllGroupsFlattened
     assertFalse(groups.isEmpty)
@@ -96,7 +97,8 @@ class LegacyAdminClientTest extends IntegrationTestHarness with Logging {
 
   @Test
   def testListAllBrokerVersionInfo() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
     val brokerVersionInfos = client.listAllBrokerVersionInfo
     val brokers = brokerList.split(",")
@@ -111,7 +113,8 @@ class LegacyAdminClientTest extends IntegrationTestHarness with Logging {
 
   @Test
   def testGetConsumerGroupSummary() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
     val group = client.describeConsumerGroup(groupId)
     assertEquals("range", group.assignmentStrategy)
@@ -126,7 +129,8 @@ class LegacyAdminClientTest extends IntegrationTestHarness with Logging {
 
   @Test
   def testDescribeConsumerGroup() {
-    subscribeAndWaitForAssignment(topic, consumers.head)
+    val consumer = createConsumer()
+    subscribeAndWaitForAssignment(topic, consumer)
 
     val consumerGroupSummary = client.describeConsumerGroup(groupId)
     assertEquals(1, consumerGroupSummary.consumers.get.size)

--- a/core/src/test/scala/integration/kafka/api/LogAppendTimeTest.scala
+++ b/core/src/test/scala/integration/kafka/api/LogAppendTimeTest.scala
@@ -53,7 +53,7 @@ class LogAppendTimeTest extends IntegrationTestHarness {
 
   @Test
   def testProduceConsume() {
-    val producer = producers.head
+    val producer = createProducer()
     val now = System.currentTimeMillis()
     val createTime = now - TimeUnit.DAYS.toMillis(1)
     val producerRecords = (1 to 10).map(i => new ProducerRecord(topic, null, createTime, s"key$i".getBytes,
@@ -64,7 +64,7 @@ class LogAppendTimeTest extends IntegrationTestHarness {
       assertTrue(recordMetadata.timestamp < now + TimeUnit.SECONDS.toMillis(60))
     }
 
-    val consumer = consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(Collections.singleton(topic))
     val consumerRecords = new ArrayBuffer[ConsumerRecord[Array[Byte], Array[Byte]]]
     TestUtils.waitUntilTrue(() => {

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -977,16 +977,16 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // subscribe all consumers to all topics and validate the assignment
 
-    val consumerGroup = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
-    consumerGroup += createConsumer()
-    consumerGroup += createConsumer()
+    val consumersInGroup = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
+    consumersInGroup += createConsumer()
+    consumersInGroup += createConsumer()
 
-    val consumerPollers = subscribeConsumers(consumerGroup, List(topic, topic1))
+    val consumerPollers = subscribeConsumers(consumersInGroup, List(topic, topic1))
     try {
       validateGroupAssignment(consumerPollers, subscriptions, s"Did not get valid initial assignment for partitions ${subscriptions.asJava}")
 
       // add 2 more consumers and validate re-assignment
-      addConsumersToGroupAndWaitForGroupAssignment(2, consumerGroup, consumerPollers, List(topic, topic1), subscriptions)
+      addConsumersToGroupAndWaitForGroupAssignment(2, consumersInGroup, consumerPollers, List(topic, topic1), subscriptions)
 
       // add one more topic and validate partition re-assignment
       val topic2 = "topic2"

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -46,14 +46,16 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     record.headers().add("headerKey", "headerValue".getBytes)
 
-    this.producers.head.send(record)
+    val producer = createProducer()
+    producer.send(record)
 
-    assertEquals(0, this.consumers.head.assignment.size)
-    this.consumers.head.assign(List(tp).asJava)
-    assertEquals(1, this.consumers.head.assignment.size)
+    val consumer = createConsumer()
+    assertEquals(0, consumer.assignment.size)
+    consumer.assign(List(tp).asJava)
+    assertEquals(1, consumer.assignment.size)
 
-    this.consumers.head.seek(tp, 0)
-    val records = consumeRecords(consumer = this.consumers.head, numRecords = numRecords)
+    consumer.seek(tp, 0)
+    val records = consumeRecords(consumer = consumer, numRecords = numRecords)
 
     assertEquals(numRecords, records.size)
 
@@ -111,19 +113,16 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     }
 
-    val producer0 = new KafkaProducer(this.producerConfig, new ByteArraySerializer(), extendedSerializer)
-    producers += producer0
-    producer0.send(record)
+    val producer = createProducer(valueSerializer = extendedSerializer)
+    producer.send(record)
 
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), extendedDeserializer)
-    consumers += consumer0
+    val consumer = createConsumer(valueDeserializer = extendedDeserializer)
+    assertEquals(0, consumer.assignment.size)
+    consumer.assign(List(tp).asJava)
+    assertEquals(1, consumer.assignment.size)
 
-    assertEquals(0, consumer0.assignment.size)
-    consumer0.assign(List(tp).asJava)
-    assertEquals(1, consumer0.assignment.size)
-
-    consumer0.seek(tp, 0)
-    val records = consumeRecords(consumer = consumer0, numRecords = numRecords)
+    consumer.seek(tp, 0)
+    val records = consumeRecords(consumer = consumer, numRecords = numRecords)
 
     assertEquals(numRecords, records.size)
   }
@@ -133,16 +132,13 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val maxPollRecords = 2
     val numRecords = 10000
 
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
     this.consumerConfig.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
-
-    consumer0.assign(List(tp).asJava)
-
-    consumeAndVerifyRecords(consumer0, numRecords = numRecords, startingOffset = 0,
-      maxPollRecords = maxPollRecords)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeAndVerifyRecords(consumer, numRecords = numRecords, startingOffset = 0, maxPollRecords = maxPollRecords)
   }
 
   @Test
@@ -151,21 +147,20 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 500.toString)
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 2000.toString)
 
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     val listener = new TestConsumerReassignmentListener()
-    consumer0.subscribe(List(topic).asJava, listener)
+    consumer.subscribe(List(topic).asJava, listener)
 
     // poll once to get the initial assignment
-    consumer0.poll(0)
+    consumer.poll(0)
     assertEquals(1, listener.callsToAssigned)
     assertEquals(1, listener.callsToRevoked)
 
     Thread.sleep(3500)
 
     // we should fall out of the group and need to rebalance
-    consumer0.poll(0)
+    consumer.poll(0)
     assertEquals(2, listener.callsToAssigned)
     assertEquals(2, listener.callsToRevoked)
   }
@@ -177,9 +172,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000.toString)
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false.toString)
 
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
-
+    val consumer = createConsumer()
     var commitCompleted = false
     var committedPosition: Long = -1
 
@@ -190,22 +183,22 @@ class PlaintextConsumerTest extends BaseConsumerTest {
           // than session timeout and then try a commit. We should still be in the group,
           // so the commit should succeed
           Utils.sleep(1500)
-          committedPosition = consumer0.position(tp)
-          consumer0.commitSync(Map(tp -> new OffsetAndMetadata(committedPosition)).asJava)
+          committedPosition = consumer.position(tp)
+          consumer.commitSync(Map(tp -> new OffsetAndMetadata(committedPosition)).asJava)
           commitCompleted = true
         }
         super.onPartitionsRevoked(partitions)
       }
     }
 
-    consumer0.subscribe(List(topic).asJava, listener)
+    consumer.subscribe(List(topic).asJava, listener)
 
     // poll once to join the group and get the initial assignment
-    consumer0.poll(0)
+    consumer.poll(0)
 
     // force a rebalance to trigger an invocation of the revocation callback while in the group
-    consumer0.subscribe(List("otherTopic").asJava, listener)
-    consumer0.poll(0)
+    consumer.subscribe(List("otherTopic").asJava, listener)
+    consumer.poll(0)
 
     assertEquals(0, committedPosition)
     assertTrue(commitCompleted)
@@ -218,9 +211,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 1000.toString)
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false.toString)
 
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
-
+    val consumer = createConsumer()
     val listener = new TestConsumerReassignmentListener {
       override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]): Unit = {
         // sleep longer than the session timeout, we should still be in the group after invocation
@@ -228,13 +219,13 @@ class PlaintextConsumerTest extends BaseConsumerTest {
         super.onPartitionsAssigned(partitions)
       }
     }
-    consumer0.subscribe(List(topic).asJava, listener)
+    consumer.subscribe(List(topic).asJava, listener)
 
     // poll once to join the group and get the initial assignment
-    consumer0.poll(0)
+    consumer.poll(0)
 
     // we should still be in the group after this invocation
-    consumer0.poll(0)
+    consumer.poll(0)
 
     assertEquals(1, listener.callsToAssigned)
     assertEquals(1, listener.callsToRevoked)
@@ -243,71 +234,80 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   @Test
   def testAutoCommitOnClose() {
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
+    val consumer = createConsumer()
 
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
-    consumer0.subscribe(List(topic).asJava)
+    consumer.subscribe(List(topic).asJava)
 
     val assignment = Set(tp, tp2)
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == assignment.asJava
-    }, s"Expected partitions ${assignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == assignment.asJava
+    }, s"Expected partitions ${assignment.asJava} but actually got ${consumer.assignment()}")
 
     // should auto-commit seeked positions before closing
-    consumer0.seek(tp, 300)
-    consumer0.seek(tp2, 500)
-    consumer0.close()
+    consumer.seek(tp, 300)
+    consumer.seek(tp2, 500)
+    consumer.close()
 
     // now we should see the committed positions from another consumer
-    assertEquals(300, this.consumers.head.committed(tp).offset)
-    assertEquals(500, this.consumers.head.committed(tp2).offset)
+    val anotherConsumer = createConsumer()
+    assertEquals(300, anotherConsumer.committed(tp).offset)
+    assertEquals(500, anotherConsumer.committed(tp2).offset)
   }
 
   @Test
   def testAutoCommitOnCloseAfterWakeup() {
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
+    val consumer = createConsumer()
 
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
-    consumer0.subscribe(List(topic).asJava)
+    consumer.subscribe(List(topic).asJava)
 
     val assignment = Set(tp, tp2)
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == assignment.asJava
-    }, s"Expected partitions ${assignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == assignment.asJava
+    }, s"Expected partitions ${assignment.asJava} but actually got ${consumer.assignment()}")
 
     // should auto-commit seeked positions before closing
-    consumer0.seek(tp, 300)
-    consumer0.seek(tp2, 500)
+    consumer.seek(tp, 300)
+    consumer.seek(tp2, 500)
 
     // wakeup the consumer before closing to simulate trying to break a poll
     // loop from another thread
-    consumer0.wakeup()
-    consumer0.close()
+    consumer.wakeup()
+    consumer.close()
 
     // now we should see the committed positions from another consumer
-    assertEquals(300, this.consumers.head.committed(tp).offset)
-    assertEquals(500, this.consumers.head.committed(tp2).offset)
+    assertEquals(300, consumer.committed(tp).offset)
+    assertEquals(500, consumer.committed(tp2).offset)
   }
 
   @Test
   def testAutoOffsetReset() {
-    sendRecords(1)
-    this.consumers.head.assign(List(tp).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = 1, startingOffset = 0)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 1, tp)
+
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 1, startingOffset = 0)
   }
 
   @Test
   def testGroupConsumption() {
-    sendRecords(10)
-    this.consumers.head.subscribe(List(topic).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = 1, startingOffset = 0)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 10, tp)
+
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 1, startingOffset = 0)
   }
 
   /**
@@ -322,28 +322,30 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   @Test
   def testPatternSubscription() {
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
     val topic1 = "tblablac" // matches subscribed pattern
     createTopic(topic1, 2, serverCount)
-    sendRecords(1000, new TopicPartition(topic1, 0))
-    sendRecords(1000, new TopicPartition(topic1, 1))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic1, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic1, 1))
 
     val topic2 = "tblablak" // does not match subscribed pattern
     createTopic(topic2, 2, serverCount)
-    sendRecords(1000, new TopicPartition(topic2, 0))
-    sendRecords(1000, new TopicPartition(topic2, 1))
+    sendRecords(producer,numRecords = 1000, new TopicPartition(topic2, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic2, 1))
 
     val topic3 = "tblab1" // does not match subscribed pattern
     createTopic(topic3, 2, serverCount)
-    sendRecords(1000, new TopicPartition(topic3, 0))
-    sendRecords(1000, new TopicPartition(topic3, 1))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic3, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic3, 1))
 
-    assertEquals(0, this.consumers.head.assignment().size)
+    val consumer = createConsumer()
+    assertEquals(0, consumer.assignment().size)
 
     val pattern = Pattern.compile("t.*c")
-    this.consumers.head.subscribe(pattern, new TestConsumerReassignmentListener)
-    this.consumers.head.poll(50)
+    consumer.subscribe(pattern, new TestConsumerReassignmentListener)
+    consumer.poll(50)
 
     var subscriptions = Set(
       new TopicPartition(topic, 0),
@@ -352,27 +354,26 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(topic1, 1))
 
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment() == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${this.consumers.head.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
     val topic4 = "tsomec" // matches subscribed pattern
     createTopic(topic4, 2, serverCount)
-    sendRecords(1000, new TopicPartition(topic4, 0))
-    sendRecords(1000, new TopicPartition(topic4, 1))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic4, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic4, 1))
 
     subscriptions ++= Set(
       new TopicPartition(topic4, 0),
       new TopicPartition(topic4, 1))
 
-
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment() == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${this.consumers.head.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
-    this.consumers.head.unsubscribe()
-    assertEquals(0, this.consumers.head.assignment().size)
+    consumer.unsubscribe()
+    assertEquals(0, consumer.assignment().size)
   }
 
   /**
@@ -387,23 +388,23 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   @Test
   def testSubsequentPatternSubscription() {
     this.consumerConfig.setProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "30000")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = numRecords, tp)
 
     // the first topic ('topic')  matches first subscription pattern only
 
     val fooTopic = "foo" // matches both subscription patterns
     createTopic(fooTopic, 1, serverCount)
-    sendRecords(1000, new TopicPartition(fooTopic, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(fooTopic, 0))
 
-    assertEquals(0, consumer0.assignment().size)
+    assertEquals(0, consumer.assignment().size)
 
     val pattern1 = Pattern.compile(".*o.*") // only 'topic' and 'foo' match this
-    consumer0.subscribe(pattern1, new TestConsumerReassignmentListener)
-    consumer0.poll(50)
+    consumer.subscribe(pattern1, new TestConsumerReassignmentListener)
+    consumer.poll(50)
 
     var subscriptions = Set(
       new TopicPartition(topic, 0),
@@ -411,17 +412,17 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(fooTopic, 0))
 
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
     val barTopic = "bar" // matches the next subscription pattern
     createTopic(barTopic, 1, serverCount)
-    sendRecords(1000, new TopicPartition(barTopic, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(barTopic, 0))
 
     val pattern2 = Pattern.compile("...") // only 'foo' and 'bar' match this
-    consumer0.subscribe(pattern2, new TestConsumerReassignmentListener)
-    consumer0.poll(50)
+    consumer.subscribe(pattern2, new TestConsumerReassignmentListener)
+    consumer.poll(50)
 
     subscriptions --= Set(
       new TopicPartition(topic, 0),
@@ -431,12 +432,12 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(barTopic, 0))
 
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
-    consumer0.unsubscribe()
-    assertEquals(0, consumer0.assignment().size)
+    consumer.unsubscribe()
+    assertEquals(0, consumer.assignment().size)
   }
 
   /**
@@ -450,17 +451,19 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   @Test
   def testPatternUnsubscription() {
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
     val topic1 = "tblablac" // matches the subscription pattern
     createTopic(topic1, 2, serverCount)
-    sendRecords(1000, new TopicPartition(topic1, 0))
-    sendRecords(1000, new TopicPartition(topic1, 1))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic1, 0))
+    sendRecords(producer, numRecords = 1000, new TopicPartition(topic1, 1))
 
-    assertEquals(0, this.consumers.head.assignment().size)
+    val consumer = createConsumer()
+    assertEquals(0, consumer.assignment().size)
 
-    this.consumers.head.subscribe(Pattern.compile("t.*c"), new TestConsumerReassignmentListener)
-    this.consumers.head.poll(50)
+    consumer.subscribe(Pattern.compile("t.*c"), new TestConsumerReassignmentListener)
+    consumer.poll(50)
 
     val subscriptions = Set(
       new TopicPartition(topic, 0),
@@ -469,39 +472,40 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       new TopicPartition(topic1, 1))
 
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment() == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${this.consumers.head.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment()}")
 
-    this.consumers.head.unsubscribe()
-    assertEquals(0, this.consumers.head.assignment().size)
+    consumer.unsubscribe()
+    assertEquals(0, consumer.assignment().size)
   }
 
   @Test
   def testCommitMetadata() {
-    this.consumers.head.assign(List(tp).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
 
     // sync commit
     val syncMetadata = new OffsetAndMetadata(5, "foo")
-    this.consumers.head.commitSync(Map((tp, syncMetadata)).asJava)
-    assertEquals(syncMetadata, this.consumers.head.committed(tp))
+    consumer.commitSync(Map((tp, syncMetadata)).asJava)
+    assertEquals(syncMetadata, consumer.committed(tp))
 
     // async commit
     val asyncMetadata = new OffsetAndMetadata(10, "bar")
     val callback = new CountConsumerCommitCallback
-    this.consumers.head.commitAsync(Map((tp, asyncMetadata)).asJava, callback)
-    awaitCommitCallback(this.consumers.head, callback)
-    assertEquals(asyncMetadata, this.consumers.head.committed(tp))
+    consumer.commitAsync(Map((tp, asyncMetadata)).asJava, callback)
+    awaitCommitCallback(consumer, callback)
+    assertEquals(asyncMetadata, consumer.committed(tp))
 
     // handle null metadata
     val nullMetadata = new OffsetAndMetadata(5, null)
-    this.consumers.head.commitSync(Map((tp, nullMetadata)).asJava)
-    assertEquals(nullMetadata, this.consumers.head.committed(tp))
+    consumer.commitSync(Map((tp, nullMetadata)).asJava)
+    assertEquals(nullMetadata, consumer.committed(tp))
   }
 
   @Test
   def testAsyncCommit() {
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
     consumer.poll(0)
 
@@ -519,18 +523,19 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val otherTopic = "other"
     val subscriptions = Set(new TopicPartition(topic, 0), new TopicPartition(topic, 1))
     val expandedSubscriptions = subscriptions ++ Set(new TopicPartition(otherTopic, 0), new TopicPartition(otherTopic, 1))
-    this.consumers.head.subscribe(List(topic).asJava)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic).asJava)
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${this.consumers.head.assignment}")
+      consumer.poll(50)
+      consumer.assignment == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment}")
 
     createTopic(otherTopic, 2, serverCount)
-    this.consumers.head.subscribe(List(topic, otherTopic).asJava)
+    consumer.subscribe(List(topic, otherTopic).asJava)
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment == expandedSubscriptions.asJava
-    }, s"Expected partitions ${expandedSubscriptions.asJava} but actually got ${this.consumers.head.assignment}")
+      consumer.poll(50)
+      consumer.assignment == expandedSubscriptions.asJava
+    }, s"Expected partitions ${expandedSubscriptions.asJava} but actually got ${consumer.assignment}")
   }
 
   @Test
@@ -539,47 +544,52 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     createTopic(otherTopic, 2, serverCount)
     val subscriptions = Set(new TopicPartition(topic, 0), new TopicPartition(topic, 1), new TopicPartition(otherTopic, 0), new TopicPartition(otherTopic, 1))
     val shrunkenSubscriptions = Set(new TopicPartition(topic, 0), new TopicPartition(topic, 1))
-    this.consumers.head.subscribe(List(topic, otherTopic).asJava)
+    val consumer = createConsumer()
+    consumer.subscribe(List(topic, otherTopic).asJava)
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment == subscriptions.asJava
-    }, s"Expected partitions ${subscriptions.asJava} but actually got ${this.consumers.head.assignment}")
+      consumer.poll(50)
+      consumer.assignment == subscriptions.asJava
+    }, s"Expected partitions ${subscriptions.asJava} but actually got ${consumer.assignment}")
 
-    this.consumers.head.subscribe(List(topic).asJava)
+    consumer.subscribe(List(topic).asJava)
     TestUtils.waitUntilTrue(() => {
-      this.consumers.head.poll(50)
-      this.consumers.head.assignment == shrunkenSubscriptions.asJava
-    }, s"Expected partitions ${shrunkenSubscriptions.asJava} but actually got ${this.consumers.head.assignment}")
+      consumer.poll(50)
+      consumer.assignment == shrunkenSubscriptions.asJava
+    }, s"Expected partitions ${shrunkenSubscriptions.asJava} but actually got ${consumer.assignment}")
   }
 
   @Test
   def testPartitionsFor() {
     val numParts = 2
     createTopic("part-test", numParts, 1)
-    val parts = this.consumers.head.partitionsFor("part-test")
+    val consumer = createConsumer()
+    val parts = consumer.partitionsFor("part-test")
     assertNotNull(parts)
     assertEquals(2, parts.size)
   }
 
   @Test
   def testPartitionsForAutoCreate() {
-    val partitions = this.consumers.head.partitionsFor("non-exist-topic")
+    val consumer = createConsumer()
+    val partitions = consumer.partitionsFor("non-exist-topic")
     assertFalse(partitions.isEmpty)
   }
 
   @Test(expected = classOf[InvalidTopicException])
   def testPartitionsForInvalidTopic() {
-    this.consumers.head.partitionsFor(";3# ads,{234")
+    val consumer = createConsumer()
+    consumer.partitionsFor(";3# ads,{234")
   }
 
   @Test
   def testSeek() {
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
     val totalRecords = 50L
     val mid = totalRecords / 2
 
     // Test seek non-compressed message
-    sendRecords(totalRecords.toInt, tp)
+    val producer = createProducer()
+    sendRecords(producer, totalRecords.toInt, tp)
     consumer.assign(List(tp).asJava)
 
     consumer.seekToEnd(List(tp).asJava)
@@ -618,8 +628,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val producerProps = new Properties()
     producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, CompressionType.GZIP.name)
     producerProps.setProperty(ProducerConfig.LINGER_MS_CONFIG, Int.MaxValue.toString)
-    val producer = TestUtils.createProducer(brokerList, securityProtocol = securityProtocol, trustStoreFile = trustStoreFile,
-        saslProperties = clientSaslProperties, lingerMs = Int.MaxValue, props = Some(producerProps))
+    val producer = createProducer(lingerMs = Int.MaxValue, configOverrides = producerProps)
     (0 until numRecords).foreach { i =>
       producer.send(new ProducerRecord(tp.topic, tp.partition, i.toLong, s"key $i".getBytes, s"value $i".getBytes))
     }
@@ -628,67 +637,73 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
   @Test
   def testPositionAndCommit() {
-    sendRecords(5)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 5, tp)
 
-    assertNull(this.consumers.head.committed(new TopicPartition(topic, 15)))
+    val consumer = createConsumer()
+    assertNull(consumer.committed(new TopicPartition(topic, 15)))
 
     // position() on a partition that we aren't subscribed to throws an exception
     intercept[IllegalStateException] {
-      this.consumers.head.position(new TopicPartition(topic, 15))
+      consumer.position(new TopicPartition(topic, 15))
     }
 
-    this.consumers.head.assign(List(tp).asJava)
+    consumer.assign(List(tp).asJava)
 
-    assertEquals("position() on a partition that we are subscribed to should reset the offset", 0L, this.consumers.head.position(tp))
-    this.consumers.head.commitSync()
-    assertEquals(0L, this.consumers.head.committed(tp).offset)
+    assertEquals("position() on a partition that we are subscribed to should reset the offset", 0L, consumer.position(tp))
+    consumer.commitSync()
+    assertEquals(0L, consumer.committed(tp).offset)
 
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = 5, startingOffset = 0)
-    assertEquals("After consuming 5 records, position should be 5", 5L, this.consumers.head.position(tp))
-    this.consumers.head.commitSync()
-    assertEquals("Committed offset should be returned", 5L, this.consumers.head.committed(tp).offset)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 5, startingOffset = 0)
+    assertEquals("After consuming 5 records, position should be 5", 5L, consumer.position(tp))
+    consumer.commitSync()
+    assertEquals("Committed offset should be returned", 5L, consumer.committed(tp).offset)
 
-    sendRecords(1)
+    sendRecords(producer, numRecords = 1, tp)
 
     // another consumer in the same group should get the same position
-    this.consumers(1).assign(List(tp).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers(1), numRecords = 1, startingOffset = 5)
+    val otherConsumer = createConsumer()
+    otherConsumer.assign(List(tp).asJava)
+    consumeAndVerifyRecords(consumer = otherConsumer, numRecords = 1, startingOffset = 5)
   }
 
   @Test
   def testPartitionPauseAndResume() {
     val partitions = List(tp).asJava
-    sendRecords(5)
-    this.consumers.head.assign(partitions)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = 5, startingOffset = 0)
-    this.consumers.head.pause(partitions)
-    sendRecords(5)
-    assertTrue(this.consumers.head.poll(0).isEmpty)
-    this.consumers.head.resume(partitions)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = 5, startingOffset = 5)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 5, tp)
+
+    val consumer = createConsumer()
+    consumer.assign(partitions)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 5, startingOffset = 0)
+    consumer.pause(partitions)
+    sendRecords(producer, numRecords = 5, tp)
+    assertTrue(consumer.poll(0).isEmpty)
+    consumer.resume(partitions)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 5, startingOffset = 5)
   }
 
   @Test
   def testFetchInvalidOffset() {
     this.consumerConfig.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     // produce one record
     val totalRecords = 2
-    sendRecords(totalRecords, tp)
-    consumer0.assign(List(tp).asJava)
+    val producer = createProducer()
+    sendRecords(producer, totalRecords, tp)
+    consumer.assign(List(tp).asJava)
 
     // poll should fail because there is no offset reset strategy set
     intercept[NoOffsetForPartitionException] {
-      consumer0.poll(50)
+      consumer.poll(50)
     }
 
     // seek to out of range position
     val outOfRangePos = totalRecords + 1
-    consumer0.seek(tp, outOfRangePos)
+    consumer.seek(tp, outOfRangePos)
     val e = intercept[OffsetOutOfRangeException] {
-      consumer0.poll(20000)
+      consumer.poll(20000)
     }
     val outOfRangePartitions = e.offsetOutOfRangePartitions()
     assertNotNull(outOfRangePartitions)
@@ -704,17 +719,17 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   }
 
   private def checkLargeRecord(producerRecordSize: Int): Unit = {
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     // produce a record that is larger than the configured fetch size
     val record = new ProducerRecord(tp.topic(), tp.partition(), "key".getBytes,
       new Array[Byte](producerRecordSize))
-    this.producers.head.send(record)
+    val producer = createProducer()
+    producer.send(record)
 
     // consuming a record that is too large should succeed since KIP-74
-    consumer0.assign(List(tp).asJava)
-    val records = consumer0.poll(20000)
+    consumer.assign(List(tp).asJava)
+    val records = consumer.poll(20000)
     assertEquals(1, records.count)
     val consumerRecord = records.iterator().next()
     assertEquals(0L, consumerRecord.offset)
@@ -733,20 +748,20 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   }
 
   private def checkFetchHonoursSizeIfLargeRecordNotFirst(largeProducerRecordSize: Int): Unit = {
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     val smallRecord = new ProducerRecord(tp.topic(), tp.partition(), "small".getBytes,
       "value".getBytes)
     val largeRecord = new ProducerRecord(tp.topic(), tp.partition(), "large".getBytes,
       new Array[Byte](largeProducerRecordSize))
 
-    this.producers.head.send(smallRecord).get
-    this.producers.head.send(largeRecord).get
+    val producer = createProducer()
+    producer.send(smallRecord).get
+    producer.send(largeRecord).get
 
     // we should only get the small record in the first `poll`
-    consumer0.assign(List(tp).asJava)
-    val records = consumer0.poll(20000)
+    consumer.assign(List(tp).asJava)
+    val records = consumer.poll(20000)
     assertEquals(1, records.count)
     val consumerRecord = records.iterator().next()
     assertEquals(0L, consumerRecord.offset)
@@ -779,8 +794,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // this behaves a little different than when remaining limit bytes is 0 and it's important to test it
     this.consumerConfig.setProperty(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, "500")
     this.consumerConfig.setProperty(ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG, "100")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     val topic1 = "topic1"
     val topic2 = "topic2"
@@ -795,17 +809,18 @@ class PlaintextConsumerTest extends BaseConsumerTest {
       (0 until partitionCount).map(new TopicPartition(topic, _))
     }
 
-    assertEquals(0, consumer0.assignment().size)
+    assertEquals(0, consumer.assignment().size)
 
-    consumer0.subscribe(List(topic1, topic2, topic3).asJava)
+    consumer.subscribe(List(topic1, topic2, topic3).asJava)
 
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == partitions.toSet.asJava
-    }, s"Expected partitions ${partitions.asJava} but actually got ${consumer0.assignment}")
+      consumer.poll(50)
+      consumer.assignment() == partitions.toSet.asJava
+    }, s"Expected partitions ${partitions.asJava} but actually got ${consumer.assignment}")
 
-    val producerRecords = partitions.flatMap(sendRecords(partitionCount, _))
-    val consumerRecords = consumeRecords(consumer0, producerRecords.size)
+    val producer = createProducer()
+    val producerRecords = partitions.flatMap(sendRecords(producer, partitionCount, _))
+    val consumerRecords = consumeRecords(consumer, producerRecords.size)
 
     val expected = producerRecords.map { record =>
       (record.topic, record.partition, new String(record.key), new String(record.value), record.timestamp)
@@ -823,43 +838,44 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // 1 consumer using round-robin assignment
     this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "roundrobin-group")
     this.consumerConfig.setProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, classOf[RoundRobinAssignor].getName)
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     // create two new topics, each having 2 partitions
     val topic1 = "topic1"
     val topic2 = "topic2"
-    val expectedAssignment = createTopicAndSendRecords(topic1, 2, 100) ++ createTopicAndSendRecords(topic2, 2, 100)
+    val producer = createProducer()
+    val expectedAssignment = createTopicAndSendRecords(producer, topic1, 2, 100) ++
+      createTopicAndSendRecords(producer, topic2, 2, 100)
 
-    assertEquals(0, consumer0.assignment().size)
+    assertEquals(0, consumer.assignment().size)
 
     // subscribe to two topics
-    consumer0.subscribe(List(topic1, topic2).asJava)
+    consumer.subscribe(List(topic1, topic2).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == expectedAssignment.asJava
-    }, s"Expected partitions ${expectedAssignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == expectedAssignment.asJava
+    }, s"Expected partitions ${expectedAssignment.asJava} but actually got ${consumer.assignment()}")
 
     // add one more topic with 2 partitions
     val topic3 = "topic3"
-    createTopicAndSendRecords(topic3, 2, 100)
+    createTopicAndSendRecords(producer, topic3, 2, 100)
 
     val newExpectedAssignment = expectedAssignment ++ Set(new TopicPartition(topic3, 0), new TopicPartition(topic3, 1))
-    consumer0.subscribe(List(topic1, topic2, topic3).asJava)
+    consumer.subscribe(List(topic1, topic2, topic3).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == newExpectedAssignment.asJava
-    }, s"Expected partitions ${newExpectedAssignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == newExpectedAssignment.asJava
+    }, s"Expected partitions ${newExpectedAssignment.asJava} but actually got ${consumer.assignment()}")
 
     // remove the topic we just added
-    consumer0.subscribe(List(topic1, topic2).asJava)
+    consumer.subscribe(List(topic1, topic2).asJava)
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == expectedAssignment.asJava
-    }, s"Expected partitions ${expectedAssignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == expectedAssignment.asJava
+    }, s"Expected partitions ${expectedAssignment.asJava} but actually got ${consumer.assignment()}")
 
-    consumer0.unsubscribe()
-    assertEquals(0, consumer0.assignment().size)
+    consumer.unsubscribe()
+    assertEquals(0, consumer.assignment().size)
   }
 
   @Test
@@ -870,16 +886,19 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // create two new topics, total number of partitions must be greater than number of consumers
     val topic1 = "topic1"
     val topic2 = "topic2"
-    val subscriptions = createTopicAndSendRecords(topic1, 5, 100) ++ createTopicAndSendRecords(topic2, 8, 100)
+    val producer = createProducer()
+    val subscriptions = createTopicAndSendRecords(producer, topic1, 5, 100) ++
+      createTopicAndSendRecords(producer, topic2, 8, 100)
 
     // create a group of consumers, subscribe the consumers to all the topics and start polling
     // for the topic partition assignment
-    val (_, consumerPollers) = createConsumerGroupAndWaitForAssignment(10, List(topic1, topic2), subscriptions)
+    val (consumerGroup, consumerPollers) = createConsumerGroupAndWaitForAssignment(10, List(topic1, topic2), subscriptions)
     try {
       validateGroupAssignment(consumerPollers, subscriptions, s"Did not get valid initial assignment for partitions ${subscriptions.asJava}")
 
       // add one more consumer and validate re-assignment
-      addConsumersToGroupAndWaitForGroupAssignment(1, consumers, consumerPollers, List(topic1, topic2), subscriptions)
+      addConsumersToGroupAndWaitForGroupAssignment(1, consumerGroup, consumerPollers,
+        List(topic1, topic2), subscriptions)
     } finally {
       consumerPollers.foreach(_.shutdown())
     }
@@ -901,23 +920,23 @@ class PlaintextConsumerTest extends BaseConsumerTest {
    */
   @Test
   def testMultiConsumerStickyAssignment() {
-    this.consumers.clear()
     this.consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "sticky-group")
     this.consumerConfig.setProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, classOf[StickyAssignor].getName)
 
     // create one new topic
     val topic = "single-topic"
     val rand = 1 + scala.util.Random.nextInt(10)
-    val partitions = createTopicAndSendRecords(topic, rand * 10, 100)
+    val producer = createProducer()
+    val partitions = createTopicAndSendRecords(producer, topic, rand * 10, 100)
 
     // create a group of consumers, subscribe the consumers to the single topic and start polling
     // for the topic partition assignment
-    val (_, consumerPollers) = createConsumerGroupAndWaitForAssignment(9, List(topic), partitions)
+    val (consumerGroup, consumerPollers) = createConsumerGroupAndWaitForAssignment(9, List(topic), partitions)
     validateGroupAssignment(consumerPollers, partitions, s"Did not get valid initial assignment for partitions ${partitions.asJava}")
     val prePartition2PollerId = reverse(consumerPollers.map(poller => (poller.getId, poller.consumerAssignment())).toMap)
 
     // add one more consumer and validate re-assignment
-    addConsumersToGroupAndWaitForGroupAssignment(1, consumers, consumerPollers, List(topic), partitions)
+    addConsumersToGroupAndWaitForGroupAssignment(1, consumerGroup, consumerPollers, List(topic), partitions)
 
     val postPartition2PollerId = reverse(consumerPollers.map(poller => (poller.getId, poller.consumerAssignment())).toMap)
     val keys = prePartition2PollerId.keySet.union(postPartition2PollerId.keySet)
@@ -944,23 +963,28 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   @Test
   def testMultiConsumerDefaultAssignment() {
     // use consumers and topics defined in this class + one more topic
-    sendRecords(100, tp)
-    sendRecords(100, tp2)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 100, tp)
+    sendRecords(producer, numRecords = 100, tp2)
     val topic1 = "topic1"
-    val subscriptions = Set(tp, tp2) ++ createTopicAndSendRecords(topic1, 5, 100)
+    val subscriptions = Set(tp, tp2) ++ createTopicAndSendRecords(producer, topic1, 5, 100)
 
     // subscribe all consumers to all topics and validate the assignment
-    val consumerPollers = subscribeConsumers(consumers, List(topic, topic1))
 
+    val consumerGroup = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
+    consumerGroup += createConsumer()
+    consumerGroup += createConsumer()
+
+    val consumerPollers = subscribeConsumers(consumerGroup, List(topic, topic1))
     try {
       validateGroupAssignment(consumerPollers, subscriptions, s"Did not get valid initial assignment for partitions ${subscriptions.asJava}")
 
       // add 2 more consumers and validate re-assignment
-      addConsumersToGroupAndWaitForGroupAssignment(2, consumers, consumerPollers, List(topic, topic1), subscriptions)
+      addConsumersToGroupAndWaitForGroupAssignment(2, consumerGroup, consumerPollers, List(topic, topic1), subscriptions)
 
       // add one more topic and validate partition re-assignment
       val topic2 = "topic2"
-      val expandedSubscriptions = subscriptions ++ createTopicAndSendRecords(topic2, 3, 100)
+      val expandedSubscriptions = subscriptions ++ createTopicAndSendRecords(producer, topic2, 3, 100)
       changeConsumerGroupSubscriptionAndValidateAssignment(consumerPollers, List(topic, topic1, topic2), expandedSubscriptions)
 
       // remove the topic we just added and validate re-assignment
@@ -989,10 +1013,11 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // create producer with interceptor
     val producerProps = new Properties()
-    producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
-    producerProps.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockProducerInterceptor")
+    producerProps.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, classOf[MockProducerInterceptor].getName)
     producerProps.put("mock.interceptor.append", appendStr)
-    val testProducer = new KafkaProducer(producerProps, new StringSerializer, new StringSerializer)
+    val testProducer = createProducer(keySerializer = new StringSerializer,
+      valueSerializer = new StringSerializer,
+      configOverrides = producerProps)
 
     // produce records
     val numRecords = 10
@@ -1013,7 +1038,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // create consumer with interceptor
     this.consumerConfig.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockConsumerInterceptor")
-    val testConsumer = new KafkaConsumer(this.consumerConfig, new StringDeserializer, new StringDeserializer)
+    val testConsumer = createConsumer(keyDeserializer = new StringDeserializer, valueDeserializer = new StringDeserializer)
     testConsumer.assign(List(tp).asJava)
     testConsumer.seek(tp, 0)
 
@@ -1053,7 +1078,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // produce records
     val numRecords = 100
-    val testProducer = new KafkaProducer[String, String](this.producerConfig, new StringSerializer, new StringSerializer)
+    val testProducer = createProducer(keySerializer = new StringSerializer, valueSerializer = new StringSerializer)
     (0 until numRecords).map { i =>
       testProducer.send(new ProducerRecord(tp.topic(), tp.partition(), s"key $i", s"value $i"))
     }.foreach(_.get)
@@ -1061,7 +1086,7 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     // create consumer with interceptor
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
     this.consumerConfig.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockConsumerInterceptor")
-    val testConsumer = new KafkaConsumer[String, String](this.consumerConfig, new StringDeserializer(), new StringDeserializer())
+    val testConsumer = createConsumer(keyDeserializer = new StringDeserializer, valueDeserializer = new StringDeserializer)
     val rebalanceListener = new ConsumerRebalanceListener {
       override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]) = {
         // keep partitions paused in this test so that we can verify the commits based on specific seeks
@@ -1104,16 +1129,14 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     producerProps.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockProducerInterceptor")
     producerProps.put("mock.interceptor.append", appendStr)
-    val testProducer = new KafkaProducer(producerProps, new ByteArraySerializer(), new ByteArraySerializer())
-    producers += testProducer
+    val testProducer = createProducer()
 
     // producing records should succeed
     testProducer.send(new ProducerRecord(tp.topic(), tp.partition(), s"key".getBytes, s"value will not be modified".getBytes))
 
     // create consumer with interceptor that has different key and value types from the consumer
     this.consumerConfig.setProperty(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, "org.apache.kafka.test.MockConsumerInterceptor")
-    val testConsumer = new KafkaConsumer[Array[Byte], Array[Byte]](this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += testConsumer
+    val testConsumer = createConsumer()
 
     testConsumer.assign(List(tp).asJava)
     testConsumer.seek(tp, 0)
@@ -1128,15 +1151,17 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def testConsumeMessagesWithCreateTime() {
     val numRecords = 50
     // Test non-compressed messages
-    sendRecords(numRecords, tp)
-    this.consumers.head.assign(List(tp).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = numRecords, startingOffset = 0, startingKeyAndValueIndex = 0,
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, startingOffset = 0, startingKeyAndValueIndex = 0,
       startingTimestamp = 0)
 
     // Test compressed messages
     sendCompressedMessages(numRecords, tp2)
-    this.consumers.head.assign(List(tp2).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = numRecords, tp = tp2, startingOffset = 0, startingKeyAndValueIndex = 0,
+    consumer.assign(List(tp2).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, tp = tp2, startingOffset = 0, startingKeyAndValueIndex = 0,
       startingTimestamp = 0)
   }
 
@@ -1152,16 +1177,19 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
     // Test non-compressed messages
     val tp1 = new TopicPartition(topicName, 0)
-    sendRecords(numRecords, tp1)
-    this.consumers.head.assign(List(tp1).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = numRecords, tp = tp1, startingOffset = 0, startingKeyAndValueIndex = 0,
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp1)
+
+    val consumer = createConsumer()
+    consumer.assign(List(tp1).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, tp = tp1, startingOffset = 0, startingKeyAndValueIndex = 0,
       startingTimestamp = startTime, timestampType = TimestampType.LOG_APPEND_TIME)
 
     // Test compressed messages
     val tp2 = new TopicPartition(topicName, 1)
     sendCompressedMessages(numRecords, tp2)
-    this.consumers.head.assign(List(tp2).asJava)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = numRecords, tp = tp2, startingOffset = 0, startingKeyAndValueIndex = 0,
+    consumer.assign(List(tp2).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, tp = tp2, startingOffset = 0, startingKeyAndValueIndex = 0,
       startingTimestamp = startTime, timestampType = TimestampType.LOG_APPEND_TIME)
   }
 
@@ -1175,7 +1203,8 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     createTopic(topic2, numParts, 1)
     createTopic(topic3, numParts, 1)
 
-    val topics = this.consumers.head.listTopics()
+    val consumer = createConsumer()
+    val topics = consumer.listTopics()
     assertNotNull(topics)
     assertEquals(5, topics.size())
     assertEquals(5, topics.keySet().size())
@@ -1197,19 +1226,20 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     createTopic(topic2, numParts, 1, props)
     createTopic(topic3, numParts, 1)
 
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
 
     // Test negative target time
     intercept[IllegalArgumentException](
       consumer.offsetsForTimes(Collections.singletonMap(new TopicPartition(topic1, 0), -1)))
 
+    val producer = createProducer()
     val timestampsToSearch = new util.HashMap[TopicPartition, java.lang.Long]()
     var i = 0
     for (topic <- List(topic1, topic2, topic3)) {
       for (part <- 0 until numParts) {
         val tp = new TopicPartition(topic, part)
         // In sendRecords(), each message will have key, value and timestamp equal to the sequence number.
-        sendRecords(100, tp)
+        sendRecords(producer, numRecords = 100, tp)
         timestampsToSearch.put(tp, i * 20)
         i += 1
       }
@@ -1239,17 +1269,18 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def testEarliestOrLatestOffsets() {
     val topic0 = "topicWithNewMessageFormat"
     val topic1 = "topicWithOldMessageFormat"
-    createTopicAndSendRecords(topicName = topic0, numPartitions = 2, recordsPerPartition = 100)
+    val producer = createProducer()
+    createTopicAndSendRecords(producer, topicName = topic0, numPartitions = 2, recordsPerPartition = 100)
     val props = new Properties()
     props.setProperty(LogConfig.MessageFormatVersionProp, "0.9.0")
     createTopic(topic1, numPartitions = 1, replicationFactor = 1, props)
-    sendRecords(100, new TopicPartition(topic1, 0))
+    sendRecords(producer, numRecords = 100, new TopicPartition(topic1, 0))
 
     val t0p0 = new TopicPartition(topic0, 0)
     val t0p1 = new TopicPartition(topic0, 1)
     val t1p0 = new TopicPartition(topic1, 0)
     val partitions = Set(t0p0, t0p1, t1p0).asJava
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
 
     val earliests = consumer.beginningOffsets(partitions)
     assertEquals(0L, earliests.get(t0p0))
@@ -1266,67 +1297,68 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def testUnsubscribeTopic() {
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "100") // timeout quickly to avoid slow test
     this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "30")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     val listener = new TestConsumerReassignmentListener()
-    consumer0.subscribe(List(topic).asJava, listener)
+    consumer.subscribe(List(topic).asJava, listener)
 
     // the initial subscription should cause a callback execution
     while (listener.callsToAssigned == 0)
-      consumer0.poll(50)
+      consumer.poll(50)
 
-    consumer0.subscribe(List[String]().asJava)
-    assertEquals(0, consumer0.assignment.size())
+    consumer.subscribe(List[String]().asJava)
+    assertEquals(0, consumer.assignment.size())
   }
 
   @Test
   def testPauseStateNotPreservedByRebalance() {
     this.consumerConfig.setProperty(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "100") // timeout quickly to avoid slow test
     this.consumerConfig.setProperty(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "30")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
-    sendRecords(5)
-    consumer0.subscribe(List(topic).asJava)
-    consumeAndVerifyRecords(consumer = consumer0, numRecords = 5, startingOffset = 0)
-    consumer0.pause(List(tp).asJava)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 5, tp)
+    consumer.subscribe(List(topic).asJava)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 5, startingOffset = 0)
+    consumer.pause(List(tp).asJava)
 
     // subscribe to a new topic to trigger a rebalance
-    consumer0.subscribe(List("topic2").asJava)
+    consumer.subscribe(List("topic2").asJava)
 
     // after rebalance, our position should be reset and our pause state lost,
     // so we should be able to consume from the beginning
-    consumeAndVerifyRecords(consumer = consumer0, numRecords = 0, startingOffset = 5)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = 0, startingOffset = 5)
   }
 
   @Test
   def testCommitSpecifiedOffsets() {
-    sendRecords(5, tp)
-    sendRecords(7, tp2)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 5, tp)
+    sendRecords(producer, numRecords = 7, tp2)
 
-    this.consumers.head.assign(List(tp, tp2).asJava)
+    val consumer = createConsumer()
+    consumer.assign(List(tp, tp2).asJava)
 
     // Need to poll to join the group
-    this.consumers.head.poll(50)
-    val pos1 = this.consumers.head.position(tp)
-    val pos2 = this.consumers.head.position(tp2)
-    this.consumers.head.commitSync(Map[TopicPartition, OffsetAndMetadata]((tp, new OffsetAndMetadata(3L))).asJava)
-    assertEquals(3, this.consumers.head.committed(tp).offset)
-    assertNull(this.consumers.head.committed(tp2))
+    consumer.poll(50)
+    val pos1 = consumer.position(tp)
+    val pos2 = consumer.position(tp2)
+    consumer.commitSync(Map[TopicPartition, OffsetAndMetadata]((tp, new OffsetAndMetadata(3L))).asJava)
+    assertEquals(3, consumer.committed(tp).offset)
+    assertNull(consumer.committed(tp2))
 
     // Positions should not change
-    assertEquals(pos1, this.consumers.head.position(tp))
-    assertEquals(pos2, this.consumers.head.position(tp2))
-    this.consumers.head.commitSync(Map[TopicPartition, OffsetAndMetadata]((tp2, new OffsetAndMetadata(5L))).asJava)
-    assertEquals(3, this.consumers.head.committed(tp).offset)
-    assertEquals(5, this.consumers.head.committed(tp2).offset)
+    assertEquals(pos1, consumer.position(tp))
+    assertEquals(pos2, consumer.position(tp2))
+    consumer.commitSync(Map[TopicPartition, OffsetAndMetadata]((tp2, new OffsetAndMetadata(5L))).asJava)
+    assertEquals(3, consumer.committed(tp).offset)
+    assertEquals(5, consumer.committed(tp2).offset)
 
     // Using async should pick up the committed changes after commit completes
     val commitCallback = new CountConsumerCommitCallback()
-    this.consumers.head.commitAsync(Map[TopicPartition, OffsetAndMetadata]((tp2, new OffsetAndMetadata(7L))).asJava, commitCallback)
-    awaitCommitCallback(this.consumers.head, commitCallback)
-    assertEquals(7, this.consumers.head.committed(tp2).offset)
+    consumer.commitAsync(Map[TopicPartition, OffsetAndMetadata]((tp2, new OffsetAndMetadata(7L))).asJava, commitCallback)
+    awaitCommitCallback(consumer, commitCallback)
+    assertEquals(7, consumer.committed(tp2).offset)
   }
 
   @Test
@@ -1335,44 +1367,44 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     createTopic(topic2, 2, serverCount)
 
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true")
-    val consumer0 = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer0
+    val consumer = createConsumer()
 
     val numRecords = 10000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
     val rebalanceListener = new ConsumerRebalanceListener {
       override def onPartitionsAssigned(partitions: util.Collection[TopicPartition]) = {
         // keep partitions paused in this test so that we can verify the commits based on specific seeks
-        consumer0.pause(partitions)
+        consumer.pause(partitions)
       }
 
       override def onPartitionsRevoked(partitions: util.Collection[TopicPartition]) = {}
     }
 
-    consumer0.subscribe(List(topic).asJava, rebalanceListener)
+    consumer.subscribe(List(topic).asJava, rebalanceListener)
 
     val assignment = Set(tp, tp2)
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == assignment.asJava
-    }, s"Expected partitions ${assignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == assignment.asJava
+    }, s"Expected partitions ${assignment.asJava} but actually got ${consumer.assignment()}")
 
-    consumer0.seek(tp, 300)
-    consumer0.seek(tp2, 500)
+    consumer.seek(tp, 300)
+    consumer.seek(tp2, 500)
 
     // change subscription to trigger rebalance
-    consumer0.subscribe(List(topic, topic2).asJava, rebalanceListener)
+    consumer.subscribe(List(topic, topic2).asJava, rebalanceListener)
 
     val newAssignment = Set(tp, tp2, new TopicPartition(topic2, 0), new TopicPartition(topic2, 1))
     TestUtils.waitUntilTrue(() => {
-      consumer0.poll(50)
-      consumer0.assignment() == newAssignment.asJava
-    }, s"Expected partitions ${newAssignment.asJava} but actually got ${consumer0.assignment()}")
+      consumer.poll(50)
+      consumer.assignment() == newAssignment.asJava
+    }, s"Expected partitions ${newAssignment.asJava} but actually got ${consumer.assignment()}")
 
     // after rebalancing, we should have reset to the committed positions
-    assertEquals(300, consumer0.committed(tp).offset)
-    assertEquals(500, consumer0.committed(tp2).offset)
+    assertEquals(300, consumer.committed(tp).offset)
+    assertEquals(500, consumer.committed(tp2).offset)
   }
 
   @Test
@@ -1381,47 +1413,44 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val topic2 = "topic2"
     createTopic(topic2, 2, serverCount)
     // send some messages.
-    sendRecords(numMessages, tp)
+    val producer = createProducer()
+    sendRecords(producer, numMessages, tp)
     // Test subscribe
     // Create a consumer and consumer some messages.
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testPerPartitionLeadMetricsCleanUpWithSubscribe")
     consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testPerPartitionLeadMetricsCleanUpWithSubscribe")
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    try {
-      val listener0 = new TestConsumerReassignmentListener
-      consumer.subscribe(List(topic, topic2).asJava, listener0)
-      var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
-      TestUtils.waitUntilTrue(() => {
-        records = consumer.poll(100)
-        !records.records(tp).isEmpty
-      }, "Consumer did not consume any message before timeout.")
-      assertEquals("should be assigned once", 1, listener0.callsToAssigned)
-      // Verify the metric exist.
-      val tags1 = new util.HashMap[String, String]()
-      tags1.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
-      tags1.put("topic", tp.topic())
-      tags1.put("partition", String.valueOf(tp.partition()))
+    val consumer = createConsumer()
+    val listener0 = new TestConsumerReassignmentListener
+    consumer.subscribe(List(topic, topic2).asJava, listener0)
+    var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
+    TestUtils.waitUntilTrue(() => {
+      records = consumer.poll(100)
+      !records.records(tp).isEmpty
+    }, "Consumer did not consume any message before timeout.")
+    assertEquals("should be assigned once", 1, listener0.callsToAssigned)
+    // Verify the metric exist.
+    val tags1 = new util.HashMap[String, String]()
+    tags1.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
+    tags1.put("topic", tp.topic())
+    tags1.put("partition", String.valueOf(tp.partition()))
 
-      val tags2 = new util.HashMap[String, String]()
-      tags2.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
-      tags2.put("topic", tp2.topic())
-      tags2.put("partition", String.valueOf(tp2.partition()))
-      val fetchLead0 = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1))
-      assertNotNull(fetchLead0)
-      assertTrue(s"The lead should be ${records.count}", fetchLead0.metricValue() == records.count)
+    val tags2 = new util.HashMap[String, String]()
+    tags2.put("client-id", "testPerPartitionLeadMetricsCleanUpWithSubscribe")
+    tags2.put("topic", tp2.topic())
+    tags2.put("partition", String.valueOf(tp2.partition()))
+    val fetchLead0 = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1))
+    assertNotNull(fetchLead0)
+    assertTrue(s"The lead should be ${records.count}", fetchLead0.metricValue() == records.count)
 
-      // Remove topic from subscription
-      consumer.subscribe(List(topic2).asJava, listener0)
-      TestUtils.waitUntilTrue(() => {
-        consumer.poll(100)
-        listener0.callsToAssigned >= 2
-      }, "Expected rebalance did not occur.")
-      // Verify the metric has gone
-      assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1)))
-      assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags2)))
-    } finally {
-      consumer.close()
-    }
+    // Remove topic from subscription
+    consumer.subscribe(List(topic2).asJava, listener0)
+    TestUtils.waitUntilTrue(() => {
+      consumer.poll(100)
+      listener0.callsToAssigned >= 2
+    }, "Expected rebalance did not occur.")
+    // Verify the metric has gone
+    assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags1)))
+    assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags2)))
   }
 
   @Test
@@ -1430,48 +1459,45 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val topic2 = "topic2"
     createTopic(topic2, 2, serverCount)
     // send some messages.
-    sendRecords(numMessages, tp)
+    val producer = createProducer()
+    sendRecords(producer, numMessages, tp)
     // Test subscribe
     // Create a consumer and consumer some messages.
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testPerPartitionLagMetricsCleanUpWithSubscribe")
     consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testPerPartitionLagMetricsCleanUpWithSubscribe")
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    try {
-      val listener0 = new TestConsumerReassignmentListener
-      consumer.subscribe(List(topic, topic2).asJava, listener0)
-      var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
-      TestUtils.waitUntilTrue(() => {
-        records = consumer.poll(100)
-        !records.records(tp).isEmpty
-      }, "Consumer did not consume any message before timeout.")
-      assertEquals("should be assigned once", 1, listener0.callsToAssigned)
-      // Verify the metric exist.
-      val tags1 = new util.HashMap[String, String]()
-      tags1.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
-      tags1.put("topic", tp.topic())
-      tags1.put("partition", String.valueOf(tp.partition()))
+    val consumer = createConsumer()
+    val listener0 = new TestConsumerReassignmentListener
+    consumer.subscribe(List(topic, topic2).asJava, listener0)
+    var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
+    TestUtils.waitUntilTrue(() => {
+      records = consumer.poll(100)
+      !records.records(tp).isEmpty
+    }, "Consumer did not consume any message before timeout.")
+    assertEquals("should be assigned once", 1, listener0.callsToAssigned)
+    // Verify the metric exist.
+    val tags1 = new util.HashMap[String, String]()
+    tags1.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
+    tags1.put("topic", tp.topic())
+    tags1.put("partition", String.valueOf(tp.partition()))
 
-      val tags2 = new util.HashMap[String, String]()
-      tags2.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
-      tags2.put("topic", tp2.topic())
-      tags2.put("partition", String.valueOf(tp2.partition()))
-      val fetchLag0 = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1))
-      assertNotNull(fetchLag0)
-      val expectedLag = numMessages - records.count
-      assertEquals(s"The lag should be $expectedLag", expectedLag, fetchLag0.value, epsilon)
+    val tags2 = new util.HashMap[String, String]()
+    tags2.put("client-id", "testPerPartitionLagMetricsCleanUpWithSubscribe")
+    tags2.put("topic", tp2.topic())
+    tags2.put("partition", String.valueOf(tp2.partition()))
+    val fetchLag0 = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1))
+    assertNotNull(fetchLag0)
+    val expectedLag = numMessages - records.count
+    assertEquals(s"The lag should be $expectedLag", expectedLag, fetchLag0.value, epsilon)
 
-      // Remove topic from subscription
-      consumer.subscribe(List(topic2).asJava, listener0)
-      TestUtils.waitUntilTrue(() => {
-        consumer.poll(100)
-        listener0.callsToAssigned >= 2
-      }, "Expected rebalance did not occur.")
-      // Verify the metric has gone
-      assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1)))
-      assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags2)))
-    } finally {
-      consumer.close()
-    }
+    // Remove topic from subscription
+    consumer.subscribe(List(topic2).asJava, listener0)
+    TestUtils.waitUntilTrue(() => {
+      consumer.poll(100)
+      listener0.callsToAssigned >= 2
+    }, "Expected rebalance did not occur.")
+    // Verify the metric has gone
+    assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags1)))
+    assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags2)))
   }
 
   @Test
@@ -1479,34 +1505,32 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val numMessages = 1000
     // Test assign
     // send some messages.
-    sendRecords(numMessages, tp)
-    sendRecords(numMessages, tp2)
+    val producer = createProducer()
+    sendRecords(producer, numMessages, tp)
+    sendRecords(producer, numMessages, tp2)
+
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testPerPartitionLeadMetricsCleanUpWithAssign")
     consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testPerPartitionLeadMetricsCleanUpWithAssign")
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    try {
-      consumer.assign(List(tp).asJava)
-      var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
-      TestUtils.waitUntilTrue(() => {
-        records = consumer.poll(100)
-        !records.records(tp).isEmpty
-      }, "Consumer did not consume any message before timeout.")
-      // Verify the metric exist.
-      val tags = new util.HashMap[String, String]()
-      tags.put("client-id", "testPerPartitionLeadMetricsCleanUpWithAssign")
-      tags.put("topic", tp.topic())
-      tags.put("partition", String.valueOf(tp.partition()))
-      val fetchLead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
-      assertNotNull(fetchLead)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
+    TestUtils.waitUntilTrue(() => {
+      records = consumer.poll(100)
+      !records.records(tp).isEmpty
+    }, "Consumer did not consume any message before timeout.")
+    // Verify the metric exist.
+    val tags = new util.HashMap[String, String]()
+    tags.put("client-id", "testPerPartitionLeadMetricsCleanUpWithAssign")
+    tags.put("topic", tp.topic())
+    tags.put("partition", String.valueOf(tp.partition()))
+    val fetchLead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
+    assertNotNull(fetchLead)
 
-      assertTrue(s"The lead should be ${records.count}", records.count == fetchLead.metricValue())
+    assertTrue(s"The lead should be ${records.count}", records.count == fetchLead.metricValue())
 
-      consumer.assign(List(tp2).asJava)
-      TestUtils.waitUntilTrue(() => !consumer.poll(100).isEmpty, "Consumer did not consume any message before timeout.")
-      assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags)))
-    } finally {
-      consumer.close()
-    }
+    consumer.assign(List(tp2).asJava)
+    TestUtils.waitUntilTrue(() => !consumer.poll(100).isEmpty, "Consumer did not consume any message before timeout.")
+    assertNull(consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags)))
   }
 
   @Test
@@ -1514,103 +1538,99 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     val numMessages = 1000
     // Test assign
     // send some messages.
-    sendRecords(numMessages, tp)
-    sendRecords(numMessages, tp2)
+    val producer = createProducer()
+    sendRecords(producer, numMessages, tp)
+    sendRecords(producer, numMessages, tp2)
+
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testPerPartitionLagMetricsCleanUpWithAssign")
     consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testPerPartitionLagMetricsCleanUpWithAssign")
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    try {
-      consumer.assign(List(tp).asJava)
-      var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
-      TestUtils.waitUntilTrue(() => {
-        records = consumer.poll(100)
-        !records.records(tp).isEmpty
-      }, "Consumer did not consume any message before timeout.")
-      // Verify the metric exist.
-      val tags = new util.HashMap[String, String]()
-      tags.put("client-id", "testPerPartitionLagMetricsCleanUpWithAssign")
-      tags.put("topic", tp.topic())
-      tags.put("partition", String.valueOf(tp.partition()))
-      val fetchLag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
-      assertNotNull(fetchLag)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
+    TestUtils.waitUntilTrue(() => {
+      records = consumer.poll(100)
+      !records.records(tp).isEmpty
+    }, "Consumer did not consume any message before timeout.")
+    // Verify the metric exist.
+    val tags = new util.HashMap[String, String]()
+    tags.put("client-id", "testPerPartitionLagMetricsCleanUpWithAssign")
+    tags.put("topic", tp.topic())
+    tags.put("partition", String.valueOf(tp.partition()))
+    val fetchLag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
+    assertNotNull(fetchLag)
 
-      val expectedLag = numMessages - records.count
-      assertEquals(s"The lag should be $expectedLag", expectedLag, fetchLag.value, epsilon)
+    val expectedLag = numMessages - records.count
+    assertEquals(s"The lag should be $expectedLag", expectedLag, fetchLag.value, epsilon)
 
-      consumer.assign(List(tp2).asJava)
-      TestUtils.waitUntilTrue(() => !consumer.poll(100).isEmpty, "Consumer did not consume any message before timeout.")
-      assertNull(consumer.metrics.get(new MetricName(tp + ".records-lag", "consumer-fetch-manager-metrics", "", tags)))
-      assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags)))
-    } finally {
-      consumer.close()
-    }
+    consumer.assign(List(tp2).asJava)
+    TestUtils.waitUntilTrue(() => !consumer.poll(100).isEmpty, "Consumer did not consume any message before timeout.")
+    assertNull(consumer.metrics.get(new MetricName(tp + ".records-lag", "consumer-fetch-manager-metrics", "", tags)))
+    assertNull(consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags)))
   }
 
   @Test
   def testPerPartitionLeadWithMaxPollRecords() {
     val numMessages = 1000
     val maxPollRecords = 10
-    sendRecords(numMessages, tp)
+    val producer = createProducer()
+    sendRecords(producer, numMessages, tp)
+
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testPerPartitionLeadWithMaxPollRecords")
     consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testPerPartitionLeadWithMaxPollRecords")
     consumerConfig.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
+    val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    try {
-      var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
-      TestUtils.waitUntilTrue(() => {
-        records = consumer.poll(100)
-        !records.isEmpty
-      }, "Consumer did not consume any message before timeout.")
+    var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
+    TestUtils.waitUntilTrue(() => {
+      records = consumer.poll(100)
+      !records.isEmpty
+    }, "Consumer did not consume any message before timeout.")
 
-      val tags = new util.HashMap[String, String]()
-      tags.put("client-id", "testPerPartitionLeadWithMaxPollRecords")
-      tags.put("topic", tp.topic())
-      tags.put("partition", String.valueOf(tp.partition()))
-      val lead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
-      assertTrue(s"The lead should be $maxPollRecords", lead.metricValue() == maxPollRecords)
-    } finally {
-      consumer.close()
-    }
+    val tags = new util.HashMap[String, String]()
+    tags.put("client-id", "testPerPartitionLeadWithMaxPollRecords")
+    tags.put("topic", tp.topic())
+    tags.put("partition", String.valueOf(tp.partition()))
+    val lead = consumer.metrics.get(new MetricName("records-lead", "consumer-fetch-manager-metrics", "", tags))
+    assertTrue(s"The lead should be $maxPollRecords", lead.metricValue() == maxPollRecords)
   }
 
   @Test
   def testPerPartitionLagWithMaxPollRecords() {
     val numMessages = 1000
     val maxPollRecords = 10
-    sendRecords(numMessages, tp)
+    val producer = createProducer()
+    sendRecords(producer, numMessages, tp)
+
     consumerConfig.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "testPerPartitionLagWithMaxPollRecords")
     consumerConfig.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "testPerPartitionLagWithMaxPollRecords")
     consumerConfig.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
+    val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
-    try {
-      var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
-      TestUtils.waitUntilTrue(() => {
-        records = consumer.poll(100)
-        !records.isEmpty
-      }, "Consumer did not consume any message before timeout.")
+    var records: ConsumerRecords[Array[Byte], Array[Byte]] = ConsumerRecords.empty()
+    TestUtils.waitUntilTrue(() => {
+      records = consumer.poll(100)
+      !records.isEmpty
+    }, "Consumer did not consume any message before timeout.")
 
-      val tags = new util.HashMap[String, String]()
-      tags.put("client-id", "testPerPartitionLagWithMaxPollRecords")
-      tags.put("topic", tp.topic())
-      tags.put("partition", String.valueOf(tp.partition()))
-      val lag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
+    val tags = new util.HashMap[String, String]()
+    tags.put("client-id", "testPerPartitionLagWithMaxPollRecords")
+    tags.put("topic", tp.topic())
+    tags.put("partition", String.valueOf(tp.partition()))
+    val lag = consumer.metrics.get(new MetricName("records-lag", "consumer-fetch-manager-metrics", "", tags))
 
-      assertEquals(s"The lag should be ${numMessages - records.count}", numMessages - records.count, lag.value, epsilon)
-    } finally {
-      consumer.close()
-    }
+    assertEquals(s"The lag should be ${numMessages - records.count}", numMessages - records.count, lag.value, epsilon)
   }
 
   @Test
   def testQuotaMetricsNotCreatedIfNoQuotasConfigured() {
     val numRecords = 1000
-    sendRecords(numRecords)
+    val producer = createProducer()
+    sendRecords(producer, numRecords, tp)
 
-    this.consumers.head.assign(List(tp).asJava)
-    this.consumers.head.seek(tp, 0)
-    consumeAndVerifyRecords(consumer = this.consumers.head, numRecords = numRecords, startingOffset = 0)
+    val consumer = createConsumer()
+    consumer.assign(List(tp).asJava)
+    consumer.seek(tp, 0)
+    consumeAndVerifyRecords(consumer = consumer, numRecords = numRecords, startingOffset = 0)
 
     def assertNoMetric(broker: KafkaServer, name: String, quotaType: QuotaType, clientId: String) {
         val metricName = broker.metrics.metricName("throttle-time",
@@ -1640,21 +1660,19 @@ class PlaintextConsumerTest extends BaseConsumerTest {
   def runMultiConsumerSessionTimeoutTest(closeConsumer: Boolean): Unit = {
     // use consumers defined in this class plus one additional consumer
     // Use topic defined in this class + one additional topic
-    sendRecords(100, tp)
-    sendRecords(100, tp2)
+    val producer = createProducer()
+    sendRecords(producer, numRecords = 100, tp)
+    sendRecords(producer, numRecords = 100, tp2)
     val topic1 = "topic1"
-    val subscriptions = Set(tp, tp2) ++ createTopicAndSendRecords(topic1, 6, 100)
+    val subscriptions = Set(tp, tp2) ++ createTopicAndSendRecords(producer, topic1, 6, 100)
 
     // first subscribe consumers that are defined in this class
     val consumerPollers = Buffer[ConsumerAssignmentPoller]()
-    for (consumer <- consumers)
-      consumerPollers += subscribeConsumerAndStartPolling(consumer, List(topic, topic1))
+    consumerPollers += subscribeConsumerAndStartPolling(createConsumer(), List(topic, topic1))
+    consumerPollers += subscribeConsumerAndStartPolling(createConsumer(), List(topic, topic1))
 
     // create one more consumer and add it to the group; we will timeout this consumer
-    val timeoutConsumer = new KafkaConsumer[Array[Byte], Array[Byte]](this.consumerConfig)
-    // Close the consumer on test teardown, unless this test will manually
-    if(!closeConsumer)
-      consumers += timeoutConsumer
+    val timeoutConsumer = createConsumer()
     val timeoutPoller = subscribeConsumerAndStartPolling(timeoutConsumer, List(topic, topic1))
     consumerPollers += timeoutPoller
 
@@ -1679,12 +1697,15 @@ class PlaintextConsumerTest extends BaseConsumerTest {
    * Creates topic 'topicName' with 'numPartitions' partitions and produces 'recordsPerPartition'
    * records to each partition
    */
-  def createTopicAndSendRecords(topicName: String, numPartitions: Int, recordsPerPartition: Int): Set[TopicPartition] = {
+  def createTopicAndSendRecords(producer: KafkaProducer[Array[Byte], Array[Byte]],
+                                topicName: String,
+                                numPartitions: Int,
+                                recordsPerPartition: Int): Set[TopicPartition] = {
     createTopic(topicName, numPartitions, serverCount)
     var parts = Set[TopicPartition]()
     for (partition <- 0 until numPartitions) {
       val tp = new TopicPartition(topicName, partition)
-      sendRecords(recordsPerPartition, tp)
+      sendRecords(producer, recordsPerPartition, tp)
       parts = parts + tp
     }
     parts
@@ -1742,12 +1763,10 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     assertTrue(consumerCount <= subscriptions.size)
     val consumerGroup = Buffer[KafkaConsumer[Array[Byte], Array[Byte]]]()
     for (_ <- 0 until consumerCount)
-      consumerGroup += new KafkaConsumer[Array[Byte], Array[Byte]](this.consumerConfig)
-    consumers ++= consumerGroup
+      consumerGroup += createConsumer()
 
     // create consumer pollers, wait for assignment and validate it
     val consumerPollers = subscribeConsumers(consumerGroup, topicsToSubscribe)
-
     (consumerGroup, consumerPollers)
   }
 
@@ -1771,14 +1790,14 @@ class PlaintextConsumerTest extends BaseConsumerTest {
                                                    subscriptions: Set[TopicPartition]): Unit = {
     assertTrue(consumerGroup.size + numOfConsumersToAdd <= subscriptions.size)
     for (_ <- 0 until numOfConsumersToAdd) {
-      val consumer = new KafkaConsumer[Array[Byte], Array[Byte]](this.consumerConfig)
+      val consumer = createConsumer()
       consumerGroup += consumer
       consumerPollers += subscribeConsumerAndStartPolling(consumer, topicsToSubscribe)
     }
 
     // wait until topics get re-assigned and validate assignment
     validateGroupAssignment(consumerPollers, subscriptions,
-      s"Did not get valid assignment for partitions ${subscriptions.asJava} after we added ${numOfConsumersToAdd} consumer(s)")
+      s"Did not get valid assignment for partitions ${subscriptions.asJava} after we added $numOfConsumersToAdd consumer(s)")
   }
 
   /**

--- a/core/src/test/scala/integration/kafka/api/PlaintextEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextEndToEndAuthorizationTest.scala
@@ -78,7 +78,8 @@ class PlaintextEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   @Test
   def testListenerName() {
     // To check the client listener name, establish a session on the server by sending any request eg sendRecords
-    intercept[TopicAuthorizationException](sendRecords(1, tp))
+    val producer = createProducer()
+    intercept[TopicAuthorizationException](sendRecords(producer, numRecords = 1, tp))
 
     assertEquals(Some("CLIENT"), PlaintextEndToEndAuthorizationTest.clientListenerName)
     assertEquals(Some("SERVER"), PlaintextEndToEndAuthorizationTest.serverListenerName)

--- a/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextProducerSendTest.scala
@@ -43,17 +43,17 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
 
   @Test
   def testBatchSizeZero() {
-    val producerProps = new Properties()
-    producerProps.setProperty(ProducerConfig.BATCH_SIZE_CONFIG, "0")
-    val producer = createProducer(brokerList = brokerList, lingerMs = Int.MaxValue, props = Some(producerProps))
+    val producer = createProducer(brokerList = brokerList,
+      lingerMs = Int.MaxValue,
+      batchSize = 0)
     sendAndVerify(producer)
   }
 
   @Test
   def testSendCompressedMessageWithLogAppendTime() {
-    val producerProps = new Properties()
-    producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")
-    val producer = createProducer(brokerList = brokerList, lingerMs = Int.MaxValue, props = Some(producerProps))
+    val producer = createProducer(brokerList = brokerList,
+      compressionType = "gzip",
+      lingerMs = Int.MaxValue)
     sendAndVerifyTimestamp(producer, TimestampType.LOG_APPEND_TIME)
   }
 
@@ -101,9 +101,7 @@ class PlaintextProducerSendTest extends BaseProducerSendTest {
     }
 
     // Test compressed messages.
-    val producerProps = new Properties()
-    producerProps.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")
-    val compressedProducer = createProducer(brokerList = brokerList, props = Some(producerProps))
+    val compressedProducer = createProducer(brokerList = brokerList, compressionType = "gzip")
     try {
       compressedProducer.send(new ProducerRecord(topic, 0, System.currentTimeMillis() - 1001, "key".getBytes, "value".getBytes)).get()
       fail("Should throw CorruptedRecordException")

--- a/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
@@ -30,7 +30,6 @@ import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.zk.ZooKeeperTestHarness
 import kafka.utils.TestUtils
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.ByteArraySerializer
 
 @RunWith(value = classOf[Parameterized])

--- a/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
+++ b/core/src/test/scala/integration/kafka/api/ProducerCompressionTest.scala
@@ -70,7 +70,7 @@ class ProducerCompressionTest(compression: String) extends ZooKeeperTestHarness 
     producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, "66000")
     producerProps.put(ProducerConfig.LINGER_MS_CONFIG, "200")
     val producer = new KafkaProducer(producerProps, new ByteArraySerializer, new ByteArraySerializer)
-    val consumer = TestUtils.createConsumer(bootstrapServers, securityProtocol = SecurityProtocol.PLAINTEXT)
+    val consumer = TestUtils.createConsumer(bootstrapServers)
 
     try {
       // create topic

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.SaslAuthenticationException
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.junit.{After, Before, Test}
 import org.junit.Assert._
 import kafka.admin.ConsumerGroupCommand.{ConsumerGroupCommandOptions, ConsumerGroupService}

--- a/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslClientsWithInvalidCredentialsTest.scala
@@ -74,11 +74,12 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
 
   @Test
   def testProducerWithAuthenticationFailure() {
-    verifyAuthenticationException(sendOneRecord(10000))
-    verifyAuthenticationException(producers.head.partitionsFor(topic))
+    val producer = createProducer()
+    verifyAuthenticationException(sendOneRecord(producer, maxWaitMs = 10000))
+    verifyAuthenticationException(producer.partitionsFor(topic))
 
     createClientCredential()
-    verifyWithRetry(sendOneRecord())
+    verifyWithRetry(sendOneRecord(producer))
   }
 
   @Test
@@ -97,14 +98,14 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
 
   @Test
   def testConsumerWithAuthenticationFailure() {
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
     verifyConsumerWithAuthenticationFailure(consumer)
   }
 
   @Test
   def testManualAssignmentConsumerWithAuthenticationFailure() {
-    val consumer = this.consumers.head
+    val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
     verifyConsumerWithAuthenticationFailure(consumer)
   }
@@ -112,11 +113,9 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
   @Test
   def testManualAssignmentConsumerWithAutoCommitDisabledWithAuthenticationFailure() {
     this.consumerConfig.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false.toString)
-    val consumer = new KafkaConsumer(this.consumerConfig, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    consumers += consumer
+    val consumer = createConsumer()
     consumer.assign(List(tp).asJava)
     consumer.seek(tp, 0)
-
     verifyConsumerWithAuthenticationFailure(consumer)
   }
 
@@ -125,7 +124,8 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     verifyAuthenticationException(consumer.partitionsFor(topic))
 
     createClientCredential()
-    verifyWithRetry(sendOneRecord())
+    val producer = createProducer()
+    verifyWithRetry(sendOneRecord(producer))
     verifyWithRetry(assertEquals(1, consumer.poll(Duration.ofMillis(1000)).count))
   }
 
@@ -161,7 +161,7 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
   def testConsumerGroupServiceWithAuthenticationFailure() {
     val consumerGroupService: ConsumerGroupService = prepareConsumerGroupService
 
-    val consumer = consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
 
     verifyAuthenticationException(consumerGroupService.listGroups)
@@ -173,7 +173,7 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     createClientCredential()
     val consumerGroupService: ConsumerGroupService = prepareConsumerGroupService
 
-    val consumer = consumers.head
+    val consumer = createConsumer()
     consumer.subscribe(List(topic).asJava)
 
     verifyWithRetry(consumer.poll(Duration.ofMillis(1000)))
@@ -201,8 +201,7 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
     createScramCredentials(zkConnect, JaasTestUtils.KafkaScramUser2, JaasTestUtils.KafkaScramPassword2)
   }
 
-  private def sendOneRecord(maxWaitMs: Long = 15000): Unit = {
-    val producer = this.producers.head
+  private def sendOneRecord(producer: KafkaProducer[Array[Byte], Array[Byte]], maxWaitMs: Long = 15000): Unit = {
     val record = new ProducerRecord(tp.topic(), tp.partition(), 0L, "key".getBytes, "value".getBytes)
     val future = producer.send(record)
     producer.flush()
@@ -243,12 +242,6 @@ class SaslClientsWithInvalidCredentialsTest extends IntegrationTestHarness with 
   private def createTransactionalProducer(): KafkaProducer[Array[Byte], Array[Byte]] = {
     producerConfig.setProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "txclient-1")
     producerConfig.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
-    val txProducer = TestUtils.createProducer(brokerList,
-                                  securityProtocol = this.securityProtocol,
-                                  saslProperties = this.clientSaslProperties,
-                                  acks = -1,
-                                  props = Some(producerConfig))
-    producers += txProducer
-    txProducer
+    createProducer()
   }
 }

--- a/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslEndToEndAuthorizationTest.scala
@@ -16,10 +16,6 @@
   */
 package kafka.api
 
-import java.util.Properties
-
-import kafka.utils.TestUtils
-import kafka.utils.Implicits._
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.errors.{GroupAuthorizationException, TopicAuthorizationException}
@@ -57,21 +53,13 @@ abstract class SaslEndToEndAuthorizationTest extends EndToEndAuthorizationTest {
   @Test(timeout = 15000)
   def testTwoConsumersWithDifferentSaslCredentials(): Unit = {
     setAclsAndProduce(tp)
-    val consumer1 = consumers.head
+    val consumer1 = createConsumer()
 
-    val consumer2Config = new Properties
-    consumer2Config ++= consumerConfig
     // consumer2 retrieves its credentials from the static JAAS configuration, so we test also this path
-    consumer2Config.remove(SaslConfigs.SASL_JAAS_CONFIG)
-    consumer2Config.remove(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS)
+    consumerConfig.remove(SaslConfigs.SASL_JAAS_CONFIG)
+    consumerConfig.remove(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS)
 
-    val consumer2 = TestUtils.createConsumer(brokerList,
-                                                securityProtocol = securityProtocol,
-                                                trustStoreFile = trustStoreFile,
-                                                saslProperties = clientSaslProperties,
-                                                props = Some(consumer2Config))
-    consumers += consumer2
-
+    val consumer2 = createConsumer()
     consumer1.assign(List(tp).asJava)
     consumer2.assign(List(tp).asJava)
 

--- a/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
@@ -46,20 +46,12 @@ class SaslMultiMechanismConsumerTest extends BaseConsumerTest with SaslSetup {
   @Test
   def testMultipleBrokerMechanisms() {
 
-    val plainSaslProducer = producers.head
-    val plainSaslConsumer = consumers.head
+    val plainSaslProducer = createProducer()
+    val plainSaslConsumer = createConsumer()
 
     val gssapiSaslProperties = kafkaClientSaslProperties("GSSAPI", dynamicJaasConfig = true)
-    val gssapiSaslProducer = TestUtils.createProducer(brokerList,
-                                                         securityProtocol = this.securityProtocol,
-                                                         trustStoreFile = this.trustStoreFile,
-                                                         saslProperties = Some(gssapiSaslProperties))
-    producers += gssapiSaslProducer
-    val gssapiSaslConsumer = TestUtils.createConsumer(brokerList,
-                                                         securityProtocol = this.securityProtocol,
-                                                         trustStoreFile = this.trustStoreFile,
-                                                         saslProperties = Some(gssapiSaslProperties))
-    consumers += gssapiSaslConsumer
+    val gssapiSaslProducer = createProducer(configOverrides = gssapiSaslProperties)
+    val gssapiSaslConsumer = createConsumer(configOverrides = gssapiSaslProperties)
     val numRecords = 1000
     var startingOffset = 0
 

--- a/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/SaslMultiMechanismConsumerTest.scala
@@ -16,7 +16,7 @@ import java.io.File
 
 import kafka.server.KafkaConfig
 import org.junit.{After, Before, Test}
-import kafka.utils.{JaasTestUtils, TestUtils}
+import kafka.utils.JaasTestUtils
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
 import scala.collection.JavaConverters._

--- a/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
@@ -22,16 +22,13 @@ import java.util.Properties
 import kafka.integration.KafkaServerTestHarness
 import kafka.server.KafkaConfig
 import kafka.utils.{ShutdownableThread, TestUtils}
-import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.internals.ErrorLoggingCallback
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.Assert._
 import org.junit.Test
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-
 
 class TransactionsBounceTest extends KafkaServerTestHarness {
   private val producerBufferSize =  65536
@@ -150,18 +147,13 @@ class TransactionsBounceTest extends KafkaServerTestHarness {
     verifyingConsumer.close()
   }
 
-  private def createConsumerAndSubscribeToTopics(groupId: String, topics: List[String], readCommitted: Boolean = false) = {
-    val props = new Properties()
-    if (readCommitted)
-      props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
-    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "2000")
-    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-    props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000")
-    props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, "3000")
-    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-
-    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = groupId,
-      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(props))
+  private def createConsumerAndSubscribeToTopics(groupId: String,
+                                                 topics: List[String],
+                                                 readCommitted: Boolean = false) = {
+    val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
+      groupId = groupId,
+      readCommitted = readCommitted,
+      enableAutoCommit = false)
     consumer.subscribe(topics.asJava)
     consumer
   }

--- a/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsBounceTest.scala
@@ -161,7 +161,7 @@ class TransactionsBounceTest extends KafkaServerTestHarness {
     props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
 
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers), groupId = groupId,
-      securityProtocol = SecurityProtocol.PLAINTEXT, props = Some(props))
+      securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(props))
     consumer.subscribe(topics.asJava)
     consumer
   }

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -576,7 +576,7 @@ class TransactionsTest extends KafkaServerTestHarness {
     props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
     props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
-      groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT, props = Some(props))
+      groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(props))
     transactionalConsumers += consumer
     consumer
   }
@@ -586,7 +586,7 @@ class TransactionsTest extends KafkaServerTestHarness {
     props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_uncommitted")
     props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
-      groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT, props = Some(props))
+      groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(props))
     nonTransactionalConsumers += consumer
     consumer
   }

--- a/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/TransactionsTest.scala
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer, OffsetA
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.kafka.common.errors.ProducerFencedException
-import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.junit.{After, Before, Test}
 import org.junit.Assert._
 
@@ -570,28 +569,28 @@ class TransactionsTest extends KafkaServerTestHarness {
     serverProps
   }
 
-  private def createReadCommittedConsumer(group: String = "group", maxPollRecords: Int = 500,
+  private def createReadCommittedConsumer(group: String = "group",
+                                          maxPollRecords: Int = 500,
                                           props: Properties = new Properties) = {
-    props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
-    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-    props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
-      groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(props))
+      groupId = group,
+      enableAutoCommit = false,
+      readCommitted = true,
+      maxPollRecords = maxPollRecords)
     transactionalConsumers += consumer
     consumer
   }
 
   private def createReadUncommittedConsumer(group: String) = {
-    val props = new Properties()
-    props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_uncommitted")
-    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
     val consumer = TestUtils.createConsumer(TestUtils.getBrokerListStrFromServers(servers),
-      groupId = group, securityProtocol = SecurityProtocol.PLAINTEXT, overrides = Some(props))
+      groupId = group,
+      enableAutoCommit = false)
     nonTransactionalConsumers += consumer
     consumer
   }
 
-  private def createTransactionalProducer(transactionalId: String, transactionTimeoutMs: Long = 60000): KafkaProducer[Array[Byte], Array[Byte]] = {
+  private def createTransactionalProducer(transactionalId: String,
+                                          transactionTimeoutMs: Long = 60000): KafkaProducer[Array[Byte], Array[Byte]] = {
     val producer = TestUtils.createTransactionalProducer(transactionalId, servers,
       transactionTimeoutMs = transactionTimeoutMs)
     transactionalProducers += producer

--- a/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserClientIdQuotaTest.scala
@@ -42,7 +42,10 @@ class UserClientIdQuotaTest extends BaseQuotaTest {
   }
 
   override def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients = {
-    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producers.head, consumers.head) {
+    val producer = createProducer()
+    val consumer = createConsumer()
+
+    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
       override def userPrincipal: KafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, "O=A client,CN=localhost")
       override def quotaMetricTags(clientId: String): Map[String, String] = {
         Map("user" -> Sanitizer.sanitize(userPrincipal.getName), "client-id" -> clientId)

--- a/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
+++ b/core/src/test/scala/integration/kafka/api/UserQuotaTest.scala
@@ -50,7 +50,10 @@ class UserQuotaTest extends BaseQuotaTest with SaslSetup {
   }
 
   override def createQuotaTestClients(topic: String, leaderNode: KafkaServer): QuotaTestClients = {
-    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producers.head, consumers.head) {
+    val producer = createProducer()
+    val consumer = createConsumer()
+
+    new QuotaTestClients(topic, leaderNode, producerClientId, consumerClientId, producer, consumer) {
       override val userPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, JaasTestUtils.KafkaClientPrincipalUnqualifiedName2)
       override def quotaMetricTags(clientId: String): Map[String, String] = {
         Map("user" -> userPrincipal.getName, "client-id" -> "")

--- a/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/DynamicBrokerReconfigurationTest.scala
@@ -42,7 +42,7 @@ import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.clients.admin.ConfigEntry.{ConfigSource, ConfigSynonym}
 import org.apache.kafka.clients.admin._
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, ConsumerRecords, KafkaConsumer}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.{ClusterResource, ClusterResourceListener, Reconfigurable, TopicPartition, TopicPartitionInfo}
 import org.apache.kafka.common.config.{ConfigException, ConfigResource}
 import org.apache.kafka.common.config.SslConfigs._
@@ -1380,16 +1380,14 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
     def deliveryTimeoutMs(timeoutMs: Int): ProducerBuilder = { _deliveryTimeoutMs= timeoutMs; this }
 
     override def build(): KafkaProducer[String, String] = {
-      val producer = TestUtils.createProducer(bootstrapServers,
-        acks = _acks,
-        requestTimeoutMs = _requestTimeoutMs,
-        deliveryTimeoutMs = _deliveryTimeoutMs,
-        retries = _retries,
-        securityProtocol = _securityProtocol,
-        trustStoreFile = Some(trustStoreFile1),
-        keySerializer = new StringSerializer,
-        valueSerializer = new StringSerializer,
-        overrides = Some(propsOverride))
+      val producerProps = propsOverride
+      producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+      producerProps.put(ProducerConfig.ACKS_CONFIG, _acks.toString)
+      producerProps.put(ProducerConfig.RETRIES_CONFIG, _retries.toString)
+      producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, _deliveryTimeoutMs.toString)
+      producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, _requestTimeoutMs.toString)
+
+      val producer = new KafkaProducer[String, String](producerProps, new StringSerializer, new StringSerializer)
       producers += producer
       producer
     }
@@ -1406,15 +1404,12 @@ class DynamicBrokerReconfigurationTest extends ZooKeeperTestHarness with SaslSet
 
     override def build(): KafkaConsumer[String, String] = {
       val consumerProps = propsOverride
+      consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+      consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, _autoOffsetReset)
+      consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, group)
       consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, _enableAutoCommit.toString)
-      val consumer = TestUtils.createConsumer(bootstrapServers,
-        group,
-        autoOffsetReset = _autoOffsetReset,
-        securityProtocol = _securityProtocol,
-        trustStoreFile = Some(trustStoreFile1),
-        keyDeserializer = new StringDeserializer,
-        valueDeserializer = new StringDeserializer,
-        overrides = Some(consumerProps))
+
+      val consumer = new KafkaConsumer[String, String](consumerProps, new StringDeserializer, new StringDeserializer)
       consumer.subscribe(Collections.singleton(_topic))
       if (_autoOffsetReset == "latest")
         awaitInitialPositions(consumer)

--- a/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
+++ b/core/src/test/scala/integration/kafka/server/GssapiAuthenticationTest.scala
@@ -33,9 +33,6 @@ import org.junit.Assert._
 import org.junit.{After, Before, Test}
 
 class GssapiAuthenticationTest extends IntegrationTestHarness with SaslSetup {
-
-  override val producerCount = 0
-  override val consumerCount = 0
   override val serverCount = 1
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
 

--- a/core/src/test/scala/integration/kafka/server/ScramServerStartupTest.scala
+++ b/core/src/test/scala/integration/kafka/server/ScramServerStartupTest.scala
@@ -17,6 +17,7 @@
   */
 
 package kafka.server
+
 import java.util.Collections
 
 import kafka.api.{IntegrationTestHarness, KafkaSasl, SaslSetup}
@@ -35,8 +36,6 @@ import scala.collection.JavaConverters._
  */
 class ScramServerStartupTest extends IntegrationTestHarness with SaslSetup {
 
-  override val producerCount = 0
-  override val consumerCount = 0
   override val serverCount = 1
 
   private val kafkaClientSaslMechanism = "SCRAM-SHA-256"

--- a/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/coordinator/group/GroupMetadataManagerTest.scala
@@ -1516,8 +1516,6 @@ class GroupMetadataManagerTest {
   @Test
   def testOffsetExpirationOfSimpleConsumer() {
     val memberId = "memberId"
-    val clientId = "clientId"
-    val clientHost = "localhost"
     val topic = "foo"
     val topicPartition1 = new TopicPartition(topic, 0)
     val offset = 37
@@ -1531,7 +1529,6 @@ class GroupMetadataManagerTest {
     val startMs = time.milliseconds
     // old clients, expiry timestamp is explicitly set
     val tp1OffsetAndMetadata = OffsetAndMetadata(offset, "", startMs)
-    val tp2OffsetAndMetadata = OffsetAndMetadata(offset, "", startMs)
     // new clients, no per-partition expiry timestamp, offsets of group expire together
     val offsets = immutable.Map(
       topicPartition1 -> tp1OffsetAndMetadata)

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -30,7 +30,6 @@ import kafka.server.{KafkaConfig, KafkaServer}
 import kafka.utils.{CoreUtils, TestUtils}
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
-import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.network.ListenerName

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -269,11 +269,11 @@ class UncleanLeaderElectionTest extends ZooKeeperTestHarness {
 
   private def consumeAllMessages(topic: String, numMessages: Int): Seq[String] = {
     val brokerList = TestUtils.bootstrapServers(servers, ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT))
-    val props = new Properties
     // Don't rely on coordinator as it may be down when this method is called
-    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
-    val consumer = TestUtils.createConsumer(brokerList, "group" + random.nextLong,
-      securityProtocol = SecurityProtocol.PLAINTEXT, valueDeserializer = new StringDeserializer, overrides = Some(props))
+    val consumer = TestUtils.createConsumer(brokerList,
+      groupId = "group" + random.nextLong,
+      enableAutoCommit = false,
+      valueDeserializer = new StringDeserializer)
     try {
       val tp = new TopicPartition(topic, partitionId)
       consumer.assign(Seq(tp).asJava)

--- a/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
+++ b/core/src/test/scala/unit/kafka/integration/UncleanLeaderElectionTest.scala
@@ -273,7 +273,7 @@ class UncleanLeaderElectionTest extends ZooKeeperTestHarness {
     // Don't rely on coordinator as it may be down when this method is called
     props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false")
     val consumer = TestUtils.createConsumer(brokerList, "group" + random.nextLong,
-      securityProtocol = SecurityProtocol.PLAINTEXT, valueDeserializer = new StringDeserializer, props = Some(props))
+      securityProtocol = SecurityProtocol.PLAINTEXT, valueDeserializer = new StringDeserializer, overrides = Some(props))
     try {
       val tp = new TopicPartition(topic, partitionId)
       consumer.assign(Seq(tp).asJava)

--- a/core/src/test/scala/unit/kafka/server/AlterReplicaLogDirsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterReplicaLogDirsRequestTest.scala
@@ -32,9 +32,8 @@ import scala.collection.mutable
 import scala.util.Random
 
 class AlterReplicaLogDirsRequestTest extends BaseRequestTest {
-  logDirCount = 5
-
-  override def numBrokers: Int = 1
+  override val logDirCount = 5
+  override val numBrokers = 1
 
   val topic = "topic"
 

--- a/core/src/test/scala/unit/kafka/server/AlterReplicaLogDirsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterReplicaLogDirsRequestTest.scala
@@ -32,9 +32,9 @@ import scala.collection.mutable
 import scala.util.Random
 
 class AlterReplicaLogDirsRequestTest extends BaseRequestTest {
+  logDirCount = 5
 
   override def numBrokers: Int = 1
-  override def logDirCount: Int = 5
 
   val topic = "topic"
 

--- a/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/BaseRequestTest.scala
@@ -22,7 +22,7 @@ import java.net.Socket
 import java.nio.ByteBuffer
 import java.util.Properties
 
-import kafka.integration.KafkaServerTestHarness
+import kafka.api.IntegrationTestHarness
 import kafka.network.SocketServer
 import kafka.utils._
 import org.apache.kafka.common.network.ListenerName
@@ -31,18 +31,17 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.requests.{AbstractRequest, AbstractRequestResponse, RequestHeader, ResponseHeader}
 import org.apache.kafka.common.security.auth.SecurityProtocol
 
-abstract class BaseRequestTest extends KafkaServerTestHarness {
+abstract class BaseRequestTest extends IntegrationTestHarness {
+  override val serverCount: Int = numBrokers
   private var correlationId = 0
 
   // If required, set number of brokers
   protected def numBrokers: Int = 3
 
-  protected def logDirCount: Int = 1
-
   // If required, override properties by mutating the passed Properties object
   protected def propertyOverrides(properties: Properties) {}
 
-  def generateConfigs = {
+  override def generateConfigs = {
     val props = TestUtils.createBrokerConfigs(numBrokers, zkConnect,
       enableControlledShutdown = false, enableDeleteTopic = true,
       interBrokerSecurityProtocol = Some(securityProtocol),

--- a/core/src/test/scala/unit/kafka/server/DescribeLogDirsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeLogDirsRequestTest.scala
@@ -26,9 +26,8 @@ import org.junit.Test
 import java.io.File
 
 class DescribeLogDirsRequestTest extends BaseRequestTest {
-  logDirCount = 2
-
-  override def numBrokers: Int = 1
+  override val logDirCount = 2
+  override val numBrokers: Int = 1
 
   val topic = "topic"
   val partitionNum = 2

--- a/core/src/test/scala/unit/kafka/server/DescribeLogDirsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeLogDirsRequestTest.scala
@@ -26,9 +26,9 @@ import org.junit.Test
 import java.io.File
 
 class DescribeLogDirsRequestTest extends BaseRequestTest {
+  logDirCount = 2
 
   override def numBrokers: Int = 1
-  override def logDirCount: Int = 2
 
   val topic = "topic"
   val partitionNum = 2

--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -23,7 +23,7 @@ import java.util.Properties
 import kafka.api.KAFKA_0_11_0_IV2
 import kafka.log.LogConfig
 import kafka.utils.TestUtils
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.record.{MemoryRecords, Record, RecordBatch}

--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -205,7 +205,7 @@ class FetchRequestTest extends BaseRequestTest {
     propsOverride.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize.toString)
     val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
       lingerMs = Int.MaxValue, keySerializer = new StringSerializer,
-      valueSerializer = new ByteArraySerializer, props = Some(propsOverride))
+      valueSerializer = new ByteArraySerializer, overrides = Some(propsOverride))
     val bytes = new Array[Byte](msgValueLen)
     val futures = try {
       (0 to 1000).map { _ =>
@@ -262,7 +262,9 @@ class FetchRequestTest extends BaseRequestTest {
   def testDownConversionFromBatchedToUnbatchedRespectsOffset(): Unit = {
     // Increase linger so that we have control over the batches created
     producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-      retries = 5, keySerializer = new StringSerializer, valueSerializer = new StringSerializer,
+      retries = 5,
+      keySerializer = new StringSerializer,
+      valueSerializer = new StringSerializer,
       lingerMs = 30 * 1000,
       deliveryTimeoutMs = 60 * 1000)
 

--- a/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/FetchRequestTest.scala
@@ -201,11 +201,11 @@ class FetchRequestTest extends BaseRequestTest {
 
     val msgValueLen = 100 * 1000
     val batchSize = 4 * msgValueLen
-    val propsOverride = new Properties
-    propsOverride.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize.toString)
     val producer = TestUtils.createProducer(TestUtils.getBrokerListStrFromServers(servers),
-      lingerMs = Int.MaxValue, keySerializer = new StringSerializer,
-      valueSerializer = new ByteArraySerializer, overrides = Some(propsOverride))
+      lingerMs = Int.MaxValue,
+      batchSize = batchSize,
+      keySerializer = new StringSerializer,
+      valueSerializer = new ByteArraySerializer)
     val bytes = new Array[Byte](msgValueLen)
     val futures = try {
       (0 to 1000).map { _ =>

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -25,7 +25,7 @@ import kafka.api.IntegrationTestHarness
 import kafka.controller.{OfflineReplica, PartitionAndReplica}
 import kafka.utils.{CoreUtils, Exit, TestUtils}
 import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.utils.Utils
 import org.apache.kafka.common.errors.{KafkaStorageException, NotLeaderForPartitionException}
@@ -97,7 +97,8 @@ class LogDirFailureTest extends IntegrationTestHarness {
 
   @Test
   def testReplicaFetcherThreadAfterLogDirFailureOnFollower() {
-    val producer = createProducer(retries = 0)
+    this.producerConfig.setProperty(ProducerConfig.RETRIES_CONFIG, "0")
+    val producer = createProducer()
     val partition = new TopicPartition(topic, 0)
 
     val partitionInfo = producer.partitionsFor(topic).asScala.find(_.partition() == 0).get
@@ -126,7 +127,10 @@ class LogDirFailureTest extends IntegrationTestHarness {
   def testProduceAfterLogDirFailureOnLeader(failureType: LogDirFailureType) {
     val consumer = createConsumer()
     subscribeAndWaitForAssignment(topic, consumer)
-    val producer = createProducer(retries = 0)
+
+    this.producerConfig.setProperty(ProducerConfig.RETRIES_CONFIG, "0")
+    val producer = createProducer()
+
     val partition = new TopicPartition(topic, 0)
     val record = new ProducerRecord(topic, 0, s"key".getBytes, s"value".getBytes)
 

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -55,16 +55,6 @@ class LogDirFailureTest extends IntegrationTestHarness {
     createTopic(topic, partitionNum, serverCount)
   }
 
-  override def createProducer: KafkaProducer[Array[Byte], Array[Byte]] = {
-    TestUtils.createProducer(brokerList,
-      retries = 0,
-      securityProtocol = this.securityProtocol,
-      trustStoreFile = this.trustStoreFile,
-      saslProperties = this.clientSaslProperties,
-      props = Some(producerConfig))
-  }
-
-
   @Test
   def testIOExceptionDuringLogRoll() {
     testProduceAfterLogDirFailureOnLeader(Roll)
@@ -107,7 +97,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
 
   @Test
   def testReplicaFetcherThreadAfterLogDirFailureOnFollower() {
-    val producer = producers.head
+    val producer = createProducer(retries = 0)
     val partition = new TopicPartition(topic, 0)
 
     val partitionInfo = producer.partitionsFor(topic).asScala.find(_.partition() == 0).get
@@ -134,9 +124,9 @@ class LogDirFailureTest extends IntegrationTestHarness {
   }
 
   def testProduceAfterLogDirFailureOnLeader(failureType: LogDirFailureType) {
-    val consumer = consumers.head
+    val consumer = createConsumer()
     subscribeAndWaitForAssignment(topic, consumer)
-    val producer = producers.head
+    val producer = createProducer(retries = 0)
     val partition = new TopicPartition(topic, 0)
     val record = new ProducerRecord(topic, 0, s"key".getBytes, s"value".getBytes)
 

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -44,8 +44,8 @@ class LogDirFailureTest extends IntegrationTestHarness {
   val serverCount: Int = 2
   private val topic = "topic"
   private val partitionNum = 12
+  override val logDirCount = 3
 
-  this.logDirCount = 3
   this.serverConfig.setProperty(KafkaConfig.ReplicaHighWatermarkCheckpointIntervalMsProp, "60000")
   this.serverConfig.setProperty(KafkaConfig.NumReplicaFetchersProp, "1")
 

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.protocol.{ApiKeys, Errors}
 import org.apache.kafka.common.requests.{MetadataRequest, MetadataResponse}
 import org.junit.Assert._
-import org.junit.Test
+import org.junit.{Before, Test}
 import org.apache.kafka.test.TestUtils.isValidClusterId
 
 import scala.collection.JavaConverters._
@@ -36,6 +36,11 @@ class MetadataRequestTest extends BaseRequestTest {
   override def propertyOverrides(properties: Properties) {
     properties.setProperty(KafkaConfig.DefaultReplicationFactorProp, "2")
     properties.setProperty(KafkaConfig.RackProp, s"rack/${properties.getProperty(KafkaConfig.BrokerIdProp)}")
+  }
+
+  @Before
+  override def setUp(): Unit = {
+    doSetup(createOffsetsTopic = false)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
@@ -411,11 +411,11 @@ class EpochDrivenReplicationProtocolAcceptanceTest extends ZooKeeperTestHarness 
   }
 
   private def createBufferingProducer: KafkaProducer[Array[Byte], Array[Byte]] = {
-    TestUtils.createProducer(getBrokerListStrFromServers(brokers), acks = -1, lingerMs = 10000,
-      overrides = Option(CoreUtils.propsWith(
-        (ProducerConfig.BATCH_SIZE_CONFIG, String.valueOf(msg.length * 1000))
-        , (ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy")
-      )))
+    TestUtils.createProducer(getBrokerListStrFromServers(brokers),
+      acks = -1,
+      lingerMs = 10000,
+      batchSize = msg.length * 1000,
+      compressionType = "snappy")
   }
 
   private def getLogFile(broker: KafkaServer, partition: Int): File = {

--- a/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
@@ -412,7 +412,7 @@ class EpochDrivenReplicationProtocolAcceptanceTest extends ZooKeeperTestHarness 
 
   private def createBufferingProducer: KafkaProducer[Array[Byte], Array[Byte]] = {
     TestUtils.createProducer(getBrokerListStrFromServers(brokers), acks = -1, lingerMs = 10000,
-      props = Option(CoreUtils.propsWith(
+      overrides = Option(CoreUtils.propsWith(
         (ProducerConfig.BATCH_SIZE_CONFIG, String.valueOf(msg.length * 1000))
         , (ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy")
       )))

--- a/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/EpochDrivenReplicationProtocolAcceptanceTest.scala
@@ -29,7 +29,7 @@ import kafka.utils.{CoreUtils, Logging, TestUtils}
 import kafka.utils.TestUtils._
 import kafka.zk.ZooKeeperTestHarness
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.RecordBatch
 import org.apache.kafka.common.serialization.Deserializer


### PR DESCRIPTION
Pre-initialization of clients in IntegrationTestHarness is a cause of significant confusion and additionally has resulted in a bunch of inconsistent client creation patterns. This patch requires test cases to create needed clients explicitly and makes the creation logic more consistent.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
