### PR TITLE
KAFKA-7304 memory leakage in org.apache.kafka.common.network.Selector

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -106,8 +106,9 @@ public class KafkaChannel {
         this.disconnected = true;
         Utils.closeAll(transportLayer, authenticator, receive);
     }
+
     boolean isDisconnected() {
-      return this.disconnected;
+        return this.disconnected;
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/KafkaChannel.java
@@ -106,6 +106,9 @@ public class KafkaChannel {
         this.disconnected = true;
         Utils.closeAll(transportLayer, authenticator, receive);
     }
+    boolean isDisconnected() {
+      return this.disconnected;
+    }
 
     /**
      * Returns the principal returned by `authenticator.principal()`.

--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -353,8 +353,9 @@ public class Selector implements Selectable, AutoCloseable {
     @Override
     public void close() {
         List<String> connections = new ArrayList<>(channels.keySet());
-        for (String id : connections)
+        for (String id : connections) {
             close(id);
+        }
         try {
             this.nioSelector.close();
         } catch (IOException | SecurityException e) {
@@ -362,6 +363,10 @@ public class Selector implements Selectable, AutoCloseable {
         }
         sensors.close();
         channelBuilder.close();
+        for (Map.Entry<String, KafkaChannel> entry : this.closingChannels.entrySet()) {
+            doClose(entry.getValue(), false);
+        }
+        this.closingChannels.clear();
     }
 
     /**
@@ -593,6 +598,7 @@ public class Selector implements Selectable, AutoCloseable {
         //this may cause starvation of reads when memory is low. to address this we shuffle the keys if memory is low.
         if (!outOfMemory && memoryPool.availableMemory() < lowMemThreshold) {
             List<SelectionKey> shuffledKeys = new ArrayList<>(selectionKeys);
+            log.warn("memory low: " + memoryPool.availableMemory() + " < " + lowMemThreshold);
             Collections.shuffle(shuffledKeys);
             return shuffledKeys;
         } else {
@@ -886,6 +892,24 @@ public class Selector implements Selectable, AutoCloseable {
      */
     public KafkaChannel closingChannel(String id) {
         return closingChannels.get(id);
+    }
+
+    /**
+     * @return the number of Channels in closingChannels Map
+     */
+    int countOfClosingChannel() {
+        return closingChannels.size();
+    }
+
+    int countOfMutedChannels() {
+        return explicitlyMutedChannels.size();
+    }
+    int countOfConnectedChannels() {
+        int count = 0;
+        for (KafkaChannel channel : channels.values()) {
+            if (!channel.isDisconnected()) count++;
+        }
+        return count;
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SelectorTest.java
@@ -95,6 +95,10 @@ public class SelectorTest {
             verifySelectorEmpty();
         } finally {
             this.selector.close();
+
+            assertEquals(0, this.selector.countOfClosingChannel());
+            assertEquals(0, this.selector.countOfMutedChannels());
+            assertEquals(0, this.selector.countOfConnectedChannels());
             this.server.close();
             this.metrics.close();
         }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslSelectorTest.java
@@ -76,6 +76,9 @@ public class SslSelectorTest extends SelectorTest {
     @After
     public void tearDown() throws Exception {
         this.selector.close();
+        assertEquals(0, selector.countOfClosingChannel());
+        assertEquals(0, this.selector.countOfMutedChannels());
+        assertEquals(0, this.selector.countOfConnectedChannels());
         this.server.close();
         this.metrics.close();
     }

--- a/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/SslTransportLayerTest.java
@@ -87,8 +87,12 @@ public class SslTransportLayerTest {
 
     @After
     public void teardown() throws Exception {
-        if (selector != null)
+        if (selector != null) {
             this.selector.close();
+            assertEquals(0, this.selector.countOfClosingChannel());
+            assertEquals(0, this.selector.countOfMutedChannels());
+            assertEquals(0, this.selector.countOfConnectedChannels());
+        }
         if (server != null)
             this.server.close();
     }


### PR DESCRIPTION
This PR fixes potential memory leak when Selector is closed.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
