### PR TITLE
Minor: set task to null at the end of shouldWrapProducerFencedExceptionWithTaskMigragedExceptionInSuspendWhenCommitting

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -249,8 +249,8 @@ public class RecordCollectorImpl implements RecordCollector {
     @Override
     public void close() {
         log.debug("Closing producer");
-        producer.close();
-        producer = null;
+        if (producer != null) producer.close();
+        else producer = null;
         checkForException();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/RecordCollectorImpl.java
@@ -249,8 +249,8 @@ public class RecordCollectorImpl implements RecordCollector {
     @Override
     public void close() {
         log.debug("Closing producer");
-        if (producer != null) producer.close();
-        else producer = null;
+        producer.close();
+        producer = null;
         checkForException();
     }
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -983,6 +983,7 @@ public class StreamTaskTest {
         } catch (final TaskMigratedException expected) {
             assertTrue(expected.getCause() instanceof ProducerFencedException);
         }
+        task = null;
 
         assertFalse(producer.transactionCommitted());
     }


### PR DESCRIPTION
Noticed the following in test output:
```
org.apache.kafka.streams.processor.internals.StreamTaskTest > shouldWrapProducerFencedExceptionWithTaskMigragedExceptionInSuspendWhenCommitting STANDARD_OUT
    [2018-08-20 17:30:10,706] ERROR task [0_0] Could not close task due to the following error: (org.apache.kafka.streams.processor.internals.StreamTask:660)
    java.lang.NullPointerException
      at org.apache.kafka.streams.processor.internals.RecordCollectorImpl.close(RecordCollectorImpl.java:252)
      at org.apache.kafka.streams.processor.internals.StreamTask.suspend(StreamTask.java:538)
      at org.apache.kafka.streams.processor.internals.StreamTask.close(StreamTask.java:656)
      at org.apache.kafka.streams.processor.internals.StreamTaskTest.cleanup(StreamTaskTest.java:176)
```
This PR adds null check for producer in RecordCollectorImpl#close .
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
