### PR TITLE
KAFKA-7484: fix suppression integration tests

### DIFF
--- a/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionDurabilityIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionDurabilityIntegrationTest.java
@@ -75,7 +75,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Category({IntegrationTest.class})
 public class SuppressionDurabilityIntegrationTest {
     @ClassRule
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(3);
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
+        3,
+        mkProperties(mkMap()),
+        0L
+    );
     private static final StringDeserializer STRING_DESERIALIZER = new StringDeserializer();
     private static final StringSerializer STRING_SERIALIZER = new StringSerializer();
     private static final Serde<String> STRING_SERDE = Serdes.String();

--- a/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/SuppressionIntegrationTest.java
@@ -75,7 +75,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Category({IntegrationTest.class})
 public class SuppressionIntegrationTest {
     @ClassRule
-    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(1);
+    public static final EmbeddedKafkaCluster CLUSTER = new EmbeddedKafkaCluster(
+        1,
+        mkProperties(mkMap()),
+        0L
+    );
     private static final StringDeserializer STRING_DESERIALIZER = new StringDeserializer();
     private static final StringSerializer STRING_SERIALIZER = new StringSerializer();
     private static final Serde<String> STRING_SERDE = Serdes.String();


### PR DESCRIPTION
The test data is based at time 0 (aka 1970), but the broker was started at time `now`.
This caused the log cleaner to delete the test data if the tests took slightly too long, despite its generous default configuration.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
