### PR TITLE
KAFKA-7186: Avoid re-instantiating UpdateMetadataReuqest and struct objects to reduce controller memory usage

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/UpdateMetadataRequestTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.requests.UpdateMetadataRequest.PartitionState;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class UpdateMetadataRequestTest {
+    @Test
+    public void testBuildUpdateMetadataRequestWithSamePayload() {
+        int someControllerId = 1;
+        int someControllerEpoch = 1;
+        Map<TopicPartition, PartitionState> partitionStates = new HashMap<>();
+        Set<UpdateMetadataRequest.Broker> liveBrokers = new HashSet<>();
+        Set<UpdateMetadataRequest> generatedUpdateMetadataRequests = new HashSet<>();
+
+        for (short version = 0; version < 5; version++) {
+            AbstractRequest.Builder updateMetadataRequestBuilder = new UpdateMetadataRequest.Builder(version, someControllerId, someControllerEpoch, partitionStates, liveBrokers);
+            UpdateMetadataRequest updateMetadataRequest1 = (UpdateMetadataRequest) updateMetadataRequestBuilder.build();
+            Struct struct1 = updateMetadataRequest1.toStruct();
+
+            // When we first generate the UpdateMetadataRequest for a specific version, it should not have been generated before
+            Assert.assertFalse(generatedUpdateMetadataRequests.contains(updateMetadataRequest1));
+            
+            UpdateMetadataRequest updateMetadataRequest2 = (UpdateMetadataRequest) updateMetadataRequestBuilder.build();
+            Struct struct2 = updateMetadataRequest2.toStruct();
+            
+            // The two UpdateMetadataRequests refer to the same object
+            Assert.assertTrue(updateMetadataRequest1 == updateMetadataRequest2);
+            // The two Structs refer to the same object
+            Assert.assertTrue(struct1 == struct2);
+
+            generatedUpdateMetadataRequests.add(updateMetadataRequest1);
+        }
+    }
+}


### PR DESCRIPTION
During controller failover and broker changes, it sends out UpdateMetadataRequest to all brokers in the cluster containing the states for all partitions and live brokers. The current implementation will instantiate the UpdateMetadataRequest object and its serialized form (Struct) for `# of brokers` times, which causes OOM if the memory exceeds the configure JVM heap size before GC kicks in. We have seen this issue in the production environment for multiple times. 

For example, if we have 100 brokers in the cluster and each broker is the leader of 2k partitions, the extra memory usage introduced by controller trying to send out UpdateMetadataRequest is around:

```
<memory used by UpdateMetadataRequest Structs> * <# of brokers> * <total # of leader parittions>
= 250B * 100 * 200k = 5GB
```

This PR avoids the recreation of UpdateMetadataReuqest and struct objects if the same builder object is used to build the request. This can significantly reduce memory footprint in Controller based on the above calculation.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
