### PR TITLE
MINOR: Update Scala to 2.12.7, lz4-java to 1.5 and others

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,12 @@ buildscript {
   dependencies {
     // For Apache Rat plugin to ignore non-Git files
     classpath "org.ajoberstar:grgit:1.9.3"
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-    classpath 'org.scoverage:gradle-scoverage:2.3.0'
-    classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.4'
-    classpath 'org.owasp:dependency-check-gradle:3.2.1'
-    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.10.0"
-    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.3"
+    classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
+    classpath 'org.scoverage:gradle-scoverage:2.4.0'
+    classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.0'
+    classpath 'org.owasp:dependency-check-gradle:3.3.2'
+    classpath "com.diffplug.spotless:spotless-plugin-gradle:3.15.0"
+    classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:1.6.4"
   }
 }
 
@@ -89,7 +89,7 @@ allprojects {
 }
 
 ext {
-  gradleVersion = "4.10"
+  gradleVersion = "4.10.2"
   minJavaVersion = "8"
   buildVersionFileName = "kafka-version.properties"
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
 
 // Add Scala version
 def defaultScala211Version = '2.11.12'
-def defaultScala212Version = '2.12.6'
+def defaultScala212Version = '2.12.7'
 if (hasProperty('scalaVersion')) {
   if (scalaVersion == '2.11') {
     versions["scala"] = defaultScala211Version
@@ -51,7 +51,7 @@ versions += [
   apacheda: "1.0.2",
   apacheds: "2.0.0-M24",
   argparse4j: "0.7.0",
-  bcpkix: "1.59",
+  bcpkix: "1.60",
   easymock: "3.6",
   jackson: "2.9.7",
   jetty: "9.4.12.v20180830",
@@ -60,7 +60,7 @@ versions += [
   log4j: "1.2.17",
   scalaLogging: "3.9.0",
   jaxb: "2.3.0",
-  jaxrs: "2.1",
+  jaxrs: "2.1.1",
   jfreechart: "1.0.0",
   jopt: "5.0.4",
   junit: "4.12",
@@ -71,8 +71,8 @@ versions += [
   kafka_10: "1.0.2",
   kafka_11: "1.1.1",
   kafka_20: "2.0.0",
-  lz4: "1.4.1",
-  mavenArtifact: "3.5.3",
+  lz4: "1.5.0",
+  mavenArtifact: "3.5.4",
   metrics: "2.2.0",
   // PowerMock 1.x doesn't support Java 9, so use PowerMock 2.0.0 beta
   powermock: "2.0.0-beta.5",


### PR DESCRIPTION
Highlights:
* 10% compilation speed improvement in Scala 2.12.7:
https://www.scala-lang.org/news/2.12.7
* 10% better decompression speed in lz4 1.8.2 (lz4-java 1.5.0
includes lz4 1.8.3):
https://github.com/lz4/lz4-java/blob/master/CHANGES.md#150
https://github.com/lz4/lz4/releases

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
