### PR TITLE
Get state store from Materialized

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -38,7 +38,9 @@ import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.StateStore;
@@ -1033,6 +1035,11 @@ public class KafkaStreams {
     public <T> T store(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         validateIsRunning();
         return queryableStoreProvider.getStore(storeName, queryableStoreType);
+    }
+
+    public <K, V, S extends StateStore> S store(final Materialized<K, V, S> materializedStore) {
+        validateIsRunning();
+        return new MaterializedInternal<>(materializedStore).storeSupplier().get();
     }
 
     /**

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/QueryableStoreProvider.java
@@ -50,7 +50,7 @@ public class QueryableStoreProvider {
     public <T> T getStore(final String storeName, final QueryableStoreType<T> queryableStoreType) {
         final List<T> globalStore = globalStoreProvider.stores(storeName, queryableStoreType);
         if (!globalStore.isEmpty()) {
-            return queryableStoreType.create(new WrappingStoreProvider(Collections.<StateStoreProvider>singletonList(globalStoreProvider)), storeName);
+            return queryableStoreType.create(new WrappingStoreProvider(Collections.singletonList(globalStoreProvider)), storeName);
         }
         final List<T> allStores = new ArrayList<>();
         for (final StateStoreProvider storeProvider : storeProviders) {

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/KTableTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/KTableTest.scala
@@ -136,7 +136,7 @@ class KTableTest extends FlatSpec with Matchers with TestDriver {
     testDriver.pipeRecord(sourceTopic1, ("1", "topic1value1"))
     testDriver.pipeRecord(sourceTopic2, ("1", "topic2value1"))
     testDriver.readRecord[String, Long](sinkTopic).value shouldBe 2
-    testDriver.getKeyValueStore[String, Long](stateStore).get("1") shouldBe 2
+    testDriver.getKeyValueStore(materialized).get("1") shouldBe 2
 
     testDriver.readRecord[String, Long](sinkTopic) shouldBe null
 

--- a/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
+++ b/streams/test-utils/src/main/java/org/apache/kafka/streams/TopologyTestDriver.java
@@ -38,6 +38,8 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.TopologyException;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.Punctuator;
@@ -598,6 +600,10 @@ public class TopologyTestDriver implements Closeable {
         return null;
     }
 
+    public StateStore getStateStore(final Materialized<?, ?, ?> materialized) {
+        return getStateStore(new MaterializedInternal<>(materialized).storeName());
+    }
+
     /**
      * Get the {@link KeyValueStore} with the given name.
      * The store can be a "regular" or global store.
@@ -616,6 +622,10 @@ public class TopologyTestDriver implements Closeable {
     public <K, V> KeyValueStore<K, V> getKeyValueStore(final String name) {
         final StateStore store = getStateStore(name);
         return store instanceof KeyValueStore ? (KeyValueStore<K, V>) store : null;
+    }
+
+    public <K, V> KeyValueStore<K, V> getKeyValueStore(final Materialized<K, V, ?> materialized) {
+        return getKeyValueStore(new MaterializedInternal<>(materialized).storeName());
     }
 
     /**
@@ -638,6 +648,10 @@ public class TopologyTestDriver implements Closeable {
         return store instanceof WindowStore ? (WindowStore<K, V>) store : null;
     }
 
+    public <K, V> WindowStore<K, V> getWindowStore(final Materialized<K, V, ?> materialized) {
+        return getWindowStore(new MaterializedInternal<>(materialized).storeName());
+    }
+
     /**
      * Get the {@link SessionStore} with the given name.
      * The store can be a "regular" or global store.
@@ -656,6 +670,9 @@ public class TopologyTestDriver implements Closeable {
     public <K, V> SessionStore<K, V> getSessionStore(final String name) {
         final StateStore store = getStateStore(name);
         return store instanceof SessionStore ? (SessionStore<K, V>) store : null;
+    }
+    public <K, V> SessionStore<K, V> getSessionStore(final Materialized<K, V, ?> materialized) {
+        return getSessionStore(new MaterializedInternal<>(materialized).storeName());
     }
 
     /**


### PR DESCRIPTION
So I have this use case I'm not too sure how to address:
```scala
val stateStore = "store"
val materialized = Materialized.as[String, Long, ByteArrayKeyValueStore](stateStore)
...
table1.join(table2, materialized)((a, b) => a + b)

val testDriver = createTestDriver(builder)
...
testDriver.getKeyValueStore[String, Long](stateStore).get("1") shouldBe 2
```

To me it sounds like we should be able to get the store from/with the `Materialized` object. It's much better typed than a `String`:
```scala
val materialized = Materialized.as[String, Long, ByteArrayKeyValueStore](stateStore)
...
table1.join(table2, materialized)((a, b) => a + b)

val testDriver = createTestDriver(builder)
...
testDriver.getKeyValueStore(materialized).get("1") shouldBe 2
```

I'm not sure if that's the way to do it exactly so feel free to comment.