### PR TITLE
KAFKA-7266: Fix MetricsTest.testMetrics flakiness by increasing batch…

### DIFF
--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -44,7 +44,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "false")
   this.serverConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableDoc, "false")
   this.producerConfig.setProperty(ProducerConfig.LINGER_MS_CONFIG, "10")
-  this.producerConfig.setProperty(ProducerConfig.BATCH_SIZE_CONFIG, "1000000")
+  this.producerConfig.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
   override protected val serverSaslProperties =
     Some(kafkaServerSaslProperties(kafkaServerSaslMechanisms, kafkaClientSaslMechanism))
@@ -78,7 +78,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
 
     // Produce and consume some records
     val numRecords = 10
-    val recordSize = 1000
+    val recordSize = 100000
     val producer = producers.head
     sendRecords(producer, numRecords, recordSize, tp)
 
@@ -198,17 +198,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
 
     verifyYammerMetricRecorded(s"kafka.server:type=BrokerTopicMetrics,name=ProduceMessageConversionsPerSec")
 
-    // Conversion time less than 1 millisecond is reported as zero, so retry with larger batches until time > 0
-    var iteration = 0
-    TestUtils.retry(5000) {
-      val conversionTimeMs = yammerMetricValue(s"$requestMetricsPrefix,name=MessageConversionsTimeMs,request=Produce").asInstanceOf[Double]
-      if (conversionTimeMs <= 0.0) {
-        iteration += 1
-        sendRecords(producers.head, 1000 * iteration, 100, tp)
-      }
-      assertTrue(s"Message conversion time not recorded $conversionTimeMs", conversionTimeMs > 0.0)
-    }
-
+    verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=MessageConversionsTimeMs,request=Produce", value => value > 0.0)
     verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=RequestBytes,request=Fetch")
     verifyYammerMetricRecorded(s"$requestMetricsPrefix,name=TemporaryMemoryBytes,request=Fetch", value => value == 0.0)
 

--- a/core/src/test/scala/integration/kafka/api/MetricsTest.scala
+++ b/core/src/test/scala/integration/kafka/api/MetricsTest.scala
@@ -44,6 +44,7 @@ class MetricsTest extends IntegrationTestHarness with SaslSetup {
   this.serverConfig.setProperty(KafkaConfig.ZkEnableSecureAclsProp, "false")
   this.serverConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableDoc, "false")
   this.producerConfig.setProperty(ProducerConfig.LINGER_MS_CONFIG, "10")
+  // intentionally slow message down conversion via gzip compression to ensure we can measure the time it takes
   this.producerConfig.setProperty(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip")
   override protected def securityProtocol = SecurityProtocol.SASL_PLAINTEXT
   override protected val serverSaslProperties =


### PR DESCRIPTION
The test `kafka.api.MetricsTest.testMetrics` has been failing intermittently in kafka builds.
The particular failure is in the `MessageConversionsTimeMs` metric assertion:
```
java.lang.AssertionError: Message conversion time not recorded 0.0
```

The test would intermittently fail because the conversion time took less than 1 millisecond. Such conversion time is reported as zero by the metric.
There has been work done previously (https://github.com/apache/kafka/pull/4681) to combat the flakiness of the test and while it has improved it, the test still fails sometimes.

Locally, this test failed 5 times out of 25.

### Changes
Increase the record size and use compression - both will slow down message conversion enough to have it be above 1ms. Locally this test has not failed in 200 runs and counting