### PR TITLE
KAFKA-7223: Add name config to Suppressed

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -397,7 +397,7 @@ public interface KTable<K, V> {
      * @param suppressed Configuration object determining what, if any, updates to suppress
      * @return A new KTable with the desired suppression characteristics.
      */
-    KTable<K, V> suppress(final Suppressed<K> suppressed);
+    KTable<K, V> suppress(final Suppressed<? super K> suppressed);
 
     /**
      * Create a new {@code KTable} by transforming the value of each record in this {@code KTable} into a new value

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -377,7 +377,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorGraphNode<K, Change<V>> node = new StatefulProcessorNode<>(
             name,
             new ProcessorParameters<>(suppressionSupplier, name),
-            new String[]{storeName},
+            null,
             new InMemoryTimeOrderedKeyValueBuffer.Builder(storeName),
             false
         );

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/KTableImpl.java
@@ -377,7 +377,7 @@ public class KTableImpl<K, S, V> extends AbstractStream<K, V> implements KTable<
         final ProcessorGraphNode<K, Change<V>> node = new StatefulProcessorNode<>(
             name,
             new ProcessorParameters<>(suppressionSupplier, name),
-            null,
+            new String[]{storeName},
             new InMemoryTimeOrderedKeyValueBuffer.Builder(storeName),
             false
         );

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -60,12 +60,12 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
         topologyBuilder.addProcessor(processorName, processorSupplier, parentNodeNames());
 
-        if (storeNames != null && storeNames.length > 0) {
-            topologyBuilder.connectProcessorAndStateStores(processorName, storeNames);
-        }
-
         if (storeBuilder != null) {
             topologyBuilder.addStateStore(storeBuilder, processorName);
+        }
+
+        if (storeNames != null && storeNames.length > 0) {
+            topologyBuilder.connectProcessorAndStateStores(processorName, storeNames);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -60,12 +60,12 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
         topologyBuilder.addProcessor(processorName, processorSupplier, parentNodeNames());
 
-        if (storeBuilder != null) {
-            topologyBuilder.addStateStore(storeBuilder, processorName);
-        }
-
         if (storeNames != null && storeNames.length > 0) {
             topologyBuilder.connectProcessorAndStateStores(processorName, storeNames);
+        }
+
+        if (storeBuilder != null) {
+            topologyBuilder.addStateStore(storeBuilder, processorName);
         }
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferConfigInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/BufferConfigInternal.java
@@ -46,9 +46,4 @@ abstract class BufferConfigInternal<BC extends Suppressed.BufferConfig<BC>> impl
     public Suppressed.BufferConfig emitEarlyWhenFull() {
         return new EagerBufferConfigImpl(maxRecords(), maxBytes());
     }
-
-    @Override
-    public Suppressed.StrictBufferConfig spillToDiskWhenFull() {
-        throw new UnsupportedOperationException("not implemented");
-    }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/FinalResultsSuppressionBuilder.java
@@ -23,14 +23,17 @@ import java.time.Duration;
 import java.util.Objects;
 
 public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppressed<K> {
+    private final String name;
     private final StrictBufferConfig bufferConfig;
 
-    public FinalResultsSuppressionBuilder(final Suppressed.StrictBufferConfig bufferConfig) {
+    public FinalResultsSuppressionBuilder(final String name, final Suppressed.StrictBufferConfig bufferConfig) {
+        this.name = name;
         this.bufferConfig = bufferConfig;
     }
 
     public SuppressedInternal<K> buildFinalResultsSuppression(final Duration gracePeriod) {
         return new SuppressedInternal<>(
+            name,
             gracePeriod,
             bufferConfig,
             TimeDefinitions.WindowEndTimeDefinition.instance(),
@@ -39,20 +42,29 @@ public class FinalResultsSuppressionBuilder<K extends Windowed> implements Suppr
     }
 
     @Override
+    public Suppressed<K> withName(final String name) {
+        return new FinalResultsSuppressionBuilder<>(name, bufferConfig);
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final FinalResultsSuppressionBuilder<?> that = (FinalResultsSuppressionBuilder<?>) o;
-        return Objects.equals(bufferConfig, that.bufferConfig);
+        return Objects.equals(name, that.name) &&
+            Objects.equals(bufferConfig, that.bufferConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(bufferConfig);
+        return Objects.hash(name, bufferConfig);
     }
 
     @Override
     public String toString() {
-        return "FinalResultsSuppressionBuilder{bufferConfig=" + bufferConfig + '}';
+        return "FinalResultsSuppressionBuilder{" +
+            "name='" + name + '\'' +
+            ", bufferConfig=" + bufferConfig +
+            '}';
     }
 }

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/KTableSuppressProcessor.java
@@ -56,11 +56,11 @@ public class KTableSuppressProcessor<K, V> implements Processor<K, Change<V>> {
         requireNonNull(suppress);
         this.keySerde = keySerde;
         this.valueSerde = valueSerde;
-        maxRecords = suppress.getBufferConfig().maxRecords();
-        maxBytes = suppress.getBufferConfig().maxBytes();
-        suppressDurationMillis = suppress.getTimeToWaitForMoreEvents().toMillis();
-        bufferTimeDefinition = suppress.getTimeDefinition();
-        bufferFullStrategy = suppress.getBufferConfig().bufferFullStrategy();
+        maxRecords = suppress.bufferConfig().maxRecords();
+        maxBytes = suppress.bufferConfig().maxBytes();
+        suppressDurationMillis = suppress.timeToWaitForMoreEvents().toMillis();
+        bufferTimeDefinition = suppress.timeDefinition();
+        bufferFullStrategy = suppress.bufferConfig().bufferFullStrategy();
         shouldSuppressTombstones = suppress.shouldSuppressTombstones();
     }
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
@@ -75,15 +75,15 @@ public class SuppressedInternal<K> implements Suppressed<K> {
         if (o == null || getClass() != o.getClass()) return false;
         final SuppressedInternal<?> that = (SuppressedInternal<?>) o;
         return suppressTombstones == that.suppressTombstones &&
-            Objects.equals(name(), that.name()) &&
-            Objects.equals(bufferConfig(), that.bufferConfig()) &&
-            Objects.equals(timeToWaitForMoreEvents(), that.timeToWaitForMoreEvents()) &&
-            Objects.equals(timeDefinition(), that.timeDefinition());
+            Objects.equals(name, that.name) &&
+            Objects.equals(bufferConfig, that.bufferConfig) &&
+            Objects.equals(timeToWaitForMoreEvents, that.timeToWaitForMoreEvents) &&
+            Objects.equals(timeDefinition, that.timeDefinition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name(), bufferConfig(), timeToWaitForMoreEvents(), timeDefinition(), suppressTombstones);
+        return Objects.hash(name, bufferConfig, timeToWaitForMoreEvents, timeDefinition, suppressTombstones);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/suppress/SuppressedInternal.java
@@ -26,30 +26,42 @@ public class SuppressedInternal<K> implements Suppressed<K> {
     private static final Duration DEFAULT_SUPPRESSION_TIME = Duration.ofMillis(Long.MAX_VALUE);
     private static final StrictBufferConfigImpl DEFAULT_BUFFER_CONFIG = (StrictBufferConfigImpl) BufferConfig.unbounded();
 
+    private final String name;
     private final BufferConfigInternal bufferConfig;
     private final Duration timeToWaitForMoreEvents;
     private final TimeDefinition<K> timeDefinition;
     private final boolean suppressTombstones;
 
-    public SuppressedInternal(final Duration suppressionTime,
+    public SuppressedInternal(final String name,
+                              final Duration suppressionTime,
                               final BufferConfig bufferConfig,
                               final TimeDefinition<K> timeDefinition,
                               final boolean suppressTombstones) {
+        this.name = name;
         this.timeToWaitForMoreEvents = suppressionTime == null ? DEFAULT_SUPPRESSION_TIME : suppressionTime;
         this.timeDefinition = timeDefinition == null ? TimeDefinitions.RecordTimeDefintion.instance() : timeDefinition;
         this.bufferConfig = bufferConfig == null ? DEFAULT_BUFFER_CONFIG : (BufferConfigInternal) bufferConfig;
         this.suppressTombstones = suppressTombstones;
     }
 
-    BufferConfigInternal getBufferConfig() {
+    @Override
+    public Suppressed<K> withName(final String name) {
+        return new SuppressedInternal<>(name, timeToWaitForMoreEvents, bufferConfig, timeDefinition, suppressTombstones);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    BufferConfigInternal bufferConfig() {
         return bufferConfig;
     }
 
-    TimeDefinition<K> getTimeDefinition() {
+    TimeDefinition<K> timeDefinition() {
         return timeDefinition;
     }
 
-    Duration getTimeToWaitForMoreEvents() {
+    Duration timeToWaitForMoreEvents() {
         return timeToWaitForMoreEvents == null ? Duration.ZERO : timeToWaitForMoreEvents;
     }
 
@@ -62,22 +74,25 @@ public class SuppressedInternal<K> implements Suppressed<K> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final SuppressedInternal<?> that = (SuppressedInternal<?>) o;
-        return Objects.equals(bufferConfig, that.bufferConfig) &&
-            Objects.equals(getTimeToWaitForMoreEvents(), that.getTimeToWaitForMoreEvents()) &&
-            Objects.equals(getTimeDefinition(), that.getTimeDefinition());
+        return suppressTombstones == that.suppressTombstones &&
+            Objects.equals(name(), that.name()) &&
+            Objects.equals(bufferConfig(), that.bufferConfig()) &&
+            Objects.equals(timeToWaitForMoreEvents(), that.timeToWaitForMoreEvents()) &&
+            Objects.equals(timeDefinition(), that.timeDefinition());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(bufferConfig, getTimeToWaitForMoreEvents(), getTimeDefinition());
+        return Objects.hash(name(), bufferConfig(), timeToWaitForMoreEvents(), timeDefinition(), suppressTombstones);
     }
 
     @Override
     public String toString() {
-        return "SuppressedInternal{" +
+        return "SuppressedInternal{name='" + name + '\'' +
             ", bufferConfig=" + bufferConfig +
             ", timeToWaitForMoreEvents=" + timeToWaitForMoreEvents +
             ", timeDefinition=" + timeDefinition +
+            ", suppressTombstones=" + suppressTombstones +
             '}';
     }
 }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/SuppressedTest.java
@@ -59,33 +59,39 @@ public class SuppressedTest {
     @Test
     public void intermediateEventsShouldAcceptAnyBufferAndSetBounds() {
         assertThat(
+            "name should be set",
+            untilTimeLimit(ofMillis(2), unbounded()).withName("myname"),
+            is(new SuppressedInternal<>("myname", ofMillis(2), unbounded(), null, false))
+        );
+
+        assertThat(
             "time alone should be set",
             untilTimeLimit(ofMillis(2), unbounded()),
-            is(new SuppressedInternal<>(ofMillis(2), unbounded(), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false))
         );
 
         assertThat(
             "time and unbounded buffer should be set",
             untilTimeLimit(ofMillis(2), unbounded()),
-            is(new SuppressedInternal<>(ofMillis(2), unbounded(), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), unbounded(), null, false))
         );
 
         assertThat(
             "time and keys buffer should be set",
             untilTimeLimit(ofMillis(2), maxRecords(2)),
-            is(new SuppressedInternal<>(ofMillis(2), maxRecords(2), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), maxRecords(2), null, false))
         );
 
         assertThat(
             "time and size buffer should be set",
             untilTimeLimit(ofMillis(2), maxBytes(2)),
-            is(new SuppressedInternal<>(ofMillis(2), maxBytes(2), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), maxBytes(2), null, false))
         );
 
         assertThat(
             "all constraints should be set",
             untilTimeLimit(ofMillis(2L), maxRecords(3L).withMaxBytes(2L)),
-            is(new SuppressedInternal<>(ofMillis(2), new EagerBufferConfigImpl(3L, 2L), null, false))
+            is(new SuppressedInternal<>(null, ofMillis(2), new EagerBufferConfigImpl(3L, 2L), null, false))
         );
     }
 
@@ -94,18 +100,35 @@ public class SuppressedTest {
 
         assertThat(
             untilWindowCloses(unbounded()),
-            is(new FinalResultsSuppressionBuilder<>(unbounded()))
+            is(new FinalResultsSuppressionBuilder<>(null, unbounded()))
         );
 
         assertThat(
             untilWindowCloses(maxRecords(2L).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN))
+            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN))
             )
         );
 
         assertThat(
             untilWindowCloses(maxBytes(2L).shutDownWhenFull()),
-            is(new FinalResultsSuppressionBuilder<>(new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN))
+            is(new FinalResultsSuppressionBuilder<>(null, new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN))
+            )
+        );
+
+        assertThat(
+            untilWindowCloses(unbounded()).withName("name"),
+            is(new FinalResultsSuppressionBuilder<>("name", unbounded()))
+        );
+
+        assertThat(
+            untilWindowCloses(maxRecords(2L).shutDownWhenFull()).withName("name"),
+            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(2L, MAX_VALUE, SHUT_DOWN))
+            )
+        );
+
+        assertThat(
+            untilWindowCloses(maxBytes(2L).shutDownWhenFull()).withName("name"),
+            is(new FinalResultsSuppressionBuilder<>("name", new StrictBufferConfigImpl(MAX_VALUE, 2L, SHUT_DOWN))
             )
         );
     }

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressScenarioTest.java
@@ -32,10 +32,10 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
-import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.SessionWindows;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -83,7 +83,7 @@ public class SuppressScenarioTest {
                     .withCachingDisabled()
                     .withLoggingDisabled()
             )
-            .groupBy((k, v) -> new KeyValue<>(v, k), Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((k, v) -> new KeyValue<>(v, k), Grouped.with(STRING_SERDE, STRING_SERDE))
             .count();
 
         valueCounts
@@ -168,7 +168,7 @@ public class SuppressScenarioTest {
                     .withCachingDisabled()
                     .withLoggingDisabled()
             )
-            .groupBy((k, v) -> new KeyValue<>(v, k), Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((k, v) -> new KeyValue<>(v, k), Grouped.with(STRING_SERDE, STRING_SERDE))
             .count();
         valueCounts
             .suppress(untilTimeLimit(ofMillis(2L), unbounded()))
@@ -240,7 +240,7 @@ public class SuppressScenarioTest {
                     .withCachingDisabled()
                     .withLoggingDisabled()
             )
-            .groupBy((k, v) -> new KeyValue<>(v, k), Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((k, v) -> new KeyValue<>(v, k), Grouped.with(STRING_SERDE, STRING_SERDE))
             .count(Materialized.with(STRING_SERDE, Serdes.Long()));
         valueCounts
             .suppress(untilTimeLimit(ofMillis(Long.MAX_VALUE), maxRecords(1L).emitEarlyWhenFull()))
@@ -306,7 +306,7 @@ public class SuppressScenarioTest {
                     .withCachingDisabled()
                     .withLoggingDisabled()
             )
-            .groupBy((k, v) -> new KeyValue<>(v, k), Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((k, v) -> new KeyValue<>(v, k), Grouped.with(STRING_SERDE, STRING_SERDE))
             .count();
         valueCounts
             // this is a bit brittle, but I happen to know that the entries are a little over 100 bytes in size.
@@ -367,7 +367,7 @@ public class SuppressScenarioTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Windowed<String>, Long> valueCounts = builder
             .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
-            .groupBy((String k, String v) -> k, Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
             .windowedBy(TimeWindows.of(2L).grace(1L))
             .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("counts").withCachingDisabled());
         valueCounts
@@ -421,7 +421,7 @@ public class SuppressScenarioTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Windowed<String>, Long> valueCounts = builder
             .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
-            .groupBy((String k, String v) -> k, Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
             .windowedBy(TimeWindows.of(2L).grace(2L))
             .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("counts").withCachingDisabled().withKeySerde(STRING_SERDE));
         valueCounts
@@ -480,7 +480,7 @@ public class SuppressScenarioTest {
         final StreamsBuilder builder = new StreamsBuilder();
         final KTable<Windowed<String>, Long> valueCounts = builder
             .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
-            .groupBy((String k, String v) -> k, Serialized.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
             .windowedBy(SessionWindows.with(5L).grace(5L))
             .count(Materialized.<String, Long, SessionStore<Bytes, byte[]>>as("counts").withCachingDisabled());
         valueCounts
@@ -528,7 +528,6 @@ public class SuppressScenarioTest {
             );
         }
     }
-
 
     private <K, V> void verify(final List<ProducerRecord<K, V>> results, final List<KeyValueTimestamp<K, V>> expectedResults) {
         if (results.size() != expectedResults.size()) {

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.kstream.internals;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.SessionWindows;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.SessionStore;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.apache.kafka.streams.kstream.Suppressed.BufferConfig.unbounded;
+import static org.apache.kafka.streams.kstream.Suppressed.untilTimeLimit;
+import static org.apache.kafka.streams.kstream.Suppressed.untilWindowCloses;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class SuppressTopologyTest {
+    private static final Serde<String> STRING_SERDE = Serdes.String();
+
+    private static final String NAMED_FINAL_TOPOLOGY = "Topologies:\n" +
+        "   Sub-topology: 0\n" +
+        "    Source: KSTREAM-SOURCE-0000000000 (topics: [input])\n" +
+        "      --> KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Processor: KSTREAM-KEY-SELECT-0000000001 (stores: [])\n" +
+        "      --> KSTREAM-FILTER-0000000004\n" +
+        "      <-- KSTREAM-SOURCE-0000000000\n" +
+        "    Processor: KSTREAM-FILTER-0000000004 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000003\n" +
+        "      <-- KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Sink: KSTREAM-SINK-0000000003 (topic: counts-repartition)\n" +
+        "      <-- KSTREAM-FILTER-0000000004\n" +
+        "\n" +
+        "  Sub-topology: 1\n" +
+        "    Source: KSTREAM-SOURCE-0000000005 (topics: [counts-repartition])\n" +
+        "      --> KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [counts])\n" +
+        "      --> myname\n" +
+        "      <-- KSTREAM-SOURCE-0000000005\n" +
+        "    Processor: myname (stores: [])\n" +
+        "      --> KTABLE-TOSTREAM-0000000006\n" +
+        "      <-- KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])\n" +
+        "      --> KSTREAM-MAP-0000000007\n" +
+        "      <-- myname\n" +
+        "    Processor: KSTREAM-MAP-0000000007 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000008\n" +
+        "      <-- KTABLE-TOSTREAM-0000000006\n" +
+        "    Sink: KSTREAM-SINK-0000000008 (topic: output-suppressed)\n" +
+        "      <-- KSTREAM-MAP-0000000007\n" +
+        "\n";
+
+    private static final String ANONYMOUS_FINAL_TOPOLOGY = "Topologies:\n" +
+        "   Sub-topology: 0\n" +
+        "    Source: KSTREAM-SOURCE-0000000000 (topics: [input])\n" +
+        "      --> KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Processor: KSTREAM-KEY-SELECT-0000000001 (stores: [])\n" +
+        "      --> KSTREAM-FILTER-0000000004\n" +
+        "      <-- KSTREAM-SOURCE-0000000000\n" +
+        "    Processor: KSTREAM-FILTER-0000000004 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000003\n" +
+        "      <-- KSTREAM-KEY-SELECT-0000000001\n" +
+        "    Sink: KSTREAM-SINK-0000000003 (topic: counts-repartition)\n" +
+        "      <-- KSTREAM-FILTER-0000000004\n" +
+        "\n" +
+        "  Sub-topology: 1\n" +
+        "    Source: KSTREAM-SOURCE-0000000005 (topics: [counts-repartition])\n" +
+        "      --> KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [counts])\n" +
+        "      --> KTABLE-SUPPRESS-0000000006\n" +
+        "      <-- KSTREAM-SOURCE-0000000005\n" +
+        "    Processor: KTABLE-SUPPRESS-0000000006 (stores: [])\n" +
+        "      --> KTABLE-TOSTREAM-0000000007\n" +
+        "      <-- KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])\n" +
+        "      --> KSTREAM-MAP-0000000008\n" +
+        "      <-- KTABLE-SUPPRESS-0000000006\n" +
+        "    Processor: KSTREAM-MAP-0000000008 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000009\n" +
+        "      <-- KTABLE-TOSTREAM-0000000007\n" +
+        "    Sink: KSTREAM-SINK-0000000009 (topic: output-suppressed)\n" +
+        "      <-- KSTREAM-MAP-0000000008\n" +
+        "\n";
+
+    private static final String NAMED_INTERMEDIATE_TOPOLOGY = "Topologies:\n" +
+        "   Sub-topology: 0\n" +
+        "    Source: KSTREAM-SOURCE-0000000000 (topics: [input])\n" +
+        "      --> KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [KSTREAM-AGGREGATE-STATE-STORE-0000000001])\n" +
+        "      --> asdf\n" +
+        "      <-- KSTREAM-SOURCE-0000000000\n" +
+        "    Processor: asdf (stores: [])\n" +
+        "      --> KTABLE-TOSTREAM-0000000003\n" +
+        "      <-- KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000003 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000004\n" +
+        "      <-- asdf\n" +
+        "    Sink: KSTREAM-SINK-0000000004 (topic: output)\n" +
+        "      <-- KTABLE-TOSTREAM-0000000003\n" +
+        "\n";
+
+    private static final String ANONYMOUS_INTERMEDIATE_TOPOLOGY = "Topologies:\n" +
+        "   Sub-topology: 0\n" +
+        "    Source: KSTREAM-SOURCE-0000000000 (topics: [input])\n" +
+        "      --> KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [KSTREAM-AGGREGATE-STATE-STORE-0000000001])\n" +
+        "      --> KTABLE-SUPPRESS-0000000003\n" +
+        "      <-- KSTREAM-SOURCE-0000000000\n" +
+        "    Processor: KTABLE-SUPPRESS-0000000003 (stores: [])\n" +
+        "      --> KTABLE-TOSTREAM-0000000004\n" +
+        "      <-- KSTREAM-AGGREGATE-0000000002\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000005\n" +
+        "      <-- KTABLE-SUPPRESS-0000000003\n" +
+        "    Sink: KSTREAM-SINK-0000000005 (topic: output)\n" +
+        "      <-- KTABLE-TOSTREAM-0000000004\n" +
+        "\n";
+
+
+    @Test
+    public void shouldUseNumberingForAnonymousFinalSuppressionNode() {
+        final StreamsBuilder anonymousNodeBuilder = new StreamsBuilder();
+        anonymousNodeBuilder
+            .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
+            .windowedBy(SessionWindows.with(5L).grace(5L))
+            .count(Materialized.<String, Long, SessionStore<Bytes, byte[]>>as("counts").withCachingDisabled())
+            .suppress(untilWindowCloses(unbounded()))
+            .toStream()
+            .map((final Windowed<String> k, final Long v) -> new KeyValue<>(k.toString(), v))
+            .to("output-suppressed", Produced.with(STRING_SERDE, Serdes.Long()));
+        final String anonymousNodeTopology = anonymousNodeBuilder.build().describe().toString();
+
+        // without the name, the suppression node increments the topology index
+        assertThat(anonymousNodeTopology, is(ANONYMOUS_FINAL_TOPOLOGY));
+    }
+
+    @Test
+    public void shouldApplyNameToFinalSuppressionNode() {
+        final StreamsBuilder namedNodeBuilder = new StreamsBuilder();
+        namedNodeBuilder
+            .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+            .groupBy((String k, String v) -> k, Grouped.with(STRING_SERDE, STRING_SERDE))
+            .windowedBy(SessionWindows.with(5L).grace(5L))
+            .count(Materialized.<String, Long, SessionStore<Bytes, byte[]>>as("counts").withCachingDisabled())
+            .suppress(untilWindowCloses(unbounded()).withName("myname"))
+            .toStream()
+            .map((final Windowed<String> k, final Long v) -> new KeyValue<>(k.toString(), v))
+            .to("output-suppressed", Produced.with(STRING_SERDE, Serdes.Long()));
+        final String namedNodeTopology = namedNodeBuilder.build().describe().toString();
+
+        // without the name, the suppression node does not increment the topology index
+        assertThat(namedNodeTopology, is(NAMED_FINAL_TOPOLOGY));
+    }
+
+    @Test
+    public void shouldUseNumberingForAnonymousSuppressionNode() {
+        final StreamsBuilder anonymousNodeBuilder = new StreamsBuilder();
+        anonymousNodeBuilder
+            .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+            .groupByKey()
+            .count()
+            .suppress(untilTimeLimit(Duration.ofSeconds(1), unbounded()))
+            .toStream()
+            .to("output", Produced.with(STRING_SERDE, Serdes.Long()));
+        final String anonymousNodeTopology = anonymousNodeBuilder.build().describe().toString();
+
+        // without the name, the suppression node increments the topology index
+        assertThat(anonymousNodeTopology, is(ANONYMOUS_INTERMEDIATE_TOPOLOGY));
+    }
+
+    @Test
+    public void shouldApplyNameToSuppressionNode() {
+        final StreamsBuilder namedNodeBuilder = new StreamsBuilder();
+        namedNodeBuilder
+            .stream("input", Consumed.with(STRING_SERDE, STRING_SERDE))
+            .groupByKey()
+            .count()
+            .suppress(untilTimeLimit(Duration.ofSeconds(1), unbounded()).withName("asdf"))
+            .toStream()
+            .to("output", Produced.with(STRING_SERDE, Serdes.Long()));
+        final String namedNodeTopology = namedNodeBuilder.build().describe().toString();
+
+        // without the name, the suppression node does not increment the topology index
+        assertThat(namedNodeTopology, is(NAMED_INTERMEDIATE_TOPOLOGY));
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/kstream/internals/SuppressTopologyTest.java
@@ -60,7 +60,7 @@ public class SuppressTopologyTest {
         "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [counts])\n" +
         "      --> myname\n" +
         "      <-- KSTREAM-SOURCE-0000000005\n" +
-        "    Processor: myname (stores: [])\n" +
+        "    Processor: myname (stores: [myname-store])\n" +
         "      --> KTABLE-TOSTREAM-0000000006\n" +
         "      <-- KSTREAM-AGGREGATE-0000000002\n" +
         "    Processor: KTABLE-TOSTREAM-0000000006 (stores: [])\n" +
@@ -92,17 +92,17 @@ public class SuppressTopologyTest {
         "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [counts])\n" +
         "      --> KTABLE-SUPPRESS-0000000006\n" +
         "      <-- KSTREAM-SOURCE-0000000005\n" +
-        "    Processor: KTABLE-SUPPRESS-0000000006 (stores: [])\n" +
-        "      --> KTABLE-TOSTREAM-0000000007\n" +
+        "    Processor: KTABLE-SUPPRESS-0000000006 (stores: [KTABLE-SUPPRESS-STATE-STORE-0000000007])\n" +
+        "      --> KTABLE-TOSTREAM-0000000008\n" +
         "      <-- KSTREAM-AGGREGATE-0000000002\n" +
-        "    Processor: KTABLE-TOSTREAM-0000000007 (stores: [])\n" +
-        "      --> KSTREAM-MAP-0000000008\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000008 (stores: [])\n" +
+        "      --> KSTREAM-MAP-0000000009\n" +
         "      <-- KTABLE-SUPPRESS-0000000006\n" +
-        "    Processor: KSTREAM-MAP-0000000008 (stores: [])\n" +
-        "      --> KSTREAM-SINK-0000000009\n" +
-        "      <-- KTABLE-TOSTREAM-0000000007\n" +
-        "    Sink: KSTREAM-SINK-0000000009 (topic: output-suppressed)\n" +
-        "      <-- KSTREAM-MAP-0000000008\n" +
+        "    Processor: KSTREAM-MAP-0000000009 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000010\n" +
+        "      <-- KTABLE-TOSTREAM-0000000008\n" +
+        "    Sink: KSTREAM-SINK-0000000010 (topic: output-suppressed)\n" +
+        "      <-- KSTREAM-MAP-0000000009\n" +
         "\n";
 
     private static final String NAMED_INTERMEDIATE_TOPOLOGY = "Topologies:\n" +
@@ -112,7 +112,7 @@ public class SuppressTopologyTest {
         "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [KSTREAM-AGGREGATE-STATE-STORE-0000000001])\n" +
         "      --> asdf\n" +
         "      <-- KSTREAM-SOURCE-0000000000\n" +
-        "    Processor: asdf (stores: [])\n" +
+        "    Processor: asdf (stores: [asdf-store])\n" +
         "      --> KTABLE-TOSTREAM-0000000003\n" +
         "      <-- KSTREAM-AGGREGATE-0000000002\n" +
         "    Processor: KTABLE-TOSTREAM-0000000003 (stores: [])\n" +
@@ -129,14 +129,14 @@ public class SuppressTopologyTest {
         "    Processor: KSTREAM-AGGREGATE-0000000002 (stores: [KSTREAM-AGGREGATE-STATE-STORE-0000000001])\n" +
         "      --> KTABLE-SUPPRESS-0000000003\n" +
         "      <-- KSTREAM-SOURCE-0000000000\n" +
-        "    Processor: KTABLE-SUPPRESS-0000000003 (stores: [])\n" +
-        "      --> KTABLE-TOSTREAM-0000000004\n" +
+        "    Processor: KTABLE-SUPPRESS-0000000003 (stores: [KTABLE-SUPPRESS-STATE-STORE-0000000004])\n" +
+        "      --> KTABLE-TOSTREAM-0000000005\n" +
         "      <-- KSTREAM-AGGREGATE-0000000002\n" +
-        "    Processor: KTABLE-TOSTREAM-0000000004 (stores: [])\n" +
-        "      --> KSTREAM-SINK-0000000005\n" +
+        "    Processor: KTABLE-TOSTREAM-0000000005 (stores: [])\n" +
+        "      --> KSTREAM-SINK-0000000006\n" +
         "      <-- KTABLE-SUPPRESS-0000000003\n" +
-        "    Sink: KSTREAM-SINK-0000000005 (topic: output)\n" +
-        "      <-- KTABLE-TOSTREAM-0000000004\n" +
+        "    Sink: KSTREAM-SINK-0000000006 (topic: output)\n" +
+        "      <-- KTABLE-TOSTREAM-0000000005\n" +
         "\n";
 
 


### PR DESCRIPTION
KIP-372 (allow naming all internal topics) was designed and
developed concurrently with suppression.

Since suppression introduces a new internal topic,
it also needs to be nameable.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
