### PR TITLE
DOCS: Better clarify topic-configured min.isr vs cluster-configured min.isr

### DIFF
--- a/docs/design.html
+++ b/docs/design.html
@@ -308,13 +308,12 @@
     In distributed systems terminology we only attempt to handle a "fail/recover" model of failures where nodes suddenly cease working and then later recover (perhaps without knowing that they have died). Kafka does not
     handle so-called "Byzantine" failures in which nodes produce arbitrary or malicious responses (perhaps due to bugs or foul play).
     <p>
-    We can now more precisely define that a message is considered committed when all in sync replicas for that partition have applied it to their log.
-    Only committed messages are ever given out to the consumer. This means that the consumer need not worry about potentially seeing a message that could be lost if the leader fails. Producers, on the other hand,
-    have the option of either waiting for the message to be committed or not, depending on their preference for tradeoff between latency and durability. This preference is controlled by the acks setting that the
-    producer uses.
-    Note that topics have a setting for the "minimum number" of in-sync replicas that is checked when the producer requests acknowledgment that a message
-    has been written to the full set of in-sync replicas. If a less stringent acknowledgement is requested by the producer, the message will be acknowledged early
-    but will not be committed, nor consumed, until all in-sync replicas apply it to their log.
+    We can now more precisely define that a message is considered committed when all in-sync replicas for that partition have applied the message to their log.
+    Only committed messages are ever given out to the consumer. This means that the consumer will not see a message that could be lost if the leader fails. Producers, on the other hand,
+    have the option of either waiting for the message to be committed or not, depending on their preference for tradeoff between latency and durability. This behavior is controlled by the producer acks setting.
+    Note that topics have a setting for the "minimum number" of in-sync replicas. This setting is checked when the producer requests acknowledgment that a message
+    has been written to the full set of in-sync replicas. If a less stringent acknowledgement is requested by the producer, the message is acknowledged early
+    but is not committed or consumed until all the in-sync replicas apply it to their log.
     <p>
     The guarantee that Kafka offers is that a committed message will not be lost, as long as there is at least one in sync replica alive, at all times.
     <p>

--- a/docs/design.html
+++ b/docs/design.html
@@ -313,8 +313,8 @@
     have the option of either waiting for the message to be committed or not, depending on their preference for tradeoff between latency and durability. This preference is controlled by the acks setting that the
     producer uses.
     Note that topics have a setting for the "minimum number" of in-sync replicas that is checked when the producer requests acknowledgment that a message
-    has been written to the full set of in-sync replicas. If a less stringent acknowledgement is requested by the producer, then the message can be committed, and consumed,
-    even if the number of in-sync replicas is lower than the minimum (e.g. it can be as low as just the leader).
+    has been written to the full set of in-sync replicas. If a less stringent acknowledgement is requested by the producer, the message will be acknowledged early
+    but will not be committed, nor consumed, until all in-sync replicas apply it to their log.
     <p>
     The guarantee that Kafka offers is that a committed message will not be lost, as long as there is at least one in sync replica alive, at all times.
     <p>

--- a/docs/design.html
+++ b/docs/design.html
@@ -312,8 +312,8 @@
     Only committed messages are ever given out to the consumer. This means that the consumer will not see a message that could be lost if the leader fails. Producers, on the other hand,
     have the option of either waiting for the message to be committed or not, depending on their preference for tradeoff between latency and durability. This behavior is controlled by the producer acks setting.
     Note that topics have a setting for the "minimum number" of in-sync replicas. This setting is checked when the producer requests acknowledgment that a message
-    has been written to the full set of in-sync replicas. If a less stringent acknowledgement is requested by the producer, the message is acknowledged early
-    but is not committed or consumed until all the in-sync replicas apply it to their log.
+    has been written to the full set of in-sync replicas. If a less stringent acknowledgment is requested by the producer, the message is
+    acknowledged early but is not committed or consumed until all the in-sync replicas, regardless of the minimum number setting, apply it to their log.
     <p>
     The guarantee that Kafka offers is that a committed message will not be lost, as long as there is at least one in sync replica alive, at all times.
     <p>


### PR DESCRIPTION
I think this better clarifies the misunderstanding in https://issues.apache.org/jira/browse/KAFKA-7474
cc 
@joel-hamill (reported the issue)
@ciudilo (reported the issue)

@hachikuji @vahidhashemian (reviewed the previous https://github.com/apache/kafka/pull/3035)