### PR TITLE
KAFKA-6647 KafkaStreams.cleanUp creates .lock file in directory it tries to clean

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -103,6 +103,10 @@ public class StateDirectory {
         return taskDir;
     }
 
+    File stateDir() {
+        return stateDir;
+    }
+
     /**
      * Get or create the directory for the global stores.
      * @return directory for the global stores
@@ -141,7 +145,7 @@ public class StateDirectory {
         }
 
         try {
-            lockFile = new File(directoryForTask(taskId), LOCK_FILE_NAME);
+            lockFile = new File(stateDir, taskId + LOCK_FILE_NAME);
         } catch (final ProcessorStateException e) {
             // directoryForTask could be throwing an exception if another thread
             // has concurrently deleted the directory
@@ -331,7 +335,8 @@ public class StateDirectory {
     private FileChannel getOrCreateFileChannel(final TaskId taskId,
                                                final Path lockPath) throws IOException {
         if (!channels.containsKey(taskId)) {
-            channels.put(taskId, FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE));
+            channels.put(taskId, FileChannel.open(lockPath, StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE, StandardOpenOption.DELETE_ON_CLOSE));
         }
         return channels.get(taskId);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StateDirectory.java
@@ -226,6 +226,10 @@ public class StateDirectory {
             final FileChannel fileChannel = channels.remove(taskId);
             if (fileChannel != null) {
                 fileChannel.close();
+                final File lockFile = new File(stateDir, taskId + LOCK_FILE_NAME);
+                if (!lockFile.delete()) {
+                  log.debug("{} was not deleted", lockFile.toString());
+                }
             }
         }
     }
@@ -336,7 +340,7 @@ public class StateDirectory {
                                                final Path lockPath) throws IOException {
         if (!channels.containsKey(taskId)) {
             channels.put(taskId, FileChannel.open(lockPath, StandardOpenOption.CREATE,
-                StandardOpenOption.WRITE, StandardOpenOption.DELETE_ON_CLOSE));
+                StandardOpenOption.WRITE));
         }
         return channels.get(taskId);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -96,7 +96,7 @@ public class StateDirectoryTest {
 
         try (
             final FileChannel channel = FileChannel.open(
-                new File(appDir, taskId+StateDirectory.LOCK_FILE_NAME).toPath(),
+                new File(appDir, taskId + StateDirectory.LOCK_FILE_NAME).toPath(),
                 StandardOpenOption.CREATE, StandardOpenOption.WRITE)
         ) {
             channel.tryLock();

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StateDirectoryTest.java
@@ -89,27 +89,6 @@ public class StateDirectoryTest {
     }
 
     @Test
-    public void shouldLockTaskStateDirectory() throws IOException {
-        final TaskId taskId = new TaskId(0, 0);
-        final File taskDirectory = directory.directoryForTask(taskId);
-
-        directory.lock(taskId);
-
-        try (
-            final FileChannel channel = FileChannel.open(
-                new File(taskDirectory, StateDirectory.LOCK_FILE_NAME).toPath(),
-                StandardOpenOption.CREATE, StandardOpenOption.WRITE)
-        ) {
-            channel.tryLock();
-            fail("shouldn't be able to lock already locked directory");
-        } catch (final OverlappingFileLockException e) {
-            // pass
-        } finally {
-            directory.unlock(taskId);
-        }
-    }
-
-    @Test
     public void shouldBeTrueIfAlreadyHoldsLock() throws IOException {
         final TaskId taskId = new TaskId(0, 0);
         directory.directoryForTask(taskId);
@@ -140,17 +119,18 @@ public class StateDirectoryTest {
     @Test
     public void shouldLockMulitpleTaskDirectories() throws IOException {
         final TaskId taskId = new TaskId(0, 0);
-        final File task1Dir = directory.directoryForTask(taskId);
+        final File task1Dir = directory.stateDir();
         final TaskId taskId2 = new TaskId(1, 0);
-        final File task2Dir = directory.directoryForTask(taskId2);
+        final File task2Dir = directory.stateDir();
 
 
         try (
             final FileChannel channel1 = FileChannel.open(
-                new File(task1Dir, StateDirectory.LOCK_FILE_NAME).toPath(),
+                new File(task1Dir, taskId + StateDirectory.LOCK_FILE_NAME).toPath(),
                 StandardOpenOption.CREATE,
                 StandardOpenOption.WRITE);
-            final FileChannel channel2 = FileChannel.open(new File(task2Dir, StateDirectory.LOCK_FILE_NAME).toPath(),
+            final FileChannel channel2 = FileChannel.open(
+                new File(task2Dir, taskId2 + StateDirectory.LOCK_FILE_NAME).toPath(),
                 StandardOpenOption.CREATE,
                 StandardOpenOption.WRITE)
         ) {
@@ -196,15 +176,14 @@ public class StateDirectoryTest {
             directory.directoryForTask(new TaskId(2, 0));
 
             List<File> files = Arrays.asList(appDir.listFiles());
-            assertEquals(3, files.size());
+            assertEquals(1, files.size());
 
             time.sleep(1000);
             directory.cleanRemovedTasks(0);
 
-            files = Arrays.asList(appDir.listFiles());
-            assertEquals(2, files.size());
-            assertTrue(files.contains(new File(appDir, task0.toString())));
-            assertTrue(files.contains(new File(appDir, task1.toString())));
+            files = Arrays.asList(directory.stateDir().listFiles());
+            // lock files have been cleaned
+            assertEquals(0, files.size());
         } finally {
             directory.unlock(task0);
             directory.unlock(task1);


### PR DESCRIPTION
Specify StandardOpenOption#DELETE_ON_CLOSE when creating the FileChannel.

Move lock file up one level.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
