### PR TITLE
MINOR: Unmap index on close follow-up

### DIFF
--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -305,8 +305,10 @@ abstract class AbstractIndex[K, V](@volatile var file: File, val baseOffset: Lon
   }
 
   protected def safeForceUnmap(): Unit = {
-    try forceUnmap()
-    catch {
+    try {
+      if (mmap != null)
+        forceUnmap()
+    } catch {
       case t: Throwable => error(s"Error unmapping index $file", t)
     }
   }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -700,7 +700,6 @@ class Log(@volatile var dir: File,
 
   /**
    * Close this log.
-   * The memory mapped buffer for index files of this log will be left open until the log is deleted.
    */
   def close() {
     debug("Closing log")
@@ -712,6 +711,7 @@ class Log(@volatile var dir: File,
         // (the clean shutdown file is written after the logs are all closed).
         producerStateManager.takeSnapshot()
         logSegments.foreach(_.close())
+        isMemoryMappedBufferClosed = true
       }
     }
   }
@@ -1671,7 +1671,6 @@ class Log(@volatile var dir: File,
   private[log] def delete() {
     maybeHandleIOException(s"Error while deleting log for $topicPartition in dir ${dir.getParent}") {
       lock synchronized {
-        checkIfMemoryMappedBufferClosed()
         removeLogMetrics()
         logSegments.foreach(_.deleteIfExists())
         segments.clear()


### PR DESCRIPTION
Update comment, isMemoryMappedBufferClosed variable and
handle `close` followed by `delete`.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
