### PR TITLE
KAFKA-7509: Reduce unnecessary and misleading “configuration supplied but not known” warning messages in Connect

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/AdminClientConfig.java
@@ -185,6 +185,20 @@ public class AdminClientConfig extends AbstractConfig {
         return CONFIG.names();
     }
 
+    /**
+     * Return whether the given property name is a known configuration. This will consider valid any property that can be passed to
+     * instances of extensions, such as the {@link #METRIC_REPORTER_CLASSES_CONFIG metrics reporter}.
+     *
+     * @param name the property name
+     * @return true if the supplied name matches a known property, or false if it is unknown
+     */
+    public static boolean isKnownConfig(String name) {
+        if (name == null) {
+            return false;
+        }
+        return configNames().contains(name) || name.startsWith(METRIC_REPORTER_CLASSES_CONFIG);
+    }
+
     public static void main(String[] args) {
         System.out.println(CONFIG.toHtmlTable());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerConfig.java
@@ -507,6 +507,22 @@ public class ConsumerConfig extends AbstractConfig {
         return CONFIG.names();
     }
 
+    /**
+     * Return whether the given property name is a known configuration. This will consider valid any property that can be passed to
+     * instances of extensions, such as the {@link #METRIC_REPORTER_CLASSES_CONFIG metrics reporter}.
+     *
+     * @param name the property name
+     * @return true if the supplied name matches a known property, or false if it is unknown
+     */
+    public static boolean isKnownConfig(String name) {
+        if (name == null) {
+            return false;
+        }
+        return configNames().contains(name)
+               || name.startsWith(KEY_DESERIALIZER_CLASS_CONFIG) || name.startsWith(VALUE_DESERIALIZER_CLASS_CONFIG)
+               || name.startsWith(METRIC_REPORTER_CLASSES_CONFIG) || name.startsWith(INTERCEPTOR_CLASSES_CONFIG);
+    }
+
     public static void main(String[] args) {
         System.out.println(CONFIG.toHtmlTable());
     }

--- a/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
+++ b/clients/src/main/java/org/apache/kafka/clients/producer/ProducerConfig.java
@@ -392,6 +392,23 @@ public class ProducerConfig extends AbstractConfig {
         return CONFIG.names();
     }
 
+    /**
+     * Return whether the given property name is a known configuration. This will consider valid any property that can be passed to
+     * instances of extensions, such as the {@link #METRIC_REPORTER_CLASSES_CONFIG metrics reporter}.
+     *
+     * @param name the property name
+     * @return true if the supplied name matches a known property, or false if it is unknown
+     */
+    public static boolean isKnownConfig(String name) {
+        if (name == null) {
+            return false;
+        }
+        return configNames().contains(name)
+               || name.startsWith(KEY_SERIALIZER_CLASS_CONFIG) || name.startsWith(VALUE_SERIALIZER_CLASS_CONFIG)
+               || name.startsWith(METRIC_REPORTER_CLASSES_CONFIG) || name.startsWith(INTERCEPTOR_CLASSES_CONFIG)
+               || name.startsWith(PARTITIONER_CLASS_CONFIG);
+    }
+
     public static void main(String[] args) {
         System.out.println(CONFIG.toHtmlTable());
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -142,9 +142,6 @@ public class Worker {
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.toString(Integer.MAX_VALUE));
         // User-specified overrides
         producerProps.putAll(config.originalsWithPrefix("producer."));
-        // Prevent logging unused config warnings
-        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
-
     }
 
     private WorkerConfigTransformer initConfigTransformer() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/Worker.java
@@ -49,6 +49,7 @@ import org.apache.kafka.connect.storage.OffsetBackingStore;
 import org.apache.kafka.connect.storage.OffsetStorageReader;
 import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
 import org.apache.kafka.connect.storage.OffsetStorageWriter;
+import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -141,6 +142,9 @@ public class Worker {
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.toString(Integer.MAX_VALUE));
         // User-specified overrides
         producerProps.putAll(config.originalsWithPrefix("producer."));
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
+
     }
 
     private WorkerConfigTransformer initConfigTransformer() {

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -472,6 +472,8 @@ class WorkerSinkTask extends WorkerTask {
 
         KafkaConsumer<byte[], byte[]> newConsumer;
         try {
+            // Prevent logging unused config warnings
+            props = ConnectUtils.retainConfigs(props, ConsumerConfig.configNames());
             newConsumer = new KafkaConsumer<>(props);
         } catch (Throwable t) {
             throw new ConnectException("Failed to create consumer", t);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/WorkerSinkTask.java
@@ -472,8 +472,6 @@ class WorkerSinkTask extends WorkerTask {
 
         KafkaConsumer<byte[], byte[]> newConsumer;
         try {
-            // Prevent logging unused config warnings
-            props = ConnectUtils.retainConfigs(props, ConsumerConfig.configNames());
             newConsumer = new KafkaConsumer<>(props);
         } catch (Throwable t) {
             throw new ConnectException("Failed to create consumer", t);

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/runtime/errors/DeadLetterQueueReporter.java
@@ -80,7 +80,7 @@ public class DeadLetterQueueReporter implements ErrorReporter {
                                                          ErrorHandlingMetrics errorHandlingMetrics) {
         String topic = sinkConfig.dlqTopicName();
 
-        Map<String, Object> adminConfig = ConnectUtils.retainConfigs(workerConfig.originals(), AdminClientConfig.configNames());
+        Map<String, Object> adminConfig = ConnectUtils.retainConfigs(workerConfig.originals(), AdminClientConfig::isKnownConfig);
         try (AdminClient admin = AdminClient.create(adminConfig)) {
             if (!admin.listTopics().names().get().contains(topic)) {
                 log.error("Topic {} doesn't exist. Will attempt to create topic.", topic);
@@ -95,7 +95,7 @@ public class DeadLetterQueueReporter implements ErrorReporter {
             }
         }
 
-        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig::isKnownConfig);
         KafkaProducer<byte[], byte[]> dlqProducer = new KafkaProducer<>(producerProps);
         return new DeadLetterQueueReporter(dlqProducer, sinkConfig, id, errorHandlingMetrics);
     }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -417,12 +418,14 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig::isKnownConfig);
+
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         // Prevent logging unused config warnings
-        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig.configNames());
-        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
+        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig::isKnownConfig);
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         NewTopic topicDescription = TopicAdmin.defineTopic(topic).

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaConfigBackingStore.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
 import org.apache.kafka.connect.runtime.distributed.ClusterConfigState;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.TopicAdmin;
@@ -419,6 +420,9 @@ public class KafkaConfigBackingStore implements ConfigBackingStore {
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig.configNames());
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         NewTopic topicDescription = TopicAdmin.defineTopic(topic).

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -16,6 +16,7 @@
  */
 package org.apache.kafka.connect.storage;
 
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -74,13 +75,13 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
         // Prevent logging unused config warnings
-        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig::isKnownConfig);
 
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         // Prevent logging unused config warnings
-        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig.configNames());
+        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig::isKnownConfig);
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         NewTopic topicDescription = TopicAdmin.defineTopic(topic).

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConvertingFutureCallback;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.TopicAdmin;
@@ -72,10 +73,14 @@ public class KafkaOffsetBackingStore implements OffsetBackingStore {
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
 
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig.configNames());
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         NewTopic topicDescription = TopicAdmin.defineTopic(topic).

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaStatusBackingStore.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.runtime.TaskStatus;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
 import org.apache.kafka.connect.util.Callback;
+import org.apache.kafka.connect.util.ConnectUtils;
 import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.KafkaBasedLog;
 import org.apache.kafka.connect.util.Table;
@@ -129,10 +130,14 @@ public class KafkaStatusBackingStore implements StatusBackingStore {
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         producerProps.put(ProducerConfig.RETRIES_CONFIG, 0); // we handle retries in this class
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(producerProps, ProducerConfig.configNames());
 
         Map<String, Object> consumerProps = new HashMap<>(originals);
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        // Prevent logging unused config warnings
+        ConnectUtils.retainConfigs(consumerProps, ConsumerConfig.configNames());
 
         Map<String, Object> adminProps = new HashMap<>(originals);
         NewTopic topicDescription = TopicAdmin.defineTopic(topic).

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -25,6 +25,10 @@ import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 public final class ConnectUtils {
@@ -64,5 +68,24 @@ public final class ConnectUtils {
             throw new ConnectException("Failed to connect to and describe Kafka cluster. "
                                        + "Check worker's broker connection and security properties.", e);
         }
+    }
+
+    /**
+     * Modify the supplied map of configurations to remove all configuration name-value pairs that are not included in the
+     * specified set of names.
+     *
+     * @param configs the map of configurations to be modified; may not be null
+     * @param configNames the names of the configuration properties that are to be retained; may not be null
+     * @return the supplied {@code configs} parameter, returned for convenience
+     */
+    public static Map<String, Object> retainConfigs(Map<String, Object> configs, Set<String> configNames) {
+        Iterator<Entry<String, Object>> entryIter = configs.entrySet().iterator();
+        while (entryIter.hasNext()) {
+            Map.Entry<String, Object> entry = entryIter.next();
+            if (!configNames.contains(entry.getKey())) {
+                entryIter.remove();
+            }
+        }
+        return configs;
     }
 }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -17,6 +17,9 @@
 package org.apache.kafka.connect.util;
 
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.record.InvalidRecordException;
 import org.apache.kafka.common.record.RecordBatch;
@@ -28,11 +31,30 @@ import org.slf4j.LoggerFactory;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 
 public final class ConnectUtils {
     private static final Logger log = LoggerFactory.getLogger(ConnectUtils.class);
+
+    protected static final String[] PRODUCER_CONFIG_PREFIXES = {
+            ProducerConfig.INTERCEPTOR_CLASSES_CONFIG,
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG,
+            ProducerConfig.PARTITIONER_CLASS_CONFIG
+    };
+
+    protected static final String[] CONSUMER_CONFIG_PREFIXES = {
+            ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG,
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG,
+            };
+
+    protected static final String[] ADMIN_CONFIG_PREFIXES = {
+            AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG
+    };
 
     public static Long checkAndConvertTimestamp(Long timestamp) {
         if (timestamp == null || timestamp >= 0)
@@ -71,18 +93,20 @@ public final class ConnectUtils {
     }
 
     /**
-     * Modify the supplied map of configurations to remove all configuration name-value pairs that are not included in the
-     * specified set of names.
+     * Modify the supplied map of configurations to retain only those configuration name-value pairs that satisfy the supplied predicate.
      *
      * @param configs the map of configurations to be modified; may not be null
-     * @param configNames the names of the configuration properties that are to be retained; may not be null
+     * @param isValid a function that is used to determine which configuration properties to retain; may not be null
      * @return the supplied {@code configs} parameter, returned for convenience
+     * @see ProducerConfig#isKnownConfig(String)
+     * @see ConsumerConfig#isKnownConfig(String)
+     * @see AdminClientConfig#isKnownConfig(String)
      */
-    public static Map<String, Object> retainConfigs(Map<String, Object> configs, Set<String> configNames) {
+    public static Map<String, Object> retainConfigs(Map<String, Object> configs, Predicate<String> isValid) {
         Iterator<Entry<String, Object>> entryIter = configs.entrySet().iterator();
         while (entryIter.hasNext()) {
             Map.Entry<String, Object> entry = entryIter.next();
-            if (!configNames.contains(entry.getKey())) {
+            if (!isValid.test(entry.getKey())) {
                 log.debug("Not retaining the '{}' config property when passing to a subcomponent", entry.getKey());
                 entryIter.remove();
             }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/ConnectUtils.java
@@ -83,6 +83,7 @@ public final class ConnectUtils {
         while (entryIter.hasNext()) {
             Map.Entry<String, Object> entry = entryIter.next();
             if (!configNames.contains(entry.getKey())) {
+                log.debug("Not retaining the '{}' config property when passing to a subcomponent", entry.getKey());
                 entryIter.remove();
             }
         }

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -166,7 +166,7 @@ public class TopicAdmin implements AutoCloseable {
      */
     public TopicAdmin(Map<String, Object> adminConfig) {
         // Prevent logging unused config warnings
-        this(adminConfig, AdminClient.create(ConnectUtils.retainConfigs(adminConfig, AdminClientConfig.configNames())));
+        this(adminConfig, AdminClient.create(ConnectUtils.retainConfigs(adminConfig, AdminClientConfig::isKnownConfig)));
     }
 
     // visible for testing

--- a/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java
@@ -165,7 +165,8 @@ public class TopicAdmin implements AutoCloseable {
      * @param adminConfig the configuration for the {@link AdminClient}
      */
     public TopicAdmin(Map<String, Object> adminConfig) {
-        this(adminConfig, AdminClient.create(adminConfig));
+        // Prevent logging unused config warnings
+        this(adminConfig, AdminClient.create(ConnectUtils.retainConfigs(adminConfig, AdminClientConfig.configNames())));
     }
 
     // visible for testing

--- a/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
+++ b/connect/runtime/src/test/java/org/apache/kafka/connect/util/ConnectUtilsTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.runtime.MockConnectMetrics.MockMetricsReporter;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -72,9 +73,11 @@ public class ConnectUtilsTest {
         configs.put(AdminClientConfig.CLIENT_ID_CONFIG, "clientId");
         configs.put(AdminClientConfig.RETRIES_CONFIG, "1");
         configs.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "100");
+        configs.put(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG, MockMetricsReporter.class.getName());
+        configs.put(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG + ".custom", "customValue");
         configs.put("some.other.property", "value");
         configs.put("other.property", "value2");
-        Map<String, Object> filtered = ConnectUtils.retainConfigs(new HashMap<>(configs), AdminClientConfig.configNames());
+        Map<String, Object> filtered = ConnectUtils.retainConfigs(new HashMap<>(configs), AdminClientConfig::isKnownConfig);
         assertEquals(configs.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG),
                      filtered.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG));
         assertEquals(configs.get(AdminClientConfig.CLIENT_ID_CONFIG),
@@ -83,6 +86,10 @@ public class ConnectUtilsTest {
                      filtered.get(AdminClientConfig.RETRIES_CONFIG));
         assertEquals(configs.get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG),
                      filtered.get(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG));
+        assertEquals(configs.get(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG),
+                     filtered.get(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG));
+        assertEquals(configs.get(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG + ".custom"),
+                     filtered.get(AdminClientConfig.METRIC_REPORTER_CLASSES_CONFIG + ".custom"));
         assertFalse(filtered.containsKey("some.other.property"));
         assertFalse(filtered.containsKey("other.property"));
         assertEquals(configs.size() - 2, filtered.size());


### PR DESCRIPTION
When running Connect, the logs contain quite a few warnings about:

    The configuration '{}' was supplied but isn't a known config.

This occurs when Connect creates producers, consumers, and admin clients, because the AbstractConfig is logging unused configuration properties upon construction. It's complicated by the fact that the `Producer`, `Consumer`, and `AdminClient` all create in their constructors private instances of `ProducerConfig`, `ConsumerConfig`, and `AdminClientConfig`, respectively, and the unused properties are logged as warnings there. Because the `AbstractConfig` instances are created by the client components, Connect is not able to call the `ignore(String key)` method to suppress those log warnings.

Unfortunately, there are no arguments in the Producer, Consumer, or AdminClient public constructors to control whether the configs log these warning in their constructors. While that might be a possible change we want to make in the future, a simpler workaround is for Connect to be more hygienic and pass to the `Producer`, `Consumer`, and `AdminClient` constructors only  those configuration properties that the `ProducerConfig`, `ConsumerConfig`, and `AdminClientConfig` configdefs know about.

This PR makes this change for Connect. 

If this approach is approved, we should consider how far back we want to port this change.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
