### PR TITLE
MINOR:Use StoreBuilder.name() for node name

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StateStoreNode.java
@@ -25,7 +25,7 @@ public class StateStoreNode extends StreamsGraphNode {
     protected final StoreBuilder storeBuilder;
 
     public StateStoreNode(final StoreBuilder storeBuilder) {
-        super(storeBuilder.toString(), false);
+        super(storeBuilder.name(), false);
 
         this.storeBuilder = storeBuilder;
     }


### PR DESCRIPTION
Initially, I wanted to make sure the name for the `StateStoreNode` was unique.

But we ensure name uniqueness in with following steps
1. we create store names by appending a number from an incrementing counter
2. if an attempt is made to add a state store with an existing name a TopologyException is thrown.

With that in mind, it will be more clear to use the `StoreBuilder.name()` instead. 

For testing, I ran the existing streams unit tests

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
