### PR TITLE
KIP-365: Make KStream.process processorSupplier parameter call by name

### DIFF
--- a/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
+++ b/streams/streams-scala/src/main/scala/org/apache/kafka/streams/scala/kstream/KStream.scala
@@ -340,7 +340,17 @@ class KStream[K, V](val inner: KStreamJ[K, V]) {
    * @param stateStoreNames   the names of the state store used by the processor
    * @see `org.apache.kafka.streams.kstream.KStream#process`
    */
-  def process(processorSupplier: () => Processor[K, V], stateStoreNames: String*): Unit = {
+  def process(processorSupplier: => Processor[K, V], stateStoreNames: String*): Unit = {
+    //noinspection ConvertExpressionToSAM // because of the 2.11 build
+    val processorSupplierJ: ProcessorSupplier[K, V] = new ProcessorSupplier[K, V] {
+      override def get(): Processor[K, V] = processorSupplier
+    }
+    inner.process(processorSupplierJ, stateStoreNames: _*)
+  }
+
+  @deprecated("Use the call by name processorSupplier instead", "2.1.0")
+  def process(processorSupplier: () => Processor[K, V],
+              stateStoreNames: String*)(implicit dummyImplicit: DummyImplicit): Unit = {
     //noinspection ConvertExpressionToSAM // because of the 2.11 build
     val processorSupplierJ: ProcessorSupplier[K, V] = new ProcessorSupplier[K, V] {
       override def get(): Processor[K, V] = processorSupplier()


### PR DESCRIPTION
```
def process(processorSupplier: () => Processor[K, V], stateStoreNames: String*)
```
should be:
```
def process(processorSupplier: => Processor[K, V], stateStoreNames: String*)
```

KIP: https://cwiki.apache.org/confluence/pages/resumedraft.action?draftId=89069981&draftShareId=a21bcef4-c388-4663-9c6f-9ccceee4cb30