### PR TITLE
KAFKA-7080: pass segmentInterval to CachingWindowStore

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/WindowStoreBuilder.java
@@ -52,7 +52,7 @@ public class WindowStoreBuilder<K, V> extends AbstractStoreBuilder<K, V, WindowS
                                         keySerde,
                                         valueSerde,
                                         storeSupplier.windowSize(),
-                                        storeSupplier.segments());
+                                        Segments.segmentInterval(storeSupplier.retentionPeriod(), storeSupplier.segments()));
     }
 
     private WindowStore<Bytes, byte[]> maybeWrapLogging(final WindowStore<Bytes, byte[]> inner) {


### PR DESCRIPTION
WindowStoreBuilder incorrectly passes the number of segments instead of the segment interval.

In trunk, we made a larger change to fix this, but for backporting we simply compute the segment interval to pass.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
