### PR TITLE
MINOR: restructure Windows to favor immutable implementation

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
@@ -112,6 +112,7 @@ public final class JoinWindows extends Windows<Window> {
      * @throws IllegalArgumentException if {@code timeDifferenceMs} is negative
      */
     public static JoinWindows of(final long timeDifferenceMs) throws IllegalArgumentException {
+        // This is a static factory method, so we initialize grace and retention to the defaults.
         return new JoinWindows(timeDifferenceMs, timeDifferenceMs, null, DEFAULT_RETENTION_MS);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/JoinWindows.java
@@ -154,6 +154,15 @@ public final class JoinWindows extends Windows<Window> {
         return beforeMs + afterMs;
     }
 
+    /**
+     * Reject late events that arrive more than {@code millisAfterWindowEnd}
+     * after the end of its window.
+     *
+     * Lateness is defined as (stream_time - record_timestamp).
+     *
+     * @param millisAfterWindowEnd The grace period to admit late-arriving events to a window.
+     * @return this updated builder
+     */
     @SuppressWarnings({"deprecation"}) // removing segments from Windows will fix this
     public JoinWindows grace(final long millisAfterWindowEnd) {
         if (millisAfterWindowEnd < 0) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindows.java
@@ -22,6 +22,8 @@ import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
 import java.time.Duration;
 import java.util.Objects;
 
+import static org.apache.kafka.streams.kstream.internals.WindowingDefaults.DEFAULT_RETENTION_MS;
+
 
 /**
  * A session based window specification used for aggregating events into sessions.
@@ -91,8 +93,7 @@ public final class SessionWindows {
         if (inactivityGapMs <= 0) {
             throw new IllegalArgumentException("Gap time (inactivityGapMs) cannot be zero or negative.");
         }
-        final long oneDayMs = 24 * 60 * 60_000L;
-        return new SessionWindows(inactivityGapMs, oneDayMs, null);
+        return new SessionWindows(inactivityGapMs, DEFAULT_RETENTION_MS, null);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
@@ -105,6 +105,7 @@ public final class TimeWindows extends Windows<TimeWindow> {
         if (sizeMs <= 0) {
             throw new IllegalArgumentException("Window size (sizeMs) must be larger than zero.");
         }
+        // This is a static factory method, so we initialize grace and retention to the defaults.
         return new TimeWindows(sizeMs, sizeMs, null, DEFAULT_RETENTION_MS);
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
@@ -25,6 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.apache.kafka.streams.kstream.internals.WindowingDefaults.DEFAULT_RETENTION_MS;
+
 /**
  * The fixed-size time-based window specifications used for aggregations.
  * <p>
@@ -53,7 +55,6 @@ import java.util.Objects;
  */
 public final class TimeWindows extends Windows<TimeWindow> {
 
-    private static final long DEFAULT_MAINTAIN_DURATION_MS = 24 * 60 * 60 * 1000L; // default: one day
     private final long maintainDurationMs;
 
     /** The size of the windows in milliseconds. */
@@ -81,8 +82,11 @@ public final class TimeWindows extends Windows<TimeWindow> {
                         final Duration grace,
                         final long maintainDurationMs,
                         final int segments) {
-        this(sizeMs, advanceMs, grace, maintainDurationMs);
-        this.segments = segments;
+        super(segments);
+        this.sizeMs = sizeMs;
+        this.advanceMs = advanceMs;
+        this.grace = grace;
+        this.maintainDurationMs = maintainDurationMs;
     }
 
     /**
@@ -101,7 +105,7 @@ public final class TimeWindows extends Windows<TimeWindow> {
         if (sizeMs <= 0) {
             throw new IllegalArgumentException("Window size (sizeMs) must be larger than zero.");
         }
-        return new TimeWindows(sizeMs, sizeMs, null, DEFAULT_MAINTAIN_DURATION_MS);
+        return new TimeWindows(sizeMs, sizeMs, null, DEFAULT_RETENTION_MS);
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
@@ -20,6 +20,7 @@ import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -52,6 +53,9 @@ import java.util.Objects;
  */
 public final class TimeWindows extends Windows<TimeWindow> {
 
+    private static final long DEFAULT_MAINTAIN_DURATION_MS = 24 * 60 * 60 * 1000L; // default: one day
+    private final long maintainDurationMs;
+
     /** The size of the windows in milliseconds. */
     public final long sizeMs;
 
@@ -60,10 +64,25 @@ public final class TimeWindows extends Windows<TimeWindow> {
      * the previous one.
      */
     public final long advanceMs;
+    private final Duration grace;
 
-    private TimeWindows(final long sizeMs, final long advanceMs) {
+    private TimeWindows(final long sizeMs, final long advanceMs, final Duration grace, final long maintainDurationMs) {
         this.sizeMs = sizeMs;
         this.advanceMs = advanceMs;
+        this.grace = grace;
+        this.maintainDurationMs = maintainDurationMs;
+    }
+
+    /** Private constructor for preserving segments. Can be removed along with Windows.segments. **/
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
+    private TimeWindows(final long sizeMs,
+                        final long advanceMs,
+                        final Duration grace,
+                        final long maintainDurationMs,
+                        final int segments) {
+        this(sizeMs, advanceMs, grace, maintainDurationMs);
+        this.segments = segments;
     }
 
     /**
@@ -82,7 +101,7 @@ public final class TimeWindows extends Windows<TimeWindow> {
         if (sizeMs <= 0) {
             throw new IllegalArgumentException("Window size (sizeMs) must be larger than zero.");
         }
-        return new TimeWindows(sizeMs, sizeMs);
+        return new TimeWindows(sizeMs, sizeMs, null, DEFAULT_MAINTAIN_DURATION_MS);
     }
 
     /**
@@ -97,11 +116,12 @@ public final class TimeWindows extends Windows<TimeWindow> {
      * @return a new window definition with default maintain duration of 1 day
      * @throws IllegalArgumentException if the advance interval is negative, zero, or larger-or-equal the window size
      */
+    @SuppressWarnings("deprecation") // will be fixed when we remove segments from Windows
     public TimeWindows advanceBy(final long advanceMs) {
         if (advanceMs <= 0 || advanceMs > sizeMs) {
             throw new IllegalArgumentException(String.format("AdvanceMs must lie within interval (0, %d].", sizeMs));
         }
-        return new TimeWindows(sizeMs, advanceMs);
+        return new TimeWindows(sizeMs, advanceMs, grace, maintainDurationMs, segments);
     }
 
     @Override
@@ -121,10 +141,21 @@ public final class TimeWindows extends Windows<TimeWindow> {
         return sizeMs;
     }
 
-    @Override
+    @SuppressWarnings("deprecation") // will be fixed when we remove segments from Windows
     public TimeWindows grace(final long millisAfterWindowEnd) {
-        super.grace(millisAfterWindowEnd);
-        return this;
+        if (millisAfterWindowEnd < 0) {
+            throw new IllegalArgumentException("Grace period must not be negative.");
+        }
+        return new TimeWindows(sizeMs, advanceMs, Duration.ofMillis(millisAfterWindowEnd), maintainDurationMs, segments);
+    }
+
+    @SuppressWarnings("deprecation") // continuing to support Windows#maintainMs/segmentInterval in fallback mode
+    @Override
+    public long gracePeriodMs() {
+        // NOTE: in the future, when we remove maintainMs,
+        // we should default the grace period to 24h to maintain the default behavior,
+        // or we can default to (24h - size) if you want to be super accurate.
+        return grace != null ? grace.toMillis() : maintainMs() - size();
     }
 
     /**
@@ -135,14 +166,14 @@ public final class TimeWindows extends Windows<TimeWindow> {
      * @deprecated since 2.1. Use {@link Materialized#retention} or directly configure the retention in a store supplier
      *             and use {@link Materialized#as(WindowBytesStoreSupplier)}.
      */
+    @SuppressWarnings("deprecation")
     @Override
     @Deprecated
     public TimeWindows until(final long durationMs) throws IllegalArgumentException {
         if (durationMs < sizeMs) {
             throw new IllegalArgumentException("Window retention time (durationMs) cannot be smaller than the window size.");
         }
-        super.until(durationMs);
-        return this;
+        return new TimeWindows(sizeMs, advanceMs, grace, durationMs, segments);
     }
 
     /**
@@ -153,33 +184,41 @@ public final class TimeWindows extends Windows<TimeWindow> {
      * @return the window maintain duration
      * @deprecated since 2.1. Use {@link Materialized#retention} instead.
      */
+    @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
     @Override
     @Deprecated
     public long maintainMs() {
-        return Math.max(super.maintainMs(), sizeMs);
+        return Math.max(maintainDurationMs, sizeMs);
     }
 
+    @SuppressWarnings({"deprecation", "NonFinalFieldReferenceInEquals"}) // removing segments from Windows will fix this
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
         final TimeWindows that = (TimeWindows) o;
-        return sizeMs == that.sizeMs &&
-            advanceMs == that.advanceMs;
+        return maintainDurationMs == that.maintainDurationMs &&
+            segments == that.segments &&
+            sizeMs == that.sizeMs &&
+            advanceMs == that.advanceMs &&
+            Objects.equals(grace, that.grace);
     }
 
+    @SuppressWarnings({"deprecation", "NonFinalFieldReferencedInHashCode"}) // removing segments from Windows will fix this
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), sizeMs, advanceMs);
+        return Objects.hash(maintainDurationMs, segments, sizeMs, advanceMs, grace);
     }
 
+    @SuppressWarnings({"deprecation"}) // removing segments from Windows will fix this
     @Override
     public String toString() {
         return "TimeWindows{" +
-            "sizeMs=" + sizeMs +
+            "maintainDurationMs=" + maintainDurationMs +
+            ", sizeMs=" + sizeMs +
             ", advanceMs=" + advanceMs +
-            ", super=" + super.toString() +
+            ", grace=" + grace +
+            ", segments=" + segments +
             '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindows.java
@@ -141,6 +141,15 @@ public final class TimeWindows extends Windows<TimeWindow> {
         return sizeMs;
     }
 
+    /**
+     * Reject late events that arrive more than {@code millisAfterWindowEnd}
+     * after the end of its window.
+     *
+     * Lateness is defined as (stream_time - record_timestamp).
+     *
+     * @param millisAfterWindowEnd The grace period to admit late-arriving events to a window.
+     * @return this updated builder
+     */
     @SuppressWarnings("deprecation") // will be fixed when we remove segments from Windows
     public TimeWindows grace(final long millisAfterWindowEnd) {
         if (millisAfterWindowEnd < 0) {

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/UnlimitedWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/UnlimitedWindows.java
@@ -63,7 +63,6 @@ public final class UnlimitedWindows extends Windows<UnlimitedWindow> {
      * @return a new unlimited window that starts at {@code startMs}
      * @throws IllegalArgumentException if the start time is negative
      */
-    @SuppressWarnings("WeakerAccess") // intentionally public - this warning probably means we need an integration test
     public UnlimitedWindows startOn(final long startMs) throws IllegalArgumentException {
         if (startMs < 0) {
             throw new IllegalArgumentException("Window start time (startMs) cannot be negative.");

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/UnlimitedWindows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/UnlimitedWindows.java
@@ -63,6 +63,7 @@ public final class UnlimitedWindows extends Windows<UnlimitedWindow> {
      * @return a new unlimited window that starts at {@code startMs}
      * @throws IllegalArgumentException if the start time is negative
      */
+    @SuppressWarnings("WeakerAccess") // intentionally public - this warning probably means we need an integration test
     public UnlimitedWindows startOn(final long startMs) throws IllegalArgumentException {
         if (startMs < 0) {
             throw new IllegalArgumentException("Window start time (startMs) cannot be negative.");
@@ -100,6 +101,7 @@ public final class UnlimitedWindows extends Windows<UnlimitedWindow> {
      * @throws IllegalArgumentException on every invocation.
      * @deprecated since 2.1.
      */
+    @SuppressWarnings("deprecation")
     @Override
     @Deprecated
     public UnlimitedWindows until(final long durationMs) {
@@ -113,42 +115,39 @@ public final class UnlimitedWindows extends Windows<UnlimitedWindow> {
      * @return the window retention time that is {@link Long#MAX_VALUE}
      * @deprecated since 2.1. Use {@link Materialized#retention} instead.
      */
+    @SuppressWarnings("deprecation")
     @Override
     @Deprecated
     public long maintainMs() {
         return Long.MAX_VALUE;
     }
 
-    /**
-     * Throws an {@link IllegalArgumentException} because the window never ends and the
-     * grace period is therefore meaningless.
-     *
-     * @throws IllegalArgumentException on every invocation
-     */
     @Override
-    public UnlimitedWindows grace(final long millisAfterWindowEnd) {
-        throw new IllegalArgumentException("Grace period cannot be set for UnlimitedWindows.");
+    public long gracePeriodMs() {
+        return 0L;
     }
 
+    @SuppressWarnings({"deprecation", "NonFinalFieldReferenceInEquals"}) // removing segments from Windows will fix this
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
         final UnlimitedWindows that = (UnlimitedWindows) o;
-        return startMs == that.startMs;
+        return startMs == that.startMs && segments == that.segments;
     }
 
+    @SuppressWarnings({"deprecation", "NonFinalFieldReferencedInHashCode"}) // removing segments from Windows will fix this
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), startMs);
+        return Objects.hash(startMs, segments);
     }
 
+    @SuppressWarnings({"deprecation"}) // removing segments from Windows will fix this
     @Override
     public String toString() {
         return "UnlimitedWindows{" +
             "startMs=" + startMs +
-            ", super=" + super.toString() +
+            ", segments=" + segments +
             '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
@@ -21,6 +21,8 @@ import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 
 import java.util.Map;
 
+import static org.apache.kafka.streams.kstream.internals.WindowingDefaults.DEFAULT_RETENTION_MS;
+
 /**
  * The window specification interface for fixed size windows that is used to define window boundaries and grace period.
  *
@@ -38,10 +40,15 @@ import java.util.Map;
  */
 public abstract class Windows<W extends Window> {
 
-    private long maintainDurationMs = 24 * 60 * 60 * 1000L; // default: one day
+    private long maintainDurationMs = DEFAULT_RETENTION_MS;
     @Deprecated public int segments = 3;
 
     protected Windows() {}
+
+    @SuppressWarnings("deprecation") // remove this constructor when we remove segments.
+    Windows(final int segments) {
+        this.segments = segments;
+    }
 
     /**
      * Set the window maintain duration (retention time) in milliseconds.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Windows.java
@@ -19,9 +19,7 @@ package org.apache.kafka.streams.kstream;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 
-import java.time.Duration;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * The window specification interface for fixed size windows that is used to define window boundaries and grace period.
@@ -43,42 +41,7 @@ public abstract class Windows<W extends Window> {
     private long maintainDurationMs = 24 * 60 * 60 * 1000L; // default: one day
     @Deprecated public int segments = 3;
 
-    private Duration grace;
-
     protected Windows() {}
-
-    /**
-     * Reject late events that arrive more than {@code millisAfterWindowEnd}
-     * after the end of its window.
-     *
-     * Lateness is defined as (stream_time - record_timestamp).
-     *
-     * @param millisAfterWindowEnd The grace period to admit late-arriving events to a window.
-     * @return this updated builder
-     */
-    public Windows<W> grace(final long millisAfterWindowEnd) {
-        if (millisAfterWindowEnd < 0) {
-            throw new IllegalArgumentException("Grace period must not be negative.");
-        }
-
-        grace = Duration.ofMillis(millisAfterWindowEnd);
-
-        return this;
-    }
-
-    /**
-     * Return the window grace period (the time to admit
-     * late-arriving events after the end of the window.)
-     *
-     * Lateness is defined as (stream_time - record_timestamp).
-     */
-    @SuppressWarnings("deprecation") // continuing to support Windows#maintainMs/segmentInterval in fallback mode
-    public long gracePeriodMs() {
-        // NOTE: in the future, when we remove maintainMs,
-        // we should default the grace period to 24h to maintain the default behavior,
-        // or we can default to (24h - size) if you want to be super accurate.
-        return grace != null ? grace.toMillis() : maintainMs() - size();
-    }
 
     /**
      * Set the window maintain duration (retention time) in milliseconds.
@@ -106,6 +69,7 @@ public abstract class Windows<W extends Window> {
      * @return the window maintain duration
      * @deprecated since 2.1. Use {@link Materialized#retention} instead.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated
     public long maintainMs() {
         return maintainDurationMs;
@@ -161,34 +125,10 @@ public abstract class Windows<W extends Window> {
     public abstract long size();
 
     /**
-     * Warning: It may be unsafe to use objects of this class in set- or map-like collections,
-     * since the equals and hashCode methods depend on mutable fields.
+     * Return the window grace period (the time to admit
+     * late-arriving events after the end of the window.)
+     *
+     * Lateness is defined as (stream_time - record_timestamp).
      */
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        final Windows<?> windows = (Windows<?>) o;
-        return maintainMs() == windows.maintainMs() &&
-            segments == windows.segments &&
-            Objects.equals(gracePeriodMs(), windows.gracePeriodMs());
-    }
-
-    /**
-     * Warning: It may be unsafe to use objects of this class in set- or map-like collections,
-     * since the equals and hashCode methods depend on mutable fields.
-     */
-    @Override
-    public int hashCode() {
-        return Objects.hash(maintainMs(), segments, gracePeriodMs());
-    }
-
-    @Override
-    public String toString() {
-        return "Windows{" +
-            "maintainDurationMs=" + maintainMs() +
-            ", segments=" + segments +
-            ", grace=" + gracePeriodMs() +
-            '}';
-    }
+    public abstract long gracePeriodMs();
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowingDefaults.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/WindowingDefaults.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+public final class WindowingDefaults {
+    private WindowingDefaults() {}
+
+    public static final long DEFAULT_RETENTION_MS = 24 * 60 * 60 * 1000L; // one day
+}

--- a/streams/src/test/java/org/apache/kafka/streams/EqualityCheck.java
+++ b/streams/src/test/java/org/apache/kafka/streams/EqualityCheck.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+public final class EqualityCheck {
+    private EqualityCheck() {}
+
+    // Inspired by EqualsTester from Guava
+    public static <T> void verifyEquality(final T o1, final T o2) {
+        // making sure we don't get an NPE in the test
+        if (o1 == null && o2 == null) {
+            return;
+        } else if (o1 == null) {
+            throw new AssertionError(String.format("o1 was null, but o2[%s] was not.", o2));
+        } else if (o2 == null) {
+            throw new AssertionError(String.format("o1[%s] was not null, but o2 was.", o1));
+        }
+        verifyGeneralEqualityProperties(o1, o2);
+
+
+        // the two objects should equal each other
+        if (!o1.equals(o2)) {
+            throw new AssertionError(String.format("o1[%s] was not equal to o2[%s].", o1, o2));
+        }
+
+        if (!o2.equals(o1)) {
+            throw new AssertionError(String.format("o2[%s] was not equal to o1[%s].", o2, o1));
+        }
+
+        verifyHashCodeConsistency(o1, o2);
+
+        // since these objects are equal, their hashcode MUST be the same
+        if (o1.hashCode() != o2.hashCode()) {
+            throw new AssertionError(String.format("o1[%s].hash[%d] was not equal to o2[%s].hash[%d].", o1, o1.hashCode(), o2, o2.hashCode()));
+        }
+    }
+
+    public static <T> void verifyInEquality(final T o1, final T o2) {
+        // making sure we don't get an NPE in the test
+        if (o1 == null && o2 == null) {
+            throw new AssertionError("Both o1 and o2 were null.");
+        } else if (o1 == null) {
+            return;
+        } else if (o2 == null) {
+            return;
+        }
+
+        verifyGeneralEqualityProperties(o1, o2);
+
+        // these two objects should NOT equal each other
+        if (o1.equals(o2)) {
+            throw new AssertionError(String.format("o1[%s] was equal to o2[%s].", o1, o2));
+        }
+
+        if (o2.equals(o1)) {
+            throw new AssertionError(String.format("o2[%s] was not equal to o1[%s].", o2, o1));
+        }
+        verifyHashCodeConsistency(o1, o2);
+
+
+        // since these objects are NOT equal, their hashcode SHOULD PROBABLY not be the same
+        if (o1.hashCode() == o2.hashCode()) {
+            throw new AssertionError(
+                String.format(
+                    "o1[%s].hash[%d] was equal to o2[%s].hash[%d], even though !o1.equals(o2). " +
+                        "This is NOT A BUG, but it is undesirable for hash collection performance.",
+                    o1,
+                    o1.hashCode(),
+                    o2,
+                    o2.hashCode()
+                )
+            );
+        }
+    }
+
+
+    @SuppressWarnings({"EqualsWithItself", "ConstantConditions", "ObjectEqualsNull"})
+    private static <T> void verifyGeneralEqualityProperties(final T o1, final T o2) {
+        // objects should equal themselves
+        if (!o1.equals(o1)) {
+            throw new AssertionError(String.format("o1[%s] was not equal to itself.", o1));
+        }
+
+        if (!o2.equals(o2)) {
+            throw new AssertionError(String.format("o2[%s] was not equal to itself.", o2));
+        }
+
+        // non-null objects should not equal null
+        if (o1.equals(null)) {
+            throw new AssertionError(String.format("o1[%s] was equal to null.", o1));
+        }
+
+        if (o2.equals(null)) {
+            throw new AssertionError(String.format("o2[%s] was equal to null.", o2));
+        }
+
+        // objects should not equal some random object
+        if (o1.equals(new Object())) {
+            throw new AssertionError(String.format("o1[%s] was equal to an anonymous Object.", o1));
+        }
+
+        if (o2.equals(new Object())) {
+            throw new AssertionError(String.format("o2[%s] was equal to an anonymous Object.", o2));
+        }
+    }
+
+
+    private static <T> void verifyHashCodeConsistency(final T o1, final T o2) {
+        {
+            final int first = o1.hashCode();
+            final int second = o1.hashCode();
+            if (first != second) {
+                throw new AssertionError(
+                    String.format(
+                        "o1[%s]'s hashcode was not consistent: [%s]!=[%s].",
+                        o1,
+                        first,
+                        second
+                    )
+                );
+            }
+        }
+
+        {
+            final int first = o2.hashCode();
+            final int second = o2.hashCode();
+            if (first != second) {
+                throw new AssertionError(
+                    String.format(
+                        "o2[%s]'s hashcode was not consistent: [%s]!=[%s].",
+                        o2,
+                        first,
+                        second
+                    )
+                );
+            }
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/EqualityCheck.java
+++ b/streams/src/test/java/org/apache/kafka/streams/EqualityCheck.java
@@ -67,7 +67,7 @@ public final class EqualityCheck {
         }
 
         if (o2.equals(o1)) {
-            throw new AssertionError(String.format("o2[%s] was not equal to o1[%s].", o2, o1));
+            throw new AssertionError(String.format("o2[%s] was equal to o1[%s].", o2, o1));
         }
         verifyHashCodeConsistency(o1, o2);
 
@@ -126,7 +126,7 @@ public final class EqualityCheck {
             if (first != second) {
                 throw new AssertionError(
                     String.format(
-                        "o1[%s]'s hashcode was not consistent: [%s]!=[%s].",
+                        "o1[%s]'s hashcode was not consistent: [%d]!=[%d].",
                         o1,
                         first,
                         second
@@ -141,7 +141,7 @@ public final class EqualityCheck {
             if (first != second) {
                 throw new AssertionError(
                     String.format(
-                        "o2[%s]'s hashcode was not consistent: [%s]!=[%s].",
+                        "o2[%s]'s hashcode was not consistent: [%d]!=[%d].",
                         o2,
                         first,
                         second

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -659,14 +659,17 @@ public class KStreamAggregationIntegrationTest {
                                                                         new KeyValue<>("jo", "pause"),
                                                                         new KeyValue<>("emily", "pause"));
 
+        final Properties producerConfig = TestUtils.producerConfig(
+            CLUSTER.bootstrapServers(),
+            StringSerializer.class,
+            StringSerializer.class,
+            new Properties()
+        );
+
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
             userSessionsStream,
             t1Messages,
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            producerConfig,
             t1);
 
         final long t2 = t1 + incrementTime;
@@ -675,11 +678,7 @@ public class KStreamAggregationIntegrationTest {
             Collections.singletonList(
                 new KeyValue<>("emily", "resume")
             ),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            producerConfig,
             t2);
         final long t3 = t2 + incrementTime;
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
@@ -688,11 +687,7 @@ public class KStreamAggregationIntegrationTest {
                 new KeyValue<>("bob", "pause"),
                 new KeyValue<>("penny", "stop")
             ),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            producerConfig,
             t3);
 
         final long t4 = t3 + incrementTime;
@@ -702,11 +697,7 @@ public class KStreamAggregationIntegrationTest {
                 new KeyValue<>("bob", "resume"), // bobs session continues
                 new KeyValue<>("jo", "resume")   // jo's starts new session
             ),
-            TestUtils.producerConfig(
-                CLUSTER.bootstrapServers(),
-                StringSerializer.class,
-                StringSerializer.class,
-                new Properties()),
+            producerConfig,
             t4);
 
         final Map<Windowed<String>, KeyValue<Long, Long>> results = new HashMap<>();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KStreamAggregationIntegrationTest.java
@@ -49,10 +49,12 @@ import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Transformer;
+import org.apache.kafka.streams.kstream.UnlimitedWindows;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
+import org.apache.kafka.streams.kstream.internals.UnlimitedWindow;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -70,6 +72,7 @@ import org.junit.experimental.categories.Category;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -643,6 +646,102 @@ public class KStreamAggregationIntegrationTest {
         assertThat(bob.next(), equalTo(KeyValue.pair(new Windowed<>("bob", new SessionWindow(t3, t4)), "pause:resume")));
         assertFalse(bob.hasNext());
 
+    }
+
+    @Test
+    public void shouldCountUnlimitedWindows() throws Exception {
+        final long startTime = mockTime.milliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS) + 1;
+        final long incrementTime = Duration.ofDays(1).toMillis();
+
+        final long t1 = mockTime.milliseconds() - TimeUnit.MILLISECONDS.convert(1, TimeUnit.HOURS);
+        final List<KeyValue<String, String>> t1Messages = Arrays.asList(new KeyValue<>("bob", "start"),
+                                                                        new KeyValue<>("penny", "start"),
+                                                                        new KeyValue<>("jo", "pause"),
+                                                                        new KeyValue<>("emily", "pause"));
+
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            userSessionsStream,
+            t1Messages,
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            t1);
+
+        final long t2 = t1 + incrementTime;
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            userSessionsStream,
+            Collections.singletonList(
+                new KeyValue<>("emily", "resume")
+            ),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            t2);
+        final long t3 = t2 + incrementTime;
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            userSessionsStream,
+            Arrays.asList(
+                new KeyValue<>("bob", "pause"),
+                new KeyValue<>("penny", "stop")
+            ),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            t3);
+
+        final long t4 = t3 + incrementTime;
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(
+            userSessionsStream,
+            Arrays.asList(
+                new KeyValue<>("bob", "resume"), // bobs session continues
+                new KeyValue<>("jo", "resume")   // jo's starts new session
+            ),
+            TestUtils.producerConfig(
+                CLUSTER.bootstrapServers(),
+                StringSerializer.class,
+                StringSerializer.class,
+                new Properties()),
+            t4);
+
+        final Map<Windowed<String>, KeyValue<Long, Long>> results = new HashMap<>();
+        final CountDownLatch latch = new CountDownLatch(5);
+
+        builder.stream(userSessionsStream, Consumed.with(Serdes.String(), Serdes.String()))
+               .groupByKey(Serialized.with(Serdes.String(), Serdes.String()))
+               .windowedBy(UnlimitedWindows.of().startOn(startTime))
+               .count()
+               .toStream()
+               .transform(() -> new Transformer<Windowed<String>, Long, KeyValue<Object, Object>>() {
+                   private ProcessorContext context;
+
+                   @Override
+                   public void init(final ProcessorContext context) {
+                       this.context = context;
+                   }
+
+                   @Override
+                   public KeyValue<Object, Object> transform(final Windowed<String> key, final Long value) {
+                       results.put(key, KeyValue.pair(value, context.timestamp()));
+                       latch.countDown();
+                       return null;
+                   }
+
+                   @Override
+                   public void close() {}
+               });
+
+        startStreams();
+        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        assertThat(results.get(new Windowed<>("bob", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(2L, t4)));
+        assertThat(results.get(new Windowed<>("penny", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(1L, t3)));
+        assertThat(results.get(new Windowed<>("jo", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(1L, t4)));
+        assertThat(results.get(new Windowed<>("emily", new UnlimitedWindow(startTime))), equalTo(KeyValue.pair(1L, t2)));
     }
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.kafka.streams.kstream;
 
-import org.apache.kafka.streams.EqualityCheck;
 import org.junit.Test;
 
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/JoinWindowsTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.kafka.streams.kstream;
 
+import org.apache.kafka.streams.EqualityCheck;
 import org.junit.Test;
 
+import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
+import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -105,92 +108,58 @@ public class JoinWindowsTest {
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        assertEquals(JoinWindows.of(3), JoinWindows.of(3));
-        assertEquals(JoinWindows.of(3).hashCode(), JoinWindows.of(3).hashCode());
+        verifyEquality(JoinWindows.of(3), JoinWindows.of(3));
 
-        assertEquals(JoinWindows.of(3).after(2), JoinWindows.of(3).after(2));
-        assertEquals(JoinWindows.of(3).after(2).hashCode(), JoinWindows.of(3).after(2).hashCode());
+        verifyEquality(JoinWindows.of(3).after(2), JoinWindows.of(3).after(2));
 
-        assertEquals(JoinWindows.of(3).before(2), JoinWindows.of(3).before(2));
-        assertEquals(JoinWindows.of(3).before(2).hashCode(), JoinWindows.of(3).before(2).hashCode());
+        verifyEquality(JoinWindows.of(3).before(2), JoinWindows.of(3).before(2));
 
-        assertEquals(JoinWindows.of(3).grace(2), JoinWindows.of(3).grace(2));
-        assertEquals(JoinWindows.of(3).grace(2).hashCode(), JoinWindows.of(3).grace(2).hashCode());
+        verifyEquality(JoinWindows.of(3).grace(2), JoinWindows.of(3).grace(2));
 
-        assertEquals(JoinWindows.of(3).until(60), JoinWindows.of(3).until(60));
-        assertEquals(JoinWindows.of(3).until(60).hashCode(), JoinWindows.of(3).until(60).hashCode());
+        verifyEquality(JoinWindows.of(3).until(60), JoinWindows.of(3).until(60));
 
-        assertEquals(
+        verifyEquality(
             JoinWindows.of(3).before(1).after(2).grace(3).until(60),
             JoinWindows.of(3).before(1).after(2).grace(3).until(60)
         );
-        assertEquals(
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode(),
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode()
-        );
         // JoinWindows is a little weird in that before and after set the same fields as of.
-        assertEquals(
+        verifyEquality(
             JoinWindows.of(9).before(1).after(2).grace(3).until(60),
             JoinWindows.of(3).before(1).after(2).grace(3).until(60)
-        );
-        assertEquals(
-            JoinWindows.of(9).before(1).after(2).grace(3).until(60).hashCode(),
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode()
         );
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForNegativeCases() {
-        assertNotEquals(JoinWindows.of(9), JoinWindows.of(3));
-        assertNotEquals(JoinWindows.of(9).hashCode(), JoinWindows.of(3).hashCode());
+        verifyInEquality(JoinWindows.of(9), JoinWindows.of(3));
 
-        assertNotEquals(JoinWindows.of(3).after(9), JoinWindows.of(3).after(2));
-        assertNotEquals(JoinWindows.of(3).after(9).hashCode(), JoinWindows.of(3).after(2).hashCode());
+        verifyInEquality(JoinWindows.of(3).after(9), JoinWindows.of(3).after(2));
 
-        assertNotEquals(JoinWindows.of(3).before(9), JoinWindows.of(3).before(2));
-        assertNotEquals(JoinWindows.of(3).before(9).hashCode(), JoinWindows.of(3).before(2).hashCode());
+        verifyInEquality(JoinWindows.of(3).before(9), JoinWindows.of(3).before(2));
 
-        assertNotEquals(JoinWindows.of(3).grace(9), JoinWindows.of(3).grace(2));
-        assertNotEquals(JoinWindows.of(3).grace(9).hashCode(), JoinWindows.of(3).grace(2).hashCode());
+        verifyInEquality(JoinWindows.of(3).grace(9), JoinWindows.of(3).grace(2));
 
-        assertNotEquals(JoinWindows.of(3).until(90), JoinWindows.of(3).until(60));
-        assertNotEquals(JoinWindows.of(3).until(90).hashCode(), JoinWindows.of(3).until(60).hashCode());
+        verifyInEquality(JoinWindows.of(3).until(90), JoinWindows.of(3).until(60));
 
 
-        assertNotEquals(
+        verifyInEquality(
             JoinWindows.of(3).before(9).after(2).grace(3).until(60),
             JoinWindows.of(3).before(1).after(2).grace(3).until(60)
         );
-        assertNotEquals(
-            JoinWindows.of(3).before(9).after(2).grace(3).until(60).hashCode(),
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode()
-        );
 
-        assertNotEquals(
+        verifyInEquality(
             JoinWindows.of(3).before(1).after(9).grace(3).until(60),
             JoinWindows.of(3).before(1).after(2).grace(3).until(60)
         );
-        assertNotEquals(
-            JoinWindows.of(3).before(1).after(9).grace(3).until(60).hashCode(),
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode()
-        );
 
-        assertNotEquals(
+        verifyInEquality(
             JoinWindows.of(3).before(1).after(2).grace(9).until(60),
             JoinWindows.of(3).before(1).after(2).grace(3).until(60)
         );
-        assertNotEquals(
-            JoinWindows.of(3).before(1).after(2).grace(9).until(60).hashCode(),
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode()
-        );
 
-        assertNotEquals(
+        verifyInEquality(
             JoinWindows.of(3).before(1).after(2).grace(3).until(90),
             JoinWindows.of(3).before(1).after(2).grace(3).until(60)
-        );
-        assertNotEquals(
-            JoinWindows.of(3).before(1).after(2).grace(3).until(90).hashCode(),
-            JoinWindows.of(3).before(1).after(2).grace(3).until(60).hashCode()
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
+import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
+import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -81,38 +83,27 @@ public class SessionWindowsTest {
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        assertEquals(SessionWindows.with(1), SessionWindows.with(1));
-        assertEquals(SessionWindows.with(1).hashCode(), SessionWindows.with(1).hashCode());
+        verifyEquality(SessionWindows.with(1), SessionWindows.with(1));
 
-        assertEquals(SessionWindows.with(1).grace(6), SessionWindows.with(1).grace(6));
-        assertEquals(SessionWindows.with(1).grace(6).hashCode(), SessionWindows.with(1).grace(6).hashCode());
+        verifyEquality(SessionWindows.with(1).grace(6), SessionWindows.with(1).grace(6));
 
-        assertEquals(SessionWindows.with(1).until(7), SessionWindows.with(1).until(7));
-        assertEquals(SessionWindows.with(1).until(7).hashCode(), SessionWindows.with(1).until(7).hashCode());
+        verifyEquality(SessionWindows.with(1).until(7), SessionWindows.with(1).until(7));
 
-        assertEquals(SessionWindows.with(1).grace(6).until(7), SessionWindows.with(1).grace(6).until(7));
-        assertEquals(SessionWindows.with(1).grace(6).until(7).hashCode(), SessionWindows.with(1).grace(6).until(7).hashCode());
+        verifyEquality(SessionWindows.with(1).grace(6).until(7), SessionWindows.with(1).grace(6).until(7));
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForNegativeCases() {
-        assertNotEquals(SessionWindows.with(9), SessionWindows.with(1));
-        assertNotEquals(SessionWindows.with(9).hashCode(), SessionWindows.with(1).hashCode());
+        verifyInEquality(SessionWindows.with(9), SessionWindows.with(1));
 
-        assertNotEquals(SessionWindows.with(1).grace(9), SessionWindows.with(1).grace(6));
-        assertNotEquals(SessionWindows.with(1).grace(9).hashCode(), SessionWindows.with(1).grace(6).hashCode());
+        verifyInEquality(SessionWindows.with(1).grace(9), SessionWindows.with(1).grace(6));
 
-        assertNotEquals(SessionWindows.with(1).until(9), SessionWindows.with(1).until(7));
-        assertNotEquals(SessionWindows.with(1).until(9).hashCode(), SessionWindows.with(1).until(7).hashCode());
+        verifyInEquality(SessionWindows.with(1).until(9), SessionWindows.with(1).until(7));
 
+        verifyInEquality(SessionWindows.with(2).grace(6).until(7), SessionWindows.with(1).grace(6).until(7));
 
-        assertNotEquals(SessionWindows.with(2).grace(6).until(7), SessionWindows.with(1).grace(6).until(7));
-        assertNotEquals(SessionWindows.with(2).grace(6).until(7).hashCode(), SessionWindows.with(1).grace(6).until(7).hashCode());
+        verifyInEquality(SessionWindows.with(1).grace(0).until(7), SessionWindows.with(1).grace(6).until(7));
 
-        assertNotEquals(SessionWindows.with(1).grace(0).until(7), SessionWindows.with(1).grace(6).until(7));
-        assertNotEquals(SessionWindows.with(1).grace(0).until(7).hashCode(), SessionWindows.with(1).grace(6).until(7).hashCode());
-
-        assertNotEquals(SessionWindows.with(1).grace(6).until(70), SessionWindows.with(1).grace(6).until(7));
-        assertNotEquals(SessionWindows.with(1).grace(6).until(70).hashCode(), SessionWindows.with(1).grace(6).until(7).hashCode());
+        verifyInEquality(SessionWindows.with(1).grace(6).until(70), SessionWindows.with(1).grace(6).until(7));
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SessionWindowsTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 public class SessionWindowsTest {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/TimeWindowsTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
+import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -150,77 +152,49 @@ public class TimeWindowsTest {
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        assertEquals(TimeWindows.of(3), TimeWindows.of(3));
-        assertEquals(TimeWindows.of(3).hashCode(), TimeWindows.of(3).hashCode());
+        verifyEquality(TimeWindows.of(3), TimeWindows.of(3));
 
-        assertEquals(TimeWindows.of(3).advanceBy(1), TimeWindows.of(3).advanceBy(1));
-        assertEquals(TimeWindows.of(3).advanceBy(1).hashCode(), TimeWindows.of(3).advanceBy(1).hashCode());
+        verifyEquality(TimeWindows.of(3).advanceBy(1), TimeWindows.of(3).advanceBy(1));
 
-        assertEquals(TimeWindows.of(3).grace(1), TimeWindows.of(3).grace(1));
-        assertEquals(TimeWindows.of(3).grace(1).hashCode(), TimeWindows.of(3).grace(1).hashCode());
+        verifyEquality(TimeWindows.of(3).grace(1), TimeWindows.of(3).grace(1));
 
-        assertEquals(TimeWindows.of(3).until(4), TimeWindows.of(3).until(4));
-        assertEquals(TimeWindows.of(3).until(4).hashCode(), TimeWindows.of(3).until(4).hashCode());
+        verifyEquality(TimeWindows.of(3).until(4), TimeWindows.of(3).until(4));
 
-        assertEquals(
+        verifyEquality(
             TimeWindows.of(3).advanceBy(1).grace(1).until(4),
             TimeWindows.of(3).advanceBy(1).grace(1).until(4)
-        );
-        assertEquals(
-            TimeWindows.of(3).advanceBy(1).grace(1).until(4).hashCode(),
-            TimeWindows.of(3).advanceBy(1).grace(1).until(4).hashCode()
         );
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForNegativeCases() {
-        assertNotEquals(TimeWindows.of(9), TimeWindows.of(3));
-        assertNotEquals(TimeWindows.of(9).hashCode(), TimeWindows.of(3).hashCode());
+        verifyInEquality(TimeWindows.of(9), TimeWindows.of(3));
 
-        assertNotEquals(TimeWindows.of(3).advanceBy(2), TimeWindows.of(3).advanceBy(1));
-        assertNotEquals(TimeWindows.of(3).advanceBy(2).hashCode(), TimeWindows.of(3).advanceBy(1).hashCode());
+        verifyInEquality(TimeWindows.of(3).advanceBy(2), TimeWindows.of(3).advanceBy(1));
 
-        assertNotEquals(TimeWindows.of(3).grace(2), TimeWindows.of(3).grace(1));
-        assertNotEquals(TimeWindows.of(3).grace(2).hashCode(), TimeWindows.of(3).grace(1).hashCode());
+        verifyInEquality(TimeWindows.of(3).grace(2), TimeWindows.of(3).grace(1));
 
-        assertNotEquals(TimeWindows.of(3).until(9), TimeWindows.of(3).until(4));
-        assertNotEquals(TimeWindows.of(3).until(9).hashCode(), TimeWindows.of(3).until(4).hashCode());
+        verifyInEquality(TimeWindows.of(3).until(9), TimeWindows.of(3).until(4));
 
 
-        assertNotEquals(
+        verifyInEquality(
             TimeWindows.of(4).advanceBy(2).grace(2).until(4),
             TimeWindows.of(3).advanceBy(2).grace(2).until(4)
         );
-        assertNotEquals(
-            TimeWindows.of(4).advanceBy(2).grace(2).until(4).hashCode(),
-            TimeWindows.of(3).advanceBy(2).grace(2).until(4).hashCode()
-        );
 
-        assertNotEquals(
+        verifyInEquality(
             TimeWindows.of(3).advanceBy(1).grace(2).until(4),
             TimeWindows.of(3).advanceBy(2).grace(2).until(4)
-        );
-        assertNotEquals(
-            TimeWindows.of(3).advanceBy(1).grace(2).until(4).hashCode(),
-            TimeWindows.of(3).advanceBy(2).grace(2).until(4).hashCode()
         );
 
         assertNotEquals(
             TimeWindows.of(3).advanceBy(2).grace(1).until(4),
             TimeWindows.of(3).advanceBy(2).grace(2).until(4)
         );
-        assertNotEquals(
-            TimeWindows.of(3).advanceBy(2).grace(1).until(4).hashCode(),
-            TimeWindows.of(3).advanceBy(2).grace(2).until(4).hashCode()
-        );
 
         assertNotEquals(
             TimeWindows.of(3).advanceBy(2).grace(2).until(9),
             TimeWindows.of(3).advanceBy(2).grace(2).until(4)
-        );
-        assertNotEquals(
-            TimeWindows.of(3).advanceBy(2).grace(2).until(9).hashCode(),
-            TimeWindows.of(3).advanceBy(2).grace(2).until(4).hashCode()
         );
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
+import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -78,18 +80,15 @@ public class UnlimitedWindowsTest {
 
     @Test
     public void equalsAndHashcodeShouldBeValidForPositiveCases() {
-        assertEquals(UnlimitedWindows.of(), UnlimitedWindows.of());
-        assertEquals(UnlimitedWindows.of().hashCode(), UnlimitedWindows.of().hashCode());
+        verifyEquality(UnlimitedWindows.of(), UnlimitedWindows.of());
 
-        assertEquals(UnlimitedWindows.of().startOn(1), UnlimitedWindows.of().startOn(1));
-        assertEquals(UnlimitedWindows.of().startOn(1).hashCode(), UnlimitedWindows.of().startOn(1).hashCode());
+        verifyEquality(UnlimitedWindows.of().startOn(1), UnlimitedWindows.of().startOn(1));
 
     }
 
     @Test
     public void equalsAndHashcodeShouldBeValidForNegativeCases() {
-        assertNotEquals(UnlimitedWindows.of().startOn(9), UnlimitedWindows.of().startOn(1));
-        assertNotEquals(UnlimitedWindows.of().startOn(9).hashCode(), UnlimitedWindows.of().startOn(1).hashCode());
+        verifyInEquality(UnlimitedWindows.of().startOn(9), UnlimitedWindows.of().startOn(1));
     }
 
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
@@ -52,16 +52,6 @@ public class UnlimitedWindowsTest {
     }
 
     @Test
-    public void gracePeriodShouldNotBeSettable() {
-        try {
-            UnlimitedWindows.of().grace(0L);
-            fail("should not be able to set grace period");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
-    }
-
-    @Test
     public void shouldIncludeRecordsThatHappenedOnWindowStart() {
         final UnlimitedWindows w = UnlimitedWindows.of().startOn(anyStartTime);
         final Map<Long, UnlimitedWindow> matchedWindows = w.windowsFor(w.startMs);

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/UnlimitedWindowsTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import static org.apache.kafka.streams.EqualityCheck.verifyEquality;
 import static org.apache.kafka.streams.EqualityCheck.verifyInEquality;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
@@ -18,7 +18,6 @@ package org.apache.kafka.streams.kstream;
 
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -26,9 +25,6 @@ import static org.junit.Assert.assertEquals;
 public class WindowsTest {
 
     private class TestWindows extends Windows {
-
-        private Duration grace;
-
         @Override
         public Map windowsFor(final long timestamp) {
             return null;

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
@@ -40,37 +40,8 @@ public class WindowsTest {
             return 0;
         }
 
-        /**
-         * Reject late events that arrive more than {@code millisAfterWindowEnd}
-         * after the end of its window.
-         *
-         * Lateness is defined as (stream_time - record_timestamp).
-         *
-         * @param millisAfterWindowEnd The grace period to admit late-arriving events to a window.
-         * @return this updated builder
-         */
-        public Windows grace(final long millisAfterWindowEnd) {
-            if (millisAfterWindowEnd < 0) {
-                throw new IllegalArgumentException("Grace period must not be negative.");
-            }
-
-            grace = Duration.ofMillis(millisAfterWindowEnd);
-
-            return this;
-        }
-
-        /**
-         * Return the window grace period (the time to admit
-         * late-arriving events after the end of the window.)
-         *
-         * Lateness is defined as (stream_time - record_timestamp).
-         */
-        @SuppressWarnings("deprecation") // continuing to support Windows#maintainMs/segmentInterval in fallback mode
         public long gracePeriodMs() {
-            // NOTE: in the future, when we remove maintainMs,
-            // we should default the grace period to 24h to maintain the default behavior,
-            // or we can default to (24h - size) if you want to be super accurate.
-            return grace != null ? grace.toMillis() : maintainMs() - size();
+            return 0L;
         }
     }
 
@@ -92,19 +63,6 @@ public class WindowsTest {
     public void shouldSetWindowRetentionTime() {
         final int anyNotNegativeRetentionTime = 42;
         assertEquals(anyNotNegativeRetentionTime, new TestWindows().until(anyNotNegativeRetentionTime).maintainMs());
-    }
-
-
-    @Test
-    public void gracePeriodShouldEnforceBoundaries() {
-        new TestWindows().grace(0L);
-
-        try {
-            new TestWindows().grace(-1L);
-            fail("should not accept negatives");
-        } catch (final IllegalArgumentException e) {
-            //expected
-        }
     }
 
     @SuppressWarnings("deprecation") // specifically testing deprecated APIs

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/WindowsTest.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class WindowsTest {
 


### PR DESCRIPTION
In #5510, I added an unsafe (but probably fine in practice) equals/hashCode to the Windows hierarchy.

I believe that this approach is better since:
* It includes no non-deprecated mutable state in equals/hashCode
* It avoids the subclass-return-type builder issues
* It restricts the public interface to only the things that need to be known about all Windows. That is, all Windows need to offer a `gracePeriodMs()`. They do *not* all need to offer a builder method to set it. See `UnlimitedWindows`, for which "grace period" is nonsense. It does not need to allow setting it, and it can return `0`, which is always correct. In contrast, consider `UnlimitedWindows#until(long)`, which has to throw a runtime exception because the interface unnecessarily requires this method to be implemented.

In general, this PR sets a direction in which, once we drop the deprecated members from `Windows`, all the members will be abstract, and `Windows` itself will basically be an interface, which offers a much cleaner and more consistent implementation target.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
