### PR TITLE
KAFKA-7284: streams should unwrap fenced exception

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -206,7 +206,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         this.transactionInFlight = false;
     }
 
-    private void verifyProducerState() {
+    private synchronized void verifyProducerState() {
         if (this.closed) {
             throw new IllegalStateException("MockProducer is already closed.");
         }
@@ -319,7 +319,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         return this.closed;
     }
 
-    public void fenceProducer() {
+    public synchronized void fenceProducer() {
         verifyProducerState();
         verifyTransactionsInitialized();
         this.producerFenced = true;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -206,7 +206,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         this.transactionInFlight = false;
     }
 
-    private synchronized void verifyProducerState() {
+    private void verifyProducerState() {
         if (this.closed) {
             throw new IllegalStateException("MockProducer is already closed.");
         }
@@ -319,7 +319,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         return this.closed;
     }
 
-    public synchronized void fenceProducer() {
+    public void fenceProducer() {
         verifyProducerState();
         verifyTransactionsInitialized();
         this.producerFenced = true;

--- a/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/MockProducer.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.clients.producer.internals.FutureRecordMetadata;
 import org.apache.kafka.clients.producer.internals.ProduceRequestResult;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -205,7 +206,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         this.transactionInFlight = false;
     }
 
-    private void verifyProducerState() {
+    private synchronized void verifyProducerState() {
         if (this.closed) {
             throw new IllegalStateException("MockProducer is already closed.");
         }
@@ -243,7 +244,12 @@ public class MockProducer<K, V> implements Producer<K, V> {
      */
     @Override
     public synchronized Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
-        verifyProducerState();
+        if (this.closed) {
+            throw new IllegalStateException("MockProducer is already closed.");
+        }
+        if (this.producerFenced) {
+            throw new KafkaException("MockProducer is fenced.", new ProducerFencedException("Fenced"));
+        }
         int partition = 0;
         if (!this.cluster.partitionsForTopic(record.topic()).isEmpty())
             partition = partition(record, this.cluster);
@@ -313,7 +319,7 @@ public class MockProducer<K, V> implements Producer<K, V> {
         return this.closed;
     }
 
-    public void fenceProducer() {
+    public synchronized void fenceProducer() {
         verifyProducerState();
         verifyTransactionsInitialized();
         this.producerFenced = true;

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -19,6 +19,7 @@ package org.apache.kafka.clients.producer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.Cluster;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
@@ -267,18 +268,9 @@ public class MockProducerTest {
         try {
             producer.send(null);
             fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
-    }
-
-    @Test
-    public void shouldThrowOnFlushIfProducerGotFenced() {
-        buildMockProducer(true);
-        producer.initTransactions();
-        producer.fenceProducer();
-        try {
-            producer.flush();
-            fail("Should have thrown as producer is fenced off");
-        } catch (ProducerFencedException e) { }
+        } catch (KafkaException e) {
+            assertTrue("The root cause of the exception should be ProducerFenced", e.getCause() instanceof ProducerFencedException);
+        }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -272,16 +272,16 @@ public class MockProducerTest {
             assertTrue("The root cause of the exception should be ProducerFenced", e.getCause() instanceof ProducerFencedException);
         }
     }
-    
-    @Test	
-    public void shouldThrowOnFlushIfProducerGotFenced() {	
-        buildMockProducer(true);	
-        producer.initTransactions();	
-        producer.fenceProducer();	
-        try {	
-            producer.flush();	
-            fail("Should have thrown as producer is fenced off");	
-        } catch (ProducerFencedException e) { }	
+
+    @Test
+    public void shouldThrowOnFlushIfProducerGotFenced() {
+        buildMockProducer(true);
+        producer.initTransactions();
+        producer.fenceProducer();
+        try {
+            producer.flush();
+            fail("Should have thrown as producer is fenced off");
+        } catch (ProducerFencedException e) { }
     }
 
     @Test

--- a/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/MockProducerTest.java
@@ -272,6 +272,17 @@ public class MockProducerTest {
             assertTrue("The root cause of the exception should be ProducerFenced", e.getCause() instanceof ProducerFencedException);
         }
     }
+    
+    @Test	
+    public void shouldThrowOnFlushIfProducerGotFenced() {	
+        buildMockProducer(true);	
+        producer.initTransactions();	
+        producer.fenceProducer();	
+        try {	
+            producer.flush();	
+            fail("Should have thrown as producer is fenced off");	
+        } catch (ProducerFencedException e) { }	
+    }
 
     @Test
     public void shouldThrowOnSendOffsetsToTransactionIfProducerGotFenced() {

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -129,6 +129,16 @@ public class RecordCollectorImpl implements RecordCollector {
                 }
                 log.warn("Timeout exception caught when sending record to topic {}; retrying with {} attempt", topic, attempt);
                 Utils.sleep(SEND_RETRY_BACKOFF);
+            } catch (final Exception uncaughtException) {
+                if (uncaughtException instanceof KafkaException &&
+                    uncaughtException.getCause() instanceof ProducerFencedException) {
+                    final KafkaException kafkaException = (KafkaException) uncaughtException;
+                    // producer.send() call may throw a KafkaException which wraps a FencedException,
+                    // in this case we should throw its wrapped inner cause so that it can be captured and re-wrapped as TaskMigrationException
+                    throw (ProducerFencedException) kafkaException.getCause();
+                } else {
+                    throw uncaughtException;
+                }
             }
         }
     }


### PR DESCRIPTION
Unwrap the ProducerFencedException in RecordCollectorImpl
so it can be caught and converted to a TaskMigratedException
instead of triggering a shutdown.

See also #5499 and #5513 

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
