### PR TITLE
MINOR: fix non-deterministic streams-scala tests

### DIFF
--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -102,7 +102,7 @@ class KStreamTest extends FlatSpec with Matchers with TestDriver {
     val sinkTopic = "sink"
 
     var acc = ""
-    builder.stream[String, String](sourceTopic).peek((k, v) => acc += v).to(sinkTopic)
+    builder.stream[String, String](sourceTopic).peek((_, v) => acc += v).to(sinkTopic)
 
     val testDriver = createTestDriver(builder)
 
@@ -147,10 +147,13 @@ class KStreamTest extends FlatSpec with Matchers with TestDriver {
     val stream2 = builder.stream[String, String](sourceTopic2)
     stream1.join(stream2)((a, b) => s"$a-$b", JoinWindows.of(ofSeconds(1))).to(sinkTopic)
 
-    val testDriver = createTestDriver(builder)
+    val now = System.currentTimeMillis()
 
-    testDriver.pipeRecord(sourceTopic1, ("1", "topic1value1"))
-    testDriver.pipeRecord(sourceTopic2, ("1", "topic2value1"))
+    val testDriver = createTestDriver(builder, now)
+
+    testDriver.pipeRecord(sourceTopic1, ("1", "topic1value1"), now)
+    testDriver.pipeRecord(sourceTopic2, ("1", "topic2value1"), now)
+
     testDriver.readRecord[String, String](sinkTopic).value shouldBe "topic1value1-topic2value1"
 
     testDriver.readRecord[String, String](sinkTopic) shouldBe null

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/TestDriver.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/TestDriver.scala
@@ -29,7 +29,7 @@ import org.scalatest.Suite
 
 trait TestDriver { this: Suite =>
 
-  def createTestDriver(builder: StreamsBuilder, initialWallClockTimeMs: Long = System.currentTimeMillis()) = {
+  def createTestDriver(builder: StreamsBuilder, initialWallClockTimeMs: Long = System.currentTimeMillis()): TopologyTestDriver = {
     val config = new Properties()
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test")
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234")

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/TestDriver.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/utils/TestDriver.scala
@@ -29,7 +29,8 @@ import org.scalatest.Suite
 
 trait TestDriver { this: Suite =>
 
-  def createTestDriver(builder: StreamsBuilder, initialWallClockTimeMs: Long = System.currentTimeMillis()): TopologyTestDriver = {
+  def createTestDriver(builder: StreamsBuilder,
+                       initialWallClockTimeMs: Long = System.currentTimeMillis()): TopologyTestDriver = {
     val config = new Properties()
     config.put(StreamsConfig.APPLICATION_ID_CONFIG, "test")
     config.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:1234")


### PR DESCRIPTION
Stop using current system time by default, as it introduces non-determinism.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
