### PR TITLE
KAFKA-7075: Allow Topology#addGlobalStore to add a window store

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -30,9 +30,11 @@ import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockKeyValueStoreBuilder;
 import org.apache.kafka.test.MockTimestampExtractor;
+import org.apache.kafka.test.MockWindowStoreBuilder;
 import org.apache.kafka.test.StreamsTestUtils;
 import org.junit.Test;
 
@@ -780,5 +782,18 @@ public class InternalTopologyBuilderTest {
             "anyTopicName",
             sameNameForSourceAndProcessor,
             new MockProcessorSupplier());
+    }
+
+    @Test
+    public void shouldAllowAddGlobalStoreWithNonKVStore() {
+        final StoreBuilder windowStoreBuilder = new MockWindowStoreBuilder("store", false);
+        builder.addGlobalStore((StoreBuilder<WindowStore>) windowStoreBuilder.withLoggingDisabled(),
+                "name",
+                null,
+                null,
+                null,
+                "topicName",
+                "otherName",
+                new MockProcessorSupplier());
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -787,7 +787,7 @@ public class InternalTopologyBuilderTest {
     @Test
     public void shouldAllowAddGlobalStoreWithNonKVStore() {
         final StoreBuilder windowStoreBuilder = new MockWindowStoreBuilder("store", false);
-        builder.addGlobalStore((StoreBuilder<WindowStore>) windowStoreBuilder.withLoggingDisabled(),
+        builder.addGlobalStore(windowStoreBuilder.withLoggingDisabled(),
                 "name",
                 null,
                 null,

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/InternalTopologyBuilderTest.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
-import org.apache.kafka.streams.state.WindowStore;
 import org.apache.kafka.test.MockProcessorSupplier;
 import org.apache.kafka.test.MockKeyValueStoreBuilder;
 import org.apache.kafka.test.MockTimestampExtractor;

--- a/streams/src/test/java/org/apache/kafka/test/MockWindowStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockWindowStore.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+
+import java.util.ArrayList;
+
+public class MockWindowStore implements WindowStore {
+
+    private final String name;
+    private final boolean persistent;
+
+    public boolean closed = true;
+    public boolean flushed = false;
+    public final ArrayList<Integer> keys = new ArrayList<>();
+
+
+    public MockWindowStore(final String name, final boolean persistent) {
+        this.name = name;
+        this.persistent = persistent;
+    }
+
+    @Override
+    public void put(final Object key, final Object value) {
+
+    }
+
+    @Override
+    public void put(final Object key, final Object value, final long windowStartTimestamp) {
+
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public void init(final ProcessorContext context, final StateStore root) {
+        context.register(root, stateRestoreCallback);
+        closed = false;
+    }
+
+    public final StateRestoreCallback stateRestoreCallback = new StateRestoreCallback() {
+        private final Deserializer<Integer> deserializer = new IntegerDeserializer();
+
+        @Override
+        public void restore(final byte[] key,
+                            final byte[] value) {
+            keys.add(deserializer.deserialize("", key));
+        }
+    };
+
+    @Override
+    public void flush() {
+        flushed = true;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    @Override
+    public boolean persistent() {
+        return persistent;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public Object fetch(final Object key, final long time) {
+        return null;
+    }
+
+    @Override
+    public WindowStoreIterator fetch(final Object key, final long timeFrom, final long timeTo) {
+        return null;
+    }
+
+    @Override
+    public KeyValueIterator fetch(final Object from, final Object to, final long timeFrom, final long timeTo) {
+        return null;
+    }
+
+    @Override
+    public KeyValueIterator all() {
+        return null;
+    }
+
+    @Override
+    public KeyValueIterator fetchAll(final long timeFrom, final long timeTo) {
+        return null;
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/test/MockWindowStore.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockWindowStore.java
@@ -99,11 +99,13 @@ public class MockWindowStore implements WindowStore {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public WindowStoreIterator fetch(final Object key, final long timeFrom, final long timeTo) {
         return null;
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public KeyValueIterator fetch(final Object from, final Object to, final long timeFrom, final long timeTo) {
         return null;
     }
@@ -114,6 +116,7 @@ public class MockWindowStore implements WindowStore {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public KeyValueIterator fetchAll(final long timeFrom, final long timeTo) {
         return null;
     }

--- a/streams/src/test/java/org/apache/kafka/test/MockWindowStoreBuilder.java
+++ b/streams/src/test/java/org/apache/kafka/test/MockWindowStoreBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.test;
+
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.kafka.streams.state.internals.AbstractStoreBuilder;
+
+public class MockWindowStoreBuilder extends AbstractStoreBuilder<Integer, byte[], WindowStore> {
+
+    private final boolean persistent;
+
+    public MockWindowStoreBuilder(final String storeName, final boolean persistent) {
+        super(storeName, Serdes.Integer(), Serdes.ByteArray(), new MockTime());
+        this.persistent = persistent;
+    }
+
+    @Override
+    public WindowStore build() {
+        return new MockWindowStore(name, persistent);
+    }
+}


### PR DESCRIPTION
`InternalTopologyBuilder#addGlobalStore` has no tests for stores other than `KeyValueStore`. This PR adds a new unit test to show that a StoreBuilder<WindowStore> can be used in InternalTopologyBuilder#addGlobalStore. This required creating two new mocks, `MockWindowStore` and `MockWindowStoreBuilder`, modelled on `MockKeyValueStore` and `MockKeyValueStoreBuilder`, respectively.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
