### PR TITLE
KAFKA-7382 We shoud guarantee at lest one replica of partition should be alive w…

### DIFF
--- a/core/src/main/scala/kafka/zk/AdminZkClient.scala
+++ b/core/src/main/scala/kafka/zk/AdminZkClient.scala
@@ -140,6 +140,12 @@ class AdminZkClient(zkClient: KafkaZkClient) extends Logging {
         throw new InvalidReplicaAssignmentException("Duplicate replica assignment found: " + partitionReplicaAssignment)
     )
 
+    val allBrokerIds = zkClient.getSortedBrokerList()
+    partitionReplicaAssignment.values.foreach ( reps =>
+      if (reps.filterNot(allBrokerIds.contains(_)).size == reps.size)
+        throw new InvalidReplicaAssignmentException("At lest one replica of partition should be alive.")
+    )
+
     // Configs only matter if a topic is being created. Changing configs via AlterTopic is not supported
     if (!update)
       LogConfig.validate(config)

--- a/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/AdminZkClientTest.scala
@@ -150,6 +150,22 @@ class AdminZkClientTest extends ZooKeeperTestHarness with Logging with RackAware
   }
 
   @Test
+  def testValidateCreateOrUpdateTopic() {
+    val topic = "test"
+    val zkMock = EasyMock.createNiceMock(classOf[KafkaZkClient])
+    EasyMock.expect(zkMock.topicExists(topic)).andReturn(false)
+    EasyMock.expect(zkMock.getSortedBrokerList).andReturn(Seq(1, 2, 3, 4))
+    EasyMock.replay(zkMock)
+    val adminZkClient = new AdminZkClient(zkMock)
+
+    val partitionReplicaAssignment = Map(0 -> Seq(1, 3, 5), 1 -> Seq(10, 11, 12))
+    intercept[InvalidReplicaAssignmentException] {
+      adminZkClient.validateCreateOrUpdateTopic(topic, partitionReplicaAssignment, new Properties, update = false)
+    }
+  }
+
+
+  @Test
   def testConcurrentTopicCreation() {
     val topic = "test-concurrent-topic-creation"
     TestUtils.createBrokersInZk(zkClient, List(0, 1, 2, 3, 4))


### PR DESCRIPTION
For example：I have brokers: 1,2,3,4,5. I create a new topic by command:
`sh kafka-topics.sh --create --topic replicaserror --zookeeper localhost:2181 --replica-assignment 11:12:13,12:13:14,14:15:11,14:12:11,13:14:11 `
Then kafkaController will process this,after partitionStateMachine and replicaStateMachine handle state change,topic metadatas and state will be strange,partitions is on NewPartition and replicas is on OnlineReplica. 
Next wo can not delete this topic(bacase state change illegal ),This will cause a number of problems.So i think wo shoud check replicas assignment when create or update topic.