### PR TITLE
MINOR: increase number of unique keys for Streams EOS system test

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 
 public class EosTestDriver extends SmokeTestUtil {
 
-    private static final int MAX_NUMBER_OF_KEYS = 100;
+    private static final int MAX_NUMBER_OF_KEYS = 10000;
     private static final long MAX_IDLE_TIME_MS = 600000L;
 
     private static boolean isRunning = true;

--- a/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/EosTestDriver.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 
 public class EosTestDriver extends SmokeTestUtil {
 
-    private static final int MAX_NUMBER_OF_KEYS = 10000;
+    private static final int MAX_NUMBER_OF_KEYS = 20000;
     private static final long MAX_IDLE_TIME_MS = 600000L;
 
     private static boolean isRunning = true;


### PR DESCRIPTION
Increasing the number of unique keys, to increase likelihood that the test exposes KAFKA-7192
