### PR TITLE
KAFKA-7442: forceUnmap mmap on linux when index resize

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -180,9 +180,7 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
         try {
           val position = mmap.position()
 
-          /* Windows won't let us modify the file length while the file is mmapped :-( */
-          if (OperatingSystem.IS_WINDOWS)
-            safeForceUnmap()
+          safeForceUnmap()
           raf.setLength(roundedNewSize)
           _length = roundedNewSize
           mmap = raf.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, roundedNewSize)


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-7442

In AbstractIndex#resize, `safeForceUnmap` should also be invoked for Linux.

*More detailed description of your change,
if necessary. The PR title and PR message become
the squashed commit message, so use a separate
comment to ping reviewers.*

*Summary of testing strategy (including rationale)
for the feature or bug fix. Unit and/or integration
tests are expected for any behaviour change and
system tests should be considered for larger changes.*

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
