### PR TITLE
KAFKA-7351 [WIP] return true for non existant ids in state map

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -42,7 +42,7 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Return true iff we can currently initiate a new connection. This will be the case if we are not
+     * Return true if we can currently initiate a new connection. This will be the case if we are not
      * connected and haven't been connected for at least the minimum reconnection backoff period.
      * @param id the connection id to check
      * @param now the current time in ms
@@ -249,7 +249,7 @@ final class ClusterConnectionStates {
      */
     public boolean isDisconnected(String id) {
         NodeConnectionState state = nodeState.get(id);
-        return state != null && state.state.isDisconnected();
+        return state == null || state.state.isDisconnected();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -249,7 +249,7 @@ final class ClusterConnectionStates {
      */
     public boolean isDisconnected(String id) {
         NodeConnectionState state = nodeState.get(id);
-        return state == null || state.state.isDisconnected();
+        return state != null && state.state.isDisconnected();
     }
 
     /**

--- a/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
+++ b/clients/src/main/java/org/apache/kafka/clients/ClusterConnectionStates.java
@@ -42,7 +42,7 @@ final class ClusterConnectionStates {
     }
 
     /**
-     * Return true if we can currently initiate a new connection. This will be the case if we are not
+     * Return true iff we can currently initiate a new connection. This will be the case if we are not
      * connected and haven't been connected for at least the minimum reconnection backoff period.
      * @param id the connection id to check
      * @param now the current time in ms

--- a/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClusterConnectionStatesTest.java
@@ -226,4 +226,11 @@ public class ClusterConnectionStatesTest {
         assertEquals(connectionStates.connectionDelay(nodeId1, time.milliseconds()),
             connectionStates.pollDelayMs(nodeId1, time.milliseconds()));
     }
+
+    @Test
+    public void testIsDisconnectedWithNonExistentIds() {
+        boolean disconnected = connectionStates.isDisconnected("non_existent_id");
+
+        assertTrue(disconnected);
+    }
 }


### PR DESCRIPTION
Description
Handle case when id of node does not exist in ClusterConnectionStates

Testing
Added unit test for specific case.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
