### PR TITLE
MINOR: increase the timeout for the streams broker resilience test

### DIFF
--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -72,7 +72,7 @@ class StreamsBrokerDownResilience(Test):
         consumer.start()
 
         wait_until(lambda: consumer.total_consumed() > 0,
-                   timeout_sec=60,
+                   timeout_sec=120,
                    err_msg="At %s streams did not process messages in 60 seconds " % test_state)
 
     def setUp(self):

--- a/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
+++ b/tests/kafkatest/tests/streams/streams_broker_down_resilience_test.py
@@ -73,7 +73,7 @@ class StreamsBrokerDownResilience(Test):
 
         wait_until(lambda: consumer.total_consumed() > 0,
                    timeout_sec=120,
-                   err_msg="At %s streams did not process messages in 60 seconds " % test_state)
+                   err_msg="At %s streams did not process messages in 120 seconds " % test_state)
 
     def setUp(self):
         self.zk.start()


### PR DESCRIPTION
After observing what seems to be a transient system test failure related to recovery just being a little slower than expected, I'm recommending to increase the timeout to the same value we use for trunk.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
