### PR TITLE
KAFKA-7487: DumpLogSegments misreports offset mismatches

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -396,7 +396,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
     if(compareIndexEntry(parseEntry(idx, 0), target, searchEntity) > 0)
       return (-1, 0)
 
-    return binarySearch(0, firstHotEntry)
+    binarySearch(0, firstHotEntry)
   }
 
   private def compareIndexEntry(indexEntry: IndexEntry, target: Long, searchEntity: IndexSearchEntity): Int = {

--- a/core/src/main/scala/kafka/log/OffsetIndex.scala
+++ b/core/src/main/scala/kafka/log/OffsetIndex.scala
@@ -67,7 +67,7 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
     inLock(lock) {
       _entries match {
         case 0 => OffsetPosition(baseOffset, 0)
-        case s => parseEntry(mmap, s - 1).asInstanceOf[OffsetPosition]
+        case s => parseEntry(mmap, s - 1)
       }
     }
   }
@@ -90,7 +90,7 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
       if(slot == -1)
         OffsetPosition(baseOffset, 0)
       else
-        parseEntry(idx, slot).asInstanceOf[OffsetPosition]
+        parseEntry(idx, slot)
     }
   }
 
@@ -106,7 +106,7 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
       if (slot == -1)
         None
       else
-        Some(parseEntry(idx, slot).asInstanceOf[OffsetPosition])
+        Some(parseEntry(idx, slot))
     }
   }
 
@@ -114,8 +114,8 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
 
   private def physical(buffer: ByteBuffer, n: Int): Int = buffer.getInt(n * entrySize + 4)
 
-  override def parseEntry(buffer: ByteBuffer, n: Int): IndexEntry = {
-      OffsetPosition(baseOffset + relativeOffset(buffer, n), physical(buffer, n))
+  override protected def parseEntry(buffer: ByteBuffer, n: Int): OffsetPosition = {
+    OffsetPosition(baseOffset + relativeOffset(buffer, n), physical(buffer, n))
   }
 
   /**
@@ -125,10 +125,9 @@ class OffsetIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writabl
    */
   def entry(n: Int): OffsetPosition = {
     maybeLock(lock) {
-      if(n >= _entries)
-        throw new IllegalArgumentException("Attempt to fetch the %dth entry from an index of size %d.".format(n, _entries))
-      val idx = mmap.duplicate
-      OffsetPosition(relativeOffset(idx, n), physical(idx, n))
+      if (n >= _entries)
+        throw new IllegalArgumentException(s"Attempt to fetch the ${n}th entry from an index of size ${_entries}.")
+      parseEntry(mmap, n)
     }
   }
 

--- a/core/src/main/scala/kafka/log/TimeIndex.scala
+++ b/core/src/main/scala/kafka/log/TimeIndex.scala
@@ -73,7 +73,7 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
     inLock(lock) {
       _entries match {
         case 0 => TimestampOffset(RecordBatch.NO_TIMESTAMP, baseOffset)
-        case s => parseEntry(mmap, s - 1).asInstanceOf[TimestampOffset]
+        case s => parseEntry(mmap, s - 1)
       }
     }
   }
@@ -87,12 +87,11 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
     maybeLock(lock) {
       if(n >= _entries)
         throw new IllegalArgumentException("Attempt to fetch the %dth entry from a time index of size %d.".format(n, _entries))
-      val idx = mmap.duplicate
-      TimestampOffset(timestamp(idx, n), relativeOffset(idx, n))
+      parseEntry(mmap, n)
     }
   }
 
-  override def parseEntry(buffer: ByteBuffer, n: Int): IndexEntry = {
+  override def parseEntry(buffer: ByteBuffer, n: Int): TimestampOffset = {
     TimestampOffset(timestamp(buffer, n), baseOffset + relativeOffset(buffer, n))
   }
 
@@ -150,10 +149,8 @@ class TimeIndex(_file: File, baseOffset: Long, maxIndexSize: Int = -1, writable:
       val slot = largestLowerBoundSlotFor(idx, targetTimestamp, IndexSearchType.KEY)
       if (slot == -1)
         TimestampOffset(RecordBatch.NO_TIMESTAMP, baseOffset)
-      else {
-        val entry = parseEntry(idx, slot).asInstanceOf[TimestampOffset]
-        TimestampOffset(entry.timestamp, entry.offset)
-      }
+      else
+        parseEntry(idx, slot)
     }
   }
 

--- a/core/src/main/scala/kafka/tools/DumpLogSegments.scala
+++ b/core/src/main/scala/kafka/tools/DumpLogSegments.scala
@@ -80,12 +80,10 @@ object DumpLogSegments {
 
     timeIndexDumpErrors.printErrors()
 
-    nonConsecutivePairsForLogFilesMap.foreach {
-      case (fileName, listOfNonConsecutivePairs) => {
-        System.err.println("Non-consecutive offsets in :" + fileName)
-        listOfNonConsecutivePairs.foreach(m => {
-          System.err.println("  %d is followed by %d".format(m._1, m._2))
-        })
+    nonConsecutivePairsForLogFilesMap.foreach { case (fileName, listOfNonConsecutivePairs) =>
+      System.err.println(s"Non-consecutive offsets in $fileName")
+      listOfNonConsecutivePairs.foreach { case (first, second) =>
+        System.err.println(s"  $first is followed by $second")
       }
     }
   }

--- a/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/OffsetIndexTest.scala
@@ -85,6 +85,19 @@ class OffsetIndexTest extends JUnitSuite {
     assertEquals(OffsetPosition(idx.baseOffset, 0), idx.lookup(idx.baseOffset))
     assertEquals(OffsetPosition(idx.baseOffset + idx.maxEntries, idx.maxEntries - 1), idx.lookup(idx.baseOffset + idx.maxEntries))
   }
+
+  @Test
+  def testEntry(): Unit = {
+    for (i <- 0 until idx.maxEntries)
+      idx.append(idx.baseOffset + i + 1, i)
+    for (i <- 0 until idx.maxEntries)
+      assertEquals(OffsetPosition(idx.baseOffset + i + 1, i), idx.entry(i))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testEntryOverflow(): Unit = {
+    idx.entry(0)
+  }
   
   @Test
   def appendTooMany() {

--- a/core/src/test/scala/unit/kafka/log/TimeIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/TimeIndexTest.scala
@@ -61,6 +61,20 @@ class TimeIndexTest extends JUnitSuite {
   }
 
   @Test
+  def testEntry(): Unit = {
+    appendEntries(maxEntries - 1)
+    assertEquals(TimestampOffset(10L, 55L), idx.entry(0))
+    assertEquals(TimestampOffset(20L, 65L), idx.entry(1))
+    assertEquals(TimestampOffset(30L, 75L), idx.entry(2))
+    assertEquals(TimestampOffset(40L, 85L), idx.entry(3))
+  }
+
+  @Test(expected = classOf[IllegalArgumentException])
+  def testEntryOverflow(): Unit = {
+    idx.entry(0)
+  }
+
+  @Test
   def testTruncate() {
     appendEntries(maxEntries - 1)
     idx.truncate()

--- a/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
+++ b/core/src/test/scala/unit/kafka/tools/DumpLogSegmentsTest.scala
@@ -17,35 +17,55 @@
 
 package kafka.tools
 
-import java.io.ByteArrayOutputStream
+import java.io.{ByteArrayOutputStream, File}
+import java.util.Properties
 
-import kafka.log.{ Log, LogConfig, LogManager }
-import kafka.server.{ BrokerTopicStats, LogDirFailureChannel }
-import kafka.utils.{ MockTime, TestUtils }
-import org.apache.kafka.common.record.{ CompressionType, MemoryRecords, SimpleRecord }
+import scala.collection.mutable
+import kafka.log.{Log, LogConfig, LogManager}
+import kafka.server.{BrokerTopicStats, LogDirFailureChannel}
+import kafka.tools.DumpLogSegments.TimeIndexDumpErrors
+import kafka.utils.{MockTime, TestUtils}
+import org.apache.kafka.common.record.{CompressionType, MemoryRecords, SimpleRecord}
 import org.apache.kafka.common.utils.Utils
 import org.junit.Assert._
-import org.junit.{ After, Before, Test }
+import org.junit.{After, Before, Test}
+
+import scala.collection.mutable.ArrayBuffer
 
 class DumpLogSegmentsTest {
 
   val tmpDir = TestUtils.tempDir()
   val logDir = TestUtils.randomPartitionLogDir(tmpDir)
-  val logFile = s"$logDir/00000000000000000000.log"
+  val segmentName = "00000000000000000000"
+  val logFilePath = s"$logDir/$segmentName.log"
+  val indexFilePath = s"$logDir/$segmentName.index"
+  val timeIndexFilePath = s"$logDir/$segmentName.timeindex"
   val time = new MockTime(0, 0)
+  val batches = new ArrayBuffer[Seq[SimpleRecord]]
 
   @Before
   def setUp(): Unit = {
-    val log = Log(logDir, LogConfig(), logStartOffset = 0L, recoveryPoint = 0L, scheduler = time.scheduler,
+    val props = new Properties
+    props.setProperty(LogConfig.IndexIntervalBytesProp, "128")
+    val log = Log(logDir, LogConfig(props), logStartOffset = 0L, recoveryPoint = 0L, scheduler = time.scheduler,
       time = time, brokerTopicStats = new BrokerTopicStats, maxProducerIdExpirationMs = 60 * 60 * 1000,
       producerIdExpirationCheckIntervalMs = LogManager.ProducerIdExpirationCheckIntervalMs,
       logDirFailureChannel = new LogDirFailureChannel(10))
 
-    /* append four messages */
-    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0,
-      new SimpleRecord("hello".getBytes), new SimpleRecord("there".getBytes)), leaderEpoch = 0)
-    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0,
-      new SimpleRecord("hello".getBytes), new SimpleRecord("there".getBytes)), leaderEpoch = 0)
+    val now = System.currentTimeMillis()
+    val firstBatchRecords = (0 until 10).map { i => new SimpleRecord(now + i * 2, s"hello there $i".getBytes)}
+    batches += firstBatchRecords
+    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, firstBatchRecords: _*),
+      leaderEpoch = 0)
+    val secondBatchRecords = (10 until 30).map { i => new SimpleRecord(now + i * 3, s"hello there again $i".getBytes)}
+    batches += secondBatchRecords
+    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, secondBatchRecords: _*),
+      leaderEpoch = 0)
+    val thirdBatchRecords = (30 until 50).map { i => new SimpleRecord(now + i * 5, s"hello there one more time $i".getBytes)}
+    batches += thirdBatchRecords
+    log.appendAsLeader(MemoryRecords.withRecords(CompressionType.NONE, 0, thirdBatchRecords: _*),
+      leaderEpoch = 0)
+    // Flush, but don't close so that the indexes are not trimmed and contain some zero entries
     log.flush()
   }
 
@@ -58,16 +78,38 @@ class DumpLogSegmentsTest {
   def testPrintDataLog(): Unit = {
 
     def verifyRecordsInOutput(args: Array[String]): Unit = {
+      def isBatch(index: Int): Boolean = {
+        var i = 0
+        batches.zipWithIndex.foreach { case (batch, batchIndex) =>
+          if (i == index)
+            return true
+
+          i += 1
+
+          batch.indices.foreach { recordIndex =>
+            if (i == index)
+              return false
+            i += 1
+          }
+        }
+        TestUtils.fail(s"No match for index $index")
+      }
+
       val output = runDumpLogSegments(args)
       val lines = output.split("\n")
       assertTrue(s"Data not printed: $output", lines.length > 2)
-      // For every three message records, verify that the first line is batch-level message record and the last two lines are message records
-      (0 until 6 ).foreach { i =>
-        val line = lines(lines.length - 6 + i)
-        if (i % 3 == 0)
-          assertTrue(s"Not a valid batch-level message record: $line", line.startsWith(s"baseOffset: ${i / 3 * 2} lastOffset: "))
-        else
-          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.RECORD_INDENT} offset: ${i - 1 - i / 3}"))
+      val totalRecords = batches.map(_.size).sum
+      var offset = 0
+      (0 until totalRecords + batches.size).foreach { index =>
+        val line = lines(lines.length - totalRecords - batches.size + index)
+        // The base offset of the batch is the offset of the first record in the batch, so we
+        // only increment the offset if it's not a batch
+        if (isBatch(index))
+          assertTrue(s"Not a valid batch-level message record: $line", line.startsWith(s"baseOffset: $offset lastOffset: "))
+        else {
+          assertTrue(s"Not a valid message record: $line", line.startsWith(s"${DumpLogSegments.RecordIndent} offset: $offset"))
+          offset += 1
+        }
       }
     }
 
@@ -77,18 +119,36 @@ class DumpLogSegmentsTest {
     }
 
     // Verify that records are printed with --print-data-log even if --deep-iteration is not specified
-    verifyRecordsInOutput(Array("--print-data-log", "--files", logFile))
+    verifyRecordsInOutput(Array("--print-data-log", "--files", logFilePath))
     // Verify that records are printed with --print-data-log if --deep-iteration is also specified
-    verifyRecordsInOutput(Array("--print-data-log", "--deep-iteration", "--files", logFile))
+    verifyRecordsInOutput(Array("--print-data-log", "--deep-iteration", "--files", logFilePath))
     // Verify that records are printed with --value-decoder even if --print-data-log is not specified
-    verifyRecordsInOutput(Array("--value-decoder-class", "kafka.serializer.StringDecoder", "--files", logFile))
+    verifyRecordsInOutput(Array("--value-decoder-class", "kafka.serializer.StringDecoder", "--files", logFilePath))
     // Verify that records are printed with --key-decoder even if --print-data-log is not specified
-    verifyRecordsInOutput(Array("--key-decoder-class", "kafka.serializer.StringDecoder", "--files", logFile))
+    verifyRecordsInOutput(Array("--key-decoder-class", "kafka.serializer.StringDecoder", "--files", logFilePath))
     // Verify that records are printed with --deep-iteration even if --print-data-log is not specified
-    verifyRecordsInOutput(Array("--deep-iteration", "--files", logFile))
+    verifyRecordsInOutput(Array("--deep-iteration", "--files", logFilePath))
 
     // Verify that records are not printed by default
-    verifyNoRecordsInOutput(Array("--files", logFile))
+    verifyNoRecordsInOutput(Array("--files", logFilePath))
+  }
+
+  @Test
+  def testDumpIndexMismatches(): Unit = {
+    val offsetMismatches = mutable.Map[String, List[(Long, Long)]]()
+    DumpLogSegments.dumpIndex(new File(indexFilePath), indexSanityOnly = false, verifyOnly = true, offsetMismatches,
+      Int.MaxValue)
+    assertEquals(Map.empty, offsetMismatches)
+  }
+
+  @Test
+  def testDumpTimeIndexErrors(): Unit = {
+    val errors = new TimeIndexDumpErrors
+    DumpLogSegments.dumpTimeIndex(new File(timeIndexFilePath), indexSanityOnly = false, verifyOnly = true, errors,
+      Int.MaxValue)
+    assertEquals(Map.empty, errors.misMatchesForTimeIndexFilesMap)
+    assertEquals(Map.empty, errors.outOfOrderTimestamp)
+    assertEquals(Map.empty, errors.shallowOffsetNotFound)
   }
 
   private def runDumpLogSegments(args: Array[String]): String = {


### PR DESCRIPTION
- Compare last offset of first batch (instead of first offset) with index offset
- Early exit from loop due to zero entries must happen before checking for mismatch
- {TimeIndex,OffsetIndex}.entry should return absolute offset like other methods.
These methods are only used by DumpLogSegments.
- DumpLogSegments now calls `closeHandlers` on OffsetIndex, TimeIndex
and FileRecords.
- Add OffsetIndex, TimeIndex and DumpLogSegments tests
- Remove unnecessary casts by using covariant returns in OffsetIndex and TimeIndex
- Minor clean-ups
- Fix `checkArgs` so that it does what it says only.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
