### PR TITLE
Fix to add rack unaware partitions using --disable-rack-aware

### DIFF
--- a/core/src/main/scala/kafka/admin/TopicCommand.scala
+++ b/core/src/main/scala/kafka/admin/TopicCommand.scala
@@ -158,8 +158,9 @@ object TopicCommand extends Logging {
           val partitionList = replicaAssignmentString.split(",").drop(startPartitionId)
           AdminUtils.parseReplicaAssignment(partitionList.mkString(","), startPartitionId)
         }
-        val allBrokers = adminZkClient.getBrokerMetadatas()
-        adminZkClient.addPartitions(topic, existingAssignment, allBrokers, nPartitions, newAssignment)
+        val rackAwareMode = if (opts.options.has(opts.disableRackAware)) RackAwareMode.Disabled
+                            else RackAwareMode.Enforced
+        adminZkClient.addPartitions(topic, existingAssignment, nPartitions, newAssignment, rackAwareMode)
         println("Adding partitions succeeded!")
       }
     }

--- a/core/src/main/scala/kafka/server/AdminManager.scala
+++ b/core/src/main/scala/kafka/server/AdminManager.scala
@@ -253,7 +253,7 @@ class AdminManager(val config: KafkaConfig,
           }.toMap
         }
 
-        val updatedReplicaAssignment = adminZkClient.addPartitions(topic, existingAssignment, allBrokers,
+        val updatedReplicaAssignment = adminZkClient.addPartitions(topic, existingAssignment,
           newPartition.totalCount, reassignment, validateOnly = validateOnly)
         CreatePartitionsMetadata(topic, updatedReplicaAssignment, ApiError.NONE)
       } catch {

--- a/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
+++ b/core/src/test/scala/integration/kafka/api/BaseProducerSendTest.scala
@@ -382,7 +382,7 @@ abstract class BaseProducerSendTest extends KafkaServerTestHarness {
     val existingAssignment = zkClient.getReplicaAssignmentForTopics(Set(topic)).map {
       case (topicPartition, replicas) => topicPartition.partition -> replicas
     }
-    adminZkClient.addPartitions(topic, existingAssignment, adminZkClient.getBrokerMetadatas(), 2)
+    adminZkClient.addPartitions(topic, existingAssignment, 2)
     // read metadata from a broker and verify the new topic partitions exist
     TestUtils.waitUntilMetadataIsPropagated(servers, topic, 0)
     TestUtils.waitUntilMetadataIsPropagated(servers, topic, 1)

--- a/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/AddPartitionsTest.scala
@@ -61,8 +61,7 @@ class AddPartitionsTest extends BaseRequestTest {
   @Test
   def testWrongReplicaCount(): Unit = {
     try {
-      adminZkClient.addPartitions(topic1, topic1Assignment, adminZkClient.getBrokerMetadatas(), 2,
-        Some(Map(0 -> Seq(0, 1), 1 -> Seq(0, 1, 2))))
+      adminZkClient.addPartitions(topic1, topic1Assignment, 2, Some(Map(0 -> Seq(0, 1), 1 -> Seq(0, 1, 2))))
       fail("Add partitions should fail")
     } catch {
       case _: InvalidReplicaAssignmentException => //this is good
@@ -72,8 +71,7 @@ class AddPartitionsTest extends BaseRequestTest {
   @Test
   def testMissingPartition0(): Unit = {
     try {
-      adminZkClient.addPartitions(topic5, topic5Assignment, adminZkClient.getBrokerMetadatas(), 2,
-        Some(Map(1 -> Seq(0, 1), 2 -> Seq(0, 1, 2))))
+      adminZkClient.addPartitions(topic5, topic5Assignment, 2, Some(Map(1 -> Seq(0, 1), 2 -> Seq(0, 1, 2))))
       fail("Add partitions should fail")
     } catch {
       case e: AdminOperationException => //this is good
@@ -83,7 +81,7 @@ class AddPartitionsTest extends BaseRequestTest {
 
   @Test
   def testIncrementPartitions(): Unit = {
-    adminZkClient.addPartitions(topic1, topic1Assignment, adminZkClient.getBrokerMetadatas(), 3)
+    adminZkClient.addPartitions(topic1, topic1Assignment, 3)
     // wait until leader is elected
     val leader1 = waitUntilLeaderIsElectedOrChanged(zkClient, topic1, 1)
     val leader2 = waitUntilLeaderIsElectedOrChanged(zkClient, topic1, 2)
@@ -109,8 +107,7 @@ class AddPartitionsTest extends BaseRequestTest {
   @Test
   def testManualAssignmentOfReplicas(): Unit = {
     // Add 2 partitions
-    adminZkClient.addPartitions(topic2, topic2Assignment, adminZkClient.getBrokerMetadatas(), 3,
-      Some(Map(0 -> Seq(1, 2), 1 -> Seq(0, 1), 2 -> Seq(2, 3))))
+    adminZkClient.addPartitions(topic2, topic2Assignment, 3, Some(Map(0 -> Seq(1, 2), 1 -> Seq(0, 1), 2 -> Seq(2, 3))))
     // wait until leader is elected
     val leader1 = waitUntilLeaderIsElectedOrChanged(zkClient, topic2, 1)
     val leader2 = waitUntilLeaderIsElectedOrChanged(zkClient, topic2, 2)
@@ -138,7 +135,7 @@ class AddPartitionsTest extends BaseRequestTest {
 
   @Test
   def testReplicaPlacementAllServers(): Unit = {
-    adminZkClient.addPartitions(topic3, topic3Assignment, adminZkClient.getBrokerMetadatas(), 7)
+    adminZkClient.addPartitions(topic3, topic3Assignment, 7)
 
     // read metadata from a broker and verify the new topic partitions exist
     TestUtils.waitUntilMetadataIsPropagated(servers, topic3, 1)
@@ -162,7 +159,7 @@ class AddPartitionsTest extends BaseRequestTest {
 
   @Test
   def testReplicaPlacementPartialServers(): Unit = {
-    adminZkClient.addPartitions(topic2, topic2Assignment, adminZkClient.getBrokerMetadatas(), 3)
+    adminZkClient.addPartitions(topic2, topic2Assignment, 3)
 
     // read metadata from a broker and verify the new topic partitions exist
     TestUtils.waitUntilMetadataIsPropagated(servers, topic2, 1)

--- a/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/DeleteTopicTest.scala
@@ -233,15 +233,12 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     assertTrue("Leader should exist for partition [test,0]", leaderIdOpt.isDefined)
     val follower = servers.filter(_.config.brokerId != leaderIdOpt.get).last
     val newPartition = new TopicPartition(topic, 1)
-    // capture the brokers before we shutdown so that we don't fail validation in `addPartitions`
-    val brokers = adminZkClient.getBrokerMetadatas()
     follower.shutdown()
     // wait until the broker has been removed from ZK to reduce non-determinism
     TestUtils.waitUntilTrue(() => zkClient.getBroker(follower.config.brokerId).isEmpty,
       s"Follower ${follower.config.brokerId} was not removed from ZK")
     // add partitions to topic
-    adminZkClient.addPartitions(topic, expectedReplicaAssignment, brokers, 2,
-      Some(Map(1 -> Seq(0, 1, 2), 2 -> Seq(0, 1, 2))))
+    adminZkClient.addPartitions(topic, expectedReplicaAssignment, 2, Some(Map(1 -> Seq(0, 1, 2), 2 -> Seq(0, 1, 2))))
     // start topic deletion
     adminZkClient.deleteTopic(topic)
     follower.startup()
@@ -258,13 +255,11 @@ class DeleteTopicTest extends ZooKeeperTestHarness {
     zkClient.createTopLevelPaths()
     val topic = "test"
     servers = createTestTopicAndCluster(topic)
-    val brokers = adminZkClient.getBrokerMetadatas()
     // start topic deletion
     adminZkClient.deleteTopic(topic)
     // add partitions to topic
     val newPartition = new TopicPartition(topic, 1)
-    adminZkClient.addPartitions(topic, expectedReplicaAssignment, brokers, 2,
-      Some(Map(1 -> Seq(0, 1, 2), 2 -> Seq(0, 1, 2))))
+    adminZkClient.addPartitions(topic, expectedReplicaAssignment, 2, Some(Map(1 -> Seq(0, 1, 2), 2 -> Seq(0, 1, 2))))
     TestUtils.verifyTopicDeletion(zkClient, topic, 1, servers)
     // verify that new partition doesn't exist on any broker either
     assertTrue("Replica logs not deleted after delete topic is complete",

--- a/core/src/test/scala/unit/kafka/admin/RackAwareTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/RackAwareTest.scala
@@ -27,6 +27,7 @@ trait RackAwareTest {
                                numPartitions: Int,
                                replicationFactor: Int,
                                verifyRackAware: Boolean = true,
+                               verifyRackUnAware: Boolean = false,
                                verifyLeaderDistribution: Boolean = true,
                                verifyReplicasDistribution: Boolean = true) {
     // always verify that no broker will be assigned for more than one replica
@@ -38,6 +39,11 @@ trait RackAwareTest {
     if (verifyRackAware) {
       val partitionRackMap = distribution.partitionRacks
       assertEquals("More than one replica of the same partition is assigned to the same rack",
+        List.fill(numPartitions)(replicationFactor), partitionRackMap.values.toList.map(_.distinct.size))
+    }
+    if (verifyRackUnAware) {
+      val partitionRackMap = distribution.partitionRacks
+      assertNotEquals("All replicas of all partitions are assigned to different racks",
         List.fill(numPartitions)(replicationFactor), partitionRackMap.values.toList.map(_.distinct.size))
     }
 

--- a/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
+++ b/core/src/test/scala/unit/kafka/admin/TopicCommandTest.scala
@@ -191,6 +191,40 @@ class TopicCommandTest extends ZooKeeperTestHarness with Logging with RackAwareT
   }
 
   @Test
+  def testCreateAlterTopicWithRackAwareDisabled() {
+    val rackInfo = Map(0 -> "rack1", 1 -> "rack2", 2 -> "rack2", 3 -> "rack1", 4 -> "rack3", 5 -> "rack3")
+    TestUtils.createBrokersInZk(toBrokerMetadata(rackInfo), zkClient)
+
+    val numPartitions = 18
+    val replicationFactor = 3
+    val createOpts = new TopicCommandOptions(Array(
+      "--partitions", numPartitions.toString,
+      "--replication-factor", replicationFactor.toString,
+      "--topic", "foo",
+      "--disable-rack-aware"))
+    TopicCommand.createTopic(zkClient, createOpts)
+
+    var assignment = zkClient.getReplicaAssignmentForTopics(Set("foo")).map { case (tp, replicas) =>
+      tp.partition -> replicas
+    }
+    checkReplicaDistribution(assignment, rackInfo, rackInfo.size, numPartitions, replicationFactor,
+      verifyRackAware = false, verifyRackUnAware = true)
+
+    val alteredNumPartitions = 36
+    // verify that adding partitions will also be rack aware
+    val alterOpts = new TopicCommandOptions(Array(
+      "--partitions", alteredNumPartitions.toString,
+      "--topic", "foo",
+      "--disable-rack-aware"))
+    TopicCommand.alterTopic(zkClient, alterOpts)
+    assignment = zkClient.getReplicaAssignmentForTopics(Set("foo")).map { case (tp, replicas) =>
+      tp.partition -> replicas
+    }
+    checkReplicaDistribution(assignment, rackInfo, rackInfo.size, alteredNumPartitions, replicationFactor,
+      verifyRackAware = false, verifyRackUnAware = true)
+  }
+
+  @Test
   def testDescribeAndListTopicsMarkedForDeletion() {
     val brokers = List(0)
     val topic = "testtopic"


### PR DESCRIPTION
*Fix for [KAFKA-7465](https://issues.apache.org/jira/browse/KAFKA-7465)*

* Maintain consistency in AdminZkClient createTopic/addPartitions methods. Accept rackAwareMode in both the methods unlike accepting brokers in addPartitions and accepting rackAwareMode in createTopic.
* Unit test to verify create/add partitions with rack aware disabled.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
