### PR TITLE
MINOR: only split at first occurrence of '='

### DIFF
--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -217,7 +217,7 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
         config_template = self.render('kafka.properties', node=node, broker_id=self.idx(node),
                                  security_config=self.security_config, num_nodes=self.num_nodes)
 
-        configs = dict( l.rstrip().split('=') for l in config_template.split('\n')
+        configs = dict( l.rstrip().split('=', 1) for l in config_template.split('\n')
                         if not l.startswith("#") and "=" in l )
 
         #load specific test override configs


### PR DESCRIPTION
This is a fix to #5226 to account for config properties that have an
equal char in the value.   Otherwise if there is one
equal char in the value the following error occurs:
```
dictionary update sequence element #XX has length 3; 2 is required
```



### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
