### PR TITLE
expose full list of offsets requested via OffsetFetchRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/Consumer.java
@@ -147,6 +147,16 @@ public interface Consumer<K, V> extends Closeable {
     long position(TopicPartition partition, final Duration timeout);
 
     /**
+     * @see KafkaConsumer#committed(Collection)
+     */
+    Map<TopicPartition, OffsetAndMetadata> committed(Collection<TopicPartition> partitions);
+
+    /**
+     * @see KafkaConsumer#committed(Collection, Duration)
+     */
+    Map<TopicPartition, OffsetAndMetadata> committed(Collection<TopicPartition> partitions, final Duration timeout);
+
+    /**
      * @see KafkaConsumer#committed(TopicPartition)
      */
     OffsetAndMetadata committed(TopicPartition partition);

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java
@@ -1639,7 +1639,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * the caller), or the timeout specified by {@code default.api.timeout.ms} expires (in which case a
      * {@link org.apache.kafka.common.errors.TimeoutException} is thrown to the caller).
      *
-     * @param partition The list of partitions to check
+     * @param partitions The list of partitions to check
      * @return The map of partitions and their last committed offsets and metadata or null if there was no prior commit
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
      *             function is called
@@ -1654,7 +1654,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      */
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committed(Collection<TopicPartition> partitions) {
-        return committed(partition, Duration.ofMillis(defaultApiTimeoutMs));
+        return committed(partitions, Duration.ofMillis(defaultApiTimeoutMs));
     }
 
     /**
@@ -1663,7 +1663,7 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
      * <p>
      * This call will block to do a remote call to get the latest committed offsets from the server.
      *
-     * @param partition The list of partitions to check
+     * @param partitions The list of partitions to check
      * @param timeout  The maximum amount of time to await the current committed offset
      * @return The map of partitions and their last committed offsets and metadata or null if there was no prior commit
      * @throws org.apache.kafka.common.errors.WakeupException if {@link #wakeup()} is called before or while this
@@ -1682,10 +1682,10 @@ public class KafkaConsumer<K, V> implements Consumer<K, V> {
         acquireAndEnsureOpen();
         try {
             Map<TopicPartition, OffsetAndMetadata> offsets = coordinator.fetchCommittedOffsets(
-                    Collections.unmodifiableCollection(partitions), time.timer(timeout));
+                    Collections.unmodifiableSet(new HashSet<>(partitions)), time.timer(timeout));
             if (offsets == null) {
                 throw new TimeoutException("Timeout of " + timeout.toMillis() + "ms expired before the last " +
-                        "committed offset for partition " + partition + " could be determined");
+                        "committed offsets for the partitions " + partitions + " could be determined");
             }
             return offsets;
         } finally {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -264,6 +264,25 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
     }
 
     @Override
+    public synchronized Map<TopicPartition, OffsetAndMetadata> committed(Collection<TopicPartition> partitions) {
+        ensureNotClosed();
+        Map<TopicPartition, OffsetAndMetadata> result = new HashMap<>();
+        for (TopicPartition partition : partitions) {
+            OffsetAndMetadata singleResult = new OffsetAndMetadata(0)
+            if (subscriptions.isAssigned(partition)) {
+                singleResult = committed.get(partition);
+            }
+            result.put(singleResult);
+        }
+        return result;
+    }
+
+    @Override
+    public Map<TopicPartition, OffsetAndMetadata> committed(Collection<TopicPartition> partitions, final Duration timeout) {
+        return committed(partition);
+    }
+
+    @Override
     public synchronized OffsetAndMetadata committed(TopicPartition partition) {
         ensureNotClosed();
         if (subscriptions.isAssigned(partition)) {

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/MockConsumer.java
@@ -268,18 +268,18 @@ public class MockConsumer<K, V> implements Consumer<K, V> {
         ensureNotClosed();
         Map<TopicPartition, OffsetAndMetadata> result = new HashMap<>();
         for (TopicPartition partition : partitions) {
-            OffsetAndMetadata singleResult = new OffsetAndMetadata(0)
+            OffsetAndMetadata singleResult = new OffsetAndMetadata(0);
             if (subscriptions.isAssigned(partition)) {
                 singleResult = committed.get(partition);
             }
-            result.put(singleResult);
+            result.put(partition, singleResult);
         }
         return result;
     }
 
     @Override
     public Map<TopicPartition, OffsetAndMetadata> committed(Collection<TopicPartition> partitions, final Duration timeout) {
-        return committed(partition);
+        return committed(partitions);
     }
 
     @Override


### PR DESCRIPTION
It does not make much sense to have an internal implementation which can request the full list of Topic offsets and do not expose it. I added methods similar to KafkaConsumer.committed with Collection of topics as argument

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
