### PR TITLE
MINOR: Missing punctuation marks in quickstart

### DIFF
--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -56,8 +56,10 @@ final Serde&lt;Long&gt; longSerde = Serdes.Long();
 // Construct a `KStream` from the input topic "streams-plaintext-input", where message values
 // represent lines of text (for the sake of this example, we ignore whatever may be stored
 // in the message keys).
-KStream&lt;String, String&gt; textLines = builder.stream("streams-plaintext-input",
-    Consumed.with(stringSerde, stringSerde));
+KStream&lt;String, String&gt; textLines = builder.stream(
+      "streams-plaintext-input",
+      Consumed.with(stringSerde, stringSerde)
+    );
 
 KTable&lt;String, Long&gt; wordCounts = textLines
     // Split each text line, by whitespace, into words.

--- a/docs/streams/quickstart.html
+++ b/docs/streams/quickstart.html
@@ -57,7 +57,7 @@ final Serde&lt;Long&gt; longSerde = Serdes.Long();
 // represent lines of text (for the sake of this example, we ignore whatever may be stored
 // in the message keys).
 KStream&lt;String, String&gt; textLines = builder.stream("streams-plaintext-input",
-    Consumed.with(stringSerde, stringSerde);
+    Consumed.with(stringSerde, stringSerde));
 
 KTable&lt;String, Long&gt; wordCounts = textLines
     // Split each text line, by whitespace, into words.
@@ -67,7 +67,7 @@ KTable&lt;String, Long&gt; wordCounts = textLines
     .groupBy((key, value) -> value)
 
     // Count the occurrences of each word (message key).
-    .count()
+    .count();
 
 // Store the running counts as a changelog stream to the output topic.
 wordCounts.toStream().to("streams-wordcount-output", Produced.with(Serdes.String(), Serdes.Long()));


### PR DESCRIPTION
Minor fix for missing punctuation marks in the quickstart.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
