### PR TITLE
MINOR: Follow up for KAFKA-6761 graph should add stores for consistency

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -168,7 +168,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
         return prefix + String.format(KTableImpl.STATE_STORE_NAME + "%010d", index.getAndIncrement());
     }
 
-    public synchronized void addStateStore(final StoreBuilder<KeyValueStore> builder) {
+    public synchronized void addStateStore(final StoreBuilder builder) {
         addGraphNode(root, new StateStoreNode(builder));
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -178,12 +178,13 @@ public class InternalStreamsBuilder implements InternalNameProvider {
                                             final ConsumedInternal consumed,
                                             final String processorName,
                                             final ProcessorSupplier stateUpdateSupplier) {
-        StreamsGraphNode globalStoreNode = new GlobalStoreNode(storeBuilder,
-                                                               sourceName,
-                                                               topic,
-                                                               consumed,
-                                                               processorName,
-                                                               stateUpdateSupplier);
+
+        final StreamsGraphNode globalStoreNode = new GlobalStoreNode(storeBuilder,
+                                                                     sourceName,
+                                                                     topic,
+                                                                     consumed,
+                                                                     processorName,
+                                                                     stateUpdateSupplier);
 
         addGraphNode(root, globalStoreNode);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import org.apache.kafka.streams.kstream.internals.ConsumedInternal;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class GlobalStoreNode extends StateStoreNode {
+
+
+    private final String sourceName;
+    private final String topic;
+    private final ConsumedInternal consumed;
+    private final String processorName;
+    private final ProcessorSupplier stateUpdateSupplier;
+
+
+    public GlobalStoreNode(final StoreBuilder<KeyValueStore> storeBuilder,
+                           final String sourceName,
+                           final String topic,
+                           final ConsumedInternal consumed,
+                           final String processorName,
+                           final ProcessorSupplier stateUpdateSupplier) {
+
+        super(storeBuilder);
+        this.sourceName = sourceName;
+        this.topic = topic;
+        this.consumed = consumed;
+        this.processorName = processorName;
+        this.stateUpdateSupplier = stateUpdateSupplier;
+    }
+
+
+    @Override
+    public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
+        storeBuilder.withLoggingDisabled();
+        topologyBuilder.addGlobalStore(storeBuilder,
+                                       sourceName,
+                                       consumed.timestampExtractor(),
+                                       consumed.keyDeserializer(),
+                                       consumed.valueDeserializer(),
+                                       topic,
+                                       processorName,
+                                       stateUpdateSupplier);
+
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -70,9 +70,7 @@ public class GlobalStoreNode extends StateStoreNode {
         return "GlobalStoreNode{" +
                "sourceName='" + sourceName + '\'' +
                ", topic='" + topic + '\'' +
-               ", consumed=" + consumed +
                ", processorName='" + processorName + '\'' +
-               ", stateUpdateSupplier=" + stateUpdateSupplier +
-               "} " + super.toString();
+               "} ";
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -63,4 +63,16 @@ public class GlobalStoreNode extends StateStoreNode {
                                        stateUpdateSupplier);
 
     }
+
+
+    @Override
+    public String toString() {
+        return "GlobalStoreNode{" +
+               "sourceName='" + sourceName + '\'' +
+               ", topic='" + topic + '\'' +
+               ", consumed=" + consumed +
+               ", processorName='" + processorName + '\'' +
+               ", stateUpdateSupplier=" + stateUpdateSupplier +
+               "} " + super.toString();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/GlobalStoreNode.java
@@ -50,6 +50,7 @@ public class GlobalStoreNode extends StateStoreNode {
 
 
     @Override
+    @SuppressWarnings("unchecked")
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
         storeBuilder.withLoggingDisabled();
         topologyBuilder.addGlobalStore(storeBuilder,

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -23,23 +23,16 @@ import org.apache.kafka.streams.state.StoreBuilder;
 public class StateStoreNode extends StreamsGraphNode {
 
     protected final StoreBuilder storeBuilder;
-    private final String[] processorNames;
 
-    public StateStoreNode(final StoreBuilder storeBuilder,
-                          final String... processorNames) {
+    public StateStoreNode(final StoreBuilder storeBuilder) {
         super(storeBuilder.toString(), false);
 
         this.storeBuilder = storeBuilder;
-        this.processorNames = processorNames;
     }
 
     @Override
     public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
 
-        if (processorNames != null && processorNames.length > 0) {
-            topologyBuilder.addStateStore(storeBuilder, processorNames);
-        } else {
-            topologyBuilder.addStateStore(storeBuilder);
-        }
+        topologyBuilder.addStateStore(storeBuilder);
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.streams.kstream.internals.graph;
+
+import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class StateStoreNode extends StreamsGraphNode {
+
+    protected final StoreBuilder<KeyValueStore> storeBuilder;
+    private final String[] processorNames;
+
+    public StateStoreNode(final StoreBuilder<KeyValueStore> storeBuilder,
+                          final String... processorNames) {
+        super(storeBuilder.toString(), false);
+
+        this.storeBuilder = storeBuilder;
+        this.processorNames = processorNames;
+    }
+
+    @Override
+    public void writeToTopology(final InternalTopologyBuilder topologyBuilder) {
+
+        if (processorNames != null && processorNames.length > 0) {
+            topologyBuilder.addStateStore(storeBuilder, processorNames);
+        } else {
+            topologyBuilder.addStateStore(storeBuilder);
+        }
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -35,4 +35,13 @@ public class StateStoreNode extends StreamsGraphNode {
 
         topologyBuilder.addStateStore(storeBuilder);
     }
+
+    @Override
+    public String toString() {
+        return "StateStoreNode{" +
+               " name='" + storeBuilder.name() +  '\'' +
+               ", logConfig=" + storeBuilder.logConfig() +
+               ", loggingEnabled='" + storeBuilder.loggingEnabled() + '\'' +
+               "} " + super.toString();
+    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -18,15 +18,14 @@
 package org.apache.kafka.streams.kstream.internals.graph;
 
 import org.apache.kafka.streams.processor.internals.InternalTopologyBuilder;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 
 public class StateStoreNode extends StreamsGraphNode {
 
-    protected final StoreBuilder<KeyValueStore> storeBuilder;
+    protected final StoreBuilder storeBuilder;
     private final String[] processorNames;
 
-    public StateStoreNode(final StoreBuilder<KeyValueStore> storeBuilder,
+    public StateStoreNode(final StoreBuilder storeBuilder,
                           final String... processorNames) {
         super(storeBuilder.toString(), false);
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -42,6 +42,6 @@ public class StateStoreNode extends StreamsGraphNode {
                " name='" + storeBuilder.name() +  '\'' +
                ", logConfig=" + storeBuilder.logConfig() +
                ", loggingEnabled='" + storeBuilder.loggingEnabled() + '\'' +
-               "} " + super.toString();
+               "} ";
     }
 }


### PR DESCRIPTION
While working on 4th PR, I noticed that I had missed adding stores via the graph vs. directly via the `InternalStreamsBuilder`.  Probably ok to do so, but we should be consistent.

For testing, I ran the existing tests in streams.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
