### PR TITLE
MINOR: replace deprecated remove with delete

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBSegmentedBytesStore.java
@@ -237,7 +237,7 @@ class RocksDBSegmentedBytesStore implements SegmentedBytesStore {
                 try {
                     final WriteBatch batch = writeBatchMap.computeIfAbsent(segment, s -> new WriteBatch());
                     if (record.value == null) {
-                        batch.remove(record.key);
+                        batch.delete(record.key);
                     } else {
                         batch.put(record.key, record.value);
                     }

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/RocksDBStore.java
@@ -283,7 +283,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
         try (final WriteBatch batch = new WriteBatch()) {
             for (final KeyValue<byte[], byte[]> record : records) {
                 if (record.value == null) {
-                    batch.remove(record.key);
+                    batch.delete(record.key);
                 } else {
                     batch.put(record.key, record.value);
                 }
@@ -323,7 +323,7 @@ public class RocksDBStore implements KeyValueStore<Bytes, byte[]> {
             for (final KeyValue<Bytes, byte[]> entry : entries) {
                 Objects.requireNonNull(entry.key, "key cannot be null");
                 if (entry.value == null) {
-                    batch.remove(entry.key.get());
+                    batch.delete(entry.key.get());
                 } else {
                     batch.put(entry.key.get(), entry.value);
                 }


### PR DESCRIPTION
According to rocksDB commit history, it should be a pure renaming and no perf / correctness implications at all. But still good to remove deprecated API.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
