### PR TITLE
KAFKA-7394; OffsetsForLeaderEpoch supports topic describe access

### DIFF
--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -194,15 +194,16 @@ class Replica(val brokerId: Int,
 
   override def toString: String = {
     val replicaString = new StringBuilder
-    replicaString.append("ReplicaId: " + brokerId)
-    replicaString.append("; Topic: " + topicPartition.topic)
-    replicaString.append("; Partition: " + topicPartition.partition)
-    replicaString.append("; isLocal: " + isLocal)
-    replicaString.append("; lastCaughtUpTimeMs: " + lastCaughtUpTimeMs)
+    replicaString.append("Replica(replicaId=" + brokerId)
+    replicaString.append(", topic=" + topicPartition.topic)
+    replicaString.append(", partition=" + topicPartition.partition)
+    replicaString.append(", isLocal=" + isLocal)
+    replicaString.append(", lastCaughtUpTimeMs=" + lastCaughtUpTimeMs)
     if (isLocal) {
-      replicaString.append("; Highwatermark: " + highWatermark)
-      replicaString.append("; LastStableOffset: " + lastStableOffset)
+      replicaString.append(", highWatermark=" + highWatermark)
+      replicaString.append(", lastStableOffset=" + lastStableOffset)
     }
+    replicaString.append(")")
     replicaString.toString
   }
 }

--- a/core/src/main/scala/kafka/cluster/Replica.scala
+++ b/core/src/main/scala/kafka/cluster/Replica.scala
@@ -195,13 +195,13 @@ class Replica(val brokerId: Int,
   override def toString: String = {
     val replicaString = new StringBuilder
     replicaString.append("Replica(replicaId=" + brokerId)
-    replicaString.append(", topic=" + topicPartition.topic)
-    replicaString.append(", partition=" + topicPartition.partition)
-    replicaString.append(", isLocal=" + isLocal)
-    replicaString.append(", lastCaughtUpTimeMs=" + lastCaughtUpTimeMs)
+    replicaString.append(s", topic=${topicPartition.topic}")
+    replicaString.append(s", partition=${topicPartition.partition}")
+    replicaString.append(s", isLocal=$isLocal")
+    replicaString.append(s", lastCaughtUpTimeMs=$lastCaughtUpTimeMs")
     if (isLocal) {
-      replicaString.append(", highWatermark=" + highWatermark)
-      replicaString.append(", lastStableOffset=" + lastStableOffset)
+      replicaString.append(s", highWatermark=$highWatermark")
+      replicaString.append(s", lastStableOffset=$lastStableOffset")
     }
     replicaString.append(")")
     replicaString.toString

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1494,4 +1494,3 @@ class ReplicaManager(val config: KafkaConfig,
     }
   }
 }
-


### PR DESCRIPTION
As part of KIP-320, allow OffsetsForLeaderEpoch requests with Topic Describe permission.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
