### PR TITLE
KAFKA-7372: Upgrade Jetty for preliminary Java 11 and TLS 1.3 support

### DIFF
--- a/docs/upgrade.html
+++ b/docs/upgrade.html
@@ -43,6 +43,8 @@
 
 <h5><a id="upgrade_210_notable" href="#upgrade_210_notable">Notable changes in 2.1.0</a></h5>
 <ul>
+    <li>Jetty has been upgraded to 9.4.12, which excludes TLS_RSA_* ciphers by default because they do not support forward
+        secrecy, see https://github.com/eclipse/jetty.project/issues/2807 for more information.</li>
     <li>Unclean leader election is automatically enabled by the controller when <code>unclean.leader.election.enable</code> config is dynamically updated by using per-topic config override.</li>
 </ul>
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ versions += [
   bcpkix: "1.59",
   easymock: "3.6",
   jackson: "2.9.6",
-  jetty: "9.4.11.v20180605",
+  jetty: "9.4.12.v20180830",
   jersey: "2.27",
   jmh: "1.21",
   log4j: "1.2.17",


### PR DESCRIPTION
"Jetty 9.4.12 includes compatibility for JDK 11. Additionally, TLS 1.3 support
has been implemented. While full functionality for new JDK features is not
yet supported, this release has been built and tested for compatibility with
the latest releases from Oracle.":

http://dev.eclipse.org/mhonarc/lists/jetty-announce/msg00124.html

Also added an upgrade note as some ciphers are now disabled by default.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
