### PR TITLE
Amend GetOffsetShell to support passing SSL properties

### DIFF
--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -97,9 +97,9 @@ object GetOffsetShell {
 
     val config = 
       if (options.has(commandConfigOpt))
-        new Properties()
+        Utils.loadProps(options.valueOf(commandConfigOpt))
       else
-        Utils.loadProps(options.valueOf(commandConfigOpt)) 
+        new Properties
 
     config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -96,8 +96,8 @@ object GetOffsetShell {
     val listOffsetsTimestamp = options.valueOf(timeOpt).longValue
 
     val config = 
-      if (options.valueOf(commandConfigOpt) == "")
-        new Properties
+      if (options.has(commandConfigOpt))
+        new Properties()
       else
         Utils.loadProps(options.valueOf(commandConfigOpt)) 
 

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -95,13 +95,15 @@ object GetOffsetShell {
     }
     val listOffsetsTimestamp = options.valueOf(timeOpt).longValue
 
-    if (commandConfigOpt == "") {
-      val config = new Properties
-      config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
-      config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
-    else {
-      Utils.loadProps(commandConfigOpt) 
-    }
+    val config = 
+      if (options.valueOf(commandConfigOpt) == "")
+        new Properties
+      else
+        Utils.loadProps(options.valueOf(commandConfigOpt)) 
+
+    config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+    config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
+
     val consumer = new KafkaConsumer(config, new ByteArrayDeserializer, new ByteArrayDeserializer)
 
     val partitionInfos = listPartitionInfos(consumer, topic, partitionIdsRequested) match {

--- a/core/src/main/scala/kafka/tools/GetOffsetShell.scala
+++ b/core/src/main/scala/kafka/tools/GetOffsetShell.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 import org.apache.kafka.common.requests.ListOffsetRequest
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.utils.Utils
 
 import scala.collection.JavaConverters._
 
@@ -51,6 +52,11 @@ object GetOffsetShell {
                            .describedAs("timestamp/-1(latest)/-2(earliest)")
                            .ofType(classOf[java.lang.Long])
                            .defaultsTo(-1L)
+    val commandConfigOpt = parser.accepts("command-config", "property file containing configs.")
+                           .withRequiredArg
+                           .describedAs("command config property file")
+                           .ofType(classOf[String])
+                           .defaultsTo("")
     parser.accepts("offsets", "DEPRECATED AND IGNORED: number of offsets returned")
                            .withRequiredArg
                            .describedAs("count")
@@ -89,9 +95,13 @@ object GetOffsetShell {
     }
     val listOffsetsTimestamp = options.valueOf(timeOpt).longValue
 
-    val config = new Properties
-    config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
-    config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
+    if (commandConfigOpt == "") {
+      val config = new Properties
+      config.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList)
+      config.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId)
+    else {
+      Utils.loadProps(commandConfigOpt) 
+    }
     val consumer = new KafkaConsumer(config, new ByteArrayDeserializer, new ByteArrayDeserializer)
 
     val partitionInfos = listPartitionInfos(consumer, topic, partitionIdsRequested) match {


### PR DESCRIPTION
We need to be able to monitor the current offset and lag on SSL enabled Kafka clusters. This functionality has been added to other classes (e.g. ConfigCommand), but not this one. I have replicated the same syntax for the command line option.

Change has been tested by calling GetOffShell using both SSL (v1.1) and non-SSL (v0.10.2.1) clusters.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
