### PR TITLE
MINOR: Update reverse lookup test to work when ipv6 not enabled

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -51,6 +51,9 @@ public class ClientUtilsTest {
         checkWithoutLookup("localhost:8080");
         checkWithoutLookup("[::1]:8000");
         checkWithoutLookup("[2001:db8:85a3:8d3:1319:8a2e:370:7348]:1234", "localhost:10000");
+
+        // With lookup of example.com, either one or two addresses are expected depending on
+        // whether ipv4 and ipv6 are enabled
         List<InetSocketAddress> validatedAddresses = checkWithLookup(Arrays.asList("example.com:10000"));
         assertTrue("Unexpected addresses " + validatedAddresses, validatedAddresses.size() >= 1);
         List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)

--- a/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ClientUtilsTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ClientUtilsTest {
 
@@ -51,10 +52,12 @@ public class ClientUtilsTest {
         checkWithoutLookup("[::1]:8000");
         checkWithoutLookup("[2001:db8:85a3:8d3:1319:8a2e:370:7348]:1234", "localhost:10000");
         List<InetSocketAddress> validatedAddresses = checkWithLookup(Arrays.asList("example.com:10000"));
-        assertEquals(2, validatedAddresses.size());
-        InetSocketAddress address = validatedAddresses.get(0);
-        assertEquals("93.184.216.34", address.getHostName());
-        assertEquals(10000, address.getPort());
+        assertTrue("Unexpected addresses " + validatedAddresses, validatedAddresses.size() >= 1);
+        List<String> validatedHostNames = validatedAddresses.stream().map(InetSocketAddress::getHostName)
+                .collect(Collectors.toList());
+        List<String> expectedHostNames = Arrays.asList("93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946");
+        assertTrue("Unexpected addresses " + validatedHostNames, expectedHostNames.containsAll(validatedHostNames));
+        validatedAddresses.forEach(address -> assertEquals(10000, address.getPort()));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
ipv6 address is not returned by InetAddress.getAllByName if ipv6 not enabled (e.g. in a docker container). Update test to work with this environment.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
