### PR TITLE
MINOR: Less restrictive assertion in flaky BufferPool test

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -175,7 +175,7 @@ public class BufferPoolTest {
         } catch (TimeoutException e) {
             // this is good
         }
-        // Thread scheduling sometimes means that no deallocation happens by this point
+        // Thread scheduling sometimes means that deallocation varies by this point
         assertTrue("available memory " + pool.availableMemory(), pool.availableMemory() >= 8 && pool.availableMemory() <= 10);
         long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
         assertTrue("TimeoutException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -176,7 +176,7 @@ public class BufferPoolTest {
             // this is good
         }
         // Thread scheduling sometimes means that no deallocation happens by this point
-        assertTrue("available memory" + pool.availableMemory(), pool.availableMemory() >= 8 && pool.availableMemory() <= 10);
+        assertTrue("available memory " + pool.availableMemory(), pool.availableMemory() >= 8 && pool.availableMemory() <= 10);
         long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
         assertTrue("TimeoutException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);
         assertTrue("TimeoutException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 1000);

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -175,9 +175,11 @@ public class BufferPoolTest {
         } catch (TimeoutException e) {
             // this is good
         }
+        // Thread scheduling sometimes means that no deallocation happens by this point
+        assertTrue("available memory" + pool.availableMemory(), pool.availableMemory() >= 8 && pool.availableMemory() <= 10);
         long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
         assertTrue("TimeoutException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);
-        assertTrue("TimeoutException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 100);
+        assertTrue("TimeoutException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 1000);
     }
 
     /**

--- a/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/producer/internals/BufferPoolTest.java
@@ -154,7 +154,7 @@ public class BufferPoolTest {
 
     /**
      * Test if Timeout exception is thrown when there is not enough memory to allocate and the elapsed time is greater than the max specified block time.
-     * And verify that the allocation should finish soon after the maxBlockTimeMs.
+     * And verify that the allocation attempt finishes soon after the maxBlockTimeMs.
      */
     @Test
     public void testBlockTimeout() throws Exception {
@@ -162,10 +162,10 @@ public class BufferPoolTest {
         ByteBuffer buffer1 = pool.allocate(1, maxBlockTimeMs);
         ByteBuffer buffer2 = pool.allocate(1, maxBlockTimeMs);
         ByteBuffer buffer3 = pool.allocate(1, maxBlockTimeMs);
-        // First two buffers will be de-allocated within maxBlockTimeMs since the most recent de-allocation
+        // The first two buffers will be de-allocated within maxBlockTimeMs since the most recent allocation
         delayedDeallocate(pool, buffer1, maxBlockTimeMs / 2);
         delayedDeallocate(pool, buffer2, maxBlockTimeMs);
-        // The third buffer will be de-allocated after maxBlockTimeMs since the most recent de-allocation
+        // The third buffer will be de-allocated after maxBlockTimeMs since the most recent allocation
         delayedDeallocate(pool, buffer3, maxBlockTimeMs / 2 * 5);
 
         long beginTimeMs = Time.SYSTEM.milliseconds();
@@ -175,9 +175,9 @@ public class BufferPoolTest {
         } catch (TimeoutException e) {
             // this is good
         }
-        assertTrue("available memory" + pool.availableMemory(), pool.availableMemory() >= 9 && pool.availableMemory() <= 10);
-        long endTimeMs = Time.SYSTEM.milliseconds();
-        assertTrue("Allocation should finish not much later than maxBlockTimeMs", endTimeMs - beginTimeMs < maxBlockTimeMs + 1000);
+        long durationMs = Time.SYSTEM.milliseconds() - beginTimeMs;
+        assertTrue("TimeoutException should not throw before maxBlockTimeMs", durationMs >= maxBlockTimeMs);
+        assertTrue("TimeoutException should throw soon after maxBlockTimeMs", durationMs < maxBlockTimeMs + 100);
     }
 
     /**
@@ -193,7 +193,8 @@ public class BufferPoolTest {
         } catch (TimeoutException e) {
             // this is good
         }
-        assertTrue(pool.queued() == 0);
+        assertEquals(0, pool.queued());
+        assertEquals(1, pool.availableMemory());
     }
 
     /**


### PR DESCRIPTION
We are routinely seeing CI failures from an assertion in `testBlockTimeout()`, which relies on the interaction between (de)allocations against a producer BufferPool, across multiple threads. I reproduced the failed assertion in my local build at a rate of 2% (N=100):
```java
assertTrue("available memory" + pool.availableMemory(), 
    pool.availableMemory() >= 9 && pool.availableMemory() <= 10);
```

Here's a summary of the test history:
- (https://github.com/apache/kafka/pull/1304) KAFKA-3648; maxTimeToBlock in BufferPool.allocate should be enforced
  - Ensured timeout was properly checked and iterated during a blocked allocation.
  - Added the test's deferred deallocations.
- (https://github.com/apache/kafka/pull/2659) KAFKA-4840 : BufferPool errors can cause buffer pool to go into a bad state
  - Ensured proper cleanup of blocked allocation requests given an exception. 
  - Added assertion in question.

This patch decreases the lower bound for expected available memory, as thread scheduling entails that a variable amount of deallocation happens by the point of assertion.

The patch also makes minor clarifications to test logic and comments. On my machine, it has a 100% passing rate (N=500).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)