### PR TITLE
KAFKA-7338: Specify AES-128 default encryption type for Kerberos tests

### DIFF
--- a/core/src/test/resources/minikdc-krb5.conf
+++ b/core/src/test/resources/minikdc-krb5.conf
@@ -18,6 +18,8 @@
 [libdefaults]
 default_realm = {0}
 udp_preference_limit = 1
+default_tkt_enctypes=aes128-cts-hmac-sha1-96
+default_tgs_enctypes=aes128-cts-hmac-sha1-96
 
 [realms]
 {0} = '{'


### PR DESCRIPTION
Java 11 enables `aes128-cts-hmac-sha256-128` and `aes256-cts-hmac-sha384-192` by default. These are not supported in earlier versions of Java and not supported by Apache DS libraries used by MiniKdc. To ensure that the default kerberos configuration used by Kafka integration and system tests work with all versions of Java 8 and above, configure `default_tkt_enctypes` and `default_tgs_enctypes` to use `aes128-cts-hmac-sha1-96`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
