### PR TITLE
KAFKA-7309: Upgrade Jacoco for Java 11 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -385,7 +385,7 @@ subprojects {
     apply plugin: "jacoco"
 
     jacoco {
-      toolVersion = "0.8.1"
+      toolVersion = "0.8.2"
     }
 
     // NOTE: Jacoco Gradle plugin does not support "offline instrumentation" this means that classes mocked by PowerMock


### PR DESCRIPTION
Jacoco 0.8.2 adds Java 11 support:

https://github.com/jacoco/jacoco/releases/tag/v0.8.2

Java 11 RC1 is out so it would be good for us to
get a working CI build.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
