### PR TITLE
KAFKA-7356 Added allDeps task to generate complete dependency report.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1537,3 +1537,7 @@ task aggregatedJavadoc(type: Javadoc) {
   excludes = projectsWithJavadoc.collectMany { it.javadoc.getExcludes() }
   options.links "http://docs.oracle.com/javase/7/docs/api/"
 }
+
+subprojects {
+    task allDeps(type: DependencyReportTask) {}
+}


### PR DESCRIPTION
This task allows a user to examine the dependency list to confirm/deny use of a specific dependency. Running `$ gradle -q dependencies` in the root directory only lists the `rat` dependencies. Adding a custom section to _build.gradle_ allows for a complete listing of the dependencies from the command line. 

```
subprojects {
    task allDeps(type: DependencyReportTask) {}
}
```

To invoke: `$ gradle allDeps`

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
