### PR TITLE
MINOR: Fix typo in Resource in org.apache.kafka.trogdor

### DIFF
--- a/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/agent/Agent.java
@@ -66,7 +66,7 @@ public final class Agent {
      * @param platform      The platform object to use.
      * @param scheduler     The scheduler to use for this Agent.
      * @param restServer    The REST server to use.
-     * @param resource      The AgentRestResoure to use.
+     * @param resource      The AgentRestResource to use.
      */
     public Agent(Platform platform, Scheduler scheduler,
                  JsonRestServer restServer, AgentRestResource resource) {

--- a/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
+++ b/tools/src/main/java/org/apache/kafka/trogdor/coordinator/Coordinator.java
@@ -70,7 +70,7 @@ public final class Coordinator {
      * @param platform      The platform object to use.
      * @param scheduler     The scheduler to use for this Coordinator.
      * @param restServer    The REST server to use.
-     * @param resource      The AgentRestResoure to use.
+     * @param resource      The AgentRestResource to use.
      */
     public Coordinator(Platform platform, Scheduler scheduler, JsonRestServer restServer,
                        CoordinatorRestResource resource, long firstWorkerId) {


### PR DESCRIPTION
I fixed 2 typos in 

org.apache.kafka.trogdor.agent.Agent
org.apache.kafka.trogdor.coordinator.Coordinator

There were missing "c" in Resource, as you can see in commit.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
