### PR TITLE
MINOR: System test for error handling and writes to DeadLetterQueue

### DIFF
--- a/tests/kafkatest/services/connect.py
+++ b/tests/kafkatest/services/connect.py
@@ -326,6 +326,11 @@ class ConnectDistributedService(ConnectServiceBase):
             raise RuntimeError("No process ids recorded")
 
 
+class ErrorTolerance(object):
+    ALL = "all"
+    NONE = "none"
+
+
 class ConnectRestError(RuntimeError):
     def __init__(self, status, msg, url):
         self.status = status

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -141,17 +141,17 @@ class ConnectStandaloneFileTest(Test):
         self.enable_deadletterqueue = True
 
         successful_records = []
-        bad_records = []
         faulty_records = []
-        for i in range(0, 10):
+        all_records = []
+        for i in range(0, 1000):
             if i % 2 == 0:
-                bad_records.append('{"some_key":' + str(i) + '}')
+                all_records.append('{"some_key":' + str(i) + '}')
                 successful_records.append('{some_key=' + str(i) + '}')
             else:
                 # badly formatted json records (missing a quote after the key)
-                bad_records.append('{"some_key:' + str(i) + '}')
+                all_records.append('{"some_key:' + str(i) + '}')
                 faulty_records.append('{"some_key:' + str(i) + '}')
-        bad_records = "\n".join(bad_records) + "\n"
+        all_records = "\n".join(all_records) + "\n"
         successful_records = "\n".join(successful_records) + "\n"
         if error_tolerance == "all":
             faulty_records = ",".join(faulty_records)
@@ -178,7 +178,7 @@ class ConnectStandaloneFileTest(Test):
         self.sink.start()
 
         # Generating data on the source node should generate new records and create new output on the sink node
-        self.source.node.account.ssh("echo -e -n " + repr(bad_records) + " >> " + self.INPUT_FILE)
+        self.source.node.account.ssh("echo -e -n " + repr(all_records) + " >> " + self.INPUT_FILE)
 
         if error_tolerance == "none":
             try:

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -18,6 +18,7 @@ from ducktape.mark.resource import cluster
 from ducktape.utils.util import wait_until
 from ducktape.mark import parametrize, matrix
 from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.errors import TimeoutError
 
 from kafkatest.services.zookeeper import ZookeeperService
 from kafkatest.services.kafka import KafkaService
@@ -127,3 +128,72 @@ class ConnectStandaloneFileTest(Test):
             return output_hash == hashlib.md5(value).hexdigest()
         except RemoteCommandError:
             return False
+
+    @parametrize(error_tolerance="all")
+    @parametrize(error_tolerance="none")
+    def test_skip_and_log_to_dlq(self, error_tolerance="none"):
+        self.kafka = KafkaService(self.test_context, self.num_brokers, self.zk,
+                                  security_protocol='PLAINTEXT', interbroker_security_protocol='PLAINTEXT',
+                                  topics=self.topics)
+
+        self.override_error_tolerance_props = error_tolerance
+        self.enable_deadletterqueue = True
+
+        successful_records = []
+        bad_records = []
+        faulty_records = []
+        for i in range(0, 10):
+            if i % 2 == 0:
+                bad_records.append('{"some_key":' + str(i) + '}')
+                successful_records.append('{some_key=' + str(i) + '}')
+            else:
+                # badly formatted json records (missing a quote after the key)
+                bad_records.append('{"some_key:' + str(i) + '}')
+                faulty_records.append('{"some_key:' + str(i) + '}')
+        bad_records = "\n".join(bad_records) + "\n"
+        successful_records = "\n".join(successful_records) + "\n"
+        if error_tolerance == "all":
+            faulty_records = ",".join(faulty_records)
+        else:
+            faulty_records = faulty_records[0]
+
+        self.source = ConnectStandaloneService(self.test_context, self.kafka, [self.INPUT_FILE, self.OFFSETS_FILE])
+        self.sink = ConnectStandaloneService(self.test_context, self.kafka, [self.OUTPUT_FILE, self.OFFSETS_FILE])
+
+        self.zk.start()
+        self.kafka.start()
+
+        self.override_key_converter = "org.apache.kafka.connect.storage.StringConverter"
+        self.override_value_converter = "org.apache.kafka.connect.storage.StringConverter"
+        self.source.set_configs(lambda node: self.render("connect-standalone.properties", node=node), [self.render("connect-file-source.properties")])
+
+        self.override_key_converter = "org.apache.kafka.connect.json.JsonConverter"
+        self.override_value_converter = "org.apache.kafka.connect.json.JsonConverter"
+        self.override_key_converter_schemas_enable = False
+        self.override_value_converter_schemas_enable = False
+        self.sink.set_configs(lambda node: self.render("connect-standalone.properties", node=node), [self.render("connect-file-sink.properties")])
+
+        self.source.start()
+        self.sink.start()
+
+        # Generating data on the source node should generate new records and create new output on the sink node
+        self.source.node.account.ssh("echo -e -n " + repr(bad_records) + " >> " + self.INPUT_FILE)
+
+        if error_tolerance == "none":
+            try:
+                wait_until(lambda: self.validate_output(successful_records), timeout_sec=15,
+                           err_msg="Clean records added to input file were not seen in the output file in a reasonable amount of time.")
+                raise Exception("Expected to not find any results in this file.")
+            except TimeoutError:
+                self.logger.info("Caught expected exception")
+        else:
+            wait_until(lambda: self.validate_output(successful_records), timeout_sec=15,
+                       err_msg="Clean records added to input file were not seen in the output file in a reasonable amount of time.")
+
+        self.logger.info("Reading records from deadletterqueue")
+        if self.enable_deadletterqueue:
+            self.consumer_validator = ConsoleConsumer(self.test_context, 1, self.kafka, "my-connector-errors",
+                                                      consumer_timeout_ms=10000)
+            self.consumer_validator.run()
+            actual = ",".join(self.consumer_validator.messages_consumed[1])
+            assert faulty_records == actual, "Expected %s but saw %s in dead letter queue" % (faulty_records, actual)

--- a/tests/kafkatest/tests/connect/connect_test.py
+++ b/tests/kafkatest/tests/connect/connect_test.py
@@ -129,6 +129,7 @@ class ConnectStandaloneFileTest(Test):
         except RemoteCommandError:
             return False
 
+    @cluster(num_nodes=5)
     @parametrize(error_tolerance="all")
     @parametrize(error_tolerance="none")
     def test_skip_and_log_to_dlq(self, error_tolerance="none"):

--- a/tests/kafkatest/tests/connect/templates/connect-file-sink.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-file-sink.properties
@@ -36,8 +36,8 @@ errors.log.include.messages=true
 
 {% if enable_deadletterqueue is defined %}
 # produce error context into the Kafka topic
-errors.deadletterqueue.topic.name=my-connector-errors
-errors.deadletterqueue.topic.replication.factor=1
+errors.deadletterqueue.topic.name={{ override_deadletterqueue_topic_name|default("my-connector-errors") }}
+errors.deadletterqueue.topic.replication.factor={{ override_deadletterqueue_replication_factor|default(1) }}
 {% endif %}
 
 # Tolerate all errors.

--- a/tests/kafkatest/tests/connect/templates/connect-file-sink.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-file-sink.properties
@@ -26,3 +26,19 @@ key.converter={{ override_key_converter }}
 {% if override_key_converter is defined %}
 value.converter={{ override_value_converter }}
 {% endif %}
+
+key.converter.schemas.enable={{ override_key_converter_schemas_enable|default(True) }}
+value.converter.schemas.enable={{ override_value_converter_schemas_enable|default(True) }}
+
+# log error context along with application logs
+errors.log.enable=true
+errors.log.include.messages=true
+
+{% if enable_deadletterqueue is defined %}
+# produce error context into the Kafka topic
+errors.deadletterqueue.topic.name=my-connector-errors
+errors.deadletterqueue.topic.replication.factor=1
+{% endif %}
+
+# Tolerate all errors.
+errors.tolerance={{ override_error_tolerance_props|default("none") }}

--- a/tests/kafkatest/tests/connect/templates/connect-file-source.properties
+++ b/tests/kafkatest/tests/connect/templates/connect-file-source.properties
@@ -26,3 +26,10 @@ key.converter={{ override_key_converter }}
 {% if override_key_converter is defined %}
 value.converter={{ override_value_converter }}
 {% endif %}
+
+# log error context along with application logs
+errors.log.enable=true
+errors.log.include.messages=true
+
+# Tolerate all errors.
+errors.tolerance={{ override_error_tolerance_props|default("none") }}


### PR DESCRIPTION
Added a system test which creates a file sink with json converter and attempts to feed it bad records. The bad records should land in the DLQ if it is enabled, and the task should be killed or bad records skipped based on test parameters.

Signed-off-by: Arjun Satish <arjun@confluent.io>

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
