### PR TITLE
MINOR: Adjust test params pursuant to KAFKA-4514.

### DIFF
--- a/tests/kafkatest/tests/client/compression_test.py
+++ b/tests/kafkatest/tests/client/compression_test.py
@@ -29,6 +29,7 @@ class CompressionTest(ProduceConsumeValidateTest):
     """
     These tests validate produce / consume for compressed topics.
     """
+    COMPRESSION_TYPES = ["snappy", "gzip", "lz4", "zstd", "none"]
 
     def __init__(self, test_context):
         """:type test_context: ducktape.tests.test.TestContext"""
@@ -42,7 +43,7 @@ class CompressionTest(ProduceConsumeValidateTest):
         self.num_partitions = 10
         self.timeout_sec = 60
         self.producer_throughput = 1000
-        self.num_producers = 5
+        self.num_producers = len(self.COMPRESSION_TYPES)
         self.messages_per_producer = 1000
         self.num_consumers = 1
 
@@ -54,14 +55,14 @@ class CompressionTest(ProduceConsumeValidateTest):
         return super(CompressionTest, self).min_cluster_size() + self.num_producers + self.num_consumers
 
     @cluster(num_nodes=8)
-    @parametrize(compression_types=["snappy","gzip","lz4","zstd","none"])
+    @parametrize(compression_types=COMPRESSION_TYPES)
     def test_compressed_topic(self, compression_types):
         """Test produce => consume => validate for compressed topics
         Setup: 1 zk, 1 kafka node, 1 topic with partitions=10, replication-factor=1
 
         compression_types parameter gives a list of compression types (or no compression if
-        "none"). Each producer in a VerifiableProducer group (num_producers = 5) will use a
-        compression type from the list based on producer's index in the group.
+        "none"). Each producer in a VerifiableProducer group (num_producers = number of compression
+        types) will use a compression type from the list based on producer's index in the group.
 
             - Produce messages in the background
             - Consume messages in the background

--- a/tests/kafkatest/tests/client/compression_test.py
+++ b/tests/kafkatest/tests/client/compression_test.py
@@ -60,7 +60,7 @@ class CompressionTest(ProduceConsumeValidateTest):
         Setup: 1 zk, 1 kafka node, 1 topic with partitions=10, replication-factor=1
 
         compression_types parameter gives a list of compression types (or no compression if
-        "none"). Each producer in a VerifiableProducer group (num_producers = 4) will use a
+        "none"). Each producer in a VerifiableProducer group (num_producers = 5) will use a
         compression type from the list based on producer's index in the group.
 
             - Produce messages in the background

--- a/tests/kafkatest/tests/client/compression_test.py
+++ b/tests/kafkatest/tests/client/compression_test.py
@@ -42,7 +42,7 @@ class CompressionTest(ProduceConsumeValidateTest):
         self.num_partitions = 10
         self.timeout_sec = 60
         self.producer_throughput = 1000
-        self.num_producers = 4
+        self.num_producers = 5
         self.messages_per_producer = 1000
         self.num_consumers = 1
 
@@ -53,7 +53,7 @@ class CompressionTest(ProduceConsumeValidateTest):
         # Override this since we're adding services outside of the constructor
         return super(CompressionTest, self).min_cluster_size() + self.num_producers + self.num_consumers
 
-    @cluster(num_nodes=7)
+    @cluster(num_nodes=8)
     @parametrize(compression_types=["snappy","gzip","lz4","zstd","none"])
     def test_compressed_topic(self, compression_types):
         """Test produce => consume => validate for compressed topics


### PR DESCRIPTION
https://github.com/apache/kafka/pull/2267 Introduced support for Zstandard compression. The relevant test expects values for `num_nodes` and `num_producers` based on the (now-incremented) count of compression types.

Passed the affected, previously-failing test:
`ducker-ak test tests/kafkatest/tests/client/compression_test.py`


