### PR TITLE
MINOR: Update minimum required Gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ See our [web site](http://kafka.apache.org) for details on the project.
 
 You need to have [Gradle](http://www.gradle.org/installation) and [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html) installed.
 
-Kafka requires Gradle 4.6 or higher.
+Kafka requires Gradle 4.7 or higher.
 
 Java 8 should be used for building in order to support both Java 8 and Java 10 at runtime.
 


### PR DESCRIPTION
After commit f123d2f18c55b1cf2edb452aeb87e6ad0743c292, the minimum required gradle version changed to 4.7

This is due to the use of `isJava11Compatible()` in build.gradle. It was introduced in version 4.7 (https://github.com/gradle/gradle/blob/master/subprojects/base-services/src/main/java/org/gradle/api/JavaVersion.java#L172-L180)

cc @ijuma @lindong28  