### PR TITLE
KAFKA-6914: Set parent classloader of DelegatingClassLoader same as the worker's

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -94,6 +94,10 @@ public class DelegatingClassLoader extends URLClassLoader {
     }
 
     public DelegatingClassLoader(List<String> pluginPaths) {
+        // Use as parent the classloader that loaded this class. In most cases this will be the
+        // System classloader. But this choice here provides additional flexibility in managed
+        // environments that control classloading differently (OSGi, Spring and others) and don't
+        // depend on the System classloader to load Connect's classes.
         this(pluginPaths, DelegatingClassLoader.class.getClassLoader());
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/isolation/DelegatingClassLoader.java
@@ -94,7 +94,7 @@ public class DelegatingClassLoader extends URLClassLoader {
     }
 
     public DelegatingClassLoader(List<String> pluginPaths) {
-        this(pluginPaths, ClassLoader.getSystemClassLoader());
+        this(pluginPaths, DelegatingClassLoader.class.getClassLoader());
     }
 
     public Set<PluginDesc<Connector>> connectors() {


### PR DESCRIPTION
The parent classloader of the DelegatingClassLoader and therefore the classloading scheme used by Connect does not have to be fixed to the System classloader.

Setting it the same as the one that was used to load the DelegatingClassLoader class itself is more flexible and, while in most cases will result in the System classloader to be used, it will also work in othr managed environments that control classloading differently (OSGi, and others).

The fix is minimal and the mainstream use is tested via system tests.