### PR TITLE
MINOR: Mark new Scala streams tests as integration tests (KIP-270 follow-up)

### DIFF
--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/StreamToTableJoinScalaIntegrationTestImplicitSerdes.scala
@@ -22,7 +22,9 @@ import org.apache.kafka.streams._
 import org.apache.kafka.streams.scala.ImplicitConversions._
 import org.apache.kafka.streams.scala.kstream._
 import org.apache.kafka.streams.scala.utils.StreamToTableJoinScalaIntegrationTestBase
+import org.apache.kafka.test.IntegrationTest
 import org.junit._
+import org.junit.experimental.categories.Category
 
 /**
  * Test suite that does an example to demonstrate stream-table joins in Kafka Streams
@@ -33,6 +35,7 @@ import org.junit._
  * Note: In the current project settings SAM type conversion is turned off as it's experimental in Scala 2.11.
  * Hence the native Java API based version is more verbose.
  */
+@Category(Array(classOf[IntegrationTest]))
 class StreamToTableJoinScalaIntegrationTestImplicitSerdes extends StreamToTableJoinScalaIntegrationTestBase {
 
   @Test def testShouldCountClicksPerRegion(): Unit = {

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/WordCountTest.scala
@@ -26,21 +26,18 @@ import org.scalatest.junit.JUnitSuite
 import org.junit.Assert._
 import org.junit._
 import org.junit.rules.TemporaryFolder
-
 import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams._
 import org.apache.kafka.streams.scala.kstream._
 import org.apache.kafka.streams.kstream.Materialized
-
 import org.apache.kafka.streams.integration.utils.{EmbeddedKafkaCluster, IntegrationTestUtils}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
-
 import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.utils.MockTime
-import org.apache.kafka.test.TestUtils
-
+import org.apache.kafka.test.{IntegrationTest, TestUtils}
 import ImplicitConversions._
+import org.junit.experimental.categories.Category
 
 /**
  * Test suite that does a classic word count example.
@@ -51,6 +48,7 @@ import ImplicitConversions._
  * Note: In the current project settings SAM type conversion is turned off as it's experimental in Scala 2.11.
  * Hence the native Java API based version is more verbose.
  */
+@Category(Array(classOf[IntegrationTest]))
 class WordCountTest extends JUnitSuite with WordCountTestData {
 
   private val privateCluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/StreamToTableJoinScalaIntegrationTestBase.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/StreamToTableJoinScalaIntegrationTestBase.scala
@@ -24,8 +24,9 @@ import org.apache.kafka.common.serialization._
 import org.apache.kafka.common.utils.MockTime
 import org.apache.kafka.streams._
 import org.apache.kafka.streams.integration.utils.{EmbeddedKafkaCluster, IntegrationTestUtils}
-import org.apache.kafka.test.TestUtils
+import org.apache.kafka.test.{IntegrationTest, TestUtils}
 import org.junit._
+import org.junit.experimental.categories.Category
 import org.junit.rules.TemporaryFolder
 import org.scalatest.junit.JUnitSuite
 
@@ -33,6 +34,7 @@ import org.scalatest.junit.JUnitSuite
  * Test suite base that prepares Kafka cluster for stream-table joins in Kafka Streams
  * <p>
  */
+@Category(Array(classOf[IntegrationTest]))
 class StreamToTableJoinScalaIntegrationTestBase extends JUnitSuite with StreamToTableJoinTestData {
 
   private val privateCluster: EmbeddedKafkaCluster = new EmbeddedKafkaCluster(1)


### PR DESCRIPTION
KIP-270 added some integration tests, but they were not marked with the appropriate annotation and bloat the `unitTest` target. This annotates them properly so we get faster unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
