### PR TITLE
MINOR: Fix small spelling error

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/graph/StatefulProcessorNode.java
@@ -32,7 +32,7 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
 
     /**
-     * Create a node representing a stateful procssor, where the named store has already been registered.
+     * Create a node representing a stateful processor, where the named store has already been registered.
      */
     public StatefulProcessorNode(final String nodeName,
                                  final ProcessorParameters<K, V> processorParameters,
@@ -48,7 +48,7 @@ public class StatefulProcessorNode<K, V> extends ProcessorGraphNode<K, V> {
 
 
     /**
-     * Create a node representing a stateful procssor,
+     * Create a node representing a stateful processor,
      * where the store needs to be built and registered as part of building this node.
      */
     public StatefulProcessorNode(final String nodeName,


### PR DESCRIPTION
Fixing a small spelling error in Javadoc for `StatefulProcessorNode`

For testing, I ran the streams test suite.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
