### PR TITLE
KAFKA-7392: Allow to specify subnet for Docker containers using stand…

### DIFF
--- a/tests/docker/ducker-ak
+++ b/tests/docker/ducker-ak
@@ -58,7 +58,7 @@ help|-h|--help
     Display this help message
 
 up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
-        [-C|--custom-ducktape DIR]
+        [-C|--custom-ducktape DIR] [-s|--subnet CIDR]
     Bring up a cluster with the specified amount of nodes (defaults to ${default_num_nodes}).
     The docker image name defaults to ${default_image_name}.  If --force is specified, we will
     attempt to bring up an image even some parameters are not valid.
@@ -66,6 +66,9 @@ up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
     If --custom-ducktape is specified, we will install the provided custom
     ducktape source code directory before bringing up the nodes.  The provided
     directory should be the ducktape git repo, not the ducktape installed module directory.
+
+    If --subnet is specified, default Docker subnet is overriden by given IP address and netmask,
+    using standard CIDR notation. For example: 192.168.1.5/24.
 
 test [test-name(s)]
     Run a test or set of tests inside the currently active Ducker nodes.
@@ -264,6 +267,7 @@ ducker_up() {
             -C|--custom-ducktape) set_once custom_ducktape "${2}" "the custom ducktape directory"; shift 2;;
             -f|--force) force=1; shift;;
             -n|--num-nodes) set_once num_nodes "${2}" "number of nodes"; shift 2;;
+            -s|--subnet) set_once subnet "${2}" "docker subnet"; shift 2;;
             *) set_once image_name "${1}" "docker image name"; shift;;
         esac
     done
@@ -310,7 +314,13 @@ attempting to start new ones."
     if docker network inspect ducknet &>/dev/null; then
         must_do -v docker network rm ducknet
     fi
-    must_do -v docker network create ducknet
+
+    if [[ -n "${subnet}" ]]; then
+      must_do -v docker network create --subnet ${subnet} ducknet
+    else
+      must_do -v docker network create ducknet
+    fi
+
     if [[ -n "${custom_ducktape}" ]]; then
         setup_custom_ducktape "${custom_ducktape}" "${image_name}"
     fi


### PR DESCRIPTION
…ard CIDR notation

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*
I have manually verified the changes:

- I tested new help message is displayed
```
/ducker-ak up --help                            
ducker-ak: a tool for running Apache Kafka tests inside Docker images.

Usage: ./ducker-ak [command] [options]

help|-h|--help
    Display this help message

up [-n|--num-nodes NUM_NODES] [-f|--force] [docker-image]
        [-C|--custom-ducktape DIR] [-s|--subnet CIDR]
    Bring up a cluster with the specified amount of nodes (defaults to 14).
    The docker image name defaults to ducker-ak.  If --force is specified, we will
    attempt to bring up an image even some parameters are not valid.

    If --custom-ducktape is specified, we will install the provided custom
    ducktape source code directory before bringing up the nodes.  The provided
    directory should be the ducktape git repo, not the ducktape installed module directory.

    If --subnet is specified, default Docker subnet is overriden by given IP address and netmask,
    using standard CIDR notation. For example: 192.168.1.5/24.
```
- Spinned up Docker containers with the new subnet argument and verified it is used by ducknet:
```
$ ./ducker-ak up -n 5 --subnet 192.168.1.5/24
...
$ docker network inspect ducknet                                            
[
    {
        "Name": "ducknet",
        "Id": "75cadf2d29077b4bebb4bd5c1c03e0a542716992b656027e8728634a2d0bd3a5",
        "Created": "2018-09-11T20:11:56.6093651Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "192.168.1.5/24"
                }
            ]
        },
...
```
- Spinned up Docker containers without the new subnet argument and verified it is used default IP range allocated by docker is used:
```
$ ./ducker-ak up -n 2 
...
$ docker network inspect ducknet
[
    {
        "Name": "ducknet",
        "Id": "7ebb38cd99e8a3fb84a65fd4eaad52dbe37e28dd83b6f0b57d512f66222397bd",
        "Created": "2018-09-09T12:22:25.6561649Z",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "172.24.0.0/16",
                    "Gateway": "172.24.0.1"
                }
            ]
        },
...
```
### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
