### PR TITLE
MINOR: Improve IntegrationTestUtils documentation

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -228,24 +228,6 @@ public class IntegrationTestUtils {
      * @param topic               Kafka topic to write the data records to
      * @param records             Data records to write to Kafka
      * @param producerConfig      Kafka producer configuration
-     * @param headers             {@link Headers} of the data records
-     * @param timestamp           Timestamp of the record
-     * @param <K>                 Key type of the data records
-     * @param <V>                 Value type of the data records
-     */
-    public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
-                                                                         final Collection<KeyValue<K, V>> records,
-                                                                         final Properties producerConfig,
-                                                                         final Headers headers,
-                                                                         final Long timestamp)
-        throws ExecutionException, InterruptedException {
-        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, headers, timestamp, false);
-    }
-
-    /**
-     * @param topic               Kafka topic to write the data records to
-     * @param records             Data records to write to Kafka
-     * @param producerConfig      Kafka producer configuration
      * @param timestamp           Timestamp of the record
      * @param enableTransactions  Send messages in a transaction
      * @param <K>                 Key type of the data records

--- a/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/utils/IntegrationTestUtils.java
@@ -98,7 +98,7 @@ public class IntegrationTestUtils {
     }
 
     /**
-     * Removes local state stores.  Useful to reset state in-between integration test runs.
+     * Removes local state stores. Useful to reset state in-between integration test runs.
      *
      * @param streamsConfiguration Streams configuration settings
      */
@@ -140,6 +140,7 @@ public class IntegrationTestUtils {
      * @param topic          Kafka topic to write the data records to
      * @param records        Data records to write to Kafka
      * @param producerConfig Kafka producer configuration
+     * @param time           Timestamp provider
      * @param <K>            Key type of the data records
      * @param <V>            Value type of the data records
      */
@@ -149,6 +150,15 @@ public class IntegrationTestUtils {
         IntegrationTestUtils.produceKeyValuesSynchronously(topic, records, producerConfig, time, false);
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param headers             {@link Headers} of the data records
+     * @param time                Timestamp provider
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
     public static <K, V> void produceKeyValuesSynchronously(
         final String topic, final Collection<KeyValue<K, V>> records, final Properties producerConfig, final Headers headers, final Time time)
         throws ExecutionException, InterruptedException {
@@ -159,6 +169,7 @@ public class IntegrationTestUtils {
      * @param topic               Kafka topic to write the data records to
      * @param records             Data records to write to Kafka
      * @param producerConfig      Kafka producer configuration
+     * @param time                Timestamp provider
      * @param enableTransactions  Send messages in a transaction
      * @param <K>                 Key type of the data records
      * @param <V>                 Value type of the data records
@@ -169,6 +180,16 @@ public class IntegrationTestUtils {
         IntegrationTestUtils.produceKeyValuesSynchronously(topic, records, producerConfig, null, time, enableTransactions);
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param headers             {@link Headers} of the data records
+     * @param time                Timestamp provider
+     * @param enableTransactions  Send messages in a transaction
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
     public static <K, V> void produceKeyValuesSynchronously(final String topic,
                                                             final Collection<KeyValue<K, V>> records,
                                                             final Properties producerConfig,
@@ -187,6 +208,14 @@ public class IntegrationTestUtils {
         }
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param timestamp           Timestamp of the record
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
     public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
                                                                          final Collection<KeyValue<K, V>> records,
                                                                          final Properties producerConfig,
@@ -195,6 +224,33 @@ public class IntegrationTestUtils {
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, timestamp, false);
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param headers             {@link Headers} of the data records
+     * @param timestamp           Timestamp of the record
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
+                                                                         final Collection<KeyValue<K, V>> records,
+                                                                         final Properties producerConfig,
+                                                                         final Headers headers,
+                                                                         final Long timestamp)
+        throws ExecutionException, InterruptedException {
+        IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, headers, timestamp, false);
+    }
+
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param timestamp           Timestamp of the record
+     * @param enableTransactions  Send messages in a transaction
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
     public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
                                                                          final Collection<KeyValue<K, V>> records,
                                                                          final Properties producerConfig,
@@ -204,15 +260,25 @@ public class IntegrationTestUtils {
         IntegrationTestUtils.produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, null, timestamp, enableTransactions);
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param headers             {@link Headers} of the data records
+     * @param timestamp           Timestamp of the record
+     * @param enableTransactions  Send messages in a transaction
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
     public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
                                                                          final Collection<KeyValue<K, V>> records,
                                                                          final Properties producerConfig,
                                                                          final Headers headers,
                                                                          final Long timestamp,
-                                                                         final boolean enabledTransactions)
+                                                                         final boolean enableTransactions)
         throws ExecutionException, InterruptedException {
         try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig)) {
-            if (enabledTransactions) {
+            if (enableTransactions) {
                 producer.initTransactions();
                 producer.beginTransaction();
             }
@@ -221,7 +287,7 @@ public class IntegrationTestUtils {
                     new ProducerRecord<>(topic, null, timestamp, record.key, record.value, headers));
                 f.get();
             }
-            if (enabledTransactions) {
+            if (enableTransactions) {
                 producer.commitTransaction();
             }
             producer.flush();
@@ -263,6 +329,17 @@ public class IntegrationTestUtils {
         }
     }
 
+    /**
+     * Produce data records and send them synchronously in an aborted transaction; that is, a transaction is started for
+     * each data record but not committed.
+     *
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param timestamp           Timestamp of the record
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     */
     public static <K, V> void produceAbortedKeyValuesSynchronouslyWithTimestamp(final String topic,
                                                                                 final Collection<KeyValue<K, V>> records,
                                                                                 final Properties producerConfig,
@@ -280,6 +357,13 @@ public class IntegrationTestUtils {
         }
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param time                Timestamp provider
+     * @param <V>                 Value type of the data records
+     */
     public static <V> void produceValuesSynchronously(final String topic,
                                                       final Collection<V> records,
                                                       final Properties producerConfig,
@@ -288,6 +372,14 @@ public class IntegrationTestUtils {
         IntegrationTestUtils.produceValuesSynchronously(topic, records, producerConfig, time, false);
     }
 
+    /**
+     * @param topic               Kafka topic to write the data records to
+     * @param records             Data records to write to Kafka
+     * @param producerConfig      Kafka producer configuration
+     * @param time                Timestamp provider
+     * @param enableTransactions  Send messages in a transaction
+     * @param <V>                 Value type of the data records
+     */
     public static <V> void produceValuesSynchronously(final String topic,
                                                       final Collection<V> records,
                                                       final Properties producerConfig,
@@ -336,12 +428,61 @@ public class IntegrationTestUtils {
         }
     }
 
+    /**
+     * Wait until enough data (consumer records) has been consumed.
+     *
+     * @param consumerConfig      Kafka Consumer configuration
+     * @param topic               Kafka topic to consume from
+     * @param expectedNumRecords  Minimum number of expected records
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     */
     public static <K, V> List<ConsumerRecord<K, V>> waitUntilMinRecordsReceived(final Properties consumerConfig,
                                                                                 final String topic,
                                                                                 final int expectedNumRecords) throws InterruptedException {
         return waitUntilMinRecordsReceived(consumerConfig, topic, expectedNumRecords, DEFAULT_TIMEOUT);
     }
 
+    /**
+     * Wait until enough data (consumer records) has been consumed.
+     *
+     * @param consumerConfig      Kafka Consumer configuration
+     * @param topic               Kafka topic to consume from
+     * @param expectedNumRecords  Minimum number of expected records
+     * @param waitTime            Upper bound of waiting time in milliseconds
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     */
+    public static <K, V> List<ConsumerRecord<K, V>> waitUntilMinRecordsReceived(final Properties consumerConfig,
+                                                                                final String topic,
+                                                                                final int expectedNumRecords,
+                                                                                final long waitTime) throws InterruptedException {
+        final List<ConsumerRecord<K, V>> accumData = new ArrayList<>();
+        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
+            final TestCondition valuesRead = () -> {
+                final List<ConsumerRecord<K, V>> readData =
+                    readRecords(topic, consumer, waitTime, expectedNumRecords);
+                accumData.addAll(readData);
+                return accumData.size() >= expectedNumRecords;
+            };
+            final String conditionDetails = "Did not receive all " + expectedNumRecords + " records from topic " + topic;
+            TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
+        }
+        return accumData;
+    }
+
+    /**
+     * Wait until enough data (key-value records) has been consumed.
+     *
+     * @param consumerConfig      Kafka Consumer configuration
+     * @param topic               Kafka topic to consume from
+     * @param expectedNumRecords  Minimum number of expected records
+     * @param <K>                 Key type of the data records
+     * @param <V>                 Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     */
     public static <K, V> List<KeyValue<K, V>> waitUntilMinKeyValueRecordsReceived(final Properties consumerConfig,
                                                                                   final String topic,
                                                                                   final int expectedNumRecords) throws InterruptedException {
@@ -352,11 +493,13 @@ public class IntegrationTestUtils {
      * Wait until enough data (key-value records) has been consumed.
      *
      * @param consumerConfig     Kafka Consumer configuration
-     * @param topic              Topic to consume from
+     * @param topic              Kafka topic to consume from
      * @param expectedNumRecords Minimum number of expected records
-     * @param waitTime           Upper bound in waiting time in milliseconds
+     * @param waitTime           Upper bound of waiting time in milliseconds
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
      * @return All the records consumed, or null if no records are consumed
-     * @throws AssertionError       if the given wait time elapses
+     * @throws AssertionError    if the given wait time elapses
      */
     public static <K, V> List<KeyValue<K, V>> waitUntilMinKeyValueRecordsReceived(final Properties consumerConfig,
                                                                                   final String topic,
@@ -377,14 +520,15 @@ public class IntegrationTestUtils {
     }
 
     /**
-     * Wait until enough data (key-value records) has been consumed.
+     * Wait until enough data (timestamped key-value records) has been consumed.
      *
      * @param consumerConfig     Kafka Consumer configuration
-     * @param topic              Topic to consume from
+     * @param topic              Kafka topic to consume from
      * @param expectedNumRecords Minimum number of expected records
-     * @param waitTime           Upper bound in waiting time in milliseconds
+     * @param waitTime           Upper bound of waiting time in milliseconds
      * @return All the records consumed, or null if no records are consumed
-     * @throws AssertionError       if the given wait time elapses
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
      */
     public static <K, V> List<KeyValue<K, KeyValue<V, Long>>> waitUntilMinKeyValueWithTimestampRecordsReceived(final Properties consumerConfig,
                                                                                                                final String topic,
@@ -404,12 +548,33 @@ public class IntegrationTestUtils {
         return accumData;
     }
 
+    /**
+     * Wait until final key-value mappings have been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Kafka topic to consume from
+     * @param expectedRecords    Expected key-value mappings
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     * @return All the mappings consumed, or null if no records are consumed
+     */
     public static <K, V> List<KeyValue<K, V>> waitUntilFinalKeyValueRecordsReceived(final Properties consumerConfig,
                                                                                     final String topic,
                                                                                     final List<KeyValue<K, V>> expectedRecords) throws InterruptedException {
         return waitUntilFinalKeyValueRecordsReceived(consumerConfig, topic, expectedRecords, DEFAULT_TIMEOUT);
     }
 
+    /**
+     * Wait until final key-value mappings have been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Kafka topic to consume from
+     * @param expectedRecords    Expected key-value mappings
+     * @param waitTime           Upper bound of waiting time in milliseconds
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     * @return All the mappings consumed, or null if no records are consumed
+     */
     public static <K, V> List<KeyValue<K, V>> waitUntilFinalKeyValueRecordsReceived(final Properties consumerConfig,
                                                                                     final String topic,
                                                                                     final List<KeyValue<K, V>> expectedRecords,
@@ -445,24 +610,15 @@ public class IntegrationTestUtils {
         return accumData;
     }
 
-    public static <K, V> List<ConsumerRecord<K, V>> waitUntilMinRecordsReceived(final Properties consumerConfig,
-                                                                                final String topic,
-                                                                                final int expectedNumRecords,
-                                                                                final long waitTime) throws InterruptedException {
-        final List<ConsumerRecord<K, V>> accumData = new ArrayList<>();
-        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
-            final TestCondition valuesRead = () -> {
-                final List<ConsumerRecord<K, V>> readData =
-                    readRecords(topic, consumer, waitTime, expectedNumRecords);
-                accumData.addAll(readData);
-                return accumData.size() >= expectedNumRecords;
-            };
-            final String conditionDetails = "Did not receive all " + expectedNumRecords + " records from topic " + topic;
-            TestUtils.waitForCondition(valuesRead, waitTime, conditionDetails);
-        }
-        return accumData;
-    }
-
+    /**
+     * Wait until enough data (value records) has been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Topic to consume from
+     * @param expectedNumRecords Minimum number of expected records
+     * @return All the records consumed, or null if no records are consumed
+     * @throws AssertionError    if the given wait time elapses
+     */
     public static <V> List<V> waitUntilMinValuesRecordsReceived(final Properties consumerConfig,
                                                                 final String topic,
                                                                 final int expectedNumRecords) throws InterruptedException {
@@ -476,9 +632,9 @@ public class IntegrationTestUtils {
      * @param consumerConfig     Kafka Consumer configuration
      * @param topic              Topic to consume from
      * @param expectedNumRecords Minimum number of expected records
-     * @param waitTime           Upper bound in waiting time in milliseconds
+     * @param waitTime           Upper bound of waiting time in milliseconds
      * @return All the records consumed, or null if no records are consumed
-     * @throws AssertionError       if the given wait time elapses
+     * @throws AssertionError    if the given wait time elapses
      */
     public static <V> List<V> waitUntilMinValuesRecordsReceived(final Properties consumerConfig,
                                                                 final String topic,


### PR DESCRIPTION
While I was writing [an example project on testing Kafka Streams](https://github.com/dongjinleekr/kafka-streams-example), I found that there are several problems with the documentation of `IntegrationTestUtils.`

- The documentation of `Time` parameter in `produceKeyValuesSynchronously` methods is missing. This parameter was added in commit de1b853, but documentation was omitted then.
- Change parameter `enableTransactions` in `produceKeyValuesSynchronouslyWithTimestamp(String, Collection, Properties, Headers headers, Long, boolean)` into `enableTransactions`: for consistency with the other overloads.
- Add Javadoc to undocumented methods, like `produceKeyValuesSynchronouslyWithTimestamp`, `waitUntilMinRecordsReceived`, etc.
- Fix ordering: `waitUntilMinRecordsReceived`
- Upper bound in ... -> Upper bound of ...

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
