### PR TITLE
KAFKA-7441; Allow LogCleanerManager.resumeCleaning() to be used concurrently

### DIFF
--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -37,16 +37,29 @@ import scala.collection.{Iterable, immutable, mutable}
 private[log] sealed trait LogCleaningState
 private[log] case object LogCleaningInProgress extends LogCleaningState
 private[log] case object LogCleaningAborted extends LogCleaningState
-private[log] case class LogCleaningPaused(times: Int) extends LogCleaningState
+private[log] case class LogCleaningPaused(pausedCount: Int) extends LogCleaningState
 
 /**
- *  Manage the state of each partition being cleaned.
- *  If a partition is to be cleaned, it enters the LogCleaningInProgress state.
- *  While a partition is being cleaned, it can be requested to be aborted and paused. Then the partition first enters
- *  the LogCleaningAborted state. Once the cleaning task is aborted, the partition enters the LogCleaningPaused state.
- *  While a partition is in the LogCleaningPaused state, it won't be scheduled for cleaning again, until cleaning is
- *  requested to be resumed.
- */
+  * This class manages the state of each partition being cleaned.
+  * LogCleaningState defines the cleaning states that a TopicPartition can be in.
+  * 1. None : No cleaning state in a TopicPartition
+  * 2. LogCleaningInProgress   : The cleaning is currently in progress. It can only be transited from None State by logcleaner.
+  *                              It can be transited to None State by logcleaner (when cleanning finished) or to
+  *                              LogCleaningAborted state by topic deletion, log truncation, or partition movement(future log).
+  *                              However, there should not be more than one entity that tries to move this state to LogCleaningAborted
+  *                              at the same time.  Logcleaner only starts working on a TopicPartition if it can put the TopicPartition
+  *                              in this state.
+  * 3. LogCleaningAborted      : The cleaning is aborted. It is transited from LogCleaningInProgress by aborting operation (see previous state)
+  *                              and can be moved to LogCleaningPaused(1) by logcleaner. Aborting already aborted
+  *                              TopicPartition is not allowed.
+  * 2. LogCleaningPaused(i)    : The cleaning is paused i times. LogCleaningPaused(1) is transited from LogCleaningAborted by logcleaner
+  *                              or from None state by log retention, log truncation, and partition movement.  LogCleaningPaused(i) can
+  *                              be moved to LogCleaningPaused(i+1) (by aborting an already paused topic partition)
+  *                              or LogCleaningPaused(i-1) (by resumeCleaning). If the end state is LogCleaningPaused(0),
+  *                              the state will be removed and becomes a None State.  log retention, topic deletion, log truncation,
+  *                              and partition movement only starts working on a TopicPartition if it can put the TopicPartition
+  *                              in LogCleaningPaused(i) state.
+  */
 private[log] class LogCleanerManager(val logDirs: Seq[File],
                                      val logs: Pool[TopicPartition, Log],
                                      val logDirFailureChannel: LogDirFailureChannel) extends Logging with KafkaMetricsGroup {
@@ -215,18 +228,15 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
       inProgress.get(topicPartition) match {
         case None =>
           inProgress.put(topicPartition, LogCleaningPaused(1))
-        case Some(state) =>
-          state match {
-            case LogCleaningInProgress =>
-              inProgress.put(topicPartition, LogCleaningAborted)
-            case LogCleaningPaused(count) =>
-              inProgress.put(topicPartition, LogCleaningPaused(count + 1))
-            case s =>
-              throw new IllegalStateException(s"Compaction for partition $topicPartition cannot be aborted and paused since it is in $s state.")
-          }
+        case Some(LogCleaningInProgress) =>
+          inProgress.put(topicPartition, LogCleaningAborted)
+        case Some(LogCleaningPaused(count)) =>
+          inProgress.put(topicPartition, LogCleaningPaused(count + 1))
+        case Some(s) =>
+          throw new IllegalStateException(s"Compaction for partition $topicPartition cannot be aborted and paused since it is in $s state.")
       }
 
-      while(!checkCleaningPaused(topicPartition))
+      while(!isCleaningInStatePaused(topicPartition))
         pausedCleaningCond.await(100, TimeUnit.MILLISECONDS)
     }
     info(s"The cleaning for partition $topicPartition is aborted and paused")
@@ -234,6 +244,9 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
 
   /**
     *  Resume the cleaning of paused partitions.
+    *  If the partition is paused by log retention and then paused again by
+    *  topic deletion, truncation or partition movement, each call of this function will undo
+    *  one pause.
     */
   def resumeCleaning(topicPartitions: Iterable[TopicPartition]){
     inLock(lock) {
@@ -244,13 +257,10 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
               throw new IllegalStateException(s"Compaction for partition $topicPartition cannot be resumed since it is not paused.")
             case Some(state) =>
               state match {
-                case LogCleaningPaused(count) =>
-                  if (count == 1)
-                    inProgress.remove(topicPartition)
-                  else if (count > 1)
-                    inProgress.put(topicPartition, LogCleaningPaused(count - 1))
-                  else
-                    throw new IllegalStateException(s"Compaction for partition $topicPartition cannot be resumed since it is in paused count = $count state.")
+                case LogCleaningPaused(count) if count == 1 =>
+                  inProgress.remove(topicPartition)
+                case LogCleaningPaused(count) if count > 1 =>
+                  inProgress.put(topicPartition, LogCleaningPaused(count - 1))
                 case s =>
                   throw new IllegalStateException(s"Compaction for partition $topicPartition cannot be resumed since it is in $s state.")
               }
@@ -276,7 +286,7 @@ private[log] class LogCleanerManager(val logDirs: Seq[File],
   /**
    *  Check if the cleaning for a partition is paused. The caller is expected to hold lock while making the call.
    */
-  private def checkCleaningPaused(topicPartition: TopicPartition): Boolean = {
+  private def isCleaningInStatePaused(topicPartition: TopicPartition): Boolean = {
     inProgress.get(topicPartition) match {
       case None => false
       case Some(state) =>

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -43,7 +43,7 @@ private[log] case class LogCleaningPaused(pausedCount: Int) extends LogCleaningS
   * This class manages the state of each partition being cleaned.
   * LogCleaningState defines the cleaning states that a TopicPartition can be in.
   * 1. None                    : No cleaning state in a TopicPartition. In this state, it can become LogCleaningInProgress
-  *                              or LogCleaningPaused(1). Valid previous state are None, LogCleaningInProgress and LogCleaningPaused(1)
+  *                              or LogCleaningPaused(1). Valid previous state are LogCleaningInProgress and LogCleaningPaused(1)
   * 2. LogCleaningInProgress   : The cleaning is currently in progress. In this state, it can become None when log cleaning is finished
   *                              or become LogCleaningAborted. Valid previous state is None.
   * 3. LogCleaningAborted      : The cleaning abort is requested. In this state, it can become LogCleaningPaused(1).

--- a/core/src/main/scala/kafka/log/LogCleanerManager.scala
+++ b/core/src/main/scala/kafka/log/LogCleanerManager.scala
@@ -42,17 +42,18 @@ private[log] case class LogCleaningPaused(pausedCount: Int) extends LogCleaningS
 /**
   * This class manages the state of each partition being cleaned.
   * LogCleaningState defines the cleaning states that a TopicPartition can be in.
-  * 1. None                    : No cleaning state in a TopicPartition.
-  *                              Valid previous state are None, LogCleaningInProgress and LogCleaningPaused(1)
-  * 2. LogCleaningInProgress   : The cleaning is currently in progress. In this state, it can become None when it finishes cleaning
-  *                              or become LogCleaningAborted when there is an abort on this topic partition.
-  *                              Valid previous state is None.
-  * 3. LogCleaningAborted      : The cleaning is aborted. In this state, it can become LogCleaningPaused(1) when abort is finished.
+  * 1. None                    : No cleaning state in a TopicPartition. In this state, it can become LogCleaningInProgress
+  *                              or LogCleaningPaused(1). Valid previous state are None, LogCleaningInProgress and LogCleaningPaused(1)
+  * 2. LogCleaningInProgress   : The cleaning is currently in progress. In this state, it can become None when log cleaning is finished
+  *                              or become LogCleaningAborted. Valid previous state is None.
+  * 3. LogCleaningAborted      : The cleaning abort is requested. In this state, it can become LogCleaningPaused(1).
   *                              Valid previous state is LogCleaningInProgress.
-  * 4. LogCleaningPaused(i)    : The cleaning is paused i times. Valid previous state of LogCleaningPaused(1) are LogCleaningAborted,
-  *                              None and LogCleaningPaused(2). LogCleaningPaused(i) can become LogCleaningPaused(i+1) or
-  *                              LogCleaningPaused(i-1). If the end state is LogCleaningPaused(0),
-  *                              the state will be removed and becomes a None State.
+  * 4-a. LogCleaningPaused(1)  : The cleaning is paused once. No log cleaning can be done in this state.
+  *                            : In this state, it can become None or LogCleaningPaused(2).
+  *                            : Valid previous state is None, LogCleaningAborted or LogCleaningPaused(2).
+  * 4-b. LogCleaningPaused(i)  : The cleaning is paused i times where i>= 2. No log cleaning can be done in this state.
+  *                              In this state, it can become LogCleaningPaused(i-1) or LogCleaningPaused(i+1).
+  *                              Valid previous state is LogCleaningPaused(i-1) or LogCleaningPaused(i+1).
   */
 private[log] class LogCleanerManager(val logDirs: Seq[File],
                                      val logs: Pool[TopicPartition, Log],

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -143,8 +143,8 @@ class LogCleanerManagerTest extends JUnitSuite with Logging {
   }
 
   /**
-    * test log race condition between log retention, log compaction,
-    * topic deletion, log truncation and topic retention policy change
+    * test log race condition between log retention,
+    * topic deletion, and log truncation
     */
   @Test
   def testLogsRaceCondition(): Unit = {
@@ -157,50 +157,13 @@ class LogCleanerManagerTest extends JUnitSuite with Logging {
     log.appendAsLeader(records, leaderEpoch = 0)
     log.onHighWatermarkIncremented(2L)
 
-    // prepare log cleanup policy
-    val deletionlogProps = new Properties()
-    deletionlogProps.put(LogConfig.CleanupPolicyProp, LogConfig.Delete)
-    val deletionConfig = LogConfig(deletionlogProps)
-
-    val compactionlogProps = new Properties()
-    compactionlogProps.put(LogConfig.CleanupPolicyProp, LogConfig.Compact)
-    compactionlogProps.put(LogConfig.MinCleanableDirtyRatioProp, 0: Integer)
-    val compactionConfig = LogConfig(compactionlogProps)
-
-    val compactAndDeleteLogProps = new Properties()
-    compactAndDeleteLogProps.put(LogConfig.CleanupPolicyProp, "compact,delete")
-    val compactAndDeleteConfig = LogConfig(compactionlogProps)
-
-    val logConfigSet = List(deletionConfig, compactionConfig, compactAndDeleteConfig)
-
     val numOfRun = 100
-    var jobRetention = 0
-    var jobCompaction = 0
 
     def logRetention(): Unit = {
       for (i <- 0 until numOfRun) {
         val retetionLogs = cleanerManager.pauseCleaningForNonCompactedPartitions()
-        if (retetionLogs.nonEmpty)
-          jobRetention += 1
         Thread.`yield`()
         cleanerManager.resumeCleaning(retetionLogs.map(_._1))
-        Thread.`yield`()
-      }
-    }
-
-    def logCompaction(): Unit = {
-      for (i <- 0 until numOfRun) {
-        cleanerManager.grabFilthiestCompactedLog(time) match {
-          case None =>
-          case Some(cleanable) =>
-            Thread.`yield`()
-            // cleanerManager.doneDeleting is equivalent to cleanerManager.doneCleaning regarding statechange
-            cleanerManager.doneDeleting(Seq(cleanable.topicPartition))
-            jobCompaction += 1
-        }
-
-        val deletable = cleanerManager.deletableLogs()
-        cleanerManager.doneDeleting(deletable.map(_._1))
         Thread.`yield`()
       }
     }
@@ -223,51 +186,22 @@ class LogCleanerManagerTest extends JUnitSuite with Logging {
       }
     }
 
-    def logChangePolicy(): Unit = {
-      for (i <- 0 until numOfRun) {
-        log.config = logConfigSet(i % logConfigSet.size)
-        Thread.`yield`()
-      }
-      // reset back to delete retention
-      log.config = deletionConfig
-    }
-
     assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
 
-    // run log retention, log compaction, and log truncation
-    // in parallel without config change function
+    // run log retention and log truncation in parallel
     TestUtils.assertConcurrent("Concurrent log race condition test",
-      Seq(logRetention, logCompaction, logTruncation),
+      Seq(logRetention, logTruncation),
       60000)
 
     // make sure state is cleared at the end
     assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
 
-    // log retention, log compaction, and topic deletion
+    // log retention and topic deletion
     TestUtils.assertConcurrent("Concurrent log race condition test",
-      Seq(logRetention, logCompaction, topicDetention),
+      Seq(logRetention, topicDetention),
       60000)
 
     assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
-
-    var retryCount = 0
-    val maxRetry = 20
-    // best effort retry to get some jobs done for both log compaction and log retention
-    do {
-      // with config change and topic deletion
-      TestUtils.assertConcurrent("Concurrent log race condition test-0 with config change ",
-        Seq(logRetention, logCompaction, topicDetention, logChangePolicy),
-        60000)
-      assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
-
-      // with config change and log truncation
-      TestUtils.assertConcurrent("Concurrent log race condition test-1 with config change 1",
-        Seq(logRetention, logCompaction, logTruncation, logChangePolicy),
-        60000)
-      assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
-
-      retryCount += 1
-    } while ((jobCompaction < 2 || jobRetention < 2) && retryCount < maxRetry)
   }
 
   /**

--- a/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogCleanerManagerTest.scala
@@ -143,11 +143,11 @@ class LogCleanerManagerTest extends JUnitSuite with Logging {
   }
 
   /**
-    * test log race condition between log retention,
-    * topic deletion, and log truncation
+    * test log retention, topic deletion, and log truncation can handle
+    * pause and resume cleaning on a topic partition correctly.
     */
   @Test
-  def testLogsRaceCondition(): Unit = {
+  def testLogsRetentionDeletionTruncationHandlePauseAndResumeCleaning(): Unit = {
     val records = TestUtils.singletonRecords("test".getBytes, key="test".getBytes)
     val log: Log = createLog(records.sizeInBytes * 5, LogConfig.Delete)
     val cleanerManager: LogCleanerManager = createCleanerManager(log)
@@ -193,14 +193,15 @@ class LogCleanerManagerTest extends JUnitSuite with Logging {
       Seq(logRetention, logTruncation),
       60000)
 
-    // make sure state is cleared at the end
+    // make sure state is cleared
     assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
 
-    // log retention and topic deletion
+    // run log retention and topic deletion in parallel
     TestUtils.assertConcurrent("Concurrent log race condition test",
       Seq(logRetention, topicDetention),
       60000)
 
+    // make sure state is cleared at the end
     assertTrue(cleanerManager.cleaningState(log.topicPartition).isEmpty)
   }
 


### PR DESCRIPTION
KAFKA-7441; Allow LogCleanerManager.resumeCleaning() to be used concurrently

The following race condition can happen: 1) log retention set a topic partition to paused state 2) topic deletion come and see it is already in paused state and proceed 3) topic deletion removed the paused state 4)log retention tries to resume the same topic partition from a NONE state and throw out an exception.

 In order to fix this situation, we allow a topic partition to be paused multiple times. Two unit tests are added to verify the fix.

### Committer Checklist (excluded from commit message)
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation (including upgrade notes)
