### PR TITLE
KAFKA-7288: Fix for SslSelectorTest.testCloseConnectionInClosingState

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -418,7 +418,9 @@ public class SelectorTest {
             selector.mute(id);
             for (int i = 0; i <= maxStagedReceives; i++) {
                 selector.send(createSend(id, String.valueOf(i)));
-                selector.poll(1000);
+                do {
+                    selector.poll(1000);
+                } while (selector.completedSends().isEmpty());
             }
 
             selector.unmute(id);


### PR DESCRIPTION
Ensure that sends are completed before waiting for channel to be closed based on idle expiry, since channel will not be expired if added to ready keys in the next poll as a result of pending sends.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
