### PR TITLE
MINOR: Introduce getPartitionAndReplicaOrException and use it in fetcher threads

### DIFF
--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -88,8 +88,8 @@ class ReplicaAlterLogDirsThread(name: String,
   // process fetched data
   def processPartitionData(topicPartition: TopicPartition, fetchOffset: Long, partitionData: PartitionData[Records],
                            records: MemoryRecords) {
-    val futureReplica = replicaMgr.getReplicaOrException(topicPartition, Request.FutureLocalReplicaId)
-    val partition = replicaMgr.getPartition(topicPartition).get
+    val (partition, futureReplica) = replicaMgr.getPartitionAndReplicaOrException(topicPartition,
+      Request.FutureLocalReplicaId)
 
     if (fetchOffset != futureReplica.logEndOffset.messageOffset)
       throw new IllegalStateException("Offset mismatch for the future replica %s: fetched offset = %d, log end offset = %d.".format(
@@ -108,8 +108,7 @@ class ReplicaAlterLogDirsThread(name: String,
 
   def handleOffsetOutOfRange(topicPartition: TopicPartition): Long = {
     val futureReplica = replicaMgr.getReplicaOrException(topicPartition, Request.FutureLocalReplicaId)
-    val currentReplica = replicaMgr.getReplicaOrException(topicPartition)
-    val partition = replicaMgr.getPartition(topicPartition).get
+    val (partition, currentReplica) = replicaMgr.getPartitionAndReplicaOrException(topicPartition)
     val logEndOffset: Long = currentReplica.logEndOffset.messageOffset
 
     if (logEndOffset < futureReplica.logEndOffset.messageOffset) {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -106,8 +106,7 @@ class ReplicaFetcherThread(name: String,
 
   // process fetched data
   def processPartitionData(topicPartition: TopicPartition, fetchOffset: Long, partitionData: PD, records: MemoryRecords) {
-    val replica = replicaMgr.getReplicaOrException(topicPartition)
-    val partition = replicaMgr.getPartition(topicPartition).get
+    val (partition, replica) = replicaMgr.getPartitionAndReplicaOrException(topicPartition)
 
     maybeWarnIfOversizedRecords(records, topicPartition)
 
@@ -155,8 +154,7 @@ class ReplicaFetcherThread(name: String,
    * Handle a partition whose offset is out of range and return a new fetch offset.
    */
   def handleOffsetOutOfRange(topicPartition: TopicPartition): Long = {
-    val replica = replicaMgr.getReplicaOrException(topicPartition)
-    val partition = replicaMgr.getPartition(topicPartition).get
+    val (partition, replica) = replicaMgr.getPartitionAndReplicaOrException(topicPartition)
 
     /**
      * Unclean leader election: A follower goes down, in the meanwhile the leader keeps appending messages. The follower comes back up
@@ -300,8 +298,7 @@ class ReplicaFetcherThread(name: String,
    * The logic for finding the truncation offset is implemented in AbstractFetcherThread.getOffsetTruncationState
    */
   override def truncate(tp: TopicPartition, epochEndOffset: EpochEndOffset): OffsetTruncationState = {
-    val replica = replicaMgr.getReplicaOrException(tp)
-    val partition = replicaMgr.getPartition(tp).get
+    val (partition, replica) = replicaMgr.getPartitionAndReplicaOrException(tp)
 
     val offsetTruncationState = getOffsetTruncationState(tp, epochEndOffset, replica)
     if (offsetTruncationState.offset < replica.highWatermark.messageOffset)


### PR DESCRIPTION
This avoids the need to get `Option.get` and makes it clearer that the Replica and
Partition associated.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
