### PR TITLE
KAFKA-6971 Passing in help flag to kafka-console-producer should print arg options

### DIFF
--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -190,6 +190,7 @@ object ConsoleConsumer extends Logging {
 
   class ConsumerConfig(args: Array[String]) {
     val parser = new OptionParser(false)
+    val help = parser.accepts("help", "Print all options and its descriptions")
     val topicIdOpt = parser.accepts("topic", "The topic id to consume on.")
       .withRequiredArg
       .describedAs("topic")
@@ -274,11 +275,12 @@ object ConsoleConsumer extends Logging {
       .describedAs("consumer group id")
       .ofType(classOf[String])
 
-    if (args.length == 0)
+    val options: OptionSet = tryParse(parser, args)
+
+    if (args.length == 0 || options.has(help))
       CommandLineUtils.printUsageAndDie(parser, "The console consumer is a tool that reads data from Kafka and outputs it to standard output.")
 
     var groupIdPassed = true
-    val options: OptionSet = tryParse(parser, args)
     val enableSystestEventsLogging = options.has(enableSystestEventsLoggingOpt)
 
     // topic must be specified.

--- a/core/src/main/scala/kafka/tools/ConsoleProducer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleProducer.scala
@@ -111,6 +111,7 @@ object ConsoleProducer {
 
   class ProducerConfig(args: Array[String]) {
     val parser = new OptionParser(false)
+    val help = parser.accepts("help", "Print all options and its descriptions")
     val topicOpt = parser.accepts("topic", "REQUIRED: The topic id to produce messages to.")
       .withRequiredArg
       .describedAs("topic")
@@ -205,7 +206,7 @@ object ConsoleProducer {
       .ofType(classOf[String])
 
     val options = parser.parse(args : _*)
-    if (args.length == 0)
+    if (args.length == 0 || options.has(help))
       CommandLineUtils.printUsageAndDie(parser, "Read data from standard input and publish it to Kafka.")
     CommandLineUtils.checkRequiredArgs(parser, options, topicOpt, brokerListOpt)
 


### PR DESCRIPTION
I've added this small fix to print all options and descriptions of console consumer and producer without parameters i.e. "console-producer" and with --help option i.e. "console-producer --help"
I did it without unit tests because it uses `System.exit(1)` after printing message and tests will be always red.