### PR TITLE
KAFKA-7128: Follower has to catch up to offset within current leader epoch to join ISR

### DIFF
--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -314,7 +314,7 @@ class PartitionTest {
     assertEquals("ISR", Set[Integer](leader, follower1, follower2), partition.inSyncReplicas.map(_.brokerId))
  }
 
-  def createRecords(records: Iterable[SimpleRecord], baseOffset: Long = 0, partitionLeaderEpoch: Int = 0): MemoryRecords = {
+  def createRecords(records: Iterable[SimpleRecord], baseOffset: Long, partitionLeaderEpoch: Int = 0): MemoryRecords = {
     val buf = ByteBuffer.allocate(DefaultRecordBatch.sizeInBytes(records.asJava))
     val builder = MemoryRecords.builder(
       buf, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.LOG_APPEND_TIME,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -272,7 +272,7 @@ class PartitionTest {
     partition.appendRecordsToLeader(batch2, isFromClient = true)
     assertEquals(s"Expected leader's HW not move", leaderReplica.logStartOffset, leaderReplica.highWatermark.messageOffset)
 
-    // let the follower in ISR move leader's HW to LEO
+    // let the follower in ISR move leader's HW to move further but below LEO
     def readResult(fetchInfo: FetchDataInfo, leaderReplica: Replica): LogReadResult = {
       LogReadResult(info = fetchInfo,
                     highWatermark = leaderReplica.highWatermark.messageOffset,

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -27,6 +27,7 @@ import kafka.common.UnexpectedAppendOffsetException
 import kafka.log.{LogConfig, LogManager, CleanerConfig}
 import kafka.server._
 import kafka.utils.{MockTime, TestUtils, MockScheduler}
+import kafka.zk.KafkaZkClient
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.ReplicaNotAvailableException
 import org.apache.kafka.common.metrics.Metrics
@@ -36,6 +37,7 @@ import org.apache.kafka.common.requests.LeaderAndIsrRequest
 import org.junit.{After, Before, Test}
 import org.junit.Assert._
 import org.scalatest.Assertions.assertThrows
+import org.easymock.EasyMock
 
 import scala.collection.JavaConverters._
 
@@ -72,10 +74,16 @@ class PartitionTest {
     val brokerProps = TestUtils.createBrokerConfig(brokerId, TestUtils.MockZkConnect)
     brokerProps.put(KafkaConfig.LogDirsProp, Seq(logDir1, logDir2).map(_.getAbsolutePath).mkString(","))
     val brokerConfig = KafkaConfig.fromProps(brokerProps)
+    val kafkaZkClient = EasyMock.createMock(classOf[KafkaZkClient])
     replicaManager = new ReplicaManager(
-      config = brokerConfig, metrics, time, zkClient = null, new MockScheduler(time),
+      config = brokerConfig, metrics, time, zkClient = kafkaZkClient, new MockScheduler(time),
       logManager, new AtomicBoolean(false), QuotaFactory.instantiate(brokerConfig, metrics, time, ""),
       brokerTopicStats, new MetadataCache(brokerId), new LogDirFailureChannel(brokerConfig.logDirs.size))
+
+    EasyMock.expect(kafkaZkClient.getEntityConfigs(EasyMock.anyString(), EasyMock.anyString())).andReturn(logProps).anyTimes()
+    EasyMock.expect(kafkaZkClient.conditionalUpdatePath(EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject(), EasyMock.anyObject()))
+      .andReturn((true, 0)).anyTimes()
+    EasyMock.replay(kafkaZkClient)
   }
 
   @After
@@ -230,10 +238,86 @@ class PartitionTest {
     assertFalse(partition.makeFollower(0, partitionStateInfo, 2))
   }
 
-  def createRecords(records: Iterable[SimpleRecord], baseOffset: Long, partitionLeaderEpoch: Int = 0): MemoryRecords = {
+  @Test
+  def testFollowerDoesNotJoinISRUntilCaughtUpToOffsetWithinCurrentLeaderEpoch(): Unit = {
+    val controllerEpoch = 3
+    val leader = brokerId
+    val follower1 = brokerId + 1
+    val follower2 = brokerId + 2
+    val controllerId = brokerId + 3
+    val replicas = List[Integer](leader, follower1, follower2).asJava
+    val isr = List[Integer](leader, follower2).asJava
+    val leaderEpoch = 8
+    val batch1 = createRecords(List(new SimpleRecord("k1".getBytes, "v1".getBytes),
+                                    new SimpleRecord("k2".getBytes, "v2".getBytes)))
+    val batch2 = createRecords(List(new SimpleRecord("k3".getBytes, "v1".getBytes),
+                                    new SimpleRecord("k4".getBytes, "v2".getBytes),
+                                    new SimpleRecord("k5".getBytes, "v3".getBytes)))
+    val batch3 = createRecords(List(new SimpleRecord("k6".getBytes, "v1".getBytes),
+                                    new SimpleRecord("k7".getBytes, "v2".getBytes)))
+
+    val partition = new Partition(topicPartition.topic, topicPartition.partition, time, replicaManager)
+    assertTrue(s"Expected first makeLeader() to return 'leader changed'",
+               partition.makeLeader(controllerId, new LeaderAndIsrRequest.PartitionState(controllerEpoch, leader, leaderEpoch, isr, 1, replicas, true), 0))
+    assertEquals(s"Current leader epoch", leaderEpoch, partition.getLeaderEpoch)
+    assertTrue(s"Expected under-replicated partitions due to one of the followers not in ISR", partition.isUnderReplicated)
+
+    // after makeLeader(() call, partition should know about all the replicas
+    val leaderReplica = partition.getReplica(leader).get
+    val follower1Replica = partition.getReplica(follower1).get
+    val follower2Replica = partition.getReplica(follower2).get
+
+    // append records with initial leader epoch
+    val lastOffsetOfFirstBatch = partition.appendRecordsToLeader(batch1, isFromClient = true).lastOffset
+    partition.appendRecordsToLeader(batch2, isFromClient = true)
+    assertEquals(s"Expected leader's HW not move", leaderReplica.logStartOffset, leaderReplica.highWatermark.messageOffset)
+
+    // let the follower in ISR move leader's HW to LEO
+    def readResult(fetchInfo: FetchDataInfo, leaderReplica: Replica): LogReadResult = {
+      LogReadResult(info = fetchInfo,
+                    highWatermark = leaderReplica.highWatermark.messageOffset,
+                    leaderLogStartOffset = leaderReplica.logStartOffset,
+                    leaderLogEndOffset = leaderReplica.logEndOffset.messageOffset,
+                    followerLogStartOffset = 0,
+                    fetchTimeMs = time.milliseconds,
+                    readSize = 10240,
+                    lastStableOffset = None)
+    }
+    partition.updateReplicaLogReadResult(
+      follower2Replica, readResult(FetchDataInfo(LogOffsetMetadata(0), batch1), leaderReplica))
+    partition.updateReplicaLogReadResult(
+      follower2Replica, readResult(FetchDataInfo(LogOffsetMetadata(lastOffsetOfFirstBatch), batch2), leaderReplica))
+    assertEquals(s"Expected leader's HW", lastOffsetOfFirstBatch, leaderReplica.highWatermark.messageOffset)
+
+    // current leader becomes follower and then leader again (without any new records appended)
+    partition.makeFollower(
+      controllerId, new LeaderAndIsrRequest.PartitionState(controllerEpoch, follower2, leaderEpoch + 1, isr, 1, replicas, false), 1)
+    assertTrue(s"Expected makeLeader() to return 'leader changed' after makeFollower()",
+               partition.makeLeader(controllerEpoch, new LeaderAndIsrRequest.PartitionState(
+                 controllerEpoch, leader, leaderEpoch + 2, isr, 1, replicas, false), 2))
+    val currentLeaderEpochStartOffset = leaderReplica.logEndOffset.messageOffset
+
+    // append records with the latest leader epoch
+    partition.appendRecordsToLeader(batch3, isFromClient = true)
+
+    // fetch from follower not in ISR from log start offset should not add this follower to ISR
+    partition.updateReplicaLogReadResult(follower1Replica,
+                                         readResult(FetchDataInfo(LogOffsetMetadata(0), batch1), leaderReplica))
+    partition.updateReplicaLogReadResult(follower1Replica,
+                                         readResult(FetchDataInfo(LogOffsetMetadata(lastOffsetOfFirstBatch), batch2), leaderReplica))
+    assertTrue(s"Expected under-replicated partitions until follower in ISR catches up to an offset within the current leader Epoch",
+               partition.isUnderReplicated)
+    // fetch from the follower not in ISR from start offset of the current leader epoch should
+    // add this follower to ISR
+    partition.updateReplicaLogReadResult(follower1Replica,
+                                         readResult(FetchDataInfo(LogOffsetMetadata(currentLeaderEpochStartOffset), batch3), leaderReplica))
+    assertFalse(s"Expected all replicas in ISR", partition.isUnderReplicated)
+ }
+
+  def createRecords(records: Iterable[SimpleRecord], baseOffset: Long = 0, partitionLeaderEpoch: Int = 0): MemoryRecords = {
     val buf = ByteBuffer.allocate(DefaultRecordBatch.sizeInBytes(records.asJava))
     val builder = MemoryRecords.builder(
-      buf, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.LOG_APPEND_TIME,
+      buf, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME,
       baseOffset, time.milliseconds, partitionLeaderEpoch)
     records.foreach(builder.append)
     builder.build()


### PR DESCRIPTION
If follower is not in ISR, it has to fetch up to start offset of the current leader epoch. Added unit test to verify this behavior.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
