### PR TITLE
KAFKA-7324: NPE due to lack of SASLExtensions in SASL/OAUTHBEARER

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/auth/SaslExtensions.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/SaslExtensions.java
@@ -24,6 +24,10 @@ import java.util.Map;
  * A simple immutable value object class holding customizable SASL extensions
  */
 public class SaslExtensions {
+    /**
+     * An "empty" instance indicating no SASL extensions
+     */
+    public static final SaslExtensions NO_SASL_EXTENSIONS = new SaslExtensions(Collections.emptyMap());
     private final Map<String, String> extensionsMap;
 
     public SaslExtensions(Map<String, String> extensionsMap) {

--- a/clients/src/main/java/org/apache/kafka/common/security/auth/SaslExtensionsCallback.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/auth/SaslExtensionsCallback.java
@@ -17,6 +17,8 @@
 
 package org.apache.kafka.common.security.auth;
 
+import java.util.Objects;
+
 import javax.security.auth.callback.Callback;
 
 /**
@@ -24,11 +26,14 @@ import javax.security.auth.callback.Callback;
  * in the SASL exchange.
  */
 public class SaslExtensionsCallback implements Callback {
-    private SaslExtensions extensions;
+    private SaslExtensions extensions = SaslExtensions.NO_SASL_EXTENSIONS;
 
     /**
-     * Returns a {@link SaslExtensions} consisting of the extension names and values that are sent by the client to
-     * the server in the initial client SASL authentication message.
+     * Returns always non-null {@link SaslExtensions} consisting of the extension
+     * names and values that are sent by the client to the server in the initial
+     * client SASL authentication message. The default value is
+     * {@link SaslExtensions#NO_SASL_EXTENSIONS} so that if this callback is
+     * unhandled the client will see a non-null value.
      */
     public SaslExtensions extensions() {
         return extensions;
@@ -36,8 +41,11 @@ public class SaslExtensionsCallback implements Callback {
 
     /**
      * Sets the SASL extensions on this callback.
+     * 
+     * @param extensions
+     *            the mandatory extensions to set
      */
     public void extensions(SaslExtensions extensions) {
-        this.extensions = extensions;
+        this.extensions = Objects.requireNonNull(extensions, "extensions must not be null");
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
@@ -23,6 +23,7 @@ import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -74,16 +75,47 @@ public class OAuthBearerClientInitialResponse {
         this.tokenValue = authMatcher.group("token");
     }
 
+    /**
+     * Constructor
+     * 
+     * @param tokenValue
+     *            the mandatory token value
+     * @param extensions
+     *            the optional extensions
+     * @throws SaslException
+     *             if any extension name or value fails to conform to the required
+     *             regular expression as defined by the specification, or if the
+     *             reserved {@code auth} appears as a key
+     */
     public OAuthBearerClientInitialResponse(String tokenValue, SaslExtensions extensions) throws SaslException {
         this(tokenValue, "", extensions);
     }
 
+    /**
+     * Constructor
+     * 
+     * @param tokenValue
+     *            the mandatory token value
+     * @param authorizationId
+     *            the optional authorization ID
+     * @param extensions
+     *            the optional extensions
+     * @throws SaslException
+     *             if any extension name or value fails to conform to the required
+     *             regular expression as defined by the specification, or if the
+     *             reserved {@code auth} appears as a key
+     */
     public OAuthBearerClientInitialResponse(String tokenValue, String authorizationId, SaslExtensions extensions) throws SaslException {
-        this.tokenValue = tokenValue;
+        this.tokenValue = Objects.requireNonNull(tokenValue, "token value must not be null");
         this.authorizationId = authorizationId == null ? "" : authorizationId;
-        this.saslExtensions = extensions != null ? validateExtensions(extensions) : NO_SASL_EXTENSIONS;
+        this.saslExtensions = validateExtensions(extensions);
     }
 
+    /**
+     * Return the always non-null extensions
+     * 
+     * @return the always non-null extensions
+     */
     public SaslExtensions extensions() {
         return saslExtensions;
     }
@@ -100,10 +132,20 @@ public class OAuthBearerClientInitialResponse {
         return message.getBytes(StandardCharsets.UTF_8);
     }
 
+    /**
+     * Return the always non-null token value
+     * 
+     * @return the always non-null toklen value
+     */
     public String tokenValue() {
         return tokenValue;
     }
 
+    /**
+     * Return the always non-null authorization ID
+     * 
+     * @return the always non-null authorization ID
+     */
     public String authorizationId() {
         return authorizationId;
     }
@@ -111,10 +153,20 @@ public class OAuthBearerClientInitialResponse {
     /**
      * Validates that the given extensions conform to the standard. They should also not contain the reserve key name {@link OAuthBearerClientInitialResponse#AUTH_KEY}
      *
+     * @param extensions
+     *            optional extensions to validate
+     * @return always non-null (potentially empty) extensions
+     * @throws SaslException
+     *             if any extension name or value fails to conform to the required
+     *             regular expression as defined by the specification, or if the
+     *             reserved {@code auth} appears as a key
+     *
      * @see <a href="https://tools.ietf.org/html/rfc7628#section-3.1">RFC 7628,
      *  Section 3.1</a>
      */
     public static SaslExtensions validateExtensions(SaslExtensions extensions) throws SaslException {
+        if (extensions == null)
+            return NO_SASL_EXTENSIONS;
         if (extensions.map().containsKey(OAuthBearerClientInitialResponse.AUTH_KEY))
             throw new SaslException("Extension name " + OAuthBearerClientInitialResponse.AUTH_KEY + " is invalid");
 

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
@@ -21,15 +21,12 @@ import org.apache.kafka.common.utils.Utils;
 
 import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class OAuthBearerClientInitialResponse {
-    private static final SaslExtensions NO_SASL_EXTENSIONS = new SaslExtensions(Collections.emptyMap());
-
     static final String SEPARATOR = "\u0001";
 
     private static final String SASLNAME = "(?:[\\x01-\\x7F&&[^=,]]|=2C|=3D)+";
@@ -111,7 +108,7 @@ public class OAuthBearerClientInitialResponse {
         this.tokenValue = Objects.requireNonNull(tokenValue, "token value must not be null");
         this.authorizationId = authorizationId == null ? "" : authorizationId;
         validateExtensions(extensions);
-        this.saslExtensions = extensions != null ? extensions : NO_SASL_EXTENSIONS;
+        this.saslExtensions = extensions != null ? extensions : SaslExtensions.NO_SASL_EXTENSIONS;
     }
 
     /**
@@ -158,7 +155,6 @@ public class OAuthBearerClientInitialResponse {
      *
      * @param extensions
      *            optional extensions to validate
-     * @return always non-null (potentially empty) extensions
      * @throws SaslException
      *             if any extension name or value fails to conform to the required
      *             regular expression as defined by the specification, or if the

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
@@ -21,11 +21,14 @@ import org.apache.kafka.common.utils.Utils;
 
 import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class OAuthBearerClientInitialResponse {
+    private static final SaslExtensions NO_SASL_EXTENSIONS = new SaslExtensions(Collections.emptyMap());
+
     static final String SEPARATOR = "\u0001";
 
     private static final String SASLNAME = "(?:[\\x01-\\x7F&&[^=,]]|=2C|=3D)+";
@@ -78,7 +81,7 @@ public class OAuthBearerClientInitialResponse {
     public OAuthBearerClientInitialResponse(String tokenValue, String authorizationId, SaslExtensions extensions) throws SaslException {
         this.tokenValue = tokenValue;
         this.authorizationId = authorizationId == null ? "" : authorizationId;
-        this.saslExtensions = validateExtensions(extensions);
+        this.saslExtensions = extensions != null ? validateExtensions(extensions) : NO_SASL_EXTENSIONS;
     }
 
     public SaslExtensions extensions() {

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponse.java
@@ -62,7 +62,9 @@ public class OAuthBearerClientInitialResponse {
         if (auth == null)
             throw new SaslException("Invalid OAUTHBEARER client first message: 'auth' not specified");
         properties.remove(AUTH_KEY);
-        this.saslExtensions = validateExtensions(new SaslExtensions(properties));
+        SaslExtensions extensions = new SaslExtensions(properties);
+        validateExtensions(extensions);
+        this.saslExtensions = extensions;
 
         Matcher authMatcher = AUTH_PATTERN.matcher(auth);
         if (!authMatcher.matches())
@@ -108,7 +110,8 @@ public class OAuthBearerClientInitialResponse {
     public OAuthBearerClientInitialResponse(String tokenValue, String authorizationId, SaslExtensions extensions) throws SaslException {
         this.tokenValue = Objects.requireNonNull(tokenValue, "token value must not be null");
         this.authorizationId = authorizationId == null ? "" : authorizationId;
-        this.saslExtensions = validateExtensions(extensions);
+        validateExtensions(extensions);
+        this.saslExtensions = extensions != null ? extensions : NO_SASL_EXTENSIONS;
     }
 
     /**
@@ -164,9 +167,9 @@ public class OAuthBearerClientInitialResponse {
      * @see <a href="https://tools.ietf.org/html/rfc7628#section-3.1">RFC 7628,
      *  Section 3.1</a>
      */
-    public static SaslExtensions validateExtensions(SaslExtensions extensions) throws SaslException {
+    public static void validateExtensions(SaslExtensions extensions) throws SaslException {
         if (extensions == null)
-            return NO_SASL_EXTENSIONS;
+            return;
         if (extensions.map().containsKey(OAuthBearerClientInitialResponse.AUTH_KEY))
             throw new SaslException("Extension name " + OAuthBearerClientInitialResponse.AUTH_KEY + " is invalid");
 
@@ -179,7 +182,6 @@ public class OAuthBearerClientInitialResponse {
             if (!EXTENSION_VALUE_PATTERN.matcher(extensionValue).matches())
                 throw new SaslException("Extension value (" + extensionValue + ") for extension " + extensionName + " is invalid");
         }
-        return extensions;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.security.oauthbearer.internals;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.kafka.common.security.auth.SaslExtensions;
 import org.junit.Test;
@@ -98,5 +99,21 @@ public class OAuthBearerClientInitialResponseTest {
         assertEquals("user@example.com", response.authorizationId());
         assertEquals("server.example.com", response.extensions().map().get("host"));
         assertEquals("143", response.extensions().map().get("port"));
+    }
+
+    @Test
+    public void testNoExtensionsFromByteArray() throws Exception {
+        String message = "n,a=user@example.com,\u0001" +
+                "auth=Bearer vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg\u0001\u0001";
+        OAuthBearerClientInitialResponse response = new OAuthBearerClientInitialResponse(message.getBytes(StandardCharsets.UTF_8));
+        assertEquals("vF9dft4qmTc2Nvb3RlckBhbHRhdmlzdGEuY29tCg", response.tokenValue());
+        assertEquals("user@example.com", response.authorizationId());
+        assertTrue(response.extensions().map().isEmpty());
+    }
+
+    @Test
+    public void testNoExtensionsFromTokenAndNullExtensions() throws Exception {
+        OAuthBearerClientInitialResponse response = new OAuthBearerClientInitialResponse("token", null);
+        assertTrue(response.extensions().map().isEmpty());
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -115,5 +116,11 @@ public class OAuthBearerClientInitialResponseTest {
     public void testNoExtensionsFromTokenAndNullExtensions() throws Exception {
         OAuthBearerClientInitialResponse response = new OAuthBearerClientInitialResponse("token", null);
         assertTrue(response.extensions().map().isEmpty());
+    }
+
+    @Test
+    public void testValidateNullExtensions() throws Exception {
+        assertEquals(new SaslExtensions(Collections.emptyMap()),
+                OAuthBearerClientInitialResponse.validateExtensions(null));
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerClientInitialResponseTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -120,7 +119,6 @@ public class OAuthBearerClientInitialResponseTest {
 
     @Test
     public void testValidateNullExtensions() throws Exception {
-        assertEquals(new SaslExtensions(Collections.emptyMap()),
-                OAuthBearerClientInitialResponse.validateExtensions(null));
+        OAuthBearerClientInitialResponse.validateExtensions(null);
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientTest.java
@@ -90,13 +90,14 @@ public class OAuthBearerSaslClientTest extends EasyMockSupport {
 
                         @Override
                         public String principalName() {
-                           return "principalName";
+                            return "principalName";
                         }
 
                         @Override
                         public Long startTimeMs() {
                             return null;
-                        }});
+                        }
+                    });
                 else if (callback instanceof SaslExtensionsCallback) {
                     if (toThrow)
                         throw new ConfigException(errorMessage);

--- a/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/oauthbearer/internals/OAuthBearerSaslClientTest.java
@@ -20,8 +20,8 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.security.auth.SaslExtensionsCallback;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.auth.SaslExtensions;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
 import org.easymock.EasyMockSupport;
 import org.junit.Test;
 
@@ -30,9 +30,11 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.sasl.SaslException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -70,7 +72,31 @@ public class OAuthBearerSaslClientTest extends EasyMockSupport {
         public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
             for (Callback callback : callbacks) {
                 if (callback instanceof OAuthBearerTokenCallback)
-                    ((OAuthBearerTokenCallback) callback).token(createMock(OAuthBearerUnsecuredJws.class));
+                    ((OAuthBearerTokenCallback) callback).token(new OAuthBearerToken() {
+                        @Override
+                        public String value() {
+                            return "";
+                        }
+
+                        @Override
+                        public Set<String> scope() {
+                            return Collections.emptySet();
+                        }
+
+                        @Override
+                        public long lifetimeMs() {
+                            return 100;
+                        }
+
+                        @Override
+                        public String principalName() {
+                           return "principalName";
+                        }
+
+                        @Override
+                        public Long startTimeMs() {
+                            return null;
+                        }});
                 else if (callback instanceof SaslExtensionsCallback) {
                     if (toThrow)
                         throw new ConfigException(errorMessage);
@@ -88,7 +114,7 @@ public class OAuthBearerSaslClientTest extends EasyMockSupport {
 
     @Test
     public void testAttachesExtensionsToFirstClientMessage() throws Exception {
-        String expectedToken = new String(new OAuthBearerClientInitialResponse(null, testExtensions).toBytes(), StandardCharsets.UTF_8);
+        String expectedToken = new String(new OAuthBearerClientInitialResponse("", testExtensions).toBytes(), StandardCharsets.UTF_8);
 
         OAuthBearerSaslClient client = new OAuthBearerSaslClient(new ExtensionsCallbackHandler(false));
 
@@ -101,7 +127,7 @@ public class OAuthBearerSaslClientTest extends EasyMockSupport {
     public void testNoExtensionsDoesNotAttachAnythingToFirstClientMessage() throws Exception {
         TEST_PROPERTIES.clear();
         testExtensions = new SaslExtensions(TEST_PROPERTIES);
-        String expectedToken = new String(new OAuthBearerClientInitialResponse(null, new SaslExtensions(TEST_PROPERTIES)).toBytes(), StandardCharsets.UTF_8);
+        String expectedToken = new String(new OAuthBearerClientInitialResponse("", new SaslExtensions(TEST_PROPERTIES)).toBytes(), StandardCharsets.UTF_8);
         OAuthBearerSaslClient client = new OAuthBearerSaslClient(new ExtensionsCallbackHandler(false));
 
         String message = new String(client.evaluateChallenge("".getBytes()), StandardCharsets.UTF_8);


### PR DESCRIPTION
Set empty extensions if null is passed in.

Signed-off-by: Ron Dagostino <rndgstn@gmail.com>
