### PR TITLE
MINOR: increase AdminClient retries for integration tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/KafkaEmbedded.java
@@ -189,6 +189,7 @@ public class KafkaEmbedded {
     public AdminClient createAdminClient() {
         final Properties adminClientConfig = new Properties();
         adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList());
+        adminClientConfig.put(AdminClientConfig.RETRIES_CONFIG, Integer.MAX_VALUE);
         final Object listeners = effectiveConfig.get(KafkaConfig$.MODULE$.ListenersProp());
         if (listeners != null && listeners.toString().contains("SSL")) {
             adminClientConfig.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, effectiveConfig.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));


### PR DESCRIPTION
Kafka Streams join integration tests are flaky recently and timeout during topic deletion. Maybe the delete request timeout in Jenkins. Hope increasing retries if admin client will fix the issues.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
