### PR TITLE
STREAMS: Multiple topics extractor proposal

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/TopicNameExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/TopicNameExtractor.java
@@ -18,6 +18,8 @@ package org.apache.kafka.streams.processor;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 
+import java.util.Collection;
+
 /**
  * An interface that allows to dynamically determine the name of the Kafka topic to send at the sink node of the topology.
  */
@@ -33,5 +35,5 @@ public interface TopicNameExtractor<K, V> {
      * @param recordContext current context metadata of the record
      * @return              the topic name this record should be sent to
      */
-    String extract(final K key, final V value, final RecordContext recordContext);
+    Collection<String> extract(final K key, final V value, final RecordContext recordContext);
 }

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StaticTopicNameExtractor.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StaticTopicNameExtractor.java
@@ -19,23 +19,26 @@ package org.apache.kafka.streams.processor.internals;
 import org.apache.kafka.streams.processor.RecordContext;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * Static topic name extractor
  */
 public class StaticTopicNameExtractor<K, V> implements TopicNameExtractor<K, V> {
 
-    public final String topicName;
+    public final Collection<String> topicSingleton;
 
     public StaticTopicNameExtractor(final String topicName) {
-        this.topicName = topicName;
+        this.topicSingleton = Collections.singleton(topicName);
     }
 
-    public String extract(final K key, final V value, final RecordContext recordContext) {
-        return topicName;
+    public Collection<String> extract(final K key, final V value, final RecordContext recordContext) {
+        return topicSingleton;
     }
 
     @Override
     public String toString() {
-        return "StaticTopicNameExtractor(" + topicName + ")";
+        return "StaticTopicNameExtractor(" + topicSingleton + ")";
     }
 }


### PR DESCRIPTION
Approach of adding possibility to extract several topics for flexible message routing.

I didn't find "nice" way how to apply such feature and keep all the changes backward compatible so I decided to ask if this change is acceptable via creating a PR. If it's OK - I'll finish all needed stuff (documentation and tests)

This would be awesome change, which will allow to chose several topics for single message dynamically based on key/value or application configuration.

Please let me know should I go further with this change and polish it.