### PR TITLE
KAFKA-7433: Introduce broker options in TopicCommand to use AdminClient (KIP-377)

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -150,8 +150,6 @@ object TopicCommand extends Logging {
       JAdminClient.create(commandConfig)
     }
 
-    def apply(adminClient: JAdminClient): AdminClientTopicService =
-      new AdminClientTopicService(adminClient)
     def apply(commandConfig: Properties, bootstrapServer: Option[String]): AdminClientTopicService =
       new AdminClientTopicService(createAdminClient(commandConfig, bootstrapServer))
   }
@@ -259,7 +257,6 @@ object TopicCommand extends Logging {
   }
 
   object ZookeeperTopicService {
-    def apply(zkClient: KafkaZkClient): ZookeeperTopicService = new ZookeeperTopicService(zkClient)
     def apply(zkConnect: Option[String]): ZookeeperTopicService =
       new ZookeeperTopicService(KafkaZkClient(zkConnect.get, JaasUtils.isZkSecurityEnabled, 30000, 30000,
         Int.MaxValue, Time.SYSTEM))

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -180,7 +180,7 @@ object TopicCommand extends Logging {
     }
 
     override def listTopics(opts: TopicCommandOptions): Unit = {
-      print(getTopics(opts.topic, opts.excludeInternalTopics).mkString("\n"))
+      println(getTopics(opts.topic, opts.excludeInternalTopics).mkString("\n"))
     }
 
     override def alterTopic(opts: TopicCommandOptions): Unit = {

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -509,11 +509,13 @@ object TopicCommand extends Logging {
     private val nl = System.getProperty("line.separator")
     private val configOpt = parser.accepts("config", "A topic configuration override for the topic being created or altered."  +
                                              "The following is a list of valid configurations: " + nl + LogConfig.configNames.map("\t" + _).mkString(nl) + nl +
-                                             "See the Kafka documentation for full details on the topic configs.")
+                                             "See the Kafka documentation for full details on the topic configs." +
+                                             "Not supported with the --bootstrap-server option.")
                            .withRequiredArg
                            .describedAs("name=value")
                            .ofType(classOf[String])
-    private val deleteConfigOpt = parser.accepts("delete-config", "A topic configuration override to be removed for an existing topic (see the list of configurations under the --config option).")
+    private val deleteConfigOpt = parser.accepts("delete-config", "A topic configuration override to be removed for an existing topic (see the list of configurations under the --config option). " +
+      "Not supported with the --bootstrap-server option.")
                            .withRequiredArg
                            .describedAs("name")
                            .ofType(classOf[String])

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -414,7 +414,7 @@ object TopicCommand extends Logging {
     println()
   }
 
-  private def doGetTopics(allTopics: Seq[String], topicWhitelist: Option[String], excludeInternalTopics: Boolean = false): Seq[String] = {
+  private def doGetTopics(allTopics: Seq[String], topicWhitelist: Option[String], excludeInternalTopics: Boolean): Seq[String] = {
     if (topicWhitelist.isDefined) {
       val topicsFilter = Whitelist(topicWhitelist.get)
       allTopics.filter(topicsFilter.isTopicAllowed(_, excludeInternalTopics))

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -597,23 +597,23 @@ object TopicCommand extends Logging {
         CommandLineUtils.printUsageAndDie(parser, "Command must include exactly one action: --list, --describe, --create, --alter or --delete")
 
       // check required args
-      if (options.has(bootstrapServerOpt) == options.has(zkConnectOpt))
+      if (has(bootstrapServerOpt) == has(zkConnectOpt))
         throw new IllegalArgumentException("Only one of --bootstrap-server or --zookeeper must be specified")
 
-      if (!options.has(bootstrapServerOpt))
+      if (!has(bootstrapServerOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, zkConnectOpt)
-      if(options.has(describeOpt) && options.has(ifExistsOpt))
+      if(has(describeOpt) && has(ifExistsOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, topicOpt)
-      if (!options.has(listOpt) && !options.has(describeOpt))
+      if (!has(listOpt) && !has(describeOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, topicOpt)
       if (has(createOpt) && !has(replicaAssignmentOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt, replicationFactorOpt)
-      if (has(alterOpt))
+      if (has(bootstrapServerOpt) && has(alterOpt))
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt)
 
       // check invalid args
-      CommandLineUtils.checkInvalidArgs(parser, options, configOpt, allTopicLevelOpts -- Set(alterOpt, createOpt))
-      CommandLineUtils.checkInvalidArgs(parser, options, deleteConfigOpt, allTopicLevelOpts -- Set(alterOpt))
+      CommandLineUtils.checkInvalidArgs(parser, options, configOpt, allTopicLevelOpts -- Set(alterOpt, createOpt) ++ Set(bootstrapServerOpt))
+      CommandLineUtils.checkInvalidArgs(parser, options, deleteConfigOpt, allTopicLevelOpts -- Set(alterOpt) ++ Set(bootstrapServerOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, partitionsOpt, allTopicLevelOpts -- Set(alterOpt, createOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, allTopicLevelOpts -- Set(createOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, replicaAssignmentOpt, allTopicLevelOpts -- Set(createOpt,alterOpt))

--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -611,7 +611,8 @@ object TopicCommand extends Logging {
         CommandLineUtils.checkRequiredArgs(parser, options, partitionsOpt)
 
       // check invalid args
-      CommandLineUtils.checkInvalidArgs(parser, options, configOpt, allTopicLevelOpts -- Set(alterOpt, createOpt) ++ Set(bootstrapServerOpt))
+      CommandLineUtils.checkInvalidArgs(parser, options, configOpt, allTopicLevelOpts -- Set(alterOpt, createOpt))
+      CommandLineUtils.checkInvalidArgsSet(parser, options, Set(bootstrapServerOpt, configOpt), Set(alterOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, deleteConfigOpt, allTopicLevelOpts -- Set(alterOpt) ++ Set(bootstrapServerOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, partitionsOpt, allTopicLevelOpts -- Set(alterOpt, createOpt))
       CommandLineUtils.checkInvalidArgs(parser, options, replicationFactorOpt, allTopicLevelOpts -- Set(createOpt))

--- a/core/src/main/scala/kafka/utils/CommandLineUtils.scala
+++ b/core/src/main/scala/kafka/utils/CommandLineUtils.scala
@@ -65,7 +65,19 @@ object CommandLineUtils extends Logging {
     if (options.has(usedOption)) {
       for (arg <- invalidOptions) {
         if (options.has(arg))
-          printUsageAndDie(parser, "Option \"" + usedOption + "\" can't be used with option\"" + arg + "\"")
+          printUsageAndDie(parser, "Option \"" + usedOption + "\" can't be used with option \"" + arg + "\"")
+      }
+    }
+  }
+
+  /**
+    * Check that none of the listed options are present with the combination of used options
+    */
+  def checkInvalidArgsSet(parser: OptionParser, options: OptionSet, usedOptions: Set[OptionSpec[_]], invalidOptions: Set[OptionSpec[_]]) {
+    if (usedOptions.count(options.has) == usedOptions.size) {
+      for (arg <- invalidOptions) {
+        if (options.has(arg))
+          printUsageAndDie(parser, "Option combination \"" + usedOptions.mkString(",") + "\" can't be used with option \"" + arg + "\"")
       }
     }
   }

--- a/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ReassignPartitionsIntegrationTest.scala
@@ -12,6 +12,7 @@
   */
 package kafka.admin
 
+import kafka.admin.TopicCommand.ZookeeperTopicService
 import kafka.utils.TestUtils
 import kafka.zk.ZooKeeperTestHarness
 import org.junit.Test
@@ -32,7 +33,7 @@ class ReassignPartitionsIntegrationTest extends ZooKeeperTestHarness with RackAw
       "--replication-factor", replicationFactor.toString,
       "--disable-rack-aware",
       "--topic", "foo"))
-    kafka.admin.TopicCommand.createTopic(zkClient, createOpts)
+    new ZookeeperTopicService(zkClient).createTopic(createOpts)
 
     val topicJson = """{"topics": [{"topic": "foo"}], "version":1}"""
     val (proposedAssignment, currentAssignment) = ReassignPartitionsCommand.generateAssignment(zkClient,

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -24,6 +24,7 @@ import org.junit.Assert._
 import org.junit.{After, Test}
 import java.util.Properties
 
+import kafka.admin.TopicCommand.ZookeeperTopicService
 import kafka.common.TopicAlreadyMarkedForDeletionException
 import kafka.controller.{OfflineReplica, PartitionAndReplica, ReplicaDeletionSuccessful}
 import org.apache.kafka.common.TopicPartition
@@ -204,7 +205,7 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
 
     // increase the partition count for topic
     val topicCommandOptions = new TopicCommand.TopicCommandOptions(Array("--zookeeper", zkConnect, "--alter", "--topic", topic, "--partitions", "2"))
-    TopicCommand.alterTopic(zkClient, topicCommandOptions)
+    new ZookeeperTopicService(zkClient).alterTopic(topicCommandOptions)
 
     // trigger a controller switch now
     val previousControllerId = controllerId

--- a/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/ReassignPartitionsCommandArgsTest.scala
@@ -113,7 +113,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--execute",
       "--reassignment-json-file", "myfile.json",
       "--topics-to-move-json-file", "myfile.json")
-    shouldFailWith("Option \"[execute]\" can't be used with option\"[topics-to-move-json-file]\"", args)
+    shouldFailWith("Option \"[execute]\" can't be used with option \"[topics-to-move-json-file]\"", args)
   }
 
   @Test
@@ -124,7 +124,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--reassignment-json-file", "myfile.json",
       "--broker-list", "101,102"
     )
-    shouldFailWith("Option \"[execute]\" can't be used with option\"[broker-list]\"", args)
+    shouldFailWith("Option \"[execute]\" can't be used with option \"[broker-list]\"", args)
   }
 
   @Test
@@ -173,7 +173,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--broker-list", "101,102",
       "--throttle", "100",
       "--topics-to-move-json-file", "myfile.json")
-    shouldFailWith("Option \"[generate]\" can't be used with option\"[throttle]\"", args)
+    shouldFailWith("Option \"[generate]\" can't be used with option \"[throttle]\"", args)
   }
 
   @Test
@@ -184,7 +184,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--broker-list", "101,102",
       "--topics-to-move-json-file", "myfile.json",
       "--reassignment-json-file", "myfile.json")
-    shouldFailWith("Option \"[generate]\" can't be used with option\"[reassignment-json-file]\"", args)
+    shouldFailWith("Option \"[generate]\" can't be used with option \"[reassignment-json-file]\"", args)
   }
 
   /**
@@ -206,7 +206,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--verify",
       "--broker-list", "100,101",
       "--reassignment-json-file", "myfile.json")
-    shouldFailWith("Option \"[verify]\" can't be used with option\"[broker-list]\"", args)
+    shouldFailWith("Option \"[verify]\" can't be used with option \"[broker-list]\"", args)
   }
 
   @Test
@@ -216,7 +216,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--verify",
       "--throttle", "100",
       "--reassignment-json-file", "myfile.json")
-    shouldFailWith("Option \"[verify]\" can't be used with option\"[throttle]\"", args)
+    shouldFailWith("Option \"[verify]\" can't be used with option \"[throttle]\"", args)
   }
 
   @Test
@@ -226,7 +226,7 @@ class ReassignPartitionsCommandArgsTest extends JUnitSuite {
       "--verify",
       "--reassignment-json-file", "myfile.json",
       "--topics-to-move-json-file", "myfile.json")
-    shouldFailWith("Option \"[verify]\" can't be used with option\"[topics-to-move-json-file]\"", args)
+    shouldFailWith("Option \"[verify]\" can't be used with option \"[topics-to-move-json-file]\"", args)
   }
 
   def shouldFailWith(msg: String, args: Array[String]): Unit = {

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -16,18 +16,268 @@
  */
 package kafka.admin
 
-import org.junit.Assert._
-import org.junit.Test
-import kafka.utils.Logging
-import kafka.utils.TestUtils
-import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode, ZooKeeperTestHarness}
+import kafka.admin.TopicCommand.{TopicCommandOptions, ZookeeperTopicService}
 import kafka.server.ConfigType
-import kafka.admin.TopicCommand.TopicCommandOptions
-import org.apache.kafka.common.errors.TopicExistsException
+import kafka.utils.ZkUtils.getDeleteTopicPath
+import kafka.utils.{Logging, TestUtils}
+import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode, ZooKeeperTestHarness}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.config.{ConfigException, ConfigResource}
+import org.apache.kafka.common.errors.{InvalidPartitionsException, InvalidReplicationFactorException, TopicExistsException}
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.config.ConfigException
+import org.junit.Assert._
+import org.junit.{After, Before, Test}
 
 class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareTest {
+
+  private var topicService: ZookeeperTopicService = _
+
+  @Before
+  def setup(): Unit = {
+    topicService = ZookeeperTopicService(zkClient)
+  }
+
+  @After
+  def teardown(): Unit = {
+    if (topicService != null)
+      topicService.close()
+  }
+
+  @Test
+  def testCreate(): Unit = {
+    val topic = "test"
+
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "2", "--replication-factor", "1", "--topic", topic)))
+
+    assertTrue(zkClient.getAllTopicsInCluster.contains(topic))
+  }
+
+  @Test
+  def testCreateWithConfigs(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, "testTopic")
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "2", "--replication-factor", "2", "--topic", configResource.name(), "--config", "delete.retention.ms=1000")))
+
+    val configs = zkClient.getEntityConfigs(ConfigType.Topic, "testTopic")
+    assertEquals(1000, Integer.valueOf(configs.getProperty("delete.retention.ms")))
+  }
+
+  @Test
+  def testCreateIfNotExists() {
+    // create brokers
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic = "test"
+    val numPartitions = 1
+
+    // create the topic
+    val createOpts = new TopicCommandOptions(
+      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic))
+    topicService.createTopic(createOpts)
+
+    // try to re-create the topic without --if-not-exists
+    intercept[TopicExistsException] {
+      topicService.createTopic(createOpts)
+    }
+
+    // try to re-create the topic with --if-not-exists
+    val createNotExistsOpts = new TopicCommandOptions(
+      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic, "--if-not-exists"))
+    topicService.createTopic(createNotExistsOpts)
+  }
+
+  @Test
+  def testCreateWithReplicaAssignment(): Unit = {
+    val topic = "test"
+
+    // create the topic
+    val createOpts = new TopicCommandOptions(
+      Array("--replica-assignment", "5:4,3:2,1:0", "--topic", topic))
+    topicService.createTopic(createOpts)
+
+    val replicas0 = zkClient.getReplicasForPartition(new TopicPartition(topic, 0))
+    assertEquals(List(5, 4), replicas0)
+    val replicas1 = zkClient.getReplicasForPartition(new TopicPartition(topic, 1))
+    assertEquals(List(3, 2), replicas1)
+    val replicas2 = zkClient.getReplicasForPartition(new TopicPartition(topic, 2))
+    assertEquals(List(1, 0), replicas2)
+  }
+
+  @Test
+  def testCreateWithInvalidReplicationFactor() {
+    val brokers = List(0)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    intercept[InvalidReplicationFactorException] {
+      topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "2", "--replication-factor", (Short.MaxValue+1).toString, "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testCreateWithNegativeReplicationFactor(): Unit = {
+    val brokers = List(0)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    intercept[InvalidReplicationFactorException] {
+      topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "2", "--replication-factor", "-1", "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testCreateWithNegativePartitionCount(): Unit = {
+    val brokers = List(0)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    intercept[InvalidPartitionsException] {
+      topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "-1", "--replication-factor", "1", "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testInvalidTopicLevelConfig(): Unit = {
+    val brokers = List(0)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val createOpts = new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", "test",
+        "--config", "message.timestamp.type=boom"))
+    intercept[ConfigException] {
+      topicService.createTopic(createOpts)
+    }
+
+    // try to create the topic with another invalid config
+    val createOpts2 = new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", "test",
+        "--config", "message.format.version=boom"))
+    intercept[ConfigException] {
+      topicService.createTopic(createOpts2)
+    }
+  }
+
+  @Test
+  def testListTopics(): Unit = {
+    val brokers = List(0)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic = "testTopic"
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", topic)))
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.listTopics(new TopicCommandOptions(Array())))
+
+    assertTrue(output.contains(topic))
+  }
+
+  @Test
+  def testListTopicsWithWhitelist(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic1 = "kafka.testTopic1"
+    val topic2 = "kafka.testTopic2"
+    val topic3 = "oooof.testTopic1"
+    adminZkClient.createTopic(topic1, 2, 2)
+    adminZkClient.createTopic(topic2, 2, 2)
+    adminZkClient.createTopic(topic3, 2, 2)
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.listTopics(new TopicCommandOptions(Array("--topic", "kafka.*"))))
+
+    assertTrue(output.contains(topic1))
+    assertTrue(output.contains(topic2))
+    assertFalse(output.contains(topic3))
+  }
+
+  @Test
+  def testListTopicsWithExcludeInternal(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic1 = "kafka.testTopic1"
+    adminZkClient.createTopic(topic1, 2, 2)
+    adminZkClient.createTopic(Topic.GROUP_METADATA_TOPIC_NAME, 2, 2)
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.listTopics(new TopicCommandOptions(Array("--exclude-internal"))))
+
+    assertTrue(output.contains(topic1))
+    assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
+  }
+
+  @Test
+  def testAlterPartitionCount(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic1 = "testTopic1"
+
+    adminZkClient.createTopic(topic1, 2, 2)
+
+    topicService.alterTopic(new TopicCommandOptions(
+      Array("--topic", topic1, "--partitions", "3")))
+
+    assertEquals(3, zkClient.getPartitionsForTopics(Set(topic1))(topic1).size)
+  }
+
+  @Test
+  def testAlterAssignment(): Unit = {
+    val brokers = List(0, 1, 2, 3, 4, 5)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic1 = "testTopic1"
+
+    adminZkClient.createTopic(topic1, 2, 2)
+
+    topicService.alterTopic(new TopicCommandOptions(
+      Array("--topic", topic1, "--replica-assignment", "5:3,3:1,4:2", "--partitions", "3")))
+
+    val replicas0 = zkClient.getReplicasForPartition(new TopicPartition(topic1, 2))
+    assertEquals(3, zkClient.getPartitionsForTopics(Set(topic1))(topic1).size)
+    assertEquals(List(4,2), replicas0)
+  }
+
+  @Test
+  def testAlterWithInvalidPartitionCount(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", "testTopic")))
+
+    intercept[InvalidPartitionsException] {
+      topicService.alterTopic(new TopicCommandOptions(
+        Array("--partitions", "-1", "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testAlterIfExists() {
+    // create brokers
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    // alter a topic that does not exist without --if-exists
+    val alterOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1"))
+    intercept[IllegalArgumentException] {
+      topicService.alterTopic(alterOpts)
+    }
+
+    // alter a topic that does not exist with --if-exists
+    val alterExistsOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1", "--if-exists"))
+    topicService.alterTopic(alterExistsOpts)
+  }
 
   @Test
   def testConfigPreservationAcrossPartitionAlteration() {
@@ -43,7 +293,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
       "--replication-factor", "1",
       "--config", cleanupKey + "=" + cleanupVal,
       "--topic", topic))
-    TopicCommand.createTopic(zkClient, createOpts)
+    topicService.createTopic(createOpts)
     val props = adminZkClient.fetchEntityConfig(ConfigType.Topic, topic)
     assertTrue("Properties after creation don't contain " + cleanupKey, props.containsKey(cleanupKey))
     assertTrue("Properties after creation have incorrect value", props.getProperty(cleanupKey).equals(cleanupVal))
@@ -54,7 +304,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     // modify the topic to add new partitions
     val numPartitionsModified = 3
     val alterOpts = new TopicCommandOptions(Array("--partitions", numPartitionsModified.toString, "--topic", topic))
-    TopicCommand.alterTopic(zkClient, alterOpts)
+    topicService.alterTopic(alterOpts)
     val newProps = adminZkClient.fetchEntityConfig(ConfigType.Topic, topic)
     assertTrue("Updated properties do not contain " + cleanupKey, newProps.containsKey(cleanupKey))
     assertTrue("Updated properties have incorrect value", newProps.getProperty(cleanupKey).equals(cleanupVal))
@@ -75,27 +325,27 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     val createOpts = new TopicCommandOptions(Array("--partitions", numPartitionsOriginal.toString,
       "--replication-factor", "1",
       "--topic", normalTopic))
-    TopicCommand.createTopic(zkClient, createOpts)
+    topicService.createTopic(createOpts)
 
     // delete the NormalTopic
     val deleteOpts = new TopicCommandOptions(Array("--topic", normalTopic))
     val deletePath = DeleteTopicsTopicZNode.path(normalTopic)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deletePath))
-    TopicCommand.deleteTopic(zkClient, deleteOpts)
+    topicService.deleteTopic(deleteOpts)
     assertTrue("Delete path for topic should exist after deletion.", zkClient.pathExists(deletePath))
 
     // create the offset topic
     val createOffsetTopicOpts = new TopicCommandOptions(Array("--partitions", numPartitionsOriginal.toString,
       "--replication-factor", "1",
       "--topic", Topic.GROUP_METADATA_TOPIC_NAME))
-    TopicCommand.createTopic(zkClient, createOffsetTopicOpts)
+    topicService.createTopic(createOffsetTopicOpts)
 
     // try to delete the Topic.GROUP_METADATA_TOPIC_NAME and make sure it doesn't
     val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
     val deleteOffsetTopicPath = DeleteTopicsTopicZNode.path(Topic.GROUP_METADATA_TOPIC_NAME)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deleteOffsetTopicPath))
     intercept[AdminOperationException] {
-      TopicCommand.deleteTopic(zkClient, deleteOffsetTopicOpts)
+      topicService.deleteTopic(deleteOffsetTopicOpts)
     }
     assertFalse("Delete path for topic shouldn't exist after deletion.", zkClient.pathExists(deleteOffsetTopicPath))
   }
@@ -109,54 +359,31 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     // delete a topic that does not exist without --if-exists
     val deleteOpts = new TopicCommandOptions(Array("--topic", "test"))
     intercept[IllegalArgumentException] {
-      TopicCommand.deleteTopic(zkClient, deleteOpts)
+      topicService.deleteTopic(deleteOpts)
     }
 
     // delete a topic that does not exist with --if-exists
     val deleteExistsOpts = new TopicCommandOptions(Array("--topic", "test", "--if-exists"))
-    TopicCommand.deleteTopic(zkClient, deleteExistsOpts)
+    topicService.deleteTopic(deleteExistsOpts)
   }
 
   @Test
-  def testAlterIfExists() {
-    // create brokers
+  def testDeleteInternalTopic(): Unit = {
     val brokers = List(0, 1, 2)
     TestUtils.createBrokersInZk(zkClient, brokers)
 
-    // alter a topic that does not exist without --if-exists
-    val alterOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1"))
-    intercept[IllegalArgumentException] {
-      TopicCommand.alterTopic(zkClient, alterOpts)
+    // create the offset topic
+    val createOffsetTopicOpts = new TopicCommandOptions(Array("--partitions", "1",
+      "--replication-factor", "1",
+      "--topic", Topic.GROUP_METADATA_TOPIC_NAME))
+    topicService.createTopic(createOffsetTopicOpts)
+
+    val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
+    val deleteOffsetTopicPath = getDeleteTopicPath(Topic.GROUP_METADATA_TOPIC_NAME)
+    assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deleteOffsetTopicPath))
+    intercept[AdminOperationException] {
+      topicService.deleteTopic(deleteOffsetTopicOpts)
     }
-
-    // alter a topic that does not exist with --if-exists
-    val alterExistsOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1", "--if-exists"))
-    TopicCommand.alterTopic(zkClient, alterExistsOpts)
-  }
-
-  @Test
-  def testCreateIfNotExists() {
-    // create brokers
-    val brokers = List(0, 1, 2)
-    TestUtils.createBrokersInZk(zkClient, brokers)
-
-    val topic = "test"
-    val numPartitions = 1
-
-    // create the topic
-    val createOpts = new TopicCommandOptions(
-      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic))
-    TopicCommand.createTopic(zkClient, createOpts)
-
-    // try to re-create the topic without --if-not-exists
-    intercept[TopicExistsException] {
-      TopicCommand.createTopic(zkClient, createOpts)
-    }
-
-    // try to re-create the topic with --if-not-exists
-    val createNotExistsOpts = new TopicCommandOptions(
-      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic, "--if-not-exists"))
-    TopicCommand.createTopic(zkClient, createNotExistsOpts)
   }
 
   @Test
@@ -188,7 +415,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
       "--partitions", numPartitions.toString,
       "--replication-factor", replicationFactor.toString,
       "--topic", "foo"))
-    TopicCommand.createTopic(zkClient, createOpts)
+    topicService.createTopic(createOpts)
 
     var assignment = zkClient.getReplicaAssignmentForTopics(Set("foo")).map { case (tp, replicas) =>
       tp.partition -> replicas
@@ -200,11 +427,39 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     val alterOpts = new TopicCommandOptions(Array(
       "--partitions", alteredNumPartitions.toString,
       "--topic", "foo"))
-    TopicCommand.alterTopic(zkClient, alterOpts)
+    topicService.alterTopic(alterOpts)
     assignment = zkClient.getReplicaAssignmentForTopics(Set("foo")).map { case (tp, replicas) =>
       tp.partition -> replicas
     }
     checkReplicaDistribution(assignment, rackInfo, rackInfo.size, alteredNumPartitions, replicationFactor)
+  }
+
+  @Test
+  def testDescribe(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val topic = "testTopic"
+    adminZkClient.createTopic(topic, 2, 2)
+    val output = TestUtils.grabConsoleOutput(
+      topicService.describeTopic(new TopicCommandOptions(Array("--topic", topic))))
+    val rows = output.split("\n")
+    assertEquals(3, rows.size)
+    rows(0).startsWith("Topic:testTopic\tPartitionCount:2")
+  }
+
+  @Test
+  def testDescribeReportOverriddenConfigs(): Unit = {
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    val config = "file.delete.delay.ms=1000"
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, "testTopic")
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "2", "--replication-factor", "2", "--topic", configResource.name(), "--config", config)))
+    val output = TestUtils.grabConsoleOutput(
+      topicService.describeTopic(new TopicCommandOptions(Array())))
+    assertTrue(output.contains(config))
   }
 
   @Test
@@ -216,59 +471,31 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     TestUtils.createBrokersInZk(zkClient, brokers)
 
     val createOpts = new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "1", "--topic", topic))
-    TopicCommand.createTopic(zkClient, createOpts)
+    topicService.createTopic(createOpts)
 
     // delete the broker first, so when we attempt to delete the topic it gets into "marked for deletion"
     TestUtils.deleteBrokersInZk(zkClient, brokers)
-    TopicCommand.deleteTopic(zkClient, new TopicCommandOptions(Array("--topic", topic)))
+    topicService.deleteTopic(new TopicCommandOptions(Array("--topic", topic)))
 
     // Test describe topics
     def describeTopicsWithConfig() {
-      TopicCommand.describeTopic(zkClient, new TopicCommandOptions(Array("--describe")))
+      topicService.describeTopic(new TopicCommandOptions(Array("--describe")))
     }
-    val outputWithConfig = TestUtils.grabConsoleOutput(describeTopicsWithConfig)
+    val outputWithConfig = TestUtils.grabConsoleOutput(describeTopicsWithConfig())
     assertTrue(outputWithConfig.contains(topic) && outputWithConfig.contains(markedForDeletionDescribe))
 
     def describeTopicsNoConfig() {
-      TopicCommand.describeTopic(zkClient, new TopicCommandOptions(Array("--describe", "--unavailable-partitions")))
+      topicService.describeTopic(new TopicCommandOptions(Array("--describe", "--unavailable-partitions")))
     }
-    val outputNoConfig = TestUtils.grabConsoleOutput(describeTopicsNoConfig)
+    val outputNoConfig = TestUtils.grabConsoleOutput(describeTopicsNoConfig())
     assertTrue(outputNoConfig.contains(topic) && outputNoConfig.contains(markedForDeletionDescribe))
 
     // Test list topics
     def listTopics() {
-      TopicCommand.listTopics(zkClient, new TopicCommandOptions(Array("--list")))
+      topicService.listTopics(new TopicCommandOptions(Array("--list")))
     }
-    val output = TestUtils.grabConsoleOutput(listTopics)
+    val output = TestUtils.grabConsoleOutput(listTopics())
     assertTrue(output.contains(topic) && output.contains(markedForDeletionList))
-  }
-
-  @Test
-  def testInvalidTopicLevelConfig(): Unit = {
-    val brokers = List(0)
-    TestUtils.createBrokersInZk(zkClient, brokers)
-
-    // create the topic
-    try {
-      val createOpts = new TopicCommandOptions(
-        Array("--partitions", "1", "--replication-factor", "1", "--topic", "test",
-          "--config", "message.timestamp.type=boom"))
-      TopicCommand.createTopic(zkClient, createOpts)
-      fail("Expected exception on invalid topic-level config.")
-    } catch {
-      case _: Exception => // topic creation should fail due to the invalid config
-    }
-
-    // try to create the topic with another invalid config
-    try {
-      val createOpts = new TopicCommandOptions(
-        Array("--partitions", "1", "--replication-factor", "1", "--topic", "test",
-          "--config", "message.format.version=boom"))
-      TopicCommand.createTopic(zkClient, createOpts)
-      fail("Expected exception on invalid topic-level config.")
-    } catch {
-      case _: ConfigException => // topic creation should fail due to the invalid config value
-    }
   }
 
   @Test
@@ -277,20 +504,20 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     val topic = "testDescribeAndListTopicsWithoutInternalTopics"
     TestUtils.createBrokersInZk(zkClient, brokers)
 
-    TopicCommand.createTopic(zkClient,
+    topicService.createTopic(
       new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "1", "--topic", topic)))
     // create a internal topic
-    TopicCommand.createTopic(zkClient,
+    topicService.createTopic(
       new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "1", "--topic", Topic.GROUP_METADATA_TOPIC_NAME)))
 
     // test describe
-    var output = TestUtils.grabConsoleOutput(TopicCommand.describeTopic(zkClient,
+    var output = TestUtils.grabConsoleOutput(topicService.describeTopic(
       new TopicCommandOptions(Array("--describe", "--exclude-internal"))))
     assertTrue(output.contains(topic))
     assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
 
     // test list
-    output = TestUtils.grabConsoleOutput(TopicCommand.listTopics(zkClient,
+    output = TestUtils.grabConsoleOutput(topicService.listTopics(
       new TopicCommandOptions(Array("--list", "--exclude-internal"))))
     assertTrue(output.contains(topic))
     assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
@@ -311,10 +538,10 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     // create the topics
     val createOpts = new TopicCommandOptions(Array("--partitions", numPartitionsOriginal.toString,
       "--replication-factor", "1", "--topic", topic1))
-    TopicCommand.createTopic(zkClient, createOpts)
+    topicService.createTopic(createOpts)
     val createOpts2 = new TopicCommandOptions(Array("--partitions", numPartitionsOriginal.toString,
       "--replication-factor", "1", "--topic", topic2))
-    TopicCommand.createTopic(zkClient, createOpts2)
+    topicService.createTopic(createOpts2)
 
     val escapedCommandOpts = new TopicCommandOptions(Array("--topic", escapedTopic))
     val unescapedCommandOpts = new TopicCommandOptions(Array("--topic", unescapedTopic))
@@ -322,10 +549,10 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     // topic actions with escaped regex do not affect 'test-topic'
     // topic actions with unescaped topic affect 'test-topic'
 
-    assertFalse(TestUtils.grabConsoleOutput(TopicCommand.describeTopic(zkClient, escapedCommandOpts)).contains(topic2))
-    assertTrue(TestUtils.grabConsoleOutput(TopicCommand.describeTopic(zkClient, unescapedCommandOpts)).contains(topic2))
+    assertFalse(TestUtils.grabConsoleOutput(topicService.describeTopic(escapedCommandOpts)).contains(topic2))
+    assertTrue(TestUtils.grabConsoleOutput(topicService.describeTopic(unescapedCommandOpts)).contains(topic2))
 
-    assertFalse(TestUtils.grabConsoleOutput(TopicCommand.deleteTopic(zkClient, escapedCommandOpts)).contains(topic2))
-    assertTrue(TestUtils.grabConsoleOutput(TopicCommand.deleteTopic(zkClient, unescapedCommandOpts)).contains(topic2))
+    assertFalse(TestUtils.grabConsoleOutput(topicService.deleteTopic(escapedCommandOpts)).contains(topic2))
+    assertTrue(TestUtils.grabConsoleOutput(topicService.deleteTopic(unescapedCommandOpts)).contains(topic2))
   }
 }

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -395,13 +395,13 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     // describe topic that does not exist
     val describeOpts = new TopicCommandOptions(Array("--topic", "test"))
     intercept[IllegalArgumentException] {
-      TopicCommand.describeTopic(zkClient, describeOpts)
+      topicService.describeTopic(describeOpts)
     }
 
     // describe topic that does not exist with --if-exists
     val describeOptsWithExists = new TopicCommandOptions(Array("--topic", "test", "--if-exists"))
     // should not throw any error
-    TopicCommand.describeTopic(zkClient, describeOptsWithExists)
+    topicService.describeTopic(describeOptsWithExists)
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -18,7 +18,6 @@ package kafka.admin
 
 import kafka.admin.TopicCommand.{TopicCommandOptions, ZookeeperTopicService}
 import kafka.server.ConfigType
-import kafka.utils.ZkUtils.getDeleteTopicPath
 import kafka.utils.{Logging, TestUtils}
 import kafka.zk.{ConfigEntityChangeNotificationZNode, DeleteTopicsTopicZNode, ZooKeeperTestHarness}
 import org.apache.kafka.common.TopicPartition
@@ -379,7 +378,7 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     topicService.createTopic(createOffsetTopicOpts)
 
     val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
-    val deleteOffsetTopicPath = getDeleteTopicPath(Topic.GROUP_METADATA_TOPIC_NAME)
+    val deleteOffsetTopicPath = DeleteTopicsTopicZNode.path(Topic.GROUP_METADATA_TOPIC_NAME)
     assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deleteOffsetTopicPath))
     intercept[AdminOperationException] {
       topicService.deleteTopic(deleteOffsetTopicOpts)

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -279,6 +279,23 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
   }
 
   @Test
+  def testAlterConfigs() {
+    // create brokers
+    val brokers = List(0, 1, 2)
+    TestUtils.createBrokersInZk(zkClient, brokers)
+
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", "testTopic")))
+
+    topicService.alterTopic(new TopicCommandOptions(
+      Array("--topic", "testTopic", "--config", "cleanup.policy=compact")))
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.describeTopic(new TopicCommandOptions(Array("--topic", "testTopic"))))
+    assertTrue("The output should contain the modified config", output.contains("Configs:cleanup.policy=compact"))
+  }
+
+  @Test
   def testConfigPreservationAcrossPartitionAlteration() {
     val topic = "test"
     val numPartitionsOriginal = 1

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -291,6 +291,13 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
     val output = TestUtils.grabConsoleOutput(
       topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
     assertTrue("The output should contain the modified config", output.contains("Configs:cleanup.policy=compact"))
+
+    topicService.alterTopic(new TopicCommandOptions(
+      Array("--topic", testTopicName, "--config", "cleanup.policy=delete")))
+
+    val output2 = TestUtils.grabConsoleOutput(
+      topicService.describeTopic(new TopicCommandOptions(Array("--topic", testTopicName))))
+    assertTrue("The output should contain the modified config", output2.contains("Configs:cleanup.policy=delete"))
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -1,0 +1,582 @@
+/**
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package unit.kafka.admin
+
+import java.util.{Collections, Properties}
+
+import kafka.admin.TopicCommand.{AdminClientTopicService, TopicCommandOptions}
+import kafka.admin.{AdminOperationException, RackAwareTest, TopicCommand}
+import kafka.common.AdminCommandFailedException
+import kafka.integration.KafkaServerTestHarness
+import kafka.server.{ConfigType, KafkaConfig}
+import kafka.utils.ZkUtils.getDeleteTopicPath
+import kafka.utils.{Exit, Logging, TestUtils}
+import kafka.zk.ConfigEntityChangeNotificationZNode
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.{AdminClient, NewTopic}
+import org.apache.kafka.common.config.{ConfigException, ConfigResource}
+import org.apache.kafka.common.internals.Topic
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.{After, Before, Test}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionException
+
+class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Logging with RackAwareTest {
+
+  /**
+    * Implementations must override this method to return a set of KafkaConfigs. This method will be invoked for every
+    * test and should not reuse previous configurations unless they select their ports randomly when servers are started.
+    */
+  override def generateConfigs: Seq[KafkaConfig] = TestUtils.createBrokerConfigs(
+    numConfigs = 6,
+    zkConnect = zkConnect,
+    rackInfo = Map(0 -> "rack1", 1 -> "rack2", 2 -> "rack2", 3 -> "rack1", 4 -> "rack3", 5 -> "rack3"
+    )).map(KafkaConfig.fromProps)
+
+  private var topicService: AdminClientTopicService = _
+  private var adminClient: AdminClient = _
+
+  def assertExitCode(expected: Int, method: () => Unit) {
+    def mockExitProcedure(exitCode: Int, exitMessage: Option[String]): Nothing = {
+      assertEquals(1, exitCode)
+      throw new RuntimeException
+    }
+    Exit.setExitProcedure(mockExitProcedure)
+    try {
+      intercept[RuntimeException] {
+        method()
+      }
+    } finally {
+      Exit.resetExitProcedure()
+    }
+  }
+
+  def assertCheckArgsExitCode(expected: Int, options: TopicCommandOptions) {
+    assertExitCode(1, options.checkArgs)
+  }
+
+  @Before
+  def setup() {
+    // create adminClient
+    val props = new Properties()
+    props.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    adminClient = AdminClient.create(props)
+    topicService = AdminClientTopicService(adminClient)
+  }
+
+  @After
+  def close(): Unit = {
+    // adminClient is closed by topicService
+    if (topicService != null)
+      topicService.close()
+  }
+
+  @Test
+  def testParseAssignment(): Unit = {
+    val actualAssignment = TopicCommand.parseReplicaAssignment("5:4,3:2,1:0")
+    val expectedAssignment = Map(0 -> List(5, 4), 1 -> List(3, 2), 2 -> List(1, 0))
+    assertEquals(expectedAssignment, actualAssignment)
+  }
+
+  @Test
+  def testParseAssignmentDuplicateEntries(): Unit = {
+    intercept[AdminCommandFailedException] {
+      TopicCommand.parseReplicaAssignment("5:5")
+    }
+  }
+
+  @Test
+  def testParseAssignmentPartitionsOfDifferentSize(): Unit = {
+    intercept[AdminOperationException] {
+      TopicCommand.parseReplicaAssignment("5:4:3,2:1")
+    }
+  }
+
+  @Test
+  def testInvalidConfigOptWithBootstrapServers(): Unit = {
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", "test", "--config", "cleanup.policy=compact")))
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", "test", "--delete-config", "cleanup.policy")))
+  }
+
+  @Test
+  def testCreate(): Unit = {
+    val topic = "test"
+
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "2", "--replication-factor", "1", "--topic", topic)))
+
+    adminClient.listTopics().names().get().contains(topic)
+  }
+
+  @Test
+  def testCreateWithConfigs(): Unit = {
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, "testTopic")
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "2", "--replication-factor", "2", "--topic", configResource.name(), "--config", "delete.retention.ms=1000")))
+
+    val configs = adminClient
+      .describeConfigs(Collections.singleton(configResource))
+      .all().get().get(configResource)
+    assertEquals(1000, Integer.valueOf(configs.get("delete.retention.ms").value()))
+  }
+
+  @Test
+  def testCreateIfNotExists(): Unit = {
+    val topic = "test"
+    val numPartitions = 1
+
+    // create the topic
+    val createOpts = new TopicCommandOptions(
+      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic))
+    val topicService = AdminClientTopicService(adminClient)
+    topicService.createTopic(createOpts)
+
+    // try to re-create the topic without --if-not-exists
+    intercept[ExecutionException] {
+      topicService.createTopic(createOpts)
+    }
+
+    // try to re-create the topic with --if-not-exists
+    val createNotExistsOpts = new TopicCommandOptions(
+      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", topic, "--if-not-exists"))
+    topicService.createTopic(createNotExistsOpts)
+
+    // try to create a new topic with --if-not-exists
+    val createNewNotExistsOpts = new TopicCommandOptions(
+      Array("--partitions", numPartitions.toString, "--replication-factor", "1", "--topic", "test2", "--if-not-exists"))
+    topicService.createTopic(createNewNotExistsOpts)
+
+    adminClient.listTopics().names().get().contains("test2")
+  }
+
+  @Test
+  def testCreateWithReplicaAssignment(): Unit = {
+    val topic = "test"
+
+    // create the topic
+    val createOpts = new TopicCommandOptions(
+      Array("--replica-assignment", "5:4,3:2,1:0", "--topic", topic))
+    topicService.createTopic(createOpts)
+
+    val partitions = adminClient
+      .describeTopics(Collections.singletonList(topic))
+      .all()
+      .get()
+      .get(topic)
+      .partitions()
+    assertEquals(3, partitions.size())
+    assertEquals(List(5, 4), partitions.get(0).replicas().asScala.map(_.id()))
+    assertEquals(List(3, 2), partitions.get(1).replicas().asScala.map(_.id()))
+    assertEquals(List(1, 0), partitions.get(2).replicas().asScala.map(_.id()))
+  }
+
+  @Test
+  def testCreateWithInvalidReplicationFactor() {
+    intercept[IllegalArgumentException] {
+      topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "2", "--replication-factor", (Short.MaxValue+1).toString, "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testCreateWithNegativeReplicationFactor(): Unit = {
+    intercept[ExecutionException] {
+      topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "2", "--replication-factor", "-1", "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testCreateWithAssignmentAndPartitionCount(): Unit = {
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(
+        Array("--bootstrap-server", brokerList,
+          "--create",
+          "--replica-assignment", "3:0,5:1",
+          "--partitions", "2",
+          "--topic", "testTopic")))
+  }
+
+  @Test
+  def testCreateWithAssignmentAndReplicationFactor(): Unit = {
+    assertCheckArgsExitCode(1,
+      new TopicCommandOptions(
+        Array("--bootstrap-server", brokerList,
+          "--create",
+          "--replica-assignment", "3:0,5:1",
+          "--replication-factor", "2",
+          "--topic", "testTopic")))
+  }
+
+  @Test
+  def testCreateWithNegativePartitionCount(): Unit = {
+    intercept[ExecutionException] {
+      topicService.createTopic(new TopicCommandOptions(
+        Array("--partitions", "-1", "--replication-factor", "1", "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testCreateWithUnspecifiedPartitionCount(): Unit = {
+    assertExitCode(1,
+      () => topicService.createTopic(new TopicCommandOptions(
+        Array("--replication-factor", "1", "--topic", "testTopic"))))
+  }
+
+  @Test
+  def testInvalidTopicLevelConfig(): Unit = {
+    val createOpts = new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", "test",
+        "--config", "message.timestamp.type=boom"))
+    intercept[ConfigException] {
+      topicService.createTopic(createOpts)
+    }
+  }
+
+  @Test
+  def testListTopics(): Unit = {
+    val topic = "testTopic"
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", topic)))
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.listTopics(new TopicCommandOptions(Array())))
+
+    assertTrue(output.contains(topic))
+  }
+
+  @Test
+  def testListTopicsWithWhitelist(): Unit = {
+    val topic1 = "kafka.testTopic1"
+    val topic2 = "kafka.testTopic2"
+    val topic3 = "oooof.testTopic1"
+    adminClient.createTopics(
+      List(new NewTopic(topic1, 2, 2),
+        new NewTopic(topic2, 2, 2),
+        new NewTopic(topic3, 2, 2)).asJavaCollection)
+      .all().get()
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.listTopics(new TopicCommandOptions(Array("--topic", "kafka.*"))))
+
+    assertTrue(output.contains(topic1))
+    assertTrue(output.contains(topic2))
+    assertFalse(output.contains(topic3))
+  }
+
+  @Test
+  def testListTopicsWithExcludeInternal(): Unit = {
+    val topic1 = "kafka.testTopic1"
+    adminClient.createTopics(
+      List(new NewTopic(topic1, 2, 2),
+        new NewTopic(Topic.GROUP_METADATA_TOPIC_NAME, 2, 2)).asJavaCollection)
+      .all().get()
+
+    val output = TestUtils.grabConsoleOutput(
+      topicService.listTopics(new TopicCommandOptions(Array("--exclude-internal"))))
+
+    assertTrue(output.contains(topic1))
+    assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
+  }
+
+  @Test
+  def testAlterPartitionCount(): Unit = {
+    val topic1 = "testTopic1"
+
+    adminClient.createTopics(
+      List(new NewTopic(topic1, 2, 2)).asJavaCollection).all().get()
+
+    topicService.alterTopic(new TopicCommandOptions(
+      Array("--topic", topic1, "--partitions", "3")))
+
+    val topicDescription = adminClient.describeTopics(Collections.singletonList(topic1)).values().get(topic1).get()
+    assertTrue(topicDescription.partitions().size() == 3)
+  }
+
+  @Test
+  def testAlterAssignment(): Unit = {
+    val topic1 = "testTopic1"
+
+    adminClient.createTopics(
+      Collections.singletonList(new NewTopic(topic1, 2, 2))).all().get()
+
+    topicService.alterTopic(new TopicCommandOptions(
+      Array("--topic", topic1, "--replica-assignment", "5:3,3:1,4:2", "--partitions", "3")))
+
+    val topicDescription = adminClient.describeTopics(Collections.singletonList(topic1)).values().get(topic1).get()
+    assertTrue(topicDescription.partitions().size() == 3)
+    assertEquals(List(4,2), topicDescription.partitions().get(2).replicas().asScala.map(_.id()))
+  }
+
+  @Test
+  def testAlterAssignmentWithMoreAssignmentThanPartitions(): Unit = {
+    val topic1 = "testTopic1"
+
+    adminClient.createTopics(
+      List(new NewTopic(topic1, 2, 2)).asJavaCollection).all().get()
+
+    intercept[ExecutionException] {
+      topicService.alterTopic(new TopicCommandOptions(
+        Array("--topic", topic1, "--replica-assignment", "5:3,3:1,4:2,3:2", "--partitions", "3")))
+    }
+  }
+
+  @Test
+  def testAlterAssignmentWithMorePartitionsThanAssignment(): Unit = {
+    val topic1 = "testTopic1"
+
+    adminClient.createTopics(
+      List(new NewTopic(topic1, 2, 2)).asJavaCollection).all().get()
+
+    intercept[ExecutionException] {
+      topicService.alterTopic(new TopicCommandOptions(
+        Array("--topic", topic1, "--replica-assignment", "5:3,3:1,4:2", "--partitions", "6")))
+    }
+  }
+
+  @Test
+  def testAlterWithInvalidPartitionCount(): Unit = {
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "1", "--replication-factor", "1", "--topic", "testTopic")))
+
+    intercept[ExecutionException] {
+      topicService.alterTopic(new TopicCommandOptions(
+        Array("--partitions", "-1", "--topic", "testTopic")))
+    }
+  }
+
+  @Test
+  def testAlterWithUnspecifiedPartitionCount(): Unit = {
+    assertCheckArgsExitCode(1, new TopicCommandOptions(
+      Array("--bootstrap-server", brokerList ,"--alter", "--topic", "testTopic")))
+  }
+
+  @Test
+  def testAlterIfExists(): Unit = {
+    // alter a topic that does not exist without --if-exists
+    val alterOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1"))
+    val topicService = AdminClientTopicService(adminClient)
+    intercept[IllegalArgumentException] {
+      topicService.alterTopic(alterOpts)
+    }
+
+    // alter a topic that does not exist with --if-exists
+    val alterExistsOpts = new TopicCommandOptions(Array("--topic", "test", "--partitions", "1", "--if-exists"))
+    topicService.alterTopic(alterExistsOpts)
+  }
+
+  @Test
+  def testCreateAlterTopicWithRackAware(): Unit = {
+    val rackInfo = Map(0 -> "rack1", 1 -> "rack2", 2 -> "rack2", 3 -> "rack1", 4 -> "rack3", 5 -> "rack3")
+
+    val numPartitions = 18
+    val replicationFactor = 3
+    val createOpts = new TopicCommandOptions(Array(
+      "--partitions", numPartitions.toString,
+      "--replication-factor", replicationFactor.toString,
+      "--topic", "foo"))
+    val topicService = AdminClientTopicService(adminClient)
+    topicService.createTopic(createOpts)
+
+    var assignment = zkClient.getReplicaAssignmentForTopics(Set("foo")).map { case (tp, replicas) =>
+      tp.partition -> replicas
+    }
+    checkReplicaDistribution(assignment, rackInfo, rackInfo.size, numPartitions, replicationFactor)
+
+    val alteredNumPartitions = 36
+    // verify that adding partitions will also be rack aware
+    val alterOpts = new TopicCommandOptions(Array(
+      "--partitions", alteredNumPartitions.toString,
+      "--topic", "foo"))
+    topicService.alterTopic(alterOpts)
+    assignment = zkClient.getReplicaAssignmentForTopics(Set("foo")).map { case (tp, replicas) =>
+      tp.partition -> replicas
+    }
+    checkReplicaDistribution(assignment, rackInfo, rackInfo.size, alteredNumPartitions, replicationFactor)
+  }
+
+  @Test
+  def testConfigPreservationAcrossPartitionAlteration(): Unit = {
+    val topic = "test"
+    val numPartitionsOriginal = 1
+    val cleanupKey = "cleanup.policy"
+    val cleanupVal = "compact"
+
+    // create the topic
+    val createOpts = new TopicCommandOptions(Array("--partitions", numPartitionsOriginal.toString,
+      "--replication-factor", "1",
+      "--config", cleanupKey + "=" + cleanupVal,
+      "--topic", topic))
+    topicService.createTopic(createOpts)
+    val props = adminZkClient.fetchEntityConfig(ConfigType.Topic, topic)
+    assertTrue("Properties after creation don't contain " + cleanupKey, props.containsKey(cleanupKey))
+    assertTrue("Properties after creation have incorrect value", props.getProperty(cleanupKey).equals(cleanupVal))
+
+    // pre-create the topic config changes path to avoid a NoNodeException
+    zkClient.makeSurePersistentPathExists(ConfigEntityChangeNotificationZNode.path)
+
+    // modify the topic to add new partitions
+    val numPartitionsModified = 3
+    val alterOpts = new TopicCommandOptions(Array("--partitions", numPartitionsModified.toString, "--topic", topic))
+    topicService.alterTopic(alterOpts)
+    val newProps = adminZkClient.fetchEntityConfig(ConfigType.Topic, topic)
+    assertTrue("Updated properties do not contain " + cleanupKey, newProps.containsKey(cleanupKey))
+    assertTrue("Updated properties have incorrect value", newProps.getProperty(cleanupKey).equals(cleanupVal))
+  }
+
+  @Test
+  def testTopicDeletion(): Unit = {
+
+    val normalTopic = "test"
+
+    // create the NormalTopic
+    val createOpts = new TopicCommandOptions(Array("--partitions", "1",
+      "--replication-factor", "1",
+      "--topic", normalTopic))
+    topicService.createTopic(createOpts)
+
+    // delete the NormalTopic
+    val deleteOpts = new TopicCommandOptions(Array("--topic", normalTopic))
+
+    val deletePath = getDeleteTopicPath(normalTopic)
+    assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deletePath))
+    topicService.deleteTopic(deleteOpts)
+    assertTrue("Delete path for topic should exist after deletion.", zkClient.pathExists(deletePath))
+  }
+
+  @Test
+  def testDeleteInternalTopic(): Unit = {
+    // create the offset topic
+    val createOffsetTopicOpts = new TopicCommandOptions(Array("--partitions", "1",
+      "--replication-factor", "1",
+      "--topic", Topic.GROUP_METADATA_TOPIC_NAME))
+    topicService.createTopic(createOffsetTopicOpts)
+
+    // Try to delete the Topic.GROUP_METADATA_TOPIC_NAME which is allowed by default.
+    // This is a difference between the new and the old command as the old one didn't allow internal topic deletion.
+    // If deleting internal topics is not desired, ACLS should be used to control it.
+    val deleteOffsetTopicOpts = new TopicCommandOptions(Array("--topic", Topic.GROUP_METADATA_TOPIC_NAME))
+    val deleteOffsetTopicPath = getDeleteTopicPath(Topic.GROUP_METADATA_TOPIC_NAME)
+    assertFalse("Delete path for topic shouldn't exist before deletion.", zkClient.pathExists(deleteOffsetTopicPath))
+    topicService.deleteTopic(deleteOffsetTopicOpts)
+    assertTrue("Delete path for topic should exist after deletion.", zkClient.pathExists(deleteOffsetTopicPath))
+  }
+
+  @Test
+  def testDeleteIfExists(): Unit = {
+    // delete a topic that does not exist without --if-exists
+    val deleteOpts = new TopicCommandOptions(Array("--topic", "test"))
+    intercept[IllegalArgumentException] {
+      topicService.deleteTopic(deleteOpts)
+    }
+
+    // delete a topic that does not exist with --if-exists
+    val deleteExistsOpts = new TopicCommandOptions(Array("--topic", "test", "--if-exists"))
+    topicService.deleteTopic(deleteExistsOpts)
+
+    // delete a topic that is already marked for deletion
+    val normalTopic = "test"
+    val numPartitionsOriginal = 1
+    val createOpts = new TopicCommandOptions(Array("--partitions", numPartitionsOriginal.toString,
+      "--replication-factor", "1",
+      "--topic", normalTopic))
+    topicService.createTopic(createOpts)
+    topicService.deleteTopic(deleteOpts)
+  }
+
+  @Test
+  def testDescribe(): Unit = {
+    val topic = "testTopic"
+    adminClient.createTopics(
+      Collections.singletonList(new NewTopic(topic, 2, 2))).all().get()
+    val output = TestUtils.grabConsoleOutput(
+      topicService.describeTopic(new TopicCommandOptions(Array("--topic", topic))))
+    val rows = output.split("\n")
+    assertEquals(3, rows.size)
+    rows(0).startsWith("Topic:testTopic\tPartitionCount:2")
+  }
+
+  @Test
+  def testDescribeUnavailablePartitions(): Unit = {
+    val topic = "testTopic"
+    adminClient.createTopics(
+      Collections.singletonList(new NewTopic(topic, 6, 1))).all().get()
+
+    try {
+      killBroker(0)
+      val output = TestUtils.grabConsoleOutput(
+        topicService.describeTopic(new TopicCommandOptions(Array("--topic", topic, "--unavailable-partitions"))))
+      val rows = output.split("\n")
+      assertTrue(rows(0).startsWith("\tTopic: testTopic"))
+      assertTrue(rows(0).endsWith("Leader: none\tReplicas: 0\tIsr: "))
+    } finally {
+      restartDeadBrokers()
+    }
+  }
+
+  @Test
+  def testDescribeUnderreplicatedPartitions(): Unit = {
+    val topic = "testTopic"
+    adminClient.createTopics(
+      Collections.singletonList(new NewTopic(topic, 1, 6))).all().get()
+
+    try {
+      killBroker(0)
+      val output = TestUtils.grabConsoleOutput(
+        topicService.describeTopic(new TopicCommandOptions(Array("--under-replicated-partitions"))))
+      val rows = output.split("\n")
+      assertTrue(rows(0).startsWith("\tTopic: testTopic"))
+    } finally {
+      restartDeadBrokers()
+    }
+  }
+
+  @Test
+  def testDescribeReportOverriddenConfigs(): Unit = {
+    val config = "file.delete.delay.ms=1000"
+    val configResource = new ConfigResource(ConfigResource.Type.TOPIC, "testTopic")
+    topicService.createTopic(new TopicCommandOptions(
+      Array("--partitions", "2", "--replication-factor", "2", "--topic", configResource.name(), "--config", config)))
+    val output = TestUtils.grabConsoleOutput(
+      topicService.describeTopic(new TopicCommandOptions(Array())))
+    assertTrue(output.contains(config))
+  }
+
+  @Test
+  def testDescribeAndListTopicsWithoutInternalTopics(): Unit = {
+    val topic = "testDescribeAndListTopicsWithoutInternalTopics"
+
+    topicService.createTopic(
+      new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "1", "--topic", topic)))
+    // create a internal topic
+    topicService.createTopic(
+      new TopicCommandOptions(Array("--partitions", "1", "--replication-factor", "1", "--topic", Topic.GROUP_METADATA_TOPIC_NAME)))
+
+    // test describe
+    var output = TestUtils.grabConsoleOutput(topicService.describeTopic(new TopicCommandOptions(Array("--describe", "--exclude-internal"))))
+    assertTrue(output.contains(topic))
+    assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
+
+    // test list
+    output = TestUtils.grabConsoleOutput(topicService.listTopics(new TopicCommandOptions(Array("--list", "--exclude-internal"))))
+    assertTrue(output.contains(topic))
+    assertFalse(output.contains(Topic.GROUP_METADATA_TOPIC_NAME))
+  }
+}

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -113,11 +113,18 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
   }
 
   @Test
-  def testInvalidConfigOptWithBootstrapServers(): Unit = {
+  def testConfigOptWithBootstrapServers(): Unit = {
     assertCheckArgsExitCode(1,
       new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--partitions", "3", "--config", "cleanup.policy=compact")))
     assertCheckArgsExitCode(1,
       new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--partitions", "3", "--delete-config", "cleanup.policy")))
+    val opts =
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--create", "--topic", testTopicName, "--partitions", "3", "--replication-factor", "3", "--config", "cleanup.policy=compact"))
+    opts.checkArgs()
+    assertTrue(opts.hasCreateOption)
+    assertEquals(brokerList, opts.bootstrapServer.get)
+    assertEquals("cleanup.policy=compact", opts.topicConfig.get.get(0))
+
   }
 
   @Test

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandWithAdminClientTest.scala
@@ -115,9 +115,9 @@ class TopicCommandWithAdminClientTest extends KafkaServerTestHarness with Loggin
   @Test
   def testInvalidConfigOptWithBootstrapServers(): Unit = {
     assertCheckArgsExitCode(1,
-      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--config", "cleanup.policy=compact")))
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--partitions", "3", "--config", "cleanup.policy=compact")))
     assertCheckArgsExitCode(1,
-      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--delete-config", "cleanup.policy")))
+      new TopicCommandOptions(Array("--bootstrap-server", brokerList ,"--alter", "--topic", testTopicName, "--partitions", "3", "--delete-config", "cleanup.policy")))
   }
 
   @Test


### PR DESCRIPTION
The PR adds --bootstrap-server and --admin.config options to TopicCommand and implements an alternative, AdminClient based way of topic management.

As testing I've duplicated the existing tests and made them working with the AdminClient options.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
