### PR TITLE
MINOR: More docs on Connector#stop

### DIFF
--- a/connect/api/src/main/java/org/apache/kafka/connect/connector/Connector.java
+++ b/connect/api/src/main/java/org/apache/kafka/connect/connector/Connector.java
@@ -114,7 +114,9 @@ public abstract class Connector implements Versioned {
     public abstract List<Map<String, String>> taskConfigs(int maxTasks);
 
     /**
-     * Stop this connector.
+     * Stop this connector. This method is invoked from deleting or pausing connector. Also, default behavior of
+     * {@link #reconfigure(Map<String, String>)} also calls {@link #stop()}.
+     * 
      */
     public abstract void stop();
 


### PR DESCRIPTION
Connector#stop/Connector#start can be invoked by PAUSE/RESUME, but ConnectorTask#stop/ConnectorTask#start can't. We should doc that for Connector.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
