### PR TITLE
MINOR: rename InternalProcessorContext.initialized

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContext.java
@@ -203,7 +203,7 @@ public abstract class AbstractProcessorContext implements InternalProcessorConte
     }
 
     @Override
-    public void initialized() {
+    public void initialize() {
         initialized = true;
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/GlobalStateUpdateTask.java
@@ -74,7 +74,7 @@ public class GlobalStateUpdateTask implements GlobalStateMaintainer {
             );
         }
         initTopology();
-        processorContext.initialized();
+        processorContext.initialize();
         return stateMgr.checkpointed();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/InternalProcessorContext.java
@@ -57,7 +57,7 @@ public interface InternalProcessorContext extends ProcessorContext {
     /**
      * Mark this context as being initialized
      */
-    void initialized();
+    void initialize();
 
     /**
      * Mark this context as being uninitialized

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StandbyTask.java
@@ -69,7 +69,7 @@ public class StandbyTask extends AbstractTask {
         log.trace("Initializing state stores");
         registerStateStores();
         checkpointedOffsets = Collections.unmodifiableMap(stateMgr.checkpointed());
-        processorContext.initialized();
+        processorContext.initialize();
         taskInitialized = true;
         return true;
     }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamTask.java
@@ -274,7 +274,7 @@ public class StreamTask extends AbstractTask implements ProcessorNodePunctuator 
             transactionInFlight = true;
         }
 
-        processorContext.initialized();
+        processorContext.initialize();
 
         taskInitialized = true;
 

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/AbstractProcessorContextTest.java
@@ -58,7 +58,7 @@ public class AbstractProcessorContextTest {
 
     @Test
     public void shouldThrowIllegalStateExceptionOnRegisterWhenContextIsInitialized() {
-        context.initialized();
+        context.initialize();
         try {
             context.register(stateStore, null);
             fail("should throw illegal state exception when context already initialized");

--- a/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/InternalMockProcessorContext.java
@@ -170,7 +170,7 @@ public class InternalMockProcessorContext extends AbstractProcessorContext imple
 
     // state mgr will be overridden by the state dir and store maps
     @Override
-    public void initialized() {}
+    public void initialize() {}
 
     public void setStreamTime(final long currentTime) {
         streamTime = currentTime;

--- a/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
+++ b/streams/src/test/java/org/apache/kafka/test/NoOpProcessorContext.java
@@ -81,7 +81,7 @@ public class NoOpProcessorContext extends AbstractProcessorContext {
     }
 
     @Override
-    public void initialized() {
+    public void initialize() {
         initialized = true;
     }
 


### PR DESCRIPTION
We named this method `initialized` because it marks the context as having been initialized.
The downside is that it sounds more like a getter upon casual reading, which is weird since it's `void`.

Note also that the inverse method is already called `uninitialize`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
