### PR TITLE
KAFKA-7370: Enhance FileConfigProvider to read a dir

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/config/provider/FileConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/FileConfigProvider.java
@@ -78,7 +78,7 @@ public class FileConfigProvider implements ConfigProvider {
         try {
             Map<String, String> data = Files.list(path)
                     .filter(Files::isRegularFile)
-                    .collect(Collectors.toMap(file -> file.getFileName().toString(), this::toString));
+                    .collect(Collectors.toMap(file -> file.getFileName().toString(), this::readAll));
             return new ConfigData(data);
         } catch (IOException e) {
             throw new ConfigException("Could not read from directory " + path);
@@ -89,7 +89,7 @@ public class FileConfigProvider implements ConfigProvider {
         Map<String, String> data = keys.stream()
                 .map(path::resolve)
                 .filter(Files::isRegularFile)
-                .collect(Collectors.toMap(file -> file.getFileName().toString(), this::toString));
+                .collect(Collectors.toMap(file -> file.getFileName().toString(), this::readAll));
         return new ConfigData(data);
     }
 
@@ -129,7 +129,7 @@ public class FileConfigProvider implements ConfigProvider {
         }
     }
 
-    private String toString(Path path) {
+    private String readAll(Path path) {
         try {
             return new String(Files.readAllBytes(path), UTF_8);
         } catch (IOException e) {

--- a/clients/src/main/java/org/apache/kafka/common/config/provider/FileConfigProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/config/provider/FileConfigProvider.java
@@ -22,15 +22,22 @@ import org.apache.kafka.common.config.ConfigException;
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * An implementation of {@link ConfigProvider} that represents a Properties file.
+ * An implementation of {@link ConfigProvider} that can read from either a file or a directory.
+ * If the given path is a file, it is interpreted as a Properties file containing key-value pairs.
+ * If the given path is a directory, the keys are the file names contained in the directory and the values are
+ * the corresponding contents of the files.
  * All property keys and values are stored as cleartext.
  */
 public class FileConfigProvider implements ConfigProvider {
@@ -39,16 +46,55 @@ public class FileConfigProvider implements ConfigProvider {
     }
 
     /**
-     * Retrieves the data at the given Properties file.
+     * Retrieves the data at the given path.
      *
-     * @param path the file where the data resides
+     * @param path the path corresponding to either a directory or a Properties file
      * @return the configuration data
      */
     public ConfigData get(String path) {
-        Map<String, String> data = new HashMap<>();
         if (path == null || path.isEmpty()) {
-            return new ConfigData(data);
+            return new ConfigData(new HashMap<>());
         }
+        Path p = Paths.get(path);
+        return Files.isDirectory(p) ? getFromDirectory(p) : getFromPropertiesFile(p);
+    }
+
+    /**
+     * Retrieves the data with the given keys at the given path.
+     *
+     * @param path the path corresponding to either a directory or a Properties file
+     * @param keys the keys whose values will be retrieved.  In the case of a directory, these are the file names.
+     * @return the configuration data
+     */
+    public ConfigData get(String path, Set<String> keys) {
+        if (path == null || path.isEmpty()) {
+            return new ConfigData(new HashMap<>());
+        }
+        Path p = Paths.get(path);
+        return Files.isDirectory(p) ? getFromDirectory(p, keys) : getFromPropertiesFile(p, keys);
+    }
+
+    private ConfigData getFromDirectory(Path path) {
+        try {
+            Map<String, String> data = Files.list(path)
+                    .filter(Files::isRegularFile)
+                    .collect(Collectors.toMap(file -> file.getFileName().toString(), this::toString));
+            return new ConfigData(data);
+        } catch (IOException e) {
+            throw new ConfigException("Could not read from directory " + path);
+        }
+    }
+
+    private ConfigData getFromDirectory(Path path, Set<String> keys) {
+        Map<String, String> data = keys.stream()
+                .map(path::resolve)
+                .filter(Files::isRegularFile)
+                .collect(Collectors.toMap(file -> file.getFileName().toString(), this::toString));
+        return new ConfigData(data);
+    }
+
+    private ConfigData getFromPropertiesFile(Path path) {
+        Map<String, String> data = new HashMap<>();
         try (Reader reader = reader(path)) {
             Properties properties = new Properties();
             properties.load(reader);
@@ -66,18 +112,8 @@ public class FileConfigProvider implements ConfigProvider {
         }
     }
 
-    /**
-     * Retrieves the data with the given keys at the given Properties file.
-     *
-     * @param path the file where the data resides
-     * @param keys the keys whose values will be retrieved
-     * @return the configuration data
-     */
-    public ConfigData get(String path, Set<String> keys) {
+    private ConfigData getFromPropertiesFile(Path path, Set<String> keys) {
         Map<String, String> data = new HashMap<>();
-        if (path == null || path.isEmpty()) {
-            return new ConfigData(data);
-        }
         try (Reader reader = reader(path)) {
             Properties properties = new Properties();
             properties.load(reader);
@@ -93,9 +129,16 @@ public class FileConfigProvider implements ConfigProvider {
         }
     }
 
-    // visible for testing
-    protected Reader reader(String path) throws IOException {
-        return Files.newBufferedReader(Paths.get(path));
+    private String toString(Path path) {
+        try {
+            return new String(Files.readAllBytes(path), UTF_8);
+        } catch (IOException e) {
+            throw new ConfigException("Could not read from file " + path);
+        }
+    }
+
+    private Reader reader(Path path) throws IOException {
+        return Files.newBufferedReader(path);
     }
 
     public void close() {


### PR DESCRIPTION
This is a backward compatible enhancement to augment FileConfigProvider
to read from a directory, where the file names are the keys and the
corresponding file contents are the values.  The former functionality of
reading a Properties file is retained.

This will allow for easier integration with secret management systems
where each secret is often written to an individual file, such as in
some Docker and Kubernetes setups.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
