### PR TITLE
KAFKA-7513: Fix timing issue in SaslAuthenticatorFailureDelayTest

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NetworkTestUtils.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.security.authenticator.CredentialCache;
-import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.test.TestUtils;
@@ -87,7 +86,7 @@ public class NetworkTestUtils {
         assertTrue(selector.isChannelReady(node));
     }
 
-    public static ChannelState waitForChannelClose(Selector selector, String node, ChannelState.State channelState, MockTime mockTime)
+    public static ChannelState waitForChannelClose(Selector selector, String node, ChannelState.State channelState)
             throws IOException {
         boolean closed = false;
         for (int i = 0; i < 300; i++) {
@@ -96,17 +95,11 @@ public class NetworkTestUtils {
                 closed = true;
                 break;
             }
-            if (mockTime != null)
-                mockTime.setCurrentTimeMs(mockTime.milliseconds() + 150);
         }
         assertTrue("Channel was not closed by timeout", closed);
         ChannelState finalState = selector.disconnected().get(node);
         assertEquals(channelState, finalState.state());
         return finalState;
-    }
-
-    public static ChannelState waitForChannelClose(Selector selector, String node, ChannelState.State channelState) throws IOException {
-        return waitForChannelClose(selector, node, channelState, null);
     }
 
     public static void completeDelayedChannelClose(Selector selector, long currentTimeNanos) {

--- a/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
+++ b/clients/src/test/java/org/apache/kafka/common/network/NioEchoServer.java
@@ -153,7 +153,7 @@ public class NioEchoServer extends Thread {
         try {
             acceptorThread.start();
             while (serverSocketChannel.isOpen()) {
-                selector.poll(1000);
+                selector.poll(100);
                 synchronized (newChannels) {
                     for (SocketChannel socketChannel : newChannels) {
                         String id = id(socketChannel);

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
@@ -53,8 +53,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(value = Parameterized.class)
 public class SaslAuthenticatorFailureDelayTest {
     private static final int BUFFER_SIZE = 4 * 1024;
-    private static MockTime time = new MockTime(10);
 
+    private final MockTime time = new MockTime(10);
     private NioEchoServer server;
     private Selector selector;
     private ChannelBuilder channelBuilder;

--- a/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/security/authenticator/SaslAuthenticatorFailureDelayTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(value = Parameterized.class)
 public class SaslAuthenticatorFailureDelayTest {
     private static final int BUFFER_SIZE = 4 * 1024;
-    private static MockTime time = new MockTime(50);
+    private static MockTime time = new MockTime(10);
 
     private NioEchoServer server;
     private Selector selector;
@@ -221,7 +221,7 @@ public class SaslAuthenticatorFailureDelayTest {
             throws Exception {
         createClientConnection(securityProtocol, node);
         ChannelState finalState = NetworkTestUtils.waitForChannelClose(selector, node,
-                ChannelState.State.AUTHENTICATION_FAILED, time);
+                ChannelState.State.AUTHENTICATION_FAILED);
         selector.close();
         selector = null;
         return finalState;


### PR DESCRIPTION
Reduce tick interval of the mock timer and avoid large timer increments to avoid hitting idle expiry on the client-side before delayed close is processed by the server. Also reduce poll interval in the server to make the test complete faster (since delayed close is only processed when poll returns).

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
