### PR TITLE
MINOR: Change order of Property Check To Avoid NPE

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -292,9 +292,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     private void maybePerformOptimizations(final Properties props) {
 
-        final StreamsConfig config = props != null ? new StreamsConfig(props) : null;
-
-        if (config != null && config.getString(StreamsConfig.TOPOLOGY_OPTIMIZATION).equals(StreamsConfig.OPTIMIZE)) {
+        if (props != null && StreamsConfig.OPTIMIZE.equals(props.getProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION))) {
             LOG.debug("Optimizing the Kafka Streams graph for repartition nodes");
             maybeOptimizeRepartitionOperations();
         }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -292,7 +292,9 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     private void maybePerformOptimizations(final Properties props) {
 
-        if (props != null && props.getProperty(StreamsConfig.TOPOLOGY_OPTIMIZATION).equals(StreamsConfig.OPTIMIZE)) {
+        final StreamsConfig config = props != null ? new StreamsConfig(props) : null;
+
+        if (config != null && config.getString(StreamsConfig.TOPOLOGY_OPTIMIZATION).equals(StreamsConfig.OPTIMIZE)) {
             LOG.debug("Optimizing the Kafka Streams graph for repartition nodes");
             maybeOptimizeRepartitionOperations();
         }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -59,9 +59,6 @@ public class StreamsBuilderTest {
     public void shouldNotThrowNullPointerIfOptimizationsNotSpecified() {
         final Properties properties = new Properties();
 
-        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "unit-test");
-        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost");
-
         final StreamsBuilder builder = new StreamsBuilder();
         builder.build(properties);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/StreamsBuilderTest.java
@@ -56,6 +56,17 @@ public class StreamsBuilderTest {
     private final Properties props = StreamsTestUtils.getStreamsConfig(Serdes.String(), Serdes.String());
 
     @Test
+    public void shouldNotThrowNullPointerIfOptimizationsNotSpecified() {
+        final Properties properties = new Properties();
+
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "unit-test");
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost");
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        builder.build(properties);
+    }
+
+    @Test
     public void shouldAllowJoinUnmaterializedFilteredKTable() {
         final KTable<Bytes, String> filteredKTable = builder.<Bytes, String>table("table-topic").filter(MockPredicate.<Bytes, String>allGoodPredicate());
         builder.<Bytes, String>stream("stream-topic").join(filteredKTable, MockValueJoiner.TOSTRING_JOINER);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
@@ -97,8 +97,6 @@ public class StreamsGraphTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizeConfig);
-        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost");
-        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
 
         final KStream<String, String> inputStream = builder.stream("input");
         final KStream<String, String> mappedKeyStream = inputStream.selectKey((k, v) -> k + v);
@@ -115,8 +113,6 @@ public class StreamsGraphTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizeConfig);
-        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost");
-        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
 
         final KStream<String, String> inputStream = builder.stream("input");
         final KStream<String, String> mappedKeyStream = inputStream.selectKey((k, v) -> k + v).through("through-topic");

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/graph/StreamsGraphTest.java
@@ -97,6 +97,8 @@ public class StreamsGraphTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizeConfig);
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost");
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
 
         final KStream<String, String> inputStream = builder.stream("input");
         final KStream<String, String> mappedKeyStream = inputStream.selectKey((k, v) -> k + v);
@@ -113,6 +115,8 @@ public class StreamsGraphTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final Properties properties = new Properties();
         properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizeConfig);
+        properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost");
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, "test");
 
         final KStream<String, String> inputStream = builder.stream("input");
         final KStream<String, String> mappedKeyStream = inputStream.selectKey((k, v) -> k + v).through("through-topic");


### PR DESCRIPTION
The `InternalStreamsBuilder#maybePerformOptimizations` should change the order of how it checks for `Topology_OPTIMIZATION` to avoid an NPE.


For testing, I added a test that results in an NPE without the provided fix and ran the existing set of streams tests.


### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
