### PR TITLE
KAFKA-7197 expand gradle build: include Scala 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The release file can be found inside `./core/build/distributions/`.
 ### Cleaning the build ###
     ./gradlew clean
 
-### Running a task with a particular version of Scala (either 2.11.x or 2.12.x) ###
+### Running a task with one of the Scala versions available (2.11.x, 2.12.x or 2.13.x) ###
 *Note that if building the jars with a version other than 2.12.x, you need to set the `SCALA_VERSION` variable or change it in `bin/kafka-run-class.sh` to run the quick start.*
 
 You can pass either the major version (eg 2.12) or the full version (eg 2.12.7):
@@ -86,7 +86,7 @@ You can pass either the major version (eg 2.12) or the full version (eg 2.12.7):
     ./gradlew -PscalaVersion=2.12 test
     ./gradlew -PscalaVersion=2.12 releaseTarGz
 
-### Running a task with all scala versions ###
+### Running a task with all the scala versions enabled by default ###
 
 Append `All` to the task name:
 

--- a/build.gradle
+++ b/build.gradle
@@ -401,7 +401,6 @@ subprojects {
       "-language:postfixOps",
       "-language:implicitConversions",
       "-language:existentials",
-      "-Xlint:by-name-right-associative",
       "-Xlint:delayedinit-select",
       "-Xlint:doc-detached",
       "-Xlint:missing-interpolator",
@@ -412,14 +411,22 @@ subprojects {
       "-Xlint:poly-implicit-overload",
       "-Xlint:private-shadow",
       "-Xlint:stars-align",
-      "-Xlint:type-parameter-shadow",
-      "-Xlint:unsound-match"
+      "-Xlint:type-parameter-shadow"
     ]
 
     if (versions.baseScala != '2.11') {
       scalaCompileOptions.additionalParameters += [
         "-Xlint:constant",
         "-Xlint:unused"
+      ]
+    }
+    
+  // these options are valid for Scala versions < 2.13 only
+  // Scala 2.13 removes them, see https://github.com/scala/scala/pull/6502 and https://github.com/scala/scala/pull/5969
+    if (versions.baseScala in ['2.11','2.12']) {
+      scalaCompileOptions.additionalParameters += [
+        "-Xlint:by-name-right-associative",
+        "-Xlint:unsound-match"
       ]
     }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,29 +22,41 @@ ext {
   libs = [:]
   
   // Enabled by default when commands like `testAll` are invoked
-  defaultScalaVersions = [ '2.11', '2.12' ]
+  defaultScalaVersions = [ '2.11', '2.12', '2.13' ]
   // Available if -PscalaVersion is used. This is useful when we want to support a Scala version that has
   // a higher minimum Java requirement than Kafka. This was previously the case for Scala 2.12 and Java 7.
-  availableScalaVersions = [ '2.11', '2.12' ]
+  availableScalaVersions = [ '2.11', '2.12', '2.13' ]
 }
 
 // Add Scala version
 def defaultScala211Version = '2.11.12'
 def defaultScala212Version = '2.12.8'
+def defaultScala213Version = '2.13.0'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
     versions["scala"] = defaultScala211Version
   } else if (scalaVersion == '2.12') {
     versions["scala"] = defaultScala212Version
-  } else {
+  } else if (scalaVersion == '2.13') {
+    versions["scala"] = defaultScala213Version
+  }  else {
     versions["scala"] = scalaVersion
   }
 } else {
-  versions["scala"] = defaultScala211Version
+  versions["scala"] = defaultScala212Version
 }
 
-// Add base Scala version
-versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
+/* Resolve base Scala version according to these patterns:
+ 1. generally available Scala versions (such as: 2.11.x, 2.12.y and 2.13.z) corresponding base versions will be: 2.11, 2.12 and 2.13 (respectively)
+ 2. pre-release Scala versions (i.e. milestone/rc, such as: 2.13.0-M5, 2.13.0-RC1, 2.14.0-M1, etc.) will have identical base versions;
+    rationale: pre-release Scala versions are not binary compatible with each other and that's the reason why libraries include the full
+    Scala release string in their name for pre-releases (see dependencies below with an artifact name suffix '_$versions.baseScala')
+*/
+if ( !versions.scala.contains('-') ) {
+  versions["baseScala"] = versions.scala.substring(0, versions.scala.lastIndexOf("."))
+} else {
+  versions["baseScala"] = versions.scala
+}
 
 versions += [
   activation: "1.1.1",
@@ -65,7 +77,7 @@ versions += [
   jmh: "1.21",
   hamcrest: "2.1",
   log4j: "1.2.17",
-  scalaLogging: "3.9.0",
+  scalaLogging: "3.9.2",
   jaxb: "2.3.0",
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",
@@ -89,9 +101,9 @@ versions += [
   reflections: "0.9.11",
   rocksDB: "5.18.3",
   scalafmt: "1.5.1",
-  scalatest: "3.0.7",
+  scalatest: "3.0.8",
   scalaJava8Compat : "0.9.0",
-  scoverage: "1.3.1",
+  scoverage: "1.4.0",
   scoveragePlugin: "2.5.0",
   shadowPlugin: "4.0.4",
   slf4j: "1.7.26",


### PR DESCRIPTION
**_Final PR description (June 2019):_**
- include Scala 2.13 into gradle build
- handle future milestone and RC versions of Scala in a better way
- if no Scala version is specified, default to scala 2.12 (bump from 2.11)
- include certain Xlint options (removed by Scala 2.13) for Scala 2.11/2.12 build only
- upgrade versions for dependencies: 
  - scalaLogging: 3.9.0 -->> 3.9.2
  - scalatest:        3.0.7 -->> 3.0.8
  - scoverage:       1.3.1 -->> 1.4.0

 - - - -

**_Initial PR description (August 2018):_**

details:
  * build expanded in order to use Scala 2.13 milestone version (version 2.13.0-M3 is used)
  * 'scoverage' version upgraded: 1.3.1 -->> 1.4.0-M3

Note: _**./gradlew -PscalaVersion=2.13 jar -q**_ returns few errors (well, as expected):

```
8 errors found

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':core:compileScala'.
> Compilation failed
```

Upgrade to Scala 2.13.0-M4 depends on: 
- https://github.com/scoverage/scalac-scoverage-plugin/pull/229  **_Add Scala 2.13.0-M4 support_**


