### PR TITLE
KAFKA-7308: Fix rat and checkstyle config for Java 11 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ if (file('.git').exists()) {
   rat {
     // Exclude everything under the directory that git should be ignoring via .gitignore or that isn't checked in. These
     // restrict us only to files that are checked in or are staged.
-    def repo = Grgit.open(project.file('.'))
+    def repo = Grgit.open(project.getRootDir())
     excludes = new ArrayList<String>(repo.clean(ignore: false, directories: true, dryRun: true))
     // And some of the files that we have checked in should also be excluded from this check
     excludes.addAll([
@@ -359,7 +359,7 @@ subprojects {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control.xml"]
+    configProperties = checkstyleConfigProperties("import-control.xml")
     toolVersion = '8.10'
   }
   test.dependsOn('checkstyleMain', 'checkstyleTest')
@@ -442,6 +442,12 @@ def fineTuneEclipseClasspathFile(eclipse, project) {
       cp.entries.removeAll { it.kind == "lib" && it.path.matches(".*/build/(classes|resources)/test") }
     }
   }
+}
+
+def checkstyleConfigProperties(configFileName) {
+  [importControlFile: "$rootDir/checkstyle/$configFileName",
+   suppressionsFile: "$rootDir/checkstyle/suppressions.xml",
+   headerFile: "$rootDir/checkstyle/java.header"]
 }
 
 // Aggregates all jacoco results into the root project directory
@@ -775,7 +781,7 @@ project(':core') {
   systemTestLibs.dependsOn('jar', 'testJar', 'copyDependantTestLibs')
 
   checkstyle {
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
+    configProperties = checkstyleConfigProperties("import-control-core.xml")
   }
 }
 
@@ -791,7 +797,7 @@ project(':examples') {
   }
 
   checkstyle {
-    configProperties = [importControlFile: "$rootDir/checkstyle/import-control-core.xml"]
+    configProperties = checkstyleConfigProperties("import-control-core.xml")
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ ext {
 
 apply from: file('wrapper.gradle')
 
-if (new File('.git').exists()) {
+if (file('.git').exists()) {
   apply from: file('gradle/rat.gradle')
   rat {
     // Exclude everything under the directory that git should be ignoring via .gitignore or that isn't checked in. These

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -25,7 +25,7 @@
 
   <!-- header -->
   <module name="Header">
-    <property name="headerFile" value="checkstyle/java.header" />
+    <property name="headerFile" value="${headerFile}" />
   </module>
 
   <module name="TreeWalker">
@@ -137,6 +137,6 @@
   </module>
 
   <module name="SuppressionFilter">
-    <property name="file" value="checkstyle/suppressions.xml"/>
+    <property name="file" value="${suppressionsFile}"/>
   </module>
 </module>

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -17,9 +17,6 @@
  * under the License.
  */
 
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.internal.project.IsolatedAntBuilder
 
 apply plugin: RatPlugin
@@ -28,18 +25,19 @@ class RatTask extends DefaultTask {
   @Input
   List<String> excludes
 
-  def reportPath = 'build/rat'
-  def stylesheet = 'gradle/resources/rat-output-to-html.xsl'
-  def xmlReport = reportPath + '/rat-report.xml'
-  def htmlReport = reportPath + '/rat-report.html'
+  def reportDir = project.file('build/rat')
+  def stylesheet = project.file('gradle/resources/rat-output-to-html.xsl').getAbsolutePath()
+  def xmlReport = new File(reportDir, 'rat-report.xml')
+  def htmlReport = new File(reportDir, 'rat-report.html')
 
   def generateXmlReport(File reportDir) {
     def antBuilder = services.get(IsolatedAntBuilder)
     def ratClasspath = project.configurations.rat
+    def projectPath = project.getRootDir().getAbsolutePath()
     antBuilder.withClasspath(ratClasspath).execute {
       ant.taskdef(resource: 'org/apache/rat/anttasks/antlib.xml')
       ant.report(format: 'xml', reportFile: xmlReport) {
-        fileset(dir: ".") {
+        fileset(dir: projectPath) {
           patternset {
             excludes.each {
               exclude(name: it)
@@ -80,7 +78,6 @@ class RatTask extends DefaultTask {
 
   @TaskAction
   def rat() {
-    File reportDir = new File(reportPath)
     if (!reportDir.exists()) {
       reportDir.mkdirs()
     }


### PR DESCRIPTION
Relative paths in Gradle break when the Gradle daemon is used
unless `user.dir` can be changed while the process is running.
Java 11 disallows this, so we use project paths instead.

Verified that `rat` and `checkstyle` work with Java 11 after these
changes.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
