### PR TITLE
KAFKA-7444: expose connector and task ID to SinkTasks

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTaskContext.java
@@ -95,4 +95,15 @@ public interface SinkTaskContext {
      */
     void requestCommit();
 
+    /**
+     * Get the tasks's ID.
+     * @return the task's ID
+     */
+    int taskId();
+
+    /**
+     * Get the connector's ID.
+     * @return the connector's ID.
+     */
+    String connectorId();
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTaskContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTaskContext.java
@@ -159,6 +159,16 @@ public class WorkerSinkTaskContext implements SinkTaskContext {
     }
 
     @Override
+    public String connectorId() {
+        return sinkTask.id().connector();
+    }
+
+    @Override
+    public int taskId() {
+        return sinkTask.id().task();
+    }
+
+    @Override
     public String toString() {
         return "WorkerSinkTaskContext{" +
                "id=" + sinkTask.id +


### PR DESCRIPTION
There is currently no good way for a SinkTask to use SinkUtils.consumerGroupId(connectorId), as there is no good way for a SinkTask to know it's connector ID. I've exposed the task ID as well. Currently, task ID is exposed via toString() methods and TaskState.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
