### PR TITLE
KAFKA-2423: Expand scalafmt coverage to core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,14 @@ buildscript {
 apply plugin: "com.diffplug.gradle.spotless"
 spotless {
   scala {
-    target 'streams/**/*.scala'
+    def slist = []
+    def spotlessRegex = project.hasProperty('spotlessRegex') ? project.getProperty('spotlessRegex') : null
+    if ( spotlessRegex != null ) {
+      def spAddList = spotlessRegex.split()
+      slist.addAll(spAddList)
+    }
+    slist.addAll('streams/**/*.scala')
+    target slist
     scalafmt('1.5.1').configFile('checkstyle/.scalafmt.conf')
   }
 }


### PR DESCRIPTION
Add "spotlessRegex" as a property.  Any files that match the property get added to the existing list of files to check.

Ran the `gradle spotlessCheck` and `gradle spotlessApply` with these options.  Verified file list manually.
* `-PspotlessRegex='core/**/*.scala'`
* `-PspotlessRegex='core/**/Replica*.scala core/**/Timer*.scala'`
* `-PspotlessRegex='core/src/main/scala/kafka/controller/TopicDeletionManager.scala'`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
