### PR TITLE
MINOR: Update README to mention the minimum required gradle version to 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See our [web site](http://kafka.apache.org) for details on the project.
 
 You need to have [Gradle](http://www.gradle.org/installation) and [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-Kafka requires Gradle 4.5 or higher.
+Kafka requires Gradle 4.6 or higher.
 
 Java 8 should be used for building in order to support both Java 8 and Java 10 at runtime.
 


### PR DESCRIPTION
After #5602 we need Gradle 4.6 as minimum required version.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
