### PR TITLE
MINOR: Fix LogDirFailureTest flake

### DIFF
--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -183,7 +183,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
       // ProduceResponse may contain KafkaStorageException and trigger metadata update
       {
         try {
-          producer.send(record).get()
+          producer.send(record).get(6000, TimeUnit.MILLISECONDS)
           true
         } catch {
           case e: ExecutionException => {

--- a/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogDirFailureTest.scala
@@ -181,7 +181,7 @@ class LogDirFailureTest extends IntegrationTestHarness {
     // Wait for producer to update metadata for the partition
     TestUtils.waitUntilTrue(() => {
       // ProduceResponse may contain KafkaStorageException and trigger metadata update
-      producer.send(record)
+      producer.send(record).get()
       producer.partitionsFor(topic).asScala.find(_.partition() == 0).get.leader().id() != leaderServerId
     }, "Expected new leader for the partition", 6000L)
 


### PR DESCRIPTION
Ensure that `TestUtils.waitUntilTrue(..)` is blocked on both send completed and a new leader being assigned

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
