### PR TITLE
WIP - KAFKA-3821 Allowing source tasks to produce offset without emitting r…

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/source/SourceTask.java
@@ -26,6 +26,25 @@ import java.util.Map;
  */
 public abstract class SourceTask implements Task {
 
+    public static class SourcePartitionAndOffset {
+
+        private final Map<String, ?> sourcePartition;
+        private final Map<String, ?> sourceOffset;
+
+        public SourcePartitionAndOffset(Map<String, ?> sourcePartition, Map<String, ?> sourceOffset) {
+            this.sourcePartition = sourcePartition;
+            this.sourceOffset = sourceOffset;
+        }
+
+        public Map<String, ?> getSourcePartition() {
+            return sourcePartition;
+        }
+
+        public Map<String, ?> getSourceOffset() {
+            return sourceOffset;
+        }
+    }
+
     protected SourceTaskContext context;
 
     /**
@@ -57,6 +76,10 @@ public abstract class SourceTask implements Task {
      * @return a list of source records
      */
     public abstract List<SourceRecord> poll() throws InterruptedException;
+
+    public SourcePartitionAndOffset getSourcePartitionAndOffset() {
+        return null;
+    }
 
     /**
      * <p>


### PR DESCRIPTION
Hi @rhauch, @ewencp et al., here's a proposal for [KAFKA-3821](https://issues.apache.org/jira/browse/KAFKA-3821) based on my latest comment on the JIRA issue. It'd need more polishing and testing, but I wanted to demonstrate the idea and see whether you agree with it before spending more time on it.

I think it's the simplest way to let source connectors produce offsets without emitting messages and without creating an awkward inheritance relationship of `SourceRecord` and a sub-class just carrying offset information. Please see [this comment](https://issues.apache.org/jira/browse/KAFKA-3821?focusedCommentId=16564900&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16564900) on the JIRA issue for the two use cases of this new functionality.

Looking forward to learn about your toughts. Thanks!

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
