### PR TITLE
KAFKA-3514: Modify pause logic if we being enforced processing

### DIFF
--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -90,6 +90,7 @@
         We have also removed some public APIs that are deprecated prior to 1.0.x in 2.0.0.
         See below for a detailed list of removed APIs.
     </p>
+
     <h3><a id="streams_api_changes_210" href="#streams_api_changes_210">Streams API changes in 2.1.0</a></h3>
     <p>
         We updated <code>TopologyDescription</code> API to allow for better runtime checking.
@@ -97,6 +98,14 @@
         instead of using <code>#topics()</code>, which has since been deprecated. Similarly, use <code>#topic()</code> and <code>#topicNameExtractor()</code>
         to get descriptions of <code>TopologyDescription.Sink</code> nodes. For more details, see
         <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-321%3A+Update+TopologyDescription+to+better+represent+Source+and+Sink+Nodes">KIP-321</a>.
+    </p>
+
+    <p>
+        We've added a new config named <code>max.task.idle.ms</code> to allow users specify how to handle out-of-ordering data within a task that may be processing multiple
+        topic-partitions (see <a href="/{{version}}/documentation/streams/core-concepts.html#streams_out_of_ordering">Out-of-Order Handling</a> section for more details).
+        The default value is set to <code>0</code>, to favor minimized latency over synchronization between multiple input streams from topic-partitions.
+        If users would like to wait for longer time when some of the topic-partitions are not data available to process and hence cannot determine its corresponding stream time,
+        they should then override this config to a larger value.
     </p>
 
     <h3><a id="streams_api_changes_200" href="#streams_api_changes_200">Streams API changes in 2.0.0</a></h3>

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -101,11 +101,11 @@
     </p>
 
     <p>
-        We've added a new config named <code>max.task.idle.ms</code> to allow users specify how to handle out-of-ordering data within a task that may be processing multiple
+        We've added a new config named <code>max.task.idle.ms</code> to allow users specify how to handle out-of-order data within a task that may be processing multiple
         topic-partitions (see <a href="/{{version}}/documentation/streams/core-concepts.html#streams_out_of_ordering">Out-of-Order Handling</a> section for more details).
         The default value is set to <code>0</code>, to favor minimized latency over synchronization between multiple input streams from topic-partitions.
-        If users would like to wait for longer time when some of the topic-partitions are not data available to process and hence cannot determine its corresponding stream time,
-        they should then override this config to a larger value.
+        If users would like to wait for longer time when some of the topic-partitions do not have data available to process and hence cannot determine its corresponding stream time,
+        they can override this config to a larger value.
     </p>
 
     <h3><a id="streams_api_changes_200" href="#streams_api_changes_200">Streams API changes in 2.0.0</a></h3>

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -367,6 +367,16 @@ public class StreamTaskTest {
         assertTrue(task.isProcessable(time.milliseconds()) && task.process());
         assertEquals(0, task.numBuffered());
         assertEquals(0, consumer.paused().size());
+
+        task.addRecords(partition2, Arrays.asList(
+            getConsumerRecord(partition2, 100),
+            getConsumerRecord(partition2, 110)
+        ));
+
+        // pause immediately if we are enforced processing when there are at least some records already
+        assertEquals(2, task.numBuffered());
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamTaskTest.java
@@ -273,7 +273,12 @@ public class StreamTaskTest {
             getConsumerRecord(partition2, 65)
         ));
 
-        assertTrue(task.process());
+        assertEquals(6, task.numBuffered());
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
+
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(5, task.numBuffered());
         assertEquals(1, source1.numReceived);
         assertEquals(0, source2.numReceived);
 
@@ -286,28 +291,81 @@ public class StreamTaskTest {
             getConsumerRecord(partition1, 50)
         ));
 
+        assertEquals(8, task.numBuffered());
         assertEquals(2, consumer.paused().size());
         assertTrue(consumer.paused().contains(partition1));
         assertTrue(consumer.paused().contains(partition2));
 
-        assertTrue(task.process());
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(7, task.numBuffered());
         assertEquals(2, source1.numReceived);
         assertEquals(0, source2.numReceived);
 
         assertEquals(1, consumer.paused().size());
         assertTrue(consumer.paused().contains(partition2));
 
-        assertTrue(task.process());
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(6, task.numBuffered());
         assertEquals(3, source1.numReceived);
         assertEquals(0, source2.numReceived);
 
         assertEquals(1, consumer.paused().size());
         assertTrue(consumer.paused().contains(partition2));
 
-        assertTrue(task.process());
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(5, task.numBuffered());
         assertEquals(3, source1.numReceived);
         assertEquals(1, source2.numReceived);
 
+        assertEquals(0, consumer.paused().size());
+
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());  // 1: 40
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());  // 2: 45
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());  // 1: 50
+        assertEquals(2, task.numBuffered());
+        assertEquals(5, source1.numReceived);
+        assertEquals(2, source2.numReceived);
+        assertEquals(0, consumer.paused().size());
+
+        assertFalse(task.isProcessable(time.milliseconds()));  // we are idle now
+
+        time.sleep(100L);
+
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());  // start enforce processing
+        assertEquals(1, task.numBuffered());
+        assertEquals(5, source1.numReceived);
+        assertEquals(3, source2.numReceived);  // 1: 55
+        assertEquals(0, consumer.paused().size());
+
+        task.addRecords(partition2, Arrays.asList(
+            getConsumerRecord(partition2, 70),
+            getConsumerRecord(partition2, 80),
+            getConsumerRecord(partition2, 90)
+        ));
+
+        assertEquals(4, task.numBuffered());
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
+
+        // we are enforced processing now
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(3, task.numBuffered());
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
+
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(2, task.numBuffered());
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
+
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(1, task.numBuffered());
+        assertEquals(1, consumer.paused().size());
+        assertTrue(consumer.paused().contains(partition2));
+
+        // only resume if we are enforced processing when the fetched partition is empty
+        assertTrue(task.isProcessable(time.milliseconds()) && task.process());
+        assertEquals(0, task.numBuffered());
         assertEquals(0, consumer.paused().size());
     }
 
@@ -1392,7 +1450,7 @@ public class StreamTaskTest {
             topicPartition.topic(),
             topicPartition.partition(),
             offset,
-            0L,
+            offset, // use the offset as the timestamp
             TimestampType.CREATE_TIME,
             0L,
             0,


### PR DESCRIPTION
1. When we are being enforced processing (idleStartTime is not UNKNOWN):
1.a we will only resume a partition if it is drained empty, instead of below the max.partition buffer
1.b we will immediately pause a partition if it has at least one record after being appended to buffer.

2. Related upgrade docs, and unit tests.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
