### PR TITLE
KAFKA-7431 : Clean up connect unit tests

### DIFF
--- a/connect/api/src/test/java/org/apache/kafka/connect/connector/ConnectorReconfigurationTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/connector/ConnectorReconfigurationTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 public class ConnectorReconfigurationTest {
 
     @Test
-    public void testDefaultReconfigure() throws Exception {
+    public void testDefaultReconfigure() {
         TestConnector conn = new TestConnector(false);
         conn.reconfigure(Collections.<String, String>emptyMap());
         assertEquals(conn.stopOrder, 0);
@@ -37,7 +37,7 @@ public class ConnectorReconfigurationTest {
     }
 
     @Test(expected = ConnectException.class)
-    public void testReconfigureStopException() throws Exception {
+    public void testReconfigureStopException() {
         TestConnector conn = new TestConnector(true);
         conn.reconfigure(Collections.<String, String>emptyMap());
     }

--- a/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
+++ b/connect/api/src/test/java/org/apache/kafka/connect/data/SchemaProjectorTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.fail;
 public class SchemaProjectorTest {
 
     @Test
-    public void testPrimitiveTypeProjection() throws Exception {
+    public void testPrimitiveTypeProjection() {
         Object projected;
         projected = SchemaProjector.project(Schema.BOOLEAN_SCHEMA, false, Schema.BOOLEAN_SCHEMA);
         assertEquals(false, projected);
@@ -79,7 +79,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testNumericTypeProjection() throws Exception {
+    public void testNumericTypeProjection() {
         Schema[] promotableSchemas = {Schema.INT8_SCHEMA, Schema.INT16_SCHEMA, Schema.INT32_SCHEMA, Schema.INT64_SCHEMA, Schema.FLOAT32_SCHEMA, Schema.FLOAT64_SCHEMA};
         Schema[] promotableOptionalSchemas = {Schema.OPTIONAL_INT8_SCHEMA, Schema.OPTIONAL_INT16_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA,
                                               Schema.OPTIONAL_FLOAT32_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA};
@@ -146,7 +146,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testPrimitiveOptionalProjection() throws Exception {
+    public void testPrimitiveOptionalProjection() {
         verifyOptionalProjection(Schema.OPTIONAL_BOOLEAN_SCHEMA, Type.BOOLEAN, false, true, false, true);
         verifyOptionalProjection(Schema.OPTIONAL_BOOLEAN_SCHEMA, Type.BOOLEAN, false, true, false, false);
 
@@ -208,7 +208,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testStructAddField() throws Exception {
+    public void testStructAddField() {
         Schema source = SchemaBuilder.struct()
                 .field("field", Schema.INT32_SCHEMA)
                 .build();
@@ -240,7 +240,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testStructRemoveField() throws Exception {
+    public void testStructRemoveField() {
         Schema source = SchemaBuilder.struct()
                 .field("field", Schema.INT32_SCHEMA)
                 .field("field2", Schema.INT32_SCHEMA)
@@ -264,7 +264,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testStructDefaultValue() throws Exception {
+    public void testStructDefaultValue() {
         Schema source = SchemaBuilder.struct().optional()
                 .field("field", Schema.INT32_SCHEMA)
                 .field("field2", Schema.INT32_SCHEMA)
@@ -289,7 +289,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testNestedSchemaProjection() throws Exception {
+    public void testNestedSchemaProjection() {
         Schema sourceFlatSchema = SchemaBuilder.struct()
                 .field("field", Schema.INT32_SCHEMA)
                 .build();
@@ -326,8 +326,8 @@ public class SchemaProjectorTest {
                                                                      targetNestedSchema);
         assertEquals(1, targetNestedStruct.get("first"));
         assertEquals("abc", targetNestedStruct.get("second"));
-        assertEquals(Arrays.asList(1, 2), (List<Integer>) targetNestedStruct.get("array"));
-        assertEquals(Collections.singletonMap(5, "def"), (Map<Integer, String>) targetNestedStruct.get("map"));
+        assertEquals(Arrays.asList(1, 2), targetNestedStruct.get("array"));
+        assertEquals(Collections.singletonMap(5, "def"), targetNestedStruct.get("map"));
 
         Struct projectedStruct = (Struct) targetNestedStruct.get("nested");
         assertEquals(113, projectedStruct.get("field"));
@@ -335,7 +335,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testLogicalTypeProjection() throws Exception {
+    public void testLogicalTypeProjection() {
         Schema[] logicalTypeSchemas = {Decimal.schema(2), Date.SCHEMA, Time.SCHEMA, Timestamp.SCHEMA};
         Object projected;
 
@@ -378,25 +378,25 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testArrayProjection() throws Exception {
+    public void testArrayProjection() {
         Schema source = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
 
         Object projected = SchemaProjector.project(source, Arrays.asList(1, 2, 3), source);
-        assertEquals(Arrays.asList(1, 2, 3), (List<Integer>) projected);
+        assertEquals(Arrays.asList(1, 2, 3), projected);
 
         Schema optionalSource = SchemaBuilder.array(Schema.INT32_SCHEMA).optional().build();
         Schema target = SchemaBuilder.array(Schema.INT32_SCHEMA).defaultValue(Arrays.asList(1, 2, 3)).build();
         projected = SchemaProjector.project(optionalSource, Arrays.asList(4, 5), target);
-        assertEquals(Arrays.asList(4, 5), (List<Integer>) projected);
+        assertEquals(Arrays.asList(4, 5), projected);
         projected = SchemaProjector.project(optionalSource, null, target);
-        assertEquals(Arrays.asList(1, 2, 3), (List<Integer>) projected);
+        assertEquals(Arrays.asList(1, 2, 3), projected);
 
         Schema promotedTarget = SchemaBuilder.array(Schema.INT64_SCHEMA).defaultValue(Arrays.asList(1L, 2L, 3L)).build();
         projected = SchemaProjector.project(optionalSource, Arrays.asList(4, 5), promotedTarget);
         List<Long> expectedProjected = Arrays.asList(4L, 5L);
-        assertEquals(expectedProjected, (List<Long>) projected);
+        assertEquals(expectedProjected, projected);
         projected = SchemaProjector.project(optionalSource, null, promotedTarget);
-        assertEquals(Arrays.asList(1L, 2L, 3L), (List<Long>) projected);
+        assertEquals(Arrays.asList(1L, 2L, 3L), projected);
 
         Schema noDefaultValueTarget = SchemaBuilder.array(Schema.INT32_SCHEMA).build();
         try {
@@ -416,21 +416,21 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testMapProjection() throws Exception {
+    public void testMapProjection() {
         Schema source = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA).optional().build();
 
         Schema target = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA).defaultValue(Collections.singletonMap(1, 2)).build();
         Object projected = SchemaProjector.project(source, Collections.singletonMap(3, 4), target);
-        assertEquals(Collections.singletonMap(3, 4), (Map<Integer, Integer>) projected);
+        assertEquals(Collections.singletonMap(3, 4), projected);
         projected = SchemaProjector.project(source, null, target);
-        assertEquals(Collections.singletonMap(1, 2), (Map<Integer, Integer>) projected);
+        assertEquals(Collections.singletonMap(1, 2), projected);
 
         Schema promotedTarget = SchemaBuilder.map(Schema.INT64_SCHEMA, Schema.FLOAT32_SCHEMA).defaultValue(
                 Collections.singletonMap(3L, 4.5F)).build();
         projected = SchemaProjector.project(source, Collections.singletonMap(3, 4), promotedTarget);
-        assertEquals(Collections.singletonMap(3L, 4.F), (Map<Long, Float>) projected);
+        assertEquals(Collections.singletonMap(3L, 4.F), projected);
         projected = SchemaProjector.project(source, null, promotedTarget);
-        assertEquals(Collections.singletonMap(3L, 4.5F), (Map<Long, Float>) projected);
+        assertEquals(Collections.singletonMap(3L, 4.5F), projected);
 
         Schema noDefaultValueTarget = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA).build();
         try {
@@ -450,7 +450,7 @@ public class SchemaProjectorTest {
     }
 
     @Test
-    public void testMaybeCompatible() throws Exception {
+    public void testMaybeCompatible() {
         Schema source = SchemaBuilder.int32().name("source").build();
         Schema target = SchemaBuilder.int32().name("target").build();
 

--- a/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
+++ b/connect/basic-auth-extension/src/test/java/org/apache/kafka/connect/rest/basic/auth/extension/JaasBasicAuthFilterTest.java
@@ -53,7 +53,7 @@ public class JaasBasicAuthFilterTest {
     private Configuration previousConfiguration;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() {
         EasyMock.reset(requestContext);
     }
 

--- a/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
+++ b/connect/json/src/test/java/org/apache/kafka/connect/json/JsonConverterTest.java
@@ -588,7 +588,7 @@ public class JsonConverterTest {
     }
 
     @Test
-    public void dateToJson() throws IOException {
+    public void dateToJson() {
         GregorianCalendar calendar = new GregorianCalendar(1970, Calendar.JANUARY, 1, 0, 0, 0);
         calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         calendar.add(Calendar.DATE, 10000);
@@ -604,7 +604,7 @@ public class JsonConverterTest {
     }
 
     @Test
-    public void timeToJson() throws IOException {
+    public void timeToJson() {
         GregorianCalendar calendar = new GregorianCalendar(1970, Calendar.JANUARY, 1, 0, 0, 0);
         calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         calendar.add(Calendar.MILLISECOND, 14400000);
@@ -620,7 +620,7 @@ public class JsonConverterTest {
     }
 
     @Test
-    public void timestampToJson() throws IOException {
+    public void timestampToJson() {
         GregorianCalendar calendar = new GregorianCalendar(1970, Calendar.JANUARY, 1, 0, 0, 0);
         calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
         calendar.add(Calendar.MILLISECOND, 2000000000);
@@ -756,7 +756,7 @@ public class JsonConverterTest {
     // The following simply verify that the delegation works.
 
     @Test
-    public void testStringHeaderToJson() throws UnsupportedEncodingException {
+    public void testStringHeaderToJson() {
         JsonNode converted = parse(converter.fromConnectHeader(TOPIC, "headerName", Schema.STRING_SCHEMA, "test-string"));
         validateEnvelope(converted);
         assertEquals(parse("{ \"type\": \"string\", \"optional\": false }"), converted.get(JsonSchema.ENVELOPE_SCHEMA_FIELD_NAME));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/AbstractHerderTest.java
@@ -300,7 +300,7 @@ public class AbstractHerderTest {
     }
 
     @Test
-    public void testReverseTransformConfigs() throws Exception {
+    public void testReverseTransformConfigs() {
         // Construct a task config with constant values for TEST_KEY and TEST_KEY2
         Map<String, String> newTaskConfig = new HashMap<>();
         newTaskConfig.put(TaskConfig.TASK_CLASS_CONFIG, BogusSourceTask.class.getName());

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
@@ -82,7 +82,7 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
     }
 
     @Test
-    public void testSchedule() throws Exception {
+    public void testSchedule() {
         Capture<Runnable> taskWrapper = EasyMock.newCapture();
 
         EasyMock.expect(executor.scheduleWithFixedDelay(

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTransformerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerConfigTransformerTest.java
@@ -61,13 +61,13 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariable() throws Exception {
+    public void testReplaceVariable() {
         Map<String, String> result = configTransformer.transform(MY_CONNECTOR, Collections.singletonMap(MY_KEY, "${test:testPath:testKey}"));
         assertEquals(TEST_RESULT, result.get(MY_KEY));
     }
 
     @Test
-    public void testReplaceVariableWithTTL() throws Exception {
+    public void testReplaceVariableWithTTL() {
         EasyMock.expect(worker.herder()).andReturn(herder);
         EasyMock.expect(herder.connectorConfigReloadAction(MY_CONNECTOR)).andReturn(Herder.ConfigReloadAction.NONE);
 
@@ -78,7 +78,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariableWithTTLAndScheduleRestart() throws Exception {
+    public void testReplaceVariableWithTTLAndScheduleRestart() {
         EasyMock.expect(worker.herder()).andReturn(herder);
         EasyMock.expect(herder.connectorConfigReloadAction(MY_CONNECTOR)).andReturn(Herder.ConfigReloadAction.RESTART);
         EasyMock.expect(herder.restartConnector(1L, MY_CONNECTOR, null)).andReturn(requestId);
@@ -90,7 +90,7 @@ public class WorkerConfigTransformerTest {
     }
 
     @Test
-    public void testReplaceVariableWithTTLFirstCancelThenScheduleRestart() throws Exception {
+    public void testReplaceVariableWithTTLFirstCancelThenScheduleRestart() {
         EasyMock.expect(worker.herder()).andReturn(herder);
         EasyMock.expect(herder.connectorConfigReloadAction(MY_CONNECTOR)).andReturn(Herder.ConfigReloadAction.RESTART);
         EasyMock.expect(herder.restartConnector(1L, MY_CONNECTOR, null)).andReturn(requestId);

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerSinkTaskTest.java
@@ -1407,7 +1407,7 @@ public class WorkerSinkTaskTest {
     }
 
     private void printMetrics() {
-        System.out.println("");
+        System.out.println();
         sinkMetricValue("sink-record-read-rate");
         sinkMetricValue("sink-record-read-total");
         sinkMetricValue("sink-record-send-rate");

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/WorkerTest.java
@@ -132,7 +132,7 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartAndStopConnector() throws Exception {
+    public void testStartAndStopConnector() {
         expectConverters();
         expectStartStorage();
 
@@ -201,7 +201,7 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartConnectorFailure() throws Exception {
+    public void testStartConnectorFailure() {
         expectConverters();
         expectStartStorage();
 
@@ -245,7 +245,7 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testAddConnectorByAlias() throws Exception {
+    public void testAddConnectorByAlias() {
         expectConverters();
         expectStartStorage();
 
@@ -309,7 +309,7 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testAddConnectorByShortAlias() throws Exception {
+    public void testAddConnectorByShortAlias() {
         expectConverters();
         expectStartStorage();
 
@@ -385,7 +385,7 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testReconfigureConnectorTasks() throws Exception {
+    public void testReconfigureConnectorTasks() {
         expectConverters();
         expectStartStorage();
 
@@ -567,7 +567,7 @@ public class WorkerTest extends ThreadedTest {
     }
 
     @Test
-    public void testStartTaskFailure() throws Exception {
+    public void testStartTaskFailure() {
         expectConverters();
         expectStartStorage();
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/distributed/DistributedHerderTest.java
@@ -836,7 +836,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testRequestProcessingOrder() throws Exception {
+    public void testRequestProcessingOrder() {
         final DistributedHerder.DistributedHerderRequest req1 = herder.addRequest(100, null, null);
         final DistributedHerder.DistributedHerderRequest req2 = herder.addRequest(10, null, null);
         final DistributedHerder.DistributedHerderRequest req3 = herder.addRequest(200, null, null);
@@ -1423,7 +1423,7 @@ public class DistributedHerderTest {
     }
 
     @Test
-    public void testInconsistentConfigs() throws Exception {
+    public void testInconsistentConfigs() {
         // FIXME: if we have inconsistent configs, we need to request forced reconfig + write of the connector's task configs
         // This requires inter-worker communication, so needs the REST API
     }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginDescTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginDescTest.java
@@ -49,7 +49,7 @@ public class PluginDescTest {
     }
 
     @Test
-    public void testRegularPluginDesc() throws Exception {
+    public void testRegularPluginDesc() {
         PluginDesc<Connector> connectorDesc = new PluginDesc<>(
                 Connector.class,
                 regularVersion,
@@ -76,7 +76,7 @@ public class PluginDescTest {
     }
 
     @Test
-    public void testPluginDescWithSystemClassLoader() throws Exception {
+    public void testPluginDescWithSystemClassLoader() {
         String location = "classpath";
         PluginDesc<SinkConnector> connectorDesc = new PluginDesc<>(
                 SinkConnector.class,
@@ -104,7 +104,7 @@ public class PluginDescTest {
     }
 
     @Test
-    public void testPluginDescWithNullVersion() throws Exception {
+    public void testPluginDescWithNullVersion() {
         String nullVersion = "null";
         PluginDesc<SourceConnector> connectorDesc = new PluginDesc<>(
                 SourceConnector.class,
@@ -130,7 +130,7 @@ public class PluginDescTest {
     }
 
     @Test
-    public void testPluginDescEquality() throws Exception {
+    public void testPluginDescEquality() {
         PluginDesc<Connector> connectorDescPluginPath = new PluginDesc<>(
                 Connector.class,
                 snaphotVersion,
@@ -177,7 +177,7 @@ public class PluginDescTest {
     }
 
     @Test
-    public void testPluginDescComparison() throws Exception {
+    public void testPluginDescComparison() {
         PluginDesc<Connector> connectorDescPluginPath = new PluginDesc<>(
                 Connector.class,
                 regularVersion,

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/isolation/PluginUtilsTest.java
@@ -45,7 +45,7 @@ public class PluginUtilsTest {
     }
 
     @Test
-    public void testJavaLibraryClasses() throws Exception {
+    public void testJavaLibraryClasses() {
         assertFalse(PluginUtils.shouldLoadInIsolation("java."));
         assertFalse(PluginUtils.shouldLoadInIsolation("java.lang.Object"));
         assertFalse(PluginUtils.shouldLoadInIsolation("java.lang.String"));
@@ -64,13 +64,13 @@ public class PluginUtilsTest {
     }
 
     @Test
-    public void testThirdPartyClasses() throws Exception {
+    public void testThirdPartyClasses() {
         assertFalse(PluginUtils.shouldLoadInIsolation("org.slf4j."));
         assertFalse(PluginUtils.shouldLoadInIsolation("org.slf4j.LoggerFactory"));
     }
 
     @Test
-    public void testConnectFrameworkClasses() throws Exception {
+    public void testConnectFrameworkClasses() {
         assertFalse(PluginUtils.shouldLoadInIsolation("org.apache.kafka.common."));
         assertFalse(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.common.config.AbstractConfig")
@@ -120,7 +120,7 @@ public class PluginUtilsTest {
     }
 
     @Test
-    public void testAllowedConnectFrameworkClasses() throws Exception {
+    public void testAllowedConnectFrameworkClasses() {
         assertTrue(PluginUtils.shouldLoadInIsolation("org.apache.kafka.connect.transforms."));
         assertTrue(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.connect.transforms.ExtractField")
@@ -173,7 +173,7 @@ public class PluginUtilsTest {
     }
 
     @Test
-    public void testClientConfigProvider() throws Exception {
+    public void testClientConfigProvider() {
         assertFalse(PluginUtils.shouldLoadInIsolation(
                 "org.apache.kafka.common.config.provider.ConfigProvider")
         );

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -52,6 +52,7 @@ import org.apache.kafka.connect.tools.SchemaSourceConnector;
 import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
 import org.easymock.EasyMock;
+import org.easymock.IAnswer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -195,7 +196,7 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithSingleErrorDueToMissingConnectorClassname() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(partialProps));
 
-        PowerMock.expectLastCall().andAnswer(() -> {
+        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(partialProps);
 
@@ -240,7 +241,7 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithSimpleName() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(() -> {
+        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
@@ -281,7 +282,7 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithAlias() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(() -> {
+        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
@@ -322,7 +323,7 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithNonExistentName() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(() -> {
+        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
@@ -359,7 +360,7 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithNonExistentAlias() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(() -> {
+        PowerMock.expectLastCall().andAnswer((IAnswer<ConfigInfos>) () -> {
             ConfigDef connectorConfigDef = ConnectorConfig.configDef();
             List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/rest/resources/ConnectorPluginsResourceTest.java
@@ -52,7 +52,6 @@ import org.apache.kafka.connect.tools.SchemaSourceConnector;
 import org.apache.kafka.connect.tools.VerifiableSinkConnector;
 import org.apache.kafka.connect.tools.VerifiableSourceConnector;
 import org.easymock.EasyMock;
-import org.easymock.IAnswer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -196,29 +195,26 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithSingleErrorDueToMissingConnectorClassname() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(partialProps));
 
-        PowerMock.expectLastCall().andAnswer(new IAnswer<ConfigInfos>() {
-            @Override
-            public ConfigInfos answer() {
-                ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-                List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(partialProps);
+        PowerMock.expectLastCall().andAnswer(() -> {
+            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(partialProps);
 
-                Connector connector = new ConnectorPluginsResourceTestConnector();
-                Config config = connector.validate(partialProps);
-                ConfigDef configDef = connector.config();
-                Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-                List<ConfigValue> configValues = config.configValues();
+            Connector connector = new ConnectorPluginsResourceTestConnector();
+            Config config = connector.validate(partialProps);
+            ConfigDef configDef = connector.config();
+            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
+            List<ConfigValue> configValues = config.configValues();
 
-                Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-                resultConfigKeys.putAll(connectorConfigDef.configKeys());
-                configValues.addAll(connectorConfigValues);
+            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
+            resultConfigKeys.putAll(connectorConfigDef.configKeys());
+            configValues.addAll(connectorConfigValues);
 
-                return AbstractHerder.generateResult(
+            return AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
-                );
-            }
+            );
         });
 
         PowerMock.replayAll();
@@ -244,29 +240,26 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithSimpleName() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(new IAnswer<ConfigInfos>() {
-            @Override
-            public ConfigInfos answer() {
-                ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-                List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
+        PowerMock.expectLastCall().andAnswer(() -> {
+            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
-                Connector connector = new ConnectorPluginsResourceTestConnector();
-                Config config = connector.validate(props);
-                ConfigDef configDef = connector.config();
-                Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-                List<ConfigValue> configValues = config.configValues();
+            Connector connector = new ConnectorPluginsResourceTestConnector();
+            Config config = connector.validate(props);
+            ConfigDef configDef = connector.config();
+            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
+            List<ConfigValue> configValues = config.configValues();
 
-                Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-                resultConfigKeys.putAll(connectorConfigDef.configKeys());
-                configValues.addAll(connectorConfigValues);
+            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
+            resultConfigKeys.putAll(connectorConfigDef.configKeys());
+            configValues.addAll(connectorConfigValues);
 
-                return AbstractHerder.generateResult(
+            return AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
-                );
-            }
+            );
         });
 
         PowerMock.replayAll();
@@ -288,29 +281,26 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithAlias() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(new IAnswer<ConfigInfos>() {
-            @Override
-            public ConfigInfos answer() {
-                ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-                List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
+        PowerMock.expectLastCall().andAnswer(() -> {
+            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
-                Connector connector = new ConnectorPluginsResourceTestConnector();
-                Config config = connector.validate(props);
-                ConfigDef configDef = connector.config();
-                Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-                List<ConfigValue> configValues = config.configValues();
+            Connector connector = new ConnectorPluginsResourceTestConnector();
+            Config config = connector.validate(props);
+            ConfigDef configDef = connector.config();
+            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
+            List<ConfigValue> configValues = config.configValues();
 
-                Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-                resultConfigKeys.putAll(connectorConfigDef.configKeys());
-                configValues.addAll(connectorConfigValues);
+            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
+            resultConfigKeys.putAll(connectorConfigDef.configKeys());
+            configValues.addAll(connectorConfigValues);
 
-                return AbstractHerder.generateResult(
+            return AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
-                );
-            }
+            );
         });
 
         PowerMock.replayAll();
@@ -332,29 +322,26 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithNonExistentName() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(new IAnswer<ConfigInfos>() {
-            @Override
-            public ConfigInfos answer() {
-                ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-                List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
+        PowerMock.expectLastCall().andAnswer(() -> {
+            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
-                Connector connector = new ConnectorPluginsResourceTestConnector();
-                Config config = connector.validate(props);
-                ConfigDef configDef = connector.config();
-                Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-                List<ConfigValue> configValues = config.configValues();
+            Connector connector = new ConnectorPluginsResourceTestConnector();
+            Config config = connector.validate(props);
+            ConfigDef configDef = connector.config();
+            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
+            List<ConfigValue> configValues = config.configValues();
 
-                Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-                resultConfigKeys.putAll(connectorConfigDef.configKeys());
-                configValues.addAll(connectorConfigValues);
+            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
+            resultConfigKeys.putAll(connectorConfigDef.configKeys());
+            configValues.addAll(connectorConfigValues);
 
-                return AbstractHerder.generateResult(
+            return AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
-                );
-            }
+            );
         });
 
         PowerMock.replayAll();
@@ -372,29 +359,26 @@ public class ConnectorPluginsResourceTest {
     public void testValidateConfigWithNonExistentAlias() throws Throwable {
         herder.validateConnectorConfig(EasyMock.eq(props));
 
-        PowerMock.expectLastCall().andAnswer(new IAnswer<ConfigInfos>() {
-            @Override
-            public ConfigInfos answer() {
-                ConfigDef connectorConfigDef = ConnectorConfig.configDef();
-                List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
+        PowerMock.expectLastCall().andAnswer(() -> {
+            ConfigDef connectorConfigDef = ConnectorConfig.configDef();
+            List<ConfigValue> connectorConfigValues = connectorConfigDef.validate(props);
 
-                Connector connector = new ConnectorPluginsResourceTestConnector();
-                Config config = connector.validate(props);
-                ConfigDef configDef = connector.config();
-                Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
-                List<ConfigValue> configValues = config.configValues();
+            Connector connector = new ConnectorPluginsResourceTestConnector();
+            Config config = connector.validate(props);
+            ConfigDef configDef = connector.config();
+            Map<String, ConfigDef.ConfigKey> configKeys = configDef.configKeys();
+            List<ConfigValue> configValues = config.configValues();
 
-                Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
-                resultConfigKeys.putAll(connectorConfigDef.configKeys());
-                configValues.addAll(connectorConfigValues);
+            Map<String, ConfigDef.ConfigKey> resultConfigKeys = new HashMap<>(configKeys);
+            resultConfigKeys.putAll(connectorConfigDef.configKeys());
+            configValues.addAll(connectorConfigValues);
 
-                return AbstractHerder.generateResult(
+            return AbstractHerder.generateResult(
                     ConnectorPluginsResourceTestConnector.class.getName(),
                     resultConfigKeys,
                     configValues,
                     Collections.singletonList("Test")
-                );
-            }
+            );
         });
 
         PowerMock.replayAll();
@@ -546,7 +530,7 @@ public class ConnectorPluginsResourceTest {
 
         @Override
         public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
-            return Arrays.<Object>asList(1, 2, 3);
+            return Arrays.asList(1, 2, 3);
         }
 
         @Override
@@ -558,7 +542,7 @@ public class ConnectorPluginsResourceTest {
     private static class ListRecommender implements Recommender {
         @Override
         public List<Object> validValues(String name, Map<String, Object> parsedConfig) {
-            return Arrays.<Object>asList("a", "b", "c");
+            return Arrays.asList("a", "b", "c");
         }
 
         @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/standalone/StandaloneHerderTest.java
@@ -140,7 +140,7 @@ public class StandaloneHerderTest {
     }
 
     @Test
-    public void testCreateConnectorFailedBasicValidation() throws Exception {
+    public void testCreateConnectorFailedBasicValidation() {
         // Basic validation should be performed and return an error, but should still evaluate the connector's config
         connector = PowerMock.createMock(BogusSourceConnector.class);
 
@@ -172,7 +172,7 @@ public class StandaloneHerderTest {
     }
 
     @Test
-    public void testCreateConnectorFailedCustomValidation() throws Exception {
+    public void testCreateConnectorFailedCustomValidation() {
         connector = PowerMock.createMock(BogusSourceConnector.class);
 
         Connector connectorMock = PowerMock.createMock(SourceConnector.class);
@@ -604,7 +604,7 @@ public class StandaloneHerderTest {
         PowerMock.verifyAll();
     }
 
-    private void expectAdd(SourceSink sourceSink) throws Exception {
+    private void expectAdd(SourceSink sourceSink) {
 
         Map<String, String> connectorProps = connectorConfig(sourceSink);
         ConnectorConfig connConfig = sourceSink == SourceSink.SOURCE ?

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaConfigBackingStoreTest.java
@@ -761,7 +761,7 @@ public class KafkaConfigBackingStoreTest {
 
     // If non-empty, deserializations should be a LinkedHashMap
     private void expectStart(final List<ConsumerRecord<String, byte[]>> preexistingRecords,
-                             final Map<byte[], Struct> deserializations) throws Exception {
+                             final Map<byte[], Struct> deserializations) {
         storeLog.start();
         PowerMock.expectLastCall().andAnswer(new IAnswer<Object>() {
             @Override

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStoreTest.java
@@ -111,7 +111,7 @@ public class KafkaOffsetBackingStoreTest {
 
     @Before
     public void setUp() throws Exception {
-        store = PowerMock.createPartialMockAndInvokeDefaultConstructor(KafkaOffsetBackingStore.class, new String[]{"createKafkaBasedLog"});
+        store = PowerMock.createPartialMockAndInvokeDefaultConstructor(KafkaOffsetBackingStore.class, "createKafkaBasedLog");
     }
 
     @Test

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/storage/OffsetStorageWriterTest.java
@@ -165,7 +165,7 @@ public class OffsetStorageWriterTest {
     }
 
     @Test(expected = ConnectException.class)
-    public void testAlreadyFlushing() throws Exception {
+    public void testAlreadyFlushing() {
         @SuppressWarnings("unchecked")
         final Callback<Void> callback = PowerMock.createMock(Callback.class);
         // Trigger the send, but don't invoke the callback so we'll still be mid-flush

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/KafkaBasedLogTest.java
@@ -132,7 +132,7 @@ public class KafkaBasedLogTest {
     };
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         store = PowerMock.createPartialMock(KafkaBasedLog.class, new String[]{"createConsumer", "createProducer"},
                 TOPIC, PRODUCER_PROPS, CONSUMER_PROPS, consumedCallback, time, initializer);
         consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);


### PR DESCRIPTION
[KAFKA-7431](https://issues.apache.org/jira/browse/KAFKA-7431)

Changes made to improve the code readability:
 - Removed `throws Exception` from the place where there won't be an
 exception
 - Removed type arguments where those can be inferred explicitly by compiler
 - Rewritten Anonymous classes to Java 8 with lambdas

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
