### PR TITLE
KAFKA-1880: Add support for checking binary/source compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Generate coverage for a single module, i.e.:
 
     ./gradlew clients:reportCoverage
 
-### Generating an API compatibility report between trunk and your local branch ###
-*Note that the branches need to be local.*
+### Generating an API compatibility report between the latest release and your local branch ###
 
     ./gradlew apiCompatibilityReport
 
@@ -82,8 +81,7 @@ incompatibility.
 
     ./gradlew apiCompatibilityReport -PfailOnBinaryIncompatibility=false -PfailOnSourceIncompatibility=true
 
-It is often a requirement to control the build outcome based on version differences. Usually it is allowed to do
-binary incompatible changes in major releases but this kind of compatibility should be kept in minor and patch 
+It is allowed to do incompatible changes in major releases but compatibility should be kept in minor and patch
 (maintenance) releases. This is called [semantic versioning](https://semver.org/spec/v2.0.0.html).
 This can be controlled the following way:
 

--- a/README.md
+++ b/README.md
@@ -69,17 +69,31 @@ Generate coverage for a single module, i.e.:
 ### Generating an API compatibility report between trunk and your local branch ###
 *Note that the branches need to be local.*
 
-    ./gradlew checkApiCompatibility
+    ./gradlew apiCompatibilityReport
 
 By default it just lists the incompatible changes. If you want a more complete report, you can set the `onlyIncompatible`
 flag to false:
 
-    ./gradlew checkApiCompatibility -PonlyIncompatible=false
+    ./gradlew apiCompatibilityReport -PonlyIncompatible=false
 
-### Generating an API compatibility report between branches or commits  ###
-*Note that the branches need to be local*
+There are some other options too. If you need to control the build result on binary or source incompatible changes, 
+then you can do it so with the following flags. The below example would result in failing only in case of source
+incompatibility.
 
-     ./gradlew checkApiCompatibility -PbaseBranch=1.1.0 -PnewBranch=1.1.1
+    ./gradlew apiCompatibilityReport -PfailOnBinaryIncompatibility=false -PfailOnSourceIncompatibility=true
+
+It is often a requirement to control the build outcome based on version differences. Usually it is allowed to do
+binary incompatible changes in major releases but this kind of compatibility should be kept in minor and patch 
+(maintenance) releases. This is called [semantic versioning](https://semver.org/spec/v2.0.0.html).
+This can be controlled the following way:
+
+    ./gradlew apiCompatibilityReport -PfailOnSemanticIncompatibility=true
+
+### Generating an API compatibility report between branches  ###
+*Note that the branches need to be local.*
+
+     ./gradlew apiCompatibilityReport -Psource=1.1.0 -Ptarget=1.1.1
+     ./gradlew apiCompatibilityReport -Psource=2.0.0 -Ptarget=my-patch-branch
     
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Generate coverage reports for the whole project:
 
     ./gradlew reportCoverage
 
+Generate coverage for a single module, i.e.: 
+
+    ./gradlew clients:reportCoverage
+
 ### Generating an API compatibility report between trunk and your local branch ###
 *Note that the branches need to be local.*
 
@@ -76,10 +80,6 @@ flag to false:
 *Note that the branches need to be local*
 
      ./gradlew checkApiCompatibility -PbaseBranch=1.1.0 -PnewBranch=1.1.1
-
-Generate coverage for a single module, i.e.: 
-
-    ./gradlew clients:reportCoverage
     
 ### Building a binary release gzipped tar ball ###
     ./gradlew clean releaseTarGz

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ This can be controlled the following way:
 
     ./gradlew apiCompatibilityReport -PfailOnSemanticIncompatibility=true
 
-### Generating an API compatibility report between branches  ###
-*Note that the branches need to be local.*
+### Generating an API compatibility report between releases  ###
 
      ./gradlew apiCompatibilityReport -Psource=1.1.0 -Ptarget=1.1.1
+
+### Generating an API compatibility report between a release and a local branch ###
+
      ./gradlew apiCompatibilityReport -Psource=2.0.0 -Ptarget=my-patch-branch
     
 ### Building a binary release gzipped tar ball ###

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ See [Test Retry Gradle Plugin](https://github.com/gradle/test-retry-gradle-plugi
 Generate coverage reports for the whole project:
 
     ./gradlew reportCoverage
+    
+### Generating an API compatibility report between trunk and your local branch ###
+*Note that the branches need to be local*
+    ./gradlew checkApiCompatibility    
+    
+### Generating an API compatibility report between branches or commits  ###
+*Note that the branches need to be local*
+     ./gradlew checkApiCompatibility -PoldRef=0.9.0 -PnewRef=trunk
 
 Generate coverage for a single module, i.e.: 
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,19 @@ Generate coverage reports for the whole project:
     ./gradlew reportCoverage
 
 ### Generating an API compatibility report between trunk and your local branch ###
-*Note that the branches need to be local*
+*Note that the branches need to be local.*
+
     ./gradlew checkApiCompatibility
+
+By default it just lists the incompatible changes. If you want a more complete report, you can set the `onlyIncompatible`
+flag to false:
+
+    ./gradlew checkApiCompatibility -PonlyIncompatible=false
 
 ### Generating an API compatibility report between branches or commits  ###
 *Note that the branches need to be local*
-     ./gradlew checkApiCompatibility -PoldRef=0.9.0 -PnewRef=trunk
+
+     ./gradlew checkApiCompatibility -PbaseBranch=1.1.0 -PnewBranch=1.1.1
 
 Generate coverage for a single module, i.e.: 
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ See [Test Retry Gradle Plugin](https://github.com/gradle/test-retry-gradle-plugi
 Generate coverage reports for the whole project:
 
     ./gradlew reportCoverage
-    
+
 ### Generating an API compatibility report between trunk and your local branch ###
 *Note that the branches need to be local*
-    ./gradlew checkApiCompatibility    
-    
+    ./gradlew checkApiCompatibility
+
 ### Generating an API compatibility report between branches or commits  ###
 *Note that the branches need to be local*
      ./gradlew checkApiCompatibility -PoldRef=0.9.0 -PnewRef=trunk

--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,8 @@ buildscript {
     classpath "com.diffplug.spotless:spotless-plugin-gradle:$versions.spotlessPlugin"
     classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$versions.spotbugsPlugin"
     classpath "org.gradle:test-retry-gradle-plugin:$versions.testRetryPlugin"
-    // Required here ONLY for intellij as it won't resolve classes used in compatibility.gradle
-    classpath "com.github.siom79.japicmp:japicmp:$versions.japicmp"
     classpath "de.undercouch:gradle-download-task:$versions.gradleDownloadTask"
+    classpath "com.github.siom79.japicmp:japicmp:$versions.japicmp"
   }
 }
 
@@ -124,8 +123,7 @@ ext {
 }
 
 apply from: file('wrapper.gradle')
-//apply plugin: 'me.champeau.gradle.japicmp'
-apply from: "$rootDir/gradle/compatibility.gradle"
+apply from: file('gradle/compatibility.gradle')
 
 if (file('.git').exists()) {
   apply from: file('gradle/rat.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ buildscript {
     classpath "com.diffplug.spotless:spotless-plugin-gradle:$versions.spotlessPlugin"
     classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$versions.spotbugsPlugin"
     classpath "org.gradle:test-retry-gradle-plugin:$versions.testRetryPlugin"
+    // For the japicmp lib, required here for intellij
+    classpath "com.github.siom79.japicmp:japicmp:0.13.0"
   }
 }
 
@@ -122,7 +124,6 @@ ext {
 
 apply from: file('wrapper.gradle')
 apply from: "$rootDir/gradle/compatibility.gradle"
-
 
 if (file('.git').exists()) {
   apply from: file('gradle/rat.gradle')
@@ -358,7 +359,7 @@ subprojects {
       exceptionFormat = testExceptionFormat
     }
     logTestStdout.rehydrate(delegate, owner, this)()
-    
+
     // The suites are for running sets of tests in IDEs.
     // Gradle will run each test class, so we exclude the suites to avoid redundantly running the tests twice.
     exclude '**/*Suite.class'

--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,8 @@ ext {
 }
 
 apply from: file('wrapper.gradle')
+apply from: "$rootDir/gradle/compatibility.gradle"
+
 
 if (file('.git').exists()) {
   apply from: file('gradle/rat.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,9 @@ buildscript {
     classpath "com.diffplug.spotless:spotless-plugin-gradle:$versions.spotlessPlugin"
     classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$versions.spotbugsPlugin"
     classpath "org.gradle:test-retry-gradle-plugin:$versions.testRetryPlugin"
-    // For the japicmp lib, required here for intellij
+    // Required here ONLY for intellij as it won't resolve classes used in compatibility.gradle
     classpath "com.github.siom79.japicmp:japicmp:$versions.japicmp"
+    classpath "de.undercouch:gradle-download-task:$versions.gradleDownloadTask"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ ext {
 }
 
 apply from: file('wrapper.gradle')
+//apply plugin: 'me.champeau.gradle.japicmp'
 apply from: "$rootDir/gradle/compatibility.gradle"
 
 if (file('.git').exists()) {

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ buildscript {
     classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:$versions.spotbugsPlugin"
     classpath "org.gradle:test-retry-gradle-plugin:$versions.testRetryPlugin"
     // For the japicmp lib, required here for intellij
-    classpath "com.github.siom79.japicmp:japicmp:0.13.0"
+    classpath "com.github.siom79.japicmp:japicmp:$versions.japicmp"
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.7.0-SNAPSHOT
-latestReleaseVersion=2.6.0
+latestReleaseVersion=2.5.0
 scalaVersion=2.13.2
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.7.0-SNAPSHOT
-lastRelease=2.6.0
+latestRelease=2.6.0
 scalaVersion=2.13.2
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.7.0-SNAPSHOT
+lastRelease=2.6.0
 scalaVersion=2.13.2
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ group=org.apache.kafka
 #  - tests/kafkatest/version.py (variable DEV_VERSION)
 #  - kafka-merge-pr.py
 version=2.7.0-SNAPSHOT
-latestRelease=2.6.0
+latestReleaseVersion=2.6.0
 scalaVersion=2.13.2
 task=build
 org.gradle.jvmargs=-Xmx2g -Xss4m -XX:+UseParallelGC

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -1,0 +1,128 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'org.ajoberstar:gradle-git:1.4.2'
+    classpath 'com.github.siom79.japicmp:japicmp:0.7.2'
+  }
+}
+
+import org.ajoberstar.grgit.Grgit
+import org.apache.tools.ant.DirectoryScanner
+import io.airlift.airline.SingleCommand;
+
+// Parameters
+def defaultOldRef = "trunk"
+def oldRef = project.hasProperty('oldRef') ? project.oldRef : defaultOldRef
+
+def defaultNewRef = "HEAD"
+def newRef = project.hasProperty('newRef') ? project.newRef : defaultNewRef
+
+// Constants
+def includes = [
+  "org.apache.kafka.common.*",
+  "org.apache.kafka.clients.*",
+  "org.apache.kafka.connect.*",
+]
+def excludes = [
+  "org.apache.kafka.common.internals.*",
+  "org.apache.kafka.clients.consumer.internals.*",
+  "org.apache.kafka.clients.producer.internals.*",
+  "org.apache.kafka.clients.common.internals.*",
+]
+def oldWorkspace = "$buildDir/tmp/compatibility/old"
+def newWorkspace = "$buildDir/tmp/compatibility/new"
+def reportDir = "$buildDir/reports/compatibility"
+def reportFile = "$reportDir/compatibilityReport.html"
+
+def prepareWorkspace(name, gitRef, workspace) {
+  def rootRepo = Grgit.open(dir: rootProject.rootDir)
+  def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directories: true, dryRun: true))
+
+  // Setup a clean workspace
+  delete workspace
+
+  // Hack to remove Ant default excludes for copy. (Reset after)
+  // See https://issues.gradle.org/browse/GRADLE-1883
+  DirectoryScanner.defaultExcludes.each { DirectoryScanner.removeDefaultExclude it } // Reset at the bottom
+  DirectoryScanner.addDefaultExclude 'something has to be in here or everything gets excluded'
+
+  copy {
+    from rootDir
+    into workspace
+    excludes = repoExcludes
+  }
+
+  // See Hack comment above
+  DirectoryScanner.resetDefaultExcludes()
+
+  // Clean up and checkout the needed branch
+  def repo = Grgit.open(dir: workspace)
+  // Add and commit changes to support comparing un-committed work
+  repo.add(patterns: ['*'], update: true)
+  repo.commit(message: 'compatibility-check commit', all: true)
+  // Switch to the correct ref and make sure the branch is clean
+  repo.checkout(branch: 'compatibility-check', startPoint: gitRef, createBranch: true, orphan: true)
+  repo.clean(ignore: false, directories: true)
+
+  // Build the project Artifacts
+  tasks.create(name: "${name}Build", type: GradleBuild) {
+    dir = workspace
+    tasks = ['clean','jar']
+  }
+  tasks."${name}Build".execute()
+}
+
+def collectArtifactJars(workspace) {
+  return new FileNameFinder().getFileNames(workspace,
+    // Includes
+    '**/build/libs/kafka-*.jar',
+    // Excludes
+    '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar ')
+}
+
+def collectClasspathJars(workspace) {
+  return new FileNameFinder().getFileNames(workspace,
+    // Includes
+    '**/build/dependent-libs/*.jar')
+}
+
+task checkApiCompatibility() {
+  doLast {
+    // Prepare Workspaces
+    prepareWorkspace("old", oldRef, oldWorkspace)
+    prepareWorkspace("new", newRef, newWorkspace)
+
+    // Setup the report file
+    new File(reportDir).mkdirs()
+    new File(reportFile).createNewFile()
+
+    // Artifacts and Classpaths
+    def oldArtifacts = collectArtifactJars(oldWorkspace)
+    def newArtifacts = collectArtifactJars(newWorkspace)
+    // TODO: Add classpath after we centralize it
+//    def oldClasspath = collectClasspathJars(oldWorkspace)
+//    def newClasspath = collectClasspathJars(newWorkspace)
+
+    // Build check tool arguments
+    String[] args = [
+      "--old", oldArtifacts.join(";"),
+//      "--old-classpath", oldClasspath.join(":"),
+      "--new", newArtifacts.join(";"),
+//      "--new-classpath", newClasspath.join(":"),
+      "--include", includes.join(";"),
+      "--exclude", excludes.join(";"),
+      "--only-modified",
+//      "--only-incompatible",
+      "-a", "protected",
+      "--html-file", reportFile
+    ]
+
+    // Run the check tool
+    SingleCommand<japicmp.cli.JApiCli.Compare> singleCommand = SingleCommand.singleCommand(japicmp.cli.JApiCli.Compare.class);
+    japicmp.cli.JApiCli.Compare cmd = singleCommand.parse(args);
+    cmd.run();
+    logger.info("API Compatibility port available in ${new File(reportFile).toURI()}")
+  }
+}

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -44,7 +44,7 @@ import org.ajoberstar.grgit.Grgit
 import org.apache.tools.ant.DirectoryScanner
 
 def rootRepo = Grgit.open(dir: rootProject.rootDir)
-def source = project.hasProperty('source') ? project.source : lastRelease
+def source = project.hasProperty('source') ? project.source : latestRelease
 def target = project.hasProperty('target') ? project.target : rootRepo.branch.current.name
 def useRootAsSource = rootRepo.branch.current.name == source
 def useRootAsTarget = rootRepo.branch.current.name == target
@@ -311,8 +311,8 @@ def getArguments(Project project, List<String> sourceArtifacts, List<String> tar
   // hence the workaround.
   if (failOnSemanticIncompatibility) {
     def targetVersion = Version.getSemanticVersion(version).get()
-    def lastReleaseVersion = Version.getSemanticVersion(lastRelease).get()
-    def changeType = lastReleaseVersion.computeChangeType(targetVersion).get()
+    def latestReleaseVersion = Version.getSemanticVersion(latestRelease).get()
+    def changeType = latestReleaseVersion.computeChangeType(targetVersion).get()
     if (changeType == SemanticVersion.ChangeType.MINOR || changeType == SemanticVersion.ChangeType.PATCH) {
       args = args + ["--error-on-binary-incompatibility"]
     }

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -17,6 +17,9 @@ buildscript {
   repositories {
     mavenCentral()
     jcenter()
+    maven {
+      url "https://plugins.gradle.org/m2/"
+    }
   }
   dependencies {
     classpath "org.ajoberstar:grgit:1.9.3"
@@ -25,151 +28,327 @@ buildscript {
 }
 
 import japicmp.cli.JApiCli
+import japicmp.versioning.Version
+import japicmp.versioning.SemanticVersion
 import org.ajoberstar.grgit.Grgit
 import org.apache.tools.ant.DirectoryScanner
+import org.gradle.api.artifacts.ResolveException
 
-// Parameters
-def baseBranch = project.hasProperty('baseBranch') ? project.baseBranch : "trunk"
-def newBranch = project.hasProperty('newBranch') ? project.newBranch : "HEAD"
-def onlyIncompatible = project.hasProperty('onlyIncompatible') ? project.onlyIncompatible : true
-def failOnBinaryIncompatibility = project.hasProperty('failOnBinaryIncompatibility') ?
-        project.failOnBinaryIncompatibility : false
-def failOnSourceIncompatibility = project.hasProperty('failOnSourceIncompatibility') ?
-        project.failOnSourceIncompatibility : false
-def failOnModifications = project.hasProperty('failOnModifications') ?
-        project.failOnModifications : false
-def failOnSemanticIncompatibility = project.hasProperty('failOnSemanticIncompatibility') ?
-        project.failOnSemanticIncompatibility : false
-
-// Constants
-def packageIncludes = [
-  "org.apache.kafka.common.*",
-  "org.apache.kafka.clients.*",
-  "org.apache.kafka.connect.*",
-]
-def packageExcludes = [
-  "org.apache.kafka.*.internals.*"
-]
-def baseWorkspace = "$buildDir/tmp/compatibility/base"
-def newWorkspace = "$buildDir/tmp/compatibility/new"
-def reportDir = "$buildDir/reports/compatibility"
-def reportFile = "$reportDir/compatibilityReport.html"
 def rootRepo = Grgit.open(dir: rootProject.rootDir)
+def source = project.hasProperty('source') ? project.source : lastRelease
+def target = project.hasProperty('target') ? project.target : rootRepo.branch.current.name
+def useRootAsSource = rootRepo.branch.current.name == source
+def useRootAsTarget = rootRepo.branch.current.name == target
+def sourceArtifactsPath = "$buildDir/tmp/compatibility/source.artifacts"
+def targetArtifactsPath = "$buildDir/tmp/compatibility/target.artifacts"
+def sourceWorkspace = useRootAsSource ? rootProject.rootDir.path : "$buildDir/tmp/compatibility/source"
+def targetWorkspace = useRootAsTarget ? rootProject.rootDir.path : "$buildDir/tmp/compatibility/target"
 
+// We won't copy stuff that is excluded by git itself
 def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directories: true, dryRun: true))
 
-static def collectArtifactJars(String workspace) {
+static def collectArtifactJars(String workspace, String extraExcludes = "") {
   String includesPattern = '**/build/libs/kafka-*.jar **/build/libs/connect-*.jar'
   String excludesPattern = '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar ' +
-          '**/build/libs/*-system-tests-*.jar **/build/libs/*-examples*.jar'
+          "**/build/libs/*-system-tests-*.jar **/build/libs/*-examples*.jar **/build/tmp/compatibility/* $extraExcludes"
   return new FileNameFinder().getFileNames(workspace, includesPattern, excludesPattern)
 }
 
-static def checkoutBranch(String workspace, String branch) {
-  // Clean up and checkout the needed branch
-  def repo = Grgit.open(dir: workspace)
-  // Add and commit changes to support comparing un-committed work
-  repo.add(patterns: ['*'], update: true)
-  repo.commit(message: 'compatibility-check commit', all: true)
-  // Switch to the correct ref and make sure the branch is clean
-  repo.checkout(branch: 'compatibility-check', startPoint: branch, createBranch: true, orphan: true)
-  repo.clean(ignore: false, directories: true)
+/**
+ * Checks if the given parameter is a version number and at least 2.0.0
+ * @param reference can be an arbitrary git reference or a version number
+ * @return true in case the parameter can be interpreted as a version, false otherwise
+ */
+static def isDownloadableVersion(String reference) {
+  def semver = Version.getSemanticVersion(reference)
+  return semver.present && semver.get().major >= 2 && !reference.endsWith('-SNAPSHOT')
+}
+
+/**
+ * Resolves the given list of archive names with a given version and saves their path to the given file.
+ * Paths are separated by new lines.
+ * @param archiveNames
+ * @param reference
+ * @param outFile
+ */
+def resolveToFile(List archiveNames, String reference, File outFile) {
+  def ba = resolveDependencies(reference, archiveNames)
+  if (outFile.exists()) {
+    outFile.delete()
+  }
+  outFile.createNewFile()
+  outFile.write(ba.join("\n"))
+}
+
+def resolveDependencies(String version, List archiveNames) {
+  Configuration config = project.getConfigurations().create("download")
+  try {
+    config.setTransitive(false)
+    archiveNames.each {
+      println("org.apache.kafka:$it:$version")
+      project.getDependencies().add(config.getName(), "org.apache.kafka:$it:$version")
+    }
+    return config.getFiles().collect { it.path }
+  } finally {
+    project.configurations.remove(config)
+  }
+}
+
+/**
+ * Copies the root workspace to the folder denoted by the 'workspace' parameter, hard resets it to HEAD and
+ * checks out the reference denoted by the corresponding parameter.
+ * @param workspace is the location for checkout
+ * @param reference is the branch or tag to checkout
+ * @param repoExcludes a list of file names to exclude from copying
+ */
+def checkoutBranch(String workspace, String reference, List<String> repoExcludes) {
+  logger.info("Checking out '$reference' reference into $workspace")
+  if (file(workspace).list().length == 0) {
+    copy {
+      from rootDir
+      into workspace
+      excludes = repoExcludes
+    }
+  }
+  Grgit repo = null
+  try {
+    repo = Grgit.open(dir: workspace)
+    repo.reset(mode: 'HARD', commit: 'HEAD')
+    repo.checkout(branch: reference)
+    logger.info("Switched to $reference")
+  } finally {
+    repo?.close()
+  }
 }
 
 task setNoDirectoryExclude {
-  // Hack to remove Ant default excludes for copy. (Reset after)
+  // Hack to remove Ant default excludes for copy. (Reset after, see the end of the file)
   // See https://issues.gradle.org/browse/GRADLE-1883
   DirectoryScanner.defaultExcludes.each { DirectoryScanner.removeDefaultExclude it } // Reset at the bottom
   DirectoryScanner.addDefaultExclude 'something has to be in here or everything gets excluded'
 }
 
-task cleanWorkspaces {
-  delete baseWorkspace
-  delete newWorkspace
-  delete reportDir
-}
-
-task checkoutCleanBaseBranch(dependsOn: [setNoDirectoryExclude, cleanWorkspaces]) {
+/**
+ * Copies and checks out the 'source' reference. It won't do anything if it's the development
+ * branch on which the user is working on.
+ */
+task checkoutSourceBranch(dependsOn: setNoDirectoryExclude) {
+  inputs.property('source', source)
+  outputs.dir(sourceWorkspace)
   doLast {
-    copy {
-      from rootDir
-      into baseWorkspace
-      excludes = repoExcludes
+    if (source != rootRepo.branch.current.name) {
+      checkoutBranch(sourceWorkspace, source, repoExcludes)
     }
-    checkoutBranch(baseWorkspace, baseBranch)
   }
 }
 
-task checkoutCleanNewBranch(dependsOn: [setNoDirectoryExclude, cleanWorkspaces]) {
+/**
+ * Copies and checks out the 'target' reference. It won't do anything if it's the development
+ * branch on which the user is working on.
+ */
+task checkoutTargetBranch(dependsOn: setNoDirectoryExclude) {
+  inputs.property('target', target)
+  outputs.dir(targetWorkspace)
   doLast {
-    copy {
-      from rootDir
-      into newWorkspace
-      excludes = repoExcludes
+    if (target != rootRepo.branch.current.name) {
+      checkoutBranch(targetWorkspace, target, repoExcludes)
     }
-    checkoutBranch(newWorkspace, newBranch)
   }
 }
 
-task buildBaseBranch(type: GradleBuild, dependsOn: checkoutCleanBaseBranch) {
-  dir = baseWorkspace
-  tasks = ['clean','jar']
+/**
+ * Builds the project at the 'source' reference and produces the artifacts jars as it's output.
+ * If it needs to build, it'll run the 'jar' task.
+ */
+task buildSourceBranch(type: GradleBuild, dependsOn: checkoutSourceBranch) {
+  inputs.property('source', source)
+  outputs.file(sourceArtifactsPath)
+
+  dir = sourceWorkspace
+  startParameter.projectProperties = gradle.startParameter.projectProperties
+
+  tasks = ['jar']
+  doLast {
+    // When collecting the jars we need to exclude the 'source' and 'target' workspaces if we use the root
+    // git repo as the one of the branches to compare. Those directories may exist (but a 'clean' would get
+    // rid of them)
+    def sourceArtifacts = collectArtifactJars(sourceWorkspace, useRootAsSource ? "**/source/ **/target/" : "")
+    file(sourceArtifactsPath).write(sourceArtifacts.join("\n"))
+  }
 }
 
-task buildNewBranch(type: GradleBuild, dependsOn: checkoutCleanNewBranch) {
-  dir = newWorkspace
-  tasks = ['clean','jar']
+/**
+ * Builds the project at the 'target' reference and produces the artifacts jars as it's output.
+ * If it needs to build, it'll run the 'jar' task.
+ */
+task buildTargetBranch(type: GradleBuild, dependsOn: checkoutTargetBranch) {
+  inputs.property('target', target)
+  outputs.file(targetArtifactsPath)
+
+  dir = targetWorkspace
+  startParameter.projectProperties = gradle.startParameter.projectProperties
+
+  tasks = ['jar']
+  doLast {
+    def targetArtifacts = collectArtifactJars(targetWorkspace, useRootAsTarget ? "**/source/ **/target/" : "")
+    file(targetArtifactsPath).write(targetArtifacts.join(System.lineSeparator()))
+  }
 }
 
-task apiCompatibilityReport(dependsOn: [buildBaseBranch, buildNewBranch]) {
+/**
+ * Collects the archive names of the project and then tries to download them. In case
+ * the provided source and target references are not actual versions that can't be
+ * downloaded from the repositories, then adds a GradleBuild dependency task which
+ * will try to check out the repository and build the version.
+ */
+task collectArtifacts {
+  inputs.property('source', source)
+  inputs.property('target', target)
+  outputs.file(sourceArtifactsPath)
+  outputs.file(targetArtifactsPath)
+
+  afterEvaluate {
+    // Compute that which one can be downloaded and which one needs to be built
+    def buildTasks = []
+    if (!isDownloadableVersion(source)) {
+      buildTasks.add(buildSourceBranch)
+    }
+    if (!isDownloadableVersion(target)) {
+      buildTasks.add(buildTargetBranch)
+    }
+    dependsOn = buildTasks
+    logger.info("Added dependencies: $buildTasks")
+  }
+
+  doLast {
+    // Collect the archive names, so we can resolve them by group:artifact:version,
+    // like org.apache.kafka:kafka-clients:2.0.0
+    // Also exclude some projects that either meta (connect), test or example
+    def archiveNames = allprojects
+            .findAll{ it != rootProject \
+                      && it.name != 'connect' \
+                      && it.name != 'jmh-benchmarks' \
+                      && !it.name.contains('system-tests') \
+                      && !it.name.contains('examples') }
+            .collect{ it.archivesBaseName }
+    // Resolve only if we don't build
+    if (!dependsOn.contains(buildSourceBranch)) {
+      resolveToFile(archiveNames, source, file(sourceArtifactsPath))
+    }
+    if (!dependsOn.contains(buildTargetBranch)) {
+      resolveToFile(archiveNames, target, file(targetArtifactsPath))
+    }
+  }
+}
+
+def getArguments(Project project, List<String> sourceArtifacts, List<String> targetArtifacts, String reportFile) {
+  def packageIncludes = [
+          "org.apache.kafka.clients.admin.*",
+          "org.apache.kafka.clients.consumer.*",
+          "org.apache.kafka.clients.producer.*",
+          "org.apache.kafka.common.*",
+          "org.apache.kafka.common.acl.*",
+          "org.apache.kafka.common.annotation.*",
+          "org.apache.kafka.common.errors.*",
+          "org.apache.kafka.common.header.*",
+          "org.apache.kafka.common.resource.*",
+          "org.apache.kafka.common.serialization.*",
+          "org.apache.kafka.common.config.*",
+          "org.apache.kafka.common.config.provider.*",
+          "org.apache.kafka.common.security.auth.*",
+          "org.apache.kafka.common.security.plain.*",
+          "org.apache.kafka.common.security.scram.*",
+          "org.apache.kafka.common.security.token.delegation.*",
+          "org.apache.kafka.common.security.oauthbearer.*",
+          "org.apache.kafka.server.policy.*",
+          "org.apache.kafka.server.quota.*"
+  ]
+  def packageExcludes = [
+          "org.apache.kafka.*.internals.*"
+  ]
+
+  // Build check tool arguments
+  String[] args = [
+          "--ignore-missing-classes",
+          "--old", sourceArtifacts.join(";"),
+          "--new", targetArtifacts.join(";"),
+          "--include", packageIncludes.join(";"),
+          "--exclude", packageExcludes.join(";"),
+          "--only-modified",
+          "-a", "protected",
+          "--html-file", reportFile
+  ]
+
+  // Reading up parameters that are passed in
+  def onlyIncompatible = project.hasProperty('onlyIncompatible') ? project.onlyIncompatible : true
+  def failOnBinaryIncompatibility = project.hasProperty('failOnBinaryIncompatibility') ?
+          project.failOnBinaryIncompatibility : false
+  def failOnSourceIncompatibility = project.hasProperty('failOnSourceIncompatibility') ?
+          project.failOnSourceIncompatibility : false
+  def failOnSemanticIncompatibility = project.hasProperty('failOnSemanticIncompatibility') ?
+          project.failOnSemanticIncompatibility : false
+
+  if(onlyIncompatible) {
+    args = args + ["--only-incompatible"]
+  }
+  if (failOnBinaryIncompatibility) {
+    args = args + ["--error-on-binary-incompatibility"]
+  }
+  if (failOnSourceIncompatibility) {
+    args = args + ["--error-on-source-incompatibility"]
+  }
+  // There is an --error-on-semantic-incompatibility flag in japicmp but it doesn't seem to work,
+  // hence the workaround.
+  if (failOnSemanticIncompatibility) {
+    def targetVersion = Version.getSemanticVersion(version).get()
+    def lastReleaseVersion = Version.getSemanticVersion(lastRelease).get()
+    def changeType = lastReleaseVersion.computeChangeType(targetVersion).get()
+    if (changeType == SemanticVersion.ChangeType.MINOR || changeType == SemanticVersion.ChangeType.PATCH) {
+      args = args + ["--error-on-binary-incompatibility"]
+    }
+  }
+
+  return args
+}
+
+/**
+ * Implements the API compatibility report generation. As an input it takes the collected artifacts
+ * and produces a report as an output.
+ *
+ * This task is inserted into the build pipeline before the 'build' task and after 'assemble'. So 'build'
+ * would depend on this task.
+ */
+task apiCompatibilityReport(dependsOn: collectArtifacts) {
   group 'API Compatibility Report'
   description 'Generates an API compatibility report with the japicmp library. ' +
           'It checks both binary and source compatibility.'
+
+  // This task must run after the 'assemble' step as a dependency of the 'check' lifecycle task
+  mustRunAfter = [assemble]
+  check.dependsOn(apiCompatibilityReport)
+
+  def reportFile = "$buildDir/reports/compatibility/compatibilityReport.html"
+
+  inputs.property('source', source)
+  inputs.property('target', target)
+  outputs.file(reportFile)
+
+  if (source == target) {
+    throw new GradleException("You must specify two different branches")
+  }
+
   doLast {
-    // See Hack comment above
-    DirectoryScanner.resetDefaultExcludes()
-    // Setup the report file
-    new File(reportDir).mkdirs()
-    new File(reportFile).createNewFile()
+    def sourceArtifacts = file(sourceArtifactsPath).readLines()
+    def targetArtifacts = file(targetArtifactsPath).readLines()
 
-    // Artifacts and Classpaths
-    def baseArtifacts = collectArtifactJars(baseWorkspace)
-    def newArtifacts = collectArtifactJars(newWorkspace)
-
-    // Build check tool arguments
-    String[] args = [
-            "--ignore-missing-classes",
-            "--old", baseArtifacts.join(";"),
-            "--new", newArtifacts.join(";"),
-            "--include", packageIncludes.join(";"),
-            "--exclude", packageExcludes.join(";"),
-            "--only-modified",
-            "-a", "protected",
-            "--html-file", reportFile
-    ]
-
-    if(onlyIncompatible) {
-      args = args + ["--only-incompatible"]
-    }
-    if (failOnBinaryIncompatibility) {
-      args = args + ["--error-on-binary-incompatibility"]
-    }
-    if (failOnSourceIncompatibility) {
-      args = args + ["--error-on-source-incompatibility"]
-    }
-    if (failOnModifications) {
-      args = args + ["--error-on-modifications"]
-    }
-    if (failOnSemanticIncompatibility) {
-      args = args + ["--error-on-semantic-incompatibility"]
-    }
-
+    def args = getArguments(project, sourceArtifacts, targetArtifacts, reportFile)
 
     // Run the check tool
     JApiCli cli = new JApiCli()
     cli.run(args)
-
     println("API Compatibility report available in ${new File(reportFile).toURI()}")
+
+    // See Hack comment above
+    DirectoryScanner.resetDefaultExcludes()
   }
 }
-

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -1,128 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 buildscript {
   repositories {
     mavenCentral()
+    jcenter()
   }
   dependencies {
-    classpath 'org.ajoberstar:gradle-git:1.4.2'
-    classpath 'com.github.siom79.japicmp:japicmp:0.7.2'
+    classpath "org.ajoberstar:grgit:1.9.3"
+    classpath "com.github.siom79.japicmp:japicmp:0.13.0"
   }
 }
 
+import japicmp.cli.JApiCli
 import org.ajoberstar.grgit.Grgit
 import org.apache.tools.ant.DirectoryScanner
-import io.airlift.airline.SingleCommand;
 
 // Parameters
-def defaultOldRef = "trunk"
-def oldRef = project.hasProperty('oldRef') ? project.oldRef : defaultOldRef
-
-def defaultNewRef = "HEAD"
-def newRef = project.hasProperty('newRef') ? project.newRef : defaultNewRef
+def baseBranch = project.hasProperty('baseBranch') ? project.baseBranch : "trunk"
+def newBranch = project.hasProperty('newBranch') ? project.newBranch : "HEAD"
+def onlyIncompatible = project.hasProperty('onlyIncompatible') ? project.onlyIncompatible : true
 
 // Constants
-def includes = [
+def packageIncludes = [
   "org.apache.kafka.common.*",
   "org.apache.kafka.clients.*",
   "org.apache.kafka.connect.*",
 ]
-def excludes = [
+def packageExcludes = [
   "org.apache.kafka.common.internals.*",
   "org.apache.kafka.clients.consumer.internals.*",
   "org.apache.kafka.clients.producer.internals.*",
   "org.apache.kafka.clients.common.internals.*",
 ]
-def oldWorkspace = "$buildDir/tmp/compatibility/old"
+def baseWorkspace = "$buildDir/tmp/compatibility/old"
 def newWorkspace = "$buildDir/tmp/compatibility/new"
 def reportDir = "$buildDir/reports/compatibility"
 def reportFile = "$reportDir/compatibilityReport.html"
+def rootRepo = Grgit.open(dir: rootProject.rootDir)
 
-def prepareWorkspace(name, gitRef, workspace) {
-  def rootRepo = Grgit.open(dir: rootProject.rootDir)
-  def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directories: true, dryRun: true))
+def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directories: true, dryRun: true))
 
-  // Setup a clean workspace
-  delete workspace
+static def collectArtifactJars(String workspace) {
+  String includesPattern = '**/build/libs/kafka-*.jar'
+  String excludesPattern = '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar'
+  return new FileNameFinder().getFileNames(workspace, includesPattern, excludesPattern)
+}
 
-  // Hack to remove Ant default excludes for copy. (Reset after)
-  // See https://issues.gradle.org/browse/GRADLE-1883
-  DirectoryScanner.defaultExcludes.each { DirectoryScanner.removeDefaultExclude it } // Reset at the bottom
-  DirectoryScanner.addDefaultExclude 'something has to be in here or everything gets excluded'
-
-  copy {
-    from rootDir
-    into workspace
-    excludes = repoExcludes
-  }
-
-  // See Hack comment above
-  DirectoryScanner.resetDefaultExcludes()
-
+static def checkoutBranch(String workspace, String branch) {
   // Clean up and checkout the needed branch
   def repo = Grgit.open(dir: workspace)
   // Add and commit changes to support comparing un-committed work
   repo.add(patterns: ['*'], update: true)
   repo.commit(message: 'compatibility-check commit', all: true)
   // Switch to the correct ref and make sure the branch is clean
-  repo.checkout(branch: 'compatibility-check', startPoint: gitRef, createBranch: true, orphan: true)
+  repo.checkout(branch: 'compatibility-check', startPoint: branch, createBranch: true, orphan: true)
   repo.clean(ignore: false, directories: true)
-
-  // Build the project Artifacts
-  tasks.create(name: "${name}Build", type: GradleBuild) {
-    dir = workspace
-    tasks = ['clean','jar']
-  }
-  tasks."${name}Build".execute()
 }
 
-def collectArtifactJars(workspace) {
-  return new FileNameFinder().getFileNames(workspace,
-    // Includes
-    '**/build/libs/kafka-*.jar',
-    // Excludes
-    '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar ')
+task setNoDirectoryExclude {
+  // Hack to remove Ant default excludes for copy. (Reset after)
+  // See https://issues.gradle.org/browse/GRADLE-1883
+  DirectoryScanner.defaultExcludes.each { DirectoryScanner.removeDefaultExclude it } // Reset at the bottom
+  DirectoryScanner.addDefaultExclude 'something has to be in here or everything gets excluded'
 }
 
-def collectClasspathJars(workspace) {
-  return new FileNameFinder().getFileNames(workspace,
-    // Includes
-    '**/build/dependent-libs/*.jar')
-}
+task checkoutCleanBaseBranch(dependsOn: setNoDirectoryExclude) {
+  delete baseWorkspace
 
-task checkApiCompatibility() {
   doLast {
-    // Prepare Workspaces
-    prepareWorkspace("old", oldRef, oldWorkspace)
-    prepareWorkspace("new", newRef, newWorkspace)
+    copy {
+      from rootDir
+      into baseWorkspace
+      excludes = repoExcludes
+    }
+    checkoutBranch(baseWorkspace, baseBranch)
+  }
+}
 
+task checkoutCleanNewBranch(dependsOn: setNoDirectoryExclude) {
+  delete newWorkspace
+
+  doLast {
+    copy {
+      from rootDir
+      into newWorkspace
+      excludes = repoExcludes
+    }
+    checkoutBranch(newWorkspace, newBranch)
+  }
+}
+
+task buildBaseBranch(type: GradleBuild, dependsOn: checkoutCleanBaseBranch) {
+  dir = baseWorkspace
+  tasks = ['clean','jar']
+}
+
+task buildNewBranch(type: GradleBuild, dependsOn: checkoutCleanNewBranch) {
+  dir = newWorkspace
+  tasks = ['clean','jar']
+}
+
+task apiCompatibilityReport(dependsOn: [buildBaseBranch, buildNewBranch]) {
+  group 'API Compatibility Report'
+  description 'Generates an API compatibility report with the japicmp library. ' +
+          'It checks both binary and source compatibility.'
+  doLast {
+    // See Hack comment above
+    DirectoryScanner.resetDefaultExcludes()
     // Setup the report file
     new File(reportDir).mkdirs()
     new File(reportFile).createNewFile()
 
     // Artifacts and Classpaths
-    def oldArtifacts = collectArtifactJars(oldWorkspace)
+    def oldArtifacts = collectArtifactJars(baseWorkspace)
     def newArtifacts = collectArtifactJars(newWorkspace)
-    // TODO: Add classpath after we centralize it
-//    def oldClasspath = collectClasspathJars(oldWorkspace)
-//    def newClasspath = collectClasspathJars(newWorkspace)
 
     // Build check tool arguments
     String[] args = [
-      "--old", oldArtifacts.join(";"),
-//      "--old-classpath", oldClasspath.join(":"),
-      "--new", newArtifacts.join(";"),
-//      "--new-classpath", newClasspath.join(":"),
-      "--include", includes.join(";"),
-      "--exclude", excludes.join(";"),
-      "--only-modified",
-//      "--only-incompatible",
-      "-a", "protected",
-      "--html-file", reportFile
+            "--ignore-missing-classes",
+            "--old", oldArtifacts.join(";"),
+            "--new", newArtifacts.join(";"),
+            "--include", packageIncludes.join(";"),
+            "--exclude", packageExcludes.join(";"),
+            "--only-modified",
+            "-a", "protected",
+            "--html-file", reportFile
     ]
 
+    if(onlyIncompatible) {
+      args = args + ["--only-incompatible"]
+    }
+
     // Run the check tool
-    SingleCommand<japicmp.cli.JApiCli.Compare> singleCommand = SingleCommand.singleCommand(japicmp.cli.JApiCli.Compare.class);
-    japicmp.cli.JApiCli.Compare cmd = singleCommand.parse(args);
-    cmd.run();
-    logger.info("API Compatibility port available in ${new File(reportFile).toURI()}")
+    JApiCli cli = new JApiCli()
+    cli.run(args)
+
+    println("API Compatibility report available in ${new File(reportFile).toURI()}")
   }
 }
+

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -45,7 +45,7 @@ def packageExcludes = [
   "org.apache.kafka.clients.producer.internals.*",
   "org.apache.kafka.clients.common.internals.*",
 ]
-def baseWorkspace = "$buildDir/tmp/compatibility/old"
+def baseWorkspace = "$buildDir/tmp/compatibility/base"
 def newWorkspace = "$buildDir/tmp/compatibility/new"
 def reportDir = "$buildDir/reports/compatibility"
 def reportFile = "$reportDir/compatibilityReport.html"
@@ -77,9 +77,12 @@ task setNoDirectoryExclude {
   DirectoryScanner.addDefaultExclude 'something has to be in here or everything gets excluded'
 }
 
-task checkoutCleanBaseBranch(dependsOn: setNoDirectoryExclude) {
+task cleanWorkspaces {
   delete baseWorkspace
+  delete newWorkspace
+}
 
+task checkoutCleanBaseBranch(dependsOn: [setNoDirectoryExclude, cleanWorkspaces]) {
   doLast {
     copy {
       from rootDir
@@ -90,9 +93,7 @@ task checkoutCleanBaseBranch(dependsOn: setNoDirectoryExclude) {
   }
 }
 
-task checkoutCleanNewBranch(dependsOn: setNoDirectoryExclude) {
-  delete newWorkspace
-
+task checkoutCleanNewBranch(dependsOn: [setNoDirectoryExclude, cleanWorkspaces]) {
   doLast {
     copy {
       from rootDir

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -60,10 +60,13 @@ def sourceScalaVersion = project.hasProperty('sourceScalaVersion') ? project.sou
 def targetScalaVersion = project.hasProperty('targetScalaVersion') ? project.targetScalaVersion : resolveScalaVersion(target, (String) versions.baseScala)
 def sourceArchiveName = resolveArchiveName(source, sourceScalaVersion)
 def targetArchiveName = resolveArchiveName(target, targetScalaVersion)
-def sourceArtifactsPath = "$buildDir/tmp/compatibility/source.artifacts"
-def targetArtifactsPath = "$buildDir/tmp/compatibility/target.artifacts"
-def sourceWorkspace = useRootAsSource ? rootProject.rootDir.path : "$buildDir/tmp/compatibility/source"
-def targetWorkspace = useRootAsTarget ? rootProject.rootDir.path : "$buildDir/tmp/compatibility/target"
+def compatibilityWorkingDir = Paths.get("$buildDir", "tmp", "compatibility").toString()
+def sourceArtifactsPath = Paths.get(compatibilityWorkingDir, "source.artifacts").toString()
+def targetArtifactsPath = Paths.get(compatibilityWorkingDir, "target.artifacts").toString()
+def releasedSourceWorkspace = useRootAsSource ? rootProject.rootDir.path : Paths.get(compatibilityWorkingDir, "releasedSource").toString()
+def releasedTargetWorkspace = useRootAsSource ? rootProject.rootDir.path : Paths.get(compatibilityWorkingDir, "releasedTarget").toString()
+def sourceWorkspace = useRootAsSource ? rootProject.rootDir.path : Paths.get(compatibilityWorkingDir, "source").toString()
+def targetWorkspace = useRootAsTarget ? rootProject.rootDir.path : Paths.get(compatibilityWorkingDir, "target").toString()
 
 // We won't copy stuff that is excluded by git itself
 def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directories: true, dryRun: true))
@@ -249,10 +252,10 @@ task resolveSourceArtifactsFromUrl(dependsOn: initArtifactNames) {
   doLast {
     download {
       src "$archivesLocation/$sourceArchiveName"
-      dest "$sourceWorkspace/$sourceArchiveName"
+      dest "$releasedSourceWorkspace/$sourceArchiveName"
       overwrite false
     }
-    List<String> interestedJars = decompressBinaries(artifactNames, file("$sourceWorkspace/$sourceArchiveName"), source, sourceWorkspace)
+    List<String> interestedJars = decompressBinaries(artifactNames, file("$releasedSourceWorkspace/$sourceArchiveName"), source, releasedSourceWorkspace)
     file(sourceArtifactsPath).write(interestedJars.join("\n"))
   }
 }
@@ -268,10 +271,10 @@ task resolveTargetArtifactsFromUrl(dependsOn: initArtifactNames) {
   doLast {
     download {
       src "$archivesLocation/$targetArchiveName"
-      dest "$targetWorkspace/$targetArchiveName"
+      dest "$releasedTargetWorkspace/$targetArchiveName"
       overwrite false
     }
-    List<String> interestedJars = decompressBinaries(artifactNames, file("$targetWorkspace/$targetArchiveName"), target, targetWorkspace)
+    List<String> interestedJars = decompressBinaries(artifactNames, file("$releasedTargetWorkspace/$targetArchiveName"), target, releasedTargetWorkspace)
     file(targetArtifactsPath).write(interestedJars.join("\n"))
   }
 }

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -22,10 +22,13 @@ buildscript {
     }
   }
   dependencies {
-    classpath "org.ajoberstar:grgit:1.9.3"
-    classpath "com.github.siom79.japicmp:japicmp:0.13.0"
+    classpath "org.ajoberstar.grgit:grgit-core:$versions.grgit"
+    classpath "com.github.siom79.japicmp:japicmp:$versions.japicmp"
+    classpath 'de.undercouch:gradle-download-task:3.4.3'
   }
 }
+
+apply plugin: 'de.undercouch.download'
 
 
 import japicmp.cli.CliParser
@@ -43,11 +46,20 @@ import japicmp.versioning.SemanticVersion
 import org.ajoberstar.grgit.Grgit
 import org.apache.tools.ant.DirectoryScanner
 
+import java.nio.file.Paths
+
 def rootRepo = Grgit.open(dir: rootProject.rootDir)
-def source = project.hasProperty('source') ? project.source : latestRelease
-def target = project.hasProperty('target') ? project.target : rootRepo.branch.current.name
+String source = project.hasProperty('source') ? project.source : latestReleaseVersion
+String target = project.hasProperty('target') ? project.target : rootRepo.branch.current.name
+
+def archivesLocation = project.hasProperty('archivesLocation') ? project.archivesLocation : 'https://s3-us-west-2.amazonaws.com/kafka-packages'
 def useRootAsSource = rootRepo.branch.current.name == source
 def useRootAsTarget = rootRepo.branch.current.name == target
+def artifactNames = new ArrayList<String>()
+def sourceScalaVersion = project.hasProperty('sourceScalaVersion') ? project.sourceScalaVersion : resolveScalaVersion(source, (String) versions.baseScala)
+def targetScalaVersion = project.hasProperty('targetScalaVersion') ? project.targetScalaVersion : resolveScalaVersion(target, (String) versions.baseScala)
+def sourceArchiveName = resolveArchiveName(source, sourceScalaVersion)
+def targetArchiveName = resolveArchiveName(target, targetScalaVersion)
 def sourceArtifactsPath = "$buildDir/tmp/compatibility/source.artifacts"
 def targetArtifactsPath = "$buildDir/tmp/compatibility/target.artifacts"
 def sourceWorkspace = useRootAsSource ? rootProject.rootDir.path : "$buildDir/tmp/compatibility/source"
@@ -58,49 +70,56 @@ def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directori
 
 static def collectArtifactJars(String workspace, String extraExcludes = "") {
   String includesPattern = '**/build/libs/kafka-*.jar **/build/libs/connect-*.jar'
-  String excludesPattern = '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar ' +
+  String excludesPattern = '**/build/libs/*-javadoc.jar **/build/libs/*-scaladoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar ' +
           "**/build/libs/*-system-tests-*.jar **/build/libs/*-examples*.jar **/build/tmp/compatibility/* $extraExcludes"
   return new FileNameFinder().getFileNames(workspace, includesPattern, excludesPattern)
 }
 
-/**
- * Checks if the given parameter is a version number and at least 2.0.0
- * @param reference can be an arbitrary git reference or a version number
- * @return true in case the parameter can be interpreted as a version, false otherwise
- */
-static def isDownloadableVersion(String reference) {
-  def semver = Version.getSemanticVersion(reference)
-  return semver.present && semver.get().major >= 2 && !reference.endsWith('-SNAPSHOT')
+static boolean canResolveFromUrl(String url, String reference, String scalaVersion) {
+  def archiveName = resolveArchiveName(reference, scalaVersion)
+  return new URI("$url/$archiveName").toURL().openConnection().contentLength > -1
 }
 
 /**
- * Resolves the given list of archive names with a given version and saves their path to the given file.
- * Paths are separated by new lines.
- * @param archiveNames
- * @param reference
- * @param outFile
+ * Resolves the archive name of a given version, like kafka_2.11-1.1.0.tgz.
+ * @param version
+ * @return
  */
-def resolveToFile(List archiveNames, String reference, File outFile) {
-  def ba = resolveDependencies(reference, archiveNames)
-  if (outFile.exists()) {
-    outFile.delete()
-  }
-  outFile.createNewFile()
-  outFile.write(ba.join("\n"))
+static String resolveArchiveName(String version, String scalaVersion) {
+  return "kafka_$scalaVersion-${version}.tgz"
 }
 
-def resolveDependencies(String version, List archiveNames) {
-  Configuration config = project.getConfigurations().create("download")
-  try {
-    config.setTransitive(false)
-    archiveNames.each {
-      println("org.apache.kafka:$it:$version")
-      project.getDependencies().add(config.getName(), "org.apache.kafka:$it:$version")
+static String resolveScalaVersion(String version, String defaultScalaVersion) {
+  def semverOpt = Version.getSemanticVersion(version)
+
+  if (!semverOpt.present)
+    return defaultScalaVersion
+
+  if (semverOpt.get().major == 0 || semverOpt.get().major == 1)
+    return "2.11"
+  else
+    return "2.12"
+}
+
+/**
+ * Takes a compressed archive, decompresses it to a given location on the workspace and collects the paths of the
+ * some given artifacts.
+ */
+List<String> decompressBinaries(List artifactNames, File downloadedArchive, String reference, String workspace) {
+  def artifacts = artifactNames.collect { "$it-${reference}.jar".toString() }
+  def artifactLocations = new ArrayList()
+  copy {
+    from tarTree(downloadedArchive.getAbsolutePath())
+    include "/**/libs/**"
+    eachFile { FileCopyDetails fcd ->
+      logger.debug("Decompressing ${fcd.path}")
+      if (artifacts.contains(fcd.name)) {
+        artifactLocations.add(Paths.get(workspace, fcd.path).toAbsolutePath().toString())
+      }
     }
-    return config.getFiles().collect { it.path }
-  } finally {
-    project.configurations.remove(config)
+    into workspace
   }
+  return artifactLocations
 }
 
 /**
@@ -204,6 +223,59 @@ task buildTargetBranch(type: GradleBuild, dependsOn: checkoutTargetBranch) {
   }
 }
 
+task initArtifactNames {
+  doLast {
+    // Collect the archive names, so we can resolve them from the given url.
+    // Also exclude some projects that either meta (connect), test or example
+    artifactNames = allprojects
+            .findAll{ it != project.rootProject \
+                && it.name != 'connect' \
+                && it.name != 'generator' \
+                && it.name != 'jmh-benchmarks' \
+                && !it.name.contains('system-tests') \
+                && !it.name.contains('examples') }
+    .collect{ it.archivesBaseName }
+  }
+}
+
+/**
+ * Downloads an archive, decompresses it and collects the required artifacts
+ */
+task resolveSourceArtifactsFromUrl(dependsOn: initArtifactNames) {
+  inputs.property('source', source)
+  inputs.property('sourceArchiveName', sourceArchiveName)
+  inputs.property('archivesLocation', archivesLocation)
+  outputs.file(sourceArtifactsPath)
+  doLast {
+    download {
+      src "$archivesLocation/$sourceArchiveName"
+      dest "$sourceWorkspace/$sourceArchiveName"
+      overwrite false
+    }
+    List<String> interestedJars = decompressBinaries(artifactNames, file("$sourceWorkspace/$sourceArchiveName"), source, sourceWorkspace)
+    file(sourceArtifactsPath).write(interestedJars.join("\n"))
+  }
+}
+
+/**
+ * Downloads an archive, decompresses it and collects the required artifacts
+ */
+task resolveTargetArtifactsFromUrl(dependsOn: initArtifactNames) {
+  inputs.property('target', target)
+  inputs.property('targetArchiveName', targetArchiveName)
+  inputs.property('archivesLocation', archivesLocation)
+  outputs.file(targetArtifactsPath)
+  doLast {
+    download {
+      src "$archivesLocation/$targetArchiveName"
+      dest "$targetWorkspace/$targetArchiveName"
+      overwrite false
+    }
+    List<String> interestedJars = decompressBinaries(artifactNames, file("$targetWorkspace/$targetArchiveName"), target, targetWorkspace)
+    file(targetArtifactsPath).write(interestedJars.join("\n"))
+  }
+}
+
 /**
  * Collects the archive names of the project and then tries to download them. In case
  * the provided source and target references are not actual versions that can't be
@@ -219,35 +291,21 @@ task collectArtifacts {
   afterEvaluate {
     // Compute that which one can be downloaded and which one needs to be built
     def buildTasks = []
-    if (!isDownloadableVersion(source)) {
+
+    if (canResolveFromUrl(archivesLocation, source, sourceScalaVersion)) {
+      buildTasks.add(resolveSourceArtifactsFromUrl)
+    } else {
       buildTasks.add(buildSourceBranch)
     }
-    if (!isDownloadableVersion(target)) {
+
+    if (canResolveFromUrl(archivesLocation, target, targetScalaVersion)) {
+      buildTasks.add(resolveTargetArtifactsFromUrl)
+    } else {
       buildTasks.add(buildTargetBranch)
     }
+
     dependsOn = buildTasks
     logger.info("Added dependencies: $buildTasks")
-  }
-
-  doLast {
-    // Collect the archive names, so we can resolve them by group:artifact:version,
-    // like org.apache.kafka:kafka-clients:2.0.0
-    // Also exclude some projects that either meta (connect), test or example
-    def archiveNames = allprojects
-            .findAll{ it != rootProject \
-                      && it.name != 'connect' \
-                      && it.name != 'generator' \
-                      && it.name != 'jmh-benchmarks' \
-                      && !it.name.contains('system-tests') \
-                      && !it.name.contains('examples') }
-            .collect{ it.archivesBaseName }
-    // Resolve only if we don't build
-    if (!dependsOn.contains(buildSourceBranch)) {
-      resolveToFile(archiveNames, source, file(sourceArtifactsPath))
-    }
-    if (!dependsOn.contains(buildTargetBranch)) {
-      resolveToFile(archiveNames, target, file(targetArtifactsPath))
-    }
   }
 }
 
@@ -310,9 +368,9 @@ def getArguments(Project project, List<String> sourceArtifacts, List<String> tar
   // There is an --error-on-semantic-incompatibility flag in japicmp but it doesn't seem to work,
   // hence the workaround.
   if (failOnSemanticIncompatibility) {
-    def targetVersion = Version.getSemanticVersion(version).get()
-    def latestReleaseVersion = Version.getSemanticVersion(latestRelease).get()
-    def changeType = latestReleaseVersion.computeChangeType(targetVersion).get()
+    def targetVersion = Version.getSemanticVersion((String) version).get()
+    def latestSemanticVersion = Version.getSemanticVersion(latestReleaseVersion).get()
+    def changeType = latestSemanticVersion.computeChangeType(targetVersion).get()
     if (changeType == SemanticVersion.ChangeType.MINOR || changeType == SemanticVersion.ChangeType.PATCH) {
       args = args + ["--error-on-binary-incompatibility"]
     }
@@ -321,7 +379,7 @@ def getArguments(Project project, List<String> sourceArtifacts, List<String> tar
   return args
 }
 
-def generateHtmlOutput(Options options, List<JApiClass> jApiClasses) {
+static def generateHtmlOutput(Options options, List<JApiClass> jApiClasses) {
   XmlOutputGeneratorOptions xmlOutputGeneratorOptions = new XmlOutputGeneratorOptions()
   xmlOutputGeneratorOptions.setCreateSchemaFile(true)
   xmlOutputGeneratorOptions.setSemanticVersioningInformation(new SemverOut(options, jApiClasses).generate())
@@ -339,11 +397,11 @@ def generateHtmlOutput(Options options, List<JApiClass> jApiClasses) {
   }
 }
 
-def createReport(String[] args) {
+static def createReport(String[] args) {
   CliParser cliParser = new CliParser()
   Options options = cliParser.parse(args)
   JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(JarArchiveComparatorOptions.of(options))
-  List<JApiClass> jApiClasses = jarArchiveComparator.compare(options.getOldArchives(), options.getNewArchives())
+  List<JApiClass> jApiClasses = jarArchiveComparator.compare(options.oldArchives, options.newArchives)
   generateHtmlOutput(options, jApiClasses)
 }
 
@@ -367,6 +425,7 @@ task apiCompatibilityReport(dependsOn: collectArtifacts) {
 
   inputs.property('source', source)
   inputs.property('target', target)
+  inputs.property('archivesLocation', archivesLocation)
   outputs.file(reportFile)
 
   if (source == target) {

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -88,6 +88,7 @@ task setNoDirectoryExclude {
 task cleanWorkspaces {
   delete baseWorkspace
   delete newWorkspace
+  delete reportDir
 }
 
 task checkoutCleanBaseBranch(dependsOn: [setNoDirectoryExclude, cleanWorkspaces]) {

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -27,12 +27,21 @@ buildscript {
   }
 }
 
-import japicmp.cli.JApiCli
+
+import japicmp.cli.CliParser
+import japicmp.cmp.JarArchiveComparator
+import japicmp.cmp.JarArchiveComparatorOptions
+import japicmp.config.Options
+import japicmp.exception.JApiCmpException
+import japicmp.model.JApiClass
+import japicmp.output.semver.SemverOut
+import japicmp.output.xml.XmlOutput
+import japicmp.output.xml.XmlOutputGenerator
+import japicmp.output.xml.XmlOutputGeneratorOptions
 import japicmp.versioning.Version
 import japicmp.versioning.SemanticVersion
 import org.ajoberstar.grgit.Grgit
 import org.apache.tools.ant.DirectoryScanner
-import org.gradle.api.artifacts.ResolveException
 
 def rootRepo = Grgit.open(dir: rootProject.rootDir)
 def source = project.hasProperty('source') ? project.source : lastRelease
@@ -312,6 +321,32 @@ def getArguments(Project project, List<String> sourceArtifacts, List<String> tar
   return args
 }
 
+def generateHtmlOutput(Options options, List<JApiClass> jApiClasses) {
+  XmlOutputGeneratorOptions xmlOutputGeneratorOptions = new XmlOutputGeneratorOptions()
+  xmlOutputGeneratorOptions.setCreateSchemaFile(true)
+  xmlOutputGeneratorOptions.setSemanticVersioningInformation(new SemverOut(options, jApiClasses).generate())
+  XmlOutputGenerator xmlGenerator = new XmlOutputGenerator(jApiClasses, options, xmlOutputGeneratorOptions)
+  XmlOutput output = null
+  try {
+    XmlOutput xmlOutput = xmlGenerator.generate()
+    XmlOutputGenerator.writeToFiles(options, xmlOutput)
+  } catch (Exception e) {
+    throw new JApiCmpException(JApiCmpException.Reason.IoException, "Could not close output streams: " + e.getMessage(), e)
+  } finally {
+    if (output != null) {
+      output.close()
+    }
+  }
+}
+
+def createReport(String[] args) {
+  CliParser cliParser = new CliParser()
+  Options options = cliParser.parse(args)
+  JarArchiveComparator jarArchiveComparator = new JarArchiveComparator(JarArchiveComparatorOptions.of(options))
+  List<JApiClass> jApiClasses = jarArchiveComparator.compare(options.getOldArchives(), options.getNewArchives())
+  generateHtmlOutput(options, jApiClasses)
+}
+
 /**
  * Implements the API compatibility report generation. As an input it takes the collected artifacts
  * and produces a report as an output.
@@ -345,9 +380,8 @@ task apiCompatibilityReport(dependsOn: collectArtifacts) {
     def args = getArguments(project, sourceArtifacts, targetArtifacts, reportFile)
 
     // Run the check tool
-    JApiCli cli = new JApiCli()
-    cli.run(args)
-    println("API Compatibility report available in ${new File(reportFile).toURI()}")
+    createReport(args)
+    println("API Compatibility report is available in ${new File(reportFile).toURI()}")
 
     // See Hack comment above
     DirectoryScanner.resetDefaultExcludes()

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -227,6 +227,7 @@ task collectArtifacts {
     def archiveNames = allprojects
             .findAll{ it != rootProject \
                       && it.name != 'connect' \
+                      && it.name != 'generator' \
                       && it.name != 'jmh-benchmarks' \
                       && !it.name.contains('system-tests') \
                       && !it.name.contains('examples') }

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -32,6 +32,14 @@ import org.apache.tools.ant.DirectoryScanner
 def baseBranch = project.hasProperty('baseBranch') ? project.baseBranch : "trunk"
 def newBranch = project.hasProperty('newBranch') ? project.newBranch : "HEAD"
 def onlyIncompatible = project.hasProperty('onlyIncompatible') ? project.onlyIncompatible : true
+def failOnBinaryIncompatibility = project.hasProperty('failOnBinaryIncompatibility') ?
+        project.failOnBinaryIncompatibility : false
+def failOnSourceIncompatibility = project.hasProperty('failOnSourceIncompatibility') ?
+        project.failOnSourceIncompatibility : false
+def failOnModifications = project.hasProperty('failOnModifications') ?
+        project.failOnModifications : false
+def failOnSemanticIncompatibility = project.hasProperty('failOnSemanticIncompatibility') ?
+        project.failOnSemanticIncompatibility : false
 
 // Constants
 def packageIncludes = [
@@ -126,13 +134,13 @@ task apiCompatibilityReport(dependsOn: [buildBaseBranch, buildNewBranch]) {
     new File(reportFile).createNewFile()
 
     // Artifacts and Classpaths
-    def oldArtifacts = collectArtifactJars(baseWorkspace)
+    def baseArtifacts = collectArtifactJars(baseWorkspace)
     def newArtifacts = collectArtifactJars(newWorkspace)
 
     // Build check tool arguments
     String[] args = [
             "--ignore-missing-classes",
-            "--old", oldArtifacts.join(";"),
+            "--old", baseArtifacts.join(";"),
             "--new", newArtifacts.join(";"),
             "--include", packageIncludes.join(";"),
             "--exclude", packageExcludes.join(";"),
@@ -144,6 +152,19 @@ task apiCompatibilityReport(dependsOn: [buildBaseBranch, buildNewBranch]) {
     if(onlyIncompatible) {
       args = args + ["--only-incompatible"]
     }
+    if (failOnBinaryIncompatibility) {
+      args = args + ["--error-on-binary-incompatibility"]
+    }
+    if (failOnSourceIncompatibility) {
+      args = args + ["--error-on-source-incompatibility"]
+    }
+    if (failOnModifications) {
+      args = args + ["--error-on-modifications"]
+    }
+    if (failOnSemanticIncompatibility) {
+      args = args + ["--error-on-semantic-incompatibility"]
+    }
+
 
     // Run the check tool
     JApiCli cli = new JApiCli()

--- a/gradle/compatibility.gradle
+++ b/gradle/compatibility.gradle
@@ -48,10 +48,7 @@ def packageIncludes = [
   "org.apache.kafka.connect.*",
 ]
 def packageExcludes = [
-  "org.apache.kafka.common.internals.*",
-  "org.apache.kafka.clients.consumer.internals.*",
-  "org.apache.kafka.clients.producer.internals.*",
-  "org.apache.kafka.clients.common.internals.*",
+  "org.apache.kafka.*.internals.*"
 ]
 def baseWorkspace = "$buildDir/tmp/compatibility/base"
 def newWorkspace = "$buildDir/tmp/compatibility/new"
@@ -62,8 +59,9 @@ def rootRepo = Grgit.open(dir: rootProject.rootDir)
 def repoExcludes = new ArrayList<String>(rootRepo.clean(ignore: false, directories: true, dryRun: true))
 
 static def collectArtifactJars(String workspace) {
-  String includesPattern = '**/build/libs/kafka-*.jar'
-  String excludesPattern = '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar'
+  String includesPattern = '**/build/libs/kafka-*.jar **/build/libs/connect-*.jar'
+  String excludesPattern = '**/build/libs/*-javadoc.jar **/build/libs/*-sources.jar **/build/libs/*-test.jar ' +
+          '**/build/libs/*-system-tests-*.jar **/build/libs/*-examples*.jar'
   return new FileNameFinder().getFileNames(workspace, includesPattern, excludesPattern)
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,6 +62,7 @@ versions += [
   checkstyle: "8.20",
   commonsCli: "1.4",
   gradle: "6.5",
+  gradleDownloadTask: "3.4.3",
   gradleVersionsPlugin: "0.28.0",
   grgit: "4.0.1",
   httpclient: "4.5.11",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -77,6 +77,7 @@ versions += [
   hamcrest: "2.2",
   log4j: "1.2.17",
   scalaLogging: "3.9.2",
+  japicmp: "0.13.0",
   jaxb: "2.3.0",
   jaxrs: "2.1.1",
   jfreechart: "1.0.0",


### PR DESCRIPTION
This PR aims to extend the gradle build with a task that can generate a report for API/ABI compatibility.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
