### PR TITLE
MINOR: Fix bug where StoreBuilder added after connecting store with processor

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -60,12 +60,12 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
         topologyBuilder.addProcessor(processorName, processorSupplier, parentNodeNames());
 
-        if (storeNames != null && storeNames.length > 0) {
-            topologyBuilder.connectProcessorAndStateStores(processorName, storeNames);
-        }
-
         if (storeBuilder != null) {
             topologyBuilder.addStateStore(storeBuilder, processorName);
+        }
+
+        if (storeNames != null && storeNames.length > 0) {
+            topologyBuilder.connectProcessorAndStateStores(processorName, storeNames);
         }
     }
 


### PR DESCRIPTION

Fixes bug found in https://github.com/apache/kafka/pull/5731 where we add a state store to the processor before adding the state store to the `InternalTopologyBuilder`

I've added a test which fails without this fix.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
