### PR TITLE
KAFKA-7462: Make token optional for OAuthBearerLoginModule

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModule.java
@@ -302,7 +302,7 @@ public class OAuthBearerLoginModule implements LoginModule {
         if (tokenRequiringCommit != null)
             identifyExtensions();
         else
-            log.info("Logged in without a token, this login cannot be used to establish client connections");
+            log.debug("Logged in without a token, this login cannot be used to establish client connections");
 
         loginState = LoginState.LOGGED_IN_NOT_COMMITTED;
         log.info("Login succeeded; invoke commit() to commit it; current committed token count={}",
@@ -370,7 +370,7 @@ public class OAuthBearerLoginModule implements LoginModule {
             }
             log.info("Done logging out my token; committed token count is now {}", committedTokenCount());
         } else
-            log.info("No tokens to logout for this login");
+            log.debug("No tokens to logout for this login");
 
         if (myCommittedExtensions != null) {
             log.info("Logging out my extensions");
@@ -378,7 +378,7 @@ public class OAuthBearerLoginModule implements LoginModule {
                 myCommittedExtensions = null;
             log.info("Done logging out my extensions");
         } else
-            log.info("No extensions to logout for this login");
+            log.debug("No extensions to logout for this login");
 
         loginState = LoginState.NOT_LOGGED_IN;
         return true;
@@ -399,7 +399,7 @@ public class OAuthBearerLoginModule implements LoginModule {
             tokenRequiringCommit = null;
             log.info("Done committing my token; committed token count is now {}", committedTokenCount());
         } else
-            log.info("No tokens to commit, this login cannot be used to establish client connections");
+            log.debug("No tokens to commit, this login cannot be used to establish client connections");
 
         if (extensionsRequiringCommit != null) {
             subject.getPublicCredentials().add(extensionsRequiringCommit);

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModule.java
@@ -237,6 +237,14 @@ import org.slf4j.LoggerFactory;
  */
 public class OAuthBearerLoginModule implements LoginModule {
 
+    /**
+     * Login state transitions:
+     *   Initial state: NOT_LOGGED_IN
+     *   login()      : NOT_LOGGED_IN => LOGGED_IN_NOT_COMMITTED
+     *   commit()     : LOGGED_IN_NOT_COMMITTED => COMMITTED
+     *   abort()      : LOGGED_IN_NOT_COMMITTED => NOT_LOGGED_IN
+     *   logout()     : Any state => NOT_LOGGED_IN
+     */
     private enum LoginState {
         NOT_LOGGED_IN,
         LOGGED_IN_NOT_COMMITTED,
@@ -291,11 +299,10 @@ public class OAuthBearerLoginModule implements LoginModule {
         }
 
         identifyToken();
-        if (tokenRequiringCommit != null) {
+        if (tokenRequiringCommit != null)
             identifyExtensions();
-        } else {
+        else
             log.info("Logged in without a token, this login cannot be used to establish client connections");
-        }
 
         loginState = LoginState.LOGGED_IN_NOT_COMMITTED;
         log.info("Login succeeded; invoke commit() to commit it; current committed token count={}",
@@ -362,18 +369,16 @@ public class OAuthBearerLoginModule implements LoginModule {
                 }
             }
             log.info("Done logging out my token; committed token count is now {}", committedTokenCount());
-        } else {
+        } else
             log.info("No tokens to logout for this login");
-        }
 
         if (myCommittedExtensions != null) {
             log.info("Logging out my extensions");
             if (subject.getPublicCredentials().removeIf(e -> myCommittedExtensions == e))
                 myCommittedExtensions = null;
             log.info("Done logging out my extensions");
-        } else {
+        } else
             log.info("No extensions to logout for this login");
-        }
 
         loginState = LoginState.NOT_LOGGED_IN;
         return true;
@@ -393,14 +398,10 @@ public class OAuthBearerLoginModule implements LoginModule {
             myCommittedToken = tokenRequiringCommit;
             tokenRequiringCommit = null;
             log.info("Done committing my token; committed token count is now {}", committedTokenCount());
-        } else {
+        } else
             log.info("No tokens to commit, this login cannot be used to establish client connections");
-        }
 
         if (extensionsRequiringCommit != null) {
-            if (myCommittedToken == null)
-                throw new IllegalStateException("Extensions being committed without a token");
-
             subject.getPublicCredentials().add(extensionsRequiringCommit);
             myCommittedExtensions = extensionsRequiringCommit;
             extensionsRequiringCommit = null;
@@ -419,8 +420,7 @@ public class OAuthBearerLoginModule implements LoginModule {
             loginState = LoginState.NOT_LOGGED_IN;
             return true;
         }
-        if (log.isDebugEnabled())
-            log.debug("Nothing here to abort");
+        log.debug("Nothing here to abort");
         return false;
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModule.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerLoginModule.java
@@ -236,6 +236,13 @@ import org.slf4j.LoggerFactory;
  * @see SaslConfigs#SASL_LOGIN_REFRESH_BUFFER_SECONDS_DOC
  */
 public class OAuthBearerLoginModule implements LoginModule {
+
+    private enum LoginState {
+        NOT_LOGGED_IN,
+        LOGGED_IN_NOT_COMMITTED,
+        COMMITTED
+    }
+
     /**
      * The SASL Mechanism name for OAuth 2: {@code OAUTHBEARER}
      */
@@ -248,6 +255,7 @@ public class OAuthBearerLoginModule implements LoginModule {
     private OAuthBearerToken myCommittedToken = null;
     private SaslExtensions extensionsRequiringCommit = null;
     private SaslExtensions myCommittedExtensions = null;
+    private LoginState loginState;
 
     static {
         OAuthBearerSaslClientProvider.initialize(); // not part of public API
@@ -266,17 +274,30 @@ public class OAuthBearerLoginModule implements LoginModule {
 
     @Override
     public boolean login() throws LoginException {
-        if (tokenRequiringCommit != null)
-            throw new IllegalStateException(String.format(
+        if (loginState == LoginState.LOGGED_IN_NOT_COMMITTED) {
+            if (tokenRequiringCommit != null)
+                throw new IllegalStateException(String.format(
                     "Already have an uncommitted token with private credential token count=%d", committedTokenCount()));
-        if (myCommittedToken != null)
-            throw new IllegalStateException(String.format(
+            else
+                throw new IllegalStateException("Already logged in without a token");
+        }
+        if (loginState == LoginState.COMMITTED) {
+            if (myCommittedToken != null)
+                throw new IllegalStateException(String.format(
                     "Already have a committed token with private credential token count=%d; must login on another login context or logout here first before reusing the same login context",
                     committedTokenCount()));
+            else
+                throw new IllegalStateException("Login has already been committed without a token");
+        }
 
         identifyToken();
-        identifyExtensions();
+        if (tokenRequiringCommit != null) {
+            identifyExtensions();
+        } else {
+            log.info("Logged in without a token, this login cannot be used to establish client connections");
+        }
 
+        loginState = LoginState.LOGGED_IN_NOT_COMMITTED;
         log.info("Login succeeded; invoke commit() to commit it; current committed token count={}",
                 committedTokenCount());
         return true;
@@ -292,7 +313,7 @@ public class OAuthBearerLoginModule implements LoginModule {
         }
 
         tokenRequiringCommit = tokenCallback.token();
-        if (tokenRequiringCommit == null) {
+        if (tokenCallback.errorCode() != null) {
             log.info("Login failed: {} : {} (URI={})", tokenCallback.errorCode(), tokenCallback.errorDescription(),
                     tokenCallback.errorUri());
             throw new LoginException(tokenCallback.errorDescription());
@@ -322,60 +343,80 @@ public class OAuthBearerLoginModule implements LoginModule {
 
     @Override
     public boolean logout() {
-        if (tokenRequiringCommit != null)
+        if (loginState == LoginState.LOGGED_IN_NOT_COMMITTED)
             throw new IllegalStateException(
                     "Cannot call logout() immediately after login(); need to first invoke commit() or abort()");
-        if (myCommittedToken == null) {
+        if (loginState != LoginState.COMMITTED) {
             if (log.isDebugEnabled())
                 log.debug("Nothing here to log out");
             return false;
         }
-        log.info("Logging out my token; current committed token count = {}", committedTokenCount());
-        for (Iterator<Object> iterator = subject.getPrivateCredentials().iterator(); iterator.hasNext();) {
-            Object privateCredential = iterator.next();
-            if (privateCredential == myCommittedToken) {
-                iterator.remove();
-                myCommittedToken = null;
-                break;
+        if (myCommittedToken != null) {
+            log.info("Logging out my token; current committed token count = {}", committedTokenCount());
+            for (Iterator<Object> iterator = subject.getPrivateCredentials().iterator(); iterator.hasNext(); ) {
+                Object privateCredential = iterator.next();
+                if (privateCredential == myCommittedToken) {
+                    iterator.remove();
+                    myCommittedToken = null;
+                    break;
+                }
             }
+            log.info("Done logging out my token; committed token count is now {}", committedTokenCount());
+        } else {
+            log.info("No tokens to logout for this login");
         }
-        log.info("Done logging out my token; committed token count is now {}", committedTokenCount());
 
-        log.info("Logging out my extensions");
-        if (subject.getPublicCredentials().removeIf(e -> myCommittedExtensions == e))
-            myCommittedExtensions = null;
-        log.info("Done logging out my extensions");
+        if (myCommittedExtensions != null) {
+            log.info("Logging out my extensions");
+            if (subject.getPublicCredentials().removeIf(e -> myCommittedExtensions == e))
+                myCommittedExtensions = null;
+            log.info("Done logging out my extensions");
+        } else {
+            log.info("No extensions to logout for this login");
+        }
 
+        loginState = LoginState.NOT_LOGGED_IN;
         return true;
     }
 
     @Override
     public boolean commit() {
-        if (tokenRequiringCommit == null) {
+        if (loginState != LoginState.LOGGED_IN_NOT_COMMITTED) {
             if (log.isDebugEnabled())
                 log.debug("Nothing here to commit");
             return false;
         }
 
-        log.info("Committing my token; current committed token count = {}", committedTokenCount());
-        subject.getPrivateCredentials().add(tokenRequiringCommit);
-        myCommittedToken = tokenRequiringCommit;
-        tokenRequiringCommit = null;
-        log.info("Done committing my token; committed token count is now {}", committedTokenCount());
+        if (tokenRequiringCommit != null) {
+            log.info("Committing my token; current committed token count = {}", committedTokenCount());
+            subject.getPrivateCredentials().add(tokenRequiringCommit);
+            myCommittedToken = tokenRequiringCommit;
+            tokenRequiringCommit = null;
+            log.info("Done committing my token; committed token count is now {}", committedTokenCount());
+        } else {
+            log.info("No tokens to commit, this login cannot be used to establish client connections");
+        }
 
-        subject.getPublicCredentials().add(extensionsRequiringCommit);
-        myCommittedExtensions = extensionsRequiringCommit;
-        extensionsRequiringCommit = null;
+        if (extensionsRequiringCommit != null) {
+            if (myCommittedToken == null)
+                throw new IllegalStateException("Extensions being committed without a token");
 
+            subject.getPublicCredentials().add(extensionsRequiringCommit);
+            myCommittedExtensions = extensionsRequiringCommit;
+            extensionsRequiringCommit = null;
+        }
+
+        loginState = LoginState.COMMITTED;
         return true;
     }
 
     @Override
     public boolean abort() {
-        if (tokenRequiringCommit != null) {
+        if (loginState == LoginState.LOGGED_IN_NOT_COMMITTED) {
             log.info("Login aborted");
             tokenRequiringCommit = null;
             extensionsRequiringCommit = null;
+            loginState = LoginState.NOT_LOGGED_IN;
             return true;
         }
         if (log.isDebugEnabled())

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerTokenCallback.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerTokenCallback.java
@@ -93,7 +93,7 @@ public class OAuthBearerTokenCallback implements Callback {
      *            the mandatory token to set
      */
     public void token(OAuthBearerToken token) {
-        this.token = Objects.requireNonNull(token);
+        this.token = token;
         this.errorCode = null;
         this.errorDescription = null;
         this.errorUri = null;

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerTokenCallback.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/OAuthBearerTokenCallback.java
@@ -90,7 +90,7 @@ public class OAuthBearerTokenCallback implements Callback {
      * Set the token. All error-related values are cleared.
      * 
      * @param token
-     *            the mandatory token to set
+     *            the optional token to set
      */
     public void token(OAuthBearerToken token) {
         this.token = token;

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
@@ -183,7 +183,7 @@ public class OAuthBearerUnsecuredLoginCallbackHandler implements AuthenticateCal
         if (callback.token() != null)
             throw new IllegalArgumentException("Callback had a token already");
         if (moduleOptions.isEmpty()) {
-            log.info("Token not provided, this login cannot be used to establish client connections");
+            log.debug("Token not provided, this login cannot be used to establish client connections");
             callback.token(null);
             return;
         }

--- a/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
+++ b/clients/src/main/java/org/apache/kafka/common/security/oauthbearer/internals/unsecured/OAuthBearerUnsecuredLoginCallbackHandler.java
@@ -182,6 +182,14 @@ public class OAuthBearerUnsecuredLoginCallbackHandler implements AuthenticateCal
     private void handleTokenCallback(OAuthBearerTokenCallback callback) {
         if (callback.token() != null)
             throw new IllegalArgumentException("Callback had a token already");
+        if (moduleOptions.isEmpty()) {
+            log.info("Token not provided, this login cannot be used to establish client connections");
+            callback.token(null);
+            return;
+        }
+        if (moduleOptions.keySet().stream().noneMatch(name -> !name.startsWith(EXTENSION_PREFIX))) {
+            throw new OAuthBearerConfigException("Extensions provided in login context without a token");
+        }
         String principalClaimNameValue = optionValue(PRINCIPAL_CLAIM_NAME_OPTION);
         String principalClaimName = principalClaimNameValue != null && !principalClaimNameValue.trim().isEmpty()
                 ? principalClaimNameValue.trim()


### PR DESCRIPTION
OAuthBearerLoginModule is used both on the server-side and client-side (similar to login modules for other mechanisms). OAUTHBEARER tokens are client credentials used only on the client-side to authenticate with servers, but the current implementation requires tokens to be provided on the server-side even if OAUTHBEARER is not used for inter-broker communication. Tokens should be optional for server-side login context to allow brokers to be configured without a token when OAUTHBEARER is not used for inter-broker communication.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
