### PR TITLE
KAFKA-7240: -total metrics in Streams are incorrect

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -41,6 +41,7 @@ import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TimestampExtractor;
+import org.apache.kafka.streams.processor.internals.metrics.CumulativeCount;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 
@@ -109,7 +110,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             );
             parent.add(
                 new MetricName("commit-total", group, "The total number of occurrence of commit operations.", allTagMap),
-                new Count()
+                new CumulativeCount()
             );
 
             // add the operation metrics with additional tags
@@ -129,7 +130,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             );
             taskCommitTimeSensor.add(
                 new MetricName("commit-total", group, "The total number of occurrence of commit operations.", tagMap),
-                new Count()
+                new CumulativeCount()
             );
 
             // add the metrics for enforced processing
@@ -140,7 +141,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             );
             taskEnforcedProcessSensor.add(
                     new MetricName("enforced-process-total", group, "The total number of occurrence of enforced-process operations.", tagMap),
-                    new Count()
+                    new CumulativeCount()
             );
 
         }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -44,6 +44,7 @@ import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TaskMetadata;
 import org.apache.kafka.streams.processor.ThreadMetadata;
+import org.apache.kafka.streams.processor.internals.metrics.CumulativeCount;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.apache.kafka.streams.state.internals.ThreadCache;
 import org.slf4j.Logger;
@@ -532,7 +533,7 @@ public class StreamThread extends Thread {
             addAvgMaxLatency(pollTimeSensor, group, tagMap(), "poll");
             // can't use addInvocationRateAndCount due to non-standard description string
             pollTimeSensor.add(metrics.metricName("poll-rate", group, "The average per-second number of record-poll calls", tagMap()), new Rate(TimeUnit.SECONDS, new Count()));
-            pollTimeSensor.add(metrics.metricName("poll-total", group, "The total number of record-poll calls", tagMap()), new Count());
+            pollTimeSensor.add(metrics.metricName("poll-total", group, "The total number of record-poll calls", tagMap()), new CumulativeCount());
 
             processTimeSensor = threadLevelSensor("process-latency", Sensor.RecordingLevel.INFO);
             addAvgMaxLatency(processTimeSensor, group, tagMap(), "process");

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -438,7 +438,7 @@ public class StreamThread extends Thread {
                 cache,
                 time,
                 () -> createProducer(taskId),
-                streamsMetrics.tasksClosedSensor);
+                streamsMetrics.taskClosedSensor);
         }
 
         private Producer<byte[], byte[]> createProducer(final TaskId id) {
@@ -455,6 +455,7 @@ public class StreamThread extends Thread {
 
         @Override
         public void close() {
+            streamsMetrics.taskClosedSensor.record();
             if (threadProducer != null) {
                 try {
                     threadProducer.close();
@@ -510,6 +511,11 @@ public class StreamThread extends Thread {
                 return null;
             }
         }
+
+        @Override
+        public void close() {
+           streamsMetrics.taskClosedSensor.record();
+        }
     }
 
     static class StreamsMetricsThreadImpl extends StreamsMetricsImpl {
@@ -519,7 +525,7 @@ public class StreamThread extends Thread {
         private final Sensor processTimeSensor;
         private final Sensor punctuateTimeSensor;
         private final Sensor taskCreatedSensor;
-        private final Sensor tasksClosedSensor;
+        private final Sensor taskClosedSensor;
 
         StreamsMetricsThreadImpl(final Metrics metrics, final String threadName) {
             super(metrics, threadName);
@@ -547,9 +553,9 @@ public class StreamThread extends Thread {
             taskCreatedSensor.add(metrics.metricName("task-created-rate", "stream-metrics", "The average per-second number of newly created tasks", tagMap()), new Rate(TimeUnit.SECONDS, new Count()));
             taskCreatedSensor.add(metrics.metricName("task-created-total", "stream-metrics", "The total number of newly created tasks", tagMap()), new Total());
 
-            tasksClosedSensor = threadLevelSensor("task-closed", Sensor.RecordingLevel.INFO);
-            tasksClosedSensor.add(metrics.metricName("task-closed-rate", group, "The average per-second number of closed tasks", tagMap()), new Rate(TimeUnit.SECONDS, new Count()));
-            tasksClosedSensor.add(metrics.metricName("task-closed-total", group, "The total number of closed tasks", tagMap()), new Total());
+            taskClosedSensor = threadLevelSensor("task-closed", Sensor.RecordingLevel.INFO);
+            taskClosedSensor.add(metrics.metricName("task-closed-rate", group, "The average per-second number of closed tasks", tagMap()), new Rate(TimeUnit.SECONDS, new Count()));
+            taskClosedSensor.add(metrics.metricName("task-closed-total", group, "The total number of closed tasks", tagMap()), new Total());
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -455,7 +455,6 @@ public class StreamThread extends Thread {
 
         @Override
         public void close() {
-            streamsMetrics.taskClosedSensor.record();
             if (threadProducer != null) {
                 try {
                     threadProducer.close();
@@ -510,11 +509,6 @@ public class StreamThread extends Thread {
                 );
                 return null;
             }
-        }
-
-        @Override
-        public void close() {
-            streamsMetrics.taskClosedSensor.record();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -514,7 +514,7 @@ public class StreamThread extends Thread {
 
         @Override
         public void close() {
-           streamsMetrics.taskClosedSensor.record();
+            streamsMetrics.taskClosedSensor.record();
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/CumulativeCount.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/CumulativeCount.java
@@ -27,12 +27,12 @@ public class CumulativeCount implements MeasurableStat {
     private double count = 0.0;
 
     @Override
-    public void record(MetricConfig config, double value, long timeMs) {
+    public void record(final MetricConfig config, final double value, final long timeMs) {
         count += 1;
     }
 
     @Override
-    public double measure(MetricConfig config, long now) {
+    public double measure(final MetricConfig config, final long now) {
         return count;
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/CumulativeCount.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/CumulativeCount.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals.metrics;
+
+import org.apache.kafka.common.metrics.MeasurableStat;
+import org.apache.kafka.common.metrics.MetricConfig;
+
+/**
+ * A non-SampledStat version of Count for measuring -total metrics in streams
+ */
+public class CumulativeCount implements MeasurableStat {
+
+    private double count = 0.0;
+
+    @Override
+    public void record(MetricConfig config, double value, long timeMs) {
+        count += 1;
+    }
+
+    @Override
+    public double measure(MetricConfig config, long now) {
+        return count;
+    }
+}

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/metrics/StreamsMetricsImpl.java
@@ -398,7 +398,7 @@ public class StreamsMetricsImpl implements StreamsMetrics {
                 "The total number of occurrence of " + operation + " operations.",
                 tags
             ),
-            new Count()
+            new CumulativeCount()
         );
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetricsImplTest.java
@@ -135,7 +135,7 @@ public class StreamsMetricsImplTest {
         final KafkaMetric totalMetric = metrics.metric(totalMetricName);
 
         for (int i = 0; i < 10; i++) {
-            assertEquals(i, totalMetric.measurable().measure(config, time.milliseconds()), 0.0001);
+            assertEquals(i, Math.round(totalMetric.measurable().measure(config, time.milliseconds())));
             sensor.record(latency, time.milliseconds());
         }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetricsImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetricsImplTest.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.junit.Assert.assertEquals;
 
 public class StreamsMetricsImplTest {
@@ -103,8 +105,8 @@ public class StreamsMetricsImplTest {
 
     @Test
     public void testTotalMetricDoesntDecrease() {
-        final MockTime time = new MockTime();
-        final MetricConfig config = new MetricConfig().eventWindow(1).samples(2);
+        final MockTime time = new MockTime(1);
+        final MetricConfig config = new MetricConfig().timeWindow(1, TimeUnit.MILLISECONDS);
         final Metrics metrics = new Metrics(config, time);
         final StreamsMetricsImpl streamsMetrics = new StreamsMetricsImpl(metrics, "");
 


### PR DESCRIPTION
Changes:
* Add `org.apache.kafka.streams.processor.internals.metrics.CumulativeCount` analogous to `Count`, but not a `SampledStat`
* Use `CumulativeCount` for -total metrics in streams instead of `Count`

Testing strategy:
* Add a test in StreamsMetricsImplTest which fails on old, incorrect behavior

The contribution is my original work and I license the work to the project under the project's open source license.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
