### PR TITLE
KAFKA-7477: Improve Streams close timeout semantics

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -831,6 +831,9 @@ public class KafkaStreams {
     public synchronized boolean close(final long timeout, final TimeUnit timeUnit) {
         long timeoutMs = timeUnit.toMillis(timeout);
 
+        log.debug("Stopping Streams client with timeoutMillis = {} ms. You are using deprecated method. " +
+            "Please, consider update your code.", timeoutMs);
+
         if (timeoutMs < 0) {
             timeoutMs = 0;
         } else if (timeoutMs == 0) {
@@ -840,14 +843,7 @@ public class KafkaStreams {
         return close(timeoutMs);
     }
 
-    /**
-     * @param timeoutMs  how long to wait for the threads to shutdown.
-     * @return {@code true} if all threads were successfully stopped&mdash;{@code false} if the timeout was reached
-     * before all threads stopped
-     */
-    private synchronized boolean close(final long timeoutMs) {
-        log.debug("Stopping Streams client with timeoutMillis = {} ms.", timeoutMs);
-
+    private boolean close(final long timeoutMs) {
         if (!setState(State.PENDING_SHUTDOWN)) {
             // if transition failed, it means it was either in PENDING_SHUTDOWN
             // or NOT_RUNNING already; just check that all threads have been stopped
@@ -927,8 +923,11 @@ public class KafkaStreams {
         ApiUtils.validateMillisecondDuration(timeout, "timeout");
 
         final long timeoutMs = timeout.toMillis();
-        if (timeoutMs < 0)
+        if (timeoutMs < 0) {
             throw new IllegalArgumentException("Timeout can't be negative.");
+        }
+
+        log.debug("Stopping Streams client with timeoutMillis = {} ms.", timeoutMs);
 
         return close(timeoutMs);
     }

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -126,7 +126,7 @@ import static org.apache.kafka.common.utils.Utils.getPort;
 public class KafkaStreams {
 
     private static final String JMX_PREFIX = "kafka.streams";
-    private static final int DEFAULT_CLOSE_TIMEOUT = 0;
+    private static final int DEFAULT_CLOSE_TIMEOUT = 30;
 
     // processId is expected to be unique across JVMs and to be used
     // in userData of the subscription request to allow assignor be aware

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -218,9 +218,10 @@ public class KafkaStreams {
         synchronized (stateLock) {
             long elapsedMs = 0L;
             while (state != targetState) {
-                if (newSemantics && waitMs == 0)
-                    return false;
-                else if (!newSemantics && waitMs == 0) {
+                if (waitMs == 0) {
+                    if (newSemantics)
+                        return false;
+
                     try {
                         stateLock.wait();
                     } catch (final InterruptedException e) {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -220,7 +220,7 @@ public class KafkaStreams {
             while (state != targetState) {
                 if (waitMs == 0) {
                     return false;
-                } else if (waitMs >= elapsedMs) {
+                } else if (waitMs > elapsedMs) {
                     final long remainingMs = waitMs - elapsedMs;
                     try {
                         stateLock.wait(remainingMs);

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -218,9 +218,7 @@ public class KafkaStreams {
         synchronized (stateLock) {
             long elapsedMs = 0L;
             while (state != targetState) {
-                if (waitMs == 0) {
-                    return false;
-                } else if (waitMs > elapsedMs) {
+                if (waitMs > elapsedMs) {
                     final long remainingMs = waitMs - elapsedMs;
                     try {
                         stateLock.wait(remainingMs);
@@ -825,7 +823,7 @@ public class KafkaStreams {
      * @return {@code true} if all threads were successfully stopped&mdash;{@code false} if the timeout was reached
      * before all threads stopped
      * Note that this method must not be called in the {@code onChange} callback of {@link StateListener}.
-     * @deprecated Use {@link #close(Duration)} instead
+     * @deprecated Use {@link #close(Duration)} instead; note, that {@link #close(Duration)} has different semantics and does not block on zero, e.g., `Duration.ofMillis(0)`.
      */
     @Deprecated
     public synchronized boolean close(final long timeout, final TimeUnit timeUnit) {

--- a/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
+++ b/streams/src/main/java/org/apache/kafka/streams/KafkaStreams.java
@@ -218,13 +218,15 @@ public class KafkaStreams {
         synchronized (stateLock) {
             long elapsedMs = 0L;
             while (state != targetState) {
-                if (!newSemantics && waitMs == 0) {
+                if (newSemantics && waitMs == 0)
+                    return false;
+                else if (!newSemantics && waitMs == 0) {
                     try {
                         stateLock.wait();
                     } catch (final InterruptedException e) {
                         // it is ok: just move on to the next iteration
                     }
-                } else if (waitMs >= elapsedMs) {
+                } else if (waitMs > elapsedMs) {
                     final long remainingMs = waitMs - elapsedMs;
                     try {
                         stateLock.wait(remainingMs);

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -548,6 +548,33 @@ public class KafkaStreamsTest {
         }
     }
 
+    @Test
+    public void shouldThrowOnNegativeTimeoutForClose() {
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+        try {
+            streams.close(Duration.ofMillis(-1L));
+            fail("should not accept negative close parameter");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        } finally {
+            streams.close();
+        }
+    }
+
+    @Test
+    public void shouldNotBlockInCloseForZeroDuration() throws InterruptedException {
+        final KafkaStreams streams = new KafkaStreams(builder.build(), props);
+        final Thread th = new Thread(() -> streams.close(Duration.ofMillis(0L)));
+
+        th.start();
+
+        try {
+            th.join(30_000L);
+        } finally {
+            streams.close();
+        }
+    }
+
     private void verifyCleanupStateDir(final String appDir, final File oldTaskDir) throws InterruptedException {
         final File taskDir = new File(appDir, "0_0");
         TestUtils.waitForCondition(

--- a/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/KafkaStreamsTest.java
@@ -570,6 +570,7 @@ public class KafkaStreamsTest {
 
         try {
             th.join(30_000L);
+            assertFalse(th.isAlive());
         } finally {
             streams.close();
         }


### PR DESCRIPTION
Second part of [KIP-358](https://cwiki.apache.org/confluence/display/KAFKA/KIP-358%3A+Migrate+Streams+API+to+Duration+instead+of+long+ms+times).

This changes based on [previous PR discussion](https://github.com/apache/kafka/pull/5682#discussion_r221473451).

Default `close` timeout is `30 seconds`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)