### PR TITLE
KAFKA-6448 Mx4jLoader#props.getBoolean("kafka_mx4jenable", false) conflict with the annotation

### DIFF
--- a/core/src/main/scala/kafka/utils/Mx4jLoader.scala
+++ b/core/src/main/scala/kafka/utils/Mx4jLoader.scala
@@ -34,7 +34,7 @@ object Mx4jLoader extends Logging {
 
   def maybeLoad(): Boolean = {
     val props = new VerifiableProperties(System.getProperties())
-    if (!props.getBoolean("kafka_mx4jenable", false))
+    if (!props.getBoolean("mx4jenable", false))
       return false
     val address = props.getString("mx4jaddress", "0.0.0.0")
     val port = props.getInt("mx4jport", 8082)


### PR DESCRIPTION
 KAFKA-6448 Mx4jLoader#props.getBoolean("kafka_mx4jenable", false) conflict with the annotation
 
*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
