### PR TITLE
MINOR: demonstrate migrating Produced config to an interface

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/Produced.java
@@ -18,11 +18,10 @@ package org.apache.kafka.streams.kstream;
 
 import org.apache.kafka.clients.producer.internals.DefaultPartitioner;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.internals.ProducedInternal;
 import org.apache.kafka.streams.kstream.internals.WindowedSerializer;
 import org.apache.kafka.streams.kstream.internals.WindowedStreamPartitioner;
 import org.apache.kafka.streams.processor.StreamPartitioner;
-
-import java.util.Objects;
 
 /**
  * This class is used to provide the optional parameters when producing to new topics
@@ -30,25 +29,7 @@ import java.util.Objects;
  * @param <K> key type
  * @param <V> value type
  */
-public class Produced<K, V> {
-
-    protected Serde<K> keySerde;
-    protected Serde<V> valueSerde;
-    protected StreamPartitioner<? super K, ? super V> partitioner;
-
-    private Produced(final Serde<K> keySerde,
-                     final Serde<V> valueSerde,
-                     final StreamPartitioner<? super K, ? super V> partitioner) {
-        this.keySerde = keySerde;
-        this.valueSerde = valueSerde;
-        this.partitioner = partitioner;
-    }
-
-    protected Produced(final Produced<K, V> produced) {
-        this.keySerde = produced.keySerde;
-        this.valueSerde = produced.valueSerde;
-        this.partitioner = produced.partitioner;
-    }
+public interface Produced<K, V> {
 
     /**
      * Create a Produced instance with provided keySerde and valueSerde.
@@ -56,13 +37,13 @@ public class Produced<K, V> {
      * @param valueSerde    Serde to use for serializing the value
      * @param <K>           key type
      * @param <V>           value type
-     * @return  A new {@link Produced} instance configured with keySerde and valueSerde
+     * @return A new {@link Produced} instance configured with keySerde and valueSerde
      * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
-    public static <K, V> Produced<K, V> with(final Serde<K> keySerde,
-                                             final Serde<V> valueSerde) {
-        return new Produced<>(keySerde, valueSerde, null);
+    static <K, V> Produced<K, V> with(final Serde<K> keySerde,
+                                      final Serde<V> valueSerde) {
+        return new ProducedInternal<>(keySerde, valueSerde, null);
     }
 
     /**
@@ -75,14 +56,14 @@ public class Produced<K, V> {
      *                      will be used
      * @param <K>           key type
      * @param <V>           value type
-     * @return  A new {@link Produced} instance configured with keySerde, valueSerde, and partitioner
+     * @return A new {@link Produced} instance configured with keySerde, valueSerde, and partitioner
      * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
-    public static <K, V> Produced<K, V> with(final Serde<K> keySerde,
-                                             final Serde<V> valueSerde,
-                                             final StreamPartitioner<? super K, ? super V> partitioner) {
-        return new Produced<>(keySerde, valueSerde, partitioner);
+    static <K, V> Produced<K, V> with(final Serde<K> keySerde,
+                                      final Serde<V> valueSerde,
+                                      final StreamPartitioner<? super K, ? super V> partitioner) {
+        return new ProducedInternal<>(keySerde, valueSerde, partitioner);
     }
 
     /**
@@ -90,12 +71,12 @@ public class Produced<K, V> {
      * @param keySerde      Serde to use for serializing the key
      * @param <K>           key type
      * @param <V>           value type
-     * @return  A new {@link Produced} instance configured with keySerde
+     * @return A new {@link Produced} instance configured with keySerde
      * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
-    public static <K, V> Produced<K, V> keySerde(final Serde<K> keySerde) {
-        return new Produced<>(keySerde, null, null);
+    static <K, V> Produced<K, V> keySerde(final Serde<K> keySerde) {
+        return new ProducedInternal<>(keySerde, null, null);
     }
 
     /**
@@ -103,12 +84,12 @@ public class Produced<K, V> {
      * @param valueSerde    Serde to use for serializing the key
      * @param <K>           key type
      * @param <V>           value type
-     * @return  A new {@link Produced} instance configured with valueSerde
+     * @return A new {@link Produced} instance configured with valueSerde
      * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
-    public static <K, V> Produced<K, V> valueSerde(final Serde<V> valueSerde) {
-        return new Produced<>(null, valueSerde, null);
+    static <K, V> Produced<K, V> valueSerde(final Serde<V> valueSerde) {
+        return new ProducedInternal<>(null, valueSerde, null);
     }
 
     /**
@@ -118,12 +99,12 @@ public class Produced<K, V> {
      *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultPartitioner} will be used
      * @param <K>           key type
      * @param <V>           value type
-     * @return  A new {@link Produced} instance configured with partitioner
+     * @return A new {@link Produced} instance configured with partitioner
      * @see KStream#through(String, Produced)
      * @see KStream#to(String, Produced)
      */
-    public static <K, V> Produced<K, V> streamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner) {
-        return new Produced<>(null, null, partitioner);
+    static <K, V> Produced<K, V> streamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner) {
+        return new ProducedInternal<>(null, null, partitioner);
     }
 
     /**
@@ -133,47 +114,19 @@ public class Produced<K, V> {
      *                      {@link WindowedStreamPartitioner} will be used&mdash;otherwise {@link DefaultPartitioner} wil be used
      * @return this
      */
-    public Produced<K, V> withStreamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner) {
-        this.partitioner = partitioner;
-        return this;
-    }
+    Produced<K, V> withStreamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner);
 
     /**
      * Produce records using the provided valueSerde.
      * @param valueSerde    Serde to use for serializing the value
      * @return this
      */
-    public Produced<K, V> withValueSerde(final Serde<V> valueSerde) {
-        this.valueSerde = valueSerde;
-        return this;
-    }
+    Produced<K, V> withValueSerde(final Serde<V> valueSerde);
 
     /**
      * Produce records using the provided keySerde.
      * @param keySerde    Serde to use for serializing the key
      * @return this
      */
-    public Produced<K, V> withKeySerde(final Serde<K> keySerde) {
-        this.keySerde = keySerde;
-        return this;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final Produced<?, ?> produced = (Produced<?, ?>) o;
-        return Objects.equals(keySerde, produced.keySerde) &&
-               Objects.equals(valueSerde, produced.valueSerde) &&
-               Objects.equals(partitioner, produced.partitioner);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(keySerde, valueSerde, partitioner);
-    }
+    Produced<K, V> withKeySerde(final Serde<K> keySerde);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KStreamImpl.java
@@ -352,7 +352,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
 
     @Override
     public KStream<K, V> through(final String topic, final Produced<K, V> produced) {
-        final ProducedInternal<K, V> producedInternal = new ProducedInternal<>(produced);
+        final ProducedInternal<K, V> producedInternal = (ProducedInternal<K, V>) produced;
         to(topic, producedInternal);
         return builder.stream(
             Collections.singleton(topic),
@@ -416,7 +416,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
     public void to(final String topic, final Produced<K, V> produced) {
         Objects.requireNonNull(topic, "topic can't be null");
         Objects.requireNonNull(produced, "Produced can't be null");
-        to(new StaticTopicNameExtractor<>(topic), new ProducedInternal<>(produced));
+        to(new StaticTopicNameExtractor<>(topic), (ProducedInternal<K, V>) produced);
     }
 
     @Override
@@ -428,7 +428,7 @@ public class KStreamImpl<K, V> extends AbstractStream<K> implements KStream<K, V
     public void to(final TopicNameExtractor<K, V> topicExtractor, final Produced<K, V> produced) {
         Objects.requireNonNull(topicExtractor, "topic extractor can't be null");
         Objects.requireNonNull(produced, "Produced can't be null");
-        to(topicExtractor, new ProducedInternal<>(produced));
+        to(topicExtractor, (ProducedInternal<K, V>) produced);
     }
 
     @SuppressWarnings("unchecked")

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ProducedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/ProducedInternal.java
@@ -20,9 +20,19 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 
-public class ProducedInternal<K, V> extends Produced<K, V> {
-    public ProducedInternal(final Produced<K, V> produced) {
-        super(produced);
+import java.util.Objects;
+
+public class ProducedInternal<K, V> implements Produced<K, V> {
+    private final Serde<K> keySerde;
+    private final Serde<V> valueSerde;
+    private final StreamPartitioner<? super K, ? super V> partitioner;
+
+    public ProducedInternal(final Serde<K> keySerde,
+                            final Serde<V> valueSerde,
+                            final StreamPartitioner<? super K, ? super V> partitioner) {
+        this.keySerde = keySerde;
+        this.valueSerde = valueSerde;
+        this.partitioner = partitioner;
     }
 
     public Serde<K> keySerde() {
@@ -35,5 +45,36 @@ public class ProducedInternal<K, V> extends Produced<K, V> {
 
     public StreamPartitioner<? super K, ? super V> streamPartitioner() {
         return partitioner;
+    }
+
+    @Override
+    public Produced<K, V> withStreamPartitioner(final StreamPartitioner<? super K, ? super V> partitioner) {
+        return new ProducedInternal<>(keySerde, valueSerde, partitioner);
+    }
+
+    @Override
+    public Produced<K, V> withValueSerde(final Serde<V> valueSerde) {
+        return new ProducedInternal<>(keySerde, valueSerde, partitioner);
+    }
+
+    @Override
+    public Produced<K, V> withKeySerde(final Serde<K> keySerde) {
+        return new ProducedInternal<>(keySerde, valueSerde, partitioner);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final ProducedInternal<?, ?> that = (ProducedInternal<?, ?>) o;
+        return Objects.equals(keySerde, that.keySerde) &&
+            Objects.equals(valueSerde, that.valueSerde) &&
+            Objects.equals(partitioner, that.partitioner);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(keySerde, valueSerde, partitioner);
     }
 }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/ProducedTest.scala
@@ -20,8 +20,8 @@ package org.apache.kafka.streams.scala.kstream
 
 import org.apache.kafka.streams.kstream.internals.ProducedInternal
 import org.apache.kafka.streams.processor.StreamPartitioner
-import org.apache.kafka.streams.scala.Serdes._
 import org.apache.kafka.streams.scala.Serdes
+import org.apache.kafka.streams.scala.Serdes._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
@@ -32,7 +32,7 @@ class ProducedTest extends FlatSpec with Matchers {
   "Create a Produced" should "create a Produced with Serdes" in {
     val produced: Produced[String, Long] = Produced.`with`[String, Long]
 
-    val internalProduced = new ProducedInternal(produced)
+    val internalProduced = produced.asInstanceOf[ProducedInternal[String, Long]]
     internalProduced.keySerde.getClass shouldBe Serdes.String.getClass
     internalProduced.valueSerde.getClass shouldBe Serdes.Long.getClass
   }
@@ -43,9 +43,9 @@ class ProducedTest extends FlatSpec with Matchers {
     }
     val produced: Produced[String, Long] = Produced.`with`(partitioner)
 
-    val internalConsumed = new ProducedInternal(produced)
-    internalConsumed.keySerde.getClass shouldBe Serdes.String.getClass
-    internalConsumed.valueSerde.getClass shouldBe Serdes.Long.getClass
-    internalConsumed.streamPartitioner shouldBe partitioner
+    val internalProduced = produced.asInstanceOf[ProducedInternal[String, Long]]
+    internalProduced.keySerde.getClass shouldBe Serdes.String.getClass
+    internalProduced.valueSerde.getClass shouldBe Serdes.Long.getClass
+    internalProduced.streamPartitioner shouldBe partitioner
   }
 }


### PR DESCRIPTION
I was wondering about the impact of changing our config objects to be interfaces on the public side. This is just a sketch of the idea for discussion.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
