### PR TITLE
MINOR: fix build from f1f71921

### DIFF
--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -66,38 +66,38 @@ class PlaintextConsumerTest extends BaseConsumerTest {
     }
   }
 
-  trait SerializerImpl {
+  trait SerializerImpl extends Serializer[Array[Byte]]{
     var serializer = new ByteArraySerializer()
 
-    def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = {
+    override def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = {
       headers.add("content-type", "application/octet-stream".getBytes)
       serializer.serialize(topic, data)
     }
 
-    def configure(configs: util.Map[String, _], isKey: Boolean): Unit = serializer.configure(configs, isKey)
+    override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = serializer.configure(configs, isKey)
 
-    def close(): Unit = serializer.close()
+    override def close(): Unit = serializer.close()
 
-    def serialize(topic: String, data: Array[Byte]): Array[Byte] = {
+    override def serialize(topic: String, data: Array[Byte]): Array[Byte] = {
       fail("method should not be invoked")
       null
     }
   }
 
-  trait DeserializerImpl {
+  trait DeserializerImpl extends Deserializer[Array[Byte]]{
     var deserializer = new ByteArrayDeserializer()
 
-    def deserialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = {
+    override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = {
       val header = headers.lastHeader("content-type")
       assertEquals("application/octet-stream", if (header == null) null else new String(header.value()))
       deserializer.deserialize(topic, data)
     }
 
-    def configure(configs: util.Map[String, _], isKey: Boolean): Unit = deserializer.configure(configs, isKey)
+    override def configure(configs: util.Map[String, _], isKey: Boolean): Unit = deserializer.configure(configs, isKey)
 
-    def close(): Unit = deserializer.close()
+    override def close(): Unit = deserializer.close()
 
-    def deserialize(topic: String, data: Array[Byte]): Array[Byte] = {
+    override def deserialize(topic: String, data: Array[Byte]): Array[Byte] = {
       fail("method should not be invoked")
       null
     }
@@ -127,24 +127,18 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
   @Test
   def testHeadersExtendedSerializerDeserializer(): Unit = {
-    val extendedSerializer = new ExtendedSerializer[Array[Byte]] with SerializerImpl {
-      override def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.serialize(topic, headers, data)
-    }
-    val extendedDeserializer = new ExtendedDeserializer[Array[Byte]] with DeserializerImpl {
-      override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.deserialize(topic, headers, data)
-    }
+    val extendedSerializer = new ExtendedSerializer[Array[Byte]] with SerializerImpl
+
+    val extendedDeserializer = new ExtendedDeserializer[Array[Byte]] with DeserializerImpl
 
     testHeadersSerializeDeserialize(extendedSerializer, extendedDeserializer)
   }
 
   @Test
   def testHeadersSerializerDeserializer(): Unit = {
-    val extendedSerializer = new Serializer[Array[Byte]] with SerializerImpl {
-      override def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.serialize(topic, headers, data)
-    }
-    val extendedDeserializer = new Deserializer[Array[Byte]] with DeserializerImpl {
-      override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.deserialize(topic, headers, data)
-    }
+    val extendedSerializer = new Serializer[Array[Byte]] with SerializerImpl
+
+    val extendedDeserializer = new Deserializer[Array[Byte]] with DeserializerImpl
 
     testHeadersSerializeDeserialize(extendedSerializer, extendedDeserializer)
   }

--- a/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
+++ b/core/src/test/scala/integration/kafka/api/PlaintextConsumerTest.scala
@@ -127,16 +127,24 @@ class PlaintextConsumerTest extends BaseConsumerTest {
 
   @Test
   def testHeadersExtendedSerializerDeserializer(): Unit = {
-    val extendedSerializer = new ExtendedSerializer[Array[Byte]] with SerializerImpl
-    val extendedDeserializer = new ExtendedDeserializer[Array[Byte]] with DeserializerImpl
+    val extendedSerializer = new ExtendedSerializer[Array[Byte]] with SerializerImpl {
+      override def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.serialize(topic, headers, data)
+    }
+    val extendedDeserializer = new ExtendedDeserializer[Array[Byte]] with DeserializerImpl {
+      override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.deserialize(topic, headers, data)
+    }
 
     testHeadersSerializeDeserialize(extendedSerializer, extendedDeserializer)
   }
 
   @Test
   def testHeadersSerializerDeserializer(): Unit = {
-    val extendedSerializer = new Serializer[Array[Byte]] with SerializerImpl
-    val extendedDeserializer = new Deserializer[Array[Byte]] with DeserializerImpl
+    val extendedSerializer = new Serializer[Array[Byte]] with SerializerImpl {
+      override def serialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.serialize(topic, headers, data)
+    }
+    val extendedDeserializer = new Deserializer[Array[Byte]] with DeserializerImpl {
+      override def deserialize(topic: String, headers: Headers, data: Array[Byte]): Array[Byte] = super.deserialize(topic, headers, data)
+    }
 
     testHeadersSerializeDeserialize(extendedSerializer, extendedDeserializer)
   }


### PR DESCRIPTION
Merging https://github.com/apache/kafka/commit/f1f719211e5f28fe5163e65dba899b1da796a8e0
broke the scala 2.12 build. This fixes it.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
