### PR TITLE
MINOR : kafka-examples, replaced deprecated KafkaConsumer.poll(long) method with KafkaConsumer.poll(Duration)

### DIFF
--- a/examples/src/main/java/kafka/examples/Consumer.java
+++ b/examples/src/main/java/kafka/examples/Consumer.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -47,7 +48,7 @@ public class Consumer extends ShutdownableThread {
     @Override
     public void doWork() {
         consumer.subscribe(Collections.singletonList(this.topic));
-        ConsumerRecords<Integer, String> records = consumer.poll(1000);
+        ConsumerRecords<Integer, String> records = consumer.poll(Duration.ofMillis(1000));
         for (ConsumerRecord<Integer, String> record : records) {
             System.out.println("Received message: (" + record.key() + ", " + record.value() + ") at offset " + record.offset());
         }


### PR DESCRIPTION
While looking at the kafka-examples code, found one of the deprecated method is used in kafka.examples.Consumer.java
 
The commit here replaces deprecated 
       **KafkaConsumer.poll(long)** 
method with 
       **KafkaConsumer.poll(Duration)**

Author: Piyush Sagar <piyushsagar725@gmail.com>