### PR TITLE
[MINOR] Improve docs by adding ToC links to Monitoring

### DIFF
--- a/docs/ops.html
+++ b/docs/ops.html
@@ -1935,9 +1935,6 @@ All the following metrics have a recording level of ``debug``:
 
   On the client side, we recommend monitoring the message/byte rate (global and per topic), request rate/size/time, and on the consumer side, max lag in messages among all partitions and min fetch request rate. For a consumer to keep up, max lag needs to be less than a threshold and min fetch rate needs to be larger than 0.
 
-  <h4><a id="basic_ops_audit" href="#basic_ops_audit">Audit</a></h4>
-  The final alerting we do is on the correctness of the data delivery. We audit that every message that is sent is consumed by all consumers and measure the lag for this to occur. For important topics we alert if a certain completeness is not achieved in a certain time period. The details of this are discussed in KAFKA-260.
-
   <h3><a id="zk" href="#zk">6.7 ZooKeeper</a></h3>
 
   <h4><a id="zkversion" href="#zkversion">Stable version</a></h4>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -101,6 +101,16 @@
                         <li><a href="#ext4">Ext4 Notes</a>
                     </ul>
                 <li><a href="#monitoring">6.6 Monitoring</a>
+                    <ul>
+                        <li><a href="#selector_monitoring">Selector Monitoring</a></li>
+                        <li><a href="#common_node_monitoring">Common Node Monitoring</a></li>
+                        <li><a href="#producer_monitoring">Producer Monitoring</a></li>
+                        <li><a href="#new_consumer_monitoring">New Consumer Monitoring</a></li>
+                        <li><a href="#connect_monitoring">Connect Monitoring</a></li>
+                        <li><a href="#kafka_streams_monitoring">Streams Monitoring</a></li>
+                        <li><a href="#others_monitoring">Others</a></li>
+                        <li><a href="#basic_ops_audit">Audit</a></li>
+                    </ul>
                 <li><a href="#zk">6.7 ZooKeeper</a>
                     <ul>
                         <li><a href="#zkversion">Stable Version</a>

--- a/docs/toc.html
+++ b/docs/toc.html
@@ -105,11 +105,10 @@
                         <li><a href="#selector_monitoring">Selector Monitoring</a></li>
                         <li><a href="#common_node_monitoring">Common Node Monitoring</a></li>
                         <li><a href="#producer_monitoring">Producer Monitoring</a></li>
-                        <li><a href="#new_consumer_monitoring">New Consumer Monitoring</a></li>
+                        <li><a href="#consumer_monitoring">Consumer Monitoring</a></li>
                         <li><a href="#connect_monitoring">Connect Monitoring</a></li>
                         <li><a href="#kafka_streams_monitoring">Streams Monitoring</a></li>
                         <li><a href="#others_monitoring">Others</a></li>
-                        <li><a href="#basic_ops_audit">Audit</a></li>
                     </ul>
                 <li><a href="#zk">6.7 ZooKeeper</a>
                     <ul>


### PR DESCRIPTION
My top 2 reasons for visiting the Kafka docs are to:
- View configurations
- View metrics 

This PR aims to improve the user experience for viewing metrics:
- Add href links to the `Monitoring` section of the Table of Contents so users do not need to scroll or Ctrl/Cmd-F to find specific metric details (Monitoring section has grown large as more component & metrics are added)

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
