### PR TITLE
KAFKA-3816: Add MDC logging to Connect runtime

### DIFF
--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -26,7 +26,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 #
 # The following parameters specified in the layout will be replaced with the corresponding values in every log message:
 #
-# Use %X{connector.type} for a shortened form of the type of connector (e.g., connector's class name)
+# Use %X{connector.class.short} for a shortened form of the connector's class name
 # Use %X{connector.name} for the name of the connector
 # Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
 # Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task

--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -20,17 +20,11 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 
 #
-# The layout of each log message can be modified to include the Mapped Diagnostic Context parameters used by Connect,
-# which will include connector-specific and task-specific information on each log message and making it easier to identify
-# which log messages belong to which connector and tasks.
+# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
+# in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
 #
-# The following parameters specified in the layout will be replaced with the corresponding values in every log message:
-#
-# Use %X{connector.name} for the name of the connector
-# Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
-# Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task
-#
-#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.name}|%X{connector.scope}%X{connector.task} %m (%c:%L)%n
+#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.zookeeper=ERROR

--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -18,6 +18,20 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+#
+# The layout of each log message can be modified to include the Mapped Diagnostic Context parameters used by Connect,
+# which will include connector-specific and task-specific information on each log message and making it easier to identify
+# which log messages belong to which connector and tasks.
+#
+# The following parameters specified in the layout will be replaced with the corresponding values in every log message:
+#
+# Use %X{connector.type} for a shortened form of the type of connector (e.g., connector's class name)
+# Use %X{connector.name} for the name of the connector
+# Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
+# Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task
+#
+#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.name}|%X{connector.scope}%X{connector.task} %m (%c:%L)%n
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.zookeeper=ERROR

--- a/config/connect-log4j.properties
+++ b/config/connect-log4j.properties
@@ -26,7 +26,6 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 #
 # The following parameters specified in the layout will be replaced with the corresponding values in every log message:
 #
-# Use %X{connector.class.short} for a shortened form of the connector's class name
 # Use %X{connector.name} for the name of the connector
 # Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
 # Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
@@ -80,11 +80,8 @@ class SourceTaskOffsetCommitter {
         ScheduledFuture<?> commitFuture = commitExecutorService.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
-                try {
-                    LoggingContext.forOffsets(id);
+                try (LoggingContext loggingContext = LoggingContext.forOffsets(id)) {
                     commit(workerTask);
-                } finally {
-                    LoggingContext.clear();
                 }
             }
         }, commitIntervalMs, commitIntervalMs, TimeUnit.MILLISECONDS);
@@ -96,8 +93,7 @@ class SourceTaskOffsetCommitter {
         if (task == null)
             return;
 
-        try {
-            LoggingContext.forTask(id);
+        try (LoggingContext loggingContext = LoggingContext.forTask(id)) {
             task.cancel(false);
             if (!task.isDone())
                 task.get();
@@ -106,15 +102,12 @@ class SourceTaskOffsetCommitter {
             log.trace("Offset commit thread was cancelled by another thread while removing connector task with id: {}", id);
         } catch (ExecutionException | InterruptedException e) {
             throw new ConnectException("Unexpected interruption in SourceTaskOffsetCommitter while removing task with id: " + id, e);
-        } finally {
-            LoggingContext.clear();
         }
     }
 
     private void commit(WorkerSourceTask workerTask) {
         log.debug("{} Committing offsets", workerTask);
-        try {
-            LoggingContext.forOffsets(workerTask.id);
+        try (LoggingContext loggingContext = LoggingContext.forOffsets(workerTask.id)) {
             if (workerTask.commitOffsets()) {
                 return;
             }
@@ -124,8 +117,6 @@ class SourceTaskOffsetCommitter {
             // thread would cause the fixed interval schedule on the ExecutorService to stop running
             // for that task
             log.error("{} Unhandled exception when committing: ", workerTask, t);
-        } finally {
-            LoggingContext.clear();
         }
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
@@ -18,6 +18,7 @@ package org.apache.kafka.connect.runtime;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.LoggingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +80,9 @@ class SourceTaskOffsetCommitter {
         ScheduledFuture<?> commitFuture = commitExecutorService.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
-                commit(workerTask);
+                try (LoggingContext logCtx = LoggingContext.forOffsets(id)) {
+                    commit(workerTask);
+                }
             }
         }, commitIntervalMs, commitIntervalMs, TimeUnit.MILLISECONDS);
         committers.put(id, commitFuture);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitter.java
@@ -107,7 +107,7 @@ class SourceTaskOffsetCommitter {
 
     private void commit(WorkerSourceTask workerTask) {
         log.debug("{} Committing offsets", workerTask);
-        try (LoggingContext loggingContext = LoggingContext.forOffsets(workerTask.id)) {
+        try {
             if (workerTask.commitOffsets()) {
                 return;
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -226,41 +226,40 @@ public class Worker {
             ConnectorStatus.Listener statusListener,
             TargetState initialState
     ) {
-        if (connectors.containsKey(connName))
-            throw new ConnectException("Connector with name " + connName + " already exists");
+        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+            if (connectors.containsKey(connName))
+                throw new ConnectException("Connector with name " + connName + " already exists");
 
-        final WorkerConnector workerConnector;
-        ClassLoader savedLoader = plugins.currentThreadLoader();
-        try {
-            LoggingContext.forConnector(connName);
-            final ConnectorConfig connConfig = new ConnectorConfig(plugins, connProps);
-            final String connClass = connConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
-            log.info("Creating connector {} of type {}", connName, connClass);
-            final Connector connector = plugins.newConnector(connClass);
-            workerConnector = new WorkerConnector(connName, connector, ctx, metrics,  statusListener);
-            log.info("Instantiated connector {} with version {} of type {}", connName, connector.version(), connector.getClass());
-            savedLoader = plugins.compareAndSwapLoaders(connector);
-            workerConnector.initialize(connConfig);
-            workerConnector.transitionTo(initialState);
-            Plugins.compareAndSwapLoaders(savedLoader);
-        } catch (Throwable t) {
-            log.error("Failed to start connector {}", connName, t);
-            // Can't be put in a finally block because it needs to be swapped before the call on
-            // statusListener
-            Plugins.compareAndSwapLoaders(savedLoader);
-            workerMetricsGroup.recordConnectorStartupFailure();
-            statusListener.onFailure(connName, t);
-            return false;
-        } finally {
-            LoggingContext.clear();
+            final WorkerConnector workerConnector;
+            ClassLoader savedLoader = plugins.currentThreadLoader();
+            try {
+                final ConnectorConfig connConfig = new ConnectorConfig(plugins, connProps);
+                final String connClass = connConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+                log.info("Creating connector {} of type {}", connName, connClass);
+                final Connector connector = plugins.newConnector(connClass);
+                workerConnector = new WorkerConnector(connName, connector, ctx, metrics, statusListener);
+                log.info("Instantiated connector {} with version {} of type {}", connName, connector.version(), connector.getClass());
+                savedLoader = plugins.compareAndSwapLoaders(connector);
+                workerConnector.initialize(connConfig);
+                workerConnector.transitionTo(initialState);
+                Plugins.compareAndSwapLoaders(savedLoader);
+            } catch (Throwable t) {
+                log.error("Failed to start connector {}", connName, t);
+                // Can't be put in a finally block because it needs to be swapped before the call on
+                // statusListener
+                Plugins.compareAndSwapLoaders(savedLoader);
+                workerMetricsGroup.recordConnectorStartupFailure();
+                statusListener.onFailure(connName, t);
+                return false;
+            }
+
+            WorkerConnector existing = connectors.putIfAbsent(connName, workerConnector);
+            if (existing != null)
+                throw new ConnectException("Connector with name " + connName + " already exists");
+
+            log.info("Finished creating connector {}", connName);
+            workerMetricsGroup.recordConnectorStartupSuccess();
         }
-
-        WorkerConnector existing = connectors.putIfAbsent(connName, workerConnector);
-        if (existing != null)
-            throw new ConnectException("Connector with name " + connName + " already exists");
-
-        log.info("Finished creating connector {}", connName);
-        workerMetricsGroup.recordConnectorStartupSuccess();
         return true;
     }
 
@@ -292,35 +291,37 @@ public class Worker {
      * @return a list of updated tasks properties.
      */
     public List<Map<String, String>> connectorTaskConfigs(String connName, ConnectorConfig connConfig) {
-        log.trace("Reconfiguring connector tasks for {}", connName);
-
-        WorkerConnector workerConnector = connectors.get(connName);
-        if (workerConnector == null)
-            throw new ConnectException("Connector " + connName + " not found in this worker.");
-
-        int maxTasks = connConfig.getInt(ConnectorConfig.TASKS_MAX_CONFIG);
-        Map<String, String> connOriginals = connConfig.originalsStrings();
-
-        Connector connector = workerConnector.connector();
         List<Map<String, String>> result = new ArrayList<>();
-        ClassLoader savedLoader = plugins.currentThreadLoader();
-        try {
-            savedLoader = plugins.compareAndSwapLoaders(connector);
-            String taskClassName = connector.taskClass().getName();
-            for (Map<String, String> taskProps : connector.taskConfigs(maxTasks)) {
-                // Ensure we don't modify the connector's copy of the config
-                Map<String, String> taskConfig = new HashMap<>(taskProps);
-                taskConfig.put(TaskConfig.TASK_CLASS_CONFIG, taskClassName);
-                if (connOriginals.containsKey(SinkTask.TOPICS_CONFIG)) {
-                    taskConfig.put(SinkTask.TOPICS_CONFIG, connOriginals.get(SinkTask.TOPICS_CONFIG));
+        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+            log.trace("Reconfiguring connector tasks for {}", connName);
+
+            WorkerConnector workerConnector = connectors.get(connName);
+            if (workerConnector == null)
+                throw new ConnectException("Connector " + connName + " not found in this worker.");
+
+            int maxTasks = connConfig.getInt(ConnectorConfig.TASKS_MAX_CONFIG);
+            Map<String, String> connOriginals = connConfig.originalsStrings();
+
+            Connector connector = workerConnector.connector();
+            ClassLoader savedLoader = plugins.currentThreadLoader();
+            try {
+                savedLoader = plugins.compareAndSwapLoaders(connector);
+                String taskClassName = connector.taskClass().getName();
+                for (Map<String, String> taskProps : connector.taskConfigs(maxTasks)) {
+                    // Ensure we don't modify the connector's copy of the config
+                    Map<String, String> taskConfig = new HashMap<>(taskProps);
+                    taskConfig.put(TaskConfig.TASK_CLASS_CONFIG, taskClassName);
+                    if (connOriginals.containsKey(SinkTask.TOPICS_CONFIG)) {
+                        taskConfig.put(SinkTask.TOPICS_CONFIG, connOriginals.get(SinkTask.TOPICS_CONFIG));
+                    }
+                    if (connOriginals.containsKey(SinkTask.TOPICS_REGEX_CONFIG)) {
+                        taskConfig.put(SinkTask.TOPICS_REGEX_CONFIG, connOriginals.get(SinkTask.TOPICS_REGEX_CONFIG));
+                    }
+                    result.add(taskConfig);
                 }
-                if (connOriginals.containsKey(SinkTask.TOPICS_REGEX_CONFIG)) {
-                    taskConfig.put(SinkTask.TOPICS_REGEX_CONFIG, connOriginals.get(SinkTask.TOPICS_REGEX_CONFIG));
-                }
-                result.add(taskConfig);
+            } finally {
+                Plugins.compareAndSwapLoaders(savedLoader);
             }
-        } finally {
-            Plugins.compareAndSwapLoaders(savedLoader);
         }
 
         return result;
@@ -340,23 +341,25 @@ public class Worker {
      * @return true if the connector belonged to this worker and was successfully stopped.
      */
     public boolean stopConnector(String connName) {
-        log.info("Stopping connector {}", connName);
+        try (LoggingContext loggingContext = LoggingContext.forConnector(connName)) {
+            log.info("Stopping connector {}", connName);
 
-        WorkerConnector workerConnector = connectors.remove(connName);
-        if (workerConnector == null) {
-            log.warn("Ignoring stop request for unowned connector {}", connName);
-            return false;
+            WorkerConnector workerConnector = connectors.remove(connName);
+            if (workerConnector == null) {
+                log.warn("Ignoring stop request for unowned connector {}", connName);
+                return false;
+            }
+
+            ClassLoader savedLoader = plugins.currentThreadLoader();
+            try {
+                savedLoader = plugins.compareAndSwapLoaders(workerConnector.connector());
+                workerConnector.shutdown();
+            } finally {
+                Plugins.compareAndSwapLoaders(savedLoader);
+            }
+
+            log.info("Stopped connector {}", connName);
         }
-
-        ClassLoader savedLoader = plugins.currentThreadLoader();
-        try {
-            savedLoader = plugins.compareAndSwapLoaders(workerConnector.connector());
-            workerConnector.shutdown();
-        } finally {
-            Plugins.compareAndSwapLoaders(savedLoader);
-        }
-
-        log.info("Stopped connector {}", connName);
         return true;
     }
 
@@ -398,87 +401,78 @@ public class Worker {
             TaskStatus.Listener statusListener,
             TargetState initialState
     ) {
-        LoggingContext.forTask(id);
-        log.info("Creating task {}", id);
-
-        if (tasks.containsKey(id))
-            throw new ConnectException("Task already exists in this worker: " + id);
-
         final WorkerTask workerTask;
-        ClassLoader savedLoader = plugins.currentThreadLoader();
-        try {
-            final ConnectorConfig connConfig = new ConnectorConfig(plugins, connProps);
-            String connType = connConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
-            ClassLoader connectorLoader = plugins.delegatingLoader().connectorLoader(connType);
-            savedLoader = Plugins.compareAndSwapLoaders(connectorLoader);
-            final TaskConfig taskConfig = new TaskConfig(taskProps);
-            final Class<? extends Task> taskClass = taskConfig.getClass(TaskConfig.TASK_CLASS_CONFIG).asSubclass(Task.class);
-            final Task task = plugins.newTask(taskClass);
-            log.info("Instantiated task {} with version {} of type {}", id, task.version(), taskClass.getName());
+        try (LoggingContext loggingContext = LoggingContext.forTask(id)) {
+            log.info("Creating task {}", id);
 
-            // By maintaining connector's specific class loader for this thread here, we first
-            // search for converters within the connector dependencies.
-            // If any of these aren't found, that means the connector didn't configure specific converters,
-            // so we should instantiate based upon the worker configuration
-            Converter keyConverter = plugins.newConverter(
-                    connConfig,
-                    WorkerConfig.KEY_CONVERTER_CLASS_CONFIG,
-                    ClassLoaderUsage.CURRENT_CLASSLOADER
-            );
-            Converter valueConverter = plugins.newConverter(
-                    connConfig,
-                    WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG,
-                    ClassLoaderUsage.CURRENT_CLASSLOADER
-            );
-            HeaderConverter headerConverter = plugins.newHeaderConverter(
-                    connConfig,
-                    WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG,
-                    ClassLoaderUsage.CURRENT_CLASSLOADER
-            );
-            if (keyConverter == null) {
-                keyConverter = plugins.newConverter(config, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
-                log.info("Set up the key converter {} for task {} using the worker config", keyConverter.getClass(), id);
-            } else {
-                log.info("Set up the key converter {} for task {} using the connector config", keyConverter.getClass(), id);
-            }
-            if (valueConverter == null) {
-                valueConverter = plugins.newConverter(config, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
-                log.info("Set up the value converter {} for task {} using the worker config", valueConverter.getClass(), id);
-            } else {
-                log.info("Set up the value converter {} for task {} using the connector config", valueConverter.getClass(), id);
-            }
-            if (headerConverter == null) {
-                headerConverter = plugins.newHeaderConverter(config, WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
-                log.info("Set up the header converter {} for task {} using the worker config", headerConverter.getClass(), id);
-            } else {
-                log.info("Set up the header converter {} for task {} using the connector config", headerConverter.getClass(), id);
+            if (tasks.containsKey(id))
+                throw new ConnectException("Task already exists in this worker: " + id);
+
+            ClassLoader savedLoader = plugins.currentThreadLoader();
+            try {
+                final ConnectorConfig connConfig = new ConnectorConfig(plugins, connProps);
+                String connType = connConfig.getString(ConnectorConfig.CONNECTOR_CLASS_CONFIG);
+                ClassLoader connectorLoader = plugins.delegatingLoader().connectorLoader(connType);
+                savedLoader = Plugins.compareAndSwapLoaders(connectorLoader);
+                final TaskConfig taskConfig = new TaskConfig(taskProps);
+                final Class<? extends Task> taskClass = taskConfig.getClass(TaskConfig.TASK_CLASS_CONFIG).asSubclass(Task.class);
+                final Task task = plugins.newTask(taskClass);
+                log.info("Instantiated task {} with version {} of type {}", id, task.version(), taskClass.getName());
+
+                // By maintaining connector's specific class loader for this thread here, we first
+                // search for converters within the connector dependencies.
+                // If any of these aren't found, that means the connector didn't configure specific converters,
+                // so we should instantiate based upon the worker configuration
+                Converter keyConverter = plugins.newConverter(connConfig, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage
+                                                                                                                           .CURRENT_CLASSLOADER);
+                Converter valueConverter = plugins.newConverter(connConfig, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.CURRENT_CLASSLOADER);
+                HeaderConverter headerConverter = plugins.newHeaderConverter(connConfig, WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG,
+                                                                             ClassLoaderUsage.CURRENT_CLASSLOADER);
+                if (keyConverter == null) {
+                    keyConverter = plugins.newConverter(config, WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
+                    log.info("Set up the key converter {} for task {} using the worker config", keyConverter.getClass(), id);
+                } else {
+                    log.info("Set up the key converter {} for task {} using the connector config", keyConverter.getClass(), id);
+                }
+                if (valueConverter == null) {
+                    valueConverter = plugins.newConverter(config, WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, ClassLoaderUsage.PLUGINS);
+                    log.info("Set up the value converter {} for task {} using the worker config", valueConverter.getClass(), id);
+                } else {
+                    log.info("Set up the value converter {} for task {} using the connector config", valueConverter.getClass(), id);
+                }
+                if (headerConverter == null) {
+                    headerConverter = plugins.newHeaderConverter(config, WorkerConfig.HEADER_CONVERTER_CLASS_CONFIG, ClassLoaderUsage
+                                                                                                                             .PLUGINS);
+                    log.info("Set up the header converter {} for task {} using the worker config", headerConverter.getClass(), id);
+                } else {
+                    log.info("Set up the header converter {} for task {} using the connector config", headerConverter.getClass(), id);
+                }
+
+                workerTask = buildWorkerTask(configState, connConfig, id, task, statusListener, initialState, keyConverter, valueConverter,
+                                             headerConverter, connectorLoader);
+                workerTask.initialize(taskConfig);
+                Plugins.compareAndSwapLoaders(savedLoader);
+            } catch (Throwable t) {
+                log.error("Failed to start task {}", id, t);
+                // Can't be put in a finally block because it needs to be swapped before the call on
+                // statusListener
+                Plugins.compareAndSwapLoaders(savedLoader);
+                workerMetricsGroup.recordTaskFailure();
+                statusListener.onFailure(id, t);
+                return false;
             }
 
-            workerTask = buildWorkerTask(configState, connConfig, id, task, statusListener, initialState, keyConverter, valueConverter, headerConverter, connectorLoader);
-            workerTask.initialize(taskConfig);
-            Plugins.compareAndSwapLoaders(savedLoader);
-        } catch (Throwable t) {
-            log.error("Failed to start task {}", id, t);
-            // Can't be put in a finally block because it needs to be swapped before the call on
-            // statusListener
-            Plugins.compareAndSwapLoaders(savedLoader);
-            workerMetricsGroup.recordTaskFailure();
-            statusListener.onFailure(id, t);
-            return false;
-        } finally {
-            LoggingContext.clear();
+            WorkerTask existing = tasks.putIfAbsent(id, workerTask);
+            if (existing != null)
+                throw new ConnectException("Task already exists in this worker: " + id);
+
+            executor.submit(workerTask);
+            if (workerTask instanceof WorkerSourceTask) {
+                sourceTaskOffsetCommitter.schedule(id, (WorkerSourceTask) workerTask);
+            }
+            workerMetricsGroup.recordTaskSuccess();
+            return true;
         }
-
-        WorkerTask existing = tasks.putIfAbsent(id, workerTask);
-        if (existing != null)
-            throw new ConnectException("Task already exists in this worker: " + id);
-
-        executor.submit(workerTask);
-        if (workerTask instanceof WorkerSourceTask) {
-            sourceTaskOffsetCommitter.schedule(id, (WorkerSourceTask) workerTask);
-        }
-        workerMetricsGroup.recordTaskSuccess();
-        return true;
     }
 
     private WorkerTask buildWorkerTask(ClusterConfigState configState,
@@ -599,22 +593,24 @@ public class Worker {
     }
 
     private void stopTask(ConnectorTaskId taskId) {
-        WorkerTask task = tasks.get(taskId);
-        if (task == null) {
-            log.warn("Ignoring stop request for unowned task {}", taskId);
-            return;
-        }
+        try (LoggingContext loggingContext = LoggingContext.forTask(taskId)) {
+            WorkerTask task = tasks.get(taskId);
+            if (task == null) {
+                log.warn("Ignoring stop request for unowned task {}", taskId);
+                return;
+            }
 
-        log.info("Stopping task {}", task.id());
-        if (task instanceof WorkerSourceTask)
-            sourceTaskOffsetCommitter.remove(task.id());
+            log.info("Stopping task {}", task.id());
+            if (task instanceof WorkerSourceTask)
+                sourceTaskOffsetCommitter.remove(task.id());
 
-        ClassLoader savedLoader = plugins.currentThreadLoader();
-        try {
-            savedLoader = Plugins.compareAndSwapLoaders(task.loader());
-            task.stop();
-        } finally {
-            Plugins.compareAndSwapLoaders(savedLoader);
+            ClassLoader savedLoader = plugins.currentThreadLoader();
+            try {
+                savedLoader = Plugins.compareAndSwapLoaders(task.loader());
+                task.stop();
+            } finally {
+                Plugins.compareAndSwapLoaders(savedLoader);
+            }
         }
     }
 
@@ -627,15 +623,19 @@ public class Worker {
     }
 
     private void awaitStopTask(ConnectorTaskId taskId, long timeout) {
-        WorkerTask task = tasks.remove(taskId);
-        if (task == null) {
-            log.warn("Ignoring await stop request for non-present task {}", taskId);
-            return;
-        }
+        try (LoggingContext loggingContext = LoggingContext.forTask(taskId)) {
+            WorkerTask task = tasks.remove(taskId);
+            if (task == null) {
+                log.warn("Ignoring await stop request for non-present task {}", taskId);
+                return;
+            }
 
-        if (!task.awaitStop(timeout)) {
-            log.error("Graceful stop of task {} failed.", task.id());
-            task.cancel();
+            if (!task.awaitStop(timeout)) {
+                log.error("Graceful stop of task {} failed.", task.id());
+                task.cancel();
+            } else {
+                log.debug("Graceful stop of task {} succeeded.", task.id());
+            }
         }
     }
 

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -216,7 +216,7 @@ abstract class WorkerTask implements Runnable {
 
     @Override
     public void run() {
-        LoggingContext logCtx = LoggingContext.forTask(id());
+        LoggingContext.forTask(id());
         ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
         String savedName = Thread.currentThread().getName();
         try {
@@ -237,8 +237,11 @@ abstract class WorkerTask implements Runnable {
                 try {
                     releaseResources();
                 } finally {
-                    taskMetricsGroup.close();
-                    logCtx.close();
+                    try {
+                        taskMetricsGroup.close();
+                    } finally {
+                        LoggingContext.clear();
+                    }
                 }
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -216,6 +216,9 @@ abstract class WorkerTask implements Runnable {
 
     @Override
     public void run() {
+        // Clear all MDC parameters, in case this thread is being reused
+        LoggingContext.clear();
+
         try (LoggingContext loggingContext = LoggingContext.forTask(id())) {
             ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
             String savedName = Thread.currentThread().getName();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerTask.java
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.runtime.ConnectMetrics.MetricGroup;
 import org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator;
 import org.apache.kafka.connect.runtime.isolation.Plugins;
 import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.apache.kafka.connect.util.LoggingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -215,6 +216,7 @@ abstract class WorkerTask implements Runnable {
 
     @Override
     public void run() {
+        LoggingContext logCtx = LoggingContext.forTask(id());
         ClassLoader savedLoader = Plugins.compareAndSwapLoaders(loader);
         String savedName = Thread.currentThread().getName();
         try {
@@ -236,6 +238,7 @@ abstract class WorkerTask implements Runnable {
                     releaseResources();
                 } finally {
                     taskMetricsGroup.close();
+                    logCtx.close();
                 }
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/LoggingContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/LoggingContext.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * A utility for defining Mapped Diagnostic Context (MDC) for SLF4J logs.
  *
  * <p>Logging contexts may be nested. In this case, the nested context may override some or all of the parameters of the outer context.
- * In these cases, both contexts may be active but the nested context takes priority. It is presumed that the nexted context will be
+ * In these cases, both contexts may be active but the nested context takes priority. It is assumed that the nested context will be
  * stopped before the outer context.
  *
  */
@@ -37,9 +37,9 @@ public final class LoggingContext implements AutoCloseable {
     public static final class Parameters {
 
         /**
-         * The name of the Mapped Diagnostic Context (MDC) key that defines the type of <i>connector</i>.
+         * The name of the Mapped Diagnostic Context (MDC) key that defines shortened class name for the <i>connector</i>.
          */
-        public static final String CONNECTOR_TYPE = "connector.type";
+        public static final String CONNECTOR_CLASS = "connector.class.short";
 
         /**
          * The name of the Mapped Diagnostic Context (MDC) key that defines the name of a <i>connector</i>.
@@ -114,7 +114,7 @@ public final class LoggingContext implements AutoCloseable {
     }
 
     /**
-     * Modify the current {@link MDC} logging context to set the {@link Parameters#CONNECTOR_TYPE connector type} to a shortened name
+     * Modify the current {@link MDC} logging context to set the {@link Parameters#CONNECTOR_CLASS connector class} to a shortened name
      * for the supplied class and the {@link Parameters#CONNECTOR_NAME connector name} to the supplied name.
      *
      * @param connectorClassName the fully qualified or shortened connector class name; may be null
@@ -122,7 +122,7 @@ public final class LoggingContext implements AutoCloseable {
      */
     public static LoggingContext forConnector(String connectorClassName, String connectorName) {
         Map<String, String> context = new HashMap<>();
-        context.put(Parameters.CONNECTOR_TYPE, shortNameFor(connectorClassName));
+        context.put(Parameters.CONNECTOR_CLASS, shortNameFor(connectorClassName));
         context.put(Parameters.CONNECTOR_NAME, connectorName);
         context.put(Parameters.CONNECTOR_SCOPE, Scope.WORKER.value());
         return new LoggingContext(context).start();

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/LoggingContext.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/LoggingContext.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A utility for defining Mapped Diagnostic Context (MDC) for SLF4J logs.
+ *
+ * <p>Logging contexts may be nested. In this case, the nested context may override some or all of the parameters of the outer context.
+ * In these cases, both contexts may be active but the nested context takes priority. It is presumed that the nexted context will be
+ * stopped before the outer context.
+ *
+ */
+public final class LoggingContext implements AutoCloseable {
+
+    /**
+     * The parameter keys used by Connect.
+     */
+    public static final class Parameters {
+
+        /**
+         * The name of the Mapped Diagnostic Context (MDC) key that defines the type of <i>connector</i>.
+         */
+        public static final String CONNECTOR_TYPE = "connector.type";
+
+        /**
+         * The name of the Mapped Diagnostic Context (MDC) key that defines the name of a <i>connector</i>.
+         */
+        public static final String CONNECTOR_NAME = "connector.name";
+
+        /**
+         * The name of the Mapped Diagnostic Context (MDC) key that defines the task number of a <i>connector</i>.
+         */
+        public static final String CONNECTOR_TASK = "connector.task";
+
+        /**
+         * The name of the Mapped Diagnostic Context (MDC) key that defines a <i>scope</i> within a connector.
+         */
+        public static final String CONNECTOR_SCOPE = "connector.scope";
+    }
+
+    /**
+     * The {@link Parameters#CONNECTOR_SCOPE scope} values used by Connect.
+     */
+    public enum Scope {
+        /**
+         * The {@link Parameters#CONNECTOR_SCOPE scope} value for the worker as it starts a connector.
+         */
+        WORKER("worker"),
+
+        /**
+         * The {@link Parameters#CONNECTOR_SCOPE scope} value for {@link org.apache.kafka.connect.connector.Task}
+         * implementations.
+         */
+        TASK("task"),
+
+        /**
+         * The {@link Parameters#CONNECTOR_SCOPE scope} value for committing offsets.
+         */
+        OFFSETS("offsets");
+
+        private final String value;
+        Scope(String value) {
+            this.value = value;
+        }
+        public String value() {
+            return this.value;
+        }
+    }
+
+    /**
+     * Modify the current {@link MDC} logging context to set the {@link Parameters#CONNECTOR_SCOPE scope} to the specified value.
+     *
+     * @param scope the scope; may be null
+     * @return the resulting LoggingContext that is already {@link LoggingContext#start() started}; never null
+     */
+    public static LoggingContext forScope(Scope scope) {
+        Map<String, String> context = new HashMap<>();
+        context.put(Parameters.CONNECTOR_SCOPE, scope.value());
+        return new LoggingContext(context).start();
+    }
+
+    /**
+     * Modify the current {@link MDC} logging context to set the {@link Parameters#CONNECTOR_NAME connector name} and
+     * {@link Parameters#CONNECTOR_TASK task number} to the same values in the supplied {@link ConnectorTaskId}.
+     *
+     * @param id the connector task ID; may be null
+     * @return the resulting LoggingContext that is already {@link LoggingContext#start() started}; never null
+     */
+    public static LoggingContext forTask(ConnectorTaskId id) {
+        Map<String, String> context = new HashMap<>();
+        context.put(Parameters.CONNECTOR_NAME, id.connector());
+        context.put(Parameters.CONNECTOR_TASK, Integer.toString(id.task()));
+        context.put(Parameters.CONNECTOR_SCOPE, Scope.TASK.value());
+        return new LoggingContext(context).start();
+    }
+
+    /**
+     * Modify the current {@link MDC} logging context to set the {@link Parameters#CONNECTOR_TYPE connector type} to a shortened name
+     * for the supplied class and the {@link Parameters#CONNECTOR_NAME connector name} to the supplied name.
+     *
+     * @param connectorClassName the fully qualified or shortened connector class name; may be null
+     * @return the resulting LoggingContext that is already {@link LoggingContext#start() started}; never null
+     */
+    public static LoggingContext forConnector(String connectorClassName, String connectorName) {
+        Map<String, String> context = new HashMap<>();
+        context.put(Parameters.CONNECTOR_TYPE, shortNameFor(connectorClassName));
+        context.put(Parameters.CONNECTOR_NAME, connectorName);
+        context.put(Parameters.CONNECTOR_SCOPE, Scope.WORKER.value());
+        return new LoggingContext(context).start();
+    }
+
+    /**
+     * Modify the current {@link MDC} logging context to set the  {@link Parameters#CONNECTOR_NAME connector name},
+     * {@link Parameters#CONNECTOR_TASK task number} and to the same values in the supplied {@link ConnectorTaskId}, and to set
+     * the scope to {@link Scope#OFFSETS}.
+     *
+     * @param id the connector task ID; may be null
+     * @return the resulting LoggingContext that is already {@link LoggingContext#start() started}; never null
+     */
+    public static LoggingContext forOffsets(ConnectorTaskId id) {
+        Map<String, String> context = new HashMap<>();
+        context.put(Parameters.CONNECTOR_NAME, id.connector());
+        context.put(Parameters.CONNECTOR_TASK, Integer.toString(id.task()));
+        context.put(Parameters.CONNECTOR_SCOPE, Scope.OFFSETS.value());
+        return new LoggingContext(context).start();
+    }
+
+    protected static String shortNameFor(String className) {
+        return className.replaceAll("^(.*)[.]", "") // greedy wildcard
+                        .replaceAll("^(.*)[$]", "") // greedy wildcard
+                        .replaceAll("Connector", "")
+                        .replaceAll("Task", "");
+    }
+
+    private static final String NULL_VALUE = null;
+
+    final Map<String, String> previous = new HashMap<>();
+    final Map<String, String> context;
+    private boolean active = false;
+
+    protected LoggingContext(Map<String, String> context) {
+        this.context = context;
+    }
+
+    /**
+     * Change the {@link MDC} to use this context's parameters.
+     *
+     * <p>This method has no effect when this context is already active.
+     *
+     * @return this instance, for chaining purposes; never null
+     */
+    public LoggingContext start() {
+        if (!active) {
+            previous.clear();
+            for (Map.Entry<String, String> entry : context.entrySet()) {
+                previous.put(entry.getKey(), MDC.get(entry.getKey()));
+                if (entry.getValue() != NULL_VALUE && entry.getValue() != null) {
+                    MDC.put(entry.getKey(), entry.getValue());
+                } else {
+                    MDC.remove(entry.getKey());
+                }
+            }
+            active = true;
+        }
+        return this;
+    }
+
+    /**
+     * Change the {@link MDC} to no longer use the parameters of this context, restoring any values for the parameters that existed
+     * when {@link #start()} was called. This method does not affect other parameters not defined on this context.
+     *
+     * <p>This method has no effect when this context is not active.
+     *
+     * @return this instance, for chaining purposes; never null
+     */
+    public LoggingContext stop() {
+        if (active) {
+            for (Map.Entry<String, String> entry : previous.entrySet()) {
+                if (entry.getValue() != NULL_VALUE && entry.getValue() != null) {
+                    MDC.put(entry.getKey(), entry.getValue());
+                } else {
+                    MDC.remove(entry.getKey());
+                }
+            }
+            active = false;
+        }
+        return this;
+    }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
+    @Override
+    public String toString() {
+        return "LoggingContext:" + context;
+    }
+
+    /**
+     * Return whether this context still active. Note that even if this is active other "nested" contexts may have been started since
+     * this was started and may take priority (e.g., they may have overwritten some or all of the parameters of this context),
+     * but once they are stopped this context will still be active.
+     *
+     * @return true if active, or false otherwise
+     */
+    protected boolean isActive() {
+        return active;
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/runtime/SourceTaskOffsetCommitterTest.java
@@ -147,6 +147,8 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
         EasyMock.expect(taskFuture.cancel(eq(false))).andReturn(false);
         EasyMock.expect(taskFuture.isDone()).andReturn(false);
         EasyMock.expect(taskFuture.get()).andReturn(null);
+        EasyMock.expect(taskId.connector()).andReturn("MyConnector");
+        EasyMock.expect(taskId.task()).andReturn(1);
         PowerMock.replayAll();
 
         committers.put(taskId, taskFuture);
@@ -160,6 +162,8 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
         EasyMock.expect(taskFuture.cancel(eq(false))).andReturn(false);
         EasyMock.expect(taskFuture.isDone()).andReturn(false);
         EasyMock.expect(taskFuture.get()).andThrow(new CancellationException());
+        EasyMock.expect(taskId.connector()).andReturn("MyConnector");
+        EasyMock.expect(taskId.task()).andReturn(1);
         mockLog.trace(EasyMock.anyString(), EasyMock.<Object>anyObject());
         PowerMock.expectLastCall();
         PowerMock.replayAll();
@@ -175,6 +179,8 @@ public class SourceTaskOffsetCommitterTest extends ThreadedTest {
         EasyMock.expect(taskFuture.cancel(eq(false))).andReturn(false);
         EasyMock.expect(taskFuture.isDone()).andReturn(false);
         EasyMock.expect(taskFuture.get()).andThrow(new InterruptedException());
+        EasyMock.expect(taskId.connector()).andReturn("MyConnector");
+        EasyMock.expect(taskId.task()).andReturn(1);
         PowerMock.replayAll();
 
         try {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -78,42 +78,42 @@ public class LoggingContextTest {
     @Test
     public void shouldCreateConnectorLoggingContext() {
         assertMdcExtrasUntouched();
-        assertMdc(null, null, null, null);
+        assertMdc(null, null, null);
 
         LoggingContext.forConnector(CONNECTOR_NAME);
-        assertMdc("MockSink", CONNECTOR_NAME, null, Scope.WORKER);
+        assertMdc(CONNECTOR_NAME, null, Scope.WORKER);
         log.info("Starting Connector");
 
         LoggingContext.clear();
         assertMdcExtrasUntouched();
-        assertMdc(null, null, null, null);
+        assertMdc(null, null, null);
     }
 
     @Test
     public void shouldCreateTaskLoggingContext() {
         assertMdcExtrasUntouched();
         LoggingContext.forTask(TASK_ID1);
-        assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
+        assertMdc(TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
         log.info("Running task");
 
         LoggingContext.clear();
         assertMdcExtrasUntouched();
-        assertMdc(null, null, null, null);
+        assertMdc(null, null, null);
     }
 
     @Test
     public void shouldCreateOffsetsLoggingContext() {
         assertMdcExtrasUntouched();
         LoggingContext.forOffsets(TASK_ID1);
-        assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.OFFSETS);
+        assertMdc(TASK_ID1.connector(), TASK_ID1.task(), Scope.OFFSETS);
         log.info("Running task");
 
         LoggingContext.clear();
         assertMdcExtrasUntouched();
-        assertMdc(null, null, null, null);
+        assertMdc(null, null, null);
     }
 
-    protected void assertMdc(String connectorShortClassName, String connectorName, Integer taskId, Scope scope) {
+    protected void assertMdc(String connectorName, Integer taskId, Scope scope) {
         assertEquals(connectorName, MDC.get(Parameters.CONNECTOR_NAME));
         assertEquals(taskId == null ? null : Integer.toString(taskId), MDC.get(Parameters.CONNECTOR_TASK));
         assertEquals(scope == null ? null : scope.value(), MDC.get(Parameters.CONNECTOR_SCOPE));

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.util;
 
-import org.apache.kafka.connect.tools.MockSinkConnector;
 import org.apache.kafka.connect.util.LoggingContext.Parameters;
 import org.apache.kafka.connect.util.LoggingContext.Scope;
 import org.junit.After;
@@ -30,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class LoggingContextTest {
 
@@ -38,7 +36,6 @@ public class LoggingContextTest {
 
     private static final String CONNECTOR_NAME = "MyConnector";
     private static final ConnectorTaskId TASK_ID1 = new ConnectorTaskId(CONNECTOR_NAME, 1);
-    private static final ConnectorTaskId TASK_ID2 = new ConnectorTaskId(CONNECTOR_NAME, 2);
     private static final String EXTRA_KEY1 = "extra.key.1";
     private static final String EXTRA_VALUE1 = "value1";
     private static final String EXTRA_KEY2 = "extra.key.2";
@@ -63,93 +60,60 @@ public class LoggingContextTest {
         MDC.setContextMap(mdc);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullConnectorNameForConnectorContext() {
+        LoggingContext.forConnector(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullTaskIdForTaskContext() {
+        LoggingContext.forTask(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldNotAllowNullTaskIdForOffsetContext() {
+        LoggingContext.forOffsets(null);
+    }
+
     @Test
-    public void shouldCreateConnectorContext() {
+    public void shouldCreateConnectorLoggingContext() {
         assertMdcExtrasUntouched();
         assertMdc(null, null, null, null);
 
-        try (LoggingContext ctx1 = LoggingContext.forConnector(MockSinkConnector.class.getName(), CONNECTOR_NAME)) {
-            assertActive(ctx1);
-            assertConnectorShortClassName(ctx1, "MockSink");
-            assertConnectorName(ctx1, CONNECTOR_NAME);
-            assertTaskId(ctx1, null);
-            assertScope(ctx1, Scope.WORKER);
-            assertMdc("MockSink", CONNECTOR_NAME, null, Scope.WORKER);
-            log.info("Starting Connector");
+        LoggingContext.forConnector(CONNECTOR_NAME);
+        assertMdc("MockSink", CONNECTOR_NAME, null, Scope.WORKER);
+        log.info("Starting Connector");
 
-            try (LoggingContext ctx2 = LoggingContext.forTask(TASK_ID1)) {
-                assertActive(ctx1);
-                assertActive(ctx2);
-                assertConnectorShortClassName(ctx2, null);
-                assertConnectorName(ctx2, TASK_ID1.connector());
-                assertTaskId(ctx2, TASK_ID1.task());
-                assertScope(ctx2, Scope.TASK);
-                assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
-                log.info("Running task");
-
-                try (LoggingContext ctx3 = LoggingContext.forScope(Scope.OFFSETS)) {
-                    assertActive(ctx1);
-                    assertActive(ctx2);
-                    assertActive(ctx3);
-                    assertConnectorShortClassName(ctx3, null);
-                    assertConnectorName(ctx3, null);
-                    assertTaskId(ctx3, null);
-                    assertScope(ctx3, Scope.OFFSETS);
-                    assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.OFFSETS);
-                    log.info("Processing offsets");
-                }
-
-                assertActive(ctx1);
-                assertActive(ctx2);
-                assertConnectorShortClassName(ctx2, null);
-                assertConnectorName(ctx2, TASK_ID1.connector());
-                assertTaskId(ctx2, TASK_ID1.task());
-                assertScope(ctx2, Scope.TASK);
-                assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
-            }
-            assertActive(ctx1);
-            assertConnectorShortClassName(ctx1, "MockSink");
-            assertConnectorName(ctx1, CONNECTOR_NAME);
-            assertTaskId(ctx1, null);
-            assertScope(ctx1, Scope.WORKER);
-            assertMdc("MockSink", CONNECTOR_NAME, null, Scope.WORKER);
-        }
-
+        LoggingContext.clear();
         assertMdcExtrasUntouched();
         assertMdc(null, null, null, null);
     }
 
     @Test
-    public void shouldComputeShortName() {
-        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.MySinkConnector"));
-        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.MySinkConnectorTask"));
-        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.MySinkTask"));
-        assertEquals("MySink", LoggingContext.shortNameFor("MySinkConnector"));
-        assertEquals("MySink", LoggingContext.shortNameFor("MySinkConnectorTask"));
-        assertEquals("MySink", LoggingContext.shortNameFor("MySinkTask"));
-        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkConnector"));
-        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkConnectorTask"));
-        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkTask"));
+    public void shouldCreateTaskLoggingContext() {
+        assertMdcExtrasUntouched();
+        LoggingContext.forTask(TASK_ID1);
+        assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
+        log.info("Running task");
+
+        LoggingContext.clear();
+        assertMdcExtrasUntouched();
+        assertMdc(null, null, null, null);
     }
 
-    protected void assertConnectorShortClassName(LoggingContext logContext, String expectedShortClassName) {
-        assertEquals(expectedShortClassName, logContext.context.get(Parameters.CONNECTOR_CLASS));
-    }
+    @Test
+    public void shouldCreateOffsetsLoggingContext() {
+        assertMdcExtrasUntouched();
+        LoggingContext.forOffsets(TASK_ID1);
+        assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.OFFSETS);
+        log.info("Running task");
 
-    protected void assertConnectorName(LoggingContext logContext, String expected) {
-        assertEquals(expected, logContext.context.get(Parameters.CONNECTOR_NAME));
-    }
-
-    protected void assertTaskId(LoggingContext logContext, Integer expected) {
-        assertEquals(expected == null ? null : Integer.toString(expected), logContext.context.get(Parameters.CONNECTOR_TASK));
-    }
-
-    protected void assertScope(LoggingContext context, Scope expected) {
-        assertEquals(expected == null ? null : expected.value(), context.context.get(Parameters.CONNECTOR_SCOPE));
+        LoggingContext.clear();
+        assertMdcExtrasUntouched();
+        assertMdc(null, null, null, null);
     }
 
     protected void assertMdc(String connectorShortClassName, String connectorName, Integer taskId, Scope scope) {
-        assertEquals(connectorShortClassName, MDC.get(Parameters.CONNECTOR_CLASS));
         assertEquals(connectorName, MDC.get(Parameters.CONNECTOR_NAME));
         assertEquals(taskId == null ? null : Integer.toString(taskId), MDC.get(Parameters.CONNECTOR_TASK));
         assertEquals(scope == null ? null : scope.value(), MDC.get(Parameters.CONNECTOR_SCOPE));
@@ -158,9 +122,5 @@ public class LoggingContextTest {
     protected void assertMdcExtrasUntouched() {
         assertEquals(EXTRA_VALUE1, MDC.get(EXTRA_KEY1));
         assertEquals(EXTRA_VALUE2, MDC.get(EXTRA_KEY2));
-    }
-
-    protected void assertActive(LoggingContext context) {
-        assertTrue(context.isActive());
     }
 }

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.kafka.connect.util;
 
-import org.apache.kafka.connect.util.LoggingContext.Parameters;
 import org.apache.kafka.connect.util.LoggingContext.Scope;
 import org.junit.After;
 import org.junit.Before;
@@ -29,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class LoggingContextTest {
 
@@ -153,9 +153,25 @@ public class LoggingContextTest {
     }
 
     protected void assertMdc(String connectorName, Integer taskId, Scope scope) {
-        assertEquals(connectorName, MDC.get(Parameters.CONNECTOR_NAME));
-        assertEquals(taskId == null ? null : Integer.toString(taskId), MDC.get(Parameters.CONNECTOR_TASK));
-        assertEquals(scope == null ? null : scope.toString(), MDC.get(Parameters.CONNECTOR_SCOPE));
+        String context = MDC.get(LoggingContext.CONNECTOR_CONTEXT);
+        if (context != null) {
+            assertEquals(
+                connectorName != null,
+                connectorName != null ? context.startsWith("[" + connectorName) : false
+            );
+            assertEquals(
+                scope != null,
+                scope != null ? context.contains(scope.toString()) : false
+            );
+            assertEquals(
+                taskId != null,
+                taskId != null ? context.contains(taskId.toString()) : false
+            );
+        } else {
+            assertNull("No logging context found, but expected it includes name of connector", connectorName);
+            assertNull("No logging context found, but expected it includes task ID", taskId);
+            assertNull("No logging context found, but expected it includes scope", scope);
+        }
     }
 
     protected void assertMdcExtrasUntouched() {

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class LoggingContextTest {
 
@@ -174,21 +175,20 @@ public class LoggingContextTest {
         String context = MDC.get(LoggingContext.CONNECTOR_CONTEXT);
         if (context != null) {
             assertEquals(
+                "Context should begin with connector name when the connector name is non-null",
                 connectorName != null,
-                connectorName != null ? context.startsWith("[" + connectorName) : false
+                context.startsWith("[" + connectorName)
             );
-            assertEquals(
-                scope != null,
-                scope != null ? context.contains(scope.toString()) : false
-            );
-            assertEquals(
-                taskId != null,
-                taskId != null ? context.contains(taskId.toString()) : false
-            );
+            if (scope != null) {
+                assertTrue("Context should contain the scope", context.contains(scope.toString()));
+            }
+            if (taskId != null) {
+                assertTrue("Context should contain the taskId", context.contains(taskId.toString()));
+            }
         } else {
-            assertNull("No logging context found, but expected it includes name of connector", connectorName);
-            assertNull("No logging context found, but expected it includes task ID", taskId);
-            assertNull("No logging context found, but expected it includes scope", scope);
+            assertNull("No logging context found, expected null connector name", connectorName);
+            assertNull("No logging context found, expected null task ID", taskId);
+            assertNull("No logging context found, expected null scope", scope);
         }
     }
 

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.connect.util;
+
+import org.apache.kafka.connect.tools.MockSinkConnector;
+import org.apache.kafka.connect.util.LoggingContext.Parameters;
+import org.apache.kafka.connect.util.LoggingContext.Scope;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LoggingContextTest {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingContextTest.class);
+
+    private static final String CONNECTOR_NAME = "MyConnector";
+    private static final ConnectorTaskId TASK_ID1 = new ConnectorTaskId(CONNECTOR_NAME, 1);
+    private static final ConnectorTaskId TASK_ID2 = new ConnectorTaskId(CONNECTOR_NAME, 2);
+    private static final String EXTRA_KEY1 = "extra.key.1";
+    private static final String EXTRA_VALUE1 = "value1";
+    private static final String EXTRA_KEY2 = "extra.key.2";
+    private static final String EXTRA_VALUE2 = "value2";
+
+    private Map<String, String> mdc;
+
+    @Before
+    public void setup() {
+        mdc = new HashMap<>();
+        Map<String, String> existing = MDC.getCopyOfContextMap();
+        if (existing != null) {
+            mdc.putAll(existing);
+        }
+        MDC.put(EXTRA_KEY1, EXTRA_VALUE1);
+        MDC.put(EXTRA_KEY2, EXTRA_VALUE2);
+    }
+
+    @After
+    public void tearDown() {
+        MDC.clear();
+        MDC.setContextMap(mdc);
+    }
+
+    @Test
+    public void shouldCreateConnectorContext() {
+        assertMdcExtrasUntouched();
+        assertMdc(null, null, null, null);
+
+        try (LoggingContext ctx1 = LoggingContext.forConnector(MockSinkConnector.class.getName(), CONNECTOR_NAME)) {
+            assertActive(ctx1);
+            assertConnectorType(ctx1, "MockSink");
+            assertConnectorName(ctx1, CONNECTOR_NAME);
+            assertTaskId(ctx1, null);
+            assertScope(ctx1, Scope.WORKER);
+            assertMdc("MockSink", CONNECTOR_NAME, null, Scope.WORKER);
+            log.info("Starting Connector");
+
+            try (LoggingContext ctx2 = LoggingContext.forTask(TASK_ID1)) {
+                assertActive(ctx1);
+                assertActive(ctx2);
+                assertConnectorType(ctx2, null);
+                assertConnectorName(ctx2, TASK_ID1.connector());
+                assertTaskId(ctx2, TASK_ID1.task());
+                assertScope(ctx2, Scope.TASK);
+                assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
+                log.info("Running task");
+
+                try (LoggingContext ctx3 = LoggingContext.forScope(Scope.OFFSETS)) {
+                    assertActive(ctx1);
+                    assertActive(ctx2);
+                    assertActive(ctx3);
+                    assertConnectorType(ctx3, null);
+                    assertConnectorName(ctx3, null);
+                    assertTaskId(ctx3, null);
+                    assertScope(ctx3, Scope.OFFSETS);
+                    assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.OFFSETS);
+                    log.info("Processing offsets");
+                }
+
+                assertActive(ctx1);
+                assertActive(ctx2);
+                assertConnectorType(ctx2, null);
+                assertConnectorName(ctx2, TASK_ID1.connector());
+                assertTaskId(ctx2, TASK_ID1.task());
+                assertScope(ctx2, Scope.TASK);
+                assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
+            }
+            assertActive(ctx1);
+            assertConnectorType(ctx1, "MockSink");
+            assertConnectorName(ctx1, CONNECTOR_NAME);
+            assertTaskId(ctx1, null);
+            assertScope(ctx1, Scope.WORKER);
+            assertMdc("MockSink", CONNECTOR_NAME, null, Scope.WORKER);
+        }
+
+        assertMdcExtrasUntouched();
+        assertMdc(null, null, null, null);
+    }
+
+    @Test
+    public void shouldComputeShortName() {
+        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.MySinkConnector"));
+        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.MySinkConnectorTask"));
+        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.MySinkTask"));
+        assertEquals("MySink", LoggingContext.shortNameFor("MySinkConnector"));
+        assertEquals("MySink", LoggingContext.shortNameFor("MySinkConnectorTask"));
+        assertEquals("MySink", LoggingContext.shortNameFor("MySinkTask"));
+        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkConnector"));
+        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkConnectorTask"));
+        assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkTask"));
+    }
+
+    protected void assertConnectorType(LoggingContext logContext, String expectedType) {
+        assertEquals(expectedType, logContext.context.get(Parameters.CONNECTOR_TYPE));
+    }
+
+    protected void assertConnectorName(LoggingContext logContext, String expected) {
+        assertEquals(expected, logContext.context.get(Parameters.CONNECTOR_NAME));
+    }
+
+    protected void assertTaskId(LoggingContext logContext, Integer expected) {
+        assertEquals(expected == null ? null : Integer.toString(expected), logContext.context.get(Parameters.CONNECTOR_TASK));
+    }
+
+    protected void assertScope(LoggingContext context, Scope expected) {
+        assertEquals(expected == null ? null : expected.value(), context.context.get(Parameters.CONNECTOR_SCOPE));
+    }
+
+    protected void assertMdc(String connectorType, String connectorName, Integer taskId, Scope scope) {
+        assertEquals(connectorType, MDC.get(Parameters.CONNECTOR_TYPE));
+        assertEquals(connectorName, MDC.get(Parameters.CONNECTOR_NAME));
+        assertEquals(taskId == null ? null : Integer.toString(taskId), MDC.get(Parameters.CONNECTOR_TASK));
+        assertEquals(scope == null ? null : scope.value(), MDC.get(Parameters.CONNECTOR_SCOPE));
+    }
+
+    protected void assertMdcExtrasUntouched() {
+        assertEquals(EXTRA_VALUE1, MDC.get(EXTRA_KEY1));
+        assertEquals(EXTRA_VALUE2, MDC.get(EXTRA_KEY2));
+    }
+
+    protected void assertActive(LoggingContext context) {
+        assertTrue(context.isActive());
+    }
+}

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/LoggingContextTest.java
@@ -70,7 +70,7 @@ public class LoggingContextTest {
 
         try (LoggingContext ctx1 = LoggingContext.forConnector(MockSinkConnector.class.getName(), CONNECTOR_NAME)) {
             assertActive(ctx1);
-            assertConnectorType(ctx1, "MockSink");
+            assertConnectorShortClassName(ctx1, "MockSink");
             assertConnectorName(ctx1, CONNECTOR_NAME);
             assertTaskId(ctx1, null);
             assertScope(ctx1, Scope.WORKER);
@@ -80,7 +80,7 @@ public class LoggingContextTest {
             try (LoggingContext ctx2 = LoggingContext.forTask(TASK_ID1)) {
                 assertActive(ctx1);
                 assertActive(ctx2);
-                assertConnectorType(ctx2, null);
+                assertConnectorShortClassName(ctx2, null);
                 assertConnectorName(ctx2, TASK_ID1.connector());
                 assertTaskId(ctx2, TASK_ID1.task());
                 assertScope(ctx2, Scope.TASK);
@@ -91,7 +91,7 @@ public class LoggingContextTest {
                     assertActive(ctx1);
                     assertActive(ctx2);
                     assertActive(ctx3);
-                    assertConnectorType(ctx3, null);
+                    assertConnectorShortClassName(ctx3, null);
                     assertConnectorName(ctx3, null);
                     assertTaskId(ctx3, null);
                     assertScope(ctx3, Scope.OFFSETS);
@@ -101,14 +101,14 @@ public class LoggingContextTest {
 
                 assertActive(ctx1);
                 assertActive(ctx2);
-                assertConnectorType(ctx2, null);
+                assertConnectorShortClassName(ctx2, null);
                 assertConnectorName(ctx2, TASK_ID1.connector());
                 assertTaskId(ctx2, TASK_ID1.task());
                 assertScope(ctx2, Scope.TASK);
                 assertMdc("MockSink", TASK_ID1.connector(), TASK_ID1.task(), Scope.TASK);
             }
             assertActive(ctx1);
-            assertConnectorType(ctx1, "MockSink");
+            assertConnectorShortClassName(ctx1, "MockSink");
             assertConnectorName(ctx1, CONNECTOR_NAME);
             assertTaskId(ctx1, null);
             assertScope(ctx1, Scope.WORKER);
@@ -132,8 +132,8 @@ public class LoggingContextTest {
         assertEquals("MySink", LoggingContext.shortNameFor("org.apache.something.Other$MySinkTask"));
     }
 
-    protected void assertConnectorType(LoggingContext logContext, String expectedType) {
-        assertEquals(expectedType, logContext.context.get(Parameters.CONNECTOR_TYPE));
+    protected void assertConnectorShortClassName(LoggingContext logContext, String expectedShortClassName) {
+        assertEquals(expectedShortClassName, logContext.context.get(Parameters.CONNECTOR_CLASS));
     }
 
     protected void assertConnectorName(LoggingContext logContext, String expected) {
@@ -148,8 +148,8 @@ public class LoggingContextTest {
         assertEquals(expected == null ? null : expected.value(), context.context.get(Parameters.CONNECTOR_SCOPE));
     }
 
-    protected void assertMdc(String connectorType, String connectorName, Integer taskId, Scope scope) {
-        assertEquals(connectorType, MDC.get(Parameters.CONNECTOR_TYPE));
+    protected void assertMdc(String connectorShortClassName, String connectorName, Integer taskId, Scope scope) {
+        assertEquals(connectorShortClassName, MDC.get(Parameters.CONNECTOR_CLASS));
         assertEquals(connectorName, MDC.get(Parameters.CONNECTOR_NAME));
         assertEquals(taskId == null ? null : Integer.toString(taskId), MDC.get(Parameters.CONNECTOR_TASK));
         assertEquals(scope == null ? null : scope.value(), MDC.get(Parameters.CONNECTOR_SCOPE));

--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -18,7 +18,22 @@ log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] (%t) %p %m (%c:%L)%n
+#
+# The layout of each log message can be modified to include the Mapped Diagnostic Context parameters used by Connect,
+# which will include connector-specific and task-specific information on each log message and making it easier to identify
+# which log messages belong to which connector and tasks.
+#
+# The following parameters specified in the layout will be replaced with the corresponding values in every log message:
+#
+# Use %X{connector.type} for a shortened form of the type of connector (e.g., connector's class name)
+# Use %X{connector.name} for the name of the connector
+# Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
+# Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task
+#
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.name}|%X{connector.scope}%X{connector.task} %m (%c:%L)%n (%t)
+#
+# The following line includes no MDC context parameters:
+#log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n (%t)
 
 log4j.logger.org.reflections=ERROR
 log4j.logger.kafka=WARN

--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -19,17 +19,11 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 #
-# The layout of each log message can be modified to include the Mapped Diagnostic Context parameters used by Connect,
-# which will include connector-specific and task-specific information on each log message and making it easier to identify
-# which log messages belong to which connector and tasks.
+# The `%X{connector.context}` parameter in the layout includes connector-specific and task-specific information
+# in the log message, where appropriate. This makes it easier to identify those log messages that apply to a
+# specific connector. Simply add this parameter to the log layout configuration below to include the contextual information.
 #
-# The following parameters specified in the layout will be replaced with the corresponding values in every log message:
-#
-# Use %X{connector.name} for the name of the connector
-# Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
-# Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task
-#
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.name}|%X{connector.scope}%X{connector.task} %m (%c:%L)%n (%t)
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %X{connector.context}%m (%c:%L)%n
 #
 # The following line includes no MDC context parameters:
 #log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n (%t)

--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -25,7 +25,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 #
 # The following parameters specified in the layout will be replaced with the corresponding values in every log message:
 #
-# Use %X{connector.type} for a shortened form of the type of connector (e.g., connector's class name)
+# Use %X{connector.class.short} for a shortened form of the connector's class name
 # Use %X{connector.name} for the name of the connector
 # Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
 # Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task

--- a/connect/runtime/src/test/resources/log4j.properties
+++ b/connect/runtime/src/test/resources/log4j.properties
@@ -25,7 +25,6 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 #
 # The following parameters specified in the layout will be replaced with the corresponding values in every log message:
 #
-# Use %X{connector.class.short} for a shortened form of the connector's class name
 # Use %X{connector.name} for the name of the connector
 # Use %X{connector.scope} for the scope within a connector (e.g., "worker", "task", or "offsets")
 # Use %X{connector.task} for the 1-based number of the task, or blank if not within a connector task


### PR DESCRIPTION
See https://cwiki.apache.org/confluence/display/KAFKA/KIP-449%3A+Add+connector+contexts+to+Connect+worker+logs

Added LoggingContext as a simple mechanism to set and unset Mapped Diagnostic Contexts (MDC) in the loggers to provide for each thread useful parameters that can be used within the logging configuration. MDC avoids having to modify lots of log statements, since the parameters are available to all log statements issued by the thread, no matter what class makes those calls.

The design intentionally minimizes the number of changes to any existing classes, and does not use Java 8 features so it can be easily backported if desired, although per this KIP it will be applied initially only in AK 2.3 and later and must be enabled via the Log4J configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
