### PR TITLE
KAFKA-7313; StopReplicaRequest should attempt to remove future replica for the partition only if future replica exists

### DIFF
--- a/core/src/main/scala/kafka/cluster/Partition.scala
+++ b/core/src/main/scala/kafka/cluster/Partition.scala
@@ -352,7 +352,8 @@ class Partition(val topicPartition: TopicPartition,
       leaderEpochStartOffsetOpt = None
       removePartitionMetrics()
       logManager.asyncDelete(topicPartition)
-      logManager.asyncDelete(topicPartition, isFuture = true)
+      if (logManager.getLog(topicPartition, isFuture = true).isDefined)
+        logManager.asyncDelete(topicPartition, isFuture = true)
     }
   }
 

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -845,7 +845,7 @@ class LogManager(logDirs: Seq[File],
       addLogToBeDeleted(removedLog)
       info(s"Log for partition ${removedLog.topicPartition} is renamed to ${removedLog.dir.getAbsolutePath} and is scheduled for deletion")
     } else if (offlineLogDirs.nonEmpty) {
-      throw new KafkaStorageException("Failed to delete log for " + topicPartition + " because it may be in one of the offline directories " + offlineLogDirs.mkString(","))
+      throw new KafkaStorageException(s"Failed to delete log for ${if (isFuture) "future" else ""} $topicPartition because it may be in one of the offline directories ${offlineLogDirs.mkString(",")}")
     }
     removedLog
   }

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -338,8 +338,10 @@ class ReplicaManager(val config: KafkaConfig,
 
     if (deletePartition) {
       val removedPartition = allPartitions.remove(topicPartition)
-      if (removedPartition eq ReplicaManager.OfflinePartition)
+      if (removedPartition eq ReplicaManager.OfflinePartition) {
+        allPartitions.put(topicPartition, ReplicaManager.OfflinePartition)
         throw new KafkaStorageException(s"Partition $topicPartition is on an offline disk")
+      }
 
       if (removedPartition != null) {
         val topicHasPartitions = allPartitions.values.exists(partition => topicPartition.topic == partition.topic)
@@ -1402,7 +1404,8 @@ class ReplicaManager(val config: KafkaConfig,
   }
 
   // logDir should be an absolute path
-  def handleLogDirFailure(dir: String) {
+  // sendZkNotification is needed for unit test
+  def handleLogDirFailure(dir: String, sendZkNotification: Boolean = true) {
     if (!logManager.isLogDirOnline(dir))
       return
     info(s"Stopping serving replicas in dir $dir")
@@ -1438,7 +1441,9 @@ class ReplicaManager(val config: KafkaConfig,
            s"for partitions ${partitionsWithOfflineFutureReplica.mkString(",")} because they are in the failed log directory $dir.")
     }
     logManager.handleLogDirFailure(dir)
-    zkClient.propagateLogDirEvent(localBrokerId)
+
+    if (sendZkNotification)
+      zkClient.propagateLogDirEvent(localBrokerId)
     info(s"Stopped serving replicas in dir $dir")
   }
 

--- a/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/StopReplicaRequestTest.scala
@@ -1,0 +1,57 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package kafka.server
+
+import kafka.utils._
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests._
+import org.junit.Assert._
+import org.junit.Test
+import collection.JavaConverters._
+
+
+class StopReplicaRequestTest extends BaseRequestTest {
+  override val logDirCount = 2
+  override val numBrokers: Int = 1
+
+  val topic = "topic"
+  val partitionNum = 2
+  val tp0 = new TopicPartition(topic, 0)
+  val tp1 = new TopicPartition(topic, 1)
+
+  @Test
+  def testStopReplicaRequest(): Unit = {
+    createTopic(topic, partitionNum, 1)
+    TestUtils.generateAndProduceMessages(servers, topic, 10)
+
+    val server = servers.head
+    val offlineDir = server.logManager.getLog(tp1).get.dir.getParent
+    server.replicaManager.handleLogDirFailure(offlineDir, sendZkNotification = false)
+
+    for (i <- 1 to 2) {
+      val request1 = new StopReplicaRequest.Builder(
+        server.config.brokerId, server.replicaManager.controllerEpoch, true, Set(tp0, tp1).asJava).build()
+      val response1 = connectAndSend(request1, ApiKeys.STOP_REPLICA, controllerSocketServer)
+      val partitionErrors1 = StopReplicaResponse.parse(response1, request1.version).responses()
+      assertEquals(Errors.NONE, partitionErrors1.get(tp0))
+      assertEquals(Errors.KAFKA_STORAGE_ERROR, partitionErrors1.get(tp1))
+    }
+  }
+
+}


### PR DESCRIPTION
This patch fixes two issues:

1) Currently if a broker received StopReplicaRequest with delete=true for the same offline replica, the first StopRelicaRequest will show KafkaStorageException and the second StopRelicaRequest will show ReplicaNotAvailableException. This is because the first StopRelicaRequest will remove the mapping (tp -> ReplicaManager.OfflinePartition) from ReplicaManager.allPartitions before returning KafkaStorageException, thus the second StopRelicaRequest will not find this partition as offline.

This result appears to be inconsistent. And since the replica is already offline and broker will not be able to delete file for this replica, the StopReplicaRequest should fail without making any change and broker should still remember that this replica is offline. 

2) Currently if broker receives StopReplicaRequest with delete=true, the broker will attempt to remove future replica for the partition, which will cause KafkaStorageException in the StopReplicaResponse if this replica does not have future replica. It is problematic to always return KafkaStorageException in the response if future replica does not exist.